### PR TITLE
scans: cancel running/queued scans from the jobs list

### DIFF
--- a/cmd/scrutineer/main.go
+++ b/cmd/scrutineer/main.go
@@ -122,7 +122,7 @@ func run(log *slog.Logger) error {
 	}
 	w.Register(q)
 
-	srv, err := web.New(gdb, q, log, broker)
+	srv, err := web.New(gdb, q, log, broker, w)
 	if err != nil {
 		return err
 	}

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -49,10 +49,11 @@ type Repository struct {
 type ScanStatus string
 
 const (
-	ScanQueued  ScanStatus = "queued"
-	ScanRunning ScanStatus = "running"
-	ScanDone    ScanStatus = "done"
-	ScanFailed  ScanStatus = "failed"
+	ScanQueued    ScanStatus = "queued"
+	ScanRunning   ScanStatus = "running"
+	ScanDone      ScanStatus = "done"
+	ScanFailed    ScanStatus = "failed"
+	ScanCancelled ScanStatus = "cancelled"
 )
 
 // Scan is one execution of a job against a repository. Kind names the job
@@ -430,7 +431,7 @@ func (s Scan) Duration() time.Duration {
 }
 
 func (s ScanStatus) Terminal() bool {
-	return s == ScanDone || s == ScanFailed
+	return s == ScanDone || s == ScanFailed || s == ScanCancelled
 }
 
 func Open(dsn string) (*gorm.DB, error) {

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -33,10 +33,11 @@ type Server struct {
 	Queue  *queue.Queue
 	Log    *slog.Logger
 	Broker *Broker
+	Worker *worker.Worker
 	tmpl   *template.Template
 }
 
-func New(gdb *gorm.DB, q *queue.Queue, log *slog.Logger, broker *Broker) (*Server, error) {
+func New(gdb *gorm.DB, q *queue.Queue, log *slog.Logger, broker *Broker, w *worker.Worker) (*Server, error) {
 	funcs := template.FuncMap{
 		"since": func(t *time.Time) string {
 			if t == nil {
@@ -108,7 +109,7 @@ func New(gdb *gorm.DB, q *queue.Queue, log *slog.Logger, broker *Broker) (*Serve
 	if err != nil {
 		return nil, err
 	}
-	return &Server{DB: gdb, Queue: q, Log: log, Broker: broker, tmpl: t}, nil
+	return &Server{DB: gdb, Queue: q, Log: log, Broker: broker, Worker: w, tmpl: t}, nil
 }
 
 func (s *Server) Handler() http.Handler {
@@ -148,6 +149,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("GET /advisories", s.advisoriesList)
 	mux.HandleFunc("GET /scans/{id}", s.scanShow)
 	mux.HandleFunc("POST /scans/{id}/retry", s.scanRetry)
+	mux.HandleFunc("POST /scans/{id}/cancel", s.scanCancel)
 	mux.HandleFunc("GET /scans/{id}/log", s.scanLog)
 	mux.HandleFunc("GET /skills", s.skillsList)
 	mux.HandleFunc("GET /skills/new", s.skillNew)
@@ -1295,6 +1297,29 @@ func (s *Server) scanRetry(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Header().Set("HX-Redirect", fmt.Sprintf("/scans/%d", newID))
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *Server) scanCancel(w http.ResponseWriter, r *http.Request) {
+	var scan db.Scan
+	if err := s.DB.First(&scan, r.PathValue("id")).Error; err != nil {
+		http.NotFound(w, r)
+		return
+	}
+	if scan.Status.Terminal() {
+		http.Error(w, "scan already finished", http.StatusBadRequest)
+		return
+	}
+	if !s.Worker.Cancel(scan.ID) {
+		// Not in flight: mark the row so the queue handler drops it on pickup.
+		now := time.Now()
+		s.DB.Model(&scan).Updates(map[string]any{
+			"status":      db.ScanCancelled,
+			"error":       "cancelled by user",
+			"finished_at": &now,
+		})
+	}
+	w.Header().Set("HX-Refresh", "true")
 	w.WriteHeader(http.StatusNoContent)
 }
 

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -14,6 +14,7 @@ import (
 
 	"scrutineer/internal/db"
 	"scrutineer/internal/queue"
+	"scrutineer/internal/worker"
 )
 
 func newTestServer(t *testing.T) (*Server, func()) {
@@ -28,7 +29,7 @@ func newTestServer(t *testing.T) (*Server, func()) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	s, err := New(gdb, q, log, NewBroker())
+	s, err := New(gdb, q, log, NewBroker(), &worker.Worker{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1154,6 +1155,57 @@ func TestRetry_preservesSubPath(t *testing.T) {
 	s.DB.Where("id != ?", orig.ID).First(&fresh)
 	if fresh.SubPath != "airflow-core" {
 		t.Errorf("retry lost sub-path: got %q, want airflow-core", fresh.SubPath)
+	}
+}
+
+func TestScanCancel_queued(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	repo := db.Repository{URL: "https://example.com/x.git", Name: "x"}
+	s.DB.Create(&repo)
+	scan := db.Scan{RepositoryID: repo.ID, Kind: "skill", Status: db.ScanQueued}
+	s.DB.Create(&scan)
+
+	req := httptest.NewRequest("POST", fmt.Sprintf("/scans/%d/cancel", scan.ID), nil)
+	req.Host = testHost
+	req.Header.Set("Sec-Fetch-Site", "same-origin")
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("cancel status %d: %s", w.Code, w.Body)
+	}
+
+	var got db.Scan
+	s.DB.First(&got, scan.ID)
+	if got.Status != db.ScanCancelled {
+		t.Errorf("status = %s, want cancelled", got.Status)
+	}
+	if got.FinishedAt == nil {
+		t.Error("FinishedAt not set")
+	}
+	if got.Error != "cancelled by user" {
+		t.Errorf("error = %q", got.Error)
+	}
+}
+
+func TestScanCancel_terminalRejected(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	repo := db.Repository{URL: "https://example.com/x.git", Name: "x"}
+	s.DB.Create(&repo)
+	fin := time.Now()
+	scan := db.Scan{RepositoryID: repo.ID, Kind: "skill", Status: db.ScanDone, FinishedAt: &fin}
+	s.DB.Create(&scan)
+
+	req := httptest.NewRequest("POST", fmt.Sprintf("/scans/%d/cancel", scan.ID), nil)
+	req.Host = testHost
+	req.Header.Set("Sec-Fetch-Site", "same-origin")
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("got %d, want 400", w.Code)
 	}
 }
 

--- a/internal/web/templates/jobs.html
+++ b/internal/web/templates/jobs.html
@@ -30,7 +30,7 @@
       <div data-popover aria-hidden="true" data-align="end">
         <div role="menu">
           <a role="menuitem" href="/scans?skill={{.Skill}}&sort={{.Sort}}">All statuses</a>
-          {{range (list "queued" "running" "done" "failed")}}
+          {{range (list "queued" "running" "done" "failed" "cancelled")}}
             <a role="menuitem" href="/scans?skill={{$.Skill}}&status={{.}}&sort={{$.Sort}}"
                {{if eq . $.Status}}aria-current="true"{{end}}>{{.}}</a>
           {{end}}
@@ -79,7 +79,11 @@
         <td class="text-muted-foreground">{{if .Model}}{{.Model}}{{else}}-{{end}}</td>
         <td>{{if .StartedAt}}{{since .StartedAt}}{{end}}</td>
         <td>{{if .FinishedAt}}{{dur .Duration}}{{end}}</td>
-        <td>{{if and (eq (status .Status) "failed") .SkillID}}<button class="btn-sm-ghost"
+        <td>{{if or (eq (status .Status) "queued") (eq (status .Status) "running")}}<button class="btn-sm-ghost"
+            hx-post="/scans/{{.ID}}/cancel" hx-swap="none"
+            hx-on:click="event.stopPropagation()"
+            data-tooltip="Cancel"><i data-lucide="x"></i></button>
+          {{else if and (or (eq (status .Status) "failed") (eq (status .Status) "cancelled")) .SkillID}}<button class="btn-sm-ghost"
             hx-post="/scans/{{.ID}}/retry" hx-swap="none"
             hx-on:click="event.stopPropagation()"
             data-tooltip="Retry"><i data-lucide="refresh-cw"></i></button>{{end}}</td>

--- a/internal/web/templates/jobs.html
+++ b/internal/web/templates/jobs.html
@@ -79,14 +79,7 @@
         <td class="text-muted-foreground">{{if .Model}}{{.Model}}{{else}}-{{end}}</td>
         <td>{{if .StartedAt}}{{since .StartedAt}}{{end}}</td>
         <td>{{if .FinishedAt}}{{dur .Duration}}{{end}}</td>
-        <td>{{if or (eq (status .Status) "queued") (eq (status .Status) "running")}}<button class="btn-sm-ghost"
-            hx-post="/scans/{{.ID}}/cancel" hx-swap="none"
-            hx-on:click="event.stopPropagation()"
-            data-tooltip="Cancel"><i data-lucide="x"></i></button>
-          {{else if and (or (eq (status .Status) "failed") (eq (status .Status) "cancelled")) .SkillID}}<button class="btn-sm-ghost"
-            hx-post="/scans/{{.ID}}/retry" hx-swap="none"
-            hx-on:click="event.stopPropagation()"
-            data-tooltip="Retry"><i data-lucide="refresh-cw"></i></button>{{end}}</td>
+        <td>{{template "scan-actions" .}}</td>
       </tr>
     {{end}}
     </tbody>

--- a/internal/web/templates/layout.html
+++ b/internal/web/templates/layout.html
@@ -205,6 +205,7 @@
 {{define "status-badge"}}
   {{if eq . "done"}}<span class="badge-secondary"><i data-lucide="check"></i> complete</span>
   {{else if eq . "failed"}}<span class="badge-destructive"><i data-lucide="x"></i> failed</span>
+  {{else if eq . "cancelled"}}<span class="badge-outline"><i data-lucide="circle-slash"></i> cancelled</span>
   {{else if eq . "running"}}<span class="badge-primary"><i data-lucide="loader-circle" class="animate-spin"></i> running</span>
   {{else}}<span class="badge-outline"><i data-lucide="clock"></i> {{.}}</span>{{end}}
 {{end}}

--- a/internal/web/templates/layout.html
+++ b/internal/web/templates/layout.html
@@ -202,6 +202,17 @@
   {{else}}<span class="badge-outline">{{.}}</span>{{end}}
 {{end}}
 
+{{define "scan-actions"}}
+  {{if or (eq (status .Status) "queued") (eq (status .Status) "running")}}<button class="btn-sm-ghost"
+    hx-post="/scans/{{.ID}}/cancel" hx-swap="none"
+    hx-on:click="event.stopPropagation()"
+    data-tooltip="Cancel"><i data-lucide="x"></i></button>
+  {{else if and (or (eq (status .Status) "failed") (eq (status .Status) "cancelled")) .SkillID}}<button class="btn-sm-ghost"
+    hx-post="/scans/{{.ID}}/retry" hx-swap="none"
+    hx-on:click="event.stopPropagation()"
+    data-tooltip="Retry"><i data-lucide="refresh-cw"></i></button>{{end}}
+{{end}}
+
 {{define "status-badge"}}
   {{if eq . "done"}}<span class="badge-secondary"><i data-lucide="check"></i> complete</span>
   {{else if eq . "failed"}}<span class="badge-destructive"><i data-lucide="x"></i> failed</span>

--- a/internal/web/templates/repo_show.html
+++ b/internal/web/templates/repo_show.html
@@ -322,7 +322,7 @@
   <div role="tabpanel" id="rp3" aria-labelledby="rt3" hidden>
     <table class="table">
       <thead>
-        <tr><th>#</th><th>Skill</th><th>Status</th><th>Findings</th><th>Model</th><th>Commit</th><th>Started</th><th>Duration</th></tr>
+        <tr><th>#</th><th>Skill</th><th>Status</th><th>Findings</th><th>Model</th><th>Commit</th><th>Started</th><th>Duration</th><th class="w-12"></th></tr>
       </thead>
       {{template "scan_rows" .}}
     </table>
@@ -350,6 +350,7 @@
     <td><code>{{short .Commit}}</code></td>
     <td>{{if .StartedAt}}{{since .StartedAt}}{{end}}</td>
     <td>{{if .FinishedAt}}{{dur .Duration}}{{end}}</td>
+    <td>{{template "scan-actions" .}}</td>
   </tr>
 {{end}}
 </tbody>

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -5,8 +5,10 @@ package worker
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
+	"sync"
 	"time"
 
 	"gorm.io/gorm"
@@ -31,6 +33,22 @@ type Worker struct {
 	APIBase string // base URL for the scrutineer skill API (http://host:port/api)
 	Runner  SkillRunner
 	OnEvent func(scanID, repoID uint, name, data string) // optional SSE bridge
+
+	mu      sync.Mutex
+	running map[uint]context.CancelFunc
+}
+
+// Cancel aborts an in-flight scan. Returns true if a running job was found and
+// signalled; false means the scan is queued (or already finished) and the
+// caller should flip the DB row itself so the queue handler drops it.
+func (w *Worker) Cancel(scanID uint) bool {
+	w.mu.Lock()
+	cancel, ok := w.running[scanID]
+	w.mu.Unlock()
+	if ok {
+		cancel()
+	}
+	return ok
 }
 
 func (w *Worker) publish(scanID, repoID uint, name, data string) {
@@ -67,6 +85,20 @@ func (w *Worker) wrap(h handler) func(context.Context, []byte) error {
 			return nil
 		}
 
+		ctx, cancel := context.WithCancel(ctx)
+		defer cancel()
+		w.mu.Lock()
+		if w.running == nil {
+			w.running = make(map[uint]context.CancelFunc)
+		}
+		w.running[scan.ID] = cancel
+		w.mu.Unlock()
+		defer func() {
+			w.mu.Lock()
+			delete(w.running, scan.ID)
+			w.mu.Unlock()
+		}()
+
 		now := time.Now()
 		scan.Status = db.ScanRunning
 		scan.StartedAt = &now
@@ -91,11 +123,16 @@ func (w *Worker) wrap(h handler) func(context.Context, []byte) error {
 
 		fin := time.Now()
 		scan.FinishedAt = &fin
-		if err != nil {
+		switch {
+		case errors.Is(ctx.Err(), context.Canceled):
+			scan.Status = db.ScanCancelled
+			scan.Error = "cancelled by user"
+			emit(Event{Kind: KindError, Text: "cancelled by user"})
+		case err != nil:
 			scan.Status = db.ScanFailed
 			scan.Error = err.Error()
 			emit(Event{Kind: KindError, Text: err.Error()})
-		} else {
+		default:
 			scan.Status = db.ScanDone
 			scan.Report = report
 		}

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -2,6 +2,15 @@ package worker
 
 import (
 	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"scrutineer/internal/db"
+	"scrutineer/internal/queue"
 )
 
 // fakeRunner stubs the SkillRunner for unit tests: emits a log line so the
@@ -15,4 +24,61 @@ type fakeRunner struct {
 func (f fakeRunner) RunSkill(_ context.Context, sj SkillJob, emit func(Event)) (SkillResult, error) {
 	emit(Event{Kind: "text", Text: "running skill " + sj.Name})
 	return f.skillRes, f.skillErr
+}
+
+type blockingRunner struct {
+	started chan struct{}
+}
+
+func (b blockingRunner) RunSkill(ctx context.Context, _ SkillJob, _ func(Event)) (SkillResult, error) {
+	close(b.started)
+	<-ctx.Done()
+	return SkillResult{}, ctx.Err()
+}
+
+func TestWorker_CancelStopsRunningScan(t *testing.T) {
+	gdb, err := db.Open(filepath.Join(t.TempDir(), "c.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo := db.Repository{URL: "https://example.com/x", Name: "x"}
+	gdb.Create(&repo)
+	skill := db.Skill{Name: "slow", Description: "x", Body: "b", Active: true, Source: "ui", Version: 1}
+	gdb.Create(&skill)
+	scan := db.Scan{RepositoryID: repo.ID, Kind: JobSkill, Status: db.ScanQueued, SkillID: &skill.ID}
+	gdb.Create(&scan)
+
+	runner := blockingRunner{started: make(chan struct{})}
+	w := &Worker{
+		DB:      gdb,
+		Log:     slog.New(slog.NewTextHandler(io.Discard, nil)),
+		DataDir: t.TempDir(),
+		Runner:  runner,
+	}
+
+	body, _ := json.Marshal(queue.Payload{ScanID: scan.ID})
+	done := make(chan error, 1)
+	go func() { done <- w.wrap(w.doSkill)(context.Background(), body) }()
+
+	<-runner.started
+	if !w.Cancel(scan.ID) {
+		t.Fatal("Cancel reported scan not running")
+	}
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("wrap returned error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("job did not stop after cancel")
+	}
+
+	var got db.Scan
+	gdb.First(&got, scan.ID)
+	if got.Status != db.ScanCancelled {
+		t.Errorf("status = %s, want cancelled (err=%q)", got.Status, got.Error)
+	}
+	if w.Cancel(scan.ID) {
+		t.Error("Cancel returned true after job finished")
+	}
 }


### PR DESCRIPTION
Adds a cross-icon button in the same column as the retry icon on `/scans`, shown for `queued` and `running` rows. Clicking it posts to `POST /scans/{id}/cancel`.

The worker now tracks per-scan `context.CancelFunc`s; cancelling a running scan kills the `claude`/`docker` subprocess via `exec.CommandContext` and the wrap path records the scan as `cancelled`. Cancelling a queued scan flips the row directly so the goqite handler drops it as terminal when it eventually picks the job up.

New `ScanStatus = "cancelled"` is terminal, has its own status badge (`circle-slash`), appears in the status filter dropdown, and is retryable like `failed`.

`web.New` now takes the `*worker.Worker` so the handler can reach `Cancel`.