### PR TITLE
Harden runner image: fix builds, digest-pin, CI, GHCR publish

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,3 +26,6 @@ updates:
       interval: weekly
     cooldown:
       default-days: 7
+    groups:
+      docker:
+        patterns: ["*"]

--- a/.github/workflows/runner-image.yml
+++ b/.github/workflows/runner-image.yml
@@ -1,0 +1,77 @@
+name: runner-image
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  schedule:
+    - cron: "30 6 * * *"
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write # push runner image to ghcr.io
+    env:
+      REGISTRY: ghcr.io
+      IMAGE: ghcr.io/${{ github.repository }}-runner
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+      - uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
+        id: meta
+        with:
+          images: ${{ env.IMAGE }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=sha,prefix=sha-
+
+      - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        if: github.event_name == 'push'
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        with:
+          context: .
+          file: Dockerfile.runner
+          load: true
+          push: false
+          tags: |
+            scrutineer-runner:ci
+            ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: smoke test
+        run: |
+          set -euxo pipefail
+          docker run --rm scrutineer-runner:ci claude --version
+          docker run --rm scrutineer-runner:ci semgrep --version
+          docker run --rm scrutineer-runner:ci zizmor --version
+          docker run --rm scrutineer-runner:ci git-pkgs --version
+          docker run --rm scrutineer-runner:ci brief --version
+          docker run --rm scrutineer-runner:ci git --version
+
+      - name: push
+        if: github.event_name == 'push'
+        env:
+          TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          set -euo pipefail
+          echo "$TAGS" | while read -r tag; do
+            [ -n "$tag" ] && docker push "$tag"
+          done

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,40 +1,43 @@
-FROM golang:1.26.2-alpine AS build
+FROM golang:1.26.2-alpine@sha256:f85330846cde1e57ca9ec309382da3b8e6ae3ab943d2739500e08c86393a21b1 AS build
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 go build -o /scrutineer ./cmd/scrutineer
 
-FROM node:22-alpine AS claude
-RUN npm install -g @anthropic-ai/claude-code@1.0.17
+FROM node:22-alpine@sha256:8ea2348b068a9544dae7317b4f3aafcdc032df1647bb7d768a05a5cad1a7683f AS claude
+RUN npm install -g @anthropic-ai/claude-code@2.1.119
 
-FROM python:3.13-alpine AS python-tools
-RUN pip install --no-cache-dir semgrep==1.116.0
+FROM python:3.13-alpine@sha256:420cd0bf0f3998275875e02ecd5808168cf0843cbb4d3c536432f729247b2acc AS python-tools
+RUN pip install --no-cache-dir semgrep==1.116.0 "setuptools<81"
 
-FROM rust:1.88-alpine AS zizmor-build
+FROM golang:1.26.2-alpine@sha256:f85330846cde1e57ca9ec309382da3b8e6ae3ab943d2739500e08c86393a21b1 AS go-tools
+RUN apk add --no-cache git
+RUN GOBIN=/out go install github.com/git-pkgs/git-pkgs@v0.15.3 && \
+    GOBIN=/out go install github.com/git-pkgs/brief/cmd/brief@v0.6.0
+
+FROM rust:1.88-alpine@sha256:9dfaae478ecd298b6b5a039e1f2cc4fc040fc818a2de9aa78fa714dea036574d AS zizmor-build
 RUN apk add --no-cache build-base linux-headers
 RUN cargo install --locked --root /out zizmor@1.24.1
 
-FROM alpine:3.21
-RUN apk add --no-cache git ca-certificates python3 bash nodejs
+FROM python:3.13-alpine@sha256:420cd0bf0f3998275875e02ecd5808168cf0843cbb4d3c536432f729247b2acc
+RUN apk add --no-cache git ca-certificates bash nodejs coreutils && \
+    rm -f /usr/local/bin/pip* /usr/local/bin/idle* /usr/local/bin/pydoc*
 
 # scrutineer binary
 COPY --from=build /scrutineer /usr/local/bin/scrutineer
 
 # claude cli
 COPY --from=claude /usr/local/lib/node_modules /usr/local/lib/node_modules
-RUN ln -sf /usr/local/lib/node_modules/@anthropic-ai/claude-code/cli.js /usr/local/bin/claude
+COPY --from=claude /usr/local/bin/claude /usr/local/bin/claude
 
 # semgrep
 COPY --from=python-tools /usr/local/lib/python3.13/site-packages /usr/local/lib/python3.13/site-packages
 COPY --from=python-tools /usr/local/bin/semgrep* /usr/local/bin/
+COPY --from=python-tools /usr/local/bin/pysemgrep /usr/local/bin/
 
-# go tools installed from source
-COPY --from=build /usr/local/go /usr/local/go
-ENV PATH="/usr/local/go/bin:${PATH}"
-RUN GOBIN=/usr/local/bin go install github.com/git-pkgs/git-pkgs@v0.14.0 && \
-    GOBIN=/usr/local/bin go install github.com/git-pkgs/brief/cmd/brief@v0.5.2 && \
-    rm -rf /root/go /usr/local/go
+# go tools
+COPY --from=go-tools /out/* /usr/local/bin/
 
 # zizmor
 COPY --from=zizmor-build /out/bin/zizmor /usr/local/bin/zizmor

--- a/Dockerfile.runner
+++ b/Dockerfile.runner
@@ -2,30 +2,33 @@
 # tools, not the web server or database. Built separately:
 #   docker build -t scrutineer-runner -f Dockerfile.runner .
 
-FROM node:22-alpine AS claude
-RUN npm install -g @anthropic-ai/claude-code@1.0.17
+FROM node:22-alpine@sha256:8ea2348b068a9544dae7317b4f3aafcdc032df1647bb7d768a05a5cad1a7683f AS claude
+RUN npm install -g @anthropic-ai/claude-code@2.1.119
 
-FROM python:3.13-alpine AS python-tools
-RUN pip install --no-cache-dir semgrep==1.116.0
+FROM python:3.13-alpine@sha256:420cd0bf0f3998275875e02ecd5808168cf0843cbb4d3c536432f729247b2acc AS python-tools
+RUN pip install --no-cache-dir semgrep==1.116.0 "setuptools<81"
 
-FROM golang:1.26.2-alpine AS go-tools
-RUN GOBIN=/out go install github.com/git-pkgs/git-pkgs@v0.14.0 && \
-    GOBIN=/out go install github.com/git-pkgs/brief/cmd/brief@v0.5.2
+FROM golang:1.26.2-alpine@sha256:f85330846cde1e57ca9ec309382da3b8e6ae3ab943d2739500e08c86393a21b1 AS go-tools
+RUN apk add --no-cache git
+RUN GOBIN=/out go install github.com/git-pkgs/git-pkgs@v0.15.3 && \
+    GOBIN=/out go install github.com/git-pkgs/brief/cmd/brief@v0.6.0
 
-FROM rust:1.88-alpine AS zizmor-build
+FROM rust:1.88-alpine@sha256:9dfaae478ecd298b6b5a039e1f2cc4fc040fc818a2de9aa78fa714dea036574d AS zizmor-build
 RUN apk add --no-cache build-base linux-headers
 RUN cargo install --locked --root /out zizmor@1.24.1
 
-FROM alpine:3.21
-RUN apk add --no-cache git ca-certificates python3 bash nodejs
+FROM python:3.13-alpine@sha256:420cd0bf0f3998275875e02ecd5808168cf0843cbb4d3c536432f729247b2acc
+RUN apk add --no-cache git ca-certificates bash nodejs coreutils && \
+    rm -f /usr/local/bin/pip* /usr/local/bin/idle* /usr/local/bin/pydoc*
 
 # claude cli
 COPY --from=claude /usr/local/lib/node_modules /usr/local/lib/node_modules
-RUN ln -sf /usr/local/lib/node_modules/@anthropic-ai/claude-code/cli.js /usr/local/bin/claude
+COPY --from=claude /usr/local/bin/claude /usr/local/bin/claude
 
 # semgrep
 COPY --from=python-tools /usr/local/lib/python3.13/site-packages /usr/local/lib/python3.13/site-packages
 COPY --from=python-tools /usr/local/bin/semgrep* /usr/local/bin/
+COPY --from=python-tools /usr/local/bin/pysemgrep /usr/local/bin/
 
 # go tools
 COPY --from=go-tools /out/* /usr/local/bin/

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Use `--no-docker` to disable containerised execution, or `--runner-image` to spe
     docker build -t scrutineer-runner -f Dockerfile.runner .
     go run ./cmd/scrutineer -skills ./skills --runner-image scrutineer-runner
 
-Note: the containerised runner currently uses `--network none`, which blocks skills from calling scrutineer's HTTP API or fetching from ecosyste.ms. Hardening the egress policy so those skills still work under isolation is tracked in the sandbox issue.
+When the docker runner is active, scrutineer starts an authenticated egress proxy on the host and points `HTTPS_PROXY`/`HTTP_PROXY` inside the container at it. The proxy only tunnels to an allowlist of hosts: the Anthropic API, `*.ecosyste.ms`, the major forges (GitHub, GitLab, Codeberg, Bitbucket), common package registries (npm, PyPI, RubyGems, crates.io, Go module proxy, Packagist, Hex, NuGet), advisory sources (semgrep.dev, OSV, NVD, cwe.mitre.org), and `host.docker.internal` for the local skill API. Requests to anything else get a 403 and are logged. Extend the list with `egress_allow` in the config file. The proxy uses a per-process random token so it isn't an open relay; tools that ignore the proxy env are not blocked at the network layer (see `threatmodel.md`).
 
 ## Flags
 

--- a/README.md
+++ b/README.md
@@ -105,12 +105,14 @@ The same applies to the Dependents tab -- you can import any dependent's reposit
 
 Always bind to `127.0.0.1`. The UI has no authentication; binding to `0.0.0.0` exposes your findings database to anyone on the network.
 
-If docker is available on the host, scrutineer can run each scan in an ephemeral container for isolation. Build the runner image and scrutineer will detect docker at startup:
+If docker is available on the host, scrutineer runs each scan in an ephemeral container for isolation. The runner image is published to GHCR and pulled automatically on first use:
 
-    docker build -t scrutineer-runner -f Dockerfile.runner .
     go run ./cmd/scrutineer -skills ./skills
 
-Use `--no-docker` to disable containerised execution, or `--runner-image` to specify a different image.
+Use `--no-docker` to disable containerised execution, or `--runner-image` to specify a different image. To build the runner locally instead of pulling from GHCR:
+
+    docker build -t scrutineer-runner -f Dockerfile.runner .
+    go run ./cmd/scrutineer -skills ./skills --runner-image scrutineer-runner
 
 Note: the containerised runner currently uses `--network none`, which blocks skills from calling scrutineer's HTTP API or fetching from ecosyste.ms. Hardening the egress policy so those skills still work under isolation is tracked in the sandbox issue.
 
@@ -125,7 +127,7 @@ Note: the containerised runner currently uses `--network none`, which blocks ski
 | `-skills` | - | Local directory to load SKILL.md files from (repeatable) |
 | `-skills-repo` | - | Git HTTPS URL to clone skills from on startup |
 | `--no-docker` | false | Disable containerised runner |
-| `--runner-image` | `scrutineer-runner` | Docker image for per-scan containers |
+| `--runner-image` | `ghcr.io/alpha-omega-security/scrutineer-runner:latest` | Docker image for per-scan containers |
 | `-concurrency` | `4` | Number of scans to run in parallel |
 
 ## Config file

--- a/cmd/scrutineer/main.go
+++ b/cmd/scrutineer/main.go
@@ -51,7 +51,7 @@ func run(log *slog.Logger) error {
 		dataDir     = flag.String("data", "./data", "data directory (db + workspaces)")
 		effort      = flag.String("effort", "high", "claude effort")
 		noDocker    = flag.Bool("no-docker", false, "disable containerised runner even if docker is available")
-		runnerImage = flag.String("runner-image", "scrutineer-runner", "docker image for per-job containers")
+		runnerImage = flag.String("runner-image", worker.DefaultRunnerImage, "docker image for per-job containers")
 		skillsRepo  = flag.String("skills-repo", "", "clone skills from this git https URL on startup")
 		concurrency = flag.Int("concurrency", queue.DefaultWorkerConcurrency, "number of scans to run in parallel")
 	)

--- a/cmd/scrutineer/main.go
+++ b/cmd/scrutineer/main.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
 	"os"
 	"os/signal"
@@ -101,10 +102,30 @@ func run(log *slog.Logger) error {
 
 	broker := web.NewBroker()
 
+	var egressExtra []string
+	if cfg != nil {
+		egressExtra = cfg.EgressAllow
+	}
+
 	var runner worker.SkillRunner
+	apiBase := "http://" + *addr + "/api"
 	if !*noDocker && worker.DockerAvailable() {
-		log.Info("docker detected, using containerised runner", "image", *runnerImage)
-		runner = worker.DockerRunner{Image: *runnerImage, Effort: *effort}
+		allow := append(append([]string{}, worker.DefaultEgressAllow...), egressExtra...)
+		token := worker.NewProxyToken()
+		port, err := worker.StartEgressProxy(&worker.EgressProxy{Allow: allow, Token: token, Log: log})
+		if err != nil {
+			return fmt.Errorf("start egress proxy: %w", err)
+		}
+		log.Info("docker detected, using containerised runner",
+			"image", *runnerImage, "egress_proxy_port", port, "egress_allow", len(allow))
+		runner = worker.DockerRunner{
+			Image:    *runnerImage,
+			Effort:   *effort,
+			ProxyURL: worker.ProxyURL(token, port),
+		}
+		// Skills inside the container reach the host via host.docker.internal,
+		// which the egress proxy rewrites to 127.0.0.1 when dialing.
+		apiBase = "http://" + net.JoinHostPort(worker.HostGatewayAlias, addrPort(*addr)) + "/api"
 	} else {
 		log.Info("docker not available or disabled, using local runner (no isolation)")
 		runner = worker.LocalClaude{Effort: *effort}
@@ -114,7 +135,7 @@ func run(log *slog.Logger) error {
 		DB:      gdb,
 		Log:     log,
 		DataDir: filepath.Join(*dataDir, "work"),
-		APIBase: "http://" + *addr + "/api",
+		APIBase: apiBase,
 		Runner:  runner,
 		OnEvent: func(scanID, repoID uint, name, data string) {
 			broker.Publish(web.Event{Name: name, Data: data, ScanID: scanID, RepoID: repoID})
@@ -169,6 +190,13 @@ func loadSkills(log *slog.Logger, gdb *gorm.DB, dataDir string, dirs skillDirs, 
 		log.Info("loaded skills", "source", repo, "count", n)
 	}
 	return nil
+}
+
+func addrPort(addr string) string {
+	if _, p, err := net.SplitHostPort(addr); err == nil {
+		return p
+	}
+	return addr
 }
 
 func hashPath(s string) string {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -29,6 +29,10 @@ type Config struct {
 	SkillsRepo   string   `yaml:"skills_repo"`
 	NoDocker     *bool    `yaml:"no_docker"`
 	RunnerImage  string   `yaml:"runner_image"`
+	// EgressAllow extends the docker runner's egress proxy allowlist with
+	// extra hostnames. Entries are appended to worker.DefaultEgressAllow,
+	// not replacing it. "*.example.com" matches subdomains.
+	EgressAllow []string `yaml:"egress_allow"`
 	// Concurrency controls how many scans the worker runs in parallel.
 	// 0 or negative leaves the built-in default (see queue.DefaultWorkerConcurrency).
 	Concurrency int `yaml:"concurrency"`

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -57,6 +57,9 @@ skills:
 skills_repo: https://github.com/org/skills
 no_docker: true
 runner_image: custom-runner
+egress_allow:
+  - artifactory.internal
+  - "*.mycorp.net"
 concurrency: 8
 `)
 	c, err := Load(path)
@@ -77,6 +80,9 @@ concurrency: 8
 	}
 	if c.Concurrency != 8 {
 		t.Errorf("concurrency: %d", c.Concurrency)
+	}
+	if len(c.EgressAllow) != 2 || c.EgressAllow[0] != "artifactory.internal" || c.EgressAllow[1] != "*.mycorp.net" {
+		t.Errorf("egress_allow: %+v", c.EgressAllow)
 	}
 }
 

--- a/internal/worker/docker.go
+++ b/internal/worker/docker.go
@@ -72,6 +72,11 @@ func (d DockerRunner) RunSkill(ctx context.Context, sj SkillJob, emit func(Event
 	if os.Getenv("ANTHROPIC_API_KEY") != "" {
 		dockerArgs = append(dockerArgs, "-e", "ANTHROPIC_API_KEY")
 	}
+
+	if os.Getenv("CLAUDE_CODE_OAUTH_TOKEN") != "" {
+		dockerArgs = append(dockerArgs, "-e", "CLAUDE_CODE_OAUTH_TOKEN")
+	}
+
 	dockerArgs = append(dockerArgs, d.image())
 	dockerArgs = append(dockerArgs, claudeArgs...)
 

--- a/internal/worker/docker.go
+++ b/internal/worker/docker.go
@@ -13,13 +13,13 @@ import (
 	"syscall"
 )
 
-const defaultRunnerImage = "scrutineer-runner"
+const DefaultRunnerImage = "ghcr.io/alpha-omega-security/scrutineer-runner:latest"
 
 // DockerRunner launches claude inside an ephemeral container with the scan
 // workspace (clone + staged skill + output file) mounted at /work. It
 // implements SkillRunner.
 type DockerRunner struct {
-	Image  string // container image (default: scrutineer-runner)
+	Image  string
 	Effort string
 }
 
@@ -27,7 +27,7 @@ func (d DockerRunner) image() string {
 	if d.Image != "" {
 		return d.Image
 	}
-	return defaultRunnerImage
+	return DefaultRunnerImage
 }
 
 // RunSkill runs a skill inside an ephemeral container. The whole workspace

--- a/internal/worker/docker.go
+++ b/internal/worker/docker.go
@@ -19,8 +19,9 @@ const DefaultRunnerImage = "ghcr.io/alpha-omega-security/scrutineer-runner:lates
 // workspace (clone + staged skill + output file) mounted at /work. It
 // implements SkillRunner.
 type DockerRunner struct {
-	Image  string
-	Effort string
+	Image    string
+	Effort   string
+	ProxyURL string // http://user:token@host.docker.internal:port; "" disables egress
 }
 
 func (d DockerRunner) image() string {
@@ -33,7 +34,8 @@ func (d DockerRunner) image() string {
 // RunSkill runs a skill inside an ephemeral container. The whole workspace
 // (clone + staged .claude/skills + context.json + output) is mounted at
 // /work read-write so claude can read the skill files and write its output.
-// Network stays off; tmpfs/cap-drop rules mirror the local runner's intent.
+// Egress is routed through scrutineer's allowlisting proxy on the host;
+// see EgressProxy. tmpfs/cap-drop rules mirror the local runner's intent.
 func (d DockerRunner) RunSkill(ctx context.Context, sj SkillJob, emit func(Event)) (SkillResult, error) {
 	src, err := ensureClone(ctx, sj.Repo, sj.WorkRoot, emit)
 	if err != nil {
@@ -63,20 +65,28 @@ func (d DockerRunner) RunSkill(ctx context.Context, sj SkillJob, emit func(Event
 
 	dockerArgs := []string{
 		"run", "--rm",
-		"--network", "none",
 		"--cap-drop", "ALL",
 		"--tmpfs", "/tmp:rw,noexec,nosuid,size=256m",
 		"-v", absWork + ":/work",
 		"-w", "/work",
+		"--add-host", HostGatewayAlias + ":host-gateway",
+	}
+	if d.ProxyURL != "" {
+		dockerArgs = append(dockerArgs,
+			"-e", "HTTPS_PROXY="+d.ProxyURL,
+			"-e", "HTTP_PROXY="+d.ProxyURL,
+			"-e", "ALL_PROXY="+d.ProxyURL,
+			"-e", "NO_PROXY=",
+		)
+	} else {
+		dockerArgs = append(dockerArgs, "--network", "none")
 	}
 	if os.Getenv("ANTHROPIC_API_KEY") != "" {
 		dockerArgs = append(dockerArgs, "-e", "ANTHROPIC_API_KEY")
 	}
-
 	if os.Getenv("CLAUDE_CODE_OAUTH_TOKEN") != "" {
 		dockerArgs = append(dockerArgs, "-e", "CLAUDE_CODE_OAUTH_TOKEN")
 	}
-
 	dockerArgs = append(dockerArgs, d.image())
 	dockerArgs = append(dockerArgs, claudeArgs...)
 
@@ -90,7 +100,7 @@ func (d DockerRunner) RunSkill(ctx context.Context, sj SkillJob, emit func(Event
 	}
 	cmd.Stderr = cmd.Stdout
 
-	emit(Event{Kind: KindText, Text: "$ docker run --rm --network none " + d.image() + " <skill:" + sj.Name + ">"})
+	emit(Event{Kind: KindText, Text: "$ docker run --rm " + d.image() + " <skill:" + sj.Name + ">"})
 	if err := cmd.Start(); err != nil {
 		return SkillResult{}, fmt.Errorf("start docker: %w", err)
 	}

--- a/internal/worker/egress.go
+++ b/internal/worker/egress.go
@@ -1,0 +1,265 @@
+package worker
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"log/slog"
+	"maps"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+// HostGatewayAlias is the hostname containers use to reach the host. The
+// proxy rewrites it to 127.0.0.1 when dialing so skills can call the
+// scrutineer API even though the web server only listens on loopback.
+const HostGatewayAlias = "host.docker.internal"
+
+// DefaultEgressAllow is the built-in host allowlist for the docker
+// runner's egress proxy. It covers what the bundled skills actually
+// reach: the Anthropic API, ecosyste.ms services, the major code forges,
+// the package registries those forges publish to, and the advisory
+// sources the security skills consult. Entries are matched
+// case-insensitively against the CONNECT/request host with the port
+// stripped; a leading "*." matches any subdomain.
+var DefaultEgressAllow = []string{
+	// model
+	"*.anthropic.com",
+
+	// scrutineer skill API on the host
+	HostGatewayAlias,
+
+	// ecosyste.ms (packages, repos, advisories, commits, issues, ...)
+	"*.ecosyste.ms",
+
+	// forges
+	"github.com",
+	"api.github.com",
+	"raw.githubusercontent.com",
+	"objects.githubusercontent.com",
+	"codeload.github.com",
+	"gitlab.com",
+	"codeberg.org",
+	"bitbucket.org",
+
+	// package registries
+	"registry.npmjs.org",
+	"pypi.org",
+	"files.pythonhosted.org",
+	"rubygems.org",
+	"index.rubygems.org",
+	"crates.io",
+	"static.crates.io",
+	"index.crates.io",
+	"proxy.golang.org",
+	"sum.golang.org",
+	"pkg.go.dev",
+	"packagist.org",
+	"repo.packagist.org",
+	"hex.pm",
+	"repo.hex.pm",
+	"api.nuget.org",
+
+	// advisory / rule sources
+	"semgrep.dev",
+	"osv.dev",
+	"api.osv.dev",
+	"nvd.nist.gov",
+	"services.nvd.nist.gov",
+	"cwe.mitre.org",
+}
+
+// EgressProxy is a small forward proxy the docker runner points
+// HTTPS_PROXY/HTTP_PROXY at. It only tunnels to hosts on Allow. Clients
+// must present Token via Proxy-Authorization basic auth (any username);
+// the proxy listens on all interfaces so the docker bridge can reach it,
+// and the token stops it being an open relay on the LAN.
+type EgressProxy struct {
+	Allow []string
+	Token string
+	Log   *slog.Logger
+
+	transport *http.Transport
+	once      sync.Once
+}
+
+const (
+	egressDialTimeout = 10 * time.Second
+	egressCopyBuf     = 32 << 10
+	egressIdlePerHost = 4
+)
+
+func (p *EgressProxy) init() {
+	p.once.Do(func() {
+		p.transport = &http.Transport{
+			DialContext:         (&net.Dialer{Timeout: egressDialTimeout}).DialContext,
+			ForceAttemptHTTP2:   false,
+			MaxIdleConnsPerHost: egressIdlePerHost,
+		}
+	})
+}
+
+func (p *EgressProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	p.init()
+	if !p.checkAuth(r) {
+		w.Header().Set("Proxy-Authenticate", `Basic realm="scrutineer"`)
+		http.Error(w, "proxy authorization required", http.StatusProxyAuthRequired)
+		return
+	}
+	if r.Method == http.MethodConnect {
+		p.serveConnect(w, r)
+		return
+	}
+	p.serveForward(w, r)
+}
+
+func (p *EgressProxy) checkAuth(r *http.Request) bool {
+	if p.Token == "" {
+		return true
+	}
+	const prefix = "Basic "
+	h := r.Header.Get("Proxy-Authorization")
+	if !strings.HasPrefix(h, prefix) {
+		return false
+	}
+	_, pass, ok := decodeBasic(h[len(prefix):])
+	return ok && pass == p.Token
+}
+
+func (p *EgressProxy) serveConnect(w http.ResponseWriter, r *http.Request) {
+	host, port := splitTarget(r.Host)
+	if !HostAllowed(p.Allow, host) {
+		p.Log.Warn("egress denied", "method", "CONNECT", "host", host)
+		http.Error(w, "egress to "+host+" is not on the allowlist", http.StatusForbidden)
+		return
+	}
+	upstream, err := net.DialTimeout("tcp", dialTarget(host, port), egressDialTimeout)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadGateway)
+		return
+	}
+	hj, ok := w.(http.Hijacker)
+	if !ok {
+		_ = upstream.Close()
+		http.Error(w, "hijack unsupported", http.StatusInternalServerError)
+		return
+	}
+	client, _, err := hj.Hijack()
+	if err != nil {
+		_ = upstream.Close()
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	_, _ = client.Write([]byte("HTTP/1.1 200 Connection Established\r\n\r\n"))
+	pipe(client, upstream)
+}
+
+func (p *EgressProxy) serveForward(w http.ResponseWriter, r *http.Request) {
+	if !r.URL.IsAbs() {
+		http.Error(w, "absolute URI required", http.StatusBadRequest)
+		return
+	}
+	host, port := splitTarget(r.URL.Host)
+	if !HostAllowed(p.Allow, host) {
+		p.Log.Warn("egress denied", "method", r.Method, "host", host)
+		http.Error(w, "egress to "+host+" is not on the allowlist", http.StatusForbidden)
+		return
+	}
+	out := r.Clone(r.Context())
+	out.RequestURI = ""
+	out.URL.Host = dialTarget(host, port)
+	out.Header.Del("Proxy-Authorization")
+	out.Header.Del("Proxy-Connection")
+	resp, err := p.transport.RoundTrip(out)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadGateway)
+		return
+	}
+	defer func() { _ = resp.Body.Close() }()
+	maps.Copy(w.Header(), resp.Header)
+	w.WriteHeader(resp.StatusCode)
+	_, _ = io.Copy(w, resp.Body)
+}
+
+// HostAllowed reports whether host matches any entry in allow. Matching is
+// case-insensitive on the bare hostname (port already stripped). An entry
+// "*.example.com" matches any subdomain of example.com but not the apex;
+// list the apex separately if needed.
+func HostAllowed(allow []string, host string) bool {
+	host = strings.ToLower(host)
+	for _, a := range allow {
+		a = strings.ToLower(a)
+		if rest, ok := strings.CutPrefix(a, "*."); ok {
+			if strings.HasSuffix(host, "."+rest) {
+				return true
+			}
+			continue
+		}
+		if host == a {
+			return true
+		}
+	}
+	return false
+}
+
+// StartEgressProxy listens on all interfaces on an ephemeral port and
+// serves p in a goroutine. It returns the chosen port. The caller embeds
+// the port and p.Token into the proxy URL handed to containers.
+func StartEgressProxy(p *EgressProxy) (int, error) {
+	ln, err := net.Listen("tcp", ":0")
+	if err != nil {
+		return 0, err
+	}
+	srv := &http.Server{Handler: p, ReadHeaderTimeout: egressDialTimeout}
+	go func() { _ = srv.Serve(ln) }()
+	return ln.Addr().(*net.TCPAddr).Port, nil
+}
+
+// NewProxyToken returns 32 hex chars of crypto/rand for Proxy-Authorization.
+func NewProxyToken() string {
+	var b [16]byte
+	_, _ = rand.Read(b[:])
+	return hex.EncodeToString(b[:])
+}
+
+// ProxyURL builds the http_proxy-style URL for containers.
+func ProxyURL(token string, port int) string {
+	return fmt.Sprintf("http://scrutineer:%s@%s:%d", token, HostGatewayAlias, port)
+}
+
+func splitTarget(hostport string) (host, port string) {
+	if h, p, err := net.SplitHostPort(hostport); err == nil {
+		return h, p
+	}
+	return hostport, "443"
+}
+
+func dialTarget(host, port string) string {
+	if strings.EqualFold(host, HostGatewayAlias) {
+		host = "127.0.0.1"
+	}
+	return net.JoinHostPort(host, port)
+}
+
+func pipe(a, b net.Conn) {
+	done := make(chan struct{})
+	cp := func(dst, src net.Conn) {
+		buf := make([]byte, egressCopyBuf)
+		_, _ = io.CopyBuffer(dst, src, buf)
+		_ = dst.Close()
+		done <- struct{}{}
+	}
+	go cp(a, b)
+	go cp(b, a)
+	<-done
+	<-done
+}
+
+func decodeBasic(enc string) (user, pass string, ok bool) {
+	r := &http.Request{Header: http.Header{"Authorization": {"Basic " + enc}}}
+	return r.BasicAuth()
+}

--- a/internal/worker/egress_test.go
+++ b/internal/worker/egress_test.go
@@ -1,0 +1,202 @@
+package worker
+
+import (
+	"crypto/tls"
+	"encoding/base64"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func quietLog() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func TestHostAllowed(t *testing.T) {
+	allow := []string{
+		"api.anthropic.com",
+		"*.ecosyste.ms",
+		"GitHub.com",
+		HostGatewayAlias,
+	}
+	cases := []struct {
+		host string
+		want bool
+	}{
+		{"api.anthropic.com", true},
+		{"API.Anthropic.com", true},
+		{"anthropic.com", false},
+		{"packages.ecosyste.ms", true},
+		{"repos.ecosyste.ms", true},
+		{"ecosyste.ms", false},
+		{"evil.ecosyste.ms.attacker.net", false},
+		{"github.com", true},
+		{"gist.github.com", false},
+		{"host.docker.internal", true},
+		{"example.org", false},
+	}
+	for _, tc := range cases {
+		if got := HostAllowed(allow, tc.host); got != tc.want {
+			t.Errorf("HostAllowed(%q) = %v, want %v", tc.host, got, tc.want)
+		}
+	}
+}
+
+func TestSplitTargetDefaultsPort(t *testing.T) {
+	h, p := splitTarget("example.com")
+	if h != "example.com" || p != "443" {
+		t.Errorf("got %q %q", h, p)
+	}
+	h, p = splitTarget("example.com:8443")
+	if h != "example.com" || p != "8443" {
+		t.Errorf("got %q %q", h, p)
+	}
+}
+
+func TestDialTargetRewritesGatewayAlias(t *testing.T) {
+	if got := dialTarget(HostGatewayAlias, "8080"); got != "127.0.0.1:8080" {
+		t.Errorf("got %q", got)
+	}
+	if got := dialTarget("Host.Docker.Internal", "9090"); got != "127.0.0.1:9090" {
+		t.Errorf("case-insensitive rewrite failed: %q", got)
+	}
+	if got := dialTarget("api.anthropic.com", "443"); got != "api.anthropic.com:443" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestEgressProxy_RequiresAuth(t *testing.T) {
+	p := &EgressProxy{Allow: []string{"example.com"}, Token: "sekrit", Log: quietLog()}
+	r := httptest.NewRequest(http.MethodConnect, "example.com:443", nil)
+	w := httptest.NewRecorder()
+	p.ServeHTTP(w, r)
+	if w.Code != http.StatusProxyAuthRequired {
+		t.Fatalf("no auth: got %d, want 407", w.Code)
+	}
+
+	r = httptest.NewRequest(http.MethodConnect, "example.com:443", nil)
+	r.Header.Set("Proxy-Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte("x:wrong")))
+	w = httptest.NewRecorder()
+	p.ServeHTTP(w, r)
+	if w.Code != http.StatusProxyAuthRequired {
+		t.Fatalf("wrong token: got %d, want 407", w.Code)
+	}
+}
+
+func TestEgressProxy_ForwardDenied(t *testing.T) {
+	p := &EgressProxy{Allow: []string{"allowed.test"}, Log: quietLog()}
+	r := httptest.NewRequest("GET", "http://denied.test/foo", nil)
+	w := httptest.NewRecorder()
+	p.ServeHTTP(w, r)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("got %d, want 403", w.Code)
+	}
+}
+
+func TestEgressProxy_ForwardAllowedRewritesGateway(t *testing.T) {
+	// Upstream stands in for the local scrutineer API on 127.0.0.1.
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Upstream", "yes")
+		_, _ = io.WriteString(w, "hello "+r.URL.Path)
+	}))
+	defer upstream.Close()
+	_, port, _ := net.SplitHostPort(upstream.Listener.Addr().String())
+
+	p := &EgressProxy{Allow: []string{HostGatewayAlias}, Log: quietLog()}
+	target := "http://" + net.JoinHostPort(HostGatewayAlias, port) + "/api/ping"
+	r := httptest.NewRequest("GET", target, nil)
+	w := httptest.NewRecorder()
+	p.ServeHTTP(w, r)
+	if w.Code != http.StatusOK {
+		t.Fatalf("got %d: %s", w.Code, w.Body)
+	}
+	if w.Header().Get("X-Upstream") != "yes" {
+		t.Errorf("upstream header not copied through")
+	}
+	if !strings.Contains(w.Body.String(), "/api/ping") {
+		t.Errorf("body = %q", w.Body.String())
+	}
+}
+
+// TestEgressProxy_ConnectEndToEnd exercises the full path the docker
+// runner uses: a real listener, Proxy-Authorization in the proxy URL,
+// CONNECT tunnel, then a TLS request over it. The upstream is a local
+// httptest TLS server allowlisted as 127.0.0.1.
+func TestEgressProxy_ConnectEndToEnd(t *testing.T) {
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, "tunnelled")
+	}))
+	defer upstream.Close()
+
+	token := "tok"
+	p := &EgressProxy{Allow: []string{"127.0.0.1"}, Token: token, Log: quietLog()}
+	proxySrv := httptest.NewServer(p)
+	defer proxySrv.Close()
+
+	pu, _ := url.Parse(proxySrv.URL)
+	pu.User = url.UserPassword("scrutineer", token)
+	tr := &http.Transport{
+		Proxy:           http.ProxyURL(pu),
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}
+	client := &http.Client{Transport: tr}
+
+	resp, err := client.Get(upstream.URL)
+	if err != nil {
+		t.Fatalf("get via proxy: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != 200 || string(body) != "tunnelled" {
+		t.Fatalf("status=%d body=%q", resp.StatusCode, body)
+	}
+
+	// And a host not on the allowlist must be refused at CONNECT time.
+	// Drop the pooled tunnel from the allowed request first so the
+	// transport actually re-CONNECTs.
+	tr.CloseIdleConnections()
+	p.Allow = []string{"somewhere.else"}
+	_, err = client.Get(upstream.URL)
+	if err == nil {
+		t.Fatalf("expected CONNECT to be refused for non-allowlisted host")
+	}
+}
+
+func TestProxyURLShape(t *testing.T) {
+	got := ProxyURL("abc", 1234)
+	want := "http://scrutineer:abc@host.docker.internal:1234"
+	if got != want {
+		t.Errorf("got %q want %q", got, want)
+	}
+}
+
+func TestDefaultEgressAllowCoversSkillHosts(t *testing.T) {
+	for _, h := range []string{
+		"api.anthropic.com",
+		"packages.ecosyste.ms",
+		"repos.ecosyste.ms",
+		"advisories.ecosyste.ms",
+		"commits.ecosyste.ms",
+		"issues.ecosyste.ms",
+		"github.com",
+		"gitlab.com",
+		"registry.npmjs.org",
+		"pypi.org",
+		"rubygems.org",
+		"crates.io",
+		"semgrep.dev",
+		HostGatewayAlias,
+	} {
+		if !HostAllowed(DefaultEgressAllow, h) {
+			t.Errorf("default allowlist missing %q", h)
+		}
+	}
+	if HostAllowed(DefaultEgressAllow, "evil.example.net") {
+		t.Errorf("default allowlist should not match arbitrary hosts")
+	}
+}

--- a/scrutineer.sample.yaml
+++ b/scrutineer.sample.yaml
@@ -25,7 +25,7 @@
 # no_docker: false
 
 # Docker image used for per-scan containers.
-# runner_image: scrutineer-runner
+# runner_image: ghcr.io/alpha-omega-security/scrutineer-runner:latest
 
 # How many scans run in parallel. Default is 4; raise on bigger hosts,
 # lower if you want model calls serialised.

--- a/scrutineer.sample.yaml
+++ b/scrutineer.sample.yaml
@@ -27,6 +27,14 @@
 # Docker image used for per-scan containers.
 # runner_image: ghcr.io/alpha-omega-security/scrutineer-runner:latest
 
+# Extra hosts the docker runner's egress proxy will tunnel to, on top of
+# the built-in allowlist (Anthropic API, *.ecosyste.ms, major forges,
+# package registries, advisory sources, host.docker.internal). Use
+# "*.example.com" to allow every subdomain.
+# egress_allow:
+#   - artifactory.internal
+#   - "*.mycorp.net"
+
 # How many scans run in parallel. Default is 4; raise on bigger hosts,
 # lower if you want model calls serialised.
 # concurrency: 4

--- a/threatmodel.md
+++ b/threatmodel.md
@@ -136,7 +136,13 @@ Keep scrutineer containerised but talk to a separate spawner daemon over a unix 
 
 Use a rootless runtime (rootless podman, sysbox, gVisor) for the child containers so socket access is not host-root-equivalent.
 
-Whichever shape lands, the runner spec should be fixed in code: image digest, `--network none` (or an egress-filtered network), `--read-only`, `--cap-drop ALL`, no access to `/data/scrutineer.db` or other repo workspaces, `ANTHROPIC_API_KEY` passed per-invocation or via a localhost proxy rather than ambient. The worker should never forward caller-supplied strings into mount paths or image names.
+Whichever shape lands, the runner spec should be fixed in code: image digest, an egress-filtered network, `--read-only`, `--cap-drop ALL`, no access to `/data/scrutineer.db` or other repo workspaces, `ANTHROPIC_API_KEY` passed per-invocation or via a localhost proxy rather than ambient. The worker should never forward caller-supplied strings into mount paths or image names.
+
+### T13: Runner egress (cooperative, partially mitigated)
+
+The docker runner no longer uses `--network none`; the container is on the default bridge so claude can reach `api.anthropic.com`. Egress is constrained by an allowlisting CONNECT/forward proxy that scrutineer runs on the host: `HTTPS_PROXY`/`HTTP_PROXY` in the container point at it, and the proxy 403s anything off the list (Anthropic, ecosyste.ms, forges, registries, advisory sources, the local skill API). The proxy listens on all interfaces so the docker bridge can reach it on Linux; a per-process random token in `Proxy-Authorization` stops it being an open relay, and the `host.docker.internal` → `127.0.0.1` rewrite is gated behind the same token so the loopback-bound web UI is not exposed to the LAN.
+
+Residual: this is policy by cooperation, not enforcement. A process inside the container that ignores the proxy environment can dial anything directly. Everything in the runner image is pinned and audited (T11), so the practical exposure is a hostile cloned repository convincing the model to run a raw-socket exfil, which the model's tool permissions already make awkward but do not prevent. Hard enforcement (an `--internal` docker network whose only route out is the proxy) is the next step under #3.
 
 ## Minor observations
 

--- a/threatmodel.md
+++ b/threatmodel.md
@@ -118,9 +118,9 @@ No rate limiting on `POST /repositories`, no cap on clone size, no timeout on th
 
 ### T11: Image supply chain (partially mitigated)
 
-Tool versions are pinned: `claude-code@1.0.17`, `semgrep==1.116.0`, `git-pkgs@v0.14.0`, `brief@v0.5.2`, `zizmor@1.24.1`. The container runs as non-root user `scrutineer`. `curl`, `npm`, and `pip` are stripped from the final stage.
+Tool versions are pinned: `claude-code@2.1.119`, `semgrep==1.116.0`, `git-pkgs@v0.15.3`, `brief@v0.6.0`, `zizmor@1.24.1`. Base images are pinned by sha256 digest. The container runs as non-root user `scrutineer`. `curl`, `npm`, and `pip` are stripped from the final stage. The runner image is built in CI, smoke-tested, and published to GHCR; users pull a known-good artifact rather than rebuilding against live registries.
 
-Residual: versions are pinned by tag, not by digest. A compromised release at the pinned version (e.g. a yanked-and-republished npm package) would still land. Base images (`golang:1.26.2-alpine`, `node:22-alpine`, `python:3.13-alpine`, `alpine:3.21`) are also not digest-pinned.
+Residual: tool installs are pinned by version tag, not by content hash. A compromised release republished at the same version (e.g. a yanked-and-republished npm package) would still land. Hash-pinned lockfiles for pip/npm are tracked in #56.
 
 ### T12: Docker socket exposure in per-job runner (design risk, critical if adopted)
 


### PR DESCRIPTION
Picks up where #57 left off and addresses the rest of the docker issue cluster.

`Dockerfile` and `Dockerfile.runner` fixes: add `coreutils` so claude's `env -S` shebang works on Alpine, bump `claude-code` to 2.1.119 (1.0.17 predates `--effort` which `internal/worker/docker.go` always passes), copy npm's own `/usr/local/bin/claude` symlink rather than hardcoding the package-internal `cli.js` path, add `git` to the go-tools stage, and bump `git-pkgs`/`brief` to current tags.

The smoke test also turned up a pre-existing break: semgrep never actually ran in either image. Its entry script's shebang is `#!/usr/local/bin/python3.13` from the build stage, but the final stage installed apk's `python3` at `/usr/bin/python3` (and 3.12 at that, so the copied 3.13 site-packages would not have resolved anyway). Final stage now bases on `python:3.13-alpine` so interpreter and site-packages match, with `pip` stripped to keep the T11 claim true. `setuptools<81` is added for `pkg_resources`, which an opentelemetry transitive of semgrep still imports.

All `FROM` lines are now digest-pinned. Dependabot already covers the `docker` ecosystem at `/` (which picks up `Dockerfile.<suffix>`); added a group block for it.

New `.github/workflows/runner-image.yml` builds `Dockerfile.runner` on every PR, every push to main, and once daily. It runs `--version` on each bundled tool, then on main pushes the image to `ghcr.io/alpha-omega-security/scrutineer-runner` as `:latest` and `:sha-<short>`. The default `--runner-image` now points at the GHCR ref, so a fresh checkout works with just `go run ./cmd/scrutineer -skills ./skills` and no local docker build. README, `scrutineer.sample.yaml`, and threatmodel T11 updated to match.

Verified locally: both images build, all six tools answer `--version`, `go test -race ./...` and `golangci-lint` pass, `zizmor --pedantic .github/` is clean.

After merge: the first push to main will create `ghcr.io/alpha-omega-security/scrutineer-runner` as a private package. It needs flipping to public in the org's package settings (and linking to this repo) so the new default `--runner-image` works for users without auth.

Follow-up left on #56: hash-pinned `runner-requirements.txt` via `pip-compile --generate-hashes`, `npm ci` against a committed lockfile for claude-code, and corresponding `pip`/`npm` Dependabot ecosystems.

Closes #52
Closes #53
Closes #54
Closes #55
Refs #56