### PR TITLE
Global advisories index (closes #17)

### DIFF
--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -136,6 +136,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("POST /dependents/{id}/scan", s.dependentScan)
 	mux.HandleFunc("GET /packages", s.packages)
 	mux.HandleFunc("GET /packages/{id}", s.packageShow)
+	mux.HandleFunc("GET /advisories", s.advisoriesList)
 	mux.HandleFunc("GET /scans/{id}", s.scanShow)
 	mux.HandleFunc("POST /scans/{id}/retry", s.scanRetry)
 	mux.HandleFunc("GET /scans/{id}/log", s.scanLog)
@@ -168,8 +169,11 @@ func (s *Server) index(w http.ResponseWriter, r *http.Request) {
 }
 
 const (
-	perPage       = 20
-	defaultSort   = "newest"
+	perPage     = 20
+	defaultSort = "newest"
+	// sortRepository is the shared sort-by-repository option used by the
+	// findings, scans, and advisories indexes.
+	sortRepository = "repository"
 )
 
 type Page struct {
@@ -369,7 +373,7 @@ func (s *Server) findings(w http.ResponseWriter, r *http.Request) {
 	switch sort {
 	case "severity":
 		q = q.Order(severityOrder).Order("id desc")
-	case "repository":
+	case sortRepository:
 		q = q.Joins("JOIN repositories r ON r.id = findings.repository_id").
 			Order("r.name").Order("findings.id desc")
 	default:
@@ -600,6 +604,74 @@ func (s *Server) packageShow(w http.ResponseWriter, r *http.Request) {
 	s.render(w, "package_show.html", data)
 }
 
+func (s *Server) advisoriesList(w http.ResponseWriter, r *http.Request) {
+	q := s.DB.Model(&db.Advisory{})
+	sev := r.URL.Query().Get("severity")
+	if sev != "" {
+		q = q.Where("severity = ?", sev)
+	}
+	search := strings.TrimSpace(r.URL.Query().Get("q"))
+	if search != "" {
+		like := "%" + search + "%"
+		q = q.Where("title LIKE ? OR packages LIKE ? OR classification LIKE ? OR uuid LIKE ?",
+			like, like, like, like)
+	}
+
+	sort := r.URL.Query().Get("sort")
+	switch sort {
+	case "newest":
+		q = q.Order("published_at desc, id desc")
+	case sortRepository:
+		q = q.Joins("JOIN repositories r ON r.id = advisories.repository_id").
+			Order("r.name").Order("advisories.cvss_score desc")
+	default:
+		sort = "severity"
+		q = q.Order("cvss_score desc, id desc")
+	}
+
+	var total int64
+	q.Count(&total)
+	page := paginate(r, total)
+
+	var rows []db.Advisory
+	q.Limit(perPage).Offset((page.N - 1) * perPage).Find(&rows)
+
+	reposByID := loadAdvisoryRepoMap(s.DB, rows)
+	var severities []string
+	s.DB.Model(&db.Advisory{}).Where("severity != ''").Distinct("severity").
+		Order("severity").Pluck("severity", &severities)
+
+	s.render(w, "advisories.html", map[string]any{
+		"Advisories": rows, "Page": page, "Severity": sev, "Sort": sort,
+		"Severities": severities, "Repos": reposByID, "Q": search,
+	})
+}
+
+// loadAdvisoryRepoMap batch-loads the repositories referenced by a slice
+// of advisories (Advisory.RepositoryID). Same pattern as loadRepoMap for
+// findings, duplicated rather than generified because the source field
+// is a different type.
+func loadAdvisoryRepoMap(gdb *gorm.DB, rows []db.Advisory) map[uint]db.Repository {
+	seen := make(map[uint]bool)
+	ids := make([]uint, 0)
+	for _, a := range rows {
+		if !seen[a.RepositoryID] {
+			seen[a.RepositoryID] = true
+			ids = append(ids, a.RepositoryID)
+		}
+	}
+	result := make(map[uint]db.Repository, len(ids))
+	if len(ids) == 0 {
+		return result
+	}
+	var repos []db.Repository
+	gdb.Where("id IN ?", ids).Find(&repos)
+	for _, r := range repos {
+		result[r.ID] = r
+	}
+	return result
+}
+
 func (s *Server) findingShow(w http.ResponseWriter, r *http.Request) {
 	var f db.Finding
 	if err := s.DB.Preload("Labels").First(&f, r.PathValue("id")).Error; err != nil {
@@ -659,7 +731,7 @@ func (s *Server) jobs(w http.ResponseWriter, r *http.Request) {
 		q = q.Order("skill_name, id desc")
 	case "status":
 		q = q.Order("status, id desc")
-	case "repository":
+	case sortRepository:
 		q = q.Joins("Repository").Order("`Repository`.name, scans.id desc")
 	default:
 		sort = defaultSort

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -171,6 +171,67 @@ func TestPackagesSearchFilters(t *testing.T) {
 	}
 }
 
+func TestAdvisoriesIndex(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	railsRepo := db.Repository{URL: "https://github.com/rails/rails", Name: "rails"}
+	s.DB.Create(&railsRepo)
+	djangoRepo := db.Repository{URL: "https://github.com/django/django", Name: "django"}
+	s.DB.Create(&djangoRepo)
+
+	now := time.Now()
+	s.DB.Create(&db.Advisory{RepositoryID: railsRepo.ID, UUID: "u1",
+		URL: "https://example.com/a1", Title: "SQL injection in activerecord",
+		Severity: "CRITICAL", CVSSScore: 9.8, Packages: "rails,activerecord",
+		Classification: "CWE-89", PublishedAt: &now})
+	s.DB.Create(&db.Advisory{RepositoryID: djangoRepo.ID, UUID: "u2",
+		URL: "https://example.com/a2", Title: "XSS in admin",
+		Severity: "MODERATE", CVSSScore: 5.4, Packages: "django",
+		Classification: "CWE-79", PublishedAt: &now})
+
+	// All advisories render.
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq("GET", "/advisories"))
+	if w.Code != 200 {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+	body := w.Body.String()
+	for _, want := range []string{
+		"SQL injection in activerecord",
+		"XSS in admin",
+		"rails", "django",
+		"9.8", "5.4",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("body missing %q", want)
+		}
+	}
+
+	// Severity filter: only CRITICAL rows.
+	w = httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq("GET", "/advisories?severity=CRITICAL"))
+	body = w.Body.String()
+	if !strings.Contains(body, "SQL injection") || strings.Contains(body, "XSS in admin") {
+		t.Errorf("severity filter: %s", body)
+	}
+
+	// Search: classification match.
+	w = httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq("GET", "/advisories?q=CWE-79"))
+	body = w.Body.String()
+	if !strings.Contains(body, "XSS in admin") || strings.Contains(body, "SQL injection") {
+		t.Errorf("search: %s", body)
+	}
+
+	// Empty-match state.
+	w = httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq("GET", "/advisories?q=NOPE_NOPE_NOPE"))
+	if !strings.Contains(w.Body.String(), "No matches") {
+		t.Error("empty-match advisories: no empty state")
+	}
+}
+
 func TestMaintainersSortOptions(t *testing.T) {
 	const (
 		zeta    = "zeta"

--- a/internal/web/templates/advisories.html
+++ b/internal/web/templates/advisories.html
@@ -1,0 +1,91 @@
+{{template "head"}}
+
+<div class="flex items-center justify-between gap-4 mb-6">
+  <h2 class="text-2xl font-semibold flex items-center gap-2">
+    <i data-lucide="shield-alert"></i> Advisories
+  </h2>
+  <div class="flex items-center gap-2">
+    <form method="get" action="/advisories" class="inline-flex">
+      <input class="input" type="search" name="q" value="{{.Q}}" placeholder="Search advisories"
+             autocomplete="off" spellcheck="false">
+      <input type="hidden" name="severity" value="{{.Severity}}">
+      <input type="hidden" name="sort" value="{{.Sort}}">
+    </form>
+    <div class="dropdown-menu">
+      <button type="button" class="btn-outline" aria-haspopup="menu" aria-expanded="false">
+        <i data-lucide="filter"></i>
+        {{if .Severity}}{{.Severity}}{{else}}Severity{{end}}
+        <i data-lucide="chevron-down"></i>
+      </button>
+      <div data-popover aria-hidden="true" data-align="end">
+        <div role="menu">
+          <a role="menuitem" href="/advisories?q={{.Q}}&sort={{.Sort}}">All</a>
+          {{range .Severities}}
+            <a role="menuitem" href="/advisories?q={{$.Q}}&severity={{.}}&sort={{$.Sort}}"
+               {{if eq . $.Severity}}aria-current="true"{{end}}>{{.}}</a>
+          {{end}}
+        </div>
+      </div>
+    </div>
+    <div class="dropdown-menu">
+      <button type="button" class="btn-outline" aria-haspopup="menu" aria-expanded="false">
+        <i data-lucide="arrow-down-wide-narrow"></i>
+        {{if eq .Sort "newest"}}Newest{{else if eq .Sort "repository"}}Repository{{else}}Severity{{end}}
+        <i data-lucide="chevron-down"></i>
+      </button>
+      <div data-popover aria-hidden="true" data-align="end">
+        <div role="menu">
+          {{range (list "severity" "newest" "repository")}}
+            <a role="menuitem" href="/advisories?q={{$.Q}}&severity={{$.Severity}}&sort={{.}}"
+               {{if eq . $.Sort}}aria-current="true"{{end}}>{{.}}</a>
+          {{end}}
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+{{if .Advisories}}
+  <table class="table w-full">
+    <thead><tr>
+      <th class="w-24">Severity</th>
+      <th class="w-16">CVSS</th>
+      <th>Title</th>
+      <th class="w-40">Repository</th>
+      <th class="w-56">Packages</th>
+      <th class="w-32">Published</th>
+    </tr></thead>
+    <tbody>
+    {{$repos := .Repos}}
+    {{range .Advisories}}
+      {{$repo := index $repos .RepositoryID}}
+      <tr class="cursor-pointer" onclick="window.open('{{.URL}}', '_blank', 'noopener')">
+        <td>
+          {{if eq .Severity "CRITICAL"}}<span class="badge-destructive">Critical</span>
+          {{else if eq .Severity "HIGH"}}<span class="badge-destructive">High</span>
+          {{else if eq .Severity "MODERATE"}}<span class="badge-primary">Moderate</span>
+          {{else}}<span class="badge-secondary">{{.Severity}}</span>{{end}}
+        </td>
+        <td class="text-muted-foreground">{{if .CVSSScore}}{{printf "%.1f" .CVSSScore}}{{end}}</td>
+        <td class="min-w-0 whitespace-normal">
+          <div class="font-medium">{{.Title}}</div>
+          {{if .Classification}}<div class="text-xs text-muted-foreground">{{.Classification}}</div>{{end}}
+        </td>
+        <td class="truncate">
+          <a href="/repositories/{{$repo.ID}}" class="hover:underline"
+             onclick="event.stopPropagation()">{{$repo.Name}}</a>
+        </td>
+        <td class="text-muted-foreground whitespace-normal text-xs">{{.Packages}}</td>
+        <td class="text-muted-foreground">{{if .PublishedAt}}{{.PublishedAt.Format "2006-01-02"}}{{end}}</td>
+      </tr>
+    {{end}}
+    </tbody>
+  </table>
+  {{template "pagination" .Page}}
+{{else if .Q}}
+  {{template "empty" (dict "Icon" "search-x" "Title" "No matches" "Body" "No advisories matched the search.")}}
+{{else}}
+  {{template "empty" (dict "Icon" "shield-alert" "Title" "No advisories" "Body" "Advisories appear here after the advisories skill runs on a repository.")}}
+{{end}}
+
+{{template "foot"}}

--- a/internal/web/templates/layout.html
+++ b/internal/web/templates/layout.html
@@ -42,6 +42,7 @@
           <li><a href="/" data-nav="repos"><i data-lucide="folder-git-2"></i><span>Repositories</span></a></li>
           <li><a href="/findings" data-nav="findings"><i data-lucide="bug"></i><span>Findings</span></a></li>
           <li><a href="/packages" data-nav="packages"><i data-lucide="package"></i><span>Packages</span></a></li>
+          <li><a href="/advisories" data-nav="advisories"><i data-lucide="shield-alert"></i><span>Advisories</span></a></li>
           <li><a href="/maintainers" data-nav="maintainers"><i data-lucide="users"></i><span>Maintainers</span></a></li>
           <li><a href="/scans" data-nav="scans"><i data-lucide="list-checks"></i><span>Scans</span></a></li>
           <li><a href="/skills" data-nav="skills"><i data-lucide="sparkles"></i><span>Skills</span></a></li>
@@ -117,6 +118,7 @@
     var key = p.indexOf('/skills') === 0 ? 'skills'
             : p.indexOf('/maintainers') === 0 ? 'maintainers'
             : p.indexOf('/packages') === 0 ? 'packages'
+            : p.indexOf('/advisories') === 0 ? 'advisories'
             : p.indexOf('/findings') === 0 ? 'findings'
             : p.indexOf('/scans') === 0 ? 'scans'
             : 'repos';


### PR DESCRIPTION
Adds a top-level `/advisories` page that lists advisories across all repositories, matching the pattern of the existing findings/packages/maintainers indexes.

- New handler `advisoriesList` in `internal/web/server.go` with `q`, `severity`, and `sort` (severity / newest / repository) params
- New template `internal/web/templates/advisories.html` with search box, severity filter, sort dropdown, and paginated table (Severity, CVSS, Title, Repository, Packages, Published)
- Row click opens the advisory URL; repository cell links to the repo page
- Sidebar entry added with `shield-alert` icon
- `TestAdvisoriesIndex` covers full list, severity filter, CWE search, and empty state
- Factored `sortRepository = "repository"` const to satisfy goconst across the sort switches

Closes #17.