### PR TITLE
fix: resolve SQL logical issue with `commit` keyword

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -495,10 +495,10 @@ func BackfillFindingRepository(gdb *gorm.DB) {
 	`)
 	gdb.Exec(`
 		UPDATE findings
-		SET commit = (
-			SELECT commit FROM scans WHERE scans.id = findings.scan_id
+		SET "commit" = (
+			SELECT "commit" FROM scans WHERE scans.id = findings.scan_id
 		)
-		WHERE ` + "`commit`" + ` IS NULL OR ` + "`commit`" + ` = ''
+		WHERE "commit" IS NULL OR "commit" = ''
 	`)
 }
 

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -2,6 +2,35 @@ package db
 
 import "testing"
 
+func TestBackfillFindingRepositoryFillsCommit(t *testing.T) {
+	gdb, err := Open(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := Repository{URL: "https://example.com/x", Name: "x"}
+	if err := gdb.Create(&r).Error; err != nil {
+		t.Fatal(err)
+	}
+	s := Scan{RepositoryID: r.ID, Kind: "claude", Status: ScanDone, Commit: "deadbeef"}
+	if err := gdb.Create(&s).Error; err != nil {
+		t.Fatal(err)
+	}
+	f := Finding{ScanID: s.ID, RepositoryID: r.ID, Title: "t", Severity: "Low"}
+	if err := gdb.Create(&f).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	BackfillFindingRepository(gdb)
+
+	var got Finding
+	if err := gdb.First(&got, f.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if got.Commit != "deadbeef" {
+		t.Errorf("Finding.Commit = %q, want %q", got.Commit, "deadbeef")
+	}
+}
+
 func TestNameFromURL(t *testing.T) {
 	cases := map[string]string{
 		"https://github.com/foo/bar":      "bar",


### PR DESCRIPTION
commit is an SQLite reserved word.
The old query quoted it in the WHERE clause but not in SET commit = ... or SELECT commit FROM scans, so the parser rejected the whole statement. gdb.Exec logged the error but didn't propagate it, masking the fact that the backfill silently did nothing.

```go
2026/04/22 11:56:25 .../scrutineer/internal/db/db.go:496 SQL logic error: near "commit": syntax error (1)
[0.007ms] [rows:0]
		UPDATE findings
		SET commit = (
			SELECT commit FROM scans WHERE scans.id = findings.scan_id
		)
		WHERE `commit` IS NULL OR `commit` = ''
```