### PR TITLE
SBOM upload: parse, resolve repos, aggregate findings

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.26
 toolchain go1.26.2
 
 require (
+	github.com/git-pkgs/sbom v0.1.0
 	github.com/glebarez/sqlite v1.11.0
 	gopkg.in/yaml.v3 v3.0.1
 	gorm.io/gorm v1.31.1

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
+github.com/git-pkgs/sbom v0.1.0 h1:rMNqpHl8qb2MPHF3g0dlL0RU5r0lfcpI3uXmJR9bd+U=
+github.com/git-pkgs/sbom v0.1.0/go.mod h1:42YiJ+W9jBsPZnYJQs6tUlOtWlC0vDBOtND8TMwE8ek=
 github.com/glebarez/go-sqlite v1.21.2 h1:3a6LFC4sKahUunAmynQKLZceZCOzUthkRkEAl9gAXWo=
 github.com/glebarez/go-sqlite v1.21.2/go.mod h1:sfxdZyhQjTM2Wry3gVYWaW072Ri1WMdWJi0k6+3382k=
 github.com/glebarez/sqlite v1.11.0 h1:wSG0irqzP6VurnMEpFGer5Li19RpIRi2qvQz++w0GMw=

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -538,6 +538,11 @@ type SBOMPackage struct {
 	PURL      string `gorm:"index"`
 	Ecosystem string
 	License   string
+	// Scope is "direct" when the SBOM's dependency graph lists this
+	// package as a dependency of the root component, "transitive" when it
+	// only appears via another package, and "" when the document had no
+	// dependency graph to derive it from.
+	Scope string `gorm:"index"`
 
 	RepositoryID *uint `gorm:"index"`
 	Repository   *Repository

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -500,10 +500,50 @@ func Open(dsn string) (*gorm.DB, error) {
 		&FindingCommunication{}, &FindingReference{}, &FindingHistory{},
 		&Dependency{}, &Package{}, &Dependent{}, &Advisory{},
 		&Maintainer{}, &Skill{}, &Subproject{},
+		&SBOMUpload{}, &SBOMPackage{},
 	); err != nil {
 		return nil, fmt.Errorf("automigrate: %w", err)
 	}
 	return gdb, nil
+}
+
+// SBOMUpload is one CycloneDX or SPDX document a user uploaded. Packages
+// are replaced wholesale on re-upload (cascade delete) but the resolved
+// Repository rows survive so prior scan results stay attached.
+type SBOMUpload struct {
+	ID uint `gorm:"primarykey"`
+
+	Name        string
+	Filename    string
+	Format      string
+	SpecVersion string
+	Raw         []byte
+
+	PackageCount int
+	Packages     []SBOMPackage `gorm:"constraint:OnDelete:CASCADE"`
+
+	CreatedAt time.Time
+	UpdatedAt time.Time
+}
+
+// SBOMPackage is one component listed in an upload. RepositoryID is set
+// asynchronously once the PURL has been resolved to a source repo and the
+// triage scan enqueued; until then it is nil.
+type SBOMPackage struct {
+	ID           uint `gorm:"primarykey"`
+	SBOMUploadID uint `gorm:"index;not null"`
+
+	Name      string
+	Version   string
+	PURL      string `gorm:"index"`
+	Ecosystem string
+	License   string
+
+	RepositoryID *uint `gorm:"index"`
+	Repository   *Repository
+	ResolveError string
+
+	CreatedAt time.Time
 }
 
 // Subproject is a scannable unit the subprojects skill discovered inside

--- a/internal/web/sboms.go
+++ b/internal/web/sboms.go
@@ -1,0 +1,206 @@
+package web
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/git-pkgs/sbom"
+
+	"scrutineer/internal/db"
+)
+
+const (
+	sbomMaxUploadBytes = 32 << 20
+	sbomResolveTimeout = 10 * time.Minute
+)
+
+func (s *Server) registerSBOMRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("GET /sboms", s.sbomList)
+	mux.HandleFunc("POST /sboms", s.sbomUpload)
+	mux.HandleFunc("GET /sboms/{id}", s.sbomShow)
+	mux.HandleFunc("POST /sboms/{id}/resolve", s.sbomResolve)
+	mux.HandleFunc("POST /sboms/{id}/delete", s.sbomDelete)
+}
+
+func (s *Server) sbomList(w http.ResponseWriter, r *http.Request) {
+	var rows []db.SBOMUpload
+	s.DB.Order("id desc").Find(&rows)
+	s.render(w, "sboms.html", map[string]any{"SBOMs": rows})
+}
+
+func (s *Server) sbomUpload(w http.ResponseWriter, r *http.Request) {
+	r.Body = http.MaxBytesReader(w, r.Body, sbomMaxUploadBytes)
+	file, header, err := r.FormFile("file")
+	if err != nil {
+		http.Error(w, "file required: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	defer func() { _ = file.Close() }()
+
+	data, err := io.ReadAll(file)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	doc, err := sbom.Parse(data)
+	if err != nil {
+		http.Error(w, "parse SBOM: "+err.Error(), http.StatusUnprocessableEntity)
+		return
+	}
+
+	up := db.SBOMUpload{
+		Name:         firstNonEmpty(doc.Document.Name, header.Filename),
+		Filename:     header.Filename,
+		Format:       string(doc.Type),
+		SpecVersion:  doc.SpecVersion,
+		Raw:          data,
+		PackageCount: len(doc.Packages),
+	}
+	for _, p := range doc.Packages {
+		up.Packages = append(up.Packages, db.SBOMPackage{
+			Name:      p.Name,
+			Version:   p.Version,
+			PURL:      p.PURL(),
+			Ecosystem: purlType(p.PURL()),
+			License:   firstNonEmpty(p.LicenseDeclared, p.LicenseConcluded),
+		})
+	}
+	if err := s.DB.Create(&up).Error; err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	s.goResolve(up.ID)
+
+	w.Header().Set("HX-Redirect", fmt.Sprintf("/sboms/%d", up.ID))
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *Server) sbomShow(w http.ResponseWriter, r *http.Request) {
+	var up db.SBOMUpload
+	if err := s.DB.Preload("Packages.Repository").First(&up, r.PathValue("id")).Error; err != nil {
+		http.NotFound(w, r)
+		return
+	}
+
+	repoIDs := make([]uint, 0, len(up.Packages))
+	for _, p := range up.Packages {
+		if p.RepositoryID != nil {
+			repoIDs = append(repoIDs, *p.RepositoryID)
+		}
+	}
+
+	var findings []db.Finding
+	if len(repoIDs) > 0 {
+		q := s.DB.Where("repository_id IN ? AND status NOT IN ?", repoIDs,
+			[]db.FindingLifecycle{db.FindingRejected, db.FindingDuplicate})
+		if sev := r.URL.Query().Get("severity"); sev != "" {
+			q = q.Where("severity = ?", sev)
+		}
+		q.Order(severityOrder).Order("id desc").Find(&findings)
+	}
+	reposByID := loadRepoMap(s.DB, findings)
+
+	resolved, withRepo := 0, 0
+	for _, p := range up.Packages {
+		if p.RepositoryID != nil || p.ResolveError != "" {
+			resolved++
+		}
+		if p.RepositoryID != nil {
+			withRepo++
+		}
+	}
+
+	s.render(w, "sbom_show.html", map[string]any{
+		"SBOM": up, "Findings": findings, "Repos": reposByID,
+		"Resolved": resolved, "WithRepo": withRepo,
+		"Severity": r.URL.Query().Get("severity"),
+	})
+}
+
+func (s *Server) sbomResolve(w http.ResponseWriter, r *http.Request) {
+	var up db.SBOMUpload
+	if err := s.DB.First(&up, r.PathValue("id")).Error; err != nil {
+		http.NotFound(w, r)
+		return
+	}
+	s.goResolve(up.ID)
+	w.Header().Set("HX-Redirect", fmt.Sprintf("/sboms/%d", up.ID))
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// goResolve launches resolveSBOMPackages. Indirected so tests can run it
+// synchronously and avoid racing the in-memory database teardown.
+func (s *Server) goResolve(uploadID uint) {
+	if s.resolveSync {
+		s.resolveSBOMPackages(uploadID)
+		return
+	}
+	go s.resolveSBOMPackages(uploadID)
+}
+
+func (s *Server) sbomDelete(w http.ResponseWriter, r *http.Request) {
+	if err := s.DB.Delete(&db.SBOMUpload{}, r.PathValue("id")).Error; err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("HX-Redirect", "/sboms")
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// resolveSBOMPackages walks every unresolved package in the upload, looks up
+// its source repository via packages.ecosyste.ms, FirstOrCreates the repo,
+// enqueues the default triage skill if the repo is new, and links the
+// package row. Runs in the background after upload so the page can render
+// immediately.
+func (s *Server) resolveSBOMPackages(uploadID uint) {
+	ctx, cancel := context.WithTimeout(context.Background(), sbomResolveTimeout)
+	defer cancel()
+
+	var pkgs []db.SBOMPackage
+	s.DB.Where("sbom_upload_id = ? AND repository_id IS NULL", uploadID).Find(&pkgs)
+
+	for i := range pkgs {
+		p := &pkgs[i]
+		if p.PURL == "" {
+			s.DB.Model(p).Update("resolve_error", "no purl")
+			continue
+		}
+		repoURL := s.resolvePURL(ctx, p.PURL)
+		if repoURL == "" {
+			s.DB.Model(p).Update("resolve_error", "no repository_url for purl")
+			continue
+		}
+		input, err := ParseRepoInput(repoURL)
+		if err != nil {
+			s.DB.Model(p).Update("resolve_error", err.Error())
+			continue
+		}
+		repo, _, err := s.createOrTriageRepo(ctx, input, "")
+		if err != nil {
+			s.DB.Model(p).Update("resolve_error", err.Error())
+			continue
+		}
+		s.DB.Model(p).Updates(map[string]any{"repository_id": repo.ID, "resolve_error": ""})
+	}
+}
+
+// purlType returns the ecosystem segment of a Package URL (the bit between
+// "pkg:" and the first "/").
+func purlType(purl string) string {
+	const prefix = "pkg:"
+	if !strings.HasPrefix(purl, prefix) {
+		return ""
+	}
+	rest := purl[len(prefix):]
+	if i := strings.IndexByte(rest, '/'); i > 0 {
+		return rest[:i]
+	}
+	return rest
+}
+

--- a/internal/web/sboms.go
+++ b/internal/web/sboms.go
@@ -88,14 +88,19 @@ func (s *Server) sbomShow(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	repoIDs := make([]uint, 0, len(up.Packages))
+	reposByID := make(map[uint]db.Repository)
 	for _, p := range up.Packages {
-		if p.RepositoryID != nil {
-			repoIDs = append(repoIDs, *p.RepositoryID)
+		if p.Repository != nil {
+			reposByID[p.Repository.ID] = *p.Repository
 		}
+	}
+	repoIDs := make([]uint, 0, len(reposByID))
+	for id := range reposByID {
+		repoIDs = append(repoIDs, id)
 	}
 
 	var findings []db.Finding
+	var advisories []db.Advisory
 	if len(repoIDs) > 0 {
 		q := s.DB.Where("repository_id IN ? AND status NOT IN ?", repoIDs,
 			[]db.FindingLifecycle{db.FindingRejected, db.FindingDuplicate})
@@ -103,8 +108,10 @@ func (s *Server) sbomShow(w http.ResponseWriter, r *http.Request) {
 			q = q.Where("severity = ?", sev)
 		}
 		q.Order(severityOrder).Order("id desc").Find(&findings)
+
+		s.DB.Where("repository_id IN ? AND withdrawn_at IS NULL", repoIDs).
+			Order("cvss_score desc, published_at desc").Find(&advisories)
 	}
-	reposByID := loadRepoMap(s.DB, findings)
 
 	resolved, withRepo := 0, 0
 	for _, p := range up.Packages {
@@ -117,7 +124,7 @@ func (s *Server) sbomShow(w http.ResponseWriter, r *http.Request) {
 	}
 
 	s.render(w, "sbom_show.html", map[string]any{
-		"SBOM": up, "Findings": findings, "Repos": reposByID,
+		"SBOM": up, "Findings": findings, "Advisories": advisories, "Repos": reposByID,
 		"Resolved": resolved, "WithRepo": withRepo,
 		"Severity": r.URL.Query().Get("severity"),
 	})

--- a/internal/web/sboms.go
+++ b/internal/web/sboms.go
@@ -125,6 +125,7 @@ func (s *Server) sbomShow(w http.ResponseWriter, r *http.Request) {
 		repoIDs = append(repoIDs, id)
 	}
 
+	sort := r.URL.Query().Get("sort")
 	var findings []db.Finding
 	var advisories []db.Advisory
 	if len(repoIDs) > 0 {
@@ -133,7 +134,17 @@ func (s *Server) sbomShow(w http.ResponseWriter, r *http.Request) {
 		if sev := r.URL.Query().Get("severity"); sev != "" {
 			q = q.Where("severity = ?", sev)
 		}
-		q.Order(severityOrder).Order("id desc").Find(&findings)
+		switch sort {
+		case sortSeverity:
+			q = q.Order(severityOrder).Order("id desc")
+		case sortRepository:
+			q = q.Joins("JOIN repositories r ON r.id = findings.repository_id").
+				Order("r.name").Order("findings.id desc")
+		default:
+			sort = defaultSort
+			q = q.Order("id desc")
+		}
+		q.Find(&findings)
 
 		s.DB.Where("repository_id IN ? AND withdrawn_at IS NULL", repoIDs).
 			Order("cvss_score desc, published_at desc").Find(&advisories)
@@ -153,8 +164,8 @@ func (s *Server) sbomShow(w http.ResponseWriter, r *http.Request) {
 		"SBOM": up, "Packages": pkgs,
 		"Findings": findings, "Advisories": advisories, "Repos": reposByID,
 		"Resolved": resolved, "WithRepo": withRepo,
-		"Severity": r.URL.Query().Get("severity"),
-		"Scope":    scope, "HasScope": hasScope,
+		"Severity": r.URL.Query().Get("severity"), "Sort": sort,
+		"Scope": scope, "HasScope": hasScope,
 	})
 }
 

--- a/internal/web/sboms.go
+++ b/internal/web/sboms.go
@@ -61,6 +61,7 @@ func (s *Server) sbomUpload(w http.ResponseWriter, r *http.Request) {
 		Raw:          data,
 		PackageCount: len(doc.Packages),
 	}
+	scope := classifyScope(doc)
 	for _, p := range doc.Packages {
 		up.Packages = append(up.Packages, db.SBOMPackage{
 			Name:      p.Name,
@@ -68,6 +69,7 @@ func (s *Server) sbomUpload(w http.ResponseWriter, r *http.Request) {
 			PURL:      p.PURL(),
 			Ecosystem: purlType(p.PURL()),
 			License:   firstNonEmpty(p.LicenseDeclared, p.LicenseConcluded),
+			Scope:     scope[p.ID],
 		})
 	}
 	if err := s.DB.Create(&up).Error; err != nil {
@@ -88,8 +90,32 @@ func (s *Server) sbomShow(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	reposByID := make(map[uint]db.Repository)
+	// The scope filter only makes sense when at least one package has a
+	// known direct/transitive value; flat-list SBOMs leave them all blank.
+	hasScope := false
 	for _, p := range up.Packages {
+		if p.Scope != "" {
+			hasScope = true
+			break
+		}
+	}
+
+	scope := r.URL.Query().Get("scope")
+	pkgs := up.Packages
+	if hasScope && (scope == scopeDirect || scope == scopeTransitive) {
+		filtered := make([]db.SBOMPackage, 0, len(up.Packages))
+		for _, p := range up.Packages {
+			if p.Scope == scope {
+				filtered = append(filtered, p)
+			}
+		}
+		pkgs = filtered
+	} else {
+		scope = ""
+	}
+
+	reposByID := make(map[uint]db.Repository)
+	for _, p := range pkgs {
 		if p.Repository != nil {
 			reposByID[p.Repository.ID] = *p.Repository
 		}
@@ -114,7 +140,7 @@ func (s *Server) sbomShow(w http.ResponseWriter, r *http.Request) {
 	}
 
 	resolved, withRepo := 0, 0
-	for _, p := range up.Packages {
+	for _, p := range pkgs {
 		if p.RepositoryID != nil || p.ResolveError != "" {
 			resolved++
 		}
@@ -124,9 +150,11 @@ func (s *Server) sbomShow(w http.ResponseWriter, r *http.Request) {
 	}
 
 	s.render(w, "sbom_show.html", map[string]any{
-		"SBOM": up, "Findings": findings, "Advisories": advisories, "Repos": reposByID,
+		"SBOM": up, "Packages": pkgs,
+		"Findings": findings, "Advisories": advisories, "Repos": reposByID,
 		"Resolved": resolved, "WithRepo": withRepo,
 		"Severity": r.URL.Query().Get("severity"),
+		"Scope":    scope, "HasScope": hasScope,
 	})
 }
 
@@ -195,6 +223,53 @@ func (s *Server) resolveSBOMPackages(uploadID uint) {
 		}
 		s.DB.Model(p).Updates(map[string]any{"repository_id": repo.ID, "resolve_error": ""})
 	}
+}
+
+const (
+	scopeDirect     = "direct"
+	scopeTransitive = "transitive"
+)
+
+// classifyScope derives direct-vs-transitive from the SBOM's relationship
+// graph. Roots are nodes that originate DEPENDS_ON edges but are never
+// themselves a DEPENDS_ON target, plus anything pointed at by a DESCRIBES
+// edge (SPDX's document → root-package link). A package is "direct" if a
+// root depends on it, "transitive" if only another package does, and
+// absent from the map (empty Scope) if the graph doesn't mention it.
+func classifyScope(doc *sbom.SBOM) map[string]string {
+	const dependsOn, describes = "DEPENDS_ON", "DESCRIBES"
+	targets := map[string]bool{}
+	sources := map[string]bool{}
+	roots := map[string]bool{}
+	for _, r := range doc.Relationships {
+		switch r.Type {
+		case dependsOn:
+			sources[r.SourceID] = true
+			targets[r.TargetID] = true
+		case describes:
+			roots[r.TargetID] = true
+		}
+	}
+	for id := range sources {
+		if !targets[id] {
+			roots[id] = true
+		}
+	}
+	if len(roots) == 0 {
+		return nil
+	}
+	out := map[string]string{}
+	for _, r := range doc.Relationships {
+		if r.Type != dependsOn {
+			continue
+		}
+		if roots[r.SourceID] {
+			out[r.TargetID] = scopeDirect
+		} else if out[r.TargetID] == "" {
+			out[r.TargetID] = scopeTransitive
+		}
+	}
+	return out
 }
 
 // purlType returns the ecosystem segment of a Package URL (the bit between

--- a/internal/web/sboms_test.go
+++ b/internal/web/sboms_test.go
@@ -187,6 +187,44 @@ func TestSBOMShow_aggregatesFindings(t *testing.T) {
 	}
 }
 
+func TestSBOMShow_findingsSort(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	repo := db.Repository{URL: "https://example.com/sort", Name: "sort"}
+	s.DB.Create(&repo)
+	scan := db.Scan{RepositoryID: repo.ID, Kind: "skill", Status: db.ScanDone}
+	s.DB.Create(&scan)
+	// Created in id order: critical first (older), low second (newer).
+	s.DB.Create(&db.Finding{ScanID: scan.ID, RepositoryID: repo.ID, Title: "old-critical", Severity: "Critical"})
+	s.DB.Create(&db.Finding{ScanID: scan.ID, RepositoryID: repo.ID, Title: "new-low", Severity: "Low"})
+
+	up := db.SBOMUpload{Name: "demo", PackageCount: 1, Packages: []db.SBOMPackage{
+		{Name: "p", RepositoryID: &repo.ID},
+	}}
+	s.DB.Create(&up)
+
+	get := func(q string) string {
+		w := httptest.NewRecorder()
+		s.Handler().ServeHTTP(w, localReq("GET", fmt.Sprintf("/sboms/%d%s", up.ID, q)))
+		if w.Code != 200 {
+			t.Fatalf("status %d: %s", w.Code, w.Body)
+		}
+		return w.Body.String()
+	}
+
+	// Default (newest): newer Low before older Critical.
+	body := get("")
+	if strings.Index(body, "new-low") > strings.Index(body, "old-critical") {
+		t.Errorf("default sort should be newest-first")
+	}
+	// sort=severity: Critical before Low.
+	body = get("?sort=severity")
+	if strings.Index(body, "old-critical") > strings.Index(body, "new-low") {
+		t.Errorf("severity sort should put Critical before Low")
+	}
+}
+
 func TestSBOMShow_listsAdvisories(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()

--- a/internal/web/sboms_test.go
+++ b/internal/web/sboms_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"scrutineer/internal/db"
 )
@@ -181,6 +182,36 @@ func TestSBOMShow_aggregatesFindings(t *testing.T) {
 	}
 	if !strings.Contains(body, "triaged") {
 		t.Errorf("finding status badge not rendered")
+	}
+}
+
+func TestSBOMShow_listsAdvisories(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	repo := db.Repository{URL: "https://example.com/adv", Name: "adv"}
+	s.DB.Create(&repo)
+	s.DB.Create(&db.Advisory{RepositoryID: repo.ID, Title: "CVE-2026-9999 prototype pollution",
+		Severity: "High", CVSSScore: 7.5, URL: "https://osv.dev/CVE-2026-9999"})
+	withdrawn := time.Now()
+	s.DB.Create(&db.Advisory{RepositoryID: repo.ID, Title: "withdrawn-one", WithdrawnAt: &withdrawn})
+
+	up := db.SBOMUpload{Name: "demo", PackageCount: 1, Packages: []db.SBOMPackage{
+		{Name: "adv-pkg", PURL: "pkg:npm/adv", RepositoryID: &repo.ID},
+	}}
+	s.DB.Create(&up)
+
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq("GET", fmt.Sprintf("/sboms/%d", up.ID)))
+	if w.Code != 200 {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, "CVE-2026-9999 prototype pollution") {
+		t.Errorf("advisory not listed")
+	}
+	if strings.Contains(body, "withdrawn-one") {
+		t.Errorf("withdrawn advisory should be hidden")
 	}
 }
 

--- a/internal/web/sboms_test.go
+++ b/internal/web/sboms_test.go
@@ -11,6 +11,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/git-pkgs/sbom"
+
 	"scrutineer/internal/db"
 )
 
@@ -228,6 +230,88 @@ func TestSBOMList_renders(t *testing.T) {
 	}
 	if !strings.Contains(w.Body.String(), "first.cdx") {
 		t.Errorf("upload not listed")
+	}
+}
+
+func TestClassifyScope(t *testing.T) {
+	t.Run("cyclonedx graph", func(t *testing.T) {
+		// root → a, b; a → c. Root is identified by having no inbound edge.
+		doc := &sbom.SBOM{Relationships: []sbom.Relationship{
+			{SourceID: "root", TargetID: "a", Type: "DEPENDS_ON"},
+			{SourceID: "root", TargetID: "b", Type: "DEPENDS_ON"},
+			{SourceID: "a", TargetID: "c", Type: "DEPENDS_ON"},
+		}}
+		got := classifyScope(doc)
+		want := map[string]string{"a": scopeDirect, "b": scopeDirect, "c": scopeTransitive}
+		for id, s := range want {
+			if got[id] != s {
+				t.Errorf("%s = %q, want %q", id, got[id], s)
+			}
+		}
+	})
+	t.Run("spdx with DESCRIBES", func(t *testing.T) {
+		// DOCUMENT --DESCRIBES--> root; root --DEPENDS_ON--> a; a --DEPENDS_ON--> b.
+		doc := &sbom.SBOM{Relationships: []sbom.Relationship{
+			{SourceID: "SPDXRef-DOCUMENT", TargetID: "root", Type: "DESCRIBES"},
+			{SourceID: "root", TargetID: "a", Type: "DEPENDS_ON"},
+			{SourceID: "a", TargetID: "b", Type: "DEPENDS_ON"},
+		}}
+		got := classifyScope(doc)
+		if got["a"] != scopeDirect || got["b"] != scopeTransitive {
+			t.Errorf("got %v", got)
+		}
+	})
+	t.Run("direct wins over transitive", func(t *testing.T) {
+		// root → a, a → b, root → b. b should still be direct.
+		doc := &sbom.SBOM{Relationships: []sbom.Relationship{
+			{SourceID: "root", TargetID: "a", Type: "DEPENDS_ON"},
+			{SourceID: "a", TargetID: "b", Type: "DEPENDS_ON"},
+			{SourceID: "root", TargetID: "b", Type: "DEPENDS_ON"},
+		}}
+		if got := classifyScope(doc); got["b"] != scopeDirect {
+			t.Errorf("b = %q, want direct", got["b"])
+		}
+	})
+	t.Run("no graph", func(t *testing.T) {
+		if got := classifyScope(&sbom.SBOM{}); got != nil {
+			t.Errorf("expected nil for empty relationships, got %v", got)
+		}
+	})
+}
+
+func TestSBOMShow_scopeFilter(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	repoA := db.Repository{URL: "https://example.com/direct-repo", Name: "direct-repo"}
+	s.DB.Create(&repoA)
+	repoB := db.Repository{URL: "https://example.com/trans-repo", Name: "trans-repo"}
+	s.DB.Create(&repoB)
+	scan := db.Scan{RepositoryID: repoA.ID, Kind: "skill", Status: db.ScanDone}
+	s.DB.Create(&scan)
+	s.DB.Create(&db.Finding{ScanID: scan.ID, RepositoryID: repoA.ID, Title: "direct-dep-finding", Severity: "High"})
+	s.DB.Create(&db.Finding{ScanID: scan.ID, RepositoryID: repoB.ID, Title: "trans-dep-finding", Severity: "High"})
+
+	up := db.SBOMUpload{Name: "demo", PackageCount: 2, Packages: []db.SBOMPackage{
+		{Name: "pkg-direct", Scope: scopeDirect, RepositoryID: &repoA.ID},
+		{Name: "pkg-trans", Scope: scopeTransitive, RepositoryID: &repoB.ID},
+	}}
+	s.DB.Create(&up)
+
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq("GET", fmt.Sprintf("/sboms/%d?scope=direct", up.ID)))
+	if w.Code != 200 {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, "pkg-direct") || strings.Contains(body, "pkg-trans") {
+		t.Errorf("scope filter not applied to packages table")
+	}
+	if !strings.Contains(body, "direct-dep-finding") {
+		t.Errorf("findings from direct-dep repo missing")
+	}
+	if strings.Contains(body, "trans-dep-finding") {
+		t.Errorf("scope filter should also scope findings")
 	}
 }
 

--- a/internal/web/sboms_test.go
+++ b/internal/web/sboms_test.go
@@ -1,0 +1,216 @@
+package web
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"scrutineer/internal/db"
+)
+
+const cdxFixture = `{
+  "bomFormat":"CycloneDX","specVersion":"1.5",
+  "metadata":{"component":{"type":"application","name":"demo","version":"1.0.0"}},
+  "components":[
+    {"type":"library","name":"lodash","version":"4.17.21","purl":"pkg:npm/lodash@4.17.21",
+     "licenses":[{"license":{"id":"MIT"}}]},
+    {"type":"library","name":"nopurl","version":"1.0.0"}
+  ]
+}`
+
+func multipartReq(t *testing.T, path, field, filename, content string) *http.Request {
+	t.Helper()
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+	fw, err := mw.CreateFormFile(field, filename)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := fw.Write([]byte(content)); err != nil {
+		t.Fatal(err)
+	}
+	_ = mw.Close()
+	r := httptest.NewRequest("POST", path, &buf)
+	r.Host = testHost
+	r.Header.Set("Content-Type", mw.FormDataContentType())
+	r.Header.Set("Sec-Fetch-Site", "same-origin")
+	return r
+}
+
+func TestSBOMUpload_parsesAndStores(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, multipartReq(t, "/sboms", "file", "demo.cdx.json", cdxFixture))
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+	if !strings.HasPrefix(w.Header().Get("HX-Redirect"), "/sboms/") {
+		t.Errorf("missing HX-Redirect, got %q", w.Header().Get("HX-Redirect"))
+	}
+
+	var up db.SBOMUpload
+	if err := s.DB.Preload("Packages").First(&up).Error; err != nil {
+		t.Fatalf("upload not created: %v", err)
+	}
+	if up.Name != "demo" {
+		t.Errorf("Name = %q, want demo (from metadata.component)", up.Name)
+	}
+	if up.Format != "cyclonedx" || up.SpecVersion != "1.5" {
+		t.Errorf("format = %s/%s", up.Format, up.SpecVersion)
+	}
+	if up.PackageCount != 2 || len(up.Packages) != 2 {
+		t.Fatalf("packages = %d (%d rows)", up.PackageCount, len(up.Packages))
+	}
+	var lodash db.SBOMPackage
+	for _, p := range up.Packages {
+		if p.Name == "lodash" {
+			lodash = p
+		}
+	}
+	if lodash.PURL != "pkg:npm/lodash@4.17.21" {
+		t.Errorf("lodash purl = %q", lodash.PURL)
+	}
+	if lodash.Ecosystem != "npm" {
+		t.Errorf("lodash ecosystem = %q", lodash.Ecosystem)
+	}
+	if lodash.License != "MIT" {
+		t.Errorf("lodash license = %q", lodash.License)
+	}
+}
+
+func TestSBOMUpload_rejectsUnrecognized(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, multipartReq(t, "/sboms", "file", "x.json", `{"foo":1}`))
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status %d, want 422: %s", w.Code, w.Body)
+	}
+}
+
+func TestSBOMResolve_linksRepoAndEnqueuesTriage(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	// Stub the ecosyste.ms lookup so lodash resolves to a fake repo URL.
+	s.resolvePURL = func(_ context.Context, purl string) string {
+		if strings.Contains(purl, "lodash") {
+			return "https://github.com/lodash/lodash"
+		}
+		return ""
+	}
+	triage := db.Skill{Name: defaultSkillName, Body: "b", Active: true}
+	s.DB.Create(&triage)
+
+	up := db.SBOMUpload{Name: "demo", Packages: []db.SBOMPackage{
+		{Name: "lodash", PURL: "pkg:npm/lodash@4.17.21"},
+		{Name: "nopurl"},
+		{Name: "noresolve", PURL: "pkg:npm/ghost@1.0.0"},
+	}}
+	s.DB.Create(&up)
+
+	s.resolveSBOMPackages(up.ID)
+
+	var pkgs []db.SBOMPackage
+	s.DB.Where("sbom_upload_id = ?", up.ID).Order("id").Find(&pkgs)
+
+	if pkgs[0].RepositoryID == nil {
+		t.Fatalf("lodash not linked: %+v", pkgs[0])
+	}
+	var repo db.Repository
+	s.DB.First(&repo, *pkgs[0].RepositoryID)
+	if repo.URL != "https://github.com/lodash/lodash.git" {
+		t.Errorf("repo url = %q", repo.URL)
+	}
+	var scans int64
+	s.DB.Model(&db.Scan{}).Where("repository_id = ?", repo.ID).Count(&scans)
+	if scans != 1 {
+		t.Errorf("triage scan not enqueued, scans = %d", scans)
+	}
+
+	if pkgs[1].ResolveError != "no purl" {
+		t.Errorf("nopurl error = %q", pkgs[1].ResolveError)
+	}
+	if pkgs[2].ResolveError != "no repository_url for purl" {
+		t.Errorf("noresolve error = %q", pkgs[2].ResolveError)
+	}
+}
+
+func TestSBOMShow_aggregatesFindings(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	repo := db.Repository{URL: "https://example.com/r", Name: "r"}
+	s.DB.Create(&repo)
+	scan := db.Scan{RepositoryID: repo.ID, Kind: "skill", Status: db.ScanDone}
+	s.DB.Create(&scan)
+	s.DB.Create(&db.Finding{ScanID: scan.ID, RepositoryID: repo.ID, Title: "rce-in-r", Severity: "High", Status: db.FindingTriaged})
+	s.DB.Create(&db.Finding{ScanID: scan.ID, RepositoryID: repo.ID, Title: "noise", Severity: "Low", Status: db.FindingRejected})
+
+	other := db.Repository{URL: "https://example.com/other", Name: "other"}
+	s.DB.Create(&other)
+	s.DB.Create(&db.Finding{ScanID: scan.ID, RepositoryID: other.ID, Title: "unrelated", Severity: "High"})
+
+	up := db.SBOMUpload{Name: "demo", PackageCount: 1, Packages: []db.SBOMPackage{
+		{Name: "r-pkg", PURL: "pkg:npm/r", RepositoryID: &repo.ID},
+	}}
+	s.DB.Create(&up)
+
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq("GET", fmt.Sprintf("/sboms/%d", up.ID)))
+	if w.Code != 200 {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, "rce-in-r") {
+		t.Errorf("finding from linked repo not shown")
+	}
+	if strings.Contains(body, "noise") {
+		t.Errorf("rejected finding should be hidden")
+	}
+	if strings.Contains(body, "unrelated") {
+		t.Errorf("finding from unlinked repo should not be shown")
+	}
+	if !strings.Contains(body, "triaged") {
+		t.Errorf("finding status badge not rendered")
+	}
+}
+
+func TestSBOMList_renders(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	s.DB.Create(&db.SBOMUpload{Name: "first.cdx", Format: "cyclonedx", PackageCount: 5})
+
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq("GET", "/sboms"))
+	if w.Code != 200 {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+	if !strings.Contains(w.Body.String(), "first.cdx") {
+		t.Errorf("upload not listed")
+	}
+}
+
+func TestPURLType(t *testing.T) {
+	tests := []struct{ in, want string }{
+		{"pkg:npm/lodash@4.17.21", "npm"},
+		{"pkg:golang/github.com/gorilla/mux@v1.8.0", "golang"},
+		{"pkg:gem/rails", "gem"},
+		{"", ""},
+		{"not-a-purl", ""},
+	}
+	for _, tt := range tests {
+		if got := purlType(tt.in); got != tt.want {
+			t.Errorf("purlType(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -35,15 +35,33 @@ type Server struct {
 	Broker *Broker
 	Worker *worker.Worker
 	tmpl   *template.Template
+
+	// resolvePURL maps a Package URL to its source repository URL via
+	// packages.ecosyste.ms. Field rather than direct call so tests can
+	// stub the network lookup.
+	resolvePURL func(ctx context.Context, purl string) string
+	resolveSync bool
 }
 
 func New(gdb *gorm.DB, q *queue.Queue, log *slog.Logger, broker *Broker, w *worker.Worker) (*Server, error) {
 	funcs := template.FuncMap{
-		"since": func(t *time.Time) string {
-			if t == nil {
+		"since": func(v any) string {
+			var t time.Time
+			switch x := v.(type) {
+			case time.Time:
+				t = x
+			case *time.Time:
+				if x == nil {
+					return ""
+				}
+				t = *x
+			default:
 				return ""
 			}
-			return humanDuration(time.Since(*t)) + " ago"
+			if t.IsZero() {
+				return ""
+			}
+			return humanDuration(time.Since(t)) + " ago"
 		},
 		"dur":     humanDuration,
 		"usd":     formatUSD,
@@ -112,7 +130,8 @@ func New(gdb *gorm.DB, q *queue.Queue, log *slog.Logger, broker *Broker, w *work
 	if err != nil {
 		return nil, err
 	}
-	return &Server{DB: gdb, Queue: q, Log: log, Broker: broker, Worker: w, tmpl: t}, nil
+	return &Server{DB: gdb, Queue: q, Log: log, Broker: broker, Worker: w, tmpl: t,
+		resolvePURL: resolvePURLRepo}, nil
 }
 
 func (s *Server) Handler() http.Handler {
@@ -157,6 +176,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("POST /scans/{id}/cancel", s.scanCancel)
 	mux.HandleFunc("GET /scans/{id}/log", s.scanLog)
 	mux.HandleFunc("GET /usage", s.usage)
+	s.registerSBOMRoutes(mux)
 	mux.HandleFunc("GET /skills", s.skillsList)
 	mux.HandleFunc("GET /skills/new", s.skillNew)
 	mux.HandleFunc("POST /skills", s.skillCreate)
@@ -752,11 +772,16 @@ func (s *Server) depScan(w http.ResponseWriter, r *http.Request) {
 }
 
 func resolveDepRepoURL(ctx context.Context, dep db.Dependency) string {
-	if dep.PURL == "" {
+	return resolvePURLRepo(ctx, dep.PURL)
+}
+
+// resolvePURLRepo asks packages.ecosyste.ms for the repository_url behind a
+// PURL. Returns empty string if the lookup fails or no repo is recorded.
+func resolvePURLRepo(ctx context.Context, purl string) string {
+	if purl == "" {
 		return ""
 	}
-	// packages.ecosyste.ms lookup by PURL
-	_, raw, err := worker.FetchPackagesByPURL(ctx, dep.PURL)
+	_, raw, err := worker.FetchPackagesByPURL(ctx, purl)
 	if err != nil {
 		return ""
 	}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -208,9 +208,10 @@ func (s *Server) index(w http.ResponseWriter, r *http.Request) {
 const (
 	perPage     = 20
 	defaultSort = "newest"
-	// sortRepository is the shared sort-by-repository option used by the
-	// findings, scans, and advisories indexes.
+	// sortRepository and sortSeverity are the shared sort options used by
+	// the findings, scans, advisories, and SBOM indexes.
 	sortRepository = "repository"
+	sortSeverity   = "severity"
 )
 
 type Page struct {
@@ -715,7 +716,7 @@ func (s *Server) findings(w http.ResponseWriter, r *http.Request) {
 
 	sort := r.URL.Query().Get("sort")
 	switch sort {
-	case "severity":
+	case sortSeverity:
 		q = q.Order(severityOrder).Order("id desc")
 	case sortRepository:
 		q = q.Joins("JOIN repositories r ON r.id = findings.repository_id").

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -1,6 +1,7 @@
 package web
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -33,6 +34,8 @@ func newTestServer(t *testing.T) (*Server, func()) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	s.resolvePURL = func(context.Context, string) string { return "" }
+	s.resolveSync = true
 	return s, func() { _ = sqldb.Close() }
 }
 

--- a/internal/web/templates/layout.html
+++ b/internal/web/templates/layout.html
@@ -43,6 +43,7 @@
           <li><a href="/orgs" data-nav="orgs"><i data-lucide="building"></i><span>Organizations</span></a></li>
           <li><a href="/findings" data-nav="findings"><i data-lucide="bug"></i><span>Findings</span></a></li>
           <li><a href="/packages" data-nav="packages"><i data-lucide="package"></i><span>Packages</span></a></li>
+          <li><a href="/sboms" data-nav="sboms"><i data-lucide="file-box"></i><span>SBOMs</span></a></li>
           <li><a href="/advisories" data-nav="advisories"><i data-lucide="shield-alert"></i><span>Advisories</span></a></li>
           <li><a href="/maintainers" data-nav="maintainers"><i data-lucide="users"></i><span>Maintainers</span></a></li>
           <li><a href="/scans" data-nav="scans"><i data-lucide="list-checks"></i><span>Scans</span></a></li>

--- a/internal/web/templates/sbom_show.html
+++ b/internal/web/templates/sbom_show.html
@@ -1,0 +1,117 @@
+{{template "head"}}
+
+{{template "crumbs" (crumbs "SBOMs" "/sboms" .SBOM.Name "")}}
+
+<div class="flex items-start justify-between gap-4 mb-6">
+  <div>
+    <h2 class="text-2xl font-semibold mt-1 flex items-center gap-2">
+      <i data-lucide="file-box"></i> {{.SBOM.Name}}
+    </h2>
+    <p class="text-sm text-muted-foreground">
+      {{.SBOM.Format}} {{.SBOM.SpecVersion}} &middot; {{.SBOM.Filename}} &middot; uploaded {{since .SBOM.CreatedAt}}
+    </p>
+  </div>
+  <div class="flex items-center gap-2">
+    <form hx-post="/sboms/{{.SBOM.ID}}/resolve">
+      <button class="btn-outline" type="submit"><i data-lucide="refresh-cw"></i> Re-resolve</button>
+    </form>
+    <form hx-post="/sboms/{{.SBOM.ID}}/delete" hx-confirm="Delete this SBOM and its package list?">
+      <button class="btn-outline" type="submit"><i data-lucide="trash"></i> Delete</button>
+    </form>
+  </div>
+</div>
+
+<div class="tabs w-full" id="sbom-tabs">
+  <nav role="tablist" aria-orientation="horizontal">
+    <button type="button" role="tab" id="st1" aria-controls="sp1" aria-selected="true">
+      Packages <span class="badge-secondary ml-1">{{.SBOM.PackageCount}}</span>
+    </button>
+    {{if .Findings}}
+    <button type="button" role="tab" id="st2" aria-controls="sp2" aria-selected="false">
+      Findings <span class="badge-destructive ml-1">{{len .Findings}}</span>
+    </button>
+    {{end}}
+  </nav>
+
+  <div role="tabpanel" id="sp1" aria-labelledby="st1">
+    <p class="text-sm text-muted-foreground mb-3">
+      {{.Resolved}} of {{.SBOM.PackageCount}} resolved &middot; {{.WithRepo}} linked to a repository.
+      {{if lt .Resolved .SBOM.PackageCount}}Resolution runs in the background; refresh to see progress.{{end}}
+    </p>
+    <table class="table table-fixed w-full">
+      <thead><tr>
+        <th>Package</th><th class="w-28">Ecosystem</th><th class="w-32">Version</th>
+        <th class="w-28">License</th><th>Repository</th>
+      </tr></thead>
+      <tbody>
+      {{range .SBOM.Packages}}
+        <tr>
+          <td class="whitespace-normal">
+            <div class="font-medium">{{.Name}}</div>
+            {{if .PURL}}<code class="text-xs text-muted-foreground break-all">{{.PURL}}</code>{{end}}
+          </td>
+          <td>{{if .Ecosystem}}<span class="badge-outline">{{.Ecosystem}}</span>{{end}}</td>
+          <td class="text-muted-foreground text-xs">{{.Version}}</td>
+          <td class="text-muted-foreground text-xs">{{.License}}</td>
+          <td class="whitespace-normal">
+            {{if .Repository}}
+              <a href="/repositories/{{.Repository.ID}}" class="hover:underline">{{.Repository.Name}}</a>
+            {{else if .ResolveError}}
+              <span class="text-xs text-muted-foreground">{{.ResolveError}}</span>
+            {{else}}
+              <span class="text-xs text-muted-foreground">resolving&hellip;</span>
+            {{end}}
+          </td>
+        </tr>
+      {{end}}
+      </tbody>
+    </table>
+  </div>
+
+  {{if .Findings}}
+  <div role="tabpanel" id="sp2" aria-labelledby="st2" hidden>
+    <div class="flex items-center justify-between mb-3">
+      <p class="text-sm text-muted-foreground">
+        Aggregated across {{.WithRepo}} resolved repositories. Rejected and duplicate findings are hidden.
+      </p>
+      <div class="dropdown-menu">
+        <button type="button" class="btn-outline" aria-haspopup="menu" aria-expanded="false">
+          <i data-lucide="filter"></i>
+          {{if .Severity}}{{.Severity}}{{else}}Severity{{end}}
+          <i data-lucide="chevron-down"></i>
+        </button>
+        <div data-popover aria-hidden="true" data-align="end">
+          <div role="menu">
+            <a role="menuitem" href="/sboms/{{.SBOM.ID}}">All severities</a>
+            {{range (list "Critical" "High" "Medium" "Low")}}
+              <a role="menuitem" href="/sboms/{{$.SBOM.ID}}?severity={{.}}"
+                 {{if eq . $.Severity}}aria-current="true"{{end}}>{{.}}</a>
+            {{end}}
+          </div>
+        </div>
+      </div>
+    </div>
+    <table class="table table-fixed w-full">
+      <thead><tr>
+        <th class="w-24">Severity</th><th>Title</th><th class="w-32">Repository</th>
+        <th class="w-24">Status</th><th class="w-20">CWE</th>
+      </tr></thead>
+      <tbody>
+      {{$repos := .Repos}}
+      {{range .Findings}}
+        {{$repo := index $repos .RepositoryID}}
+        <tr class="cursor-pointer" hx-get="/findings/{{.ID}}" hx-target="body" hx-push-url="true">
+          <td>{{template "severity-badge" .Severity}}</td>
+          <td class="min-w-0 whitespace-normal font-medium">{{.Title}}</td>
+          <td class="truncate">{{$repo.Name}}</td>
+          <td>{{template "finding-status" (fstatus .Status)}}</td>
+          <td class="text-muted-foreground">{{.CWE}}</td>
+        </tr>
+      {{end}}
+      </tbody>
+    </table>
+  </div>
+  {{end}}
+</div>
+
+{{template "foot"}}

--- a/internal/web/templates/sbom_show.html
+++ b/internal/web/templates/sbom_show.html
@@ -107,19 +107,36 @@
       <p class="text-sm text-muted-foreground">
         Aggregated across {{.WithRepo}} resolved repositories{{if .Scope}} ({{.Scope}} only){{end}}. Rejected and duplicate findings are hidden.
       </p>
-      <div class="dropdown-menu">
-        <button type="button" class="btn-outline" aria-haspopup="menu" aria-expanded="false">
-          <i data-lucide="filter"></i>
-          {{if .Severity}}{{.Severity}}{{else}}Severity{{end}}
-          <i data-lucide="chevron-down"></i>
-        </button>
-        <div data-popover aria-hidden="true" data-align="end">
-          <div role="menu">
-            <a role="menuitem" href="/sboms/{{.SBOM.ID}}?scope={{.Scope}}">All severities</a>
-            {{range (list "Critical" "High" "Medium" "Low")}}
-              <a role="menuitem" href="/sboms/{{$.SBOM.ID}}?scope={{$.Scope}}&severity={{.}}"
-                 {{if eq . $.Severity}}aria-current="true"{{end}}>{{.}}</a>
-            {{end}}
+      <div class="flex items-center gap-2">
+        <div class="dropdown-menu">
+          <button type="button" class="btn-outline" aria-haspopup="menu" aria-expanded="false">
+            <i data-lucide="filter"></i>
+            {{if .Severity}}{{.Severity}}{{else}}Severity{{end}}
+            <i data-lucide="chevron-down"></i>
+          </button>
+          <div data-popover aria-hidden="true" data-align="end">
+            <div role="menu">
+              <a role="menuitem" href="/sboms/{{.SBOM.ID}}?scope={{.Scope}}&sort={{.Sort}}">All severities</a>
+              {{range (list "Critical" "High" "Medium" "Low")}}
+                <a role="menuitem" href="/sboms/{{$.SBOM.ID}}?scope={{$.Scope}}&sort={{$.Sort}}&severity={{.}}"
+                   {{if eq . $.Severity}}aria-current="true"{{end}}>{{.}}</a>
+              {{end}}
+            </div>
+          </div>
+        </div>
+        <div class="dropdown-menu">
+          <button type="button" class="btn-outline" aria-haspopup="menu" aria-expanded="false">
+            <i data-lucide="arrow-down-wide-narrow"></i>
+            {{if eq .Sort "severity"}}Severity{{else if eq .Sort "repository"}}Repository{{else}}Newest{{end}}
+            <i data-lucide="chevron-down"></i>
+          </button>
+          <div data-popover aria-hidden="true" data-align="end">
+            <div role="menu">
+              {{range (list "newest" "severity" "repository")}}
+                <a role="menuitem" href="/sboms/{{$.SBOM.ID}}?scope={{$.Scope}}&severity={{$.Severity}}&sort={{.}}"
+                   {{if eq . $.Sort}}aria-current="true"{{end}}>{{.}}</a>
+              {{end}}
+            </div>
           </div>
         </div>
       </div>

--- a/internal/web/templates/sbom_show.html
+++ b/internal/web/templates/sbom_show.html
@@ -31,6 +31,11 @@
       Findings <span class="badge-destructive ml-1">{{len .Findings}}</span>
     </button>
     {{end}}
+    {{if .Advisories}}
+    <button type="button" role="tab" id="st3" aria-controls="sp3" aria-selected="false">
+      Advisories <span class="badge-secondary ml-1">{{len .Advisories}}</span>
+    </button>
+    {{end}}
   </nav>
 
   <div role="tabpanel" id="sp1" aria-labelledby="st1">
@@ -106,6 +111,35 @@
           <td class="truncate">{{$repo.Name}}</td>
           <td>{{template "finding-status" (fstatus .Status)}}</td>
           <td class="text-muted-foreground">{{.CWE}}</td>
+        </tr>
+      {{end}}
+      </tbody>
+    </table>
+  </div>
+  {{end}}
+
+  {{if .Advisories}}
+  <div role="tabpanel" id="sp3" aria-labelledby="st3" hidden>
+    <p class="text-sm text-muted-foreground mb-3">
+      Published CVEs for the {{.WithRepo}} resolved repositories. Withdrawn advisories are hidden.
+    </p>
+    <table class="table table-fixed w-full">
+      <thead><tr>
+        <th class="w-24">Severity</th><th class="w-16">CVSS</th><th>Title</th>
+        <th class="w-32">Repository</th><th class="w-32">Published</th><th class="w-12"></th>
+      </tr></thead>
+      <tbody>
+      {{$repos := .Repos}}
+      {{range .Advisories}}
+        {{$repo := index $repos .RepositoryID}}
+        <tr>
+          <td>{{template "severity-badge" .Severity}}</td>
+          <td class="text-muted-foreground">{{if .CVSSScore}}{{printf "%.1f" .CVSSScore}}{{end}}</td>
+          <td class="min-w-0 whitespace-normal font-medium">{{.Title}}</td>
+          <td class="truncate"><a href="/repositories/{{$repo.ID}}" class="hover:underline">{{$repo.Name}}</a></td>
+          <td class="text-muted-foreground">{{if .PublishedAt}}{{.PublishedAt.Format "2006-01-02"}}{{end}}</td>
+          <td>{{if .URL}}<a href="{{.URL}}" target="_blank" rel="noopener" class="btn-sm-ghost"
+              data-tooltip="View advisory"><i data-lucide="external-link"></i></a>{{end}}</td>
         </tr>
       {{end}}
       </tbody>

--- a/internal/web/templates/sbom_show.html
+++ b/internal/web/templates/sbom_show.html
@@ -39,23 +39,51 @@
   </nav>
 
   <div role="tabpanel" id="sp1" aria-labelledby="st1">
-    <p class="text-sm text-muted-foreground mb-3">
-      {{.Resolved}} of {{.SBOM.PackageCount}} resolved &middot; {{.WithRepo}} linked to a repository.
-      {{if lt .Resolved .SBOM.PackageCount}}Resolution runs in the background; refresh to see progress.{{end}}
-    </p>
+    <div class="flex items-center justify-between mb-3">
+      <p class="text-sm text-muted-foreground">
+        {{.Resolved}} of {{len .Packages}} resolved &middot; {{.WithRepo}} linked to a repository.
+        {{if lt .Resolved (len .Packages)}}Resolution runs in the background; refresh to see progress.{{end}}
+      </p>
+      {{if .HasScope}}
+      <div class="dropdown-menu">
+        <button type="button" class="btn-outline" aria-haspopup="menu" aria-expanded="false">
+          <i data-lucide="filter"></i>
+          {{if eq .Scope "direct"}}Direct{{else if eq .Scope "transitive"}}Transitive{{else}}All deps{{end}}
+          <i data-lucide="chevron-down"></i>
+        </button>
+        <div data-popover aria-hidden="true" data-align="end">
+          <div role="menu">
+            <a role="menuitem" href="/sboms/{{.SBOM.ID}}">All deps</a>
+            <a role="menuitem" href="/sboms/{{.SBOM.ID}}?scope=direct"
+               {{if eq .Scope "direct"}}aria-current="true"{{end}}>Direct</a>
+            <a role="menuitem" href="/sboms/{{.SBOM.ID}}?scope=transitive"
+               {{if eq .Scope "transitive"}}aria-current="true"{{end}}>Transitive</a>
+          </div>
+        </div>
+      </div>
+      {{end}}
+    </div>
     <table class="table table-fixed w-full">
       <thead><tr>
-        <th>Package</th><th class="w-28">Ecosystem</th><th class="w-32">Version</th>
-        <th class="w-28">License</th><th>Repository</th>
+        <th>Package</th><th class="w-28">Ecosystem</th>
+        {{if .HasScope}}<th class="w-24">Scope</th>{{end}}
+        <th class="w-32">Version</th><th class="w-28">License</th><th>Repository</th>
       </tr></thead>
       <tbody>
-      {{range .SBOM.Packages}}
+      {{$hasScope := .HasScope}}
+      {{range .Packages}}
         <tr>
           <td class="whitespace-normal">
             <div class="font-medium">{{.Name}}</div>
             {{if .PURL}}<code class="text-xs text-muted-foreground break-all">{{.PURL}}</code>{{end}}
           </td>
           <td>{{if .Ecosystem}}<span class="badge-outline">{{.Ecosystem}}</span>{{end}}</td>
+          {{if $hasScope}}
+          <td>
+            {{if eq .Scope "direct"}}<span class="badge-primary">direct</span>
+            {{else if eq .Scope "transitive"}}<span class="badge-outline">transitive</span>{{end}}
+          </td>
+          {{end}}
           <td class="text-muted-foreground text-xs">{{.Version}}</td>
           <td class="text-muted-foreground text-xs">{{.License}}</td>
           <td class="whitespace-normal">
@@ -77,7 +105,7 @@
   <div role="tabpanel" id="sp2" aria-labelledby="st2" hidden>
     <div class="flex items-center justify-between mb-3">
       <p class="text-sm text-muted-foreground">
-        Aggregated across {{.WithRepo}} resolved repositories. Rejected and duplicate findings are hidden.
+        Aggregated across {{.WithRepo}} resolved repositories{{if .Scope}} ({{.Scope}} only){{end}}. Rejected and duplicate findings are hidden.
       </p>
       <div class="dropdown-menu">
         <button type="button" class="btn-outline" aria-haspopup="menu" aria-expanded="false">
@@ -87,9 +115,9 @@
         </button>
         <div data-popover aria-hidden="true" data-align="end">
           <div role="menu">
-            <a role="menuitem" href="/sboms/{{.SBOM.ID}}">All severities</a>
+            <a role="menuitem" href="/sboms/{{.SBOM.ID}}?scope={{.Scope}}">All severities</a>
             {{range (list "Critical" "High" "Medium" "Low")}}
-              <a role="menuitem" href="/sboms/{{$.SBOM.ID}}?severity={{.}}"
+              <a role="menuitem" href="/sboms/{{$.SBOM.ID}}?scope={{$.Scope}}&severity={{.}}"
                  {{if eq . $.Severity}}aria-current="true"{{end}}>{{.}}</a>
             {{end}}
           </div>

--- a/internal/web/templates/sboms.html
+++ b/internal/web/templates/sboms.html
@@ -1,0 +1,50 @@
+{{template "head"}}
+
+<div class="flex items-center justify-between gap-4 mb-6">
+  <h2 class="text-2xl font-semibold flex items-center gap-2">
+    <i data-lucide="file-box"></i> SBOMs
+  </h2>
+  <button type="button" class="btn" onclick="document.getElementById('sbom-upload').showModal()">
+    <i data-lucide="upload"></i> Upload SBOM
+  </button>
+</div>
+
+<dialog id="sbom-upload" class="dialog">
+  <article>
+    <header>
+      <h2>Upload SBOM</h2>
+      <p class="text-sm text-muted-foreground">CycloneDX or SPDX, JSON only.</p>
+    </header>
+    <form method="post" action="/sboms" enctype="multipart/form-data"
+          hx-post="/sboms" hx-encoding="multipart/form-data" class="form grid gap-4">
+      <input class="input" type="file" name="file" accept=".json,application/json" required>
+      <footer class="flex justify-end gap-2">
+        <button type="button" class="btn-outline" onclick="this.closest('dialog').close()">Cancel</button>
+        <button type="submit" class="btn">Upload</button>
+      </footer>
+    </form>
+  </article>
+</dialog>
+
+{{if .SBOMs}}
+  <table class="table w-full">
+    <thead><tr>
+      <th>Name</th><th class="w-28">Format</th><th class="w-24 text-right">Packages</th>
+      <th class="w-40">Uploaded</th>
+    </tr></thead>
+    <tbody>
+    {{range .SBOMs}}
+      <tr class="cursor-pointer" hx-get="/sboms/{{.ID}}" hx-target="body" hx-push-url="true">
+        <td class="font-medium">{{.Name}}<div class="text-xs text-muted-foreground">{{.Filename}}</div></td>
+        <td><span class="badge-outline">{{.Format}} {{.SpecVersion}}</span></td>
+        <td class="text-right text-muted-foreground">{{.PackageCount}}</td>
+        <td class="text-muted-foreground">{{since .CreatedAt}}</td>
+      </tr>
+    {{end}}
+    </tbody>
+  </table>
+{{else}}
+  {{template "empty" (dict "Icon" "file-box" "Title" "No SBOMs yet" "Body" "Upload a CycloneDX or SPDX JSON document to scan every package it lists.")}}
+{{end}}
+
+{{template "foot"}}


### PR DESCRIPTION
First pass at #32.

Upload a CycloneDX or SPDX JSON document and scrutineer parses it with the new `github.com/git-pkgs/sbom` module (zero-dep Go port of `andrew/sbom`), stores one `SBOMUpload` row plus an `SBOMPackage` per component, then resolves each PURL to a source repo via packages.ecosyste.ms in the background and enqueues the triage skill on any repo not already known. The show page lists packages with their resolution state and rolls up findings across every linked repo (severity filter, rejected/duplicate hidden, status badge shown).

New routes: `GET/POST /sboms`, `GET /sboms/{id}`, `POST /sboms/{id}/resolve`, `POST /sboms/{id}/delete`. Sidebar entry added under Packages.

Supporting changes: `resolvePURL` is now a field on `*Server` so tests stub the ecosyste.ms lookup, `resolveDepRepoURL` delegates to a shared helper, and the `since` template func now accepts both `time.Time` and `*time.Time`.

Not in this PR: re-upload/refresh semantics (a second upload currently creates a new row rather than replacing), and the findings sort dropdown. Both noted on #32.