### PR TITLE
fix: show Findings tab based on all repo findings, not just latest scan

### DIFF
--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -1276,6 +1276,9 @@ func (s *Server) repoShow(w http.ResponseWriter, r *http.Request) {
 	var advisories []db.Advisory
 	s.DB.Where("repository_id = ?", repo.ID).Order("cvss_score desc").Find(&advisories)
 
+	var allFindings []db.Finding
+	s.DB.Where("repository_id = ?", repo.ID).Order("severity, id").Find(&allFindings)
+
 	knownURLs := buildKnownURLs(s.DB)
 	knownPURLs := buildKnownPURLs(s.DB)
 
@@ -1312,6 +1315,7 @@ func (s *Server) repoShow(w http.ResponseWriter, r *http.Request) {
 		"Skills":       activeSkills,
 		"Subprojects":  subprojects,
 		"SubScanCount": subScanCount,
+		"AllFindings":  allFindings,
 	}
 	if r.Header.Get("HX-Target") == "scan-rows" {
 		s.maybeToast(w, r, repo.Name, scans)

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -1373,6 +1373,43 @@ func TestSubprojectsRenderedOnRepoPage(t *testing.T) {
 	}
 }
 
+func TestRepoShow_findingsTabShownForOlderScans(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	repo := db.Repository{URL: "https://github.com/foo/bar.git", Name: "bar"}
+	s.DB.Create(&repo)
+
+	// Older deep-dive scan produces two findings.
+	deep := db.Scan{RepositoryID: repo.ID, Kind: "skill", Status: db.ScanDone, SkillName: "security-deep-dive"}
+	s.DB.Create(&deep)
+	s.DB.Create(&db.Finding{ScanID: deep.ID, RepositoryID: repo.ID, Title: "SSRF", Severity: "high"})
+	s.DB.Create(&db.Finding{ScanID: deep.ID, RepositoryID: repo.ID, Title: "XSS", Severity: "medium"})
+
+	// Newer scan (different skill, no findings) becomes the latest scan.
+	s.DB.Create(&db.Scan{RepositoryID: repo.ID, Kind: "skill", Status: db.ScanDone, SkillName: "repo-overview"})
+
+	req := httptest.NewRequest("GET", fmt.Sprintf("/repositories/%d", repo.ID), nil)
+	req.Host = testHost
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+	if w.Code != 200 {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+	body := w.Body.String()
+
+	// Findings tab should be present with the aggregate count (2).
+	if !strings.Contains(body, `<span class="badge-destructive ml-1">2</span>`) {
+		t.Errorf("expected Findings tab badge showing 2, got body=%s", body)
+	}
+	// Both finding titles should appear in the findings panel.
+	for _, title := range []string{"SSRF", "XSS"} {
+		if !strings.Contains(body, title) {
+			t.Errorf("expected finding %q in body", title)
+		}
+	}
+}
+
 func TestScanShowRenders(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()

--- a/internal/web/templates/repo_show.html
+++ b/internal/web/templates/repo_show.html
@@ -43,12 +43,12 @@
 </div>
 
 <div class="tabs w-full" id="repo-tabs">
-  {{$findings := and .Latest .Latest.Findings}}
+  {{$findings := .AllFindings}}
   <nav role="tablist" aria-orientation="horizontal">
     <button type="button" role="tab" id="rt1" aria-controls="rp1" aria-selected="true">Summary</button>
     {{if $findings}}
       <button type="button" role="tab" id="rt4" aria-controls="rp4" aria-selected="false">
-        Findings <span class="badge-destructive ml-1">{{len .Latest.Findings}}</span>
+        Findings <span class="badge-destructive ml-1">{{len .AllFindings}}</span>
       </button>
     {{end}}
     {{if .Pkgs}}
@@ -171,12 +171,8 @@
 
   {{if $findings}}
   <div role="tabpanel" id="rp4" aria-labelledby="rt4" hidden>
-    <p class="text-sm text-muted-foreground mb-4">
-      From scan <a class="underline" href="/scans/{{.Latest.ID}}">#{{.Latest.ID}}</a>
-      ({{.Latest.Model}}, {{since .Latest.StartedAt}}).
-    </p>
     <div class="grid gap-4">
-      {{range .Latest.Findings}}
+      {{range .AllFindings}}
         <div class="card cursor-pointer" hx-get="/findings/{{.ID}}" hx-target="body" hx-push-url="true">
           <header>
             <div class="flex items-center gap-2">


### PR DESCRIPTION
Agent-Logs-Url: https://github.com/mbarbero/scrutineer/sessions/6eaad190-28e6-49e6-9008-a96fe8c1c060