### PR TITLE
Fingerprint-based finding dedup across rescans

### DIFF
--- a/cmd/scrutineer/main.go
+++ b/cmd/scrutineer/main.go
@@ -79,6 +79,7 @@ func run(log *slog.Logger) error {
 	}
 	db.BackfillFindings(gdb)
 	db.BackfillFindingRepository(gdb)
+	db.BackfillFindingFingerprints(gdb)
 	if err := db.SeedDefaultLabels(gdb); err != nil {
 		return fmt.Errorf("seed labels: %w", err)
 	}

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -118,21 +118,21 @@ type Scan struct {
 
 // Package is one registry entry from packages.ecosyste.ms linked to this repo.
 type Package struct {
-	ID           uint       `gorm:"primarykey"`
-	RepositoryID uint       `gorm:"index;not null"`
+	ID           uint `gorm:"primarykey"`
+	RepositoryID uint `gorm:"index;not null"`
 	Repository   Repository
 
-	Name                  string
-	Ecosystem             string `gorm:"index"`
-	PURL                  string
-	Licenses              string
-	LatestVersion         string
-	VersionsCount         int
-	Downloads             int64 `gorm:"index"`
-	DependentPackages     int
-	DependentRepos        int   `gorm:"index"`
-	RegistryURL           string
-	LatestReleaseAt       *time.Time
+	Name                 string
+	Ecosystem            string `gorm:"index"`
+	PURL                 string
+	Licenses             string
+	LatestVersion        string
+	VersionsCount        int
+	Downloads            int64 `gorm:"index"`
+	DependentPackages    int
+	DependentRepos       int `gorm:"index"`
+	RegistryURL          string
+	LatestReleaseAt      *time.Time
 	DependentPackagesURL string
 	Metadata             string `gorm:"type:text"`
 
@@ -142,7 +142,7 @@ type Package struct {
 type MaintainerStatus string
 
 const (
-	MaintainerActive  MaintainerStatus = "active"
+	MaintainerActive   MaintainerStatus = "active"
 	MaintainerInactive MaintainerStatus = "inactive"
 	MaintainerUnknown  MaintainerStatus = "unknown"
 )
@@ -151,14 +151,14 @@ const (
 // of the disclosure CRM: findings batch into conversations per maintainer,
 // not per repo.
 type Maintainer struct {
-	ID     uint   `gorm:"primarykey"`
-	Login  string `gorm:"uniqueIndex;not null"` // github username or equivalent
-	Name   string
-	Email  string
-	Company string
+	ID        uint   `gorm:"primarykey"`
+	Login     string `gorm:"uniqueIndex;not null"` // github username or equivalent
+	Name      string
+	Email     string
+	Company   string
 	AvatarURL string
-	Status MaintainerStatus `gorm:"index;default:unknown"`
-	Notes  string
+	Status    MaintainerStatus `gorm:"index;default:unknown"`
+	Notes     string
 
 	// DoNotContact suppresses this maintainer from disclosure routing.
 	// Toggled per-maintainer from the UI. The analyst sets it when the
@@ -200,7 +200,7 @@ type Advisory struct {
 	Severity       string `gorm:"index"`
 	CVSSScore      float64
 	Classification string
-	Packages       string // comma-joined affected package names
+	Packages       string     // comma-joined affected package names
 	PublishedAt    *time.Time `gorm:"index"`
 	WithdrawnAt    *time.Time
 
@@ -258,9 +258,9 @@ const (
 type FindingSource string
 
 const (
-	SourceTool     FindingSource = "tool"
-	SourceModel    FindingSource = "model_suggested"
-	SourceAnalyst  FindingSource = "analyst"
+	SourceTool    FindingSource = "tool"
+	SourceModel   FindingSource = "model_suggested"
+	SourceAnalyst FindingSource = "analyst"
 )
 
 // Finding is one vulnerability reported by a scan. The Finding row holds
@@ -268,9 +268,9 @@ const (
 // changed each one and from which source. Labels, notes, communications,
 // and references are normalised into sibling tables.
 type Finding struct {
-	ID           uint `gorm:"primarykey"`
-	ScanID       uint `gorm:"index;not null"`
-	Scan         Scan
+	ID     uint `gorm:"primarykey"`
+	ScanID uint `gorm:"index;not null"`
+	Scan   Scan
 	// RepositoryID, Commit, and SubPath are denormalized from Scan so list
 	// queries don't have to join through Scan (GORM's Preload/Joins on
 	// Finding.Scan doesn't round-trip cleanly on sqlite). Set at
@@ -278,9 +278,19 @@ type Finding struct {
 	// marked not-null so AutoMigrate can widen the column on existing
 	// databases without a default; BackfillFindingRepository fills
 	// existing rows on startup.
-	RepositoryID uint `gorm:"index"`
+	RepositoryID uint `gorm:"index;index:idx_findings_repo_fp,priority:1"`
 	Commit       string
 	SubPath      string `gorm:"index"`
+
+	// Fingerprint dedupes the same vulnerability reported by repeated
+	// scans; see FingerprintFinding. ScanID/Commit are first-seen;
+	// LastSeenScanID/LastSeenCommit/SeenCount track re-observation. The
+	// composite index makes the (repo, fingerprint) lookup at ingest
+	// cheap without requiring uniqueness (legacy rows may collide).
+	Fingerprint    string `gorm:"index:idx_findings_repo_fp,priority:2"`
+	LastSeenScanID uint
+	LastSeenCommit string
+	SeenCount      int
 
 	FindingID string // e.g. F1, F2 within the report
 	Sinks     string // comma-joined sink IDs
@@ -346,8 +356,8 @@ type FindingLabel struct {
 // FindingNote is one timestamped internal analyst note about a finding.
 // Replaces the old single Notes column so the comment trail is preserved.
 type FindingNote struct {
-	ID        uint `gorm:"primarykey"`
-	FindingID uint `gorm:"index;not null"`
+	ID        uint   `gorm:"primarykey"`
+	FindingID uint   `gorm:"index;not null"`
 	Body      string `gorm:"type:text"`
 	By        string // free-text author; scrutineer is single-user so usually empty
 
@@ -359,8 +369,8 @@ type FindingNote struct {
 // Kept distinct from FindingNote since the semantics (channel, direction,
 // external actor) don't fit a generic note.
 type FindingCommunication struct {
-	ID        uint `gorm:"primarykey"`
-	FindingID uint `gorm:"index;not null"`
+	ID        uint   `gorm:"primarykey"`
+	FindingID uint   `gorm:"index;not null"`
 	Channel   string // email | ghsa | issue | pr | direct | registry
 	Direction string // outbound | inbound
 	Actor     string // name/handle of the other party
@@ -414,17 +424,17 @@ type FindingHistory struct {
 type Skill struct {
 	ID uint `gorm:"primarykey"`
 
-	Name        string `gorm:"uniqueIndex;not null"`
-	Description string
-	License     string
+	Name          string `gorm:"uniqueIndex;not null"`
+	Description   string
+	License       string
 	Compatibility string
 	AllowedTools  string
 	Metadata      string `gorm:"type:text"` // raw frontmatter metadata map as JSON
 
 	Body       string `gorm:"type:text"` // markdown body after frontmatter
 	SchemaJSON string `gorm:"type:text"` // optional schema.json contents
-	OutputFile string                   // from metadata["scrutineer.output_file"]
-	OutputKind string `gorm:"index"`     // from metadata["scrutineer.output_kind"]
+	OutputFile string // from metadata["scrutineer.output_file"]
+	OutputKind string `gorm:"index"` // from metadata["scrutineer.output_kind"]
 
 	Version int  `gorm:"not null;default:1"`
 	Active  bool `gorm:"not null;default:true"`

--- a/internal/db/fingerprint.go
+++ b/internal/db/fingerprint.go
@@ -1,0 +1,76 @@
+package db
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+
+	"gorm.io/gorm"
+)
+
+// FingerprintFinding returns a stable hash for deduplicating the same
+// vulnerability reported across repeated scans of one repository.
+//
+// The inputs are the producing skill, the scan sub-path, the CWE, and the
+// file path from Location with any :line:col suffix stripped. File-level
+// (not line-level) matching means a finding that drifts a few lines
+// between commits still dedupes; the cost is that two distinct same-CWE
+// issues in the same file collide into one row. When both CWE and
+// Location are empty the title is folded in so freeform-style findings
+// still get a key.
+func FingerprintFinding(skillName, subPath, cwe, location, title string) string {
+	loc := normaliseLocation(location)
+	parts := []string{
+		strings.ToLower(skillName),
+		strings.ToLower(strings.Trim(subPath, "/")),
+		strings.ToUpper(strings.TrimSpace(cwe)),
+		loc,
+	}
+	if cwe == "" && loc == "" {
+		parts = append(parts, strings.ToLower(strings.TrimSpace(title)))
+	}
+	h := sha256.Sum256([]byte(strings.Join(parts, "|")))
+	return hex.EncodeToString(h[:])
+}
+
+// normaliseLocation reduces "path/to/file.go:42:7" to "path/to/file.go".
+// A leading "./" is stripped so "./src/x.go" and "src/x.go" agree.
+func normaliseLocation(loc string) string {
+	loc = strings.TrimSpace(loc)
+	loc = strings.TrimPrefix(loc, "./")
+	if i := strings.IndexByte(loc, ':'); i >= 0 {
+		loc = loc[:i]
+	}
+	return strings.ToLower(loc)
+}
+
+// BackfillFindingFingerprints fills Finding.Fingerprint for rows created
+// before the column existed, joining through Scan for skill_name. It does
+// not merge existing duplicates; it just sets the column so future scans
+// dedupe against them. Safe to call on every startup.
+func BackfillFindingFingerprints(gdb *gorm.DB) {
+	type row struct {
+		ID        uint
+		SubPath   string
+		CWE       string
+		Location  string
+		Title     string
+		SkillName string
+	}
+	var rows []row
+	gdb.Raw(`
+		SELECT f.id, f.sub_path, f.cwe, f.location, f.title, s.skill_name
+		FROM findings f JOIN scans s ON s.id = f.scan_id
+		WHERE f.fingerprint IS NULL OR f.fingerprint = ''
+	`).Scan(&rows)
+	for _, r := range rows {
+		fp := FingerprintFinding(r.SkillName, r.SubPath, r.CWE, r.Location, r.Title)
+		gdb.Model(&Finding{}).Where("id = ?", r.ID).
+			Updates(map[string]any{
+				"fingerprint":       fp,
+				"last_seen_scan_id": gorm.Expr("COALESCE(NULLIF(last_seen_scan_id, 0), scan_id)"),
+				"last_seen_commit":  gorm.Expr(`COALESCE(NULLIF(last_seen_commit, ''), "commit")`),
+				"seen_count":        gorm.Expr("CASE WHEN seen_count = 0 THEN 1 ELSE seen_count END"),
+			})
+	}
+}

--- a/internal/db/fingerprint_test.go
+++ b/internal/db/fingerprint_test.go
@@ -1,0 +1,85 @@
+package db
+
+import "testing"
+
+func TestNormaliseLocation(t *testing.T) {
+	cases := map[string]string{
+		"src/users.rb:42":     "src/users.rb",
+		"src/users.rb:42:7":   "src/users.rb",
+		"src/users.rb":        "src/users.rb",
+		"./src/users.rb:1":    "src/users.rb",
+		"  Src/Users.rb:10  ": "src/users.rb",
+		"":                    "",
+	}
+	for in, want := range cases {
+		if got := normaliseLocation(in); got != want {
+			t.Errorf("normaliseLocation(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestFingerprintFinding(t *testing.T) {
+	base := FingerprintFinding("security-deep-dive", "", "CWE-89", "src/users.rb:42", "SQLi")
+
+	if base != FingerprintFinding("security-deep-dive", "", "CWE-89", "src/users.rb:77", "SQLi rephrased") {
+		t.Errorf("line drift / title change must not change fingerprint")
+	}
+	if base != FingerprintFinding("Security-Deep-Dive", "", "cwe-89", "./SRC/users.rb", "x") {
+		t.Errorf("skill/cwe/location case must not change fingerprint")
+	}
+	if base == FingerprintFinding("security-deep-dive", "", "CWE-89", "src/admin.rb:42", "SQLi") {
+		t.Errorf("different file must change fingerprint")
+	}
+	if base == FingerprintFinding("security-deep-dive", "", "CWE-79", "src/users.rb:42", "SQLi") {
+		t.Errorf("different CWE must change fingerprint")
+	}
+	if base == FingerprintFinding("semgrep", "", "CWE-89", "src/users.rb:42", "SQLi") {
+		t.Errorf("different skill must change fingerprint")
+	}
+	if base == FingerprintFinding("security-deep-dive", "core", "CWE-89", "src/users.rb:42", "SQLi") {
+		t.Errorf("different sub-path must change fingerprint")
+	}
+
+	// With neither CWE nor location, title is the discriminator.
+	a := FingerprintFinding("freeform", "", "", "", "Hardcoded secret")
+	b := FingerprintFinding("freeform", "", "", "", "Hardcoded Secret")
+	c := FingerprintFinding("freeform", "", "", "", "Weak crypto")
+	if a != b {
+		t.Errorf("title fallback should be case-insensitive")
+	}
+	if a == c {
+		t.Errorf("different title must change fingerprint when it is the only key")
+	}
+}
+
+func TestBackfillFindingFingerprints(t *testing.T) {
+	gdb, err := Open(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := Repository{URL: "https://x/r", Name: "r"}
+	gdb.Create(&r)
+	s := Scan{RepositoryID: r.ID, Kind: "skill", SkillName: "security-deep-dive", Status: ScanDone, Commit: "abc"}
+	gdb.Create(&s)
+	f := Finding{ScanID: s.ID, RepositoryID: r.ID, Commit: "abc", CWE: "CWE-89", Location: "src/users.rb:42", Title: "SQLi"}
+	gdb.Create(&f)
+
+	BackfillFindingFingerprints(gdb)
+
+	var got Finding
+	gdb.First(&got, f.ID)
+	want := FingerprintFinding("security-deep-dive", "", "CWE-89", "src/users.rb:42", "SQLi")
+	if got.Fingerprint != want {
+		t.Errorf("fingerprint = %q, want %q", got.Fingerprint, want)
+	}
+	if got.LastSeenScanID != s.ID || got.LastSeenCommit != "abc" || got.SeenCount != 1 {
+		t.Errorf("last-seen backfill: scan=%d commit=%q seen=%d", got.LastSeenScanID, got.LastSeenCommit, got.SeenCount)
+	}
+
+	// Idempotent: a second run does not bump SeenCount.
+	BackfillFindingFingerprints(gdb)
+	gdb.First(&got, f.ID)
+	if got.SeenCount != 1 {
+		t.Errorf("backfill not idempotent: seen=%d", got.SeenCount)
+	}
+}

--- a/internal/web/templates/finding_show.html
+++ b/internal/web/templates/finding_show.html
@@ -55,6 +55,21 @@
     <dt class="text-muted-foreground">Model</dt>
     <dd>{{$scan.Model}}</dd>
   </div>
+  <div>
+    <dt class="text-muted-foreground">First seen</dt>
+    <dd><a href="/scans/{{$f.ScanID}}" class="hover:underline">scan #{{$f.ScanID}}</a>
+      {{if $f.Commit}}<code class="text-xs text-muted-foreground">@{{short $f.Commit}}</code>{{end}}</dd>
+  </div>
+  <div>
+    <dt class="text-muted-foreground">Last seen</dt>
+    <dd>
+      {{if $f.LastSeenScanID}}
+        <a href="/scans/{{$f.LastSeenScanID}}" class="hover:underline">scan #{{$f.LastSeenScanID}}</a>
+        {{if $f.LastSeenCommit}}<code class="text-xs text-muted-foreground">@{{short $f.LastSeenCommit}}</code>{{end}}
+        {{if gt $f.SeenCount 1}}<span class="text-xs text-muted-foreground">({{$f.SeenCount}}x)</span>{{end}}
+      {{else}}-{{end}}
+    </dd>
+  </div>
   {{if $f.CVEID}}
   <div>
     <dt class="text-muted-foreground">CVE</dt>

--- a/internal/worker/findings_dedup_test.go
+++ b/internal/worker/findings_dedup_test.go
@@ -1,0 +1,165 @@
+package worker
+
+import (
+	"io"
+	"log/slog"
+	"path/filepath"
+	"testing"
+
+	"scrutineer/internal/db"
+)
+
+func TestParseFindingsOutput_dedupesAcrossScans(t *testing.T) {
+	gdb, err := db.Open(filepath.Join(t.TempDir(), "p.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo := db.Repository{URL: "https://x/r", Name: "r"}
+	gdb.Create(&repo)
+
+	w := &Worker{DB: gdb, Log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	emit := func(Event) {}
+
+	mkScan := func(commit string) *db.Scan {
+		s := &db.Scan{RepositoryID: repo.ID, Kind: JobSkill, SkillName: "security-deep-dive",
+			Status: db.ScanDone, Commit: commit}
+		gdb.Create(s)
+		return s
+	}
+
+	// Scan 1: two findings.
+	report1 := `{"findings":[
+		{"id":"F1","title":"SQLi in users","severity":"High","cwe":"CWE-89","location":"src/users.rb:42"},
+		{"id":"F2","title":"XSS in view","severity":"Medium","cwe":"CWE-79","location":"src/view.erb:10"}
+	]}`
+	s1 := mkScan("abc")
+	if err := w.parseFindingsOutput(s1, report1, emit); err != nil {
+		t.Fatal(err)
+	}
+
+	var after1 []db.Finding
+	gdb.Order("id").Find(&after1)
+	if len(after1) != 2 {
+		t.Fatalf("after first scan: %d findings, want 2", len(after1))
+	}
+	if after1[0].SeenCount != 1 || after1[0].LastSeenScanID != s1.ID {
+		t.Errorf("new finding seen-count/last-seen wrong: %+v", after1[0])
+	}
+
+	// Scan 2: F1 reappears at a different line, F2 gone, new F3.
+	report2 := `{"findings":[
+		{"id":"F1","title":"SQL injection in users","severity":"High","cwe":"CWE-89","location":"src/users.rb:77"},
+		{"id":"F3","title":"Path traversal","severity":"High","cwe":"CWE-22","location":"src/files.rb:5"}
+	]}`
+	s2 := mkScan("def")
+	if err := w.parseFindingsOutput(s2, report2, emit); err != nil {
+		t.Fatal(err)
+	}
+
+	var after2 []db.Finding
+	gdb.Order("id").Find(&after2)
+	if len(after2) != 3 {
+		t.Fatalf("after second scan: %d findings, want 3 (F1 deduped, F3 new)", len(after2))
+	}
+
+	// F1 (first row) should have last-seen bumped, seen=2, but ScanID/Commit
+	// (first-seen) and Title unchanged.
+	f1 := after2[0]
+	if f1.ScanID != s1.ID || f1.Commit != "abc" {
+		t.Errorf("F1 first-seen overwritten: scan=%d commit=%q", f1.ScanID, f1.Commit)
+	}
+	if f1.LastSeenScanID != s2.ID || f1.LastSeenCommit != "def" || f1.SeenCount != 2 {
+		t.Errorf("F1 last-seen not bumped: %+v", f1)
+	}
+	if f1.Title != "SQLi in users" {
+		t.Errorf("F1 title overwritten by rescan: %q", f1.Title)
+	}
+
+	// F2 untouched.
+	f2 := after2[1]
+	if f2.LastSeenScanID != s1.ID || f2.SeenCount != 1 {
+		t.Errorf("F2 should be unchanged: %+v", f2)
+	}
+
+	// F3 is new from scan 2.
+	f3 := after2[2]
+	if f3.ScanID != s2.ID || f3.CWE != "CWE-22" || f3.SeenCount != 1 {
+		t.Errorf("F3: %+v", f3)
+	}
+
+	// History row for the re-observation.
+	var hist []db.FindingHistory
+	gdb.Where("finding_id = ? AND field = ?", f1.ID, "observed").Find(&hist)
+	if len(hist) != 1 || hist[0].By != "security-deep-dive" {
+		t.Errorf("want one observed history row for F1, got %+v", hist)
+	}
+}
+
+func TestParseFindingsOutput_preservesAnalystStatusOnReobservation(t *testing.T) {
+	gdb, err := db.Open(filepath.Join(t.TempDir(), "p.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo := db.Repository{URL: "https://x/r", Name: "r"}
+	gdb.Create(&repo)
+	w := &Worker{DB: gdb, Log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	emit := func(Event) {}
+
+	report := `{"findings":[{"id":"F1","title":"noise","severity":"Low","cwe":"CWE-200","location":"x.go:1"}]}`
+	s1 := &db.Scan{RepositoryID: repo.ID, Kind: JobSkill, SkillName: "semgrep", Status: db.ScanDone, Commit: "abc"}
+	gdb.Create(s1)
+	if err := w.parseFindingsOutput(s1, report, emit); err != nil {
+		t.Fatal(err)
+	}
+
+	// Analyst rejects it.
+	gdb.Model(&db.Finding{}).Where("repository_id = ?", repo.ID).Update("status", db.FindingRejected)
+
+	s2 := &db.Scan{RepositoryID: repo.ID, Kind: JobSkill, SkillName: "semgrep", Status: db.ScanDone, Commit: "def"}
+	gdb.Create(s2)
+	if err := w.parseFindingsOutput(s2, report, emit); err != nil {
+		t.Fatal(err)
+	}
+
+	var rows []db.Finding
+	gdb.Find(&rows)
+	if len(rows) != 1 {
+		t.Fatalf("rejected finding should still dedupe, got %d rows", len(rows))
+	}
+	if rows[0].Status != db.FindingRejected {
+		t.Errorf("rescan must not resurrect a rejected finding: status=%s", rows[0].Status)
+	}
+	if rows[0].SeenCount != 2 {
+		t.Errorf("seen count = %d, want 2", rows[0].SeenCount)
+	}
+}
+
+func TestParseFindingsOutput_intraScanCollisionCreatesOneRow(t *testing.T) {
+	gdb, err := db.Open(filepath.Join(t.TempDir(), "p.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo := db.Repository{URL: "https://x/r", Name: "r"}
+	gdb.Create(&repo)
+	w := &Worker{DB: gdb, Log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+
+	// Same CWE, same file, two lines: file-level fingerprint collides.
+	report := `{"findings":[
+		{"id":"F1","title":"a","severity":"Low","cwe":"CWE-89","location":"q.go:10"},
+		{"id":"F2","title":"b","severity":"Low","cwe":"CWE-89","location":"q.go:20"}
+	]}`
+	s := &db.Scan{RepositoryID: repo.ID, Kind: JobSkill, SkillName: "k", Status: db.ScanDone, Commit: "abc"}
+	gdb.Create(s)
+	if err := w.parseFindingsOutput(s, report, func(Event) {}); err != nil {
+		t.Fatal(err)
+	}
+
+	var n int64
+	gdb.Model(&db.Finding{}).Count(&n)
+	if n != 1 {
+		t.Errorf("intra-scan fingerprint collision should yield one row, got %d", n)
+	}
+	if s.FindingsCount != 2 {
+		t.Errorf("scan.FindingsCount should report what the scan found (2), got %d", s.FindingsCount)
+	}
+}

--- a/internal/worker/skill.go
+++ b/internal/worker/skill.go
@@ -27,12 +27,12 @@ type skillContext struct {
 }
 
 type skillContextScrutineer struct {
-	APIBase   string `json:"api_base"`              // e.g. http://127.0.0.1:8080/api
-	ScanID    uint   `json:"scan_id"`               // the scan that owns this run
-	Token     string `json:"token"`                 // bearer for api_base
-	RepoID    uint   `json:"repository_id"`         // convenience for URL building
-	SkillID   uint   `json:"skill_id,omitempty"`    // the running skill
-	FindingID uint   `json:"finding_id,omitempty"`  // set for finding-scoped scans
+	APIBase   string `json:"api_base"`             // e.g. http://127.0.0.1:8080/api
+	ScanID    uint   `json:"scan_id"`              // the scan that owns this run
+	Token     string `json:"token"`                // bearer for api_base
+	RepoID    uint   `json:"repository_id"`        // convenience for URL building
+	SkillID   uint   `json:"skill_id,omitempty"`   // the running skill
+	FindingID uint   `json:"finding_id,omitempty"` // set for finding-scoped scans
 	// ScanSubPath scopes code analysis to a sub-folder of ./src (monorepo
 	// support). Empty means the repo root. Skills that walk files honour
 	// this; skills that query external APIs ignore it.
@@ -154,6 +154,9 @@ func (w *Worker) doSkill(ctx context.Context, scan *db.Scan, emit func(Event)) (
 
 // parseFindingsOutput feeds the existing spec-deep parser so skill-driven
 // audits surface in the Findings tab alongside the legacy claude job.
+// Findings are deduped against prior scans of the same repository by
+// fingerprint: a match bumps last-seen on the existing row instead of
+// creating a duplicate, so analyst triage state survives a rescan (#75).
 func (w *Worker) parseFindingsOutput(scan *db.Scan, report string, emit func(Event)) error {
 	rep, err := parseReport([]byte(report))
 	if err != nil {
@@ -161,12 +164,49 @@ func (w *Worker) parseFindingsOutput(scan *db.Scan, report string, emit func(Eve
 	}
 	findings := rep.toFindings(scan.ID, scan.RepositoryID, scan.Commit, scan.SubPath)
 	scan.FindingsCount = len(findings)
-	if len(findings) > 0 {
-		if err := w.DB.Create(&findings).Error; err != nil {
-			return fmt.Errorf("save findings: %w", err)
+
+	created, observed := 0, 0
+	seenThisScan := map[string]bool{}
+	for i := range findings {
+		f := &findings[i]
+		f.Fingerprint = db.FingerprintFinding(scan.SkillName, f.SubPath, f.CWE, f.Location, f.Title)
+		f.LastSeenScanID = scan.ID
+		f.LastSeenCommit = scan.Commit
+		f.SeenCount = 1
+
+		if seenThisScan[f.Fingerprint] {
+			continue
 		}
+		seenThisScan[f.Fingerprint] = true
+
+		var existing db.Finding
+		err := w.DB.Where("repository_id = ? AND fingerprint = ?", scan.RepositoryID, f.Fingerprint).
+			Order("id").First(&existing).Error
+		if err == nil {
+			if uerr := w.DB.Model(&db.Finding{}).Where("id = ?", existing.ID).Updates(map[string]any{
+				"last_seen_scan_id": scan.ID,
+				"last_seen_commit":  scan.Commit,
+				"seen_count":        existing.SeenCount + 1,
+			}).Error; uerr != nil {
+				return fmt.Errorf("update finding %d: %w", existing.ID, uerr)
+			}
+			_ = w.DB.Create(&db.FindingHistory{
+				FindingID: existing.ID,
+				Field:     "observed",
+				NewValue:  fmt.Sprintf("scan %d @ %s", scan.ID, scan.Commit),
+				Source:    db.SourceTool,
+				By:        scan.SkillName,
+			}).Error
+			observed++
+			continue
+		}
+		if cerr := w.DB.Create(f).Error; cerr != nil {
+			return fmt.Errorf("save finding: %w", cerr)
+		}
+		created++
 	}
-	emit(Event{Kind: KindText, Text: fmt.Sprintf("parsed %d finding(s)", len(findings))})
+	emit(Event{Kind: KindText, Text: fmt.Sprintf("parsed %d finding(s): %d new, %d re-observed",
+		len(findings), created, observed)})
 	return nil
 }
 


### PR DESCRIPTION
After #72 the repo Findings tab aggregates across every scan, so re-scanning produces near-identical rows for issues that haven't been fixed. This gives each finding a stable fingerprint and dedupes on ingest so analyst triage state survives a rescan.

`db.FingerprintFinding(skill, subPath, cwe, location, title)` hashes `skill | subpath | CWE | file-path` after stripping `:line:col` and `./` from the location and normalising case. File-level matching means a finding that drifts a few lines between commits still dedupes; two distinct same-CWE issues in the same file collide into one row, which is the v1 trade-off called out in the issue. Title only enters the hash when both CWE and location are empty.

`Finding` gains `Fingerprint` (composite-indexed with `RepositoryID`), `LastSeenScanID`, `LastSeenCommit`, `SeenCount`. `parseFindingsOutput` now upserts per finding: on `(repository_id, fingerprint)` match it bumps last-seen and seen-count and writes a `FindingHistory{Field:"observed"}` row; on miss it creates. Status, severity, and prose on the existing row are never overwritten, so a rejected finding stays rejected and a triaged one stays triaged. Intra-scan collisions create one row. `scan.FindingsCount` still reports what the scan found.

`BackfillFindingFingerprints` runs at startup alongside the existing backfills, joining `Scan` for `skill_name` and seeding `last_seen_*`/`seen_count` from first-seen values. Idempotent. It does not merge existing duplicate rows; it just sets the column so future scans dedupe against them.

The finding page now shows first-seen scan/commit and last-seen scan/commit with the observation count.

Tests: `normaliseLocation` table, `FingerprintFinding` invariants (line drift, case, file/CWE/skill/subpath discriminate, title fallback), backfill + idempotency, dedup across two scans with line drift, rejected status preserved on re-observation, and intra-scan collision yielding one row.

Closes #75