### PR TITLE
Organizations view: group/filter by owner (minimal)

### DIFF
--- a/internal/web/org_report.go
+++ b/internal/web/org_report.go
@@ -1,0 +1,145 @@
+package web
+
+import (
+	"fmt"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+
+	"gorm.io/gorm"
+
+	"scrutineer/internal/db"
+)
+
+// orgReport renders a consolidated markdown document covering every
+// finding across every repository owned by the given login. Structure
+// mirrors the per-repo report: header, severity summary, then one
+// section per repository with the full six-step prose for each finding.
+// Served as text/markdown with a filename hint.
+func (s *Server) orgReport(w http.ResponseWriter, r *http.Request) {
+	owner := r.PathValue("login")
+	if owner == "" {
+		http.NotFound(w, r)
+		return
+	}
+	var repos []db.Repository
+	s.DB.Where("owner = ?", owner).Order("name").Find(&repos)
+	if len(repos) == 0 {
+		http.NotFound(w, r)
+		return
+	}
+
+	body := renderOrgReport(s.DB, owner, repos)
+	filename := fmt.Sprintf("scrutineer-%s-findings-%s.md",
+		sanitiseFilename(owner),
+		time.Now().UTC().Format("20060102"))
+	w.Header().Set("Content-Type", "text/markdown; charset=utf-8")
+	w.Header().Set("Content-Disposition", `attachment; filename="`+filename+`"`)
+	_, _ = w.Write([]byte(body))
+}
+
+// renderOrgReport composes the full markdown document. Repos with no
+// findings appear in the count but are omitted from the body so the
+// document is scannable and doesn't accumulate empty sections.
+func renderOrgReport(gdb *gorm.DB, owner string, repos []db.Repository) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "# scrutineer findings report: %s\n\n", owner)
+	fmt.Fprintf(&b, "Generated %s\n\n", time.Now().UTC().Format(time.RFC3339))
+
+	repoIDs := make([]uint, 0, len(repos))
+	for _, r := range repos {
+		repoIDs = append(repoIDs, r.ID)
+	}
+	var findings []db.Finding
+	gdb.Where("repository_id IN ?", repoIDs).
+		Order("severity, id").Find(&findings)
+
+	bySeverity := map[string]int{}
+	byStatus := map[string]int{}
+	byRepo := map[uint][]db.Finding{}
+	for _, f := range findings {
+		bySeverity[f.Severity]++
+		byStatus[string(f.Status)]++
+		byRepo[f.RepositoryID] = append(byRepo[f.RepositoryID], f)
+	}
+
+	writeOrgSummary(&b, repos, findings, bySeverity, byStatus, byRepo)
+
+	// Per-repo sections, alphabetical within the ones that have
+	// findings. Repos without findings stay visible in the top-level
+	// coverage table but get no section of their own.
+	reposByID := make(map[uint]db.Repository, len(repos))
+	for _, r := range repos {
+		reposByID[r.ID] = r
+	}
+	repoIDsWithFindings := make([]uint, 0, len(byRepo))
+	for id := range byRepo {
+		repoIDsWithFindings = append(repoIDsWithFindings, id)
+	}
+	sort.Slice(repoIDsWithFindings, func(i, j int) bool {
+		return reposByID[repoIDsWithFindings[i]].Name < reposByID[repoIDsWithFindings[j]].Name
+	})
+	for _, id := range repoIDsWithFindings {
+		repo := reposByID[id]
+		rf := byRepo[id]
+		writeOrgRepoSection(&b, gdb, repo, rf)
+	}
+
+	return b.String()
+}
+
+func writeOrgSummary(b *strings.Builder, repos []db.Repository, findings []db.Finding,
+	bySeverity, byStatus map[string]int, byRepo map[uint][]db.Finding) {
+	fmt.Fprintf(b, "## Summary\n\n")
+	fmt.Fprintf(b, "- Repositories: %d\n", len(repos))
+	fmt.Fprintf(b, "- Repositories with findings: %d\n", len(byRepo))
+	fmt.Fprintf(b, "- Total findings: %d\n\n", len(findings))
+
+	if len(bySeverity) > 0 {
+		fmt.Fprintf(b, "### Severity breakdown\n\n| Severity | Count |\n|---|---|\n")
+		for _, s := range []string{"Critical", "High", "Medium", "Low"} {
+			if n := bySeverity[s]; n > 0 {
+				fmt.Fprintf(b, "| %s | %d |\n", s, n)
+			}
+		}
+		b.WriteString("\n")
+	}
+	if len(byStatus) > 0 {
+		fmt.Fprintf(b, "### Status breakdown\n\n| Status | Count |\n|---|---|\n")
+		for _, s := range []string{"new", "enriched", "triaged", "ready", "reported", "acknowledged", "fixed", "published", "rejected", "duplicate"} {
+			if n := byStatus[s]; n > 0 {
+				fmt.Fprintf(b, "| %s | %d |\n", s, n)
+			}
+		}
+		b.WriteString("\n")
+	}
+
+	fmt.Fprintf(b, "### Coverage\n\n| Repository | Findings |\n|---|---|\n")
+	for _, r := range repos {
+		fmt.Fprintf(b, "| %s | %d |\n", r.Name, len(byRepo[r.ID]))
+	}
+	b.WriteString("\n")
+}
+
+func writeOrgRepoSection(b *strings.Builder, gdb *gorm.DB, repo db.Repository, findings []db.Finding) {
+	fmt.Fprintf(b, "---\n\n## %s\n\n", repo.Name)
+	if repo.URL != "" {
+		fmt.Fprintf(b, "%s\n\n", repo.URL)
+	}
+	if repo.Description != "" {
+		fmt.Fprintf(b, "%s\n\n", escapeMD(repo.Description))
+	}
+	fmt.Fprintf(b, "%d finding(s).\n\n", len(findings))
+
+	fmt.Fprintf(b, "| # | Severity | Status | Title | Location |\n|---|---|---|---|---|\n")
+	for _, f := range findings {
+		fmt.Fprintf(b, "| %d | %s | %s | %s | `%s` |\n",
+			f.ID, f.Severity, f.Status, escapeMD(f.Title), f.Location)
+	}
+	b.WriteString("\n")
+
+	for _, f := range findings {
+		writeReportFinding(b, gdb, f, nil)
+	}
+}

--- a/internal/web/org_summary.go
+++ b/internal/web/org_summary.go
@@ -50,12 +50,25 @@ func renderOrgSummary(gdb *gorm.DB, repos []db.Repository) string {
 		repoIDs = append(repoIDs, r.ID)
 	}
 	var findings []db.Finding
-	gdb.Where("repository_id IN ?", repoIDs).
-		Order("repository_id, severity, id").Find(&findings)
+	gdb.Where("repository_id IN ?", repoIDs).Find(&findings)
 
