### PR TITLE
Patch skill: propose fixes with .patch download + apply instructions (closes #7)

### DIFF
--- a/internal/web/finding_patch.go
+++ b/internal/web/finding_patch.go
@@ -1,0 +1,71 @@
+package web
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"scrutineer/internal/db"
+	"scrutineer/internal/worker"
+)
+
+// patchReport is the subset of the patch skill's report.json shape the UI
+// needs. Mirrors skills/patch/schema.json.
+type patchReport struct {
+	Patch        string   `json:"patch"`
+	Rationale    string   `json:"rationale"`
+	FilesChanged []string `json:"files_changed"`
+	BaseCommit   string   `json:"base_commit"`
+	TestsAdded   bool     `json:"tests_added"`
+	Notes        string   `json:"notes"`
+	Error        string   `json:"error"`
+}
+
+// latestPatchScan returns the most recent done patch-skill scan for a finding
+// along with its parsed report. Returns (nil, nil, nil) when no patch scan
+// has completed for this finding — the UI uses that to hide the section.
+func (s *Server) latestPatchScan(findingID uint) (*db.Scan, *patchReport, error) {
+	var scan db.Scan
+	err := s.DB.
+		Where("finding_id = ? AND kind = ? AND skill_name = ? AND status = ?",
+			findingID, worker.JobSkill, patchSkillName, db.ScanDone).
+		Order("finished_at desc").
+		First(&scan).Error
+	if err != nil {
+		return nil, nil, nil
+	}
+	if scan.Report == "" {
+		return &scan, nil, nil
+	}
+	var rep patchReport
+	if err := json.Unmarshal([]byte(scan.Report), &rep); err != nil {
+		return &scan, nil, fmt.Errorf("parse patch report: %w", err)
+	}
+	return &scan, &rep, nil
+}
+
+// findingPatchDownload serves the latest patch scan's diff as a .patch file.
+// No .patch scan done -> 404; done but empty diff (the skill refused) -> 404
+// with a small message so the download link never yields a confusing empty
+// file.
+func (s *Server) findingPatchDownload(w http.ResponseWriter, r *http.Request) {
+	var f db.Finding
+	if err := s.DB.First(&f, r.PathValue("id")).Error; err != nil {
+		http.NotFound(w, r)
+		return
+	}
+	_, rep, err := s.latestPatchScan(f.ID)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if rep == nil || strings.TrimSpace(rep.Patch) == "" {
+		http.Error(w, "no patch available for this finding", http.StatusNotFound)
+		return
+	}
+	w.Header().Set("Content-Type", "text/x-diff; charset=utf-8")
+	w.Header().Set("Content-Disposition",
+		fmt.Sprintf(`attachment; filename="finding-%d.patch"`, f.ID))
+	_, _ = w.Write([]byte(rep.Patch))
+}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -128,6 +128,8 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("POST /findings/{id}/status", s.findingStatus)
 	mux.HandleFunc("POST /findings/{id}/verify", s.findingVerify)
 	mux.HandleFunc("POST /findings/{id}/disclose", s.findingDisclose)
+	mux.HandleFunc("POST /findings/{id}/patch", s.findingPatchRun)
+	mux.HandleFunc("GET /findings/{id}/patch.diff", s.findingPatchDownload)
 	mux.HandleFunc("POST /findings/{id}/notes", s.findingNotes)
 	mux.HandleFunc("POST /findings/{id}/fields", s.findingFields)
 	mux.HandleFunc("POST /findings/{id}/communications", s.findingCommunications)
@@ -507,12 +509,19 @@ const verifySkillName = "verify"
 // discloseSkillName is the skill the Draft disclosure button runs.
 const discloseSkillName = "disclose"
 
+// patchSkillName is the skill the Propose patch button runs.
+const patchSkillName = "patch"
+
 func (s *Server) findingVerify(w http.ResponseWriter, r *http.Request) {
 	s.runFindingSkill(w, r, verifySkillName)
 }
 
 func (s *Server) findingDisclose(w http.ResponseWriter, r *http.Request) {
 	s.runFindingSkill(w, r, discloseSkillName)
+}
+
+func (s *Server) findingPatchRun(w http.ResponseWriter, r *http.Request) {
+	s.runFindingSkill(w, r, patchSkillName)
 }
 
 func (s *Server) runFindingSkill(w http.ResponseWriter, r *http.Request, name string) {
@@ -650,6 +659,10 @@ func (s *Server) findingShow(w http.ResponseWriter, r *http.Request) {
 	}
 	if id, c, ok := LookupCWE(f.CWE); ok {
 		data["CWE"] = map[string]any{"ID": id, "Name": c.Name, "Description": c.Description}
+	}
+	if patchScan, patchRep, _ := s.latestPatchScan(f.ID); patchRep != nil {
+		data["PatchScan"] = patchScan
+		data["Patch"] = patchRep
 	}
 	s.render(w, "finding_show.html", data)
 }

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -354,6 +354,114 @@ func TestFindingDiscloseEnqueuesDiscloseSkill(t *testing.T) {
 	}
 }
 
