### PR TITLE
Disclose skill: draft GHSA-shaped advisory content (closes #6)

### DIFF
--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -127,6 +127,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("GET /findings/{id}", s.findingShow)
 	mux.HandleFunc("POST /findings/{id}/status", s.findingStatus)
 	mux.HandleFunc("POST /findings/{id}/verify", s.findingVerify)
+	mux.HandleFunc("POST /findings/{id}/disclose", s.findingDisclose)
 	mux.HandleFunc("POST /findings/{id}/notes", s.findingNotes)
 	mux.HandleFunc("POST /findings/{id}/fields", s.findingFields)
 	mux.HandleFunc("POST /findings/{id}/communications", s.findingCommunications)
@@ -503,7 +504,18 @@ func (s *Server) findingStatus(w http.ResponseWriter, r *http.Request) {
 // verifySkillName is the skill the Verify button on the finding page runs.
 const verifySkillName = "verify"
 
+// discloseSkillName is the skill the Draft disclosure button runs.
+const discloseSkillName = "disclose"
+
 func (s *Server) findingVerify(w http.ResponseWriter, r *http.Request) {
+	s.runFindingSkill(w, r, verifySkillName)
+}
+
+func (s *Server) findingDisclose(w http.ResponseWriter, r *http.Request) {
+	s.runFindingSkill(w, r, discloseSkillName)
+}
+
+func (s *Server) runFindingSkill(w http.ResponseWriter, r *http.Request, name string) {
 	var f db.Finding
 	if err := s.DB.First(&f, r.PathValue("id")).Error; err != nil {
 		http.NotFound(w, r)
@@ -515,8 +527,8 @@ func (s *Server) findingVerify(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	var skill db.Skill
-	if err := s.DB.Where("name = ? AND active = ?", verifySkillName, true).First(&skill).Error; err != nil {
-		http.Error(w, verifySkillName+" skill is not installed", http.StatusPreconditionFailed)
+	if err := s.DB.Where("name = ? AND active = ?", name, true).First(&skill).Error; err != nil {
+		http.Error(w, name+" skill is not installed", http.StatusPreconditionFailed)
 		return
 	}
 	fid := f.ID

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -319,6 +319,62 @@ func TestCreateRepoEnqueuesTriageSkill(t *testing.T) {
 	}
 }
 
+func TestFindingDiscloseEnqueuesDiscloseSkill(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	repo := db.Repository{URL: "https://github.com/foo/bar", Name: "bar"}
+	s.DB.Create(&repo)
+	scan := db.Scan{RepositoryID: repo.ID, Kind: "skill", Status: db.ScanDone, SkillName: "security-deep-dive"}
+	s.DB.Create(&scan)
+	finding := db.Finding{ScanID: scan.ID, RepositoryID: repo.ID, FindingID: "F1", Title: "x", Severity: "High", Status: db.FindingTriaged}
+	s.DB.Create(&finding)
+	disclose := db.Skill{Name: "disclose", Description: "d", Body: "b", OutputFile: "report.json", OutputKind: "freeform", Version: 1, Active: true, Source: "ui"}
+	s.DB.Create(&disclose)
+
+	req := httptest.NewRequest("POST", "/findings/1/disclose", nil)
+	req.Host = testHost
+	req.Header.Set("Sec-Fetch-Site", "same-origin")
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+	if !strings.HasPrefix(w.Header().Get("HX-Redirect"), "/scans/") {
+		t.Errorf("expected HX-Redirect to scan, got %q", w.Header().Get("HX-Redirect"))
+	}
+
+	var row db.Scan
+	s.DB.Where("skill_id = ?", disclose.ID).First(&row)
+	if row.FindingID == nil || *row.FindingID != finding.ID {
+		t.Errorf("scan FindingID = %v, want %d", row.FindingID, finding.ID)
+	}
+	if row.APIToken == "" {
+		t.Error("scan missing api token")
+	}
+}
+
+func TestFindingDisclose404WhenSkillMissing(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	repo := db.Repository{URL: "https://github.com/foo/bar", Name: "bar"}
+	s.DB.Create(&repo)
+	scan := db.Scan{RepositoryID: repo.ID, Kind: "skill", Status: db.ScanDone, SkillName: "x"}
+	s.DB.Create(&scan)
+	finding := db.Finding{ScanID: scan.ID, RepositoryID: repo.ID, FindingID: "F1", Title: "x", Severity: "High", Status: db.FindingTriaged}
+	s.DB.Create(&finding)
+
+	req := httptest.NewRequest("POST", "/findings/1/disclose", nil)
+	req.Host = testHost
+	req.Header.Set("Sec-Fetch-Site", "same-origin")
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusPreconditionFailed {
+		t.Fatalf("expected 412 when disclose skill not installed, got %d: %s", w.Code, w.Body)
+	}
+}
+
 func TestScanShowRenders(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()

--- a/internal/web/templates/finding_workflow.html
+++ b/internal/web/templates/finding_workflow.html
@@ -13,7 +13,7 @@
         <p class="text-sm text-muted-foreground">The confirm job ran and validated this finding. Review the evidence and triage.</p>
       {{else if eq $s "triaged"}}
         <p class="text-sm mb-1 font-medium">Triaged, ready to prepare disclosure</p>
-        <p class="text-sm text-muted-foreground">You've confirmed this is a real finding. Next: prepare the disclosure draft with CVSS, references, and text.</p>
+        <p class="text-sm text-muted-foreground">You've confirmed this is a real finding. Run the disclose skill to get a GHSA-shaped draft, review and edit, then mark ready.</p>
       {{else if eq $s "ready"}}
         <p class="text-sm mb-1 font-medium">Disclosure draft ready</p>
         <p class="text-sm text-muted-foreground">The draft is prepared. Review it in the notes, edit if needed, then send to the maintainer.</p>
@@ -59,8 +59,11 @@
         </button>
 
       {{else if eq $s "triaged"}}
-        <button class="btn" hx-post="/findings/{{$id}}/status" hx-vals='{"status":"ready"}' hx-swap="none">
-          <i data-lucide="file-pen"></i> Prepare disclosure
+        <button class="btn" hx-post="/findings/{{$id}}/disclose" hx-swap="none">
+          <i data-lucide="file-pen"></i> Draft disclosure
+        </button>
+        <button class="btn-outline" hx-post="/findings/{{$id}}/status" hx-vals='{"status":"ready"}' hx-swap="none">
+          Mark ready
         </button>
         <button class="btn-ghost" hx-post="/findings/{{$id}}/status" hx-vals='{"status":"rejected"}' hx-swap="none">
           Reject

--- a/skills/disclose/SKILL.md
+++ b/skills/disclose/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: disclose
+description: Draft the disclosure content for a finding in GitHub Security Advisory shape. Produces a title, markdown description, affected package block, CVSS vector, CWE list, and references, then writes them back to the finding so the analyst can paste them into the GHSA form (or POST to GitHub's repository-advisories REST endpoint) rather than composing from scratch.
+license: MIT
+compatibility: Needs network access to the scrutineer API (http://host:port/api). Finding-scoped; runs on one finding at a time.
+metadata:
+  scrutineer.output_file: report.json
+  scrutineer.output_kind: freeform
+---
+
+# disclose
+
+Draft disclosure content for an existing finding in a shape that maps one-to-one to GitHub's repository security advisory (GHSA) form. You are not deciding whether the bug is real — the triage and verify skills did that. Your job is to turn a confirmed finding into text a maintainer can paste into `https://github.com/{org}/{repo}/security/advisories/new`, or that a caller can POST to `POST /repos/{owner}/{repo}/security-advisories`.
+
+## Workspace
+
+- `./src` — the repository at its current HEAD, so you can link to file:line and read tag history
+- `./context.json` — has `scrutineer.api_base`, `scrutineer.token`, `scrutineer.repository_id`, and `scrutineer.finding_id` (required; this skill only makes sense finding-scoped)
+- `./report.json` — write a GHSA-shaped record of what you drafted
+- `./schema.json` — shape of `report.json`
+
+## What to do
+
+1. Read `./context.json`. If `scrutineer.finding_id` is missing, write `{"error": "no finding_id in context.json; disclose is finding-scoped"}` to `report.json` and exit 0.
+
+2. Fetch the finding: `GET {api_base}/findings/{finding_id}` with `Authorization: Bearer {token}`. You get title, severity, cwe (comma-joined), location, affected, cvss_vector, cve_id, fix_version, fix_commit, and the six-step prose (trace, boundary, validation, prior_art, reach, rating). Also fetch:
+   - `GET {api_base}/repositories/{repository_id}` for the upstream URL and default branch
+   - `GET {api_base}/repositories/{repository_id}/packages` for the list of published packages; you need this to fill GHSA's affected-package block
+
+3. Compose the GHSA fields below. Every field names the GHSA REST key (`summary`, `description`, `vulnerabilities`, etc.) so the mapping is explicit. Keep each one factual and derived from the finding — do not invent details the audit did not establish.
+
+   **`summary` (title).** A single sentence, under 80 characters. Start with the impact verb ("Arbitrary file write in …", "Prototype pollution in …"), not the package name. Reuse the finding's `title` if it already fits that shape.
+
+   **`description` (markdown body).** This is the main document a maintainer reads. Structure as below. Each section is required unless marked optional.
+
+   ```
+   ## Summary
+
+   Two or three sentences describing the vulnerability in the maintainer's own domain terms. Repeat the one-line summary then expand.
+
+   ## Impact
+
+   What an attacker can do. Stay tight — reuse the Rating prose if it already covers this. Name the attacker model (unauthenticated remote, local, authenticated user) in the first sentence.
+
+   ## Affected versions
+
+   A line per affected range, matching the `vulnerabilities[].vulnerable_version_range` values. Example:
+   - `>= 1.0, < 2.3.1` (all pre-2.3.1 releases)
+
+   ## Patched versions
+
+   If a fix has shipped, list the first patched version. Otherwise write "Not yet patched" and state whether the `fix_commit` on the finding is on the default branch.
+
+   ## Proof of concept
+
+   Reuse the Validation prose, formatted as a short runnable recipe. Include the minimum needed to trigger the bug. A fenced code block when a script exists.
+
+   ## Fix suggestion
+
+   One or two sentences on where the guard belongs (sanitise here, validate there, remove the sink). Do not claim a specific patch unless the Trace identifies the exact line.
+
+   ## References
+
+   - `{repo.html_url}/blob/{default_branch}/{location}` — the vulnerable code
+   - `https://cwe.mitre.org/data/definitions/{n}.html` — one line per CWE
+   - any URL that appeared verbatim in the prior_art field of the finding
+   ```
+
+   GHSA's REST endpoint has no structured references field — all URLs live inside the description markdown. You will still post them as scrutineer references (step 4) so the UI surfaces them as links, but the maintainer-facing copy is the markdown list.
+
+   **`vulnerabilities[]` (affected products).** One entry per published package. Build from the repository's packages list. Each entry has:
+
+   ```json
+   {
+     "package": { "ecosystem": "<ghsa-ecosystem>", "name": "<package-name>" },
+     "vulnerable_version_range": ">= 1.0, < 2.3.1",
+     "patched_versions": "2.3.1",
+     "vulnerable_functions": ["pkg.Parse", "pkg.ParseFile"]
+   }
+   ```
+
+   Normalise the ecosystem string to the exact GHSA enum — all lowercase, with these specific spellings: `rubygems` (not `RubyGems`), `npm`, `pip` (not `pypi` or `PyPI`), `maven`, `nuget`, `composer`, `go`, `rust`, `erlang`, `actions`, `pub`, `other`. If a scrutineer package has `ecosystem: "Packagist"`, emit `"composer"`; if `"Cargo"`, emit `"rust"`. Map anything unrecognised to `"other"`.
+
+   If the repository has no packages, omit the `vulnerabilities` array entirely and note in the `notes` field of `report.json` that this advisory is source-only (a maintainer filing it would still need to add an affected-product block manually).
+
+   `vulnerable_functions` is optional; fill it only when the Trace field names specific exported symbols (e.g. `pkg.Foo`, `Class#method`). Leave empty otherwise.
+
+   **`severity` / `cvss_vector_string`.** GHSA accepts exactly one of the two; prefer the CVSS vector when you can derive one confidently, fall back to the severity label otherwise.
+
+   Use CVSS 3.1. Derive each metric from the finding prose: `AV` from the attack surface described in Boundary, `AC` from how contrived the trigger is in Validation, `PR`/`UI` from whether the trigger needs authentication or human interaction, `S` from whether the impact crosses a trust boundary, and `C`/`I`/`A` from the dangerous behaviour in Rating. Write the full vector string (e.g. `CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H`).
+
+   For the severity label fallback, map scrutineer's `severity` field (`Critical`/`High`/`Medium`/`Low`) to GHSA's lowercase `critical`/`high`/`medium`/`low`. If the finding has a pre-existing `cvss_vector`, leave it alone and reuse it here — do not overwrite analyst edits.
+
+   **`cwe_ids[]`.** Split the finding's comma-joined `cwe` field into an array of `CWE-N` strings (GHSA accepts multiple). Do not invent CWEs not in the finding.
+
+   **`cve_id`.** Pass through whatever the finding carries; leave blank (omit the key) if unset. CVE IDs are assigned by a CNA, not drafted — do not fabricate one.
+
+   **`credits[]`.** Omit unless the finding prose explicitly attributes the discovery (e.g. a prior_art reference to a named researcher). Leave empty by default.
+
+4. Write the composed pieces back via the scrutineer API.
+
+   **PATCH the finding** — `PATCH {api_base}/findings/{finding_id}` with `Authorization: Bearer {token}` and JSON body:
+
+   ```json
+   {
+     "fields": {
+       "title": "<summary>",
+       "cvss_vector": "CVSS:3.1/...",
+       "affected": ">=1.0, <2.3.1",
+       "fix_version": "2.3.1",
+       "disclosure_draft": "<description markdown>"
+     },
+     "by": "disclose"
+   }
+   ```
+
+   Only include fields you want to change. If the finding already had a non-empty `cvss_vector`, `affected`, `fix_version`, or `title`, leave those keys out of the body so the analyst's value is preserved. `disclosure_draft` may be overwritten — a re-run is allowed to produce a fresh draft.
+
+   **POST each reference** — for every URL cited in the description, `POST {api_base}/findings/{finding_id}/references` with:
+
+   ```json
+   { "url": "https://...", "tags": "upstream|cwe|prior-art", "summary": "short label" }
+   ```
+
+   Before posting, `GET {api_base}/findings/{finding_id}/references` and skip URLs that already exist — re-runs should not create duplicates.
+
+5. Write `./report.json`. The top-level `ghsa` block is the drop-in body for `POST /repos/{owner}/{repo}/security-advisories`; an operator or downstream skill can submit it as-is.
+
+   ```json
+   {
+     "ghsa": {
+       "summary": "...",
+       "description": "...",
+       "vulnerabilities": [
+         {
+           "package": { "ecosystem": "go", "name": "example.com/pkg" },
+           "vulnerable_version_range": ">= 1.0, < 2.3.1",
+           "patched_versions": "2.3.1",
+           "vulnerable_functions": ["pkg.Parse"]
+         }
+       ],
+       "cwe_ids": ["CWE-22"],
+       "cvss_vector_string": "CVSS:3.1/...",
+       "cve_id": null,
+       "credits": []
+     },
+     "patched": ["cvss_vector", "affected", "fix_version", "disclosure_draft"],
+     "preserved": ["title"],
+     "references_added": 3,
+     "references_skipped": 1,
+     "notes": "short prose about anything non-obvious: no published packages (source-only advisory), an ambiguous tag range, a missing prior-art link, etc."
+   }
+   ```
+
+   `ghsa` mirrors the GHSA REST body: every key is drawn from GitHub's repository-advisories schema, so downstream code can POST it without a translation step. `patched` lists fields you actually sent in the PATCH /findings body. `preserved` lists fields you chose not to touch because the analyst had already set them.
+
+## Constraints
+
+- Do not mark the finding as `ready` — lifecycle transitions belong to the analyst. Your output is input for their review, not a replacement for it.
+- Do not post communications. `POST /findings/{id}/communications` records maintainer contact, which this skill has not made.
+- Do not fabricate a CVE ID, a CWE, a credit, or a vulnerable function name. Every value in the `ghsa` block must be derivable from the finding, the repo, or the packages list.
+- Do not emit `severity` and `cvss_vector_string` together — GHSA rejects the pair. Prefer the CVSS vector; use `severity` only when you cannot derive a vector.
+- If the finding prose is too thin to draft from (empty Trace, empty Validation), write `{"error": "finding {id} has insufficient prose to draft disclosure"}` to `report.json` and exit 0. Do not PATCH anything.

--- a/skills/disclose/schema.json
+++ b/skills/disclose/schema.json
@@ -1,0 +1,125 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "disclose report",
+  "description": "Drop-in GHSA body plus a write-back audit trail.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "ghsa": {
+      "type": "object",
+      "description": "Body for POST /repos/{owner}/{repo}/security-advisories. Keys match GitHub's repository-advisories REST schema so the block can be submitted as-is.",
+      "additionalProperties": false,
+      "properties": {
+        "summary": {
+          "type": "string",
+          "description": "Advisory title. Under 80 characters. Maps to GHSA `summary`."
+        },
+        "description": {
+          "type": "string",
+          "description": "Markdown body. Maps to GHSA `description`."
+        },
+        "vulnerabilities": {
+          "type": "array",
+          "description": "Affected products. One entry per published package. Omit entirely for source-only advisories.",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["package"],
+            "properties": {
+              "package": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["ecosystem"],
+                "properties": {
+                  "ecosystem": {
+                    "type": "string",
+                    "enum": ["rubygems", "npm", "pip", "maven", "nuget", "composer", "go", "rust", "erlang", "actions", "pub", "other"],
+                    "description": "GHSA ecosystem enum. Lowercase. `pip` not `pypi`, `rubygems` not `RubyGems`."
+                  },
+                  "name": { "type": "string" }
+                }
+              },
+              "vulnerable_version_range": {
+                "type": "string",
+                "description": "e.g. `>= 1.0.0, < 2.3.1`."
+              },
+              "patched_versions": {
+                "type": "string",
+                "description": "First patched version, e.g. `2.3.1`."
+              },
+              "vulnerable_functions": {
+                "type": "array",
+                "items": { "type": "string" },
+                "description": "Exported symbols that contain the sink. Optional; fill only when the Trace names them."
+              }
+            }
+          }
+        },
+        "cwe_ids": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^CWE-[0-9]+$"
+          },
+          "description": "CWE identifiers. GHSA accepts multiple."
+        },
+        "cvss_vector_string": {
+          "type": "string",
+          "description": "CVSS 3.1 vector. Mutually exclusive with `severity`."
+        },
+        "severity": {
+          "type": "string",
+          "enum": ["critical", "high", "medium", "low"],
+          "description": "Qualitative severity. Use only when a CVSS vector cannot be derived."
+        },
+        "cve_id": {
+          "type": ["string", "null"],
+          "description": "CVE identifier. Pass through whatever the finding carries; null when unset."
+        },
+        "credits": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["login", "type"],
+            "properties": {
+              "login": { "type": "string" },
+              "type": {
+                "type": "string",
+                "enum": ["analyst", "finder", "reporter", "coordinator", "remediation_developer", "remediation_reviewer", "remediation_verifier", "tool", "sponsor", "other"]
+              }
+            }
+          }
+        }
+      }
+    },
+    "patched": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Field names sent in the PATCH /findings/{id} body. Subset of: title, cvss_vector, affected, fix_version, disclosure_draft."
+    },
+    "preserved": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Fields left untouched because the finding already carried an analyst-set value."
+    },
+    "references_added": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Number of references POSTed to /findings/{id}/references."
+    },
+    "references_skipped": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Number of references skipped because the URL was already on the finding."
+    },
+    "notes": {
+      "type": "string",
+      "description": "Free-form prose: gaps in the source prose, ambiguity in the version range, source-only (no packages), anything the analyst should know."
+    },
+    "error": {
+      "type": "string",
+      "description": "Set only when the skill refused to draft (missing finding_id, insufficient prose)."
+    }
+  }
+}