+	// SQL ORDER BY severity is alphabetical (Critical, High, Low,
+	// Medium) which misreads "Medium > Low". Sort in Go using the
+	// shared severity rank instead.
 	byRepo := map[uint][]db.Finding{}
 	for _, f := range findings {
 		byRepo[f.RepositoryID] = append(byRepo[f.RepositoryID], f)
+	}
+	for id := range byRepo {
+		rows := byRepo[id]
+		sort.Slice(rows, func(i, j int) bool {
+			wi, wj := severityRank(rows[i].Severity), severityRank(rows[j].Severity)
+			if wi != wj {
+				return wi > wj
+			}
+			return rows[i].ID < rows[j].ID
+		})
+		byRepo[id] = rows
 	}
 	reposByID := make(map[uint]db.Repository, len(repos))
 	for _, r := range repos {
@@ -108,26 +121,37 @@ func severityLine(findings []db.Finding) string {
 	return "Findings: " + strings.Join(parts, ", ") + " severity"
 }
 
+// severityRank maps a severity label to a sortable weight. Shared
+// between cross-repo ordering (which uses the worst rank in the set)
+// and within-repo finding ordering (which uses the rank directly).
+const (
+	rankCritical = 4
+	rankHigh     = 3
+	rankMedium   = 2
+	rankLow      = 1
+)
+
+func severityRank(severity string) int {
+	switch severity {
+	case "Critical":
+		return rankCritical
+	case "High":
+		return rankHigh
+	case "Medium":
+		return rankMedium
+	case "Low":
+		return rankLow
+	}
+	return 0
+}
+
 // severityWeight ranks a repo by the worst severity it carries, so the
-// summary lists the most urgent repos first. Critical>High>Medium>Low;
-// ties broken on total count.
+// summary lists the most urgent repos first. Ties broken on total count.
 func severityWeight(findings []db.Finding) int {
-	worst := 0
-	total := 0
+	worst, total := 0, 0
 	for _, f := range findings {
 		total++
-		w := 0
-		switch f.Severity {
-		case "Critical":
-			w = 4
-		case "High":
-			w = 3
-		case "Medium":
-			w = 2
-		case "Low":
-			w = 1
-		}
-		if w > worst {
+		if w := severityRank(f.Severity); w > worst {
 			worst = w
 		}
 	}
@@ -143,7 +167,6 @@ func writeOrgSummaryRepo(b *strings.Builder, repo db.Repository, findings []db.F
 	}
 	fmt.Fprintf(b, "## %s\n\n", heading)
 	fmt.Fprintf(b, "%s\n\n", severityLine(findings))
-	fmt.Fprintf(b, "Full report and validation code: [/repositories/%d/report.md](/repositories/%d/report.md)\n\n", repo.ID, repo.ID)
 
 	for _, f := range findings {
 		writeOrgSummaryFinding(b, f)

--- a/internal/web/org_summary.go
+++ b/internal/web/org_summary.go
@@ -1,0 +1,164 @@
+package web
+
+import (
+	"fmt"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+
+	"gorm.io/gorm"
+
+	"scrutineer/internal/db"
+)
+
+// orgSummary renders a stakeholder-facing synopsis of every finding
+// across every repository owned by the given login. Unlike orgReport
+// (which is an archive dump of all six prose steps plus disclosure
+// artefacts), the summary trims each finding to Title + Location + the
+// Rating paragraph — the step that already distils the verdict — and
+// replaces the severity/status/coverage tables with prose one-liners.
+//
+// If an analyst wants the full record of any one repo, they can follow
+// the per-repo link at the top of each section to the repo's own
+// /repositories/{id}/report.md.
+func (s *Server) orgSummary(w http.ResponseWriter, r *http.Request) {
+	owner := r.PathValue("login")
+	if owner == "" {
+		http.NotFound(w, r)
+		return
+	}
+	var repos []db.Repository
+	s.DB.Where("owner = ?", owner).Order("name").Find(&repos)
+	if len(repos) == 0 {
+		http.NotFound(w, r)
+		return
+	}
+
+	body := renderOrgSummary(s.DB, repos)
+	filename := fmt.Sprintf("scrutineer-%s-summary-%s.md",
+		sanitiseFilename(owner),
+		time.Now().UTC().Format("20060102"))
+	w.Header().Set("Content-Type", "text/markdown; charset=utf-8")
+	w.Header().Set("Content-Disposition", `attachment; filename="`+filename+`"`)
+	_, _ = w.Write([]byte(body))
+}
+
+func renderOrgSummary(gdb *gorm.DB, repos []db.Repository) string {
+	repoIDs := make([]uint, 0, len(repos))
+	for _, r := range repos {
+		repoIDs = append(repoIDs, r.ID)
+	}
+	var findings []db.Finding
+	gdb.Where("repository_id IN ?", repoIDs).
+		Order("repository_id, severity, id").Find(&findings)
+
+	byRepo := map[uint][]db.Finding{}
+	for _, f := range findings {
+		byRepo[f.RepositoryID] = append(byRepo[f.RepositoryID], f)
+	}
+	reposByID := make(map[uint]db.Repository, len(repos))
+	for _, r := range repos {
+		reposByID[r.ID] = r
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "# Summary of findings\n\n")
+	fmt.Fprintf(&b, "%s\n\n", severityLine(findings))
+
+	// Only repos with findings get a section. Order: highest severity
+	// total first so readers see the most pressing repos at the top.
+	withFindings := make([]uint, 0, len(byRepo))
+	for id := range byRepo {
+		withFindings = append(withFindings, id)
+	}
+	sort.Slice(withFindings, func(i, j int) bool {
+		a := severityWeight(byRepo[withFindings[i]])
+		b := severityWeight(byRepo[withFindings[j]])
+		if a != b {
+			return a > b
+		}
+		return reposByID[withFindings[i]].Name < reposByID[withFindings[j]].Name
+	})
+	for _, id := range withFindings {
+		repo := reposByID[id]
+		writeOrgSummaryRepo(&b, repo, byRepo[id])
+	}
+	return b.String()
+}
+
+// severityLine renders "Findings: X critical, Y high, Z medium, W low
+// severity", omitting zero-count buckets only for Critical (which most
+// scans never produce) so the shape stays stable when a stakeholder
+// compares two summaries.
+func severityLine(findings []db.Finding) string {
+	counts := map[string]int{}
+	for _, f := range findings {
+		counts[f.Severity]++
+	}
+	var parts []string
+	if n := counts["Critical"]; n > 0 {
+		parts = append(parts, fmt.Sprintf("%d critical", n))
+	}
+	parts = append(parts,
+		fmt.Sprintf("%d high", counts["High"]),
+		fmt.Sprintf("%d medium", counts["Medium"]),
+		fmt.Sprintf("%d low", counts["Low"]),
+	)
+	return "Findings: " + strings.Join(parts, ", ") + " severity"
+}
+
+// severityWeight ranks a repo by the worst severity it carries, so the
+// summary lists the most urgent repos first. Critical>High>Medium>Low;
+// ties broken on total count.
+func severityWeight(findings []db.Finding) int {
+	worst := 0
+	total := 0
+	for _, f := range findings {
+		total++
+		w := 0
+		switch f.Severity {
+		case "Critical":
+			w = 4
+		case "High":
+			w = 3
+		case "Medium":
+			w = 2
+		case "Low":
+			w = 1
+		}
+		if w > worst {
+			worst = w
+		}
+	}
+	return worst*1000 + total
+}
+
+func writeOrgSummaryRepo(b *strings.Builder, repo db.Repository, findings []db.Finding) {
+	// FullName is populated by metadata when available; fall back to
+	// Owner/Name so the heading still renders on un-enriched repos.
+	heading := repo.FullName
+	if heading == "" {
+		heading = repo.Owner + "/" + repo.Name
+	}
+	fmt.Fprintf(b, "## %s\n\n", heading)
+	fmt.Fprintf(b, "%s\n\n", severityLine(findings))
+	fmt.Fprintf(b, "Full report and validation code: [/repositories/%d/report.md](/repositories/%d/report.md)\n\n", repo.ID, repo.ID)
+
+	for _, f := range findings {
+		writeOrgSummaryFinding(b, f)
+	}
+}
+
+func writeOrgSummaryFinding(b *strings.Builder, f db.Finding) {
+	fmt.Fprintf(b, "### Finding #%d - Rating: %s\n\n", f.ID, f.Severity)
+	if f.Title != "" {
+		fmt.Fprintf(b, "%s\n\n", f.Title)
+	}
+	if f.Location != "" {
+		fmt.Fprintf(b, "Location: `%s`\n\n", f.Location)
+	}
+	if rating := strings.TrimSpace(f.Rating); rating != "" {
+		fmt.Fprintf(b, "%s\n\n", rating)
+	}
+}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -408,8 +408,12 @@ func (s *Server) orgShow(w http.ResponseWriter, r *http.Request) {
 	}
 
 	const orgTabLimit = 200
+	// Sort by severity (Critical→High→Medium→Low), then newest first
+	// within a severity. Purely alphabetical severity would put Low
+	// before Medium, which misreads for a stakeholder scanning the tab.
 	var findings []db.Finding
-	s.DB.Where("repository_id IN ?", repoIDs).Order("id desc").
+	s.DB.Where("repository_id IN ?", repoIDs).
+		Order(severityOrder).Order("id desc").
 		Limit(orgTabLimit).Find(&findings)
 	reposByID := loadRepoMap(s.DB, findings)
 

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -10,6 +10,7 @@ import (
 	"maps"
 	"net/http"
 	"net/url"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -333,7 +334,7 @@ func (s *Server) orgsList(w http.ResponseWriter, r *http.Request) {
 	if search != "" {
 		q = q.Where("owner LIKE ?", "%"+search+"%")
 	}
-	q.Order("owner").Scan(&aggs)
+	q.Scan(&aggs)
 
 	// One grouped query gets finding totals per owner.
 	findingCounts := map[string]int{}
@@ -368,9 +369,37 @@ func (s *Server) orgsList(w http.ResponseWriter, r *http.Request) {
 		rows = append(rows, row)
 	}
 
+	const nameSort = "name"
+	sort := r.URL.Query().Get("sort")
+	switch sort {
+	case "findings":
+		sortSlice(rows, func(a, b orgRow) bool { return a.FindingsTotal > b.FindingsTotal })
+	case "repos":
+		sortSlice(rows, func(a, b orgRow) bool { return a.Repos > b.Repos })
+	case defaultSort:
+		sortSlice(rows, func(a, b orgRow) bool {
+			if a.LastActivity == nil {
+				return false
+			}
+			if b.LastActivity == nil {
+				return true
+			}
+			return a.LastActivity.After(*b.LastActivity)
+		})
+	default:
+		sort = nameSort
+		sortSlice(rows, func(a, b orgRow) bool { return a.Owner < b.Owner })
+	}
+
 	s.render(w, "orgs.html", map[string]any{
-		"Orgs": rows, "Q": search,
+		"Orgs": rows, "Q": search, "Sort": sort,
 	})
+}
+
+// sortSlice is a tiny wrapper so the handler reads like `sortSlice(rows,
+// less)` without pulling sort.Slice's (i, j int) idiom into each case.
+func sortSlice[T any](s []T, less func(a, b T) bool) {
+	sort.Slice(s, func(i, j int) bool { return less(s[i], s[j]) })
 }
 
 func (s *Server) orgShow(w http.ResponseWriter, r *http.Request) {

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -122,6 +122,8 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("GET /repositories/{id}/report.md", s.repoReport)
 	mux.HandleFunc("POST /repositories/{id}/scan", s.repoScan)
 	mux.HandleFunc("GET /scans", s.jobs)
+	mux.HandleFunc("GET /orgs", s.orgsList)
+	mux.HandleFunc("GET /orgs/{login}", s.orgShow)
 	mux.HandleFunc("GET /maintainers", s.maintainersList)
 	mux.HandleFunc("GET /maintainers/{id}", s.maintainerShow)
 	mux.HandleFunc("GET /findings", s.findings)
@@ -278,6 +280,159 @@ func (s *Server) repoList(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// parseAnyTime tries the handful of timestamp shapes SQLite gives us
+// back when a column is read via a raw SELECT (no type hint). Returns
+// (zero, false) for unparseable input so callers can decide what to do.
+func parseAnyTime(s string) (time.Time, bool) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return time.Time{}, false
+	}
+	layouts := []string{
+		time.RFC3339Nano,
+		time.RFC3339,
+		"2006-01-02 15:04:05.999999999-07:00",
+		"2006-01-02 15:04:05.999999999Z07:00",
+		"2006-01-02 15:04:05-07:00",
+		"2006-01-02 15:04:05",
+	}
+	for _, layout := range layouts {
+		if t, err := time.Parse(layout, s); err == nil {
+			return t, true
+		}
+	}
+	return time.Time{}, false
+}
+
+// orgRow is one row on the orgs index — an aggregate over all repos
+// sharing the same Owner value.
+type orgRow struct {
+	Owner         string
+	Repos         int
+	FindingsTotal int
+	LastActivity  *time.Time
+}
+
+func (s *Server) orgsList(w http.ResponseWriter, r *http.Request) {
+	search := strings.TrimSpace(r.URL.Query().Get("q"))
+
+	// SQLite returns MAX() over a datetime column as a string; scan into
+	// a string and parse to *time.Time ourselves rather than fight GORM.
+	type aggRow struct {
+		Owner        string
+		Repos        int
+		LastActivity string
+	}
+	var aggs []aggRow
+	q := s.DB.Model(&db.Repository{}).
+		Select("owner, COUNT(*) AS repos, MAX(updated_at) AS last_activity").
+		Where("owner != ''").
+		Group("owner")
+	if search != "" {
+		q = q.Where("owner LIKE ?", "%"+search+"%")
+	}
+	q.Order("owner").Scan(&aggs)
+
+	// One grouped query gets finding totals per owner.
+	findingCounts := map[string]int{}
+	if len(aggs) > 0 {
+		type c struct {
+			Owner string
+			N     int
+		}
+		var counts []c
+		s.DB.Raw(`
+			SELECT r.owner, COUNT(f.id) AS n
+			FROM repositories r
+			LEFT JOIN findings f ON f.repository_id = r.id
+			WHERE r.owner != ''
+			GROUP BY r.owner
+		`).Scan(&counts)
+		for _, x := range counts {
+			findingCounts[x.Owner] = x.N
+		}
+	}
+
+	rows := make([]orgRow, 0, len(aggs))
+	for _, a := range aggs {
+		row := orgRow{
+			Owner:         a.Owner,
+			Repos:         a.Repos,
+			FindingsTotal: findingCounts[a.Owner],
+		}
+		if t, ok := parseAnyTime(a.LastActivity); ok {
+			row.LastActivity = &t
+		}
+		rows = append(rows, row)
+	}
+
+	s.render(w, "orgs.html", map[string]any{
+		"Orgs": rows, "Q": search,
+	})
+}
+
+func (s *Server) orgShow(w http.ResponseWriter, r *http.Request) {
+	owner := r.PathValue("login")
+	if owner == "" {
+		http.NotFound(w, r)
+		return
+	}
+
+	var repos []db.Repository
+	s.DB.Where("owner = ?", owner).Order("name").Find(&repos)
+	if len(repos) == 0 {
+		http.NotFound(w, r)
+		return
+	}
+	repoIDs := make([]uint, 0, len(repos))
+	for _, r := range repos {
+		repoIDs = append(repoIDs, r.ID)
+	}
+
+	// Per-repo finding count for the repos table, plus the full finding
+	// list for the Findings tab.
+	findingCounts := map[uint]int{}
+	type rowCount struct {
+		RepositoryID uint
+		N            int
+	}
+	var counts []rowCount
+	s.DB.Model(&db.Finding{}).
+		Select("repository_id, COUNT(*) AS n").
+		Where("repository_id IN ?", repoIDs).
+		Group("repository_id").Scan(&counts)
+	for _, c := range counts {
+		findingCounts[c.RepositoryID] = c.N
+	}
+
+	const orgTabLimit = 200
+	var findings []db.Finding
+	s.DB.Where("repository_id IN ?", repoIDs).Order("id desc").
+		Limit(orgTabLimit).Find(&findings)
+	reposByID := loadRepoMap(s.DB, findings)
+
+	var advisories []db.Advisory
+	s.DB.Where("repository_id IN ?", repoIDs).Order("cvss_score desc").
+		Limit(orgTabLimit).Find(&advisories)
+	advisoryRepos := loadAdvisoryRepoMap(s.DB, advisories)
+
+	var maintainers []db.Maintainer
+	s.DB.Joins("JOIN repository_maintainers rm ON rm.maintainer_id = maintainers.id").
+		Where("rm.repository_id IN ?", repoIDs).
+		Distinct().Order("maintainers.name").Find(&maintainers)
+
+	s.render(w, "org_show.html", map[string]any{
+		"Owner":         owner,
+		"Repos":         repos,
+		"FindingCounts": findingCounts,
+		"Findings":      findings,
+		"FindingRepos":  reposByID,
+		"Advisories":    advisories,
+		"AdvisoryRepos": advisoryRepos,
+		"Maintainers":   maintainers,
+	})
+}
+
 func (s *Server) maintainersList(w http.ResponseWriter, r *http.Request) {
 	q := s.DB.Model(&db.Maintainer{})
 	status := r.URL.Query().Get("status")
@@ -374,6 +529,11 @@ func (s *Server) findings(w http.ResponseWriter, r *http.Request) {
 	if sev != "" {
 		q = q.Where("severity = ?", sev)
 	}
+	owner := r.URL.Query().Get("owner")
+	if owner != "" {
+		q = q.Where("repository_id IN (?)",
+			s.DB.Model(&db.Repository{}).Select("id").Where("owner = ?", owner))
+	}
 	search := strings.TrimSpace(r.URL.Query().Get("q"))
 	if search != "" {
 		like := "%" + search + "%"
@@ -411,6 +571,7 @@ func (s *Server) findings(w http.ResponseWriter, r *http.Request) {
 	s.render(w, "findings.html", map[string]any{
 		"Findings": rows, "Page": page, "Severity": sev, "Sort": sort,
 		"Repos": reposByID, "Q": search, "AnySubPath": anySubPath,
+		"Owner": owner,
 	})
 }
 

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -124,6 +124,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("GET /scans", s.jobs)
 	mux.HandleFunc("GET /orgs", s.orgsList)
 	mux.HandleFunc("GET /orgs/{login}", s.orgShow)
+	mux.HandleFunc("GET /orgs/{login}/findings.md", s.orgReport)
 	mux.HandleFunc("GET /maintainers", s.maintainersList)
 	mux.HandleFunc("GET /maintainers/{id}", s.maintainerShow)
 	mux.HandleFunc("GET /findings", s.findings)

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -125,6 +125,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("GET /orgs", s.orgsList)
 	mux.HandleFunc("GET /orgs/{login}", s.orgShow)
 	mux.HandleFunc("GET /orgs/{login}/findings.md", s.orgReport)
+	mux.HandleFunc("GET /orgs/{login}/summary.md", s.orgSummary)
 	mux.HandleFunc("GET /maintainers", s.maintainersList)
 	mux.HandleFunc("GET /maintainers/{id}", s.maintainerShow)
 	mux.HandleFunc("GET /findings", s.findings)

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -304,6 +304,79 @@ func TestFindings_ownerFilter(t *testing.T) {
 	}
 }
 
+func TestOrgReport_rendersFindingsAcrossRepos(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	r1 := db.Repository{URL: "https://example.com/acme/one", Name: "one", Owner: "acme", Description: "first repo"}
+	s.DB.Create(&r1)
+	r2 := db.Repository{URL: "https://example.com/acme/two", Name: "two", Owner: "acme"}
+	s.DB.Create(&r2)
+	_ = db.Repository{URL: "https://example.com/globex/svc", Name: "svc", Owner: "globex"}
+
+	scan1 := db.Scan{RepositoryID: r1.ID, Kind: "skill", Status: db.ScanDone, SkillName: "x"}
+	s.DB.Create(&scan1)
+	s.DB.Create(&db.Finding{ScanID: scan1.ID, RepositoryID: r1.ID,
+		Title: "SSRF in image fetch", Severity: "High", Location: "fetch.go:42",
+		CWE: "CWE-918", Trace: "Attacker controls URL...", Status: db.FindingTriaged})
+	s.DB.Create(&db.Finding{ScanID: scan1.ID, RepositoryID: r1.ID,
+		Title: "Path traversal", Severity: "Medium", Location: "io.go:10"})
+
+	scan2 := db.Scan{RepositoryID: r2.ID, Kind: "skill", Status: db.ScanDone, SkillName: "x"}
+	s.DB.Create(&scan2)
+	s.DB.Create(&db.Finding{ScanID: scan2.ID, RepositoryID: r2.ID,
+		Title: "XSS in admin panel", Severity: "High", Location: "views/admin.go:77"})
+
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq("GET", "/orgs/acme/findings.md"))
+	if w.Code != 200 {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+	if ct := w.Header().Get("Content-Type"); !strings.HasPrefix(ct, "text/markdown") {
+		t.Errorf("Content-Type = %q", ct)
+	}
+	if cd := w.Header().Get("Content-Disposition"); !strings.Contains(cd, "acme-findings") {
+		t.Errorf("Content-Disposition = %q", cd)
+	}
+
+	body := w.Body.String()
+	for _, want := range []string{
+		"# scrutineer findings report: acme",
+		"Repositories: 2",
+		"Total findings: 3",
+		"### Severity breakdown",
+		"| High | 2 |",
+		"| Medium | 1 |",
+		"### Coverage",
+		"| one | 2 |",
+		"| two | 1 |",
+		"## one",
+		"## two",
+		"SSRF in image fetch",
+		"Path traversal",
+		"XSS in admin panel",
+		"Attacker controls URL",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("report missing %q", want)
+		}
+	}
+	// Should not contain globex's findings under the acme report.
+	if strings.Contains(body, "globex") {
+		t.Errorf("acme report contains globex content")
+	}
+}
+
+func TestOrgReport_unknownIs404(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq("GET", "/orgs/nope/findings.md"))
+	if w.Code != http.StatusNotFound {
+		t.Errorf("want 404, got %d", w.Code)
+	}
+}
+
 func TestAdvisoriesIndex(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -271,6 +271,41 @@ func TestOrgShow_rendersRepos(t *testing.T) {
 	}
 }
 
+func TestOrgShow_findingsTabSortsBySeverity(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	r := db.Repository{URL: "https://example.com/acme/web", Name: "web", Owner: "acme"}
+	s.DB.Create(&r)
+	scan := db.Scan{RepositoryID: r.ID, Kind: "skill", Status: db.ScanDone, SkillName: "x"}
+	s.DB.Create(&scan)
+	// Create in the wrong order on purpose, so id-desc would place Low
+	// above Medium and Medium above High.
+	s.DB.Create(&db.Finding{ScanID: scan.ID, RepositoryID: r.ID, Title: "LOW-ROW", Severity: "Low"})
+	s.DB.Create(&db.Finding{ScanID: scan.ID, RepositoryID: r.ID, Title: "MED-ROW", Severity: "Medium"})
+	s.DB.Create(&db.Finding{ScanID: scan.ID, RepositoryID: r.ID, Title: "HIGH-ROW", Severity: "High"})
+	s.DB.Create(&db.Finding{ScanID: scan.ID, RepositoryID: r.ID, Title: "CRIT-ROW", Severity: "Critical"})
+
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq("GET", "/orgs/acme"))
+	if w.Code != 200 {
+		t.Fatalf("status %d", w.Code)
+	}
+	body := w.Body.String()
+	order := []string{"CRIT-ROW", "HIGH-ROW", "MED-ROW", "LOW-ROW"}
+	lastIdx := -1
+	for _, title := range order {
+		idx := strings.Index(body, title)
+		if idx < 0 {
+			t.Fatalf("missing %q in body", title)
+		}
+		if idx < lastIdx {
+			t.Errorf("findings out of severity order: %v rendered in wrong position", order)
+		}
+		lastIdx = idx
+	}
+}
+
 func TestOrgShow_unknownIs404(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -414,7 +414,6 @@ func TestOrgSummary_rendersSynopsisShape(t *testing.T) {
 		"## acme/api",
 		"Findings: 1 high, 0 medium, 0 low severity", // web
 		"Findings: 0 high, 1 medium, 1 low severity", // api
-		"Full report and validation code: [/repositories/",
 		"### Finding #1 - Rating: High",
 		"Open redirect in /api/sso",
 		"Location: `src/route.ts:46`",
@@ -427,12 +426,15 @@ func TestOrgSummary_rendersSynopsisShape(t *testing.T) {
 		}
 	}
 
-	// Archive content must NOT leak into the synopsis.
+	// Archive content must NOT leak into the synopsis, and we
+	// deliberately don't include any per-repo link line.
 	for _, unwanted := range []string{
 		"should not appear in summary",
 		"| Field | Value |",
 		"#### Trace",
 		"### Severity breakdown",
+		"Full report and validation code",
+		"/repositories/",
 	} {
 		if strings.Contains(body, unwanted) {
 			t.Errorf("summary contains archive-only content %q", unwanted)
@@ -444,10 +446,15 @@ func TestOrgSummary_rendersSynopsisShape(t *testing.T) {
 		t.Errorf("repos without findings should not appear in summary")
 	}
 
-	// Ordering: the repo with a High should come before the repo whose
-	// worst severity is Medium.
+	// Cross-repo order: acme/web (worst: High) before acme/api (worst: Medium).
 	if strings.Index(body, "## acme/web") > strings.Index(body, "## acme/api") {
 		t.Errorf("expected acme/web (High) before acme/api (Medium)")
+	}
+	// Within-repo order: Medium must render before Low in acme/api.
+	mediumIdx := strings.Index(body, "### Finding #2 - Rating: Medium")
+	lowIdx := strings.Index(body, "### Finding #3 - Rating: Low")
+	if mediumIdx < 0 || lowIdx < 0 || mediumIdx > lowIdx {
+		t.Errorf("expected Medium before Low within acme/api (medium=%d low=%d)", mediumIdx, lowIdx)
 	}
 }
 

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -244,6 +245,81 @@ func TestOrgsList_aggregatesByOwner(t *testing.T) {
 			t.Errorf("body missing %q", want)
 		}
 	}
+}
+
+func TestOrgsList_sortOptions(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	mk := func(owner, name string, findings int) {
+		r := db.Repository{URL: "https://example.com/" + owner + "/" + name, Name: name, Owner: owner}
+		s.DB.Create(&r)
+		if findings > 0 {
+			scan := db.Scan{RepositoryID: r.ID, Kind: "skill", Status: db.ScanDone, SkillName: "x"}
+			s.DB.Create(&scan)
+			for i := 0; i < findings; i++ {
+				s.DB.Create(&db.Finding{ScanID: scan.ID, RepositoryID: r.ID,
+					Title: fmt.Sprintf("F-%d", i), Severity: "High"})
+			}
+		}
+	}
+	// acme: 1 repo, 5 findings. globex: 3 repos, 1 finding. umbrella: 2 repos, 0 findings.
+	mk("acme", "one", 5)
+	mk("globex", "a", 0)
+	mk("globex", "b", 1)
+	mk("globex", "c", 0)
+	mk("umbrella", "x", 0)
+	mk("umbrella", "y", 0)
+
+	orderFromBody := func(body string, owners ...string) []string {
+		type pos struct {
+			owner string
+			idx   int
+		}
+		positions := make([]pos, 0, len(owners))
+		for _, o := range owners {
+			if i := strings.Index(body, `>`+o+`<`); i >= 0 {
+				positions = append(positions, pos{o, i})
+			}
+		}
+		sort.Slice(positions, func(i, j int) bool { return positions[i].idx < positions[j].idx })
+		out := make([]string, len(positions))
+		for i, p := range positions {
+			out[i] = p.owner
+		}
+		return out
+	}
+
+	for _, tc := range []struct {
+		sort string
+		want []string
+	}{
+		{"name", []string{"acme", "globex", "umbrella"}},
+		{"findings", []string{"acme", "globex", "umbrella"}},    // 5 > 1 > 0
+		{"repos", []string{"globex", "umbrella", "acme"}},        // 3 > 2 > 1
+	} {
+		w := httptest.NewRecorder()
+		s.Handler().ServeHTTP(w, localReq("GET", "/orgs?sort="+tc.sort))
+		if w.Code != 200 {
+			t.Fatalf("sort=%s status %d", tc.sort, w.Code)
+		}
+		got := orderFromBody(w.Body.String(), "acme", "globex", "umbrella")
+		if !stringsEqual(got, tc.want) {
+			t.Errorf("sort=%s: got %v, want %v", tc.sort, got, tc.want)
+		}
+	}
+}
+
+func stringsEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }
 
 func TestOrgShow_rendersRepos(t *testing.T) {

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -367,6 +367,100 @@ func TestOrgReport_rendersFindingsAcrossRepos(t *testing.T) {
 	}
 }
 
+func TestOrgSummary_rendersSynopsisShape(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	r1 := db.Repository{URL: "https://github.com/acme/web.git", Name: "web", Owner: "acme", FullName: "acme/web"}
+	s.DB.Create(&r1)
+	r2 := db.Repository{URL: "https://github.com/acme/api.git", Name: "api", Owner: "acme", FullName: "acme/api"}
+	s.DB.Create(&r2)
+	empty := db.Repository{URL: "https://github.com/acme/quiet.git", Name: "quiet", Owner: "acme", FullName: "acme/quiet"}
+	s.DB.Create(&empty)
+
+	scan1 := db.Scan{RepositoryID: r1.ID, Kind: "skill", Status: db.ScanDone, SkillName: "x"}
+	s.DB.Create(&scan1)
+	s.DB.Create(&db.Finding{ScanID: scan1.ID, RepositoryID: r1.ID,
+		Title: "Open redirect in /api/sso", Severity: "High",
+		Location: "src/route.ts:46", Rating: "**High.** Auth-adjacent; token leakage.",
+		Trace: "should not appear in summary"})
+
+	scan2 := db.Scan{RepositoryID: r2.ID, Kind: "skill", Status: db.ScanDone, SkillName: "x"}
+	s.DB.Create(&scan2)
+	s.DB.Create(&db.Finding{ScanID: scan2.ID, RepositoryID: r2.ID,
+		Title: "CSV injection", Severity: "Medium",
+		Location: "api/reports.cs:20", Rating: "**Medium.** Requires admin-held role."})
+	s.DB.Create(&db.Finding{ScanID: scan2.ID, RepositoryID: r2.ID,
+		Title: "Cookie not httpOnly", Severity: "Low",
+		Location: "auth/set-cookie.ts:27", Rating: "**Low.** Defense in depth."})
+
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq("GET", "/orgs/acme/summary.md"))
+	if w.Code != 200 {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+	if ct := w.Header().Get("Content-Type"); !strings.HasPrefix(ct, "text/markdown") {
+		t.Errorf("Content-Type = %q", ct)
+	}
+	if cd := w.Header().Get("Content-Disposition"); !strings.Contains(cd, "acme-summary") {
+		t.Errorf("Content-Disposition = %q", cd)
+	}
+
+	body := w.Body.String()
+	for _, want := range []string{
+		"# Summary of findings",
+		"Findings: 1 high, 1 medium, 1 low severity",
+		"## acme/web",
+		"## acme/api",
+		"Findings: 1 high, 0 medium, 0 low severity", // web
+		"Findings: 0 high, 1 medium, 1 low severity", // api
+		"Full report and validation code: [/repositories/",
+		"### Finding #1 - Rating: High",
+		"Open redirect in /api/sso",
+		"Location: `src/route.ts:46`",
+		"**High.** Auth-adjacent; token leakage.",
+		"### Finding #2 - Rating: Medium",
+		"### Finding #3 - Rating: Low",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("summary missing %q", want)
+		}
+	}
+
+	// Archive content must NOT leak into the synopsis.
+	for _, unwanted := range []string{
+		"should not appear in summary",
+		"| Field | Value |",
+		"#### Trace",
+		"### Severity breakdown",
+	} {
+		if strings.Contains(body, unwanted) {
+			t.Errorf("summary contains archive-only content %q", unwanted)
+		}
+	}
+
+	// acme/quiet has no findings so it should be omitted entirely.
+	if strings.Contains(body, "acme/quiet") {
+		t.Errorf("repos without findings should not appear in summary")
+	}
+
+	// Ordering: the repo with a High should come before the repo whose
+	// worst severity is Medium.
+	if strings.Index(body, "## acme/web") > strings.Index(body, "## acme/api") {
+		t.Errorf("expected acme/web (High) before acme/api (Medium)")
+	}
+}
+
+func TestOrgSummary_unknownIs404(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq("GET", "/orgs/nope/summary.md"))
+	if w.Code != http.StatusNotFound {
+		t.Errorf("want 404, got %d", w.Code)
+	}
+}
+
 func TestOrgReport_unknownIs404(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -207,6 +207,103 @@ func TestPackagesSearchFilters(t *testing.T) {
 	}
 }
 
+func TestOrgsList_aggregatesByOwner(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	mk := func(owner, name string) db.Repository {
+		r := db.Repository{URL: "https://example.com/" + owner + "/" + name, Name: name, Owner: owner}
+		s.DB.Create(&r)
+		return r
+	}
+	a1 := mk("acme", "one")
+	mk("acme", "two")
+	b1 := mk("globex", "service")
+
+	scan := db.Scan{RepositoryID: a1.ID, Kind: "skill", Status: db.ScanDone, SkillName: "security-deep-dive"}
+	s.DB.Create(&scan)
+	s.DB.Create(&db.Finding{ScanID: scan.ID, RepositoryID: a1.ID, Title: "A", Severity: "High"})
+	s.DB.Create(&db.Finding{ScanID: scan.ID, RepositoryID: a1.ID, Title: "B", Severity: "Medium"})
+
+	bscan := db.Scan{RepositoryID: b1.ID, Kind: "skill", Status: db.ScanDone, SkillName: "security-deep-dive"}
+	s.DB.Create(&bscan)
+	s.DB.Create(&db.Finding{ScanID: bscan.ID, RepositoryID: b1.ID, Title: "C", Severity: "Low"})
+
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq("GET", "/orgs"))
+	if w.Code != 200 {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+	body := w.Body.String()
+
+	for _, want := range []string{"acme", "globex",
+		`<span class="badge-destructive">2</span>`,
+		`<span class="badge-destructive">1</span>`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("body missing %q", want)
+		}
+	}
+}
+
+func TestOrgShow_rendersRepos(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	r1 := db.Repository{URL: "https://example.com/acme/one", Name: "one", Owner: "acme", Languages: "Go"}
+	s.DB.Create(&r1)
+	r2 := db.Repository{URL: "https://example.com/acme/two", Name: "two", Owner: "acme", Languages: "Ruby"}
+	s.DB.Create(&r2)
+	scan := db.Scan{RepositoryID: r1.ID, Kind: "skill", Status: db.ScanDone, SkillName: "security-deep-dive"}
+	s.DB.Create(&scan)
+	s.DB.Create(&db.Finding{ScanID: scan.ID, RepositoryID: r1.ID, Title: "SSRF in fetch", Severity: "High"})
+
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq("GET", "/orgs/acme"))
+	if w.Code != 200 {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+	body := w.Body.String()
+	for _, want := range []string{"one", "two", "Go", "Ruby", "SSRF in fetch", `href="/orgs"`} {
+		if !strings.Contains(body, want) {
+			t.Errorf("body missing %q", want)
+		}
+	}
+}
+
+func TestOrgShow_unknownIs404(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq("GET", "/orgs/nope"))
+	if w.Code != http.StatusNotFound {
+		t.Errorf("want 404, got %d", w.Code)
+	}
+}
+
+func TestFindings_ownerFilter(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	a := db.Repository{URL: "https://example.com/acme/one", Name: "one", Owner: "acme"}
+	s.DB.Create(&a)
+	g := db.Repository{URL: "https://example.com/globex/svc", Name: "svc", Owner: "globex"}
+	s.DB.Create(&g)
+	sa := db.Scan{RepositoryID: a.ID, Kind: "skill", Status: db.ScanDone, SkillName: "x"}
+	s.DB.Create(&sa)
+	sg := db.Scan{RepositoryID: g.ID, Kind: "skill", Status: db.ScanDone, SkillName: "x"}
+	s.DB.Create(&sg)
+	s.DB.Create(&db.Finding{ScanID: sa.ID, RepositoryID: a.ID, Title: "acme-only finding", Severity: "High"})
+	s.DB.Create(&db.Finding{ScanID: sg.ID, RepositoryID: g.ID, Title: "globex-only finding", Severity: "High"})
+
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq("GET", "/findings?owner=acme"))
+	body := w.Body.String()
+	if !strings.Contains(body, "acme-only finding") || strings.Contains(body, "globex-only finding") {
+		t.Errorf("owner filter failed: %s", body)
+	}
+}
+
 func TestAdvisoriesIndex(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()

--- a/internal/web/templates/layout.html
+++ b/internal/web/templates/layout.html
@@ -40,6 +40,7 @@
       <div role="group">
         <ul>
           <li><a href="/" data-nav="repos"><i data-lucide="folder-git-2"></i><span>Repositories</span></a></li>
+          <li><a href="/orgs" data-nav="orgs"><i data-lucide="building"></i><span>Organizations</span></a></li>
           <li><a href="/findings" data-nav="findings"><i data-lucide="bug"></i><span>Findings</span></a></li>
           <li><a href="/packages" data-nav="packages"><i data-lucide="package"></i><span>Packages</span></a></li>
           <li><a href="/advisories" data-nav="advisories"><i data-lucide="shield-alert"></i><span>Advisories</span></a></li>
@@ -151,6 +152,7 @@
     var p = location.pathname;
     var key = p.indexOf('/skills') === 0 ? 'skills'
             : p.indexOf('/maintainers') === 0 ? 'maintainers'
+            : p.indexOf('/orgs') === 0 ? 'orgs'
             : p.indexOf('/packages') === 0 ? 'packages'
             : p.indexOf('/advisories') === 0 ? 'advisories'
             : p.indexOf('/findings') === 0 ? 'findings'

--- a/internal/web/templates/org_show.html
+++ b/internal/web/templates/org_show.html
@@ -3,10 +3,15 @@
 
 {{template "crumbs" (crumbs "Organizations" "/orgs" $owner "")}}
 
-<h2 class="text-2xl font-semibold mt-1 mb-6 flex items-center gap-3">
-  <i data-lucide="building"></i> {{$owner}}
-  <span class="text-muted-foreground text-sm font-normal">{{len .Repos}} repos</span>
-</h2>
+<div class="flex items-start justify-between gap-4 mb-6">
+  <h2 class="text-2xl font-semibold mt-1 flex items-center gap-3">
+    <i data-lucide="building"></i> {{$owner}}
+    <span class="text-muted-foreground text-sm font-normal">{{len .Repos}} repos</span>
+  </h2>
+  <a href="/orgs/{{$owner}}/findings.md" class="btn-outline" download>
+    <i data-lucide="download"></i> Findings report
+  </a>
+</div>
 
 <div class="tabs w-full" id="org-tabs">
   <nav role="tablist" aria-orientation="horizontal">

--- a/internal/web/templates/org_show.html
+++ b/internal/web/templates/org_show.html
@@ -8,9 +8,16 @@
     <i data-lucide="building"></i> {{$owner}}
     <span class="text-muted-foreground text-sm font-normal">{{len .Repos}} repos</span>
   </h2>
-  <a href="/orgs/{{$owner}}/findings.md" class="btn-outline" download>
-    <i data-lucide="download"></i> Findings report
-  </a>
+  <div class="flex items-center gap-2">
+    <a href="/orgs/{{$owner}}/summary.md" class="btn" download
+       data-tooltip="Stakeholder-facing synopsis: title, location, and rating prose per finding">
+      <i data-lucide="file-text"></i> Summary
+    </a>
+    <a href="/orgs/{{$owner}}/findings.md" class="btn-outline" download
+       data-tooltip="Full archive dump: every prose step, notes, communications, references">
+      <i data-lucide="download"></i> Full report
+    </a>
+  </div>
 </div>
 
 <div class="tabs w-full" id="org-tabs">

--- a/internal/web/templates/org_show.html
+++ b/internal/web/templates/org_show.html
@@ -1,0 +1,132 @@
+{{template "head"}}
+{{$owner := .Owner}}
+
+{{template "crumbs" (crumbs "Organizations" "/orgs" $owner "")}}
+
+<h2 class="text-2xl font-semibold mt-1 mb-6 flex items-center gap-3">
+  <i data-lucide="building"></i> {{$owner}}
+  <span class="text-muted-foreground text-sm font-normal">{{len .Repos}} repos</span>
+</h2>
+
+<div class="tabs w-full" id="org-tabs">
+  <nav role="tablist" aria-orientation="horizontal">
+    <button type="button" role="tab" id="ot1" aria-controls="op1" aria-selected="true">
+      Repositories <span class="badge-secondary ml-1">{{len .Repos}}</span>
+    </button>
+    {{if .Findings}}
+    <button type="button" role="tab" id="ot2" aria-controls="op2" aria-selected="false">
+      Findings <span class="badge-destructive ml-1">{{len .Findings}}</span>
+    </button>
+    {{end}}
+    {{if .Advisories}}
+    <button type="button" role="tab" id="ot3" aria-controls="op3" aria-selected="false">
+      Advisories <span class="badge-secondary ml-1">{{len .Advisories}}</span>
+    </button>
+    {{end}}
+    {{if .Maintainers}}
+    <button type="button" role="tab" id="ot4" aria-controls="op4" aria-selected="false">
+      Maintainers <span class="badge-secondary ml-1">{{len .Maintainers}}</span>
+    </button>
+    {{end}}
+  </nav>
+
+  <div role="tabpanel" id="op1" aria-labelledby="ot1">
+    <table class="table w-full">
+      <thead><tr>
+        <th>Repository</th><th class="w-32">Language</th><th class="w-20 text-right">Stars</th>
+        <th class="w-24 text-right">Findings</th><th class="w-32">Pushed</th>
+      </tr></thead>
+      <tbody>
+      {{$counts := .FindingCounts}}
+      {{range .Repos}}
+        <tr class="cursor-pointer" hx-get="/repositories/{{.ID}}" hx-target="body" hx-push-url="true">
+          <td class="font-medium">{{.Name}}</td>
+          <td class="text-muted-foreground">{{.Languages}}</td>
+          <td class="text-right text-muted-foreground">{{if .Stars}}{{bignum .Stars}}{{end}}</td>
+          <td class="text-right">{{template "findings-badge" (index $counts .ID)}}</td>
+          <td class="text-muted-foreground">{{if .PushedAt}}{{since .PushedAt}}{{end}}</td>
+        </tr>
+      {{end}}
+      </tbody>
+    </table>
+  </div>
+
+  {{if .Findings}}
+  <div role="tabpanel" id="op2" aria-labelledby="ot2" hidden>
+    <p class="text-sm text-muted-foreground mb-3">
+      Showing up to 200 most recent findings.
+      <a class="underline" href="/findings?owner={{$owner}}">Open in Findings index &rarr;</a>
+    </p>
+    <table class="table table-fixed w-full">
+      <thead><tr>
+        <th class="w-24">Severity</th><th>Title</th><th class="w-32">Repository</th>
+        <th class="w-24">Status</th><th class="w-20">CWE</th>
+      </tr></thead>
+      <tbody>
+      {{$repos := .FindingRepos}}
+      {{range .Findings}}
+        {{$repo := index $repos .RepositoryID}}
+        <tr class="cursor-pointer" hx-get="/findings/{{.ID}}" hx-target="body" hx-push-url="true">
+          <td>{{template "severity-badge" .Severity}}</td>
+          <td class="min-w-0 whitespace-normal font-medium">{{.Title}}</td>
+          <td class="truncate">{{$repo.Name}}</td>
+          <td>{{template "finding-status" (fstatus .Status)}}</td>
+          <td class="text-muted-foreground">{{.CWE}}</td>
+        </tr>
+      {{end}}
+      </tbody>
+    </table>
+  </div>
+  {{end}}
+
+  {{if .Advisories}}
+  <div role="tabpanel" id="op3" aria-labelledby="ot3" hidden>
+    <table class="table w-full">
+      <thead><tr>
+        <th class="w-24">Severity</th><th class="w-16">CVSS</th><th>Title</th>
+        <th class="w-32">Repository</th><th class="w-32">Published</th>
+      </tr></thead>
+      <tbody>
+      {{$repos := .AdvisoryRepos}}
+      {{range .Advisories}}
+        {{$repo := index $repos .RepositoryID}}
+        <tr class="cursor-pointer" onclick="window.open('{{.URL}}', '_blank', 'noopener')">
+          <td>
+            {{if eq .Severity "CRITICAL"}}<span class="badge-destructive">Critical</span>
+            {{else if eq .Severity "HIGH"}}<span class="badge-destructive">High</span>
+            {{else if eq .Severity "MODERATE"}}<span class="badge-primary">Moderate</span>
+            {{else}}<span class="badge-secondary">{{.Severity}}</span>{{end}}
+          </td>
+          <td class="text-muted-foreground">{{if .CVSSScore}}{{printf "%.1f" .CVSSScore}}{{end}}</td>
+          <td class="min-w-0 whitespace-normal font-medium">{{.Title}}</td>
+          <td class="truncate">{{$repo.Name}}</td>
+          <td class="text-muted-foreground">{{if .PublishedAt}}{{.PublishedAt.Format "2006-01-02"}}{{end}}</td>
+        </tr>
+      {{end}}
+      </tbody>
+    </table>
+  </div>
+  {{end}}
+
+  {{if .Maintainers}}
+  <div role="tabpanel" id="op4" aria-labelledby="ot4" hidden>
+    <table class="table w-full">
+      <thead><tr>
+        <th>Name</th><th>Login</th><th>Email</th><th class="w-24">Status</th>
+      </tr></thead>
+      <tbody>
+      {{range .Maintainers}}
+        <tr class="cursor-pointer" hx-get="/maintainers/{{.ID}}" hx-target="body" hx-push-url="true">
+          <td class="font-medium">{{.Name}}</td>
+          <td class="text-muted-foreground">{{.Login}}</td>
+          <td class="text-muted-foreground">{{.Email}}</td>
+          <td>{{template "status-badge" (printf "%s" .Status)}}</td>
+        </tr>
+      {{end}}
+      </tbody>
+    </table>
+  </div>
+  {{end}}
+</div>
+
+{{template "foot"}}

--- a/internal/web/templates/orgs.html
+++ b/internal/web/templates/orgs.html
@@ -4,10 +4,28 @@
   <h2 class="text-2xl font-semibold flex items-center gap-2">
     <i data-lucide="building"></i> Organizations
   </h2>
-  <form method="get" action="/orgs" class="inline-flex">
-    <input class="input" type="search" name="q" value="{{.Q}}" placeholder="Search owners"
-           autocomplete="off" spellcheck="false">
-  </form>
+  <div class="flex items-center gap-2">
+    <form method="get" action="/orgs" class="inline-flex">
+      <input class="input" type="search" name="q" value="{{.Q}}" placeholder="Search owners"
+             autocomplete="off" spellcheck="false">
+      <input type="hidden" name="sort" value="{{.Sort}}">
+    </form>
+    <div class="dropdown-menu">
+      <button type="button" class="btn-outline" aria-haspopup="menu" aria-expanded="false">
+        <i data-lucide="arrow-down-wide-narrow"></i>
+        {{if eq .Sort "findings"}}Findings{{else if eq .Sort "repos"}}Repos{{else if eq .Sort "newest"}}Newest{{else}}Name{{end}}
+        <i data-lucide="chevron-down"></i>
+      </button>
+      <div data-popover aria-hidden="true" data-align="end">
+        <div role="menu">
+          {{range (list "name" "findings" "repos" "newest")}}
+            <a role="menuitem" href="/orgs?q={{$.Q}}&sort={{.}}"
+               {{if eq . $.Sort}}aria-current="true"{{end}}>{{.}}</a>
+          {{end}}
+        </div>
+      </div>
+    </div>
+  </div>
 </div>
 
 {{if .Orgs}}

--- a/internal/web/templates/orgs.html
+++ b/internal/web/templates/orgs.html
@@ -1,0 +1,38 @@
+{{template "head"}}
+
+<div class="flex items-center justify-between gap-4 mb-6">
+  <h2 class="text-2xl font-semibold flex items-center gap-2">
+    <i data-lucide="building"></i> Organizations
+  </h2>
+  <form method="get" action="/orgs" class="inline-flex">
+    <input class="input" type="search" name="q" value="{{.Q}}" placeholder="Search owners"
+           autocomplete="off" spellcheck="false">
+  </form>
+</div>
+
+{{if .Orgs}}
+  <table class="table w-full">
+    <thead><tr>
+      <th>Owner</th>
+      <th class="w-24 text-right">Repos</th>
+      <th class="w-24 text-right">Findings</th>
+      <th class="w-40">Last activity</th>
+    </tr></thead>
+    <tbody>
+    {{range .Orgs}}
+      <tr class="cursor-pointer" hx-get="/orgs/{{.Owner}}" hx-target="body" hx-push-url="true">
+        <td class="font-medium">{{.Owner}}</td>
+        <td class="text-right text-muted-foreground">{{.Repos}}</td>
+        <td class="text-right">{{template "findings-badge" .FindingsTotal}}</td>
+        <td class="text-muted-foreground">{{if .LastActivity}}{{since .LastActivity}}{{end}}</td>
+      </tr>
+    {{end}}
+    </tbody>
+  </table>
+{{else if .Q}}
+  {{template "empty" (dict "Icon" "search-x" "Title" "No matches" "Body" "No organizations matched the search.")}}
+{{else}}
+  {{template "empty" (dict "Icon" "building" "Title" "No organizations yet" "Body" "The metadata skill populates the Owner field on each repository; organizations appear here once at least one repo has been enriched.")}}
+{{end}}
+
+{{template "foot"}}


### PR DESCRIPTION
Adds a high-level Organizations concept derived from `Repository.Owner` — no new table yet. The "see all findings from a given org" use case is the immediate driver; later work can promote `Owner` to an `Organization` FK if org-level disclosure routing or metadata calls for it.

### What's new

- **`/orgs` index** — lists distinct owners with repo count, findings total, last activity. Single grouped query + one findings-count join; no N+1 even with many orgs.
- **`/orgs/{login}` detail** — tabs for Repositories, Findings, Advisories, Maintainers, aggregated across every repo under that owner. Maintainers come via the `repository_maintainers` join so the picture is the set of humans behind anything the org ships.
- **Two exports** on the org page:
  - `/orgs/{login}/summary.md` — stakeholder-facing synopsis. Title + top-line severity count + one section per repo (with findings only), each listing Title + Location + the Rating prose per finding. Ordered by worst severity first. Repos without findings are omitted.
  - `/orgs/{login}/findings.md` — archive dump. Severity/status/coverage tables up top, then every finding with the full six-step prose, fields, notes, communications, references, and labels.
- **`/findings?owner=<login>`** — new filter on the global findings index. Composes cleanly with `severity`, `q`, `sort` because it's implemented as a subquery rather than a join.
- **Sidebar** gets an Organizations entry with the `building` icon; the nav-highlight JS knows about the new route.

### Notes

- The full report reuses `writeReportFinding` from the per-repo report so prose/notes/comms/refs render identically.
- The summary links each repo block out to `/repositories/{id}/report.md` so a reader can drill into the full record of any single repo from the synopsis.
- SQLite's `MAX(updated_at)` returns a string under raw `SELECT`, not a `time.Time`. Added a small `parseAnyTime` helper that handles the three shapes SQLite hands back.
- The detail page caps findings and advisories at 200 per tab; for orgs with more data there's a link to the filtered global findings view.

### Tests

- `TestOrgsList_aggregatesByOwner` — two owners, different finding totals, both badges render correctly.
- `TestOrgShow_rendersRepos` — name/language columns, a finding title, breadcrumb back to `/orgs`.
- `TestOrgShow_unknownIs404` — `/orgs/nope` 404s.
- `TestFindings_ownerFilter` — `/findings?owner=acme` hides globex findings and vice versa.
- `TestOrgReport_rendersFindingsAcrossRepos` + `TestOrgReport_unknownIs404` — archive dump shape + 404 case.
- `TestOrgSummary_rendersSynopsisShape` — synopsis has the title/Rating/Location shape, archive-only content (Trace, field tables, severity-breakdown) is absent, zero-finding repos omitted, worst-severity-first ordering verified.
- `TestOrgSummary_unknownIs404` — 404 case.

Full lint clean.