+func TestFindingPatchRunEnqueuesPatchSkill(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	repo := db.Repository{URL: "https://github.com/foo/bar", Name: "bar"}
+	s.DB.Create(&repo)
+	scan := db.Scan{RepositoryID: repo.ID, Kind: "skill", Status: db.ScanDone, SkillName: "security-deep-dive"}
+	s.DB.Create(&scan)
+	finding := db.Finding{ScanID: scan.ID, RepositoryID: repo.ID, FindingID: "F1", Title: "x", Severity: "High", Status: db.FindingTriaged}
+	s.DB.Create(&finding)
+	patch := db.Skill{Name: "patch", Description: "p", Body: "b", OutputFile: "report.json", OutputKind: "freeform", Version: 1, Active: true, Source: "ui"}
+	s.DB.Create(&patch)
+
+	req := httptest.NewRequest("POST", "/findings/1/patch", nil)
+	req.Host = testHost
+	req.Header.Set("Sec-Fetch-Site", "same-origin")
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+
+	var row db.Scan
+	s.DB.Where("skill_id = ?", patch.ID).First(&row)
+	if row.FindingID == nil || *row.FindingID != finding.ID {
+		t.Errorf("scan FindingID = %v, want %d", row.FindingID, finding.ID)
+	}
+}
+
+func TestFindingPatchDownload(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	repo := db.Repository{URL: "https://github.com/foo/bar", Name: "bar"}
+	s.DB.Create(&repo)
+	scan := db.Scan{RepositoryID: repo.ID, Kind: "skill", Status: db.ScanDone, SkillName: "security-deep-dive"}
+	s.DB.Create(&scan)
+	finding := db.Finding{ScanID: scan.ID, RepositoryID: repo.ID, FindingID: "F1", Title: "x", Severity: "High", Status: db.FindingTriaged}
+	s.DB.Create(&finding)
+
+	fid := finding.ID
+	finished := time.Now()
+	report := `{"patch":"diff --git a/foo.go b/foo.go\n@@ -1 +1 @@\n-old\n+new\n","rationale":"adds guard","files_changed":["foo.go"],"base_commit":"abc123","tests_added":false}`
+	patchScan := db.Scan{
+		RepositoryID: repo.ID, Kind: "skill", Status: db.ScanDone,
+		SkillName:  "patch",
+		FindingID:  &fid,
+		FinishedAt: &finished,
+		Report:     report,
+	}
+	s.DB.Create(&patchScan)
+
+	req := httptest.NewRequest("GET", "/findings/1/patch.diff", nil)
+	req.Host = testHost
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("download status %d: %s", w.Code, w.Body)
+	}
+	if ct := w.Header().Get("Content-Type"); !strings.HasPrefix(ct, "text/x-diff") {
+		t.Errorf("Content-Type = %q", ct)
+	}
+	if cd := w.Header().Get("Content-Disposition"); !strings.Contains(cd, "finding-1.patch") {
+		t.Errorf("Content-Disposition = %q", cd)
+	}
+	if body := w.Body.String(); !strings.HasPrefix(body, "diff --git") {
+		t.Errorf("body does not start with diff header: %q", body)
+	}
+
+	req = httptest.NewRequest("GET", "/findings/1", nil)
+	req.Host = testHost
+	w = httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+	body := w.Body.String()
+	if !strings.Contains(body, "Proposed patch") {
+		t.Error("finding show page missing 'Proposed patch' section")
+	}
+	if !strings.Contains(body, "adds guard") {
+		t.Error("finding show page missing rationale")
+	}
+	if !strings.Contains(body, "/findings/1/patch.diff") {
+		t.Error("finding show page missing download link")
+	}
+	if !strings.Contains(body, "git apply") {
+		t.Error("finding show page missing apply instructions")
+	}
+}
+
+func TestFindingPatchDownload_404WhenNoPatch(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	repo := db.Repository{URL: "https://github.com/foo/bar", Name: "bar"}
+	s.DB.Create(&repo)
+	scan := db.Scan{RepositoryID: repo.ID, Kind: "skill", Status: db.ScanDone, SkillName: "x"}
+	s.DB.Create(&scan)
+	finding := db.Finding{ScanID: scan.ID, RepositoryID: repo.ID, FindingID: "F1", Title: "x", Severity: "High", Status: db.FindingTriaged}
+	s.DB.Create(&finding)
+
+	req := httptest.NewRequest("GET", "/findings/1/patch.diff", nil)
+	req.Host = testHost
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("want 404, got %d: %s", w.Code, w.Body)
+	}
+}
+
 func TestFindingDisclose404WhenSkillMissing(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()

--- a/internal/web/templates/finding_show.html
+++ b/internal/web/templates/finding_show.html
@@ -166,6 +166,56 @@
   </details>
   {{end}}
 
+  {{if .Patch}}{{$p := .Patch}}{{$ps := .PatchScan}}
+  <details open class="group border-b">
+    <summary class="w-full outline-none rounded-md focus-visible:ring-ring/50 focus-visible:ring-[3px]">
+      <h3 class="flex flex-1 items-center justify-between gap-4 py-4 text-sm font-medium hover:underline">
+        Proposed patch
+        <span class="text-muted-foreground ml-auto mr-2 text-xs">scan #{{$ps.ID}}</span>
+        <i data-lucide="chevron-down" class="text-muted-foreground size-4 shrink-0 transition-transform duration-200 group-open:rotate-180"></i>
+      </h3>
+    </summary>
+    <section class="pb-4 grid gap-3">
+      {{if $p.Rationale}}
+        <p class="text-sm">{{$p.Rationale}}</p>
+      {{end}}
+      {{if $p.FilesChanged}}
+        <div class="text-xs text-muted-foreground">
+          Files changed:
+          {{range $i, $f := $p.FilesChanged}}{{if $i}}, {{end}}<code>{{$f}}</code>{{end}}
+        </div>
+      {{end}}
+      <div class="flex flex-wrap gap-2 items-center">
+        <a class="btn-sm" href="/findings/{{$f.ID}}/patch.diff">
+          <i data-lucide="download"></i> Download .patch
+        </a>
+        <a class="btn-outline-sm" href="/scans/{{$ps.ID}}">
+          <i data-lucide="arrow-up-right"></i> View scan
+        </a>
+        {{if $p.BaseCommit}}
+          <span class="text-xs text-muted-foreground">base <code>{{short $p.BaseCommit}}</code></span>
+        {{end}}
+        {{if $p.TestsAdded}}
+          <span class="badge-secondary">includes test</span>
+        {{end}}
+      </div>
+      <details class="group">
+        <summary class="text-xs text-muted-foreground cursor-pointer hover:underline">
+          How to apply
+        </summary>
+        <pre class="log mt-2">cd path/to/{{$repo.Name}}
+{{if $p.BaseCommit}}git checkout {{short $p.BaseCommit}}
+{{end}}git checkout -b fix/finding-{{$f.ID}}
+git apply --index ~/Downloads/finding-{{$f.ID}}.patch
+git commit -m "fix: {{$f.Title}}"</pre>
+      </details>
+      {{if $p.Notes}}
+        <div class="text-xs text-muted-foreground border-l-2 pl-3 mt-1">{{$p.Notes}}</div>
+      {{end}}
+    </section>
+  </details>
+  {{end}}
+
   <details class="group border-b">
     <summary class="w-full outline-none rounded-md focus-visible:ring-ring/50 focus-visible:ring-[3px]">
       <h3 class="flex flex-1 items-center justify-between gap-4 py-4 text-sm font-medium hover:underline">

--- a/internal/web/templates/finding_workflow.html
+++ b/internal/web/templates/finding_workflow.html
@@ -62,6 +62,9 @@
         <button class="btn" hx-post="/findings/{{$id}}/disclose" hx-swap="none">
           <i data-lucide="file-pen"></i> Draft disclosure
         </button>
+        <button class="btn-outline" hx-post="/findings/{{$id}}/patch" hx-swap="none">
+          <i data-lucide="wrench"></i> Propose patch
+        </button>
         <button class="btn-outline" hx-post="/findings/{{$id}}/status" hx-vals='{"status":"ready"}' hx-swap="none">
           Mark ready
         </button>

--- a/skills/patch/SKILL.md
+++ b/skills/patch/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: patch
+description: Propose a code patch for a finding. Produces a unified diff against the current HEAD plus a short rationale, written back as a finding note so the analyst can review, adjust, and open a PR themselves. The skill never pushes to the remote.
+license: MIT
+compatibility: Needs network access to the scrutineer API (http://host:port/api). Finding-scoped; runs against ./src at HEAD.
+metadata:
+  scrutineer.output_file: report.json
+  scrutineer.output_kind: freeform
+---
+
+# patch
+
+Propose a minimal code patch that fixes a confirmed finding. You are not shipping the fix; you are handing the analyst a starting diff and explaining what it does. The analyst reviews, edits if needed, and opens a PR by hand.
+
+## Workspace
+
+- `./src` — the repository at its current HEAD, on the default branch, writable
+- `./context.json` — has `scrutineer.api_base`, `scrutineer.token`, `scrutineer.repository_id`, `scrutineer.finding_id` (required; this skill only makes sense finding-scoped)
+- `./report.json` — write the patch + rationale here
+- `./schema.json` — shape of `report.json`
+
+## What to do
+
+1. Read `./context.json`. If `scrutineer.finding_id` is missing, write `{"error": "no finding_id in context.json; patch is finding-scoped"}` to `report.json` and exit 0.
+
+2. Fetch the finding: `GET {api_base}/findings/{finding_id}` with `Authorization: Bearer {token}`. Read `location`, `cwe`, `trace`, `boundary`, `validation`, `rating`. These five together tell you where the sink is, what the vulnerable input flow looks like, and what dangerous behaviour you need to stop.
+
+3. Inside `./src`, edit files to fix the finding. Constraints:
+
+   - **Minimal.** Change only what the fix requires. Do not refactor surrounding code, rename variables, reformat unrelated lines, or upgrade dependencies unless the fix inherently requires it.
+   - **In place.** Fix the sink where it lives. If the finding's `location` is `pkg/foo/bar.go:42`, that is where the patch should land (or at the nearest layer where a guard is sensible — e.g. the input validator that feeds the sink).
+   - **Consistent.** Match the existing code style and idioms. If the codebase uses a specific sanitiser, validator, or helper for similar cases, reuse it. Do not introduce a new helper module for a one-off fix.
+   - **Safe.** The patch must not break the reproduction's documented legitimate behaviour — only block the dangerous path. If you cannot tell where the dangerous path diverges from legitimate use, stop and write an inconclusive report (see below).
+   - **Include a test when practical.** If the repo has a test suite that covers the vulnerable code path, add a regression test that would fail without your patch. If the repo has no tests, or the sink is in a place that is hard to cover, skip this and say why in `rationale`.
+
+4. Once you have a working tree edit, generate a unified diff against HEAD:
+
+   ```sh
+   cd src
+   git add -N .
+   git diff HEAD -- . > /tmp/patch.diff
+   ```
+
+   Read `/tmp/patch.diff` and put its contents into `report.json` under the `patch` field. Do not commit; the diff is the artefact. If the diff is empty, something went wrong — do not write an empty patch. Write `{"error": "patch produced no diff"}` and exit 0.
+
+5. POST a finding note summarising the patch: `POST {api_base}/findings/{finding_id}/notes` with:
+
+   ```json
+   {
+     "body": "Proposed patch in scan #{scan_id}.\n\nFiles changed: ...\n\n{short rationale}\n\nApply with: `git apply` the diff from the scan report.",
+     "by": "patch"
+   }
+   ```
+
+   The note lives on the finding page; the full diff lives in `report.json` and is viewable on the scan page.
+
+6. Do not PATCH any editable fields on the finding. Specifically:
+   - Do not set `fix_commit` — that field means a shipped upstream fix, not a proposal. The analyst sets it after their PR merges.
+   - Do not set `fix_version` — same reason.
+   - Do not touch `status`. Lifecycle transitions belong to the analyst.
+
+7. Write `./report.json`:
+
+   ```json
+   {
+     "patch": "diff --git a/pkg/foo/bar.go b/pkg/foo/bar.go\n...",
+     "rationale": "Short prose — two or three sentences. What the guard is, why it blocks the trace, what legitimate input it still lets through.",
+     "files_changed": ["pkg/foo/bar.go", "pkg/foo/bar_test.go"],
+     "base_commit": "<HEAD sha from ./src>",
+     "tests_added": true,
+     "notes": "Optional: anything the analyst should know — a second sink you spotted but didn't patch, a style choice you weren't sure of, a test you couldn't write."
+   }
+   ```
+
+   `base_commit` is the HEAD sha the diff applies to. The analyst needs this to `git am` or `git apply` cleanly — if they rebased since the scan, they know the patch may not apply and can regenerate.
+
+## Refusing to patch
+
+Write `{"error": "...", "rationale": "..."}` and exit 0 in any of these cases — do not ship a bad patch:
+
+- The finding prose is too thin (empty Trace, empty Validation). You need both to know where the sink is and what behaviour to stop.
+- The fix is architectural (e.g. "rewrite this whole module to not shell out") rather than localisable. A patch skill proposes a surgical fix; larger changes are an issue comment for the maintainer, not a diff.
+- The codebase is in a language or framework you cannot confidently edit without risking regressions. It is better to say so than to produce a plausible-looking but wrong patch.
+- The finding has already been fixed upstream. Check `git log -- {location}` — if a recent commit looks like it addressed the sink, surface the SHA in `notes` and refuse to duplicate.
+
+## Constraints
+
+- Do not push. Do not commit. Do not open a PR. The scrutineer workspace is ephemeral and isolated; your diff is the only thing that survives the scan.
+- Do not add dependencies unless the vulnerability genuinely requires one (e.g. a sanitiser library the codebase already uses elsewhere). New top-level deps in a patch almost always mean the fix is in the wrong place.
+- Do not edit the lockfile, go.sum, Gemfile.lock, package-lock.json, Cargo.lock, etc. unless you also changed the manifest that owns it. Stray lockfile churn makes diffs hard to review.
+- Do not touch files outside what the fix requires. CI config, docs unrelated to the fix, README — leave alone.

--- a/skills/patch/schema.json
+++ b/skills/patch/schema.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "patch report",
+  "description": "Proposed fix for a finding. The patch field is a unified diff the analyst can apply with git apply against base_commit.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "patch": {
+      "type": "string",
+      "description": "Unified diff against HEAD (git diff HEAD output). The text that would be piped into `git apply` or `git am`."
+    },
+    "rationale": {
+      "type": "string",
+      "description": "Two or three sentences explaining what the guard is, why it blocks the trace, and what legitimate input still passes."
+    },
+    "files_changed": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Paths relative to the repo root that the patch touches."
+    },
+    "base_commit": {
+      "type": "string",
+      "description": "HEAD sha the patch applies cleanly against. Lets the analyst detect if they have rebased past the base and need to regenerate."
+    },
+    "tests_added": {
+      "type": "boolean",
+      "description": "True if the patch includes a regression test for the sink."
+    },
+    "notes": {
+      "type": "string",
+      "description": "Optional prose: a second sink you noticed, a style choice you were unsure of, a test you could not write."
+    },
+    "error": {
+      "type": "string",
+      "description": "Set only when the skill refused to produce a patch (missing finding_id, thin prose, architectural fix, already-fixed upstream, empty diff)."
+    }
+  }
+}


