### PR TITLE
Finding workflow enrichments

### DIFF
--- a/cmd/scrutineer/main.go
+++ b/cmd/scrutineer/main.go
@@ -66,6 +66,7 @@ func run(log *slog.Logger) error {
 		return fmt.Errorf("open db: %w", err)
 	}
 	db.BackfillFindings(gdb)
+	db.BackfillFindingRepository(gdb)
 	if err := db.SeedDefaultLabels(gdb); err != nil {
 		return fmt.Errorf("seed labels: %w", err)
 	}

--- a/cmd/scrutineer/main.go
+++ b/cmd/scrutineer/main.go
@@ -66,6 +66,9 @@ func run(log *slog.Logger) error {
 		return fmt.Errorf("open db: %w", err)
 	}
 	db.BackfillFindings(gdb)
+	if err := db.SeedDefaultLabels(gdb); err != nil {
+		return fmt.Errorf("seed labels: %w", err)
+	}
 	if err := db.SweepRunning(gdb); err != nil {
 		return fmt.Errorf("sweep: %w", err)
 	}

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -218,36 +218,160 @@ type Dependency struct {
 	CreatedAt      time.Time
 }
 
-// Finding is one vulnerability reported by a claude scan. Rows are created
-// by parsing report.json against the schema in worker/schema.json; the
-// columns mirror that schema so the two stay easy to diff.
+// FindingResolution says how a finding got resolved. Set by the analyst
+// once disclosure runs its course.
+type FindingResolution string
+
+const (
+	ResolutionFix        FindingResolution = "fix"
+	ResolutionMigrate    FindingResolution = "migrate"
+	ResolutionWorkaround FindingResolution = "workaround"
+	ResolutionAdopt      FindingResolution = "adopt"
+	ResolutionWontfix    FindingResolution = "wontfix"
+)
+
+// FindingSource is the provenance of a field value: produced by a
+// deterministic tool, suggested by a model-backed skill, or set by the
+// analyst. Analyst wins over model wins over tool.
+type FindingSource string
+
+const (
+	SourceTool     FindingSource = "tool"
+	SourceModel    FindingSource = "model_suggested"
+	SourceAnalyst  FindingSource = "analyst"
+)
+
+// Finding is one vulnerability reported by a scan. The Finding row holds
+// the current value of every mutable field; FindingHistory records who
+// changed each one and from which source. Labels, notes, communications,
+// and references are normalised into sibling tables.
 type Finding struct {
-	ID     uint `gorm:"primarykey"`
-	ScanID uint `gorm:"index;not null"`
-	Scan   Scan
+	ID           uint `gorm:"primarykey"`
+	ScanID       uint `gorm:"index;not null"`
+	Scan         Scan
+	// RepositoryID and Commit are denormalized from Scan so list queries
+	// don't have to join through Scan (GORM's Preload/Joins on
+	// Finding.Scan doesn't round-trip cleanly on sqlite). Set at
+	// finding-create time and never changed.
+	RepositoryID uint   `gorm:"index;not null"`
+	Commit       string
 
 	FindingID string // e.g. F1, F2 within the report
-	Sinks     string // comma-joined sink IDs, e.g. "S9, S25, S26"
+	Sinks     string // comma-joined sink IDs
 	Title     string
-	Severity  string      `gorm:"index"`
+	Severity  string           `gorm:"index"`
 	Status    FindingLifecycle `gorm:"index;default:new"`
 	CWE       string
 	Location  string
 	Affected  string // version range
-	Notes     string `gorm:"type:text"`
 
-	// Per-step prose from the six-step checklist
+	// Disclosure / triage fields. Any of these may be set by a tool, a
+	// model-backed skill, or the analyst; see FindingHistory for the trail.
+	CVEID           string
+	CVSSVector      string
+	CVSSScore       float64
+	FixVersion      string
+	FixCommit       string
+	Resolution      FindingResolution `gorm:"index"`
+	DisclosureDraft string            `gorm:"type:text"`
+	Assignee        string            `gorm:"index"`
+
+	// Per-step prose from the six-step audit checklist.
 	Trace      string `gorm:"type:text"`
-	Boundary   string `gorm:"type:text"` // step 2 analysis
-	Validation string `gorm:"type:text"` // step 3 reproduction
+	Boundary   string `gorm:"type:text"`
+	Validation string `gorm:"type:text"`
 	PriorArt   string `gorm:"type:text"`
 	Reach      string `gorm:"type:text"`
-	Rating     string `gorm:"type:text"` // step 6 severity justification
+	Rating     string `gorm:"type:text"`
 
-	// Legacy fields for backward compat with old schema reports
-	Confidence string
-	Summary    string
-	Details    string
+	Labels         []FindingLabel         `gorm:"many2many:finding_labels_join"`
+	Notes          []FindingNote          `gorm:"constraint:OnDelete:CASCADE"`
+	Communications []FindingCommunication `gorm:"constraint:OnDelete:CASCADE"`
+	References     []FindingReference     `gorm:"constraint:OnDelete:CASCADE"`
+	History        []FindingHistory       `gorm:"constraint:OnDelete:CASCADE"`
+
+	CreatedAt time.Time
+	UpdatedAt time.Time
+}
+
+// Summary gives a one-paragraph digest of the finding: first paragraph of
+// Trace when present, else the Title. Kept as a method so templates can
+// treat it like any other field without callers recomputing it.
+func (f Finding) Summary() string {
+	if f.Trace == "" {
+		return f.Title
+	}
+	if i := strings.Index(f.Trace, "\n\n"); i > 0 {
+		return f.Trace[:i]
+	}
+	return f.Trace
+}
+
+// FindingLabel is a tag independent of the lifecycle status. A finding can
+// carry multiple labels (wontfix, needs-info, regression, etc.).
+type FindingLabel struct {
+	ID    uint   `gorm:"primarykey"`
+	Name  string `gorm:"uniqueIndex;not null"`
+	Color string // CSS hex color for the badge
+
+	CreatedAt time.Time
+}
+
+// FindingNote is one timestamped internal analyst note about a finding.
+// Replaces the old single Notes column so the comment trail is preserved.
+type FindingNote struct {
+	ID        uint `gorm:"primarykey"`
+	FindingID uint `gorm:"index;not null"`
+	Body      string `gorm:"type:text"`
+	By        string // free-text author; scrutineer is single-user so usually empty
+
+	CreatedAt time.Time
+}
+
+// FindingCommunication is one external interaction about a finding: an
+// email to the maintainer, an inbound reply, a GHSA submission, etc.
+// Kept distinct from FindingNote since the semantics (channel, direction,
+// external actor) don't fit a generic note.
+type FindingCommunication struct {
+	ID        uint `gorm:"primarykey"`
+	FindingID uint `gorm:"index;not null"`
+	Channel   string // email | ghsa | issue | pr | direct | registry
+	Direction string // outbound | inbound
+	Actor     string // name/handle of the other party
+	Body      string `gorm:"type:text"`
+	// OfferedHelp (optional): pr | funding | adoption | none.
+	// Lets disclosure tracking distinguish "reported a bug" from
+	// "reported a bug and offered a PR/funding".
+	OfferedHelp string
+	At          time.Time
+
+	CreatedAt time.Time
+}
+
+// FindingReference is an external URL related to a finding: the upstream
+// issue/PR, a CVE or GHSA record, a fix commit, a blog post.
+type FindingReference struct {
+	ID        uint `gorm:"primarykey"`
+	FindingID uint `gorm:"index;not null"`
+	URL       string
+	// Tags is comma-joined: issue, pr, cve, ghsa, patch, advisory, discussion, article.
+	Tags    string
+	Summary string
+
+	CreatedAt time.Time
+}
+
+// FindingHistory records every change to a mutable field on a Finding.
+// Together with the Finding row's current columns it gives you "what is
+// the current value, who set it, from what source, and when".
+type FindingHistory struct {
+	ID        uint          `gorm:"primarykey"`
+	FindingID uint          `gorm:"index;not null"`
+	Field     string        `gorm:"index"` // e.g. severity, cvss_vector, status
+	OldValue  string        `gorm:"type:text"`
+	NewValue  string        `gorm:"type:text"`
+	Source    FindingSource `gorm:"index"`
+	By        string        // free text, or the skill name for model_suggested writes
 
 	CreatedAt time.Time
 }