### PR DESCRIPTION
New finding-scoped skill that drafts disclosure content for a confirmed finding.

Output is structured to match GitHub's repository security advisory (GHSA) form so the maintainer-facing copy is paste-ready and `report.json.ghsa` is a drop-in body for `POST /repos/{owner}/{repo}/security-advisories`.

Drafts the following GHSA fields:

- `summary` — one-line title under 80 chars
- `description` — markdown body with Summary / Impact / Affected versions / Patched versions / Proof of concept / Fix suggestion / References sections
- `vulnerabilities[]` — per-package affected block with ecosystem (normalized to the GHSA enum: `rubygems`, `npm`, `pip`, `maven`, `nuget`, `composer`, `go`, `rust`, `erlang`, `actions`, `pub`, `other`), `vulnerable_version_range`, `patched_versions`, `vulnerable_functions`
- `cvss_vector_string` (or `severity` fallback — they are mutually exclusive in GHSA)
- `cwe_ids[]`
- `cve_id` pass-through
- `credits[]` (only when prose attributes it)

The skill PATCHes `title` / `cvss_vector` / `affected` / `fix_version` / `disclosure_draft` back on the finding and POSTs each reference URL, skipping ones already present so re-runs stay idempotent. Does not touch analyst-set values and does not transition the lifecycle status — that stays a manual action.

### UI

- New `POST /findings/{id}/disclose` handler
- \"Draft disclosure\" button on the `triaged` workflow state, alongside a separate \"Mark ready\" button for the manual transition
- `runFindingSkill` helper factored out so verify and disclose share the enqueue path

### Tests

- `TestFindingDiscloseEnqueuesDiscloseSkill` — button enqueues a finding-scoped scan with the right skill and finding id
- `TestFindingDisclose404WhenSkillMissing` — returns 412 when the `disclose` skill is not installed

Closes #6.