### PR TITLE
web: normalise repo URLs for dedup

### DIFF
--- a/internal/web/parse_repo_url.go
+++ b/internal/web/parse_repo_url.go
@@ -27,6 +27,12 @@ type RepoInput struct {
 // The fragment form is the forge-agnostic way to scope to a sub-path for
 // non-GitHub hosts. /tree/ parsing is GitHub-specific but matches the URL
 // users paste from the web UI.
+//
+// CloneURL is normalised so the same repository pasted in different forms
+// dedupes to one row: the host is lowercased, the query string is dropped,
+// trailing slashes are stripped, `.git` is appended once, and for forges
+// known to treat owner/repo case-insensitively the path is lowercased.
+// Branch names and sub-paths keep their case.
 func ParseRepoInput(raw string) (RepoInput, error) {
 	raw = strings.TrimSpace(raw)
 	if raw == "" {
@@ -39,15 +45,17 @@ func ParseRepoInput(raw string) (RepoInput, error) {
 	if err != nil {
 		return RepoInput{}, fmt.Errorf("parse url: %w", err)
 	}
+	u.Host = strings.ToLower(u.Host)
+	u.RawQuery = ""
 
 	// Fragment form: url#sub/path. Always wins if present, since the user
 	// typed it explicitly.
 	if u.Fragment != "" {
-		clean := *u
-		clean.Fragment = ""
+		sub := strings.Trim(u.Fragment, "/")
+		u.Fragment = ""
 		return RepoInput{
-			CloneURL: ensureGitSuffix(clean.String()),
-			SubPath:  strings.Trim(u.Fragment, "/"),
+			CloneURL: cloneURL(u, u.Path),
+			SubPath:  sub,
 		}, nil
 	}
 
@@ -68,23 +76,39 @@ func ParseRepoInput(raw string) (RepoInput, error) {
 		if treeIdx+2 < len(parts) {
 			subPath = strings.Join(parts[treeIdx+2:], "/")
 		}
-		clean := *u
-		clean.Path = repoPath
 		return RepoInput{
-			CloneURL: ensureGitSuffix(clean.String()),
+			CloneURL: cloneURL(u, repoPath),
 			SubPath:  subPath,
 			Branch:   branch,
 		}, nil
 	}
 
 	// Plain clone URL.
-	return RepoInput{
-		CloneURL: ensureGitSuffix(raw),
-	}, nil
+	return RepoInput{CloneURL: cloneURL(u, u.Path)}, nil
+}
+
+// caseInsensitiveForges treat owner/repo path segments as
+// case-insensitive, so lowercasing them is safe and lets bulk import
+// dedupe `Foo/Bar` against `foo/bar`. Unknown hosts keep their path case.
+var caseInsensitiveForges = map[string]bool{
+	"github.com":    true,
+	"gitlab.com":    true,
+	"bitbucket.org": true,
+	"codeberg.org":  true,
+}
+
+func cloneURL(u *url.URL, path string) string {
+	c := *u
+	c.Path = path
+	if caseInsensitiveForges[c.Host] {
+		c.Path = strings.ToLower(c.Path)
+	}
+	return ensureGitSuffix(c.String())
 }
 
 // ensureGitSuffix returns u with a single trailing ".git". Idempotent.
 func ensureGitSuffix(u string) string {
+	u = strings.TrimRight(u, "/")
 	if strings.HasSuffix(u, ".git") {
 		return u
 	}

--- a/internal/web/parse_repo_url_test.go
+++ b/internal/web/parse_repo_url_test.go
@@ -4,10 +4,10 @@ import "testing"
 
 func TestParseRepoInput(t *testing.T) {
 	cases := []struct {
-		name     string
-		input    string
-		want     RepoInput
-		wantErr  bool
+		name    string
+		input   string
+		want    RepoInput
+		wantErr bool
 	}{
 		{
 			name:  "plain github url without .git",
@@ -70,6 +70,53 @@ func TestParseRepoInput(t *testing.T) {
 				CloneURL: "https://github.com/rails/rails.git",
 				SubPath:  "railties",
 			},
+		},
+		{
+			name:  "trailing slash stripped",
+			input: "https://github.com/rails/rails/",
+			want:  RepoInput{CloneURL: "https://github.com/rails/rails.git"},
+		},
+		{
+			name:  "query string dropped",
+			input: "https://github.com/rails/rails?tab=readme-ov-file",
+			want:  RepoInput{CloneURL: "https://github.com/rails/rails.git"},
+		},
+		{
+			name:  "host lowercased",
+			input: "https://GitHub.com/rails/rails",
+			want:  RepoInput{CloneURL: "https://github.com/rails/rails.git"},
+		},
+		{
+			name:  "owner/repo lowercased on known forge",
+			input: "https://github.com/Rails/Rails",
+			want:  RepoInput{CloneURL: "https://github.com/rails/rails.git"},
+		},
+		{
+			name:  "tree url owner/repo lowercased but branch and sub-path keep case",
+			input: "https://github.com/Apache/Airflow/tree/Main/Airflow-Core",
+			want: RepoInput{
+				CloneURL: "https://github.com/apache/airflow.git",
+				SubPath:  "Airflow-Core",
+				Branch:   "Main",
+			},
+		},
+		{
+			name:  "fragment sub-path keeps case",
+			input: "https://github.com/Rails/Rails#ActionPack",
+			want: RepoInput{
+				CloneURL: "https://github.com/rails/rails.git",
+				SubPath:  "ActionPack",
+			},
+		},
+		{
+			name:  "unknown host keeps path case",
+			input: "https://git.internal/Team/Project",
+			want:  RepoInput{CloneURL: "https://git.internal/Team/Project.git"},
+		},
+		{
+			name:  "all of the above at once",
+			input: "https://GitHub.com/Rails/Rails/?tab=readme",
+			want:  RepoInput{CloneURL: "https://github.com/rails/rails.git"},
 		},
 		{
 			name:    "non-https rejected",

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -1190,6 +1190,39 @@ func TestRepoShow_findingsTabAggregatesAcrossScans(t *testing.T) {
 	}
 }
 
+func TestBulkImport_dedupesNormalisedURLs(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	s.DB.Create(&db.Skill{Name: "triage", Description: "o", Body: "b", Active: true, Source: "ui", Version: 1})
+
+	// Same repo four ways: canonical, mixed case, trailing slash, query string.
+	urls := strings.Join([]string{
+		"https://github.com/rails/rails",
+		"https://github.com/Rails/Rails",
+		"https://github.com/rails/rails/",
+		"https://GitHub.com/rails/rails?tab=readme",
+	}, "\n")
+	form := url.Values{"urls": {urls}}
+	req := httptest.NewRequest("POST", "/repositories/bulk", strings.NewReader(form.Encode()))
+	req.Host = testHost
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+	trigger := w.Header().Get("HX-Trigger")
+	if !strings.Contains(trigger, "1 added") || !strings.Contains(trigger, "3 already present") {
+		t.Errorf("toast = %s, want 1 added / 3 already present", trigger)
+	}
+
+	var repos []db.Repository
+	s.DB.Find(&repos)
+	if len(repos) != 1 || repos[0].URL != "https://github.com/rails/rails.git" {
+		t.Fatalf("want one normalised row, got %+v", repos)
+	}
+}
+
 func TestBulkImport_createsAndEnqueues(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()


### PR DESCRIPTION
`ParseRepoInput` now normalises the clone URL so the same repository pasted in different forms dedupes to one row: host is lowercased, query string is dropped, trailing `/` is stripped before the `.git` suffix, and on forges known to treat owner/repo case-insensitively (github.com, gitlab.com, bitbucket.org, codeberg.org) the path is lowercased. Unknown hosts keep their path case. Branch names and sub-paths from `/tree/` and `#fragment` forms keep their case since those are case-sensitive on disk.

Previously `https://github.com/rails/rails/` produced `https://github.com/rails/rails/.git` (broken clone URL and a distinct DB key), and `Rails/Rails` vs `rails/rails` created two rows.

Eight new table cases in `parse_repo_url_test.go` and a `TestBulkImport_dedupesNormalisedURLs` that posts the same repo four ways and asserts one row plus a "1 added, 3 already present" toast.

Existing rows keep whatever form they were stored with, so a normalised paste of a repo already present under a different casing will still create a second row until that data is cleaned up.

Closes #74