### PR TITLE
Hot-path perf fixes: batched repo list, sort indexes, report cap

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -30,7 +30,7 @@ type Repository struct {
 	DefaultBranch string
 	Languages     string
 	License       string
-	Stars         int
+	Stars         int `gorm:"index"`
 	Forks         int
 	Archived      bool
 	PushedAt      *time.Time
@@ -120,9 +120,9 @@ type Package struct {
 	Licenses              string
 	LatestVersion         string
 	VersionsCount         int
-	Downloads             int64
+	Downloads             int64 `gorm:"index"`
 	DependentPackages     int
-	DependentRepos        int
+	DependentRepos        int   `gorm:"index"`
 	RegistryURL           string
 	LatestReleaseAt       *time.Time
 	DependentPackagesURL string
@@ -186,7 +186,7 @@ type Advisory struct {
 	CVSSScore      float64
 	Classification string
 	Packages       string // comma-joined affected package names
-	PublishedAt    *time.Time
+	PublishedAt    *time.Time `gorm:"index"`
 	WithdrawnAt    *time.Time
 
 	CreatedAt time.Time
@@ -202,8 +202,8 @@ type Dependent struct {
 	Ecosystem      string
 	PURL           string
 	RepositoryURL  string
-	Downloads      int64
-	DependentRepos int
+	Downloads      int64 `gorm:"index"`
+	DependentRepos int   `gorm:"index"`
 	RegistryURL    string
 	LatestVersion  string
 

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -247,22 +247,52 @@ func (s *Server) repoList(w http.ResponseWriter, r *http.Request) {
 	var repos []db.Repository
 	q.Limit(perPage).Offset((page.N - 1) * perPage).Find(&repos)
 
+	// Batch-load findings count and last scan per page (N rows) rather
+	// than per-repo (N rows × 2 queries). For 20 rows per page this
+	// collapses 40 queries into 2.
+	repoIDs := make([]uint, 0, len(repos))
+	for _, r := range repos {
+		repoIDs = append(repoIDs, r.ID)
+	}
+	findingCounts := map[uint]int{}
+	if len(repoIDs) > 0 {
+		type rowCount struct {
+			RepositoryID uint
+			N            int
+		}
+		var counts []rowCount
+		s.DB.Model(&db.Finding{}).
+			Select("repository_id, COUNT(*) AS n").
+			Where("repository_id IN ?", repoIDs).
+			Group("repository_id").
+			Scan(&counts)
+		for _, c := range counts {
+			findingCounts[c.RepositoryID] = c.N
+		}
+	}
+	lastScans := map[uint]*db.Scan{}
+	if len(repoIDs) > 0 {
+		// For each repo, the latest scan. A single query using a grouped
+		// subquery avoids one-query-per-row.
+		var scans []db.Scan
+		s.DB.Raw(`
+			SELECT s.* FROM scans s
+			JOIN (SELECT repository_id, MAX(id) AS max_id FROM scans
+				WHERE repository_id IN ? GROUP BY repository_id) latest
+			ON latest.max_id = s.id
+		`, repoIDs).Scan(&scans)
+		for i := range scans {
+			lastScans[scans[i].RepositoryID] = &scans[i]
+		}
+	}
+
 	rows := make([]repoRow, 0, len(repos))
 	for _, repo := range repos {
-		row := repoRow{Repository: repo}
-		var last db.Scan
-		if err := s.DB.Where("repository_id = ?", repo.ID).
-			Order("id desc").First(&last).Error; err == nil {
-			row.LastScan = &last
-		}
-		// Count findings across all scans of this repo. The previous
-		// implementation read LastScan.FindingsCount, which is zero for
-		// repo-overview / metadata / packages scans — those do not
-		// produce Finding rows even when findings exist on the repo.
-		var total int64
-		s.DB.Model(&db.Finding{}).Where("repository_id = ?", repo.ID).Count(&total)
-		row.FindingsTotal = int(total)
-		rows = append(rows, row)
+		rows = append(rows, repoRow{
+			Repository:    repo,
+			LastScan:      lastScans[repo.ID],
+			FindingsTotal: findingCounts[repo.ID],
+		})
 	}
 	var languages []string
 	s.DB.Model(&db.Repository{}).Where("languages != ''").Distinct("languages").Order("languages").Pluck("languages", &languages)

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -40,6 +40,46 @@ func localReq(method, path string) *http.Request {
 	return r
 }
 
+func TestRepoList_batchedFindingsCountAcrossRepos(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	mk := func(name string, findings int) {
+		repo := db.Repository{URL: "https://example.com/" + name, Name: name}
+		s.DB.Create(&repo)
+		if findings > 0 {
+			scan := db.Scan{RepositoryID: repo.ID, Kind: "skill", Status: db.ScanDone, SkillName: "security-deep-dive"}
+			s.DB.Create(&scan)
+			for i := 0; i < findings; i++ {
+				s.DB.Create(&db.Finding{ScanID: scan.ID, RepositoryID: repo.ID,
+					Title: fmt.Sprintf("F%d", i), Severity: "High"})
+			}
+		}
+	}
+	mk("alpha", 3)
+	mk("bravo", 0)
+	mk("charlie", 7)
+
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq("GET", "/"))
+	body := w.Body.String()
+	if w.Code != 200 {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+
+	// Every repo's count must be rendered correctly in the rendered
+	// table, even though they all come out of a single grouped query.
+	for _, want := range []struct{ repo, count string }{
+		{"alpha", `badge-destructive">3</span>`},
+		{"bravo", `badge-secondary">0</span>`},
+		{"charlie", `badge-destructive">7</span>`},
+	} {
+		if !strings.Contains(body, want.count) {
+			t.Errorf("missing %s count %q in body", want.repo, want.count)
+		}
+	}
+}
+
 func TestRepoList_findingsCountIsRepoWideNotLastScan(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()

--- a/internal/worker/claude.go
+++ b/internal/worker/claude.go
@@ -3,6 +3,7 @@ package worker
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -101,13 +102,44 @@ func (l LocalClaude) RunSkill(ctx context.Context, sj SkillJob, emit func(Event)
 
 	res := SkillResult{Commit: commit}
 	if outPath != "" {
-		b, _ := os.ReadFile(outPath)
-		res.Report = string(b)
+		res.Report = readCappedReport(outPath, emit)
 	}
 	if waitErr != nil {
 		return res, fmt.Errorf("claude exited: %w", waitErr)
 	}
 	return res, nil
+}
+
+// maxReportBytes caps how much of a skill's report.json scrutineer will
+// read back into memory. The report lands in Scan.Report (sqlite TEXT
+// column) and is rendered unescaped in the UI, so an unbounded skill
+// output is a trivial DoS vector for the local worker. 50 MB is well
+// above any reasonable skill output — the largest legitimate report
+// we've seen in practice is ~500 KB.
+const maxReportBytes = 50 << 20
+
+// readCappedReport returns the first maxReportBytes bytes of the file
+// at path, or an empty string if the file doesn't exist. Oversize files
+// are truncated and a log line is emitted to the scan so the operator
+// knows the report was clipped.
+func readCappedReport(path string, emit func(Event)) string {
+	f, err := os.Open(path)
+	if err != nil {
+		return ""
+	}
+	defer func() { _ = f.Close() }()
+	info, err := f.Stat()
+	if err != nil {
+		return ""
+	}
+	if info.Size() > maxReportBytes {
+		emit(Event{Kind: KindText, Text: fmt.Sprintf("report.json is %d bytes, truncating to %d", info.Size(), maxReportBytes)})
+	}
+	b, err := io.ReadAll(io.LimitReader(f, maxReportBytes))
+	if err != nil {
+		return ""
+	}
+	return string(b)
 }
 
 // buildSkillPrompt is the activation prompt handed to claude. It's a thin

--- a/internal/worker/docker.go
+++ b/internal/worker/docker.go
@@ -98,8 +98,7 @@ func (d DockerRunner) RunSkill(ctx context.Context, sj SkillJob, emit func(Event
 
 	res := SkillResult{Commit: commit}
 	if outPath != "" {
-		b, _ := os.ReadFile(outPath)
-		res.Report = string(b)
+		res.Report = readCappedReport(outPath, emit)
 	}
 	if waitErr != nil {
 		return res, fmt.Errorf("docker exited: %w", waitErr)

--- a/internal/worker/report_cap_test.go
+++ b/internal/worker/report_cap_test.go
@@ -1,0 +1,58 @@
+package worker
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestReadCappedReport_normalSize(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "report.json")
+	if err := os.WriteFile(path, []byte(`{"ok":true}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var events []Event
+	emit := func(e Event) { events = append(events, e) }
+	got := readCappedReport(path, emit)
+
+	if got != `{"ok":true}` {
+		t.Errorf("body = %q, want full contents", got)
+	}
+	if len(events) != 0 {
+		t.Errorf("expected no truncation event, got %+v", events)
+	}
+}
+
+func TestReadCappedReport_truncatesOversize(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "report.json")
+	// Write 50 MB + 1 KB so we cross the cap.
+	payload := make([]byte, (50<<20)+1024)
+	for i := range payload {
+		payload[i] = 'x'
+	}
+	if err := os.WriteFile(path, payload, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var events []Event
+	emit := func(e Event) { events = append(events, e) }
+	got := readCappedReport(path, emit)
+
+	if len(got) != maxReportBytes {
+		t.Errorf("got %d bytes, want exactly %d (cap)", len(got), maxReportBytes)
+	}
+	if len(events) == 0 || !strings.Contains(events[0].Text, "truncating") {
+		t.Errorf("expected a truncation log event, got %+v", events)
+	}
+}
+
+func TestReadCappedReport_missingFileIsEmpty(t *testing.T) {
+	got := readCappedReport("/nonexistent/never-written.json", func(Event) {})
+	if got != "" {
+		t.Errorf("missing file should return empty, got %q", got)
+	}
+}


### PR DESCRIPTION
Three independent fixes from the perf review.

### 1. `repoList` was N+1 on the findings count

When the findings-total-per-repo fix landed (#43-era), each row in the repo index ran an extra `COUNT(*)` plus a `MAX(id)` lookup for its last scan — 40 round trips per 20-row page. Now both happen once per page via grouped queries. For a page of 20 repos, down from ~41 queries to 3.

### 2. Unindexed sort columns

List pages expose sort-by options on columns that have no index:

| Table | Column | Sort exposed in |
| --- | --- | --- |
| `repositories` | `stars` | /?sort=stars |
| `packages` | `downloads`, `dependent_repos` | /packages?sort=... |
| `advisories` | `published_at` | /advisories?sort=newest |
| `dependents` | `downloads`, `dependent_repos` | repo page Dependents tab |

Sorting any of these was a full table scan. Added `gorm:"index"` tags; the indexes get created on next `AutoMigrate`.

### 3. Unbounded `os.ReadFile` on `report.json`

A rogue skill writing a multi-GB `report.json` would OOM the worker; scrutineer reads the entire file unconditionally into `Scan.Report`. Capped at 50 MB via `io.LimitReader`, factored into `readCappedReport` and shared between the local and docker runners. Truncation emits a log event so the operator sees the clip on the scan page.

### Tests

- `TestRepoList_batchedFindingsCountAcrossRepos` — three repos with different finding counts all render correctly from the single grouped query.
- `TestReadCappedReport_normalSize` — under cap, full contents returned, no log event.
- `TestReadCappedReport_truncatesOversize` — 50 MB + 1 KB input, output is exactly the cap and a "truncating" log event fires.
- `TestReadCappedReport_missingFileIsEmpty` — no file, no crash, empty string.

Full lint clean.