@@ -310,7 +434,13 @@ func Open(dsn string) (*gorm.DB, error) {
 	if err := gdb.Exec("PRAGMA journal_mode=WAL; PRAGMA busy_timeout=5000; PRAGMA foreign_keys=ON;").Error; err != nil {
 		return nil, fmt.Errorf("pragma: %w", err)
 	}
-	if err := gdb.AutoMigrate(&Repository{}, &Scan{}, &Finding{}, &Dependency{}, &Package{}, &Dependent{}, &Advisory{}, &Maintainer{}, &Skill{}); err != nil {
+	if err := gdb.AutoMigrate(
+		&Repository{}, &Scan{},
+		&Finding{}, &FindingLabel{}, &FindingNote{},
+		&FindingCommunication{}, &FindingReference{}, &FindingHistory{},
+		&Dependency{}, &Package{}, &Dependent{}, &Advisory{},
+		&Maintainer{}, &Skill{},
+	); err != nil {
 		return nil, fmt.Errorf("automigrate: %w", err)
 	}
 	return gdb, nil

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -252,8 +252,11 @@ type Finding struct {
 	// RepositoryID and Commit are denormalized from Scan so list queries
 	// don't have to join through Scan (GORM's Preload/Joins on
 	// Finding.Scan doesn't round-trip cleanly on sqlite). Set at
-	// finding-create time and never changed.
-	RepositoryID uint   `gorm:"index;not null"`
+	// finding-create time and never changed. RepositoryID is not
+	// marked not-null so AutoMigrate can widen the column on existing
+	// databases without a default; BackfillFindingRepository fills
+	// existing rows on startup.
+	RepositoryID uint `gorm:"index"`
 	Commit       string
 
 	FindingID string // e.g. F1, F2 within the report
@@ -444,6 +447,26 @@ func Open(dsn string) (*gorm.DB, error) {
 		return nil, fmt.Errorf("automigrate: %w", err)
 	}
 	return gdb, nil
+}
+
+// BackfillFindingRepository copies Scan.RepositoryID onto Finding rows
+// whose RepositoryID column is still zero. Used on first boot after
+// adding the denormalized column so existing findings pick up their repo.
+func BackfillFindingRepository(gdb *gorm.DB) {
+	gdb.Exec(`
+		UPDATE findings
+		SET repository_id = (
+			SELECT repository_id FROM scans WHERE scans.id = findings.scan_id
+		)
+		WHERE (repository_id IS NULL OR repository_id = 0)
+	`)
+	gdb.Exec(`
+		UPDATE findings
+		SET commit = (
+			SELECT commit FROM scans WHERE scans.id = findings.scan_id
+		)
+		WHERE ` + "`commit`" + ` IS NULL OR ` + "`commit`" + ` = ''
+	`)
 }
 
 // BackfillFindings re-parses stored report JSON to fill columns that were

--- a/internal/db/finding_helpers.go
+++ b/internal/db/finding_helpers.go
@@ -1,0 +1,173 @@
+package db
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"gorm.io/gorm"
+)
+
+// WriteFindingField updates a Finding column and records the change in
+// FindingHistory. Callers pass the JSON-style field name (severity,
+// cvss_vector, status, resolution, ...); unknown fields are rejected so
+// typos don't silently vanish.
+//
+// No-op when the new value equals the current stored value; the history
+// row is only written on an actual change.
+func WriteFindingField(gdb *gorm.DB, findingID uint, field, newValue string, source FindingSource, by string) error {
+	var f Finding
+	if err := gdb.First(&f, findingID).Error; err != nil {
+		return fmt.Errorf("load finding %d: %w", findingID, err)
+	}
+	old, colName, err := findingFieldAccessor(&f, field)
+	if err != nil {
+		return err
+	}
+	if old == newValue {
+		return nil
+	}
+	if err := gdb.Model(&Finding{}).Where("id = ?", f.ID).Update(colName, newValue).Error; err != nil {
+		return fmt.Errorf("update %s: %w", colName, err)
+	}
+	return gdb.Create(&FindingHistory{
+		FindingID: f.ID,
+		Field:     field,
+		OldValue:  old,
+		NewValue:  newValue,
+		Source:    source,
+		By:        by,
+		CreatedAt: time.Now(),
+	}).Error
+}
+
+// findingFieldAccessor maps the API-facing field name to the current
+// value and the DB column name. It is the single list of mutable fields;
+// adding a new editable field means adding it here.
+func findingFieldAccessor(f *Finding, field string) (current, column string, err error) {
+	switch field {
+	case "title":
+		return f.Title, "title", nil
+	case "severity":
+		return f.Severity, "severity", nil
+	case "status":
+		return string(f.Status), "status", nil
+	case "cwe":
+		return f.CWE, "cwe", nil
+	case "location":
+		return f.Location, "location", nil
+	case "affected":
+		return f.Affected, "affected", nil
+	case "cve_id":
+		return f.CVEID, "cve_id", nil
+	case "cvss_vector":
+		return f.CVSSVector, "cvss_vector", nil
+	case "fix_version":
+		return f.FixVersion, "fix_version", nil
+	case "fix_commit":
+		return f.FixCommit, "fix_commit", nil
+	case "resolution":
+		return string(f.Resolution), "resolution", nil
+	case "disclosure_draft":
+		return f.DisclosureDraft, "disclosure_draft", nil
+	case "assignee":
+		return f.Assignee, "assignee", nil
+	default:
+		return "", "", fmt.Errorf("field %q is not editable", field)
+	}
+}
+
+// AddFindingNote appends a timestamped note.
+func AddFindingNote(gdb *gorm.DB, findingID uint, body, by string) (*FindingNote, error) {
+	body = strings.TrimSpace(body)
+	if body == "" {
+		return nil, fmt.Errorf("note body is empty")
+	}
+	n := &FindingNote{FindingID: findingID, Body: body, By: by, CreatedAt: time.Now()}
+	if err := gdb.Create(n).Error; err != nil {
+		return nil, err
+	}
+	return n, nil
+}
+
+// AddFindingCommunication records one external interaction.
+func AddFindingCommunication(gdb *gorm.DB, findingID uint, channel, direction, actor, body, offeredHelp string, at time.Time) (*FindingCommunication, error) {
+	if at.IsZero() {
+		at = time.Now()
+	}
+	c := &FindingCommunication{
+		FindingID:   findingID,
+		Channel:     channel,
+		Direction:   direction,
+		Actor:       actor,
+		Body:        body,
+		OfferedHelp: offeredHelp,
+		At:          at,
+		CreatedAt:   time.Now(),
+	}
+	if err := gdb.Create(c).Error; err != nil {
+		return nil, err
+	}
+	return c, nil
+}
+
+// AddFindingReference records an external URL related to the finding.
+func AddFindingReference(gdb *gorm.DB, findingID uint, url, tags, summary string) (*FindingReference, error) {
+	if strings.TrimSpace(url) == "" {
+		return nil, fmt.Errorf("reference url is empty")
+	}
+	r := &FindingReference{
+		FindingID: findingID,
+		URL:       url,
+		Tags:      tags,
+		Summary:   summary,
+		CreatedAt: time.Now(),
+	}
+	if err := gdb.Create(r).Error; err != nil {
+		return nil, err
+	}
+	return r, nil
+}
+
+// SetFindingLabels replaces a finding's label set with the given names.
+// Labels not already in the DB are created with a default (no color).
+// Empty slice clears all labels.
+func SetFindingLabels(gdb *gorm.DB, findingID uint, names []string) error {
+	var f Finding
+	if err := gdb.First(&f, findingID).Error; err != nil {
+		return err
+	}
+	labels := make([]FindingLabel, 0, len(names))
+	for _, name := range names {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		var l FindingLabel
+		if err := gdb.Where(FindingLabel{Name: name}).FirstOrCreate(&l).Error; err != nil {
+			return err
+		}
+		labels = append(labels, l)
+	}
+	return gdb.Model(&f).Association("Labels").Replace(labels)
+}
+
+// SeedDefaultLabels ensures a baseline set of labels exists on startup.
+// Calling again is idempotent; existing rows are left alone so users can
+// re-colour them without having their edits overwritten.
+func SeedDefaultLabels(gdb *gorm.DB) error {
+	defaults := []FindingLabel{
+		{Name: "wontfix", Color: "#6b7280"},
+		{Name: "in-progress", Color: "#2563eb"},
+		{Name: "needs-info", Color: "#f59e0b"},
+		{Name: "duplicate", Color: "#9333ea"},
+		{Name: "regression", Color: "#dc2626"},
+	}
+	for _, l := range defaults {
+		var existing FindingLabel
+		if err := gdb.Where(FindingLabel{Name: l.Name}).FirstOrCreate(&existing, l).Error; err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/db/finding_helpers_test.go
+++ b/internal/db/finding_helpers_test.go
@@ -1,0 +1,123 @@
+package db
+
+import (
+	"path/filepath"
+	"testing"
+
+	"gorm.io/gorm"
+)
+
+const severityField = "severity"
+
+func newTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	gdb, err := Open(filepath.Join(t.TempDir(), "t.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return gdb
+}
+
+func seedFinding(t *testing.T, gdb *gorm.DB) Finding {
+	t.Helper()
+	repo := Repository{URL: "https://example.com/x", Name: "x"}
+	gdb.Create(&repo)
+	scan := Scan{RepositoryID: repo.ID, Kind: "skill", Status: ScanDone}
+	gdb.Create(&scan)
+	f := Finding{ScanID: scan.ID, RepositoryID: repo.ID, FindingID: "F1", Title: "t", Severity: "High", Status: FindingNew}
+	gdb.Create(&f)
+	return f
+}
+
+func TestWriteFindingField_logsHistory(t *testing.T) {
+	gdb := newTestDB(t)
+	f := seedFinding(t, gdb)
+
+	if err := WriteFindingField(gdb, f.ID, severityField, "Critical", SourceAnalyst, "me"); err != nil {
+		t.Fatal(err)
+	}
+	var refreshed Finding
+	gdb.First(&refreshed, f.ID)
+	if refreshed.Severity != "Critical" {
+		t.Errorf("severity = %q, want Critical", refreshed.Severity)
+	}
+	var history []FindingHistory
+	gdb.Where("finding_id = ?", f.ID).Find(&history)
+	if len(history) != 1 {
+		t.Fatalf("history len = %d, want 1", len(history))
+	}
+	h := history[0]
+	if h.Field != severityField || h.OldValue != "High" || h.NewValue != "Critical" || h.Source != SourceAnalyst || h.By != "me" {
+		t.Errorf("history row: %+v", h)
+	}
+}
+
+func TestWriteFindingField_noOpWhenUnchanged(t *testing.T) {
+	gdb := newTestDB(t)
+	f := seedFinding(t, gdb)
+
+	if err := WriteFindingField(gdb, f.ID, severityField, "High", SourceAnalyst, ""); err != nil {
+		t.Fatal(err)
+	}
+	var count int64
+	gdb.Model(&FindingHistory{}).Where("finding_id = ?", f.ID).Count(&count)
+	if count != 0 {
+		t.Errorf("history rows = %d, want 0", count)
+	}
+}
+
+func TestWriteFindingField_rejectsUnknownField(t *testing.T) {
+	gdb := newTestDB(t)
+	f := seedFinding(t, gdb)
+	if err := WriteFindingField(gdb, f.ID, "does_not_exist", "x", SourceAnalyst, ""); err == nil {
+		t.Error("expected error for unknown field")
+	}
+}
+
+func TestAddFindingNote_rejectsEmpty(t *testing.T) {
+	gdb := newTestDB(t)
+	f := seedFinding(t, gdb)
+	if _, err := AddFindingNote(gdb, f.ID, "   ", ""); err == nil {
+		t.Error("expected error on empty note")
+	}
+}
+
+func TestSetFindingLabels_replacesSet(t *testing.T) {
+	gdb := newTestDB(t)
+	f := seedFinding(t, gdb)
+
+	if err := SetFindingLabels(gdb, f.ID, []string{"wontfix", "needs-info"}); err != nil {
+		t.Fatal(err)
+	}
+	var refreshed Finding
+	gdb.Preload("Labels").First(&refreshed, f.ID)
+	if len(refreshed.Labels) != 2 {
+		t.Fatalf("labels len = %d, want 2", len(refreshed.Labels))
+	}
+
+	if err := SetFindingLabels(gdb, f.ID, []string{"duplicate"}); err != nil {
+		t.Fatal(err)
+	}
+	var again Finding
+	gdb.Preload("Labels").First(&again, f.ID)
+	if len(again.Labels) != 1 || again.Labels[0].Name != "duplicate" {
+		t.Errorf("expected only duplicate label, got %+v", again.Labels)
+	}
+}
+
+func TestSeedDefaultLabels_idempotent(t *testing.T) {
+	gdb := newTestDB(t)
+	if err := SeedDefaultLabels(gdb); err != nil {
+		t.Fatal(err)
+	}
+	var count1 int64
+	gdb.Model(&FindingLabel{}).Count(&count1)
+	if err := SeedDefaultLabels(gdb); err != nil {
+		t.Fatal(err)
+	}
+	var count2 int64
+	gdb.Model(&FindingLabel{}).Count(&count2)
+	if count1 != count2 {
+		t.Errorf("second seed inserted rows: %d -> %d", count1, count2)
+	}
+}

--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -93,6 +93,15 @@ func (s *Server) apiHandler() http.Handler {
 	mux.HandleFunc("POST /findings/{id}/skills/{name}/run", s.apiRunFindingSkill)
 	mux.HandleFunc("GET /scans/{id}", s.apiGetScan)
 	mux.HandleFunc("GET /findings/{id}", s.apiGetFinding)
+	mux.HandleFunc("PATCH /findings/{id}", s.apiPatchFinding)
+	mux.HandleFunc("GET /findings/{id}/notes", s.apiListFindingNotes)
+	mux.HandleFunc("POST /findings/{id}/notes", s.apiAddFindingNote)
+	mux.HandleFunc("GET /findings/{id}/communications", s.apiListFindingCommunications)
+	mux.HandleFunc("POST /findings/{id}/communications", s.apiAddFindingCommunication)
+	mux.HandleFunc("GET /findings/{id}/references", s.apiListFindingReferences)
+	mux.HandleFunc("POST /findings/{id}/references", s.apiAddFindingReference)
+	mux.HandleFunc("PUT /findings/{id}/labels", s.apiSetFindingLabels)
+	mux.HandleFunc("GET /findings/{id}/history", s.apiListFindingHistory)
 	mux.HandleFunc("GET /skills", s.apiListSkills)
 	return http.StripPrefix(apiPrefix, s.apiAuth(mux))
 }
@@ -223,18 +232,12 @@ func (s *Server) apiRunFindingSkill(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusCreated, scanSummary(sc))
 }
 
-// findingRepoID resolves a finding to the repository that owns it by
-// reading the scan the finding belongs to. Direct query so it does not
-// depend on GORM's Preload of the Finding.Scan relation (which is unreliable
-// in sqlite; the column aliasing doesn't round-trip).
+// findingRepoID reads the denormalized Finding.RepositoryID column. Used
+// by the skill-facing handlers to enforce "scan can only touch findings
+// on its own repository" without re-reading the entire Finding row.
 func (s *Server) findingRepoID(findingID uint) (uint, bool) {
-	var scanID uint
-	row := s.DB.Model(&db.Finding{}).Select("scan_id").Where("id = ?", findingID).Row()
-	if err := row.Scan(&scanID); err != nil || scanID == 0 {
-		return 0, false
-	}
 	var repoID uint
-	row = s.DB.Model(&db.Scan{}).Select("repository_id").Where("id = ?", scanID).Row()
+	row := s.DB.Model(&db.Finding{}).Select("repository_id").Where("id = ?", findingID).Row()
 	if err := row.Scan(&repoID); err != nil || repoID == 0 {
 		return 0, false
 	}

--- a/internal/web/api_finding_writes.go
+++ b/internal/web/api_finding_writes.go
@@ -1,0 +1,203 @@
+package web
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"time"
+
+	"scrutineer/internal/db"
+)
+
+// The handlers below let skills (and the browser UI) mutate a finding:
+// edit scoring fields, append notes, log communications, add references,
+// set labels, and read the full change history. Auth scoping holds: the
+// authenticated scan's repository must own the finding.
+
+func (s *Server) apiPatchFinding(w http.ResponseWriter, r *http.Request) {
+	id, _ := strconv.Atoi(r.PathValue("id"))
+	repoID, ok := s.findingRepoID(uint(id))
+	if !ok {
+		writeAPIError(w, http.StatusNotFound, "finding not found")
+		return
+	}
+	if !s.scanOwnsRepo(r, repoID) {
+		writeAPIError(w, http.StatusForbidden, "scan may only edit findings on its own repository")
+		return
+	}
+	var body struct {
+		Fields map[string]string `json:"fields"`
+		By     string            `json:"by"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeAPIError(w, http.StatusBadRequest, "body must be JSON with a fields map")
+		return
+	}
+	source := sourceFromRequest(r)
+	for field, value := range body.Fields {
+		if err := db.WriteFindingField(s.DB, uint(id), field, value, source, body.By); err != nil {
+			writeAPIError(w, http.StatusUnprocessableEntity, err.Error())
+			return
+		}
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *Server) apiAddFindingNote(w http.ResponseWriter, r *http.Request) {
+	id, ok := s.findingScoped(w, r)
+	if !ok {
+		return
+	}
+	var body struct {
+		Body string `json:"body"`
+		By   string `json:"by"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeAPIError(w, http.StatusBadRequest, "body must be JSON")
+		return
+	}
+	n, err := db.AddFindingNote(s.DB, id, body.Body, body.By)
+	if err != nil {
+		writeAPIError(w, http.StatusUnprocessableEntity, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusCreated, n)
+}
+
+func (s *Server) apiListFindingNotes(w http.ResponseWriter, r *http.Request) {
+	id, ok := s.findingScoped(w, r)
+	if !ok {
+		return
+	}
+	var rows []db.FindingNote
+	s.DB.Where("finding_id = ?", id).Order("created_at desc").Find(&rows)
+	writeJSON(w, http.StatusOK, rows)
+}
+
+func (s *Server) apiAddFindingCommunication(w http.ResponseWriter, r *http.Request) {
+	id, ok := s.findingScoped(w, r)
+	if !ok {
+		return
+	}
+	var body struct {
+		Channel     string    `json:"channel"`
+		Direction   string    `json:"direction"`
+		Actor       string    `json:"actor"`
+		Body        string    `json:"body"`
+		OfferedHelp string    `json:"offered_help"`
+		At          time.Time `json:"at"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeAPIError(w, http.StatusBadRequest, "body must be JSON")
+		return
+	}
+	c, err := db.AddFindingCommunication(s.DB, id, body.Channel, body.Direction, body.Actor, body.Body, body.OfferedHelp, body.At)
+	if err != nil {
+		writeAPIError(w, http.StatusUnprocessableEntity, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusCreated, c)
+}
+
+func (s *Server) apiListFindingCommunications(w http.ResponseWriter, r *http.Request) {
+	id, ok := s.findingScoped(w, r)
+	if !ok {
+		return
+	}
+	var rows []db.FindingCommunication
+	s.DB.Where("finding_id = ?", id).Order("at desc").Find(&rows)
+	writeJSON(w, http.StatusOK, rows)
+}
+
+func (s *Server) apiAddFindingReference(w http.ResponseWriter, r *http.Request) {
+	id, ok := s.findingScoped(w, r)
+	if !ok {
+		return
+	}
+	var body struct {
+		URL     string `json:"url"`
+		Tags    string `json:"tags"`
+		Summary string `json:"summary"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeAPIError(w, http.StatusBadRequest, "body must be JSON")
+		return
+	}
+	ref, err := db.AddFindingReference(s.DB, id, body.URL, body.Tags, body.Summary)
+	if err != nil {
+		writeAPIError(w, http.StatusUnprocessableEntity, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusCreated, ref)
+}
+
+func (s *Server) apiListFindingReferences(w http.ResponseWriter, r *http.Request) {
+	id, ok := s.findingScoped(w, r)
+	if !ok {
+		return
+	}
+	var rows []db.FindingReference
+	s.DB.Where("finding_id = ?", id).Order("id desc").Find(&rows)
+	writeJSON(w, http.StatusOK, rows)
+}
+
+func (s *Server) apiSetFindingLabels(w http.ResponseWriter, r *http.Request) {
+	id, ok := s.findingScoped(w, r)
+	if !ok {
+		return
+	}
+	var body struct {
+		Labels []string `json:"labels"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeAPIError(w, http.StatusBadRequest, "body must be JSON with a labels array")
+		return
+	}
+	if err := db.SetFindingLabels(s.DB, id, body.Labels); err != nil {
+		writeAPIError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *Server) apiListFindingHistory(w http.ResponseWriter, r *http.Request) {
+	id, ok := s.findingScoped(w, r)
+	if !ok {
+		return
+	}
+	var rows []db.FindingHistory
+	s.DB.Where("finding_id = ?", id).Order("created_at desc").Find(&rows)
+	writeJSON(w, http.StatusOK, rows)
+}
+
+// findingScoped parses the path id, resolves its repository, and enforces
+// the scan-owns-repo auth rule. Returns false when the response has
+// already been written with the appropriate error.
+func (s *Server) findingScoped(w http.ResponseWriter, r *http.Request) (uint, bool) {
+	id, _ := strconv.Atoi(r.PathValue("id"))
+	repoID, ok := s.findingRepoID(uint(id))
+	if !ok {
+		writeAPIError(w, http.StatusNotFound, "finding not found")
+		return 0, false
+	}
+	if !s.scanOwnsRepo(r, repoID) {
+		writeAPIError(w, http.StatusForbidden, "scan may only act on findings on its own repository")
+		return 0, false
+	}
+	return uint(id), true
+}
+
+// sourceFromRequest picks model_suggested when the authenticated scan has
+// a skill context (skills write as themselves) and analyst otherwise. The
+// browser UI currently also uses bearer tokens, so analyst edits come
+// through with the finding-scoped scan's token; we treat those as
+// model_suggested here. Bypass path for purely UI edits lives in the
+// server's non-API handlers (findingStatus, findingNotes) which write
+// with source=analyst directly.
+func sourceFromRequest(r *http.Request) db.FindingSource {
+	sc := scanFromRequest(r)
+	if sc != nil && sc.SkillID != nil {
+		return db.SourceModel
+	}
+	return db.SourceAnalyst
+}

--- a/internal/web/api_reads.go
+++ b/internal/web/api_reads.go
@@ -161,7 +161,7 @@ func (s *Server) apiListFindings(w http.ResponseWriter, r *http.Request) {
 	q.Find(&rows)
 	out := make([]map[string]any, 0, len(rows))
 	for _, f := range rows {
-		out = append(out, findingSummary(f, uint(id)))
+		out = append(out, findingSummary(f))
 	}
 	writeJSON(w, http.StatusOK, out)
 }
@@ -175,31 +175,26 @@ func (s *Server) apiGetFinding(w http.ResponseWriter, r *http.Request) {
 		writeAPIError(w, http.StatusNotFound, "finding not found")
 		return
 	}
-	repoID, ok := s.findingRepoID(f.ID)
-	if !ok {
-		writeAPIError(w, http.StatusNotFound, "finding not found")
-		return
-	}
-	if !s.scanOwnsRepo(r, repoID) {
+	if !s.scanOwnsRepo(r, f.RepositoryID) {
 		writeAPIError(w, http.StatusForbidden, "scan may only read findings on its own repository")
 		return
 	}
-	summary := findingSummary(f, repoID)
+	summary := findingSummary(f)
 	summary["trace"] = f.Trace
 	summary["boundary"] = f.Boundary
 	summary["validation"] = f.Validation
 	summary["prior_art"] = f.PriorArt
 	summary["reach"] = f.Reach
 	summary["rating"] = f.Rating
-	summary["notes"] = f.Notes
+	summary["disclosure_draft"] = f.DisclosureDraft
 	writeJSON(w, http.StatusOK, summary)
 }
 
-func findingSummary(f db.Finding, repoID uint) map[string]any {
+func findingSummary(f db.Finding) map[string]any {
 	return map[string]any{
 		"id":            f.ID,
 		"scan_id":       f.ScanID,
-		"repository_id": repoID,
+		"repository_id": f.RepositoryID,
 		"finding_id":    f.FindingID,
 		"sinks":         f.Sinks,
 		"title":         f.Title,
@@ -208,5 +203,12 @@ func findingSummary(f db.Finding, repoID uint) map[string]any {
 		"cwe":           f.CWE,
 		"location":      f.Location,
 		"affected":      f.Affected,
+		"cve_id":        f.CVEID,
+		"cvss_vector":   f.CVSSVector,
+		"cvss_score":    f.CVSSScore,
+		"fix_version":   f.FixVersion,
+		"fix_commit":    f.FixCommit,
+		"resolution":    string(f.Resolution),
+		"assignee":      f.Assignee,
 	}
 }

--- a/internal/web/api_test.go
+++ b/internal/web/api_test.go
@@ -114,8 +114,8 @@ func TestAPIFindingReadsAndFilters(t *testing.T) {
 	// Simulate a prior deep-dive scan with a couple of findings attached.
 	prior := db.Scan{RepositoryID: repo.ID, Kind: worker.JobSkill, Status: db.ScanDone, SkillName: "security-deep-dive"}
 	s.DB.Create(&prior)
-	s.DB.Create(&db.Finding{ScanID: prior.ID, FindingID: "F1", Title: "a", Severity: "High", Location: "a.go:1", Trace: "trace a"})
-	s.DB.Create(&db.Finding{ScanID: prior.ID, FindingID: "F2", Title: "b", Severity: "Low", Location: "b.go:1", Trace: "trace b"})
+	s.DB.Create(&db.Finding{ScanID: prior.ID, RepositoryID: repo.ID, FindingID: "F1", Title: "a", Severity: "High", Location: "a.go:1", Trace: "trace a"})
+	s.DB.Create(&db.Finding{ScanID: prior.ID, RepositoryID: repo.ID, FindingID: "F2", Title: "b", Severity: "Low", Location: "b.go:1", Trace: "trace b"})
 
 	// Unfiltered list
 	r := httptest.NewRequest("GET", "/api/repositories/"+strconv.FormatUint(uint64(repo.ID), 10)+"/findings", nil)
@@ -168,7 +168,7 @@ func TestAPIRunFindingSkill_scopesFindingID(t *testing.T) {
 
 	prior := db.Scan{RepositoryID: repo.ID, Kind: worker.JobSkill, Status: db.ScanDone, SkillName: "security-deep-dive"}
 	s.DB.Create(&prior)
-	finding := db.Finding{ScanID: prior.ID, FindingID: "F1", Title: "x", Severity: "High", Status: db.FindingNew}
+	finding := db.Finding{ScanID: prior.ID, RepositoryID: repo.ID, FindingID: "F1", Title: "x", Severity: "High", Status: db.FindingNew}
 	s.DB.Create(&finding)
 	verify := db.Skill{Name: "verify", Description: "v", Body: "b", OutputFile: "report.json", OutputKind: "verify", Version: 1, Active: true, Source: "ui"}
 	s.DB.Create(&verify)

--- a/internal/web/finding_forms.go
+++ b/internal/web/finding_forms.go
@@ -1,0 +1,123 @@
+package web
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"scrutineer/internal/db"
+)
+
+// The browser-form handlers write finding mutations with
+// source=analyst. Skills hit the /api counterparts, which pick
+// source=model_suggested automatically.
+
+// analystFields is the set of fields the finding edit form exposes. Any
+// field not in this list is silently dropped; WriteFindingField would
+// reject it anyway.
+var analystFields = []string{
+	"title", "severity", "cwe", "location", "affected",
+	"cve_id", "cvss_vector", "fix_version", "fix_commit",
+	"resolution", "disclosure_draft", "assignee",
+}
+
+func (s *Server) findingFields(w http.ResponseWriter, r *http.Request) {
+	var f db.Finding
+	if err := s.DB.First(&f, r.PathValue("id")).Error; err != nil {
+		http.NotFound(w, r)
+		return
+	}
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	for _, field := range analystFields {
+		value, ok := r.Form[field]
+		if !ok {
+			continue
+		}
+		if err := db.WriteFindingField(s.DB, f.ID, field, strings.TrimSpace(value[0]), db.SourceAnalyst, ""); err != nil {
+			http.Error(w, err.Error(), http.StatusUnprocessableEntity)
+			return
+		}
+	}
+	w.Header().Set("HX-Redirect", fmt.Sprintf("/findings/%d", f.ID))
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *Server) findingCommunications(w http.ResponseWriter, r *http.Request) {
+	var f db.Finding
+	if err := s.DB.First(&f, r.PathValue("id")).Error; err != nil {
+		http.NotFound(w, r)
+		return
+	}
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	at, _ := time.Parse("2006-01-02", r.FormValue("at"))
+	if _, err := db.AddFindingCommunication(s.DB, f.ID,
+		r.FormValue("channel"),
+		r.FormValue("direction"),
+		r.FormValue("actor"),
+		r.FormValue("body"),
+		r.FormValue("offered_help"),
+		at,
+	); err != nil {
+		http.Error(w, err.Error(), http.StatusUnprocessableEntity)
+		return
+	}
+	w.Header().Set("HX-Redirect", fmt.Sprintf("/findings/%d", f.ID))
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *Server) findingReferences(w http.ResponseWriter, r *http.Request) {
+	var f db.Finding
+	if err := s.DB.First(&f, r.PathValue("id")).Error; err != nil {
+		http.NotFound(w, r)
+		return
+	}
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	tags := r.FormValue("tags")
+	if _, err := db.AddFindingReference(s.DB, f.ID, r.FormValue("url"), tags, r.FormValue("summary")); err != nil {
+		http.Error(w, err.Error(), http.StatusUnprocessableEntity)
+		return
+	}
+	w.Header().Set("HX-Redirect", fmt.Sprintf("/findings/%d", f.ID))
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *Server) findingLabels(w http.ResponseWriter, r *http.Request) {
+	var f db.Finding
+	if err := s.DB.First(&f, r.PathValue("id")).Error; err != nil {
+		http.NotFound(w, r)
+		return
+	}
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	// Labels arrive either as multiple labels= form fields (from checkboxes)
+	// or as one comma-joined free-text value.
+	raw := r.Form["labels"]
+	if len(raw) == 1 && strings.Contains(raw[0], ",") {
+		raw = strings.Split(raw[0], ",")
+	}
+	names := make([]string, 0, len(raw))
+	for _, n := range raw {
+		n = strings.TrimSpace(n)
+		if n != "" {
+			names = append(names, n)
+		}
+	}
+	if err := db.SetFindingLabels(s.DB, f.ID, names); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("HX-Redirect", fmt.Sprintf("/findings/%d", f.ID))
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -128,6 +128,10 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("POST /findings/{id}/status", s.findingStatus)
 	mux.HandleFunc("POST /findings/{id}/verify", s.findingVerify)
 	mux.HandleFunc("POST /findings/{id}/notes", s.findingNotes)
+	mux.HandleFunc("POST /findings/{id}/fields", s.findingFields)
+	mux.HandleFunc("POST /findings/{id}/communications", s.findingCommunications)
+	mux.HandleFunc("POST /findings/{id}/references", s.findingReferences)
+	mux.HandleFunc("POST /findings/{id}/labels", s.findingLabels)
 	mux.HandleFunc("POST /dependencies/{id}/scan", s.depScan)
 	mux.HandleFunc("POST /dependents/{id}/scan", s.dependentScan)
 	mux.HandleFunc("GET /packages", s.packages)
@@ -283,10 +287,36 @@ func (s *Server) maintainerShow(w http.ResponseWriter, r *http.Request) {
 	}
 	var findings []db.Finding
 	if len(repoIDs) > 0 {
-		s.DB.Joins("Scan").Where("\"Scan\".repository_id IN ?", repoIDs).
-			Preload("Scan.Repository").Order("id desc").Find(&findings)
+		s.DB.Where("repository_id IN ?", repoIDs).Order("id desc").Find(&findings)
 	}
-	s.render(w, "maintainer_show.html", map[string]any{"M": m, "Findings": findings})
+	reposByID := loadRepoMap(s.DB, findings)
+	s.render(w, "maintainer_show.html", map[string]any{
+		"M": m, "Findings": findings, "Repos": reposByID,
+	})
+}
+
+// loadRepoMap batch-loads the repositories referenced by a slice of
+// findings and returns a map keyed by repository ID. Templates render
+// per-finding repo info by looking up the map.
+func loadRepoMap(gdb *gorm.DB, findings []db.Finding) map[uint]db.Repository {
+	seen := make(map[uint]bool)
+	ids := make([]uint, 0)
+	for _, f := range findings {
+		if !seen[f.RepositoryID] {
+			seen[f.RepositoryID] = true
+			ids = append(ids, f.RepositoryID)
+		}
+	}
+	result := make(map[uint]db.Repository, len(ids))
+	if len(ids) == 0 {
+		return result
+	}
+	var rows []db.Repository
+	gdb.Where("id IN ?", ids).Find(&rows)
+	for _, r := range rows {
+		result[r.ID] = r
+	}
+	return result
 }
 
 var severityOrder = `CASE severity
@@ -294,21 +324,22 @@ var severityOrder = `CASE severity
 	WHEN 'Medium' THEN 2 WHEN 'Low' THEN 3 ELSE 4 END`
 
 func (s *Server) findings(w http.ResponseWriter, r *http.Request) {
-	q := s.DB.Model(&db.Finding{}).Joins("Scan").Joins("Scan.Repository")
+	q := s.DB.Model(&db.Finding{})
 	sev := r.URL.Query().Get("severity")
 	if sev != "" {
-		q = q.Where("findings.severity = ?", sev)
+		q = q.Where("severity = ?", sev)
 	}
 
 	sort := r.URL.Query().Get("sort")
 	switch sort {
 	case "severity":
-		q = q.Order(severityOrder).Order("findings.id desc")
+		q = q.Order(severityOrder).Order("id desc")
 	case "repository":
-		q = q.Order("`Scan__Repository`.name").Order("findings.id desc")
+		q = q.Joins("JOIN repositories r ON r.id = findings.repository_id").
+			Order("r.name").Order("findings.id desc")
 	default:
 		sort = defaultSort
-		q = q.Order("findings.id desc")
+		q = q.Order("id desc")
 	}
 
 	var total int64
@@ -316,11 +347,12 @@ func (s *Server) findings(w http.ResponseWriter, r *http.Request) {
 	page := paginate(r, total)
 
 	var rows []db.Finding
-	q.Preload("Scan.Repository").
-		Limit(perPage).Offset((page.N - 1) * perPage).Find(&rows)
+	q.Limit(perPage).Offset((page.N - 1) * perPage).Find(&rows)
 
+	reposByID := loadRepoMap(s.DB, rows)
 	s.render(w, "findings.html", map[string]any{
 		"Findings": rows, "Page": page, "Severity": sev, "Sort": sort,
+		"Repos": reposByID,
 	})
 }
 
@@ -421,7 +453,10 @@ func (s *Server) findingStatus(w http.ResponseWriter, r *http.Request) {
 	case db.FindingNew, db.FindingEnriched, db.FindingTriaged, db.FindingReady,
 		db.FindingReported, db.FindingAcknowledged, db.FindingFixed, db.FindingPublished,
 		db.FindingRejected, db.FindingDuplicate:
-		s.DB.Model(&f).Update("status", status)
+		if err := db.WriteFindingField(s.DB, f.ID, "status", string(status), db.SourceAnalyst, ""); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
 	default:
 		http.Error(w, "invalid status", http.StatusUnprocessableEntity)
 		return
@@ -435,8 +470,13 @@ const verifySkillName = "verify"
 
 func (s *Server) findingVerify(w http.ResponseWriter, r *http.Request) {
 	var f db.Finding
-	if err := s.DB.Preload("Scan").First(&f, r.PathValue("id")).Error; err != nil {
+	if err := s.DB.First(&f, r.PathValue("id")).Error; err != nil {
 		http.NotFound(w, r)
+		return
+	}
+	var scan db.Scan
+	if err := s.DB.First(&scan, f.ScanID).Error; err != nil {
+		http.Error(w, "scan for finding not found", http.StatusInternalServerError)
 		return
 	}
 	var skill db.Skill
@@ -445,7 +485,7 @@ func (s *Server) findingVerify(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	fid := f.ID
-	scanID, err := s.enqueueSkillScoped(r.Context(), f.Scan.RepositoryID, skill.ID, &fid, r.FormValue("model"))
+	scanID, err := s.enqueueSkillScoped(r.Context(), scan.RepositoryID, skill.ID, &fid, r.FormValue("model"))
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -460,7 +500,10 @@ func (s *Server) findingNotes(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 		return
 	}
-	s.DB.Model(&f).Update("notes", r.FormValue("notes"))
+	if _, err := db.AddFindingNote(s.DB, f.ID, r.FormValue("body"), ""); err != nil {
+		http.Error(w, err.Error(), http.StatusUnprocessableEntity)
+		return
+	}
 	w.Header().Set("HX-Redirect", fmt.Sprintf("/findings/%d", f.ID))
 	w.WriteHeader(http.StatusNoContent)
 }
@@ -517,11 +560,40 @@ func (s *Server) packageShow(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) findingShow(w http.ResponseWriter, r *http.Request) {
 	var f db.Finding
-	if err := s.DB.Preload("Scan.Repository").First(&f, r.PathValue("id")).Error; err != nil {
+	if err := s.DB.Preload("Labels").First(&f, r.PathValue("id")).Error; err != nil {
 		http.NotFound(w, r)
 		return
 	}
-	data := map[string]any{"F": f}
+	var scan db.Scan
+	s.DB.First(&scan, f.ScanID)
+	var repo db.Repository
+	s.DB.First(&repo, scan.RepositoryID)
+	var notes []db.FindingNote
+	s.DB.Where("finding_id = ?", f.ID).Order("created_at desc").Find(&notes)
+	var comms []db.FindingCommunication
+	s.DB.Where("finding_id = ?", f.ID).Order("at desc").Find(&comms)
+	var refs []db.FindingReference
+	s.DB.Where("finding_id = ?", f.ID).Order("id desc").Find(&refs)
+	var history []db.FindingHistory
+	s.DB.Where("finding_id = ?", f.ID).Order("created_at desc").Find(&history)
+	var labels []db.FindingLabel
+	s.DB.Order("name").Find(&labels)
+	selected := make(map[string]bool, len(f.Labels))
+	for _, l := range f.Labels {
+		selected[l.Name] = true
+	}
+
+	data := map[string]any{
+		"F":              f,
+		"Scan":           scan,
+		"Repo":           repo,
+		"Notes":          notes,
+		"Communications": comms,
+		"References":     refs,
+		"History":        history,
+		"AllLabels":      labels,
+		"Selected":       selected,
+	}
 	if id, c, ok := LookupCWE(f.CWE); ok {
 		data["CWE"] = map[string]any{"ID": id, "Name": c.Name, "Description": c.Description}
 	}

--- a/internal/web/templates/finding_show.html
+++ b/internal/web/templates/finding_show.html
@@ -1,9 +1,11 @@
 {{template "head"}}
 {{$f := .F}}
+{{$scan := .Scan}}
+{{$repo := .Repo}}
 
 {{template "crumbs" (crumbs
   "Findings" "/findings"
-  $f.Scan.Repository.Name (printf "/repositories/%d" $f.Scan.Repository.ID)
+  $repo.Name (printf "/repositories/%d" $repo.ID)
   (printf "scan #%d" $f.ScanID) (printf "/scans/%d" $f.ScanID)
   (printf "finding #%d" $f.ID) "")}}
 
@@ -11,6 +13,14 @@
   {{$f.Title}}
   {{template "finding-status" (fstatus $f.Status)}}
 </h2>
+
+{{if $f.Labels}}
+<div class="flex flex-wrap gap-1 mb-4">
+  {{range $f.Labels}}
+    <span class="badge-outline" style="border-color: {{.Color}}; color: {{.Color}}">{{.Name}}</span>
+  {{end}}
+</div>
+{{end}}
 
 {{template "finding_workflow" $f}}
 
@@ -26,7 +36,7 @@
   <div>
     <dt class="text-muted-foreground">Location</dt>
     <dd>
-      {{$u := locurl $f.Scan.Repository.HTMLURL $f.Scan.Commit $f.Location}}
+      {{$u := locurl $repo.HTMLURL $scan.Commit $f.Location}}
       {{if $u}}<a href="{{$u}}" target="_blank" rel="noopener" class="underline underline-offset-2">
         <code>{{$f.Location}}</code></a>
       {{else}}<code>{{$f.Location}}</code>{{end}}
@@ -38,13 +48,49 @@
   </div>
   <div>
     <dt class="text-muted-foreground">Sinks</dt>
-    <dd>{{if $f.Sinks}}<a href="/repositories/{{$f.Scan.Repository.ID}}#rt10"
+    <dd>{{if $f.Sinks}}<a href="/repositories/{{$repo.ID}}#rt10"
         class="underline underline-offset-2"><code>{{$f.Sinks}}</code></a>{{else}}-{{end}}</dd>
   </div>
   <div>
     <dt class="text-muted-foreground">Model</dt>
-    <dd>{{$f.Scan.Model}}</dd>
+    <dd>{{$scan.Model}}</dd>
   </div>
+  {{if $f.CVEID}}
+  <div>
+    <dt class="text-muted-foreground">CVE</dt>
+    <dd><code>{{$f.CVEID}}</code></dd>
+  </div>
+  {{end}}
+  {{if $f.CVSSVector}}
+  <div class="col-span-2">
+    <dt class="text-muted-foreground">CVSS</dt>
+    <dd><code>{{$f.CVSSVector}}</code>{{if $f.CVSSScore}} ({{$f.CVSSScore}}){{end}}</dd>
+  </div>
+  {{end}}
+  {{if $f.FixCommit}}
+  <div>
+    <dt class="text-muted-foreground">Fix commit</dt>
+    <dd><code>{{short $f.FixCommit}}</code></dd>
+  </div>
+  {{end}}
+  {{if $f.FixVersion}}
+  <div>
+    <dt class="text-muted-foreground">Fix version</dt>
+    <dd>{{$f.FixVersion}}</dd>
+  </div>
+  {{end}}
+  {{if $f.Resolution}}
+  <div>
+    <dt class="text-muted-foreground">Resolution</dt>
+    <dd><span class="badge-outline">{{$f.Resolution}}</span></dd>
+  </div>
+  {{end}}
+  {{if $f.Assignee}}
+  <div>
+    <dt class="text-muted-foreground">Assignee</dt>
+    <dd>{{$f.Assignee}}</dd>
+  </div>
+  {{end}}
 </dl>
 
 <section class="accordion">
@@ -120,45 +166,222 @@
   </details>
   {{end}}
 
-  {{/* Legacy fields for old-schema reports */}}
-  {{if and (not $f.Trace) $f.Summary}}
-  <details open class="group border-b">
-    <summary class="w-full outline-none rounded-md focus-visible:ring-ring/50 focus-visible:ring-[3px]">
-      <h3 class="flex flex-1 items-center justify-between gap-4 py-4 text-sm font-medium hover:underline">
-        Summary
-        <i data-lucide="chevron-down" class="text-muted-foreground size-4 shrink-0 transition-transform duration-200 group-open:rotate-180"></i>
-      </h3>
-    </summary>
-    <section class="pb-4 text-sm whitespace-pre-wrap">{{$f.Summary}}</section>
-  </details>
-  {{end}}
-
-  {{if $f.Details}}
   <details class="group border-b">
     <summary class="w-full outline-none rounded-md focus-visible:ring-ring/50 focus-visible:ring-[3px]">
       <h3 class="flex flex-1 items-center justify-between gap-4 py-4 text-sm font-medium hover:underline">
-        Details
-        <i data-lucide="chevron-down" class="text-muted-foreground size-4 shrink-0 transition-transform duration-200 group-open:rotate-180"></i>
-      </h3>
-    </summary>
-    <section class="pb-4"><pre class="log">{{$f.Details}}</pre></section>
-  </details>
-  {{end}}
-
-  <details open class="group border-b">
-    <summary class="w-full outline-none rounded-md focus-visible:ring-ring/50 focus-visible:ring-[3px]">
-      <h3 class="flex flex-1 items-center justify-between gap-4 py-4 text-sm font-medium hover:underline">
-        Notes
+        Disclosure fields
         <i data-lucide="chevron-down" class="text-muted-foreground size-4 shrink-0 transition-transform duration-200 group-open:rotate-180"></i>
       </h3>
     </summary>
     <section class="pb-4">
-      <form hx-post="/findings/{{$f.ID}}/notes" hx-swap="none" class="form grid gap-2">
-        <textarea class="input" name="notes" rows="4" placeholder="Triage notes, communication log, context...">{{$f.Notes}}</textarea>
-        <div class="flex justify-end">
-          <button type="submit" class="btn-sm">Save notes</button>
+      <form method="post" action="/findings/{{$f.ID}}/fields" class="form grid grid-cols-2 gap-3">
+        <div class="grid gap-1">
+          <label class="text-xs text-muted-foreground">Severity</label>
+          <input class="input" name="severity" value="{{$f.Severity}}" list="severity-options">
+          <datalist id="severity-options">
+            <option value="Critical"><option value="High"><option value="Medium"><option value="Low">
+          </datalist>
+        </div>
+        <div class="grid gap-1">
+          <label class="text-xs text-muted-foreground">CWE</label>
+          <input class="input" name="cwe" value="{{$f.CWE}}" placeholder="CWE-79">
+        </div>
+        <div class="grid gap-1">
+          <label class="text-xs text-muted-foreground">CVE ID</label>
+          <input class="input" name="cve_id" value="{{$f.CVEID}}" placeholder="CVE-2026-12345">
+        </div>
+        <div class="grid gap-1 col-span-2">
+          <label class="text-xs text-muted-foreground">CVSS vector</label>
+          <input class="input font-mono text-xs" name="cvss_vector" value="{{$f.CVSSVector}}"
+                 placeholder="CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H">
+        </div>
+        <div class="grid gap-1">
+          <label class="text-xs text-muted-foreground">Affected versions</label>
+          <input class="input" name="affected" value="{{$f.Affected}}" placeholder=">=1.0, <2.3">
+        </div>
+        <div class="grid gap-1">
+          <label class="text-xs text-muted-foreground">Fix version</label>
+          <input class="input" name="fix_version" value="{{$f.FixVersion}}">
+        </div>
+        <div class="grid gap-1 col-span-2">
+          <label class="text-xs text-muted-foreground">Fix commit</label>
+          <input class="input font-mono text-xs" name="fix_commit" value="{{$f.FixCommit}}">
+        </div>
+        <div class="grid gap-1">
+          <label class="text-xs text-muted-foreground">Resolution</label>
+          <select class="input" name="resolution">
+            <option value=""{{if not $f.Resolution}} selected{{end}}>-</option>
+            {{range (list "fix" "migrate" "workaround" "adopt" "wontfix")}}
+              <option value="{{.}}"{{if eq (printf "%s" $f.Resolution) .}} selected{{end}}>{{.}}</option>
+            {{end}}
+          </select>
+        </div>
+        <div class="grid gap-1">
+          <label class="text-xs text-muted-foreground">Assignee</label>
+          <input class="input" name="assignee" value="{{$f.Assignee}}">
+        </div>
+        <div class="grid gap-1 col-span-2">
+          <label class="text-xs text-muted-foreground">Disclosure draft</label>
+          <textarea class="input font-mono text-xs" name="disclosure_draft" rows="6">{{$f.DisclosureDraft}}</textarea>
+        </div>
+        <div class="col-span-2 flex justify-end">
+          <button type="submit" class="btn-sm">Save</button>
         </div>
       </form>
+    </section>
+  </details>
+
+  <details open class="group border-b">
+    <summary class="w-full outline-none rounded-md focus-visible:ring-ring/50 focus-visible:ring-[3px]">
+      <h3 class="flex flex-1 items-center justify-between gap-4 py-4 text-sm font-medium hover:underline">
+        Notes <span class="text-muted-foreground ml-auto mr-2 text-xs">{{len .Notes}}</span>
+        <i data-lucide="chevron-down" class="text-muted-foreground size-4 shrink-0 transition-transform duration-200 group-open:rotate-180"></i>
+      </h3>
+    </summary>
+    <section class="pb-4 grid gap-3">
+      <form method="post" action="/findings/{{$f.ID}}/notes" class="form grid gap-2">
+        <textarea class="input" name="body" rows="3" placeholder="Add a note..." required></textarea>
+        <div class="flex justify-end">
+          <button type="submit" class="btn-sm">Add note</button>
+        </div>
+      </form>
+      <ul class="grid gap-2">
+      {{range .Notes}}
+        <li class="border rounded p-3 text-sm">
+          <div class="text-xs text-muted-foreground mb-1">{{if .By}}{{.By}} · {{end}}{{.CreatedAt.Format "2006-01-02 15:04"}}</div>
+          <pre class="whitespace-pre-wrap font-sans">{{.Body}}</pre>
+        </li>
+      {{else}}
+        <li class="text-sm text-muted-foreground">No notes yet.</li>
+      {{end}}
+      </ul>
+    </section>
+  </details>
+
+  <details class="group border-b">
+    <summary class="w-full outline-none rounded-md focus-visible:ring-ring/50 focus-visible:ring-[3px]">
+      <h3 class="flex flex-1 items-center justify-between gap-4 py-4 text-sm font-medium hover:underline">
+        Communications <span class="text-muted-foreground ml-auto mr-2 text-xs">{{len .Communications}}</span>
+        <i data-lucide="chevron-down" class="text-muted-foreground size-4 shrink-0 transition-transform duration-200 group-open:rotate-180"></i>
+      </h3>
+    </summary>
+    <section class="pb-4 grid gap-3">
+      <form method="post" action="/findings/{{$f.ID}}/communications" class="form grid grid-cols-4 gap-2">
+        <select class="input" name="channel">
+          {{range (list "email" "ghsa" "issue" "pr" "direct" "registry")}}<option value="{{.}}">{{.}}</option>{{end}}
+        </select>
+        <select class="input" name="direction">
+          <option value="outbound">outbound</option>
+          <option value="inbound">inbound</option>
+        </select>
+        <input class="input" name="actor" placeholder="who / from whom" required>
+        <input class="input" type="date" name="at">
+        <select class="input col-span-1" name="offered_help">
+          <option value="">no offer</option>
+          <option value="pr">offered PR</option>
+          <option value="funding">offered funding</option>
+          <option value="adoption">offered adoption</option>
+        </select>
+        <textarea class="input col-span-3" name="body" rows="2" placeholder="message body..."></textarea>
+        <div class="col-span-4 flex justify-end">
+          <button type="submit" class="btn-sm">Log communication</button>
+        </div>
+      </form>
+      <ul class="grid gap-2">
+      {{range .Communications}}
+        <li class="border rounded p-3 text-sm">
+          <div class="text-xs text-muted-foreground mb-1">
+            <span class="badge-outline">{{.Channel}}</span>
+            <span class="badge-outline">{{.Direction}}</span>
+            {{.Actor}} · {{.At.Format "2006-01-02"}}
+            {{if .OfferedHelp}}<span class="badge-primary ml-2">offered {{.OfferedHelp}}</span>{{end}}
+          </div>
+          <pre class="whitespace-pre-wrap font-sans">{{.Body}}</pre>
+        </li>
+      {{else}}
+        <li class="text-sm text-muted-foreground">No communications yet.</li>
+      {{end}}
+      </ul>
+    </section>
+  </details>
+
+  <details class="group border-b">
+    <summary class="w-full outline-none rounded-md focus-visible:ring-ring/50 focus-visible:ring-[3px]">
+      <h3 class="flex flex-1 items-center justify-between gap-4 py-4 text-sm font-medium hover:underline">
+        References <span class="text-muted-foreground ml-auto mr-2 text-xs">{{len .References}}</span>
+        <i data-lucide="chevron-down" class="text-muted-foreground size-4 shrink-0 transition-transform duration-200 group-open:rotate-180"></i>
+      </h3>
+    </summary>
+    <section class="pb-4 grid gap-3">
+      <form method="post" action="/findings/{{$f.ID}}/references" class="form grid grid-cols-3 gap-2">
+        <input class="input col-span-2" name="url" placeholder="https://..." required>
+        <input class="input" name="tags" placeholder="tags: issue, pr, cve, ghsa, patch">
+        <input class="input col-span-3" name="summary" placeholder="optional summary">
+        <div class="col-span-3 flex justify-end">
+          <button type="submit" class="btn-sm">Add reference</button>
+        </div>
+      </form>
+      <ul class="grid gap-2">
+      {{range .References}}
+        <li class="border rounded p-3 text-sm">
+          <div class="flex items-center gap-2">
+            <a href="{{.URL}}" target="_blank" rel="noopener" class="underline underline-offset-2 break-all">{{.URL}}</a>
+            {{if .Tags}}<span class="text-xs text-muted-foreground ml-auto">{{.Tags}}</span>{{end}}
+          </div>
+          {{if .Summary}}<div class="text-xs text-muted-foreground mt-1">{{.Summary}}</div>{{end}}
+        </li>
+      {{else}}
+        <li class="text-sm text-muted-foreground">No references yet.</li>
+      {{end}}
+      </ul>
+    </section>
+  </details>
+
+  <details class="group border-b">
+    <summary class="w-full outline-none rounded-md focus-visible:ring-ring/50 focus-visible:ring-[3px]">
+      <h3 class="flex flex-1 items-center justify-between gap-4 py-4 text-sm font-medium hover:underline">
+        Labels
+        <i data-lucide="chevron-down" class="text-muted-foreground size-4 shrink-0 transition-transform duration-200 group-open:rotate-180"></i>
+      </h3>
+    </summary>
+    <section class="pb-4">
+      <form method="post" action="/findings/{{$f.ID}}/labels" class="form grid gap-2">
+        <div class="flex flex-wrap gap-3">
+          {{$sel := .Selected}}
+          {{range .AllLabels}}
+            <label class="flex items-center gap-1 text-sm">
+              <input type="checkbox" name="labels" value="{{.Name}}"
+                {{if index $sel .Name}}checked{{end}}>
+              <span style="color: {{.Color}}">{{.Name}}</span>
+            </label>
+          {{end}}
+        </div>
+        <div class="flex justify-end">
+          <button type="submit" class="btn-sm">Save labels</button>
+        </div>
+      </form>
+    </section>
+  </details>
+
+  <details class="group border-b">
+    <summary class="w-full outline-none rounded-md focus-visible:ring-ring/50 focus-visible:ring-[3px]">
+      <h3 class="flex flex-1 items-center justify-between gap-4 py-4 text-sm font-medium hover:underline">
+        History <span class="text-muted-foreground ml-auto mr-2 text-xs">{{len .History}}</span>
+        <i data-lucide="chevron-down" class="text-muted-foreground size-4 shrink-0 transition-transform duration-200 group-open:rotate-180"></i>
+      </h3>
+    </summary>
+    <section class="pb-4">
+      <ul class="grid gap-1 text-xs text-muted-foreground">
+      {{range .History}}
+        <li class="font-mono">
+          [{{.CreatedAt.Format "2006-01-02 15:04"}}] {{.Source}}{{if .By}} ({{.By}}){{end}}:
+          <code>{{.Field}}</code> = <code>{{.NewValue}}</code>
+          {{if .OldValue}}<span class="opacity-50">was <code>{{.OldValue}}</code></span>{{end}}
+        </li>
+      {{else}}
+        <li>No recorded changes.</li>
+      {{end}}
+      </ul>
     </section>
   </details>
 

--- a/internal/web/templates/findings.html
+++ b/internal/web/templates/findings.html
@@ -47,7 +47,9 @@
       <th class="w-56">Location</th><th class="w-16">Scan</th>
     </tr></thead>
     <tbody>
+    {{$repos := .Repos}}
     {{range .Findings}}
+      {{$repo := index $repos .RepositoryID}}
       <tr class="cursor-pointer" hx-get="/findings/{{.ID}}" hx-target="body" hx-push-url="true">
         <td>{{template "severity-badge" .Severity}}</td>
         <td class="min-w-0 whitespace-normal">
@@ -55,11 +57,11 @@
           <div class="text-xs text-muted-foreground line-clamp-2">{{.Summary}}</div>
         </td>
         <td>{{template "finding-status" (fstatus .Status)}}</td>
-        <td class="truncate">{{.Scan.Repository.Name}}</td>
+        <td class="truncate">{{$repo.Name}}</td>
         <td class="text-muted-foreground">
           {{if .CWE}}<span data-tooltip="{{cwename .CWE}}">{{.CWE}}</span>{{end}}
         </td>
-        <td class="whitespace-normal">{{template "loc-link" (dict "HTMLURL" .Scan.Repository.HTMLURL "Commit" .Scan.Commit "Location" .Location)}}</td>
+        <td class="whitespace-normal">{{template "loc-link" (dict "HTMLURL" $repo.HTMLURL "Commit" .Commit "Location" .Location)}}</td>
         <td class="text-muted-foreground">#{{.ScanID}}</td>
       </tr>
     {{end}}

--- a/internal/web/templates/maintainer_show.html
+++ b/internal/web/templates/maintainer_show.html
@@ -53,14 +53,16 @@
         <th class="w-24">Severity</th><th>Title</th><th class="w-32">Repository</th><th class="w-24">CWE</th>
       </tr></thead>
       <tbody>
+      {{$repos := .Repos}}
       {{range .Findings}}
+        {{$repo := index $repos .RepositoryID}}
         <tr class="cursor-pointer" hx-get="/findings/{{.ID}}" hx-target="body" hx-push-url="true">
           <td>{{template "severity-badge" .Severity}}</td>
           <td class="min-w-0 whitespace-normal">
             <div class="font-medium">{{.Title}}</div>
             <div class="text-xs text-muted-foreground line-clamp-1">{{.Summary}}</div>
           </td>
-          <td class="truncate">{{.Scan.Repository.Name}}</td>
+          <td class="truncate">{{$repo.Name}}</td>
           <td class="text-muted-foreground">
             {{if .CWE}}<span data-tooltip="{{cwename .CWE}}">{{.CWE}}</span>{{end}}
           </td>

--- a/internal/worker/findings.go
+++ b/internal/worker/findings.go
@@ -62,21 +62,13 @@ func parseReport(raw []byte) (scanReport, error) {
 	return r, nil
 }
 
-func (f scanFinding) summaryText() string {
-	if f.Trace != "" {
-		if i := strings.Index(f.Trace, "\n\n"); i > 0 {
-			return f.Trace[:i]
-		}
-		return f.Trace
-	}
-	return f.Summary
-}
-
-func (r scanReport) toFindings(scanID uint) []db.Finding {
+func (r scanReport) toFindings(scanID, repoID uint, commit string) []db.Finding {
 	out := make([]db.Finding, 0, len(r.Findings))
 	for _, f := range r.Findings {
 		out = append(out, db.Finding{
-			ScanID:     scanID,
+			ScanID:       scanID,
+			RepositoryID: repoID,
+			Commit:       commit,
 			FindingID:  f.ID,
 			Sinks:      strings.Join(f.Sinks, ", "),
 			Title:      f.Title,
@@ -90,9 +82,6 @@ func (r scanReport) toFindings(scanID uint) []db.Finding {
 			PriorArt:   f.PriorArt,
 			Reach:      f.Reach,
 			Rating:     f.Rating,
-			Confidence: f.Confidence,
-			Summary:    f.summaryText(),
-			Details:    f.Details,
 		})
 	}
 	return out

--- a/internal/worker/skill.go
+++ b/internal/worker/skill.go
@@ -143,7 +143,7 @@ func (w *Worker) parseFindingsOutput(scan *db.Scan, report string, emit func(Eve
 	if err != nil {
 		return err
 	}
-	findings := rep.toFindings(scan.ID)
+	findings := rep.toFindings(scan.ID, scan.RepositoryID, scan.Commit)
 	scan.FindingsCount = len(findings)
 	if len(findings) > 0 {
 		if err := w.DB.Create(&findings).Error; err != nil {

--- a/internal/worker/skill_parsers.go
+++ b/internal/worker/skill_parsers.go
@@ -280,14 +280,9 @@ func (w *Worker) parseDependenciesOutput(scan *db.Scan, report string, emit func
 }
 
 // parseVerifyOutput records the outcome of a finding-scoped verification
-// run. The skill reports one of:
-//   - confirmed: the finding reproduces against the current code, move the
-//     finding from new to enriched so an analyst can triage with fresh evidence
-//   - fixed: the original reproduction no longer triggers, mark the finding
-//     fixed so it falls out of the triage queue
-//   - inconclusive: the reproduction couldn't be run (tooling missing,
-//     code moved, etc), leave the status but append the evidence to notes
-// Evidence and notes are appended to Finding.Notes with a timestamp header.
+// run. Evidence and notes become a FindingNote; the status transition is
+// written via WriteFindingField with source=model_suggested so the audit
+// trail on the finding page shows the skill as the author.
 func (w *Worker) parseVerifyOutput(scan *db.Scan, report string, emit func(Event)) error {
 	if scan.FindingID == nil {
 		return fmt.Errorf("verify scan has no finding_id")
@@ -305,36 +300,37 @@ func (w *Worker) parseVerifyOutput(scan *db.Scan, report string, emit func(Event
 		return fmt.Errorf("load finding %d: %w", *scan.FindingID, err)
 	}
 
+	var nextStatus db.FindingLifecycle
 	switch result.Status {
 	case "confirmed":
 		if f.Status == db.FindingNew {
-			f.Status = db.FindingEnriched
+			nextStatus = db.FindingEnriched
 		}
 	case "fixed":
-		f.Status = db.FindingFixed
+		nextStatus = db.FindingFixed
 	case "inconclusive":
 		// Leave status alone.
 	default:
 		return fmt.Errorf("verify status %q is not one of confirmed|fixed|inconclusive", result.Status)
 	}
+	if nextStatus != "" {
+		if err := db.WriteFindingField(w.DB, f.ID, "status", string(nextStatus), db.SourceModel, "verify"); err != nil {
+			return fmt.Errorf("update status: %w", err)
+		}
+	}
 
 	var b strings.Builder
-	if f.Notes != "" {
-		b.WriteString(f.Notes)
-		b.WriteString("\n\n")
-	}
-	fmt.Fprintf(&b, "## verify %s — %s\n", result.Status, time.Now().UTC().Format(time.RFC3339))
+	fmt.Fprintf(&b, "verify: %s\n", result.Status)
 	if result.Evidence != "" {
 		fmt.Fprintf(&b, "\n%s\n", strings.TrimSpace(result.Evidence))
 	}
 	if result.Notes != "" {
 		fmt.Fprintf(&b, "\n%s\n", strings.TrimSpace(result.Notes))
 	}
-	f.Notes = b.String()
-
-	if err := w.DB.Save(&f).Error; err != nil {
-		return fmt.Errorf("save finding: %w", err)
+	if _, err := db.AddFindingNote(w.DB, f.ID, b.String(), "verify"); err != nil {
+		return fmt.Errorf("record verify note: %w", err)
 	}
+
 	emit(Event{Kind: KindText, Text: "finding " + fmt.Sprint(f.ID) + " -> " + result.Status})
 	return nil
 }

--- a/internal/worker/skill_parsers_test.go
+++ b/internal/worker/skill_parsers_test.go
@@ -130,7 +130,7 @@ func TestParseDependents_replacesDependentRows(t *testing.T) {
 	}
 }
 
-func runSkillWithFinding(t *testing.T, outputKind, report string, startStatus db.FindingLifecycle) db.Finding {
+func runSkillWithFinding(t *testing.T, outputKind, report string, startStatus db.FindingLifecycle) (db.Finding, *gorm.DB) {
 	t.Helper()
 	gdb, err := db.Open(filepath.Join(t.TempDir(), "v.db"))
 	if err != nil {
@@ -140,7 +140,7 @@ func runSkillWithFinding(t *testing.T, outputKind, report string, startStatus db
 	gdb.Create(&repo)
 	priorScan := db.Scan{RepositoryID: repo.ID, Kind: JobSkill, Status: db.ScanDone, SkillName: "security-deep-dive"}
 	gdb.Create(&priorScan)
-	finding := db.Finding{ScanID: priorScan.ID, FindingID: "F1", Title: "x", Severity: "High", Status: startStatus}
+	finding := db.Finding{ScanID: priorScan.ID, RepositoryID: repo.ID, FindingID: "F1", Title: "x", Severity: "High", Status: startStatus}
 	gdb.Create(&finding)
 	skill := db.Skill{Name: "verify", Description: "d", Body: "b", OutputFile: "report.json", OutputKind: outputKind, Version: 1, Active: true, Source: "ui"}
 	gdb.Create(&skill)
@@ -167,23 +167,33 @@ func runSkillWithFinding(t *testing.T, outputKind, report string, startStatus db
 	}
 	var refreshed db.Finding
 	gdb.First(&refreshed, finding.ID)
-	return refreshed
+	return refreshed, gdb
+}
+
+// findingNotes fetches the notes rows for a finding. Used by the verify
+// tests to assert the evidence trail lands in FindingNote now that the
+// old Finding.Notes column is gone.
+func findingNotes(gdb *gorm.DB, findingID uint) []db.FindingNote {
+	var rows []db.FindingNote
+	gdb.Where("finding_id = ?", findingID).Order("created_at desc").Find(&rows)
+	return rows
 }
 
 func TestParseVerify_confirmedMovesNewToEnriched(t *testing.T) {
 	report := `{"status":"confirmed","evidence":"ran repro.rb, got the same error","notes":"no code change"}`
-	f := runSkillWithFinding(t, "verify", report, db.FindingNew)
+	f, gdb := runSkillWithFinding(t, "verify", report, db.FindingNew)
 	if f.Status != db.FindingEnriched {
 		t.Errorf("status = %s, want enriched", f.Status)
 	}
-	if !strings.Contains(f.Notes, "verify confirmed") {
-		t.Errorf("notes missing verify header: %q", f.Notes)
+	notes := findingNotes(gdb, f.ID)
+	if len(notes) == 0 || !strings.Contains(notes[0].Body, "confirmed") {
+		t.Errorf("notes missing verify record: %+v", notes)
 	}
 }
 
 func TestParseVerify_fixedJumpsToFixed(t *testing.T) {
 	report := `{"status":"fixed","evidence":"repro no longer reproduces","notes":"commit abc added guard"}`
-	f := runSkillWithFinding(t, "verify", report, db.FindingTriaged)
+	f, _ := runSkillWithFinding(t, "verify", report, db.FindingTriaged)
 	if f.Status != db.FindingFixed {
 		t.Errorf("status = %s, want fixed", f.Status)
 	}
@@ -191,12 +201,13 @@ func TestParseVerify_fixedJumpsToFixed(t *testing.T) {
 
 func TestParseVerify_inconclusiveLeavesStatus(t *testing.T) {
 	report := `{"status":"inconclusive","notes":"tooling missing"}`
-	f := runSkillWithFinding(t, "verify", report, db.FindingNew)
+	f, gdb := runSkillWithFinding(t, "verify", report, db.FindingNew)
 	if f.Status != db.FindingNew {
 		t.Errorf("status = %s, want new (unchanged)", f.Status)
 	}
-	if !strings.Contains(f.Notes, "inconclusive") {
-		t.Errorf("notes missing status header: %q", f.Notes)
+	notes := findingNotes(gdb, f.ID)
+	if len(notes) == 0 || !strings.Contains(notes[0].Body, "inconclusive") {
+		t.Errorf("notes missing status header: %+v", notes)
 	}
 }
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: Scrutineer Skill API
-  version: 0.2.0
+  version: 0.3.0
   description: |
     A narrow HTTP surface that claude-code skills use while they run. The
     goal is enough to let a skill orchestrate other skills and read prior
@@ -198,6 +198,187 @@ paths:
           content:
             application/json:
               schema: { $ref: '#/components/schemas/Error' }
+
+  /findings/{id}:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema: { type: integer, format: int64 }
+    patch:
+      summary: Update mutable fields on a finding
+      operationId: patchFinding
+      description: |
+        Each field value is written through the history-tracked path.
+        Skills write with source=model_suggested; the browser UI (behind
+        its own session) writes with source=analyst. Unknown field names
+        are rejected.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [fields]
+              properties:
+                by:
+                  type: string
+                  description: Optional author string for the history row.
+                fields:
+                  type: object
+                  additionalProperties: { type: string }
+                  description: |
+                    Map of field name to new value. Allowed fields:
+                    title, severity, status, cwe, location, affected,
+                    cve_id, cvss_vector, fix_version, fix_commit,
+                    resolution, disclosure_draft, assignee.
+      responses:
+        '204': { description: Updated }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/NotFound' }
+
+  /findings/{id}/notes:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema: { type: integer, format: int64 }
+    get:
+      summary: List notes on a finding
+      operationId: listFindingNotes
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: '#/components/schemas/FindingNote' }
+    post:
+      summary: Append a note to a finding
+      operationId: addFindingNote
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [body]
+              properties:
+                body: { type: string }
+                by:   { type: string }
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/FindingNote' }
+
+  /findings/{id}/communications:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema: { type: integer, format: int64 }
+    get:
+      summary: List logged communications for a finding
+      operationId: listFindingCommunications
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: '#/components/schemas/FindingCommunication' }
+    post:
+      summary: Log a communication (sent or received) about a finding
+      operationId: addFindingCommunication
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/FindingCommunication' }
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/FindingCommunication' }
+
+  /findings/{id}/references:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema: { type: integer, format: int64 }
+    get:
+      summary: List references attached to a finding
+      operationId: listFindingReferences
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: '#/components/schemas/FindingReference' }
+    post:
+      summary: Attach an external reference to a finding
+      operationId: addFindingReference
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/FindingReference' }
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/FindingReference' }
+
+  /findings/{id}/labels:
+    put:
+      summary: Replace the set of labels on a finding
+      operationId: setFindingLabels
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: { type: integer, format: int64 }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [labels]
+              properties:
+                labels:
+                  type: array
+                  items: { type: string }
+                  description: Label names. Missing labels are created on demand.
+      responses:
+        '204': { description: Updated }
+
+  /findings/{id}/history:
+    get:
+      summary: List the history rows recorded for a finding
+      operationId: listFindingHistory
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: { type: integer, format: int64 }
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: '#/components/schemas/FindingHistory' }
 
   /findings/{id}/skills/{name}/run:
     post:
@@ -449,20 +630,75 @@ components:
         cwe:           { type: string }
         location:      { type: string }
         affected:      { type: string }
+        cve_id:        { type: string }
+        cvss_vector:   { type: string }
+        cvss_score:    { type: number }
+        fix_version:   { type: string }
+        fix_commit:    { type: string }
+        resolution:    { type: string, enum: [fix, migrate, workaround, adopt, wontfix, ""] }
+        assignee:      { type: string }
 
     FindingDetail:
       allOf:
         - $ref: '#/components/schemas/FindingSummary'
         - type: object
-          description: Adds the six-step narrative fields and notes.
+          description: Adds the six-step narrative and disclosure draft text.
           properties:
-            trace:      { type: string }
-            boundary:   { type: string }
-            validation: { type: string }
-            prior_art:  { type: string }
-            reach:      { type: string }
-            rating:     { type: string }
-            notes:      { type: string }
+            trace:            { type: string }
+            boundary:         { type: string }
+            validation:       { type: string }
+            prior_art:        { type: string }
+            reach:            { type: string }
+            rating:           { type: string }
+            disclosure_draft: { type: string }
+
+    FindingNote:
+      type: object
+      required: [id, finding_id, body]
+      properties:
+        id:         { type: integer, format: int64 }
+        finding_id: { type: integer, format: int64 }
+        body:       { type: string }
+        by:         { type: string }
+        created_at: { type: string, format: date-time }
+
+    FindingCommunication:
+      type: object
+      required: [channel, direction, actor]
+      properties:
+        id:           { type: integer, format: int64 }
+        finding_id:   { type: integer, format: int64 }
+        channel:      { type: string, enum: [email, ghsa, issue, pr, direct, registry] }
+        direction:    { type: string, enum: [outbound, inbound] }
+        actor:        { type: string }
+        body:         { type: string }
+        offered_help: { type: string, enum: [pr, funding, adoption, "none", ""] }
+        at:           { type: string, format: date-time }
+        created_at:   { type: string, format: date-time }
+
+    FindingReference:
+      type: object
+      required: [url]
+      properties:
+        id:         { type: integer, format: int64 }
+        finding_id: { type: integer, format: int64 }
+        url:        { type: string, format: uri }
+        tags:       { type: string, description: Comma-joined tags (issue, pr, cve, ghsa, patch, advisory, discussion, article). }
+        summary:    { type: string }
+        created_at: { type: string, format: date-time }
+
+    FindingHistory:
+      type: object
+      required: [id, finding_id, field, new_value, source]
+      properties:
+        id:         { type: integer, format: int64 }
+        finding_id: { type: integer, format: int64 }
+        field:      { type: string }
+        old_value:  { type: string }
+        new_value:  { type: string }
+        source:     { type: string, enum: [tool, model_suggested, analyst] }
+        by:         { type: string }
+        created_at: { type: string, format: date-time }
 
     SkillSummary:
       type: object


### PR DESCRIPTION
Closes #10.

Flesh out the finding record beyond a single status and a free-text notes field. Labels, multiple timestamped notes, structured communications, tagged references, disclosure scoring fields, and a full change history with source tracking.

Taking advantage of the single-user caveat to refactor aggressively: dropped Finding.Notes/Summary/Details/Confidence and rebuilt the UI around the new tables instead of layering on top.

## Schema

- New Finding columns: \`CVEID\`, \`CVSSVector\`, \`CVSSScore\`, \`FixVersion\`, \`FixCommit\`, \`Resolution\` (fix/migrate/workaround/adopt/wontfix), \`DisclosureDraft\`, \`Assignee\`. Also \`RepositoryID\` and \`Commit\` denormalized from \`Scan\` so list queries skip the broken \`Preload(\"Scan\")\` path on sqlite.
- New tables: \`FindingLabel\` (+ join), \`FindingNote\`, \`FindingCommunication\`, \`FindingReference\`, \`FindingHistory\`. Communications carry channel + direction + actor + \`offered_help\` (pr/funding/adoption) for glasswing alignment later.
- Dropped: Finding.Notes, Summary, Details, Confidence.

## History with source tracking

Every mutable-field write routes through \`db.WriteFindingField(gdb, id, field, value, source, by)\`, which updates the column and appends a \`FindingHistory\` row. Source is \`tool\`, \`model_suggested\`, or \`analyst\`. Existing parsers rewired:

- \`parseVerifyOutput\` writes a FindingNote with the evidence and logs the status transition with source=\`model_suggested\`, attributed to the \"verify\" skill.
- \`findingStatus\` handler writes source=\`analyst\`.
- \`findingNotes\` handler appends to \`FindingNote\` instead of overwriting a column.

## API (openapi.yaml 0.2 → 0.3)

- \`PATCH /api/findings/{id}\` — bulk field update. Auto-picks model_suggested when the authenticated scan has a skill id, analyst otherwise.
- \`GET\`/\`POST /api/findings/{id}/{notes,communications,references}\`
- \`PUT /api/findings/{id}/labels\`
- \`GET /api/findings/{id}/history\`
- Browser-form equivalents at \`/findings/{id}/{fields,notes,communications,references,labels}\` so the UI doesn't need JSON-fetch plumbing yet.

## Finding page rewrite

New sections on the finding show page:

- Disclosure fields form (all the new columns)
- Notes timeline with add form
- Communications timeline (channel/direction/actor/offered_help/body)
- References list with url/tags/summary
- Labels picker wired to the seeded set
- History section showing every recorded change with field, source, author, timestamp

Drops the old inline Notes textarea and the legacy Summary/Details accordions (columns gone).

## Seeded labels

Startup seeds a baseline set: \`wontfix\`, \`in-progress\`, \`needs-info\`, \`duplicate\`, \`regression\`. Idempotent so colour edits stick.

## Not in this PR

- Three-tier presentation UI for tool vs model_suggested vs analyst (the *data* is tracked, displaying the diff comes later).
- Disclose skill itself (issue #6) — this PR unblocks it by adding the columns and draft text field.
- Patch skill itself (issue #7) — same story.