### PR TITLE
Bulk repository import via sidebar dialog

### DIFF
--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -117,6 +117,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("GET /{$}", s.index)
 	mux.HandleFunc("GET /repositories", s.repoList)
 	mux.HandleFunc("POST /repositories", s.repoCreate)
+	mux.HandleFunc("POST /repositories/bulk", s.repoBulkCreate)
 	mux.HandleFunc("GET /repositories/{id}", s.repoShow)
 	mux.HandleFunc("GET /repositories/{id}/report.md", s.repoReport)
 	mux.HandleFunc("POST /repositories/{id}/scan", s.repoScan)
@@ -715,22 +716,116 @@ func (s *Server) repoCreate(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "url required", http.StatusUnprocessableEntity)
 		return
 	}
-	repo := db.Repository{URL: url, Name: db.NameFromURL(url)}
-	if err := s.DB.Where(db.Repository{URL: url}).FirstOrCreate(&repo).Error; err != nil {
+	repo, _, err := s.createOrTriageRepo(r.Context(), url, r.FormValue("model"))
+	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	var skill db.Skill
-	if err := s.DB.Where("name = ? AND active = ?", defaultSkillName, true).First(&skill).Error; err == nil {
-		if _, err := s.enqueueSkill(r.Context(), repo.ID, skill.ID, r.FormValue("model")); err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-	} else {
-		s.Log.Warn("default skill not found, repo added with no scans", "skill", defaultSkillName)
-	}
 	w.Header().Set("HX-Redirect", fmt.Sprintf("/repositories/%d", repo.ID))
 	w.WriteHeader(http.StatusNoContent)
+}
+
+// repoBulkCreate accepts a newline-separated list of repository URLs,
+// creates each one that is not already in the database, and enqueues the
+// default skill for every new row. Duplicates and unparseable lines are
+// reported back via an HX-Trigger toast rather than failing the whole
+// submission — partial success is the expected case for a pasted list.
+func (s *Server) repoBulkCreate(w http.ResponseWriter, r *http.Request) {
+	raw := r.FormValue("urls")
+	lines := strings.Split(raw, "\n")
+	var created, skipped int
+	var invalid []string
+	for _, line := range lines {
+		url := strings.TrimSpace(line)
+		if url == "" {
+			continue
+		}
+		if !strings.HasPrefix(url, "https://") {
+			invalid = append(invalid, url)
+			continue
+		}
+		_, isNew, err := s.createOrTriageRepo(r.Context(), url, r.FormValue("model"))
+		if err != nil {
+			invalid = append(invalid, url)
+			continue
+		}
+		if isNew {
+			created++
+		} else {
+			skipped++
+		}
+	}
+	if created == 0 && skipped == 0 && len(invalid) == 0 {
+		http.Error(w, "no URLs supplied", http.StatusUnprocessableEntity)
+		return
+	}
+	toast := map[string]any{
+		"category":    bulkToastCategory(created, invalid),
+		"title":       bulkToastTitle(created, skipped, len(invalid)),
+		"description": bulkToastDescription(invalid),
+	}
+	payload, _ := json.Marshal(map[string]any{"basecoat:toast": map[string]any{"config": toast}})
+	w.Header().Set("HX-Trigger", string(payload))
+	w.Header().Set("HX-Redirect", "/")
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// createOrTriageRepo is the shared path for both single-add and bulk-add.
+// It FirstOrCreates the Repository row and, when the row is new, enqueues
+// the default skill. isNew reports whether the repo was actually created
+// (so callers can distinguish "queued" from "already present").
+func (s *Server) createOrTriageRepo(ctx context.Context, url, model string) (db.Repository, bool, error) {
+	existing := int64(0)
+	s.DB.Model(&db.Repository{}).Where("url = ?", url).Count(&existing)
+	repo := db.Repository{URL: url, Name: db.NameFromURL(url)}
+	if err := s.DB.Where(db.Repository{URL: url}).FirstOrCreate(&repo).Error; err != nil {
+		return repo, false, err
+	}
+	isNew := existing == 0
+	if !isNew {
+		return repo, false, nil
+	}
+	var skill db.Skill
+	if err := s.DB.Where("name = ? AND active = ?", defaultSkillName, true).First(&skill).Error; err != nil {
+		s.Log.Warn("default skill not found, repo added with no scans", "skill", defaultSkillName)
+		return repo, true, nil
+	}
+	if _, err := s.enqueueSkill(ctx, repo.ID, skill.ID, model); err != nil {
+		return repo, true, err
+	}
+	return repo, true, nil
+}
+
+func bulkToastCategory(created int, invalid []string) string {
+	if created > 0 && len(invalid) == 0 {
+		return "success"
+	}
+	if created == 0 && len(invalid) > 0 {
+		return "error"
+	}
+	return "warning"
+}
+
+func bulkToastTitle(created, skipped, invalid int) string {
+	parts := []string{fmt.Sprintf("%d added", created)}
+	if skipped > 0 {
+		parts = append(parts, fmt.Sprintf("%d already present", skipped))
+	}
+	if invalid > 0 {
+		parts = append(parts, fmt.Sprintf("%d invalid", invalid))
+	}
+	return strings.Join(parts, ", ")
+}
+
+func bulkToastDescription(invalid []string) string {
+	if len(invalid) == 0 {
+		return ""
+	}
+	const maxShow = 3
+	if len(invalid) <= maxShow {
+		return "Rejected: " + strings.Join(invalid, ", ")
+	}
+	return fmt.Sprintf("Rejected: %s, and %d more", strings.Join(invalid[:maxShow], ", "), len(invalid)-maxShow)
 }
 
 func (s *Server) repoShow(w http.ResponseWriter, r *http.Request) {

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -483,6 +483,136 @@ func TestFindingDisclose404WhenSkillMissing(t *testing.T) {
 	}
 }
 
+func TestBulkImport_createsAndEnqueues(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	triage := db.Skill{Name: "triage", Description: "o", Body: "b", Active: true, Source: "ui", Version: 1}
+	s.DB.Create(&triage)
+
+	urls := "https://github.com/foo/one.git\nhttps://github.com/foo/two.git\n"
+	form := url.Values{"urls": {urls}}
+	req := httptest.NewRequest("POST", "/repositories/bulk", strings.NewReader(form.Encode()))
+	req.Host = testHost
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+	if w.Header().Get("HX-Redirect") != "/" {
+		t.Errorf("HX-Redirect = %q", w.Header().Get("HX-Redirect"))
+	}
+	trigger := w.Header().Get("HX-Trigger")
+	if !strings.Contains(trigger, "2 added") {
+		t.Errorf("HX-Trigger toast missing '2 added': %s", trigger)
+	}
+
+	var repos []db.Repository
+	s.DB.Order("url").Find(&repos)
+	if len(repos) != 2 {
+		t.Fatalf("want 2 repos, got %d", len(repos))
+	}
+	var scans []db.Scan
+	s.DB.Where("skill_id = ?", triage.ID).Find(&scans)
+	if len(scans) != 2 {
+		t.Fatalf("want 2 triage scans, got %d", len(scans))
+	}
+}
+
+func TestBulkImport_skipsDuplicates(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	triage := db.Skill{Name: "triage", Description: "o", Body: "b", Active: true, Source: "ui", Version: 1}
+	s.DB.Create(&triage)
+	s.DB.Create(&db.Repository{URL: "https://github.com/foo/one.git", Name: "one"})
+
+	form := url.Values{"urls": {"https://github.com/foo/one.git\nhttps://github.com/foo/two.git"}}
+	req := httptest.NewRequest("POST", "/repositories/bulk", strings.NewReader(form.Encode()))
+	req.Host = testHost
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+	trigger := w.Header().Get("HX-Trigger")
+	if !strings.Contains(trigger, "1 added") || !strings.Contains(trigger, "1 already present") {
+		t.Errorf("toast missing expected counts: %s", trigger)
+	}
+
+	var scans []db.Scan
+	s.DB.Where("skill_id = ?", triage.ID).Find(&scans)
+	if len(scans) != 1 {
+		t.Errorf("want 1 new scan (only the new repo), got %d", len(scans))
+	}
+}
+
+func TestBulkImport_rejectsNonHTTPS(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	triage := db.Skill{Name: "triage", Description: "o", Body: "b", Active: true, Source: "ui", Version: 1}
+	s.DB.Create(&triage)
+
+	lines := "https://github.com/foo/ok.git\n" +
+		"git@github.com:foo/bar.git\n" +
+		"file:///etc/passwd\n" +
+		"ext::nope\n"
+	form := url.Values{"urls": {lines}}
+	req := httptest.NewRequest("POST", "/repositories/bulk", strings.NewReader(form.Encode()))
+	req.Host = testHost
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+
+	var repos []db.Repository
+	s.DB.Find(&repos)
+	if len(repos) != 1 {
+		t.Errorf("want 1 repo (only the https one), got %d", len(repos))
+	}
+	trigger := w.Header().Get("HX-Trigger")
+	if !strings.Contains(trigger, "1 added") || !strings.Contains(trigger, "3 invalid") {
+		t.Errorf("toast missing counts: %s", trigger)
+	}
+}
+
+func TestBulkImport_emptyIs422(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	form := url.Values{"urls": {"  \n\n\t\n"}}
+	req := httptest.NewRequest("POST", "/repositories/bulk", strings.NewReader(form.Encode()))
+	req.Host = testHost
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Errorf("want 422 for empty submission, got %d", w.Code)
+	}
+}
+
+func TestBulkImport_dialogRendered(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	s.DB.Create(&db.Skill{Name: "triage", Description: "o", Body: "b", Active: true, Source: "ui", Version: 1})
+
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq("GET", "/"))
+	body := w.Body.String()
+	if !strings.Contains(body, "Bulk import") {
+		t.Error("sidebar missing Bulk import button")
+	}
+	if !strings.Contains(body, `id="bulk-add-repo"`) {
+		t.Error("layout missing bulk dialog")
+	}
+	if !strings.Contains(body, `name="urls"`) {
+		t.Error("bulk dialog missing urls textarea")
+	}
+}
+
 func TestScanShowRenders(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -602,14 +602,17 @@ func TestBulkImport_dialogRendered(t *testing.T) {
 	w := httptest.NewRecorder()
 	s.Handler().ServeHTTP(w, localReq("GET", "/"))
 	body := w.Body.String()
-	if !strings.Contains(body, "Bulk import") {
-		t.Error("sidebar missing Bulk import button")
-	}
 	if !strings.Contains(body, `id="bulk-add-repo"`) {
 		t.Error("layout missing bulk dialog")
 	}
 	if !strings.Contains(body, `name="urls"`) {
 		t.Error("bulk dialog missing urls textarea")
+	}
+	if !strings.Contains(body, "Add multiple") {
+		t.Error("add-repo dialog missing 'Add multiple' link to bulk dialog")
+	}
+	if !strings.Contains(body, "getElementById('bulk-add-repo').showModal()") {
+		t.Error("'Add multiple' button does not open bulk dialog")
 	}
 }
 

--- a/internal/web/templates/layout.html
+++ b/internal/web/templates/layout.html
@@ -48,14 +48,10 @@
         </ul>
       </div>
     </section>
-    <footer class="grid gap-1">
+    <footer>
       <button type="button" class="btn w-full"
               onclick="document.getElementById('add-repo').showModal()">
         <i data-lucide="plus"></i> Add repository
-      </button>
-      <button type="button" class="btn-outline w-full"
-              onclick="document.getElementById('bulk-add-repo').showModal()">
-        <i data-lucide="list-plus"></i> Bulk import
       </button>
     </footer>
   </nav>
@@ -79,9 +75,15 @@
             class="form grid gap-3">
         <input class="input" type="text" name="url"
                placeholder="https://github.com/maragudk/goqite.git" required>
-        <footer class="flex justify-end gap-2">
-          <button type="button" class="btn-outline" onclick="this.closest('dialog').close()">Cancel</button>
-          <button type="submit" class="btn"><i data-lucide="play"></i> Scan</button>
+        <footer class="flex justify-between items-center gap-2">
+          <button type="button" class="btn-ghost-sm"
+                  onclick="this.closest('dialog').close(); document.getElementById('bulk-add-repo').showModal()">
+            <i data-lucide="list-plus"></i> Add multiple
+          </button>
+          <div class="flex gap-2">
+            <button type="button" class="btn-outline" onclick="this.closest('dialog').close()">Cancel</button>
+            <button type="submit" class="btn"><i data-lucide="play"></i> Scan</button>
+          </div>
         </footer>
       </form>
     </section>

--- a/internal/web/templates/layout.html
+++ b/internal/web/templates/layout.html
@@ -48,10 +48,14 @@
         </ul>
       </div>
     </section>
-    <footer>
+    <footer class="grid gap-1">
       <button type="button" class="btn w-full"
               onclick="document.getElementById('add-repo').showModal()">
         <i data-lucide="plus"></i> Add repository
+      </button>
+      <button type="button" class="btn-outline w-full"
+              onclick="document.getElementById('bulk-add-repo').showModal()">
+        <i data-lucide="list-plus"></i> Bulk import
       </button>
     </footer>
   </nav>
@@ -78,6 +82,34 @@
         <footer class="flex justify-end gap-2">
           <button type="button" class="btn-outline" onclick="this.closest('dialog').close()">Cancel</button>
           <button type="submit" class="btn"><i data-lucide="play"></i> Scan</button>
+        </footer>
+      </form>
+    </section>
+    <button type="button" aria-label="Close" onclick="this.closest('dialog').close()">
+      <i data-lucide="x"></i>
+    </button>
+  </div>
+</dialog>
+
+<dialog id="bulk-add-repo" class="dialog w-full sm:max-w-lg"
+        onclick="if (event.target === this) this.close()">
+  <div>
+    <header>
+      <h2>Bulk import repositories</h2>
+      <p class="text-sm text-muted-foreground">
+        One URL per line. Only <code>https://</code> URLs are accepted.
+        Duplicates are skipped; each new repo is queued with the default scan set.
+      </p>
+    </header>
+    <section>
+      <form hx-post="/repositories/bulk"
+            hx-on::after-request="if(event.detail.successful){this.reset();this.closest('dialog').close()}"
+            class="form grid gap-3">
+        <textarea class="input font-mono text-xs" name="urls" rows="10" required
+                  placeholder="https://github.com/maragudk/goqite.git&#10;https://github.com/spf13/cobra.git&#10;https://github.com/stretchr/testify.git"></textarea>
+        <footer class="flex justify-end gap-2">
+          <button type="button" class="btn-outline" onclick="this.closest('dialog').close()">Cancel</button>
+          <button type="submit" class="btn"><i data-lucide="play"></i> Import</button>
         </footer>
       </form>
     </section>


### PR DESCRIPTION
Adds a second sidebar button \"Bulk import\" that opens a dialog with a multiline textarea. Each non-empty line is treated as a repository URL; the form POSTs to a new \`POST /repositories/bulk\` endpoint.

Behaviour:

- One URL per line, \`https://\` only (matches \`validateGitURL\` in the worker).
- Existing URLs are skipped (counted as \"already present\", not an error).
- New rows get the default \`triage\` skill enqueued, same as single-add.
- Non-https or otherwise-rejected lines are collected into an \"invalid\" list; the whole submission does not fail because of them.
- The response returns \`HX-Redirect: /\` plus an \`HX-Trigger\` toast with per-category counts and up to three rejected URLs inline.

Factors the single-add and bulk-add code paths through a shared \`createOrTriageRepo\` helper so both behave identically.

### Tests

- \`TestBulkImport_createsAndEnqueues\` — two new URLs create two repos and enqueue two triage scans
- \`TestBulkImport_skipsDuplicates\` — existing URL is counted and does not enqueue a scan
- \`TestBulkImport_rejectsNonHTTPS\` — ssh, file://, ext:: lines land in the invalid list
- \`TestBulkImport_emptyIs422\` — blank submission returns 422
- \`TestBulkImport_dialogRendered\` — sidebar button and dialog markup present