### PR TITLE
cmd/scrutineer: write data/go.mod sentinel to fence off scan workspaces

### DIFF
--- a/cmd/scrutineer/main.go
+++ b/cmd/scrutineer/main.go
@@ -73,6 +73,9 @@ func run(log *slog.Logger) error {
 		return err
 	}
 	_ = os.Chmod(*dataDir, dataPermSecure)
+	// Module-boundary sentinel so go tooling on the parent repo never
+	// walks into cloned scan workspaces under data/work/.
+	_ = os.WriteFile(filepath.Join(*dataDir, "go.mod"), []byte("module scrutineer/data\n"), dataPermSecure)
 
 	gdb, err := db.Open(filepath.Join(*dataDir, "scrutineer.db"))
 	if err != nil {


### PR DESCRIPTION
Cloned repos under `data/work/` can contain Go source that breaks `gofmt -l .`, `go vet ./...`, golangci-lint, etc. when run from the project root. Writing a `go.mod` at `data/` on startup makes that directory its own module so the parent repo's tooling stops at the boundary.

Salvaged from the closed #78 where it was bundled with the webview wrapper.