### PR TITLE
cmd/scrutineer-desktop: OS-webview wrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /data/
 /scrutineer
+/scrutineer-desktop
 *.db
 *.db-shm
 *.db-wal

--- a/README.md
+++ b/README.md
@@ -98,6 +98,17 @@ The Dependencies tab on a repo groups packages by name and shows all manifest fi
 
 The same applies to the Dependents tab -- you can import any dependent's repository with one click.
 
+## Desktop app
+
+`cmd/scrutineer-desktop` builds a self-contained binary that starts the server on a random localhost port and opens it in the OS-native webview, so it runs like a standalone app rather than a browser tab. Closing the window shuts the server down.
+
+    go build ./cmd/scrutineer-desktop
+    ./scrutineer-desktop
+
+On macOS this links the system WebKit framework so there are no extra dependencies. On Linux you need the WebKitGTK development headers (`apt install libwebkit2gtk-4.1-dev` on Debian/Ubuntu, `dnf install webkit2gtk4.1-devel` on Fedora). On Windows it uses WebView2, which ships with Windows 11 and recent Windows 10.
+
+The desktop build always uses the local runner and reads `./data` and `./skills` relative to where you launch it. For flags, the config file, or the docker runner, use `cmd/scrutineer`.
+
 ## Docker
 
     docker build -t scrutineer .

--- a/cmd/scrutineer-desktop/main.go
+++ b/cmd/scrutineer-desktop/main.go
@@ -1,0 +1,128 @@
+// Command scrutineer-desktop runs the scrutineer web server on a random
+// localhost port and opens it in the OS-native webview, so it behaves
+// like a standalone desktop app. Closing the window shuts the server
+// down. It uses the local (non-docker) runner and the same ./data and
+// ./skills layout as cmd/scrutineer; for flags, config files, or the
+// docker runner, use cmd/scrutineer instead.
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"time"
+
+	webview "github.com/webview/webview_go"
+
+	"scrutineer/internal/db"
+	"scrutineer/internal/queue"
+	"scrutineer/internal/skills"
+	"scrutineer/internal/web"
+	"scrutineer/internal/worker"
+)
+
+const (
+	dataDir         = "./data"
+	skillsDir       = "./skills"
+	effort          = "high"
+	dataPerm        = 0o700
+	windowWidth     = 1400
+	windowHeight    = 900
+	shutdownTimeout = 5 * time.Second
+)
+
+func main() {
+	log := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	if err := run(log); err != nil {
+		log.Error("fatal", "err", err)
+		os.Exit(1)
+	}
+}
+
+func run(log *slog.Logger) error {
+	if err := os.MkdirAll(dataDir, dataPerm); err != nil {
+		return err
+	}
+	_ = os.Chmod(dataDir, dataPerm)
+	// Module-boundary sentinel so go tooling on the parent repo never
+	// walks into cloned scan workspaces under data/work/.
+	_ = os.WriteFile(filepath.Join(dataDir, "go.mod"), []byte("module scrutineer/data\n"), dataPerm)
+
+	gdb, err := db.Open(filepath.Join(dataDir, "scrutineer.db"))
+	if err != nil {
+		return fmt.Errorf("open db: %w", err)
+	}
+	db.BackfillFindings(gdb)
+	db.BackfillFindingRepository(gdb)
+	if err := db.SeedDefaultLabels(gdb); err != nil {
+		return fmt.Errorf("seed labels: %w", err)
+	}
+	if err := db.SweepRunning(gdb); err != nil {
+		return fmt.Errorf("sweep: %w", err)
+	}
+	sqldb, err := gdb.DB()
+	if err != nil {
+		return err
+	}
+
+	q, err := queue.New(sqldb, log, queue.DefaultWorkerConcurrency)
+	if err != nil {
+		return fmt.Errorf("queue: %w", err)
+	}
+
+	if _, err := os.Stat(skillsDir); err == nil {
+		n, err := skills.LoadDirectory(gdb, log, skillsDir, "local")
+		if err != nil {
+			return fmt.Errorf("load skills: %w", err)
+		}
+		log.Info("loaded skills", "source", skillsDir, "count", n)
+	}
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return err
+	}
+	addr := ln.Addr().String()
+
+	broker := web.NewBroker()
+	w := &worker.Worker{
+		DB:      gdb,
+		Log:     log,
+		DataDir: filepath.Join(dataDir, "work"),
+		APIBase: "http://" + addr + "/api",
+		Runner:  worker.LocalClaude{Effort: effort},
+		OnEvent: func(scanID, repoID uint, name, data string) {
+			broker.Publish(web.Event{Name: name, Data: data, ScanID: scanID, RepoID: repoID})
+		},
+	}
+	w.Register(q)
+
+	srv, err := web.New(gdb, q, log, broker, w)
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go q.Start(ctx)
+
+	httpSrv := &http.Server{Handler: srv.Handler(), ReadHeaderTimeout: shutdownTimeout}
+	go func() { _ = httpSrv.Serve(ln) }()
+	log.Info("listening", "addr", "http://"+addr)
+
+	wv := webview.New(false)
+	defer wv.Destroy()
+	wv.SetTitle("Scrutineer")
+	wv.SetSize(windowWidth, windowHeight, webview.HintNone)
+	wv.Navigate("http://" + addr)
+	wv.Run()
+
+	cancel()
+	sctx, scancel := context.WithTimeout(context.Background(), shutdownTimeout)
+	defer scancel()
+	return httpSrv.Shutdown(sctx)
+}

