### PR TITLE
web: pretty-print JSON in <pre> blocks

### DIFF
--- a/internal/web/jsontree.go
+++ b/internal/web/jsontree.go
@@ -1,6 +1,7 @@
 package web
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"html"
@@ -8,6 +9,16 @@ import (
 	"sort"
 	"strings"
 )
+
+// prettyJSON re-indents raw if it parses as JSON, otherwise returns it
+// unchanged so non-JSON reports (markdown, plain text) pass through.
+func prettyJSON(raw string) string {
+	var buf bytes.Buffer
+	if err := json.Indent(&buf, []byte(strings.TrimSpace(raw)), "", "  "); err != nil {
+		return raw
+	}
+	return buf.String()
+}
 
 // jsonTree turns a JSON document into a nested <dl> for the Data tab.
 // Objects become dl/dt/dd, arrays become ul, scalars are escaped text.

--- a/internal/web/jsontree_test.go
+++ b/internal/web/jsontree_test.go
@@ -25,3 +25,14 @@ func TestJSONTreeBadInput(t *testing.T) {
 		t.Errorf("should fall back to pre: %s", out)
 	}
 }
+
+func TestPrettyJSON(t *testing.T) {
+	got := prettyJSON(`{"a":1,"b":[2,3]}`)
+	want := "{\n  \"a\": 1,\n  \"b\": [\n    2,\n    3\n  ]\n}"
+	if got != want {
+		t.Errorf("indent:\ngot  %q\nwant %q", got, want)
+	}
+	if prettyJSON("# heading\nnot json") != "# heading\nnot json" {
+		t.Error("non-JSON input should pass through unchanged")
+	}
+}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -61,7 +61,8 @@ func New(gdb *gorm.DB, q *queue.Queue, log *slog.Logger, broker *Broker) (*Serve
 			}
 			return ""
 		},
-		"jsontree": jsonTree,
+		"jsontree":   jsonTree,
+		"prettyjson": prettyJSON,
 		"bignum": bignum,
 		"lookup": func(m any, key string) uint {
 			if mm, ok := m.(map[string]uint); ok {

--- a/internal/web/templates/repo_show.html
+++ b/internal/web/templates/repo_show.html
@@ -312,7 +312,7 @@
       {{jsontree .Repo.Metadata}}
       <details class="mt-4">
         <summary class="cursor-pointer text-sm text-muted-foreground">raw json</summary>
-        <pre class="log mt-2">{{.Repo.Metadata}}</pre>
+        <pre class="log mt-2">{{prettyjson .Repo.Metadata}}</pre>
       </details>
     {{else}}
       <p class="text-muted-foreground text-sm p-4">No metadata stored.</p>

--- a/internal/web/templates/scan_show.html
+++ b/internal/web/templates/scan_show.html
@@ -83,10 +83,10 @@
       </table>
       <details>
         <summary class="cursor-pointer text-sm text-muted-foreground">raw report.json</summary>
-        <pre class="log mt-2">{{.Report}}</pre>
+        <pre class="log mt-2">{{prettyjson .Report}}</pre>
       </details>
     {{else if .Report}}
-      <pre class="log">{{.Report}}</pre>
+      <pre class="log">{{prettyjson .Report}}</pre>
     {{else}}
       <p class="text-muted-foreground text-sm p-4">No result yet.</p>
     {{end}}

--- a/internal/web/templates/skill_show.html
+++ b/internal/web/templates/skill_show.html
@@ -32,7 +32,7 @@
 {{if .SchemaJSON}}
 <section class="card p-4 mb-6">
   <h3 class="font-medium mb-3">schema.json</h3>
-  <pre class="text-xs whitespace-pre-wrap font-mono bg-muted p-3 rounded">{{.SchemaJSON}}</pre>
+  <pre class="text-xs whitespace-pre-wrap font-mono bg-muted p-3 rounded">{{prettyjson .SchemaJSON}}</pre>
 </section>
 {{end}}
 {{end}}


### PR DESCRIPTION
Adds a `prettyjson` template func that runs `json.Indent` on the input and falls back to the raw string when it isn't valid JSON, so markdown/plain-text reports are untouched.

Applied to the `<pre>` blocks that dump raw JSON: scan report on `/scans/{id}`, `schema.json` on `/skills/{id}`, and the raw metadata expander on the repo Data tab.