### PR TITLE
Surface scan cost/tokens and add /usage stats page

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -103,6 +103,14 @@ type Scan struct {
 	FinishedAt *time.Time
 	CostUSD    float64
 	Turns      int
+	// Token usage from the claude-code result event. CacheWriteTokens is
+	// cache_creation_input_tokens; CacheReadTokens is
+	// cache_read_input_tokens. AutoMigrate adds these as zero-default
+	// integer columns on existing databases.
+	InputTokens      int
+	OutputTokens     int
+	CacheReadTokens  int
+	CacheWriteTokens int
 
 	Prompt string
 	Report string
@@ -118,21 +126,21 @@ type Scan struct {
 
 // Package is one registry entry from packages.ecosyste.ms linked to this repo.
 type Package struct {
-	ID           uint       `gorm:"primarykey"`
-	RepositoryID uint       `gorm:"index;not null"`
+	ID           uint `gorm:"primarykey"`
+	RepositoryID uint `gorm:"index;not null"`
 	Repository   Repository
 
-	Name                  string
-	Ecosystem             string `gorm:"index"`
-	PURL                  string
-	Licenses              string
-	LatestVersion         string
-	VersionsCount         int
-	Downloads             int64 `gorm:"index"`
-	DependentPackages     int
-	DependentRepos        int   `gorm:"index"`
-	RegistryURL           string
-	LatestReleaseAt       *time.Time
+	Name                 string
+	Ecosystem            string `gorm:"index"`
+	PURL                 string
+	Licenses             string
+	LatestVersion        string
+	VersionsCount        int
+	Downloads            int64 `gorm:"index"`
+	DependentPackages    int
+	DependentRepos       int `gorm:"index"`
+	RegistryURL          string
+	LatestReleaseAt      *time.Time
 	DependentPackagesURL string
 	Metadata             string `gorm:"type:text"`
 
@@ -142,7 +150,7 @@ type Package struct {
 type MaintainerStatus string
 
 const (
-	MaintainerActive  MaintainerStatus = "active"
+	MaintainerActive   MaintainerStatus = "active"
 	MaintainerInactive MaintainerStatus = "inactive"
 	MaintainerUnknown  MaintainerStatus = "unknown"
 )
@@ -151,14 +159,14 @@ const (
 // of the disclosure CRM: findings batch into conversations per maintainer,
 // not per repo.
 type Maintainer struct {
-	ID     uint   `gorm:"primarykey"`
-	Login  string `gorm:"uniqueIndex;not null"` // github username or equivalent
-	Name   string
-	Email  string
-	Company string
+	ID        uint   `gorm:"primarykey"`
+	Login     string `gorm:"uniqueIndex;not null"` // github username or equivalent
+	Name      string
+	Email     string
+	Company   string
 	AvatarURL string
-	Status MaintainerStatus `gorm:"index;default:unknown"`
-	Notes  string
+	Status    MaintainerStatus `gorm:"index;default:unknown"`
+	Notes     string
 
 	// DoNotContact suppresses this maintainer from disclosure routing.
 	// Toggled per-maintainer from the UI. The analyst sets it when the
@@ -200,7 +208,7 @@ type Advisory struct {
 	Severity       string `gorm:"index"`
 	CVSSScore      float64
 	Classification string
-	Packages       string // comma-joined affected package names
+	Packages       string     // comma-joined affected package names
 	PublishedAt    *time.Time `gorm:"index"`
 	WithdrawnAt    *time.Time
 
@@ -258,9 +266,9 @@ const (
 type FindingSource string
 
 const (
-	SourceTool     FindingSource = "tool"
-	SourceModel    FindingSource = "model_suggested"
-	SourceAnalyst  FindingSource = "analyst"
+	SourceTool    FindingSource = "tool"
+	SourceModel   FindingSource = "model_suggested"
+	SourceAnalyst FindingSource = "analyst"
 )
 
 // Finding is one vulnerability reported by a scan. The Finding row holds
@@ -268,9 +276,9 @@ const (
 // changed each one and from which source. Labels, notes, communications,
 // and references are normalised into sibling tables.
 type Finding struct {
-	ID           uint `gorm:"primarykey"`
-	ScanID       uint `gorm:"index;not null"`
-	Scan         Scan
+	ID     uint `gorm:"primarykey"`
+	ScanID uint `gorm:"index;not null"`
+	Scan   Scan
 	// RepositoryID, Commit, and SubPath are denormalized from Scan so list
 	// queries don't have to join through Scan (GORM's Preload/Joins on
 	// Finding.Scan doesn't round-trip cleanly on sqlite). Set at
@@ -346,8 +354,8 @@ type FindingLabel struct {
 // FindingNote is one timestamped internal analyst note about a finding.
 // Replaces the old single Notes column so the comment trail is preserved.
 type FindingNote struct {
-	ID        uint `gorm:"primarykey"`
-	FindingID uint `gorm:"index;not null"`
+	ID        uint   `gorm:"primarykey"`
+	FindingID uint   `gorm:"index;not null"`
 	Body      string `gorm:"type:text"`
 	By        string // free-text author; scrutineer is single-user so usually empty
 
@@ -359,8 +367,8 @@ type FindingNote struct {
 // Kept distinct from FindingNote since the semantics (channel, direction,
 // external actor) don't fit a generic note.
 type FindingCommunication struct {
-	ID        uint `gorm:"primarykey"`
-	FindingID uint `gorm:"index;not null"`
+	ID        uint   `gorm:"primarykey"`
+	FindingID uint   `gorm:"index;not null"`
 	Channel   string // email | ghsa | issue | pr | direct | registry
 	Direction string // outbound | inbound
 	Actor     string // name/handle of the other party
@@ -414,17 +422,17 @@ type FindingHistory struct {
 type Skill struct {
 	ID uint `gorm:"primarykey"`
 
-	Name        string `gorm:"uniqueIndex;not null"`
-	Description string
-	License     string
+	Name          string `gorm:"uniqueIndex;not null"`
+	Description   string
+	License       string
 	Compatibility string
 	AllowedTools  string
 	Metadata      string `gorm:"type:text"` // raw frontmatter metadata map as JSON
 
 	Body       string `gorm:"type:text"` // markdown body after frontmatter
 	SchemaJSON string `gorm:"type:text"` // optional schema.json contents
-	OutputFile string                   // from metadata["scrutineer.output_file"]
-	OutputKind string `gorm:"index"`     // from metadata["scrutineer.output_kind"]
+	OutputFile string // from metadata["scrutineer.output_file"]
+	OutputKind string `gorm:"index"` // from metadata["scrutineer.output_kind"]
 
 	Version int  `gorm:"not null;default:1"`
 	Active  bool `gorm:"not null;default:true"`
@@ -442,6 +450,22 @@ func (s Scan) Duration() time.Duration {
 		return 0
 	}
 	return s.FinishedAt.Sub(*s.StartedAt)
+}
+
+// TotalInputTokens is everything billed on the input side: fresh input plus
+// both cache categories.
+func (s Scan) TotalInputTokens() int {
+	return s.InputTokens + s.CacheReadTokens + s.CacheWriteTokens
+}
+
+// CacheHitRatio is the share of total input tokens served from the prompt
+// cache. 0 when nothing has been recorded.
+func (s Scan) CacheHitRatio() float64 {
+	total := s.TotalInputTokens()
+	if total == 0 {
+		return 0
+	}
+	return float64(s.CacheReadTokens) / float64(total)
 }
 
 func (s ScanStatus) Terminal() bool {

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -1,6 +1,23 @@
 package db
 
-import "testing"
+import (
+	"math"
+	"testing"
+)
+
+func TestScanTokenHelpers(t *testing.T) {
+	s := Scan{InputTokens: 100, CacheReadTokens: 800, CacheWriteTokens: 100, OutputTokens: 50}
+	if s.TotalInputTokens() != 1000 {
+		t.Errorf("TotalInputTokens = %d", s.TotalInputTokens())
+	}
+	if math.Abs(s.CacheHitRatio()-0.8) > 1e-9 {
+		t.Errorf("CacheHitRatio = %v", s.CacheHitRatio())
+	}
+	var z Scan
+	if z.CacheHitRatio() != 0 {
+		t.Errorf("zero scan CacheHitRatio = %v", z.CacheHitRatio())
+	}
+}
 
 func TestBackfillFindingRepositoryFillsCommit(t *testing.T) {
 	gdb, err := Open(":memory:")
@@ -33,13 +50,13 @@ func TestBackfillFindingRepositoryFillsCommit(t *testing.T) {
 
 func TestNameFromURL(t *testing.T) {
 	cases := map[string]string{
-		"https://github.com/foo/bar":      "bar",
-		"https://github.com/foo/bar.git":  "bar",
-		"https://github.com/foo/bar/":     "bar",
-		"git@github.com:foo/bar.git":      "bar",
-		"ssh://git@host.xz/path/to/repo":  "repo",
-		"https://gitlab.com/g/sub/proj":   "proj",
-		"":                                "repo",
+		"https://github.com/foo/bar":     "bar",
+		"https://github.com/foo/bar.git": "bar",
+		"https://github.com/foo/bar/":    "bar",
+		"git@github.com:foo/bar.git":     "bar",
+		"ssh://git@host.xz/path/to/repo": "repo",
+		"https://gitlab.com/g/sub/proj":  "proj",
+		"":                               "repo",
 	}
 	for in, want := range cases {
 		if got := NameFromURL(in); got != want {

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -46,6 +46,8 @@ func New(gdb *gorm.DB, q *queue.Queue, log *slog.Logger, broker *Broker, w *work
 			return humanDuration(time.Since(*t)) + " ago"
 		},
 		"dur":     humanDuration,
+		"usd":     formatUSD,
+		"pct":     formatPct,
 		"status":  func(s db.ScanStatus) string { return string(s) },
 		"fstatus": func(s db.FindingLifecycle) string { return string(s) },
 		"dict": func(kv ...any) map[string]any {
@@ -154,6 +156,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("POST /scans/{id}/retry", s.scanRetry)
 	mux.HandleFunc("POST /scans/{id}/cancel", s.scanCancel)
 	mux.HandleFunc("GET /scans/{id}/log", s.scanLog)
+	mux.HandleFunc("GET /usage", s.usage)
 	mux.HandleFunc("GET /skills", s.skillsList)
 	mux.HandleFunc("GET /skills/new", s.skillNew)
 	mux.HandleFunc("POST /skills", s.skillCreate)
@@ -1264,6 +1267,10 @@ func (s *Server) repoShow(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	var totalCost float64
+	s.DB.Model(&db.Scan{}).Where("repository_id = ?", repo.ID).
+		Select("COALESCE(SUM(cost_usd), 0)").Scan(&totalCost)
+
 	// All findings across every scan of this repo, not just the latest
 	// deep-dive run. rejected/duplicate are analyst-dispositioned noise and
 	// stay off the tab; everything else is shown so an empty or failed
@@ -1320,9 +1327,10 @@ func (s *Server) repoShow(w http.ResponseWriter, r *http.Request) {
 
 	data := map[string]any{
 		"Repo": repo, "Scans": scans, "Active": active, "Latest": latest,
-		"Findings": findings,
-		"TMCommit": tmCommit,
-		"Deps":     deps, "Pkgs": pkgs, "Dependents": dependents, "Advisories": advisories, "Maintainers": maintainers, "ThreatModel": threatModel,
+		"Findings":  findings,
+		"TotalCost": totalCost,
+		"TMCommit":  tmCommit,
+		"Deps":      deps, "Pkgs": pkgs, "Dependents": dependents, "Advisories": advisories, "Maintainers": maintainers, "ThreatModel": threatModel,
 		"KnownURLs": knownURLs, "KnownPURLs": knownPURLs,
 		"Skills":       activeSkills,
 		"Subprojects":  subprojects,
@@ -1638,6 +1646,21 @@ func humanDuration(d time.Duration) string {
 	default:
 		return fmt.Sprintf("%dd", int(d.Hours())/hourPerDay)
 	}
+}
+
+const pctScale = 100
+
+func formatPct(v float64) string { return fmt.Sprintf("%.0f%%", v*pctScale) }
+
+// formatUSD renders a dollar amount with enough precision that the cheap
+// metadata-style scans (fractions of a cent) don't all read as $0.00,
+// while keeping deep-dive runs at the two decimal places people expect.
+func formatUSD(v float64) string {
+	const smallDollar = 0.10
+	if v > 0 && v < smallDollar {
+		return fmt.Sprintf("$%.4f", v)
+	}
+	return fmt.Sprintf("$%.2f", v)
 }
 
 // securityHeaders enforces T3 mitigations: host header check to prevent DNS

--- a/internal/web/templates/jobs.html
+++ b/internal/web/templates/jobs.html
@@ -61,7 +61,7 @@
       <tr>
         <th>#</th><th>Repository</th>
         {{if .AnySubPath}}<th>Sub-path</th>{{end}}
-        <th>Skill</th><th>Status</th><th>Findings</th><th>Model</th><th>Started</th><th>Duration</th><th class="w-12"></th>
+        <th>Skill</th><th>Status</th><th>Findings</th><th>Model</th><th>Cost</th><th>Started</th><th>Duration</th><th class="w-12"></th>
       </tr>
     </thead>
     <tbody>
@@ -77,6 +77,7 @@
         <td>{{template "status-badge" (status .Status)}}</td>
         <td>{{if gt .FindingsCount 0}}{{template "findings-badge" .FindingsCount}}{{end}}</td>
         <td class="text-muted-foreground">{{if .Model}}{{.Model}}{{else}}-{{end}}</td>
+        <td class="text-muted-foreground">{{if gt .CostUSD 0.0}}{{usd .CostUSD}}{{else}}-{{end}}</td>
         <td>{{if .StartedAt}}{{since .StartedAt}}{{end}}</td>
         <td>{{if .FinishedAt}}{{dur .Duration}}{{end}}</td>
         <td>{{template "scan-actions" .}}</td>

--- a/internal/web/templates/layout.html
+++ b/internal/web/templates/layout.html
@@ -47,6 +47,7 @@
           <li><a href="/maintainers" data-nav="maintainers"><i data-lucide="users"></i><span>Maintainers</span></a></li>
           <li><a href="/scans" data-nav="scans"><i data-lucide="list-checks"></i><span>Scans</span></a></li>
           <li><a href="/skills" data-nav="skills"><i data-lucide="sparkles"></i><span>Skills</span></a></li>
+          <li><a href="/usage" data-nav="usage"><i data-lucide="coins"></i><span>Usage</span></a></li>
         </ul>
       </div>
     </section>
@@ -150,7 +151,8 @@
   else window.addEventListener('load', restoreTab);
   (function () {
     var p = location.pathname;
-    var key = p.indexOf('/skills') === 0 ? 'skills'
+    var key = p.indexOf('/usage') === 0 ? 'usage'
+            : p.indexOf('/skills') === 0 ? 'skills'
             : p.indexOf('/maintainers') === 0 ? 'maintainers'
             : p.indexOf('/orgs') === 0 ? 'orgs'
             : p.indexOf('/packages') === 0 ? 'packages'

--- a/internal/web/templates/repo_show.html
+++ b/internal/web/templates/repo_show.html
@@ -89,6 +89,7 @@
         {{if .Repo.Stars}}<span class="badge-outline"><i data-lucide="star"></i>{{bignum .Repo.Stars}}</span>{{end}}
         {{if .Repo.License}}<span class="badge-outline"><i data-lucide="scale"></i>{{.Repo.License}}</span>{{end}}
         {{if .Repo.PushedAt}}<span class="badge-outline"><i data-lucide="clock"></i>pushed {{since .Repo.PushedAt}}</span>{{end}}
+        {{if gt .TotalCost 0.0}}<span class="badge-outline" data-tooltip="Total scan spend on this repository"><i data-lucide="coins"></i>{{usd .TotalCost}}</span>{{end}}
         {{if .Repo.Archived}}<span class="badge-destructive"><i data-lucide="archive"></i>archived</span>{{end}}
       </div>
     {{else}}
@@ -338,7 +339,7 @@
   <div role="tabpanel" id="rp3" aria-labelledby="rt3" hidden>
     <table class="table">
       <thead>
-        <tr><th>#</th><th>Skill</th><th>Status</th><th>Findings</th><th>Model</th><th>Commit</th><th>Started</th><th>Duration</th><th class="w-12"></th></tr>
+        <tr><th>#</th><th>Skill</th><th>Status</th><th>Findings</th><th>Model</th><th>Cost</th><th>Commit</th><th>Started</th><th>Duration</th><th class="w-12"></th></tr>
       </thead>
       {{template "scan_rows" .}}
     </table>
@@ -363,6 +364,7 @@
     <td>{{template "status-badge" (status .Status)}}</td>
     <td>{{if gt .FindingsCount 0}}{{template "findings-badge" .FindingsCount}}{{end}}</td>
     <td class="text-muted-foreground">{{if .Model}}{{.Model}}{{else}}-{{end}}</td>
+    <td class="text-muted-foreground">{{if gt .CostUSD 0.0}}{{usd .CostUSD}}{{else}}-{{end}}</td>
     <td><code>{{short .Commit}}</code></td>
     <td>{{if .StartedAt}}{{since .StartedAt}}{{end}}</td>
     <td>{{if .FinishedAt}}{{dur .Duration}}{{end}}</td>

--- a/internal/web/templates/scan_show.html
+++ b/internal/web/templates/scan_show.html
@@ -38,7 +38,26 @@
     <dt class="text-muted-foreground">Turns</dt>
     <dd>{{if .Turns}}{{.Turns}}{{else}}-{{end}}</dd>
   </div>
+  <div>
+    <dt class="text-muted-foreground">Cost</dt>
+    <dd>{{if gt .CostUSD 0.0}}{{usd .CostUSD}}{{else}}-{{end}}</dd>
+  </div>
 </dl>
+
+{{if gt .TotalInputTokens 0}}
+<table class="table w-full max-w-2xl mb-6">
+  <thead><tr>
+    <th>Input</th><th>Cache read</th><th>Cache write</th><th>Output</th><th>Cache hit</th>
+  </tr></thead>
+  <tbody><tr>
+    <td>{{bignum .InputTokens}}</td>
+    <td>{{bignum .CacheReadTokens}}</td>
+    <td>{{bignum .CacheWriteTokens}}</td>
+    <td>{{bignum .OutputTokens}}</td>
+    <td>{{pct .CacheHitRatio}}</td>
+  </tr></tbody>
+</table>
+{{end}}
 
 {{if .Error}}
   <div class="alert-destructive mb-6">

--- a/internal/web/templates/usage.html
+++ b/internal/web/templates/usage.html
@@ -1,0 +1,54 @@
+{{template "head"}}
+
+<div class="flex items-center justify-between gap-4 mb-2">
+  <h2 class="text-2xl font-semibold flex items-center gap-2">
+    <i data-lucide="coins"></i> Usage
+  </h2>
+  <div class="flex items-center gap-2">
+    <span class="badge-outline">{{.TotalRuns}} runs</span>
+    <span class="badge-outline">{{usd .TotalCost}} total</span>
+  </div>
+</div>
+<p class="text-sm text-muted-foreground mb-6">
+  Cost and turn-count distribution per skill across every completed or failed scan.
+  Queued, running and cancelled scans are excluded.
+</p>
+
+{{if .Rows}}
+  <table class="table w-full">
+    <thead><tr>
+      <th>Skill</th>
+      <th class="text-right">Runs</th>
+      <th class="text-right">Min</th>
+      <th class="text-right">Median</th>
+      <th class="text-right">p90</th>
+      <th class="text-right">Max</th>
+      <th class="text-right">Total</th>
+      <th class="text-right">Tokens in</th>
+      <th class="text-right">Tokens out</th>
+      <th class="text-right">Median turns</th>
+      <th class="text-right">p90 turns</th>
+    </tr></thead>
+    <tbody>
+    {{range .Rows}}
+      <tr>
+        <td class="font-medium">{{.Skill}}</td>
+        <td class="text-right text-muted-foreground">{{.Runs}}</td>
+        <td class="text-right">{{usd .Cost.Min}}</td>
+        <td class="text-right">{{usd .Cost.Median}}</td>
+        <td class="text-right">{{usd .Cost.P90}}</td>
+        <td class="text-right">{{usd .Cost.Max}}</td>
+        <td class="text-right font-medium">{{usd .Cost.Sum}}</td>
+        <td class="text-right text-muted-foreground">{{bignum .TokensIn}}</td>
+        <td class="text-right text-muted-foreground">{{bignum .TokensOut}}</td>
+        <td class="text-right text-muted-foreground">{{printf "%.0f" .Turns.Median}}</td>
+        <td class="text-right text-muted-foreground">{{printf "%.0f" .Turns.P90}}</td>
+      </tr>
+    {{end}}
+    </tbody>
+  </table>
+{{else}}
+  {{template "empty" (dict "Icon" "coins" "Title" "No usage yet" "Body" "Cost data appears here once scans have completed.")}}
+{{end}}
+
+{{template "foot"}}

--- a/internal/web/usage.go
+++ b/internal/web/usage.go
@@ -1,0 +1,115 @@
+package web
+
+import (
+	"net/http"
+	"sort"
+
+	"scrutineer/internal/db"
+)
+
+// SkillUsage is one row of the /usage page: aggregate cost and turn
+// statistics for every completed scan of a given skill across the
+// corpus. Percentiles are computed in Go because sqlite has no
+// percentile_cont; with low-thousands of scans the sort is trivial.
+type SkillUsage struct {
+	Skill     string
+	Runs      int
+	Cost      Stats
+	Turns     Stats
+	TokensIn  int
+	TokensOut int
+}
+
+type Stats struct {
+	Min    float64
+	Median float64
+	P90    float64
+	Max    float64
+	Sum    float64
+}
+
+func (s *Server) usage(w http.ResponseWriter, r *http.Request) {
+	// Only completed runs contribute to the distribution; queued/running
+	// rows have zero cost and would drag the floor down, and failed runs
+	// did still spend tokens so they stay in.
+	var scans []db.Scan
+	s.DB.Select("skill_name", "cost_usd", "turns",
+		"input_tokens", "output_tokens", "cache_read_tokens", "cache_write_tokens").
+		Where("status IN ?", []db.ScanStatus{db.ScanDone, db.ScanFailed}).
+		Where("skill_name != ''").
+		Find(&scans)
+
+	costBy := map[string][]float64{}
+	turnsBy := map[string][]float64{}
+	inBy := map[string]int{}
+	outBy := map[string]int{}
+	for _, sc := range scans {
+		costBy[sc.SkillName] = append(costBy[sc.SkillName], sc.CostUSD)
+		turnsBy[sc.SkillName] = append(turnsBy[sc.SkillName], float64(sc.Turns))
+		inBy[sc.SkillName] += sc.TotalInputTokens()
+		outBy[sc.SkillName] += sc.OutputTokens
+	}
+
+	rows := make([]SkillUsage, 0, len(costBy))
+	var totalCost float64
+	var totalRuns int
+	for name, costs := range costBy {
+		c := summarise(costs)
+		rows = append(rows, SkillUsage{
+			Skill:     name,
+			Runs:      len(costs),
+			Cost:      c,
+			Turns:     summarise(turnsBy[name]),
+			TokensIn:  inBy[name],
+			TokensOut: outBy[name],
+		})
+		totalCost += c.Sum
+		totalRuns += len(costs)
+	}
+	sort.Slice(rows, func(i, j int) bool { return rows[i].Cost.Sum > rows[j].Cost.Sum })
+
+	s.render(w, "usage.html", map[string]any{
+		"Rows":      rows,
+		"TotalCost": totalCost,
+		"TotalRuns": totalRuns,
+	})
+}
+
+const (
+	pMedian = 0.5
+	p90     = 0.9
+)
+
+func summarise(xs []float64) Stats {
+	if len(xs) == 0 {
+		return Stats{}
+	}
+	sort.Float64s(xs)
+	var sum float64
+	for _, x := range xs {
+		sum += x
+	}
+	return Stats{
+		Min:    xs[0],
+		Median: percentile(xs, pMedian),
+		P90:    percentile(xs, p90),
+		Max:    xs[len(xs)-1],
+		Sum:    sum,
+	}
+}
+
+// percentile returns the p-th percentile (0..1) of a sorted slice using
+// linear interpolation between the two nearest ranks (the same method
+// numpy uses by default), so p50 of an even-length set is the midpoint.
+func percentile(sorted []float64, p float64) float64 {
+	if len(sorted) == 1 {
+		return sorted[0]
+	}
+	pos := p * float64(len(sorted)-1)
+	lo := int(pos)
+	frac := pos - float64(lo)
+	if lo+1 >= len(sorted) {
+		return sorted[len(sorted)-1]
+	}
+	return sorted[lo] + frac*(sorted[lo+1]-sorted[lo])
+}

--- a/internal/web/usage_test.go
+++ b/internal/web/usage_test.go
@@ -1,0 +1,135 @@
+package web
+
+import (
+	"math"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"scrutineer/internal/db"
+)
+
+func almostEq(a, b float64) bool { return math.Abs(a-b) < 1e-9 }
+
+func TestPercentile(t *testing.T) {
+	cases := []struct {
+		xs   []float64
+		p    float64
+		want float64
+	}{
+		{[]float64{5}, 0.5, 5},
+		{[]float64{1, 2, 3, 4}, 0.5, 2.5},
+		{[]float64{1, 2, 3, 4, 5}, 0.5, 3},
+		{[]float64{0, 10}, 0.9, 9},
+		{[]float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, 0.9, 9.1},
+		{[]float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, 1.0, 10},
+		{[]float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, 0.0, 1},
+	}
+	for _, tc := range cases {
+		if got := percentile(tc.xs, tc.p); !almostEq(got, tc.want) {
+			t.Errorf("percentile(%v, %v) = %v, want %v", tc.xs, tc.p, got, tc.want)
+		}
+	}
+}
+
+func TestSummarise(t *testing.T) {
+	got := summarise([]float64{4, 1, 3, 2})
+	if !almostEq(got.Min, 1) || !almostEq(got.Max, 4) || !almostEq(got.Sum, 10) || !almostEq(got.Median, 2.5) {
+		t.Errorf("summarise = %+v", got)
+	}
+	if z := summarise(nil); z != (Stats{}) {
+		t.Errorf("empty summarise = %+v", z)
+	}
+}
+
+func TestFormatUSD(t *testing.T) {
+	cases := []struct {
+		v    float64
+		want string
+	}{
+		{0, "$0.00"},
+		{0.0042, "$0.0042"},
+		{0.09, "$0.0900"},
+		{0.10, "$0.10"},
+		{12.345, "$12.35"},
+	}
+	for _, tc := range cases {
+		if got := formatUSD(tc.v); got != tc.want {
+			t.Errorf("formatUSD(%v) = %q, want %q", tc.v, got, tc.want)
+		}
+	}
+}
+
+func TestUsage_perSkillStatsAndOrdering(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	repo := db.Repository{URL: "https://x/u", Name: "u"}
+	s.DB.Create(&repo)
+
+	mk := func(skill string, status db.ScanStatus, cost float64, turns int) {
+		s.DB.Create(&db.Scan{RepositoryID: repo.ID, Kind: "skill", SkillName: skill,
+			Status: status, CostUSD: cost, Turns: turns})
+	}
+	// deep-dive: three done runs spread across the cost range.
+	mk("security-deep-dive", db.ScanDone, 1.00, 10)
+	mk("security-deep-dive", db.ScanDone, 3.00, 30)
+	mk("security-deep-dive", db.ScanDone, 8.00, 80)
+	// metadata: two cheap runs, one failed (still counted).
+	mk("metadata", db.ScanDone, 0.0012, 1)
+	mk("metadata", db.ScanFailed, 0.0034, 2)
+	// queued/running excluded.
+	mk("metadata", db.ScanQueued, 0, 0)
+	mk("security-deep-dive", db.ScanRunning, 0, 0)
+
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq("GET", "/usage"))
+	if w.Code != 200 {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+	body := w.Body.String()
+
+	// Grand total = 12.0046, rendered at 2dp.
+	if !strings.Contains(body, "$12.00") {
+		t.Errorf("missing grand total in body")
+	}
+	// 5 counted runs (queued/running excluded).
+	if !strings.Contains(body, "5 runs") {
+		t.Errorf("missing run count")
+	}
+	// deep-dive median is $3.00, max $8.00.
+	for _, want := range []string{"security-deep-dive", "$3.00", "$8.00"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("missing %q", want)
+		}
+	}
+	// metadata costs are sub-dollar so render at 4dp.
+	if !strings.Contains(body, "$0.0012") {
+		t.Errorf("missing 4dp metadata min cost")
+	}
+	// Ordered by total cost desc: deep-dive ($12) before metadata ($0.0046).
+	if strings.Index(body, "security-deep-dive") > strings.Index(body, ">metadata<") {
+		t.Errorf("expected deep-dive row before metadata row")
+	}
+}
+
+func TestRepoShow_totalCostBadge(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	now := time.Now()
+	repo := db.Repository{URL: "https://x/spend", Name: "spend", FetchedAt: &now}
+	s.DB.Create(&repo)
+	s.DB.Create(&db.Scan{RepositoryID: repo.ID, Kind: "skill", SkillName: "a", Status: db.ScanDone, CostUSD: 1.50})
+	s.DB.Create(&db.Scan{RepositoryID: repo.ID, Kind: "skill", SkillName: "b", Status: db.ScanDone, CostUSD: 0.25})
+
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq("GET", "/repositories/1"))
+	if w.Code != 200 {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+	if !strings.Contains(w.Body.String(), "$1.75") {
+		t.Errorf("repo summary missing total cost $1.75")
+	}
+}

--- a/internal/worker/stream.go
+++ b/internal/worker/stream.go
@@ -22,10 +22,19 @@ const (
 // into something a human can read in a log view.
 type Event struct {
 	Kind    string
-	Tool    string  // for KindTool
+	Tool    string // for KindTool
 	Text    string
 	CostUSD float64 // for KindResult
 	Turns   int     // for KindResult
+	Usage   Usage   // for KindResult
+}
+
+// Usage is the token breakdown from a result event.
+type Usage struct {
+	InputTokens      int `json:"input_tokens"`
+	OutputTokens     int `json:"output_tokens"`
+	CacheReadTokens  int `json:"cache_read_input_tokens"`
+	CacheWriteTokens int `json:"cache_creation_input_tokens"`
 }
 
 type streamMessage struct {
@@ -36,6 +45,7 @@ type streamMessage struct {
 	CostUSD  *float64        `json:"total_cost_usd"`
 	Duration *int64          `json:"duration_ms"`
 	NumTurns *int            `json:"num_turns"`
+	Usage    *Usage          `json:"usage"`
 	Error    json.RawMessage `json:"error"`
 }
 
@@ -122,6 +132,9 @@ func resultEvent(msg streamMessage) Event {
 	}
 	if msg.NumTurns != nil {
 		ev.Turns = *msg.NumTurns
+	}
+	if msg.Usage != nil {
+		ev.Usage = *msg.Usage
 	}
 	return ev
 }

--- a/internal/worker/stream_test.go
+++ b/internal/worker/stream_test.go
@@ -11,7 +11,7 @@ func TestParseStream(t *testing.T) {
 {"type":"assistant","message":{"content":[{"type":"tool_use","name":"Bash","input":{"command":"ls -la"}}]}}
 {"type":"assistant","message":{"content":[{"type":"text","text":"done"}]}}
 not json at all
-{"type":"result","result":"ok","total_cost_usd":0.42,"num_turns":7,"duration_ms":1000}
+{"type":"result","result":"ok","total_cost_usd":0.42,"num_turns":7,"duration_ms":1000,"usage":{"input_tokens":10,"output_tokens":66,"cache_read_input_tokens":1200,"cache_creation_input_tokens":34000}}
 
 `
 	var got []Event
@@ -34,6 +34,10 @@ not json at all
 	}
 	if got[4].Kind != KindResult || got[4].CostUSD != 0.42 || got[4].Turns != 7 {
 		t.Errorf("ev4: %+v", got[4])
+	}
+	wantU := Usage{InputTokens: 10, OutputTokens: 66, CacheReadTokens: 1200, CacheWriteTokens: 34000}
+	if got[4].Usage != wantU {
+		t.Errorf("ev4 usage: %+v", got[4].Usage)
 	}
 }
 

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -115,6 +115,10 @@ func (w *Worker) wrap(h handler) func(context.Context, []byte) error {
 			if e.Kind == KindResult {
 				scan.CostUSD = e.CostUSD
 				scan.Turns = e.Turns
+				scan.InputTokens = e.Usage.InputTokens
+				scan.OutputTokens = e.Usage.OutputTokens
+				scan.CacheReadTokens = e.Usage.CacheReadTokens
+				scan.CacheWriteTokens = e.Usage.CacheWriteTokens
 			}
 			w.publish(scan.ID, scan.RepositoryID, "scan-log", line+"\n")
 		}


### PR DESCRIPTION
Covers the UI and capture work from #37 and all of #68.

Token capture: `db.Scan` gains `InputTokens`, `OutputTokens`, `CacheReadTokens`, `CacheWriteTokens`. `internal/worker/stream.go` now parses the `usage` block from the claude-code result event and `worker.go` persists it alongside `CostUSD`/`Turns`. Field names verified against a live `--output-format stream-json` result. AutoMigrate adds the columns as zero-default ints, so existing scan rows read as zero until re-run.

Cost surfacing: a `usd` template helper (4dp under $0.10, 2dp otherwise) and a `pct` helper. Cost now shows on the scan detail page, the `/scans` index, and the repo Scans tab. The repo Summary header gets a total-spend badge from `SUM(cost_usd)`.

Scan detail tokens: a small table under the header with input / cache-read / cache-write / output and the cache-hit percentage (`CacheReadTokens / TotalInputTokens`). Only renders when token data exists so legacy rows don't show an empty table.

`/usage` page: new sidebar entry. One row per `skill_name` across every done/failed scan with run count, cost min/median/p90/max/total, total input and output tokens, and median/p90 turns. Ordered by total spend. Percentiles are computed in Go with linear interpolation since sqlite has no `percentile_cont`. Queued/running/cancelled scans are excluded.

Tests: `percentile`/`summarise`/`formatUSD` table tests, `/usage` handler test (excludes queued/running, orders by spend, 4dp for sub-cent skills, grand-total badge), repo total-cost badge test, `Scan.TotalInputTokens`/`CacheHitRatio` test, and the stream parser test extended with a real-shape `usage` block.

Not in this PR: the SLOC/sinks correlation, outlier writeup, and the docs page from #37. Those need someone to read `/usage` against a real corpus and write the prose.

Refs #37
Closes #68