--- a/cmd/scrutineer/main.go
+++ b/cmd/scrutineer/main.go
@@ -72,6 +72,9 @@ func run(log *slog.Logger) error {
 		return err
 	}
 	_ = os.Chmod(*dataDir, dataPermSecure)
+	// Module-boundary sentinel so go tooling on the parent repo never
+	// walks into cloned scan workspaces under data/work/.
+	_ = os.WriteFile(filepath.Join(*dataDir, "go.mod"), []byte("module scrutineer/data\n"), dataPermSecure)
 
 	gdb, err := db.Open(filepath.Join(*dataDir, "scrutineer.db"))
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ toolchain go1.26.2
 
 require (
 	github.com/glebarez/sqlite v1.11.0
+	github.com/webview/webview_go v0.0.0-20240831120633-6173450d4dd6
 	gopkg.in/yaml.v3 v3.0.1
 	gorm.io/gorm v1.31.1
 	maragu.dev/goqite v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -30,6 +30,8 @@ github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOF
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
+github.com/webview/webview_go v0.0.0-20240831120633-6173450d4dd6 h1:VQpB2SpK88C6B5lPHTuSZKb2Qee1QWwiFlC5CKY4AW0=
+github.com/webview/webview_go v0.0.0-20240831120633-6173450d4dd6/go.mod h1:yE65LFCeWf4kyWD5re+h4XNvOHJEXOCOuJZ4v8l5sgk=
 golang.org/x/crypto v0.45.0 h1:jMBrvKuj23MTlT0bQEOBcAE0mjg8mK9RXFhRH6nyF3Q=
 golang.org/x/crypto v0.45.0/go.mod h1:XTGrrkGJve7CYK7J8PEww4aY7gM3qMCElcJQ8n8JdX4=
 golang.org/x/mod v0.33.0 h1:tHFzIWbBifEmbwtGz65eaWyGiGZatSrT9prnU8DbVL8=


### PR DESCRIPTION
Adds a second entrypoint that starts the existing server on a random `127.0.0.1` port and opens it in the OS-native webview via `github.com/webview/webview_go`, so scrutineer runs as a standalone window instead of a browser tab. Closing the window cancels the queue context and shuts the HTTP server down.

The desktop build is intentionally minimal: local runner only, `./data` and `./skills` relative to the launch dir, no flags or config file. For anything else use `cmd/scrutineer`.

Both mains now also write a `data/go.mod` sentinel after creating the data directory, so `go mod tidy` and `govulncheck ./...` on a checkout with populated scan workspaces don't try to walk into cloned third-party Go repos under `data/work/`.

README gets a "Desktop app" section with build instructions and the per-OS dependency note (macOS: none, Linux: WebKitGTK headers, Windows: WebView2). `.gitignore` picks up the new binary name.

Builds to a 22M arm64 Mach-O locally; `go test ./...`, `golangci-lint`, `govulncheck`, and `deadcode` all clean.

Closes #18.