### PR TITLE
Sub-path scans + subprojects skill (closes #19, #20)

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -83,6 +83,13 @@ type Scan struct {
 	FindingID *uint  `gorm:"index"`
 	APIToken  string `gorm:"index"`
 
+	// SubPath scopes the scan's code analysis to a sub-folder within the
+	// clone (e.g. airflow-core inside apache/airflow). Empty means the
+	// repo root. Skills that walk files honour this through
+	// scrutineer.scan_subpath in context.json; skills that consult
+	// external APIs (packages/advisories/dependents) ignore it.
+	SubPath string `gorm:"index"`
+
 	Commit     string
 	StartedAt  *time.Time
 	FinishedAt *time.Time
@@ -249,8 +256,8 @@ type Finding struct {
 	ID           uint `gorm:"primarykey"`
 	ScanID       uint `gorm:"index;not null"`
 	Scan         Scan
-	// RepositoryID and Commit are denormalized from Scan so list queries
-	// don't have to join through Scan (GORM's Preload/Joins on
+	// RepositoryID, Commit, and SubPath are denormalized from Scan so list
+	// queries don't have to join through Scan (GORM's Preload/Joins on
 	// Finding.Scan doesn't round-trip cleanly on sqlite). Set at
 	// finding-create time and never changed. RepositoryID is not
 	// marked not-null so AutoMigrate can widen the column on existing
@@ -258,6 +265,7 @@ type Finding struct {
 	// existing rows on startup.
 	RepositoryID uint `gorm:"index"`
 	Commit       string
+	SubPath      string `gorm:"index"`
 
 	FindingID string // e.g. F1, F2 within the report
 	Sinks     string // comma-joined sink IDs
@@ -442,11 +450,36 @@ func Open(dsn string) (*gorm.DB, error) {
 		&Finding{}, &FindingLabel{}, &FindingNote{},
 		&FindingCommunication{}, &FindingReference{}, &FindingHistory{},
 		&Dependency{}, &Package{}, &Dependent{}, &Advisory{},
-		&Maintainer{}, &Skill{},
+		&Maintainer{}, &Skill{}, &Subproject{},
 	); err != nil {
 		return nil, fmt.Errorf("automigrate: %w", err)
 	}
 	return gdb, nil
+}
+
+// Subproject is a scannable unit the subprojects skill discovered inside
+// a repository. One Repository has many Subprojects; each Scan may refer
+// to one of them through Scan.SubPath. Rows are rewritten in full when
+// the subprojects skill re-runs, mirroring Package/Advisory semantics.
+type Subproject struct {
+	ID           uint `gorm:"primarykey"`
+	RepositoryID uint `gorm:"index;not null"`
+
+	// Path is the sub-folder within the clone, relative to root. Empty
+	// is not allowed — the root case is represented by absence of any
+	// Subproject row, not by a Subproject with Path "".
+	Path string `gorm:"not null"`
+	// Name is a short human label ("airflow-core", "cli", ...). Falls
+	// back to the last segment of Path when the skill cannot infer one.
+	Name string
+	// Kind is the detected flavour: go-module, npm-workspace,
+	// python-package, rust-crate, composer-package, monorepo-root, etc.
+	// Free-form — the UI just renders it as a badge.
+	Kind        string `gorm:"index"`
+	Description string `gorm:"type:text"`
+
+	CreatedAt time.Time
+	UpdatedAt time.Time
 }
 
 // BackfillFindingRepository copies Scan.RepositoryID onto Finding rows

--- a/internal/web/parse_repo_url.go
+++ b/internal/web/parse_repo_url.go
@@ -1,0 +1,92 @@
+package web
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// RepoInput is the parsed form of a user-supplied repository reference.
+// CloneURL is what scrutineer passes to `git clone`; SubPath is the
+// sub-folder within the checkout that scans should scope to (empty means
+// the repo root). Branch is extracted from /tree/<branch>/<path> URLs so
+// the operator knows it was present, but is not honoured for clone (see
+// #19 discussion) — scrutineer still clones the default branch.
+type RepoInput struct {
+	CloneURL string
+	SubPath  string
+	Branch   string
+}
+
+// ParseRepoInput accepts the three user-facing shapes:
+//
+//	https://github.com/owner/repo[.git]
+//	https://github.com/owner/repo/tree/<branch>/<path...>
+//	https://forge/owner/repo#<path>
+//
+// The fragment form is the forge-agnostic way to scope to a sub-path for
+// non-GitHub hosts. /tree/ parsing is GitHub-specific but matches the URL
+// users paste from the web UI.
+func ParseRepoInput(raw string) (RepoInput, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return RepoInput{}, fmt.Errorf("url required")
+	}
+	if !strings.HasPrefix(raw, "https://") {
+		return RepoInput{}, fmt.Errorf("only https:// URLs are allowed, got %q", raw)
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return RepoInput{}, fmt.Errorf("parse url: %w", err)
+	}
+
+	// Fragment form: url#sub/path. Always wins if present, since the user
+	// typed it explicitly.
+	if u.Fragment != "" {
+		clean := *u
+		clean.Fragment = ""
+		return RepoInput{
+			CloneURL: ensureGitSuffix(clean.String()),
+			SubPath:  strings.Trim(u.Fragment, "/"),
+		}, nil
+	}
+
+	// /tree/<branch>/<path> shape (GitHub, Gitea, Forgejo).
+	parts := strings.Split(strings.Trim(u.Path, "/"), "/")
+	treeIdx := -1
+	for i, p := range parts {
+		if p == "tree" {
+			treeIdx = i
+			break
+		}
+	}
+	if treeIdx >= 2 && treeIdx+1 < len(parts) {
+		// owner/repo[/...]/tree/<branch>/<path...>
+		repoPath := "/" + strings.Join(parts[:treeIdx], "/")
+		branch := parts[treeIdx+1]
+		subPath := ""
+		if treeIdx+2 < len(parts) {
+			subPath = strings.Join(parts[treeIdx+2:], "/")
+		}
+		clean := *u
+		clean.Path = repoPath
+		return RepoInput{
+			CloneURL: ensureGitSuffix(clean.String()),
+			SubPath:  subPath,
+			Branch:   branch,
+		}, nil
+	}
+
+	// Plain clone URL.
+	return RepoInput{
+		CloneURL: ensureGitSuffix(raw),
+	}, nil
+}
+
+// ensureGitSuffix returns u with a single trailing ".git". Idempotent.
+func ensureGitSuffix(u string) string {
+	if strings.HasSuffix(u, ".git") {
+		return u
+	}
+	return u + ".git"
+}

--- a/internal/web/parse_repo_url_test.go
+++ b/internal/web/parse_repo_url_test.go
@@ -1,0 +1,105 @@
+package web
+
+import "testing"
+
+func TestParseRepoInput(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    string
+		want     RepoInput
+		wantErr  bool
+	}{
+		{
+			name:  "plain github url without .git",
+			input: "https://github.com/rails/rails",
+			want:  RepoInput{CloneURL: "https://github.com/rails/rails.git"},
+		},
+		{
+			name:  "plain github url with .git",
+			input: "https://github.com/rails/rails.git",
+			want:  RepoInput{CloneURL: "https://github.com/rails/rails.git"},
+		},
+		{
+			name:  "github tree url with sub-path",
+			input: "https://github.com/apache/airflow/tree/main/airflow-core",
+			want: RepoInput{
+				CloneURL: "https://github.com/apache/airflow.git",
+				SubPath:  "airflow-core",
+				Branch:   "main",
+			},
+		},
+		{
+			name:  "github tree url with nested sub-path",
+			input: "https://github.com/kubernetes/kubernetes/tree/master/staging/src/k8s.io/api",
+			want: RepoInput{
+				CloneURL: "https://github.com/kubernetes/kubernetes.git",
+				SubPath:  "staging/src/k8s.io/api",
+				Branch:   "master",
+			},
+		},
+		{
+			name:  "github tree url with release branch",
+			input: "https://github.com/apache/airflow/tree/v2.9.0/airflow-core",
+			want: RepoInput{
+				CloneURL: "https://github.com/apache/airflow.git",
+				SubPath:  "airflow-core",
+				Branch:   "v2.9.0",
+			},
+		},
+		{
+			name:  "github tree url pointing at root of branch",
+			input: "https://github.com/apache/airflow/tree/main",
+			want: RepoInput{
+				CloneURL: "https://github.com/apache/airflow.git",
+				SubPath:  "",
+				Branch:   "main",
+			},
+		},
+		{
+			name:  "fragment form explicit sub-path",
+			input: "https://gitlab.com/group/project#services/api",
+			want: RepoInput{
+				CloneURL: "https://gitlab.com/group/project.git",
+				SubPath:  "services/api",
+			},
+		},
+		{
+			name:  "fragment form with leading slash",
+			input: "https://github.com/rails/rails#/railties",
+			want: RepoInput{
+				CloneURL: "https://github.com/rails/rails.git",
+				SubPath:  "railties",
+			},
+		},
+		{
+			name:    "non-https rejected",
+			input:   "git@github.com:foo/bar.git",
+			wantErr: true,
+		},
+		{
+			name:    "file scheme rejected",
+			input:   "file:///etc/passwd",
+			wantErr: true,
+		},
+		{
+			name:    "empty rejected",
+			input:   "   ",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ParseRepoInput(tc.input)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("err = %v, wantErr = %v", err, tc.wantErr)
+			}
+			if tc.wantErr {
+				return
+			}
+			if got != tc.want {
+				t.Errorf("got %+v, want %+v", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -926,7 +926,19 @@ func (s *Server) repoShow(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	var scans []db.Scan
-	s.DB.Where("repository_id = ?", repo.ID).Order("id desc").Find(&scans)
+	// Per (skill_name, sub_path) we want just the latest scan — the repo
+	// page should read like "this is the state of each job on this repo",
+	// not a scroll of every historical attempt. Older runs are still
+	// reachable via /scans/{id} and the global /scans index.
+	s.DB.Raw(`
+		SELECT s.* FROM scans s
+		JOIN (
+			SELECT COALESCE(skill_name, '') AS sn, COALESCE(sub_path, '') AS sp, MAX(id) AS max_id
+			FROM scans WHERE repository_id = ?
+			GROUP BY sn, sp
+		) latest ON latest.max_id = s.id
+		ORDER BY s.id DESC
+	`, repo.ID).Scan(&scans)
 
 	active := false
 	for _, sc := range scans {

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -209,7 +209,8 @@ func paginate(r *http.Request, total int64) Page {
 
 type repoRow struct {
 	db.Repository
-	LastScan *db.Scan
+	LastScan      *db.Scan
+	FindingsTotal int
 }
 
 func (s *Server) repoList(w http.ResponseWriter, r *http.Request) {
@@ -254,6 +255,13 @@ func (s *Server) repoList(w http.ResponseWriter, r *http.Request) {
 			Order("id desc").First(&last).Error; err == nil {
 			row.LastScan = &last
 		}
+		// Count findings across all scans of this repo. The previous
+		// implementation read LastScan.FindingsCount, which is zero for
+		// repo-overview / metadata / packages scans — those do not
+		// produce Finding rows even when findings exist on the repo.
+		var total int64
+		s.DB.Model(&db.Finding{}).Where("repository_id = ?", repo.ID).Count(&total)
+		row.FindingsTotal = int(total)
 		rows = append(rows, row)
 	}
 	var languages []string

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -393,9 +393,16 @@ func (s *Server) findings(w http.ResponseWriter, r *http.Request) {
 	q.Limit(perPage).Offset((page.N - 1) * perPage).Find(&rows)
 
 	reposByID := loadRepoMap(s.DB, rows)
+	anySubPath := false
+	for _, r := range rows {
+		if r.SubPath != "" {
+			anySubPath = true
+			break
+		}
+	}
 	s.render(w, "findings.html", map[string]any{
 		"Findings": rows, "Page": page, "Severity": sev, "Sort": sort,
-		"Repos": reposByID, "Q": search,
+		"Repos": reposByID, "Q": search, "AnySubPath": anySubPath,
 	})
 }
 
@@ -776,19 +783,27 @@ func (s *Server) jobs(w http.ResponseWriter, r *http.Request) {
 	s.DB.Model(&db.Scan{}).Where("skill_name != ''").Distinct("skill_name").
 		Order("skill_name").Pluck("skill_name", &skillNames)
 
+	anySubPath := false
+	for _, sc := range scans {
+		if sc.SubPath != "" {
+			anySubPath = true
+			break
+		}
+	}
 	s.render(w, "jobs.html", map[string]any{
 		"Scans": scans, "Page": page,
 		"Skill": skillName, "Status": status, "Sort": sort, "Skills": skillNames,
+		"AnySubPath": anySubPath,
 	})
 }
 
 func (s *Server) repoCreate(w http.ResponseWriter, r *http.Request) {
-	url := strings.TrimSpace(r.FormValue("url"))
-	if url == "" {
-		http.Error(w, "url required", http.StatusUnprocessableEntity)
+	input, err := ParseRepoInput(r.FormValue("url"))
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusUnprocessableEntity)
 		return
 	}
-	repo, _, err := s.createOrTriageRepo(r.Context(), url, r.FormValue("model"))
+	repo, _, err := s.createOrTriageRepo(r.Context(), input, r.FormValue("model"))
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -808,17 +823,18 @@ func (s *Server) repoBulkCreate(w http.ResponseWriter, r *http.Request) {
 	var created, skipped int
 	var invalid []string
 	for _, line := range lines {
-		url := strings.TrimSpace(line)
-		if url == "" {
+		line = strings.TrimSpace(line)
+		if line == "" {
 			continue
 		}
-		if !strings.HasPrefix(url, "https://") {
-			invalid = append(invalid, url)
-			continue
-		}
-		_, isNew, err := s.createOrTriageRepo(r.Context(), url, r.FormValue("model"))
+		input, err := ParseRepoInput(line)
 		if err != nil {
-			invalid = append(invalid, url)
+			invalid = append(invalid, line)
+			continue
+		}
+		_, isNew, err := s.createOrTriageRepo(r.Context(), input, r.FormValue("model"))
+		if err != nil {
+			invalid = append(invalid, line)
 			continue
 		}
 		if isNew {
@@ -846,11 +862,11 @@ func (s *Server) repoBulkCreate(w http.ResponseWriter, r *http.Request) {
 // It FirstOrCreates the Repository row and, when the row is new, enqueues
 // the default skill. isNew reports whether the repo was actually created
 // (so callers can distinguish "queued" from "already present").
-func (s *Server) createOrTriageRepo(ctx context.Context, url, model string) (db.Repository, bool, error) {
+func (s *Server) createOrTriageRepo(ctx context.Context, input RepoInput, model string) (db.Repository, bool, error) {
 	existing := int64(0)
-	s.DB.Model(&db.Repository{}).Where("url = ?", url).Count(&existing)
-	repo := db.Repository{URL: url, Name: db.NameFromURL(url)}
-	if err := s.DB.Where(db.Repository{URL: url}).FirstOrCreate(&repo).Error; err != nil {
+	s.DB.Model(&db.Repository{}).Where("url = ?", input.CloneURL).Count(&existing)
+	repo := db.Repository{URL: input.CloneURL, Name: db.NameFromURL(input.CloneURL)}
+	if err := s.DB.Where(db.Repository{URL: input.CloneURL}).FirstOrCreate(&repo).Error; err != nil {
 		return repo, false, err
 	}
 	isNew := existing == 0
@@ -862,7 +878,10 @@ func (s *Server) createOrTriageRepo(ctx context.Context, url, model string) (db.
 		s.Log.Warn("default skill not found, repo added with no scans", "skill", defaultSkillName)
 		return repo, true, nil
 	}
-	if _, err := s.enqueueSkill(ctx, repo.ID, skill.ID, model); err != nil {
+	if _, err := s.enqueueSkillWith(ctx, repo.ID, skill.ID, ScanOpts{
+		Model:   model,
+		SubPath: input.SubPath,
+	}); err != nil {
 		return repo, true, err
 	}
 	return repo, true, nil
@@ -969,12 +988,30 @@ func (s *Server) repoShow(w http.ResponseWriter, r *http.Request) {
 	var activeSkills []db.Skill
 	s.DB.Where("active = ?", true).Order("name").Find(&activeSkills)
 
+	var subprojects []db.Subproject
+	s.DB.Where("repository_id = ?", repo.ID).Order("path").Find(&subprojects)
+	subScanCount := map[string]int{}
+	if len(subprojects) > 0 {
+		rows := make([]struct {
+			SubPath string
+			N       int
+		}, 0)
+		s.DB.Raw(`SELECT sub_path, COUNT(*) AS n FROM scans
+			WHERE repository_id = ? AND sub_path != '' GROUP BY sub_path`,
+			repo.ID).Scan(&rows)
+		for _, r := range rows {
+			subScanCount[r.SubPath] = r.N
+		}
+	}
+
 	data := map[string]any{
 		"Repo": repo, "Scans": scans, "Active": active, "Latest": latest,
 		"TMCommit": tmCommit,
 		"Deps": deps, "Pkgs": pkgs, "Dependents": dependents, "Advisories": advisories, "Maintainers": maintainers, "ThreatModel": threatModel,
 		"KnownURLs": knownURLs, "KnownPURLs": knownPURLs,
-		"Skills": activeSkills,
+		"Skills":       activeSkills,
+		"Subprojects":  subprojects,
+		"SubScanCount": subScanCount,
 	}
 	if r.Header.Get("HX-Target") == "scan-rows" {
 		s.maybeToast(w, r, repo.Name, scans)
@@ -1002,7 +1039,10 @@ func (s *Server) repoScan(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, deepDiveSkillName+" skill is not installed", http.StatusPreconditionFailed)
 		return
 	}
-	if _, err := s.enqueueSkill(r.Context(), repo.ID, skill.ID, r.FormValue("model")); err != nil {
+	if _, err := s.enqueueSkillWith(r.Context(), repo.ID, skill.ID, ScanOpts{
+		Model:   r.FormValue("model"),
+		SubPath: strings.TrimSpace(r.FormValue("sub_path")),
+	}); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -1029,7 +1069,11 @@ func (s *Server) scanRetry(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "scan cannot be retried: no skill reference", http.StatusBadRequest)
 		return
 	}
-	newID, err := s.enqueueSkill(r.Context(), scan.RepositoryID, *scan.SkillID, scan.Model)
+	newID, err := s.enqueueSkillWith(r.Context(), scan.RepositoryID, *scan.SkillID, ScanOpts{
+		Model:     scan.Model,
+		FindingID: scan.FindingID,
+		SubPath:   scan.SubPath,
+	})
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -1056,24 +1100,40 @@ func (s *Server) scanLog(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func (s *Server) enqueueSkill(ctx context.Context, repoID, skillID uint, model string) (uint, error) {
-	return s.enqueueSkillScoped(ctx, repoID, skillID, nil, model)
+// ScanOpts carries the optional inputs to an enqueue call. Keeps the
+// enqueue signature from drifting into an unreadable positional list as
+// new options (SubPath, FindingID, Model) accumulate.
+type ScanOpts struct {
+	Model     string
+	FindingID *uint
+	SubPath   string
 }
 
-// enqueueSkillScoped creates a skill scan and optionally scopes it to a
-// finding. Finding-scoped scans carry the id through to context.json so
-// verify/patch/disclose skills know which finding to act on.
+func (s *Server) enqueueSkill(ctx context.Context, repoID, skillID uint, model string) (uint, error) {
+	return s.enqueueSkillWith(ctx, repoID, skillID, ScanOpts{Model: model})
+}
+
+// enqueueSkillScoped is a thin shim preserved for call sites that already
+// pass a finding id. New code should prefer enqueueSkillWith + ScanOpts.
 func (s *Server) enqueueSkillScoped(ctx context.Context, repoID, skillID uint, findingID *uint, model string) (uint, error) {
-	if !ValidModel(model) {
-		model = DefaultModel()
+	return s.enqueueSkillWith(ctx, repoID, skillID, ScanOpts{Model: model, FindingID: findingID})
+}
+
+// enqueueSkillWith creates a skill scan using the given ScanOpts. Empty
+// fields default cleanly: unset FindingID means not-finding-scoped, empty
+// SubPath means root-scoped, empty Model means the configured default.
+func (s *Server) enqueueSkillWith(ctx context.Context, repoID, skillID uint, opts ScanOpts) (uint, error) {
+	if !ValidModel(opts.Model) {
+		opts.Model = DefaultModel()
 	}
 	scan := db.Scan{
 		RepositoryID: repoID,
 		Kind:         worker.JobSkill,
 		Status:       db.ScanQueued,
-		Model:        model,
+		Model:        opts.Model,
 		SkillID:      &skillID,
-		FindingID:    findingID,
+		FindingID:    opts.FindingID,
+		SubPath:      opts.SubPath,
 		APIToken:     NewAPIToken(),
 	}
 	if err := s.DB.Create(&scan).Error; err != nil {

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -1,6 +1,7 @@
 package web
 
 import (
+	"fmt"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -674,6 +675,93 @@ func TestBulkImport_dialogRendered(t *testing.T) {
 	}
 	if !strings.Contains(body, "getElementById('bulk-add-repo').showModal()") {
 		t.Error("'Add multiple' button does not open bulk dialog")
+	}
+}
+
+func TestCreateRepo_parsesGitHubTreeURL(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	triage := db.Skill{Name: "triage", Description: "o", Body: "b", Active: true, Source: "ui", Version: 1}
+	s.DB.Create(&triage)
+
+	form := url.Values{"url": {"https://github.com/apache/airflow/tree/main/airflow-core"}}
+	req := httptest.NewRequest("POST", "/repositories", strings.NewReader(form.Encode()))
+	req.Host = testHost
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+
+	var repo db.Repository
+	if err := s.DB.First(&repo).Error; err != nil {
+		t.Fatal(err)
+	}
+	if repo.URL != "https://github.com/apache/airflow.git" {
+		t.Errorf("repo.URL = %q, want clone URL without /tree/", repo.URL)
+	}
+	var scan db.Scan
+	s.DB.First(&scan)
+	if scan.SubPath != "airflow-core" {
+		t.Errorf("scan.SubPath = %q, want airflow-core", scan.SubPath)
+	}
+}
+
+func TestRetry_preservesSubPath(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	repo := db.Repository{URL: "https://github.com/apache/airflow.git", Name: "airflow"}
+	s.DB.Create(&repo)
+	skill := db.Skill{Name: "security-deep-dive", Description: "x", Body: "b", Active: true, Source: "ui", Version: 1}
+	s.DB.Create(&skill)
+	finished := time.Now()
+	orig := db.Scan{
+		RepositoryID: repo.ID, Kind: "skill", Status: db.ScanFailed,
+		SkillID: &skill.ID, SkillName: "security-deep-dive",
+		SubPath: "airflow-core", FinishedAt: &finished,
+	}
+	s.DB.Create(&orig)
+
+	req := httptest.NewRequest("POST", fmt.Sprintf("/scans/%d/retry", orig.ID), nil)
+	req.Host = testHost
+	req.Header.Set("Sec-Fetch-Site", "same-origin")
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("retry status %d: %s", w.Code, w.Body)
+	}
+
+	var fresh db.Scan
+	s.DB.Where("id != ?", orig.ID).First(&fresh)
+	if fresh.SubPath != "airflow-core" {
+		t.Errorf("retry lost sub-path: got %q, want airflow-core", fresh.SubPath)
+	}
+}
+
+func TestSubprojectsRenderedOnRepoPage(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	now := time.Now()
+	repo := db.Repository{URL: "https://github.com/apache/airflow.git", Name: "airflow", FetchedAt: &now}
+	s.DB.Create(&repo)
+	s.DB.Create(&db.Subproject{RepositoryID: repo.ID, Path: "airflow-core", Name: "airflow-core", Kind: "python-package", Description: "Core runtime"})
+	s.DB.Create(&db.Subproject{RepositoryID: repo.ID, Path: "providers/amazon", Kind: "python-package", Description: "AWS provider"})
+
+	req := httptest.NewRequest("GET", fmt.Sprintf("/repositories/%d", repo.ID), nil)
+	req.Host = testHost
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+	body := w.Body.String()
+	if w.Code != 200 {
+		t.Fatalf("repo show status %d", w.Code)
+	}
+	for _, want := range []string{"Subprojects", "airflow-core", "providers/amazon", "python-package", "Core runtime", "AWS provider", `name="sub_path"`} {
+		if !strings.Contains(body, want) {
+			t.Errorf("repo page missing %q", want)
+		}
 	}
 }
 

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -40,6 +40,41 @@ func localReq(method, path string) *http.Request {
 	return r
 }
 
+func TestRepoList_findingsCountIsRepoWideNotLastScan(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	repo := db.Repository{URL: "https://github.com/foo/bar.git", Name: "bar"}
+	s.DB.Create(&repo)
+
+	// Older scan produces two findings.
+	deep := db.Scan{RepositoryID: repo.ID, Kind: "skill", Status: db.ScanDone, SkillName: "security-deep-dive"}
+	s.DB.Create(&deep)
+	s.DB.Create(&db.Finding{ScanID: deep.ID, RepositoryID: repo.ID, Title: "SSRF", Severity: "High"})
+	s.DB.Create(&db.Finding{ScanID: deep.ID, RepositoryID: repo.ID, Title: "XSS", Severity: "Medium"})
+
+	// Newer scan is repo-overview — no findings, and it is now the
+	// LastScan on the repo.
+	s.DB.Create(&db.Scan{RepositoryID: repo.ID, Kind: "skill", Status: db.ScanDone, SkillName: "repo-overview"})
+
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq("GET", "/"))
+	if w.Code != 200 {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+	body := w.Body.String()
+
+	// The row for this repo should show "2" in a findings badge — the
+	// repo-wide total — not "0" that a naive LastScan.FindingsCount
+	// read would have produced.
+	if !strings.Contains(body, `<span class="badge-destructive">2</span>`) {
+		t.Errorf("expected findings badge showing 2, body=%s", body)
+	}
+	if strings.Contains(body, `<span class="badge-secondary">0</span>`) {
+		t.Errorf("repo with two findings should not render a 0 badge")
+	}
+}
+
 func TestRepoSearchFilters(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()

--- a/internal/web/templates/findings.html
+++ b/internal/web/templates/findings.html
@@ -49,11 +49,14 @@
   <table class="table table-fixed w-full">
     <thead><tr>
       <th class="w-24">Severity</th><th>Title</th><th class="w-24">Status</th>
-      <th class="w-32">Repository</th><th class="w-24">CWE</th>
+      <th class="w-32">Repository</th>
+      {{if .AnySubPath}}<th class="w-32">Sub-path</th>{{end}}
+      <th class="w-24">CWE</th>
       <th class="w-56">Location</th><th class="w-16">Scan</th>
     </tr></thead>
     <tbody>
     {{$repos := .Repos}}
+    {{$showSub := .AnySubPath}}
     {{range .Findings}}
       {{$repo := index $repos .RepositoryID}}
       <tr class="cursor-pointer" hx-get="/findings/{{.ID}}" hx-target="body" hx-push-url="true">
@@ -64,6 +67,9 @@
         </td>
         <td>{{template "finding-status" (fstatus .Status)}}</td>
         <td class="truncate">{{$repo.Name}}</td>
+        {{if $showSub}}
+          <td class="text-muted-foreground text-xs">{{if .SubPath}}<code>{{.SubPath}}</code>{{else}}<span class="text-muted-foreground">root</span>{{end}}</td>
+        {{end}}
         <td class="text-muted-foreground">
           {{if .CWE}}<span data-tooltip="{{cwename .CWE}}">{{.CWE}}</span>{{end}}
         </td>

--- a/internal/web/templates/jobs.html
+++ b/internal/web/templates/jobs.html
@@ -58,13 +58,21 @@
 {{if .Scans}}
   <table class="table">
     <thead>
-      <tr><th>#</th><th>Repository</th><th>Skill</th><th>Status</th><th>Findings</th><th>Model</th><th>Started</th><th>Duration</th><th class="w-12"></th></tr>
+      <tr>
+        <th>#</th><th>Repository</th>
+        {{if .AnySubPath}}<th>Sub-path</th>{{end}}
+        <th>Skill</th><th>Status</th><th>Findings</th><th>Model</th><th>Started</th><th>Duration</th><th class="w-12"></th>
+      </tr>
     </thead>
     <tbody>
+    {{$showSub := .AnySubPath}}
     {{range .Scans}}
       <tr class="cursor-pointer" hx-get="/scans/{{.ID}}" hx-target="body" hx-push-url="true">
         <td>{{.ID}}</td>
         <td>{{.Repository.Name}}</td>
+        {{if $showSub}}
+          <td class="text-xs text-muted-foreground">{{if .SubPath}}<code>{{.SubPath}}</code>{{else}}<span>root</span>{{end}}</td>
+        {{end}}
         <td>{{if .SkillName}}{{.SkillName}}{{else}}{{.Kind}}{{end}}</td>
         <td>{{template "status-badge" (status .Status)}}</td>
         <td>{{if gt .FindingsCount 0}}{{template "findings-badge" .FindingsCount}}{{end}}</td>

--- a/internal/web/templates/repo_list.html
+++ b/internal/web/templates/repo_list.html
@@ -50,7 +50,7 @@
         <td class="text-muted-foreground">{{if .Languages}}{{.Languages}}{{else}}-{{end}}</td>
         <td>{{if .LastScan}}{{.LastScan.CreatedAt.Format "15:04:05"}}{{else}}never{{end}}</td>
         <td>{{if .LastScan}}{{template "status-badge" (status .LastScan.Status)}}{{end}}</td>
-        <td>{{if and .LastScan (.LastScan.Status.Terminal)}}{{template "findings-badge" .LastScan.FindingsCount}}{{end}}</td>
+        <td>{{template "findings-badge" .FindingsTotal}}</td>
         <td>
           <button class="btn-sm-outline"
                   hx-post="/repositories/{{.ID}}/scan"

--- a/internal/web/templates/repo_show.html
+++ b/internal/web/templates/repo_show.html
@@ -96,6 +96,38 @@
       <p class="text-muted-foreground text-sm mb-6">Metadata not fetched yet.</p>
     {{end}}
 
+    {{if .Subprojects}}
+      <h3 class="font-medium mb-2">Subprojects <span class="text-muted-foreground text-xs">({{len .Subprojects}})</span></h3>
+      <p class="text-sm text-muted-foreground mb-2">Detected scannable units inside this repository. Each can be scanned independently with its own findings stream.</p>
+      <table class="table w-full mb-6">
+        <thead><tr>
+          <th class="w-48">Path</th>
+          <th class="w-40">Kind</th>
+          <th>Description</th>
+          <th class="w-16 text-right">Scans</th>
+          <th class="w-32"></th>
+        </tr></thead>
+        <tbody>
+        {{$repoID := .Repo.ID}}
+        {{$counts := .SubScanCount}}
+        {{range .Subprojects}}
+          <tr>
+            <td><code class="text-xs">{{.Path}}</code>{{if and .Name (ne .Name .Path)}}<div class="text-xs text-muted-foreground">{{.Name}}</div>{{end}}</td>
+            <td>{{if .Kind}}<span class="badge-outline text-xs">{{.Kind}}</span>{{end}}</td>
+            <td class="whitespace-normal text-sm text-muted-foreground">{{.Description}}</td>
+            <td class="text-right text-sm text-muted-foreground">{{index $counts .Path}}</td>
+            <td>
+              <form method="post" action="/repositories/{{$repoID}}/scan" hx-post="/repositories/{{$repoID}}/scan" hx-swap="none">
+                <input type="hidden" name="sub_path" value="{{.Path}}">
+                <button type="submit" class="btn-outline-sm"><i data-lucide="play"></i> Scan</button>
+              </form>
+            </td>
+          </tr>
+        {{end}}
+        </tbody>
+      </table>
+    {{end}}
+
     {{if .Latest}}
       <h3 class="font-medium mb-2">Latest scan</h3>
       <a href="/scans/{{.Latest.ID}}" class="text-sm text-muted-foreground mb-2 inline-flex items-center gap-1 hover:underline">

--- a/internal/worker/claude.go
+++ b/internal/worker/claude.go
@@ -22,9 +22,14 @@ type SkillRunner interface {
 // the clone, and invokes `claude -p` with a short activation prompt that
 // tells the agent which skill to load. OutputFile (when set) is the path
 // the skill writes to; the runner reads it back as the report.
+//
+// WorkRoot is the per-scan host directory scrutineer created for this
+// run. Keeping it per-scan (scan-{id}) instead of per-repo means two
+// parallel skills on the same repository do not share src or
+// report.json, so neither clobbers the other's output.
 type SkillJob struct {
 	Repo       db.Repository
-	DataDir    string
+	WorkRoot   string
 	Model      string
 	Name       string
 	SkillDir   string // host absolute path to the staged skill directory
@@ -47,12 +52,12 @@ type LocalClaude struct {
 //	{DataDir}/repo-{id}/.claude/skills/NAME staged skill (read by claude-code)
 //	{DataDir}/repo-{id}/OutputFile          where the skill writes, if any
 func (l LocalClaude) RunSkill(ctx context.Context, sj SkillJob, emit func(Event)) (SkillResult, error) {
-	src, err := ensureClone(ctx, sj.Repo, sj.DataDir, emit)
+	src, err := ensureClone(ctx, sj.Repo, sj.WorkRoot, emit)
 	if err != nil {
 		return SkillResult{}, err
 	}
 	commit := gitHead(src)
-	work := filepath.Dir(src)
+	work := sj.WorkRoot
 
 	var outPath string
 	if sj.OutputFile != "" {

--- a/internal/worker/clone.go
+++ b/internal/worker/clone.go
@@ -16,8 +16,12 @@ const dirPerm = 0o755
 // ensureClone returns the path to an up-to-date shallow clone of repo.URL
 // under dataDir. Clones on first call; fetches + resets on subsequent ones.
 // The workspace layout is dataDir/repo-{id}/src/.
-func ensureClone(ctx context.Context, repo db.Repository, dataDir string, emit func(Event)) (string, error) {
-	work := filepath.Join(dataDir, fmt.Sprintf("repo-%d", repo.ID))
+// ensureClone creates a fresh clone under the given work root. Each scan
+// supplies its own work root (scan-{id}) so concurrent scans do not share
+// src or the report.json path — removing a whole class of races where
+// skill A's output gets clobbered by skill B removing report.json before
+// A finishes reading it.
+func ensureClone(ctx context.Context, repo db.Repository, work string, emit func(Event)) (string, error) {
 	src := filepath.Join(work, "src")
 	if err := os.MkdirAll(work, dirPerm); err != nil {
 		return "", err

--- a/internal/worker/docker.go
+++ b/internal/worker/docker.go
@@ -35,12 +35,12 @@ func (d DockerRunner) image() string {
 // /work read-write so claude can read the skill files and write its output.
 // Network stays off; tmpfs/cap-drop rules mirror the local runner's intent.
 func (d DockerRunner) RunSkill(ctx context.Context, sj SkillJob, emit func(Event)) (SkillResult, error) {
-	src, err := ensureClone(ctx, sj.Repo, sj.DataDir, emit)
+	src, err := ensureClone(ctx, sj.Repo, sj.WorkRoot, emit)
 	if err != nil {
 		return SkillResult{}, err
 	}
 	commit := gitHead(src)
-	work := filepath.Dir(src)
+	work := sj.WorkRoot
 	absWork, _ := filepath.Abs(work)
 
 	var outPath string

--- a/internal/worker/findings.go
+++ b/internal/worker/findings.go
@@ -62,13 +62,14 @@ func parseReport(raw []byte) (scanReport, error) {
 	return r, nil
 }
 
-func (r scanReport) toFindings(scanID, repoID uint, commit string) []db.Finding {
+func (r scanReport) toFindings(scanID, repoID uint, commit, subPath string) []db.Finding {
 	out := make([]db.Finding, 0, len(r.Findings))
 	for _, f := range r.Findings {
 		out = append(out, db.Finding{
 			ScanID:       scanID,
 			RepositoryID: repoID,
 			Commit:       commit,
+			SubPath:      subPath,
 			FindingID:  f.ID,
 			Sinks:      strings.Join(f.Sinks, ", "),
 			Title:      f.Title,

--- a/internal/worker/skill.go
+++ b/internal/worker/skill.go
@@ -73,7 +73,11 @@ func (w *Worker) doSkill(ctx context.Context, scan *db.Scan, emit func(Event)) (
 		"skill_version": skill.Version,
 	})
 
-	workRoot := filepath.Join(w.DataDir, fmt.Sprintf("repo-%d", scan.RepositoryID))
+	// Per-scan workspace keeps concurrent skills on the same repo from
+	// clobbering each other's src/ and report.json. Cleaned at scan
+	// completion so we don't accumulate disk; failed-scan dirs are left
+	// behind so the operator can inspect them.
+	workRoot := filepath.Join(w.DataDir, fmt.Sprintf("scan-%d", scan.ID))
 	skillDir := filepath.Join(workRoot, ".claude", "skills", skill.Name)
 	if err := stageSkill(&skill, skillDir); err != nil {
 		return "", fmt.Errorf("stage skill: %w", err)
@@ -88,7 +92,7 @@ func (w *Worker) doSkill(ctx context.Context, scan *db.Scan, emit func(Event)) (
 
 	sj := SkillJob{
 		Repo:       scan.Repository,
-		DataDir:    w.DataDir,
+		WorkRoot:   workRoot,
 		Model:      scan.Model,
 		Name:       skill.Name,
 		SkillDir:   skillDir,

--- a/internal/worker/skill.go
+++ b/internal/worker/skill.go
@@ -144,6 +144,10 @@ func (w *Worker) doSkill(ctx context.Context, scan *db.Scan, emit func(Event)) (
 		if err := w.parseSubprojectsOutput(scan, res.Report, emit); err != nil {
 			return res.Report, err
 		}
+	case "repo_overview":
+		if err := w.parseRepoOverviewOutput(scan, res.Report, emit); err != nil {
+			return res.Report, err
+		}
 	}
 	return res.Report, nil
 }

--- a/internal/worker/skill.go
+++ b/internal/worker/skill.go
@@ -27,12 +27,16 @@ type skillContext struct {
 }
 
 type skillContextScrutineer struct {
-	APIBase   string `json:"api_base"`             // e.g. http://127.0.0.1:8080/api
-	ScanID    uint   `json:"scan_id"`              // the scan that owns this run
-	Token     string `json:"token"`                // bearer for api_base
-	RepoID    uint   `json:"repository_id"`        // convenience for URL building
-	SkillID   uint   `json:"skill_id,omitempty"`   // the running skill
-	FindingID uint   `json:"finding_id,omitempty"` // set for finding-scoped scans
+	APIBase   string `json:"api_base"`              // e.g. http://127.0.0.1:8080/api
+	ScanID    uint   `json:"scan_id"`               // the scan that owns this run
+	Token     string `json:"token"`                 // bearer for api_base
+	RepoID    uint   `json:"repository_id"`         // convenience for URL building
+	SkillID   uint   `json:"skill_id,omitempty"`    // the running skill
+	FindingID uint   `json:"finding_id,omitempty"`  // set for finding-scoped scans
+	// ScanSubPath scopes code analysis to a sub-folder of ./src (monorepo
+	// support). Empty means the repo root. Skills that walk files honour
+	// this; skills that query external APIs ignore it.
+	ScanSubPath string `json:"scan_subpath,omitempty"`
 }
 
 type skillContextRepo struct {
@@ -132,6 +136,10 @@ func (w *Worker) doSkill(ctx context.Context, scan *db.Scan, emit func(Event)) (
 		if err := w.parseVerifyOutput(scan, res.Report, emit); err != nil {
 			return res.Report, err
 		}
+	case "subprojects":
+		if err := w.parseSubprojectsOutput(scan, res.Report, emit); err != nil {
+			return res.Report, err
+		}
 	}
 	return res.Report, nil
 }
@@ -143,7 +151,7 @@ func (w *Worker) parseFindingsOutput(scan *db.Scan, report string, emit func(Eve
 	if err != nil {
 		return err
 	}
-	findings := rep.toFindings(scan.ID, scan.RepositoryID, scan.Commit)
+	findings := rep.toFindings(scan.ID, scan.RepositoryID, scan.Commit, scan.SubPath)
 	scan.FindingsCount = len(findings)
 	if len(findings) > 0 {
 		if err := w.DB.Create(&findings).Error; err != nil {
@@ -297,6 +305,9 @@ func stageContext(workRoot, apiBase string, scan *db.Scan, repo *db.Repository) 
 	}
 	if scan.FindingID != nil {
 		ctx.Scrutineer.FindingID = *scan.FindingID
+	}
+	if scan.SubPath != "" {
+		ctx.Scrutineer.ScanSubPath = scan.SubPath
 	}
 	b, err := json.MarshalIndent(ctx, "", "  ")
 	if err != nil {

--- a/internal/worker/skill_parsers.go
+++ b/internal/worker/skill_parsers.go
@@ -279,6 +279,48 @@ func (w *Worker) parseDependenciesOutput(scan *db.Scan, report string, emit func
 	return nil
 }
 
+// parseSubprojectsOutput replaces Subproject rows for the scan's
+// repository. Subprojects are a projection of the repo layout produced
+// by the subprojects skill; a fresh run reflects the current clone and
+// replaces any prior set.
+func (w *Worker) parseSubprojectsOutput(scan *db.Scan, report string, emit func(Event)) error {
+	var result struct {
+		Subprojects []struct {
+			Path        string `json:"path"`
+			Name        string `json:"name"`
+			Kind        string `json:"kind"`
+			Description string `json:"description"`
+		} `json:"subprojects"`
+	}
+	if err := json.Unmarshal([]byte(report), &result); err != nil {
+		return fmt.Errorf("parse subprojects: %w", err)
+	}
+	if err := w.DB.Where("repository_id = ?", scan.RepositoryID).Delete(&db.Subproject{}).Error; err != nil {
+		return fmt.Errorf("delete old subprojects: %w", err)
+	}
+	rows := make([]db.Subproject, 0, len(result.Subprojects))
+	for _, sp := range result.Subprojects {
+		path := strings.Trim(sp.Path, "/ \t\n")
+		if path == "" {
+			continue
+		}
+		rows = append(rows, db.Subproject{
+			RepositoryID: scan.RepositoryID,
+			Path:         path,
+			Name:         sp.Name,
+			Kind:         sp.Kind,
+			Description:  sp.Description,
+		})
+	}
+	if len(rows) > 0 {
+		if err := w.DB.Create(&rows).Error; err != nil {
+			return fmt.Errorf("save subprojects: %w", err)
+		}
+	}
+	emit(Event{Kind: KindText, Text: fmt.Sprintf("saved %d subproject(s)", len(rows))})
+	return nil
+}
+
 // parseVerifyOutput records the outcome of a finding-scoped verification
 // run. Evidence and notes become a FindingNote; the status transition is
 // written via WriteFindingField with source=model_suggested so the audit

--- a/internal/worker/skill_parsers.go
+++ b/internal/worker/skill_parsers.go
@@ -321,24 +321,30 @@ func (w *Worker) parseSubprojectsOutput(scan *db.Scan, report string, emit func(
 	return nil
 }
 
-// parseRepoOverviewOutput reads `brief`'s structured output and backfills
-// fields on the Repository row that the metadata skill left empty. Only
-// empty fields are touched — a value coming from ecosyste.ms (via the
-// metadata skill) is considered authoritative and won't be overwritten
-// by brief's heuristic detection.
+// parseRepoOverviewOutput reads `brief`'s structured output and writes
+// the detected fields onto the Repository row. Brief wins over
+// ecosyste.ms for the fields it produces (languages, default branch,
+// license) — the detection is typically more accurate than the upstream
+// API for self-hosted or sparsely-populated repos. Fields brief leaves
+// empty are left alone, so ecosyste.ms still fills gaps.
 func (w *Worker) parseRepoOverviewOutput(scan *db.Scan, report string, emit func(Event)) error {
 	var result struct {
+		Git struct {
+			DefaultBranch string `json:"default_branch"`
+		} `json:"git"`
 		Languages []struct {
 			Name     string `json:"name"`
 			Category string `json:"category"`
 		} `json:"languages"`
+		Resources struct {
+			LicenseType string `json:"license_type"`
+		} `json:"resources"`
 	}
 	if err := json.Unmarshal([]byte(report), &result); err != nil {
-		// brief output may be wrapped or errored; don't fail the scan
-		// over a backfill pass.
 		emit(Event{Kind: KindText, Text: "repo-overview: skipping backfill, unparseable JSON"})
 		return nil
 	}
+	updates := map[string]any{}
 	var names []string
 	for _, l := range result.Languages {
 		if l.Category != "" && l.Category != "language" {
@@ -348,22 +354,26 @@ func (w *Worker) parseRepoOverviewOutput(scan *db.Scan, report string, emit func
 			names = append(names, l.Name)
 		}
 	}
-	if len(names) == 0 {
+	if len(names) > 0 {
+		updates["languages"] = strings.Join(names, ", ")
+	}
+	if result.Git.DefaultBranch != "" {
+		updates["default_branch"] = result.Git.DefaultBranch
+	}
+	if result.Resources.LicenseType != "" {
+		updates["license"] = result.Resources.LicenseType
+	}
+	if len(updates) == 0 {
 		return nil
 	}
-	var repo db.Repository
-	if err := w.DB.First(&repo, scan.RepositoryID).Error; err != nil {
-		return fmt.Errorf("load repo: %w", err)
+	if err := w.DB.Model(&db.Repository{}).Where("id = ?", scan.RepositoryID).Updates(updates).Error; err != nil {
+		return fmt.Errorf("update repo: %w", err)
 	}
-	if strings.TrimSpace(repo.Languages) != "" {
-		return nil
+	keys := make([]string, 0, len(updates))
+	for k := range updates {
+		keys = append(keys, k)
 	}
-	joined := strings.Join(names, ", ")
-	if err := w.DB.Model(&db.Repository{}).Where("id = ?", repo.ID).
-		Update("languages", joined).Error; err != nil {
-		return fmt.Errorf("update languages: %w", err)
-	}
-	emit(Event{Kind: KindText, Text: "repo-overview: backfilled languages = " + joined})
+	emit(Event{Kind: KindText, Text: "repo-overview: wrote " + strings.Join(keys, ", ")})
 	return nil
 }
 

--- a/internal/worker/skill_parsers.go
+++ b/internal/worker/skill_parsers.go
@@ -321,6 +321,52 @@ func (w *Worker) parseSubprojectsOutput(scan *db.Scan, report string, emit func(
 	return nil
 }
 
+// parseRepoOverviewOutput reads `brief`'s structured output and backfills
+// fields on the Repository row that the metadata skill left empty. Only
+// empty fields are touched — a value coming from ecosyste.ms (via the
+// metadata skill) is considered authoritative and won't be overwritten
+// by brief's heuristic detection.
+func (w *Worker) parseRepoOverviewOutput(scan *db.Scan, report string, emit func(Event)) error {
+	var result struct {
+		Languages []struct {
+			Name     string `json:"name"`
+			Category string `json:"category"`
+		} `json:"languages"`
+	}
+	if err := json.Unmarshal([]byte(report), &result); err != nil {
+		// brief output may be wrapped or errored; don't fail the scan
+		// over a backfill pass.
+		emit(Event{Kind: KindText, Text: "repo-overview: skipping backfill, unparseable JSON"})
+		return nil
+	}
+	var names []string
+	for _, l := range result.Languages {
+		if l.Category != "" && l.Category != "language" {
+			continue
+		}
+		if l.Name != "" {
+			names = append(names, l.Name)
+		}
+	}
+	if len(names) == 0 {
+		return nil
+	}
+	var repo db.Repository
+	if err := w.DB.First(&repo, scan.RepositoryID).Error; err != nil {
+		return fmt.Errorf("load repo: %w", err)
+	}
+	if strings.TrimSpace(repo.Languages) != "" {
+		return nil
+	}
+	joined := strings.Join(names, ", ")
+	if err := w.DB.Model(&db.Repository{}).Where("id = ?", repo.ID).
+		Update("languages", joined).Error; err != nil {
+		return fmt.Errorf("update languages: %w", err)
+	}
+	emit(Event{Kind: KindText, Text: "repo-overview: backfilled languages = " + joined})
+	return nil
+}
+
 // parseVerifyOutput records the outcome of a finding-scoped verification
 // run. Evidence and notes become a FindingNote; the status transition is
 // written via WriteFindingField with source=model_suggested so the audit

--- a/skills/repo-overview/SKILL.md
+++ b/skills/repo-overview/SKILL.md
@@ -5,7 +5,7 @@ license: MIT
 compatibility: Requires the `brief` CLI (https://github.com/ecosyste-ms/brief) on PATH.
 metadata:
   scrutineer.output_file: report.json
-  scrutineer.output_kind: freeform
+  scrutineer.output_kind: repo_overview
 ---
 
 # repo-overview

--- a/skills/repo-overview/SKILL.md
+++ b/skills/repo-overview/SKILL.md
@@ -20,6 +20,14 @@ Produce an overview of the repository cloned at `./src` by invoking the `brief` 
 
 ## What to run
 
+If `./context.json` has `scrutineer.scan_subpath` set, run `brief` against that sub-folder instead of the repo root:
+
+```bash
+brief --json ./src/$(jq -r '.scrutineer.scan_subpath // ""' ./context.json | sed 's:^/*::') > ./report.json
+```
+
+For a root scan (no `scan_subpath`), that reduces to the original:
+
 ```bash
 brief --json ./src > ./report.json
 ```

--- a/skills/security-deep-dive/SKILL.md
+++ b/skills/security-deep-dive/SKILL.md
@@ -15,7 +15,7 @@ The audit has two phases. Phase 1 produces an inventory of every sink in the cod
 
 Workspace layout:
 - `./src` — the cloned repository
-- `./context.json` — repo identity plus a `scrutineer` block with `api_base`, `token`, `repository_id`. If prior scans of this repo have run (metadata, packages, advisories, dependents, maintainers), their results are available at the API documented below; use them instead of re-fetching from upstream.
+- `./context.json` — repo identity plus a `scrutineer` block with `api_base`, `token`, `repository_id`. If `scrutineer.scan_subpath` is set, scope every inventory, trace, and validation step to `./src/{scan_subpath}` only — do not reach outside that sub-folder for code analysis, and treat the sub-folder as the project root for all relative locations in the report. Other repositories' concerns (packages, advisories, maintainers) remain repo-wide. If prior scans of this repo have run (metadata, packages, advisories, dependents, maintainers), their results are available at the API documented below; use them instead of re-fetching from upstream.
 - `./report.json` — write your final report here
 - `./schema.json` — the JSON schema your report must conform to
 

--- a/skills/semgrep/SKILL.md
+++ b/skills/semgrep/SKILL.md
@@ -5,7 +5,7 @@ license: MIT
 compatibility: Requires `semgrep` (https://semgrep.dev) and `python3` on PATH.
 metadata:
   scrutineer.output_file: report.json
-  scrutineer.output_kind: findings
+  scrutineer.output_kind: freeform
 ---
 
 # semgrep

--- a/skills/subprojects/SKILL.md
+++ b/skills/subprojects/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: subprojects
+description: Enumerate scannable sub-folders inside a repository. Identifies monorepo packages, workspaces, and discrete modules so the analyst can scope deep-dive scans to a specific sub-path instead of treating a huge tree as one unit. Runs at repo level; writes back a list that surfaces on the repo overview.
+license: MIT
+compatibility: Needs network access to the scrutineer API only for logging; the enumeration itself is filesystem-only against ./src.
+metadata:
+  scrutineer.output_file: report.json
+  scrutineer.output_kind: subprojects
+---
+
+# subprojects
+
+List the discrete scannable units inside a repository so the analyst can scope security scans to a sub-path instead of the whole tree. A repository with a single package at the root gets an empty list — that is the expected shape for the common case. A monorepo like apache/airflow or kubernetes/kubernetes gets a row per sub-package.
+
+## Workspace
+
+- `./src` — the repository at HEAD. Read-only.
+- `./context.json` — has `scrutineer.api_base`, `scrutineer.token`, `scrutineer.repository_id`. Not finding-scoped, not sub-path-scoped (this skill *produces* sub-paths; it does not consume one).
+- `./report.json` — write the enumeration here.
+- `./schema.json` — output shape.
+
+## How to identify subprojects
+
+A subproject is a sub-folder that looks like an independently buildable, scannable unit. Heuristics, in descending order of signal strength:
+
+1. **Explicit monorepo declarations.** If the repo has any of these at the root, the file names the workspaces directly — use them verbatim:
+   - `pnpm-workspace.yaml` — `packages:` glob list
+   - `lerna.json` — `packages:` array
+   - `nx.json` / `workspace.json` — NX workspace layout
+   - `turbo.json` alongside a root `package.json` with a `workspaces` field
+   - `go.work` — `use (...)` list
+   - root `Cargo.toml` with `[workspace].members`
+   - `pyproject.toml` with `[tool.uv.workspace].members` or Rye/hatch equivalents
+
+2. **Sub-folder package manifests.** When no workspace declaration exists, scan sub-folders (depth ≤ 3, skip `node_modules`, `vendor`, `.git`, `dist`, `build`, `target`) for any of:
+   - `go.mod` → go-module
+   - `package.json` with a `name` field → npm-package
+   - `pyproject.toml` / `setup.py` / `setup.cfg` → python-package
+   - `Cargo.toml` with `[package]` → rust-crate
+   - `composer.json` → composer-package
+   - `pom.xml` or `build.gradle[.kts]` → maven/gradle-module
+   - `Gemfile` and/or `*.gemspec` → ruby-gem
+   - `Package.swift` → swift-package
+   - `Dockerfile` alongside a README in a `services/` or `apps/` tree → service
+
+3. **Cluster by top-level directory.** If heuristic 2 produces many hits under a common parent (e.g. `providers/amazon`, `providers/google` each has its own `pyproject.toml`), keep each sub-folder as its own row rather than rolling them up — an analyst may want to scan just one cloud provider's code.
+
+## What NOT to emit
+
+- **The root as a subproject.** A repo with one package at the root has zero subprojects; scrutineer already treats root as the default scan scope.
+- **Test fixtures, examples, vendored deps.** Folders called `testdata/`, `fixtures/`, `examples/`, `vendor/`, `third_party/`, `external/` almost always ship code that is not the project itself — skip them.
+- **Build outputs.** `dist/`, `build/`, `out/`, `target/`, `node_modules/`, `.venv/`, `__pycache__/` — same.
+- **Nested workspaces with no independent manifest.** If a sub-folder has no manifest and is not named by a workspace declaration, it is not a subproject; it is just a sub-folder.
+
+## Output
+
+Write `./report.json`:
+
+```json
+{
+  "subprojects": [
+    {
+      "path": "airflow-core",
+      "name": "airflow-core",
+      "kind": "python-package",
+      "description": "Core Airflow scheduler, webserver, and DAG runtime."
+    },
+    {
+      "path": "airflow-ctl",
+      "name": "airflow-ctl",
+      "kind": "python-package",
+      "description": "Airflow CLI distributed as a separate package."
+    },
+    {
+      "path": "providers/amazon",
+      "name": "apache-airflow-providers-amazon",
+      "kind": "python-package",
+      "description": "AWS provider package. Ships operators, hooks, and sensors for S3, EMR, Glue, and other AWS services."
+    }
+  ]
+}
+```
+
+Fields:
+
+- `path` — required, relative to repo root, no leading slash. This is what scrutineer stores on `Scan.sub_path` when the analyst scans it.
+- `name` — short human label. Use the package's own name when the manifest has one (`name` in package.json, `module` path in go.mod, `[package].name` in Cargo.toml); otherwise the last segment of `path`.
+- `kind` — the detection hit: `go-module`, `npm-package`, `python-package`, `rust-crate`, `composer-package`, `maven-module`, `gradle-module`, `ruby-gem`, `swift-package`, `service`, `monorepo-root`, etc. Free-form; the UI renders it as a badge.
+- `description` — one or two sentences. Read the README in the sub-folder if present, or infer from the package name and directory structure. Keep it specific ("AWS provider package", not "code for AWS").
+
+## Constraints
+
+- Empty list is the correct output for a single-package repo. Do not invent subprojects to avoid an empty array.
+- Do not include the root directory as a row. Root is implicit.
+- Do not add more than ~50 rows. If a monorepo is bigger than that, pick the 50 most significant (largest manifests, deepest tree, or named in a workspace declaration) and note the truncation in a `notes` field (the schema allows it).
+- Scrutineer replaces the full set on each re-run, so missing rows from a previous run will disappear — do not try to merge with prior output.

--- a/skills/subprojects/schema.json
+++ b/skills/subprojects/schema.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "subprojects report",
+  "description": "Scannable sub-folders within a repository. Empty list means the repo is a single unit at the root.",
+  "type": "object",
+  "required": ["subprojects"],
+  "additionalProperties": false,
+  "properties": {
+    "subprojects": {
+      "type": "array",
+      "maxItems": 50,
+      "items": {
+        "type": "object",
+        "required": ["path"],
+        "additionalProperties": false,
+        "properties": {
+          "path": {
+            "type": "string",
+            "pattern": "^[^/].*",
+            "description": "Sub-folder relative to repo root. No leading slash. This value is stored on Scan.sub_path when the analyst scopes a scan to this subproject."
+          },
+          "name": {
+            "type": "string",
+            "description": "Short human label. Prefer the manifest's own package name over the directory name."
+          },
+          "kind": {
+            "type": "string",
+            "description": "Detected flavour: go-module, npm-package, python-package, rust-crate, composer-package, maven-module, gradle-module, ruby-gem, swift-package, service, monorepo-root."
+          },
+          "description": {
+            "type": "string",
+            "description": "One or two sentences on what this subproject is. Read the local README or infer from the manifest."
+          }
+        }
+      }
+    },
+    "notes": {
+      "type": "string",
+      "description": "Optional: anything the analyst should know. Truncation (more than 50 subprojects), unfamiliar monorepo layout, heuristics that fired ambiguously."
+    }
+  }
+}

--- a/skills/triage/SKILL.md
+++ b/skills/triage/SKILL.md
@@ -30,6 +30,7 @@ For every remaining skill in the list below, enqueue it: `POST {api_base}/reposi
 - `dependencies`
 - `sbom`
 - `maintainers`
+- `subprojects`
 - `repo-overview`
 - `semgrep`
 - `zizmor`

--- a/skills/zizmor/SKILL.md
+++ b/skills/zizmor/SKILL.md
@@ -5,7 +5,7 @@ license: MIT
 compatibility: Requires `zizmor` (https://github.com/woodruffw/zizmor) and `python3` on PATH.
 metadata:
   scrutineer.output_file: report.json
-  scrutineer.output_kind: findings
+  scrutineer.output_kind: freeform
 ---
 
 # zizmor


### PR DESCRIPTION
Treats the sub-path within a repository as a scan-level property rather than a repository-level one: one \`Repository\` row per clone URL, many scans against it, each optionally scoped to a sub-folder.

### Scope decisions

- Packages, advisories, dependents, and maintainers stay repo-wide. They come from external APIs keyed by URL, so duplicating them per sub-path would not reflect reality.
- Only the skills that walk source (security-deep-dive, repo-overview) honour sub-path. verify/disclose/patch inherit it from their originating finding.
- Branch in a \`/tree/<branch>/<path>\` URL is parsed but ignored for now (logged, not stored). Always clones the default branch.
- Repository stays one-per-URL — sub-path is a scan property, never a repo property.

### Schema

- \`Scan.sub_path\` (empty = root)
- \`Finding.sub_path\` (denormalised from scan, same pattern as the existing \`RepositoryID\`/\`Commit\` denorm)
- New \`subprojects\` table populated by the new skill

### URL parsing

\`ParseRepoInput\` accepts three shapes:

| Input | CloneURL | SubPath |
| --- | --- | --- |
| \`https://github.com/apache/airflow\` | \`…airflow.git\` | (empty) |
| \`https://github.com/apache/airflow/tree/main/airflow-core\` | \`…airflow.git\` | \`airflow-core\` |
| \`https://gitlab.com/group/project#services/api\` | \`…project.git\` | \`services/api\` |

Shared by single-add. Branch (\`main\`, \`v2.9.0\`, …) is returned for logging only.

### Skill changes

- New \`skills/subprojects/\` — enumerates monorepo sub-packages from workspace declarations (\`pnpm-workspace.yaml\`, \`lerna.json\`, \`go.work\`, \`Cargo.toml [workspace]\`, etc.) and sub-folder manifests (\`go.mod\`, \`package.json\`, \`pyproject.toml\`, \`Cargo.toml\`, \`pom.xml\`, \`Gemfile\`, …). Empty list = single-package repo. Output kind \`subprojects\`.
- \`triage\` — includes \`subprojects\` in the default set so monorepos get a sub-path map automatically.
- \`security-deep-dive\` — if \`scrutineer.scan_subpath\` is set, scope all inventory/trace/validation to \`./src/{subpath}\` and treat it as project root for locations.
- \`repo-overview\` — runs \`brief\` against the sub-folder when set.

### UI

- Pasting a GitHub tree URL into the add-repo dialog now routes correctly: the Repository is created at the clone URL, the initial triage runs with sub_path.
- Repo summary tab lists detected subprojects with a one-click Scan button per row that enqueues a sub-path-scoped security-deep-dive.
- Findings and scans tables grow a Sub-path column when any row has one (hidden for repos with no sub-path scans, so single-package repos stay uncluttered).
- Retry preserves sub-path.

### Enqueue refactor

Introduced \`ScanOpts\` struct (Model, FindingID, SubPath) and a new \`enqueueSkillWith\` helper. The old \`enqueueSkill\` / \`enqueueSkillScoped\` wrappers are preserved so existing call sites compile unchanged.

### Tests

- \`TestParseRepoInput\` — 11 cases covering plain, tree, fragment, malformed inputs
- \`TestCreateRepo_parsesGitHubTreeURL\` — pasted airflow tree URL yields the right Repository + sub_path-scoped scan
- \`TestRetry_preservesSubPath\` — retry carries sub_path onto the new scan
- \`TestSubprojectsRenderedOnRepoPage\` — repo page surfaces the list + Scan form

Full test + lint clean.

Closes #19, #20.