### PR TITLE
Contact routes + maintainer enrichments (closes #11)

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -39,6 +39,13 @@ type Repository struct {
 	Metadata      string `gorm:"type:text"`
 	FetchedAt     *time.Time
 
+	// DisclosureChannel is the preferred vector for reporting a
+	// vulnerability in this repo — an email, GHSA URL, registry owner
+	// handle, or SECURITY.md URL. Written by the maintainers skill from
+	// SECURITY.md / CODEOWNERS / registry data; the analyst can overwrite
+	// it from the repo page.
+	DisclosureChannel string
+
 	CreatedAt time.Time
 	UpdatedAt time.Time
 
@@ -152,6 +159,13 @@ type Maintainer struct {
 	AvatarURL string
 	Status MaintainerStatus `gorm:"index;default:unknown"`
 	Notes  string
+
+	// DoNotContact suppresses this maintainer from disclosure routing.
+	// Toggled per-maintainer from the UI. The analyst sets it when the
+	// maintainer has asked not to be contacted, or when evidence says
+	// routing through them is known to leak. Reports and disclosure
+	// drafts omit them when true.
+	DoNotContact bool `gorm:"index"`
 
 	Repositories []Repository `gorm:"many2many:repository_maintainers"`
 

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -124,6 +124,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("GET /repositories/{id}", s.repoShow)
 	mux.HandleFunc("GET /repositories/{id}/report.md", s.repoReport)
 	mux.HandleFunc("POST /repositories/{id}/scan", s.repoScan)
+	mux.HandleFunc("POST /repositories/{id}/disclosure-channel", s.repoDisclosureChannel)
 	mux.HandleFunc("GET /scans", s.jobs)
 	mux.HandleFunc("GET /orgs", s.orgsList)
 	mux.HandleFunc("GET /orgs/{login}", s.orgShow)
@@ -131,6 +132,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("GET /orgs/{login}/summary.md", s.orgSummary)
 	mux.HandleFunc("GET /maintainers", s.maintainersList)
 	mux.HandleFunc("GET /maintainers/{id}", s.maintainerShow)
+	mux.HandleFunc("POST /maintainers/{id}/do-not-contact", s.maintainerDoNotContact)
 	mux.HandleFunc("GET /findings", s.findings)
 	mux.HandleFunc("GET /findings/{id}", s.findingShow)
 	mux.HandleFunc("POST /findings/{id}/status", s.findingStatus)
@@ -537,9 +539,58 @@ func (s *Server) maintainersList(w http.ResponseWriter, r *http.Request) {
 	q.Preload("Repositories").
 		Limit(perPage).Offset((page.N - 1) * perPage).Find(&rows)
 
+	// Batch-count findings across each maintainer's linked repositories
+	// in a single grouped query rather than one query per maintainer.
+	findingCounts := map[uint]int{}
+	if len(rows) > 0 {
+		ids := make([]uint, 0, len(rows))
+		for _, m := range rows {
+			ids = append(ids, m.ID)
+		}
+		type row struct {
+			MaintainerID uint
+			N            int
+		}
+		var counts []row
+		s.DB.Raw(`
+			SELECT rm.maintainer_id, COUNT(f.id) AS n
+			FROM repository_maintainers rm
+			LEFT JOIN findings f ON f.repository_id = rm.repository_id
+			WHERE rm.maintainer_id IN ?
+			GROUP BY rm.maintainer_id
+		`, ids).Scan(&counts)
+		for _, c := range counts {
+			findingCounts[c.MaintainerID] = c.N
+		}
+	}
+
 	s.render(w, "maintainers.html", map[string]any{
-		"Maintainers": rows, "Page": page, "Status": status, "Q": search, "Sort": sort,
+		"Maintainers":   rows,
+		"Page":          page,
+		"Status":        status,
+		"Q":             search,
+		"Sort":          sort,
+		"FindingCounts": findingCounts,
 	})
+}
+
+// maintainerDoNotContact flips the DoNotContact flag on a maintainer.
+// Toggle semantics — form posts an explicit `value` of "true" or "false".
+func (s *Server) maintainerDoNotContact(w http.ResponseWriter, r *http.Request) {
+	id, _ := strconv.Atoi(r.PathValue("id"))
+	var m db.Maintainer
+	if err := s.DB.First(&m, id).Error; err != nil {
+		http.NotFound(w, r)
+		return
+	}
+	value := r.FormValue("value") == "true"
+	if err := s.DB.Model(&db.Maintainer{}).Where("id = ?", m.ID).
+		Update("do_not_contact", value).Error; err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("HX-Redirect", fmt.Sprintf("/maintainers/%d", m.ID))
+	w.WriteHeader(http.StatusNoContent)
 }
 
 func (s *Server) maintainerShow(w http.ResponseWriter, r *http.Request) {
@@ -1292,6 +1343,26 @@ func (s *Server) repoScan(w http.ResponseWriter, r *http.Request) {
 		Model:   r.FormValue("model"),
 		SubPath: strings.TrimSpace(r.FormValue("sub_path")),
 	}); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("HX-Redirect", fmt.Sprintf("/repositories/%d", repo.ID))
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// repoDisclosureChannel lets the analyst overwrite (or clear) the
+// disclosure channel that the maintainers skill wrote onto the repo.
+// Empty submission clears the field.
+func (s *Server) repoDisclosureChannel(w http.ResponseWriter, r *http.Request) {
+	id, _ := strconv.Atoi(r.PathValue("id"))
+	var repo db.Repository
+	if err := s.DB.First(&repo, id).Error; err != nil {
+		http.NotFound(w, r)
+		return
+	}
+	value := strings.TrimSpace(r.FormValue("disclosure_channel"))
+	if err := s.DB.Model(&db.Repository{}).Where("id = ?", repo.ID).
+		Update("disclosure_channel", value).Error; err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -82,6 +82,105 @@ func TestRepoList_batchedFindingsCountAcrossRepos(t *testing.T) {
 	}
 }
 
+func TestMaintainersIndex_rendersFindingsCountAndDNCBadge(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	repo := db.Repository{URL: "https://github.com/foo/bar.git", Name: "bar"}
+	s.DB.Create(&repo)
+	scan := db.Scan{RepositoryID: repo.ID, Kind: "skill", Status: db.ScanDone, SkillName: "security-deep-dive"}
+	s.DB.Create(&scan)
+	s.DB.Create(&db.Finding{ScanID: scan.ID, RepositoryID: repo.ID, Title: "A", Severity: "High"})
+	s.DB.Create(&db.Finding{ScanID: scan.ID, RepositoryID: repo.ID, Title: "B", Severity: "Medium"})
+
+	alice := db.Maintainer{Login: "alice", Name: "Alice", Status: db.MaintainerActive, DoNotContact: true}
+	s.DB.Create(&alice)
+	bob := db.Maintainer{Login: "bob", Name: "Bob", Status: db.MaintainerActive}
+	s.DB.Create(&bob)
+	if err := s.DB.Model(&repo).Association("Maintainers").Append([]db.Maintainer{alice, bob}); err != nil {
+		t.Fatal(err)
+	}
+
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq("GET", "/maintainers"))
+	if w.Code != 200 {
+		t.Fatalf("status %d", w.Code)
+	}
+	body := w.Body.String()
+
+	// Both maintainers share the one repo and its two findings, so both
+	// rows should render the "2" findings badge.
+	if strings.Count(body, `<span class="badge-destructive">2</span>`) < 2 {
+		t.Errorf("expected two maintainer rows with findings=2 badge")
+	}
+	// Alice carries the DNC badge; Bob should not.
+	if !strings.Contains(body, `data-tooltip="Do not contact">DNC`) {
+		t.Errorf("missing DNC badge for alice")
+	}
+}
+
+func TestMaintainerDoNotContactToggle(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	m := db.Maintainer{Login: "alice", Name: "Alice", Status: db.MaintainerActive}
+	s.DB.Create(&m)
+
+	post := func(value string) {
+		form := url.Values{"value": {value}}
+		r := httptest.NewRequest("POST", fmt.Sprintf("/maintainers/%d/do-not-contact", m.ID), strings.NewReader(form.Encode()))
+		r.Host = testHost
+		r.Header.Set("Sec-Fetch-Site", "same-origin")
+		r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		w := httptest.NewRecorder()
+		s.Handler().ServeHTTP(w, r)
+		if w.Code != http.StatusNoContent {
+			t.Fatalf("value=%s status %d: %s", value, w.Code, w.Body)
+		}
+	}
+	post("true")
+	var got db.Maintainer
+	s.DB.First(&got, m.ID)
+	if !got.DoNotContact {
+		t.Error("expected DoNotContact=true after toggle")
+	}
+	post("false")
+	s.DB.First(&got, m.ID)
+	if got.DoNotContact {
+		t.Error("expected DoNotContact=false after clear")
+	}
+}
+
+func TestRepoDisclosureChannel_setAndClear(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	repo := db.Repository{URL: "https://github.com/foo/bar.git", Name: "bar"}
+	s.DB.Create(&repo)
+
+	post := func(v string) {
+		form := url.Values{"disclosure_channel": {v}}
+		r := httptest.NewRequest("POST", fmt.Sprintf("/repositories/%d/disclosure-channel", repo.ID), strings.NewReader(form.Encode()))
+		r.Host = testHost
+		r.Header.Set("Sec-Fetch-Site", "same-origin")
+		r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		w := httptest.NewRecorder()
+		s.Handler().ServeHTTP(w, r)
+		if w.Code != http.StatusNoContent {
+			t.Fatalf("status %d: %s", w.Code, w.Body)
+		}
+	}
+	post("security@example.org")
+	var got db.Repository
+	s.DB.First(&got, repo.ID)
+	if got.DisclosureChannel != "security@example.org" {
+		t.Errorf("got %q", got.DisclosureChannel)
+	}
+	post("")
+	s.DB.First(&got, repo.ID)
+	if got.DisclosureChannel != "" {
+		t.Errorf("empty submission should clear; got %q", got.DisclosureChannel)
+	}
+}
+
 func TestRepoList_findingsCountIsRepoWideNotLastScan(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()
@@ -336,8 +435,8 @@ func TestOrgsList_sortOptions(t *testing.T) {
 		want []string
 	}{
 		{"name", []string{"acme", "globex", "umbrella"}},
-		{"findings", []string{"acme", "globex", "umbrella"}},    // 5 > 1 > 0
-		{"repos", []string{"globex", "umbrella", "acme"}},        // 3 > 2 > 1
+		{"findings", []string{"acme", "globex", "umbrella"}}, // 5 > 1 > 0
+		{"repos", []string{"globex", "umbrella", "acme"}},    // 3 > 2 > 1
 	} {
 		w := httptest.NewRecorder()
 		s.Handler().ServeHTTP(w, localReq("GET", "/orgs?sort="+tc.sort))

--- a/internal/web/templates/maintainer_show.html
+++ b/internal/web/templates/maintainer_show.html
@@ -14,7 +14,22 @@
     </p>
     {{if $m.Email}}<p class="text-sm text-muted-foreground">{{$m.Email}}</p>{{end}}
   </div>
-  <span class="ml-auto">{{template "status-badge" (printf "%s" $m.Status)}}</span>
+  <span class="ml-auto flex items-center gap-2">
+    {{if $m.DoNotContact}}
+      <span class="badge-destructive" data-tooltip="Maintainer has asked not to be contacted, or routing is known to leak">Do not contact</span>
+      <button class="btn-outline-sm" hx-post="/maintainers/{{$m.ID}}/do-not-contact"
+              hx-vals='{"value":"false"}' hx-swap="none">
+        Clear flag
+      </button>
+    {{else}}
+      <button class="btn-outline-sm" hx-post="/maintainers/{{$m.ID}}/do-not-contact"
+              hx-vals='{"value":"true"}' hx-swap="none"
+              data-tooltip="Suppress from disclosure routing">
+        <i data-lucide="ban"></i> Do not contact
+      </button>
+    {{end}}
+    {{template "status-badge" (printf "%s" $m.Status)}}
+  </span>
 </div>
 
 <div class="tabs w-full" id="maintainer-tabs">

--- a/internal/web/templates/maintainers.html
+++ b/internal/web/templates/maintainers.html
@@ -48,16 +48,21 @@
 {{if .Maintainers}}
   <table class="table w-full">
     <thead><tr>
-      <th>Name</th><th>Login</th><th>Email</th><th>Company</th><th>Repos</th><th>Status</th>
+      <th>Name</th><th>Login</th><th>Email</th><th>Company</th><th>Repos</th><th>Findings</th><th>Status</th>
     </tr></thead>
     <tbody>
+    {{$counts := .FindingCounts}}
     {{range .Maintainers}}
       <tr class="cursor-pointer" hx-get="/maintainers/{{.ID}}" hx-target="body" hx-push-url="true">
-        <td class="font-medium">{{.Name}}</td>
+        <td class="font-medium">
+          {{.Name}}
+          {{if .DoNotContact}}<span class="badge-destructive ml-1" data-tooltip="Do not contact">DNC</span>{{end}}
+        </td>
         <td class="text-muted-foreground">{{.Login}}</td>
         <td class="text-muted-foreground">{{.Email}}</td>
         <td class="text-muted-foreground">{{.Company}}</td>
         <td class="text-muted-foreground">{{len .Repositories}}</td>
+        <td>{{template "findings-badge" (index $counts .ID)}}</td>
         <td>{{template "status-badge" (printf "%s" .Status)}}</td>
       </tr>
     {{end}}

--- a/internal/web/templates/repo_show.html
+++ b/internal/web/templates/repo_show.html
@@ -96,6 +96,20 @@
       <p class="text-muted-foreground text-sm mb-6">Metadata not fetched yet.</p>
     {{end}}
 
+    <details class="mb-4 max-w-3xl">
+      <summary class="text-sm text-muted-foreground cursor-pointer hover:underline">
+        <i data-lucide="send"></i>
+        Disclosure channel{{if .Repo.DisclosureChannel}}: <code class="text-xs">{{.Repo.DisclosureChannel}}</code>{{else}}<span class="italic"> not set</span>{{end}}
+      </summary>
+      <form method="post" action="/repositories/{{.Repo.ID}}/disclosure-channel" class="form grid grid-cols-[1fr_auto] gap-2 mt-2">
+        <input class="input font-mono text-xs" type="text" name="disclosure_channel"
+               value="{{.Repo.DisclosureChannel}}"
+               placeholder="security@example.org, https://…/security/advisories, …">
+        <button class="btn-sm" type="submit">Save</button>
+      </form>
+      <p class="text-xs text-muted-foreground mt-1">Auto-filled by the maintainers skill from <code>SECURITY.md</code>, registry owner data, or CODEOWNERS. Edit freely.</p>
+    </details>
+
     {{if .Subprojects}}
       <h3 class="font-medium mb-2">Subprojects <span class="text-muted-foreground text-xs">({{len .Subprojects}})</span></h3>
       <p class="text-sm text-muted-foreground mb-2">Detected scannable units inside this repository. Each can be scanned independently with its own findings stream.</p>

--- a/internal/worker/skill.go
+++ b/internal/worker/skill.go
@@ -183,6 +183,7 @@ func (w *Worker) parseMaintainersOutput(scan *db.Scan, report string, emit func(
 			Status   string `json:"status"`
 			Evidence string `json:"evidence"`
 		} `json:"maintainers"`
+		DisclosureChannel string `json:"disclosure_channel"`
 	}
 	if err := json.Unmarshal([]byte(report), &result); err != nil {
 		return fmt.Errorf("parse maintainers report: %w", err)
@@ -190,6 +191,12 @@ func (w *Worker) parseMaintainersOutput(scan *db.Scan, report string, emit func(
 	var repo db.Repository
 	if err := w.DB.First(&repo, scan.RepositoryID).Error; err != nil {
 		return err
+	}
+	if strings.TrimSpace(result.DisclosureChannel) != "" {
+		if err := w.DB.Model(&db.Repository{}).Where("id = ?", repo.ID).
+			Update("disclosure_channel", result.DisclosureChannel).Error; err != nil {
+			return fmt.Errorf("update disclosure channel: %w", err)
+		}
 	}
 	var linked []db.Maintainer
 	for _, rm := range result.Maintainers {

--- a/internal/worker/skill_parsers_test.go
+++ b/internal/worker/skill_parsers_test.go
@@ -118,6 +118,55 @@ func TestParseAdvisories_replacesAdvisoryRows(t *testing.T) {
 	}
 }
 
+func TestParseMaintainers_persistsDisclosureChannel(t *testing.T) {
+	report := `{
+		"maintainers": [
+			{"login": "alice", "name": "Alice", "email": "a@example.org", "role": "lead", "status": "active", "evidence": "14 PRs merged"}
+		],
+		"disclosure_channel": "security@example.org"
+	}`
+	repo, gdb := runSkillWithReport(t, "maintainers", report)
+
+	var got db.Repository
+	gdb.First(&got, repo.ID)
+	if got.DisclosureChannel != "security@example.org" {
+		t.Errorf("DisclosureChannel = %q, want security@example.org", got.DisclosureChannel)
+	}
+	var m db.Maintainer
+	gdb.Where("login = ?", "alice").First(&m)
+	if m.Login != "alice" {
+		t.Error("maintainer not upserted")
+	}
+}
+
+func TestParseMaintainers_emptyChannelLeavesRepoAlone(t *testing.T) {
+	// If the skill reports no channel, we must not clobber a previous
+	// value or an analyst-edited value.
+	report := `{"maintainers": [{"login":"a","role":"lead","status":"active"}]}`
+	repo, gdb := runSkillWithReport(t, "maintainers", report)
+	gdb.Model(&db.Repository{}).Where("id = ?", repo.ID).Update("disclosure_channel", "kept-by-analyst@example.org")
+
+	// Re-run the parser via another skill scan with still no channel.
+	report2 := `{"maintainers": []}`
+	// Spin up a second scan to invoke the parser again with the same DB.
+	skill := db.Skill{Name: "k2", Description: "d", Body: "b", OutputFile: "report.json", OutputKind: "maintainers", Version: 1, Active: true, Source: "ui"}
+	gdb.Create(&skill)
+	scan := db.Scan{RepositoryID: repo.ID, Kind: JobSkill, Status: db.ScanQueued, Model: "fake", SkillID: &skill.ID}
+	gdb.Create(&scan)
+	w := &Worker{DB: gdb, Log: slog.New(slog.NewTextHandler(io.Discard, nil)), DataDir: t.TempDir(),
+		Runner: fakeRunner{skillRes: SkillResult{Commit: "abc", Report: report2}}}
+	body, _ := json.Marshal(queue.Payload{ScanID: scan.ID})
+	if err := w.wrap(w.doSkill)(context.Background(), body); err != nil {
+		t.Fatal(err)
+	}
+
+	var got db.Repository
+	gdb.First(&got, repo.ID)
+	if got.DisclosureChannel != "kept-by-analyst@example.org" {
+		t.Errorf("prior value clobbered: got %q", got.DisclosureChannel)
+	}
+}
+
 func TestParseDependents_replacesDependentRows(t *testing.T) {
 	report := `{"dependents":[
 		{"name":"rails-x","ecosystem":"rubygems","purl":"pkg:gem/rails-x","downloads":5000,"dependent_repos":200,"latest_version":"7.0.0"}


### PR DESCRIPTION
Closes #11. Most of the work was already done — the maintainers skill already reads `SECURITY.md`, `.github/SECURITY.md`, `CODEOWNERS`, and registry owner data, and its output schema has a `disclosure_channel` field. The parser was just throwing it away. This PR persists it and adds the three small missing pieces.

### Repository.DisclosureChannel

New column. Written by the maintainers skill parser when the skill produces a non-empty `disclosure_channel`. Editable on the repo page via a collapsible form (top of Summary tab, under the metadata badges). Empty skill output leaves the existing value alone so an analyst edit survives re-runs of the skill.

### Maintainer.DoNotContact

New boolean column. Toggleable from the maintainer show page (header actions). Surfaces as a `DNC` badge on the maintainers index so a reporter can see at a glance who to skip. Indexed so a future "exclude DNC from disclosure routing" filter is cheap.

### Finding count per maintainer

Maintainers index gains a Findings column. A single grouped query through `repository_maintainers → findings` gives per-maintainer totals in one round-trip regardless of page size.

### Tests

- `TestMaintainersIndex_rendersFindingsCountAndDNCBadge` — findings badges + DNC badge both render for linked maintainers.
- `TestMaintainerDoNotContactToggle` — set and clear round-trip through the handler.
- `TestRepoDisclosureChannel_setAndClear` — empty submission clears, non-empty persists.
- `TestParseMaintainers_persistsDisclosureChannel` — skill output flows into the repo row.
- `TestParseMaintainers_emptyChannelLeavesRepoAlone` — analyst-edited value is not clobbered by a subsequent skill re-run with no channel.

Full lint clean.