### PR TITLE
Configurable worker concurrency

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Note: the containerised runner currently uses `--network none`, which blocks ski
 | `-skills-repo` | - | Git HTTPS URL to clone skills from on startup |
 | `--no-docker` | false | Disable containerised runner |
 | `--runner-image` | `scrutineer-runner` | Docker image for per-scan containers |
+| `-concurrency` | `4` | Number of scans to run in parallel |
 
 ## Config file
 

--- a/cmd/scrutineer/main.go
+++ b/cmd/scrutineer/main.go
@@ -53,6 +53,7 @@ func run(log *slog.Logger) error {
 		noDocker    = flag.Bool("no-docker", false, "disable containerised runner even if docker is available")
 		runnerImage = flag.String("runner-image", "scrutineer-runner", "docker image for per-job containers")
 		skillsRepo  = flag.String("skills-repo", "", "clone skills from this git https URL on startup")
+		concurrency = flag.Int("concurrency", queue.DefaultWorkerConcurrency, "number of scans to run in parallel")
 	)
 	var skillLocal skillDirs
 	flag.Var(&skillLocal, "skills", "directory to load SKILL.md files from (repeatable)")
@@ -63,7 +64,7 @@ func run(log *slog.Logger) error {
 		return err
 	}
 	if cfg != nil {
-		applyConfig(cfg, addr, dataDir, effort, noDocker, runnerImage, skillsRepo, &skillLocal)
+		applyConfig(cfg, addr, dataDir, effort, noDocker, runnerImage, skillsRepo, concurrency, &skillLocal)
 		log.Info("loaded config", "path", cfgPath(*configPath))
 	}
 
@@ -89,7 +90,7 @@ func run(log *slog.Logger) error {
 		return err
 	}
 
-	q, err := queue.New(sqldb, log)
+	q, err := queue.New(sqldb, log, *concurrency)
 	if err != nil {
 		return fmt.Errorf("queue: %w", err)
 	}
@@ -182,6 +183,7 @@ func applyConfig(cfg *config.Config,
 	addr, dataDir, effort *string,
 	noDocker *bool,
 	runnerImage, skillsRepo *string,
+	concurrency *int,
 	skillLocal *skillDirs,
 ) {
 	set := make(map[string]bool)
@@ -207,6 +209,9 @@ func applyConfig(cfg *config.Config,
 	}
 	if len(cfg.Skills) > 0 && !set["skills"] {
 		*skillLocal = append(*skillLocal, cfg.Skills...)
+	}
+	if cfg.Concurrency > 0 && !set["concurrency"] {
+		*concurrency = cfg.Concurrency
 	}
 
 	if len(cfg.Models) > 0 {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -29,6 +29,9 @@ type Config struct {
 	SkillsRepo   string   `yaml:"skills_repo"`
 	NoDocker     *bool    `yaml:"no_docker"`
 	RunnerImage  string   `yaml:"runner_image"`
+	// Concurrency controls how many scans the worker runs in parallel.
+	// 0 or negative leaves the built-in default (see queue.DefaultWorkerConcurrency).
+	Concurrency int `yaml:"concurrency"`
 }
 
 // Model is a display-name plus the claude model id it resolves to. The

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -57,6 +57,7 @@ skills:
 skills_repo: https://github.com/org/skills
 no_docker: true
 runner_image: custom-runner
+concurrency: 8
 `)
 	c, err := Load(path)
 	if err != nil {
@@ -73,6 +74,9 @@ runner_image: custom-runner
 	}
 	if c.NoDocker == nil || !*c.NoDocker {
 		t.Errorf("no_docker: %v", c.NoDocker)
+	}
+	if c.Concurrency != 8 {
+		t.Errorf("concurrency: %d", c.Concurrency)
 	}
 }
 

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -31,11 +31,16 @@ type Queue struct {
 }
 
 const (
-	visibilityTimeout  = 30 * time.Second
-	workerConcurrency  = 4
+	visibilityTimeout       = 30 * time.Second
+	DefaultWorkerConcurrency = 4
 )
 
-func New(sqldb *sql.DB, log *slog.Logger) (*Queue, error) {
+// New builds a queue wired to goqite. concurrency controls how many jobs
+// the runner processes in parallel; pass 0 to use DefaultWorkerConcurrency.
+func New(sqldb *sql.DB, log *slog.Logger, concurrency int) (*Queue, error) {
+	if concurrency <= 0 {
+		concurrency = DefaultWorkerConcurrency
+	}
 	if _, err := sqldb.Exec(schema); err != nil {
 		return nil, fmt.Errorf("goqite schema: %w", err)
 	}
@@ -47,7 +52,7 @@ func New(sqldb *sql.DB, log *slog.Logger) (*Queue, error) {
 	r := jobs.NewRunner(jobs.NewRunnerOpts{
 		Queue:        q,
 		Log:          slogAdapter{log},
-		Limit:        workerConcurrency,
+		Limit:        concurrency,
 		PollInterval: time.Second,
 		Extend:       visibilityTimeout,
 	})

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -22,7 +22,7 @@ func newTestServer(t *testing.T) (*Server, func()) {
 	}
 	sqldb, _ := gdb.DB()
 	log := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
-	q, err := queue.New(sqldb, log)
+	q, err := queue.New(sqldb, log, 0)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/scrutineer.sample.yaml
+++ b/scrutineer.sample.yaml
@@ -27,6 +27,10 @@
 # Docker image used for per-scan containers.
 # runner_image: scrutineer-runner
 
+# How many scans run in parallel. Default is 4; raise on bigger hosts,
+# lower if you want model calls serialised.
+# concurrency: 4
+
 # The model picker in the UI. Replacing this list replaces the built-in
 # set (Sonnet, Opus). Leave it out to keep the built-in list.
 # models:


### PR DESCRIPTION
\`queue.New\` now takes a concurrency argument. Main exposes it via a \`-concurrency\` flag and a matching \`concurrency:\` config key. Flag wins over config; both default to 4 (the previous hardcoded value).

Use case is raising it on bigger hosts, or lowering to serialise model calls when you want deterministic scan ordering for debugging.

Tests: config loader round-trips the new field.