### PR TITLE
Fix Docker builds for both scrutineer and -runner containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,11 @@ FROM node:22-alpine AS claude
 RUN npm install -g @anthropic-ai/claude-code@1.0.17
 
 FROM python:3.13-alpine AS python-tools
-RUN pip install --no-cache-dir semgrep==1.115.0
+RUN pip install --no-cache-dir semgrep==1.116.0
+
+FROM rust:1.88-alpine AS zizmor-build
+RUN apk add --no-cache build-base linux-headers
+RUN cargo install --locked --root /out zizmor@1.24.1
 
 FROM alpine:3.21
 RUN apk add --no-cache git ca-certificates python3 bash nodejs
@@ -29,15 +33,11 @@ COPY --from=python-tools /usr/local/bin/semgrep* /usr/local/bin/
 COPY --from=build /usr/local/go /usr/local/go
 ENV PATH="/usr/local/go/bin:${PATH}"
 RUN GOBIN=/usr/local/bin go install github.com/git-pkgs/git-pkgs@v0.14.0 && \
-    GOBIN=/usr/local/bin go install github.com/git-pkgs/brief@v0.10.0 && \
+    GOBIN=/usr/local/bin go install github.com/git-pkgs/brief/cmd/brief@v0.5.2 && \
     rm -rf /root/go /usr/local/go
 
 # zizmor
-RUN apk add --no-cache --virtual .build-deps cargo && \
-    cargo install zizmor@1.6.0 && \
-    cp /root/.cargo/bin/zizmor /usr/local/bin/ && \
-    rm -rf /root/.cargo && \
-    apk del .build-deps
+COPY --from=zizmor-build /out/bin/zizmor /usr/local/bin/zizmor
 
 # Non-root user (T1/T11: reduce blast radius)
 RUN adduser -D -h /home/scrutineer scrutineer && \

--- a/Dockerfile.runner
+++ b/Dockerfile.runner
@@ -6,11 +6,15 @@ FROM node:22-alpine AS claude
 RUN npm install -g @anthropic-ai/claude-code@1.0.17
 
 FROM python:3.13-alpine AS python-tools
-RUN pip install --no-cache-dir semgrep==1.115.0
+RUN pip install --no-cache-dir semgrep==1.116.0
 
 FROM golang:1.26.2-alpine AS go-tools
 RUN GOBIN=/out go install github.com/git-pkgs/git-pkgs@v0.14.0 && \
-    GOBIN=/out go install github.com/git-pkgs/brief@v0.10.0
+    GOBIN=/out go install github.com/git-pkgs/brief/cmd/brief@v0.5.2
+
+FROM rust:1.88-alpine AS zizmor-build
+RUN apk add --no-cache build-base linux-headers
+RUN cargo install --locked --root /out zizmor@1.24.1
 
 FROM alpine:3.21
 RUN apk add --no-cache git ca-certificates python3 bash nodejs
@@ -27,11 +31,7 @@ COPY --from=python-tools /usr/local/bin/semgrep* /usr/local/bin/
 COPY --from=go-tools /out/* /usr/local/bin/
 
 # zizmor
-RUN apk add --no-cache --virtual .build-deps cargo && \
-    cargo install zizmor@1.6.0 && \
-    cp /root/.cargo/bin/zizmor /usr/local/bin/ && \
-    rm -rf /root/.cargo && \
-    apk del .build-deps
+COPY --from=zizmor-build /out/bin/zizmor /usr/local/bin/zizmor
 
 # Non-root
 RUN adduser -D -h /home/runner runner

--- a/threatmodel.md
+++ b/threatmodel.md
@@ -118,7 +118,7 @@ No rate limiting on `POST /repositories`, no cap on clone size, no timeout on th
 
 ### T11: Image supply chain (partially mitigated)
 
-Tool versions are pinned: `claude-code@1.0.17`, `semgrep==1.115.0`, `git-pkgs@v0.14.0`, `brief@v0.10.0`, `zizmor@1.6.0`. The container runs as non-root user `scrutineer`. `curl`, `npm`, and `pip` are stripped from the final stage.
+Tool versions are pinned: `claude-code@1.0.17`, `semgrep==1.116.0`, `git-pkgs@v0.14.0`, `brief@v0.5.2`, `zizmor@1.24.1`. The container runs as non-root user `scrutineer`. `curl`, `npm`, and `pip` are stripped from the final stage.
 
 Residual: versions are pinned by tag, not by digest. A compromised release at the pinned version (e.g. a yanked-and-republished npm package) would still land. Base images (`golang:1.26.2-alpine`, `node:22-alpine`, `python:3.13-alpine`, `alpine:3.21`) are also not digest-pinned.
 


### PR DESCRIPTION
Address three issues when building.

I couldn't get the project on macOS/arm64 and had to solve three installation issues

 - semgrep==1.115.0 was no longer installable, minimal update to 1.116.0
 - brief now installs the latest released version github.com/git-pkgs/brief/cmd/brief@v0.5.2 over trying to find @v0.10 (which I don't think exists as a tag or release) 
 - dedicated rust:1.88-alpine stage for zizmor as it could not be build with Alpine’s older Rust/Cargo version

Tested with:

```
docker build -t scrutineer .
docker build -t scrutineer-runner -f Dockerfile.runner .
```