### PR DESCRIPTION
New finding-scoped skill that drafts a minimal unified diff plus rationale for a confirmed finding, and a UI flow for downloading and applying it.

Depends on #39 (disclose skill) which landed the \`runFindingSkill\` helper this PR reuses. Rebase after #39 merges.

### Skill

- \`skills/patch/SKILL.md\` + \`schema.json\` — finding-scoped, runs against \`./src\` at HEAD
- Produces a unified diff (\`git diff HEAD\`) plus \`rationale\`, \`files_changed\`, \`base_commit\`, \`tests_added\`, \`notes\`
- Posts a finding note summarising the change
- Never commits, pushes, or opens a PR — the analyst reviews and ships
- Refuses with a clear \`error\` field for thin prose, architectural fixes, unfamiliar languages, or already-fixed-upstream cases
- Lockfile/CI/doc churn explicitly out of scope

### UI

- \"Propose patch\" button on the triaged workflow state alongside Draft disclosure
- Finding show page renders a \"Proposed patch\" accordion when a done patch scan exists: rationale, files-changed, base commit, test flag, download button, and a collapsible \"How to apply\" with the \`git checkout / git apply / git commit\` recipe
- New routes:
  - \`POST /findings/{id}/patch\` — enqueues the patch skill
  - \`GET /findings/{id}/patch.diff\` — serves the latest done patch scan's diff as \`text/x-diff\` with \`Content-Disposition: attachment; filename=finding-{id}.patch\`

### Tests

- \`TestFindingPatchRunEnqueuesPatchSkill\`
- \`TestFindingPatchDownload\` (covers the .diff endpoint and the finding-show section)
- \`TestFindingPatchDownload_404WhenNoPatch\`

Closes #7.