### PR TITLE
web: show finding status in all listings

### DIFF
--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -1190,6 +1190,32 @@ func TestRepoShow_findingsTabAggregatesAcrossScans(t *testing.T) {
 	}
 }
 
+func TestRepoShow_displaysFindingStatus(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	repo := db.Repository{URL: "https://example.com/fstatus", Name: "fstatus"}
+	s.DB.Create(&repo)
+
+	scan := db.Scan{RepositoryID: repo.ID, Kind: "skill", SkillName: deepDiveSkillName, Status: db.ScanDone}
+	s.DB.Create(&scan)
+	s.DB.Create(&db.Finding{ScanID: scan.ID, RepositoryID: repo.ID, Title: "rce", Severity: "High", Status: db.FindingTriaged})
+
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq("GET", fmt.Sprintf("/repositories/%d", repo.ID)))
+	if w.Code != 200 {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+	body := w.Body.String()
+
+	// The finding renders once in the Summary tab's latest-scan table and
+	// once as a card in the Findings tab; both must show the lifecycle
+	// status (#82).
+	if n := strings.Count(body, "triaged"); n < 2 {
+		t.Errorf("expected finding status to render in both Summary and Findings tabs, saw %d occurrences", n)
+	}
+}
+
 func TestBulkImport_dedupesNormalisedURLs(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()
@@ -1506,6 +1532,7 @@ func TestScanShowRenders(t *testing.T) {
 		StartedAt: &now, FinishedAt: &now, Report: "# hi", Log: "line1\n",
 	}
 	s.DB.Create(&scan)
+	s.DB.Create(&db.Finding{ScanID: scan.ID, RepositoryID: repo.ID, Title: "rce", Severity: "High", Status: db.FindingTriaged})
 
 	w := httptest.NewRecorder()
 	s.Handler().ServeHTTP(w, localReq("GET", "/scans/1"))
@@ -1515,5 +1542,30 @@ func TestScanShowRenders(t *testing.T) {
 	body := w.Body.String()
 	if !strings.Contains(body, "# hi") || !strings.Contains(body, "line1") {
 		t.Errorf("missing report/log: %s", body)
+	}
+	if !strings.Contains(body, "triaged") {
+		t.Errorf("finding status not rendered in scan results table")
+	}
+}
+
+func TestMaintainerShow_displaysFindingStatus(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	repo := db.Repository{URL: "https://example.com/m", Name: "m"}
+	s.DB.Create(&repo)
+	m := db.Maintainer{Login: "alice", Repositories: []db.Repository{repo}}
+	s.DB.Create(&m)
+	scan := db.Scan{RepositoryID: repo.ID, Kind: "skill", Status: db.ScanDone}
+	s.DB.Create(&scan)
+	s.DB.Create(&db.Finding{ScanID: scan.ID, RepositoryID: repo.ID, Title: "rce", Severity: "High", Status: db.FindingReported})
+
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq("GET", fmt.Sprintf("/maintainers/%d", m.ID)))
+	if w.Code != 200 {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+	if !strings.Contains(w.Body.String(), "reported") {
+		t.Errorf("finding status not rendered in maintainer findings tab")
 	}
 }

--- a/internal/web/templates/maintainer_show.html
+++ b/internal/web/templates/maintainer_show.html
@@ -65,7 +65,8 @@
   <div role="tabpanel" id="mp2" aria-labelledby="mt2" hidden>
     <table class="table table-fixed w-full">
       <thead><tr>
-        <th class="w-24">Severity</th><th>Title</th><th class="w-32">Repository</th><th class="w-24">CWE</th>
+        <th class="w-24">Severity</th><th>Title</th><th class="w-32">Repository</th>
+        <th class="w-24">Status</th><th class="w-24">CWE</th>
       </tr></thead>
       <tbody>
       {{$repos := .Repos}}
@@ -78,6 +79,7 @@
             <div class="text-xs text-muted-foreground line-clamp-1">{{.Summary}}</div>
           </td>
           <td class="truncate">{{$repo.Name}}</td>
+          <td>{{template "finding-status" (fstatus .Status)}}</td>
           <td class="text-muted-foreground">
             {{if .CWE}}<span data-tooltip="{{cwename .CWE}}">{{.CWE}}</span>{{end}}
           </td>

--- a/internal/web/templates/repo_show.html
+++ b/internal/web/templates/repo_show.html
@@ -151,13 +151,14 @@
       {{if .Latest.Findings}}
         <table class="table table-fixed w-full">
           <thead><tr>
-            <th class="w-24">Severity</th><th>Title</th><th class="w-64">Location</th>
+            <th class="w-24">Severity</th><th>Title</th><th class="w-24">Status</th><th class="w-64">Location</th>
           </tr></thead>
           <tbody>
           {{range .Latest.Findings}}
             <tr class="cursor-pointer" hx-get="/findings/{{.ID}}" hx-target="body" hx-push-url="true">
               <td>{{template "severity-badge" .Severity}}</td>
               <td class="min-w-0 whitespace-normal">{{.Title}}</td>
+              <td>{{template "finding-status" (fstatus .Status)}}</td>
               <td class="whitespace-normal"><code class="text-xs break-all">{{.Location}}</code></td>
             </tr>
           {{end}}
@@ -181,6 +182,7 @@
           <header>
             <div class="flex items-center gap-2">
               {{template "severity-badge" .Severity}}
+              {{template "finding-status" (fstatus .Status)}}
               <h3>{{.Title}}</h3>
               {{if .CWE}}<span class="badge-outline ml-auto" data-tooltip="{{cwename .CWE}}">{{.CWE}}</span>{{end}}
             </div>

--- a/internal/web/templates/scan_show.html
+++ b/internal/web/templates/scan_show.html
@@ -81,7 +81,7 @@
     {{if .Findings}}
       <table class="table table-fixed w-full mb-4">
         <thead><tr>
-          <th class="w-24">Severity</th><th>Title</th>
+          <th class="w-24">Severity</th><th>Title</th><th class="w-24">Status</th>
           <th class="w-28">CWE</th><th class="w-64">Location</th>
         </tr></thead>
         <tbody>
@@ -92,6 +92,7 @@
               <div class="font-medium">{{.Title}}</div>
               <div class="text-xs text-muted-foreground line-clamp-2">{{.Summary}}</div>
             </td>
+            <td>{{template "finding-status" (fstatus .Status)}}</td>
             <td class="text-muted-foreground">
               {{if .CWE}}<span data-tooltip="{{cwename .CWE}}">{{.CWE}}</span>{{end}}
             </td>


### PR DESCRIPTION
Closes #82.

The lifecycle status badge (new/triaged/reported/etc.) was already shown on `/findings` and the org Findings tab but missing from the per-repo views. This adds it to:

- repo Summary tab, latest-scan table
- repo Findings tab cards
- scan Result tab table
- maintainer Findings tab

All four reuse the existing `finding-status` partial so styling stays consistent. Tests added for each render path.