### PR TITLE
web: split language filter into individual languages

### DIFF
--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -226,11 +226,37 @@ type repoRow struct {
 	FindingsTotal int
 }
 
+// distinctLanguages returns the sorted set of individual language names
+// across every repository. Repository.Languages is a ", "-joined string
+// written by the metadata/repo-overview parsers, so the dropdown has to
+// split it rather than DISTINCT the column, otherwise every combination
+// (and ordering) of languages becomes its own filter option.
+func distinctLanguages(gdb *gorm.DB) []string {
+	var raw []string
+	gdb.Model(&db.Repository{}).Where("languages != ''").Distinct("languages").Pluck("languages", &raw)
+	seen := map[string]struct{}{}
+	for _, joined := range raw {
+		for l := range strings.SplitSeq(joined, ",") {
+			if l = strings.TrimSpace(l); l != "" {
+				seen[l] = struct{}{}
+			}
+		}
+	}
+	out := make([]string, 0, len(seen))
+	for l := range seen {
+		out = append(out, l)
+	}
+	sort.Strings(out)
+	return out
+}
+
 func (s *Server) repoList(w http.ResponseWriter, r *http.Request) {
 	q := s.DB.Model(&db.Repository{})
 	lang := r.URL.Query().Get("language")
 	if lang != "" {
-		q = q.Where("languages = ?", lang)
+		// languages is a ", "-joined list; wrapping both sides lets one
+		// LIKE match start/middle/end/only without four OR clauses.
+		q = q.Where("(', ' || languages || ', ') LIKE ?", "%, "+lang+", %")
 	}
 	search := strings.TrimSpace(r.URL.Query().Get("q"))
 	if search != "" {
@@ -312,8 +338,7 @@ func (s *Server) repoList(w http.ResponseWriter, r *http.Request) {
 			FindingsTotal: findingCounts[repo.ID],
 		})
 	}
-	var languages []string
-	s.DB.Model(&db.Repository{}).Where("languages != ''").Distinct("languages").Order("languages").Pluck("languages", &languages)
+	languages := distinctLanguages(s.DB)
 
 	data := map[string]any{
 		"Rows": rows, "Page": page, "Language": lang, "Sort": sort, "Languages": languages,

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -259,6 +259,55 @@ func TestRepoList_sortByFindings(t *testing.T) {
 	}
 }
 
+func TestDistinctLanguages_splitsJoinedColumn(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	s.DB.Create(&db.Repository{URL: "https://x/1", Name: "a", Languages: "Kotlin, Java, Prolog"})
+	s.DB.Create(&db.Repository{URL: "https://x/2", Name: "b", Languages: "Kotlin, Prolog, Java"})
+	s.DB.Create(&db.Repository{URL: "https://x/3", Name: "c", Languages: "Go"})
+	s.DB.Create(&db.Repository{URL: "https://x/4", Name: "d", Languages: "Go, Python"})
+	s.DB.Create(&db.Repository{URL: "https://x/5", Name: "e", Languages: ""})
+
+	got := distinctLanguages(s.DB)
+	want := []string{"Go", "Java", "Kotlin", "Prolog", "Python"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestRepoList_languageFilterMatchesWithinList(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	s.DB.Create(&db.Repository{URL: "https://x/only-java", Name: "a", Languages: "Java"})
+	s.DB.Create(&db.Repository{URL: "https://x/first-java", Name: "b", Languages: "Java, Python"})
+	s.DB.Create(&db.Repository{URL: "https://x/mid-java", Name: "c", Languages: "Kotlin, Java, Prolog"})
+	s.DB.Create(&db.Repository{URL: "https://x/last-java", Name: "d", Languages: "Python, Java"})
+	s.DB.Create(&db.Repository{URL: "https://x/jsrepo", Name: "e", Languages: "JavaScript"})
+	s.DB.Create(&db.Repository{URL: "https://x/gorepo", Name: "f", Languages: "Go"})
+
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq("GET", "/?language=Java"))
+	if w.Code != 200 {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+	body := w.Body.String()
+
+	for _, want := range []string{"x/only-java", "x/first-java", "x/mid-java", "x/last-java"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("language=Java should include %q", want)
+		}
+	}
+	// "Java" must not substring-match "JavaScript".
+	if strings.Contains(body, "x/jsrepo") {
+		t.Errorf("language=Java wrongly matched JavaScript repo")
+	}
+	if strings.Contains(body, "x/gorepo") {
+		t.Errorf("language=Java wrongly matched Go repo")
+	}
+}
+
 func TestRepoSearchFilters(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()


### PR DESCRIPTION
`Repository.Languages` is stored as a `, `-joined string. The repo index dropdown was doing `DISTINCT languages` on the whole column and filtering with `languages = ?`, so every combination and ordering of languages became its own option ("Kotlin, Java, Prolog" and "Kotlin, Prolog, Java" both appeared) and picking one only matched repos with that exact string.

`distinctLanguages()` now plucks the column, splits on comma, dedupes, and sorts so the dropdown lists individual language names. The filter uses `(', ' || languages || ', ') LIKE '%, <lang>, %'` so "Java" matches a repo with `Languages = "Kotlin, Java, Prolog"` in any position without substring-matching "JavaScript".

Tests cover the dropdown split (different orderings collapse to one set) and the filter (only/first/mid/last positions all match; JavaScript and Go don't).