### PR TITLE
worker: scan_timeout (default 1h) and max_turns config

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,9 @@ When the docker runner is active, scrutineer starts an authenticated egress prox
 | `--no-docker` | false | Disable containerised runner |
 | `--runner-image` | `ghcr.io/alpha-omega-security/scrutineer-runner:latest` | Docker image for per-scan containers |
 | `-concurrency` | `4` | Number of scans to run in parallel |
+| `-clone` | `shallow` | Clone depth: `shallow` (`--depth 1`) or `full` |
+| `-scan-timeout` | `1h` | Wall-clock limit per scan; exceeded scans fail |
+| `-max-turns` | `0` | Passed as `--max-turns` to claude-code (0 = unlimited) |
 
 ## Config file
 

--- a/cmd/scrutineer/main.go
+++ b/cmd/scrutineer/main.go
@@ -58,6 +58,8 @@ type flags struct {
 	skillsRepo  string
 	concurrency int
 	cloneMode   string
+	scanTimeout time.Duration
+	maxTurns    int
 	skillLocal  skillDirs
 
 	// set records which flags were passed on the command line so merge
@@ -76,6 +78,8 @@ func parseFlags() *flags {
 	flag.StringVar(&f.skillsRepo, "skills-repo", "", "clone skills from this git https URL on startup")
 	flag.IntVar(&f.concurrency, "concurrency", queue.DefaultWorkerConcurrency, "number of scans to run in parallel")
 	flag.StringVar(&f.cloneMode, "clone", "shallow", "clone depth: shallow (--depth 1) or full")
+	flag.DurationVar(&f.scanTimeout, "scan-timeout", worker.DefaultScanTimeout, "wall-clock limit per scan")
+	flag.IntVar(&f.maxTurns, "max-turns", 0, "claude --max-turns limit (0 = unlimited)")
 	flag.Var(&f.skillLocal, "skills", "directory to load SKILL.md files from (repeatable)")
 	flag.Parse()
 
@@ -114,6 +118,12 @@ func (f *flags) merge(cfg *config.Config) {
 	}
 	if cfg.Clone != "" && !f.set["clone"] {
 		f.cloneMode = cfg.Clone
+	}
+	if d, _ := config.ParseScanTimeout(cfg.ScanTimeout); d > 0 && !f.set["scan-timeout"] {
+		f.scanTimeout = d
+	}
+	if cfg.MaxTurns > 0 && !f.set["max-turns"] {
+		f.maxTurns = cfg.MaxTurns
 	}
 
 	if len(cfg.Models) > 0 {
@@ -203,21 +213,23 @@ func run(log *slog.Logger) error {
 			Effort:    f.effort,
 			ProxyURL:  worker.ProxyURL(token, port),
 			FullClone: f.fullClone(),
+			MaxTurns:  f.maxTurns,
 		}
 		// Skills inside the container reach the host via host.docker.internal,
 		// which the egress proxy rewrites to 127.0.0.1 when dialing.
 		apiBase = "http://" + net.JoinHostPort(worker.HostGatewayAlias, addrPort(f.addr)) + "/api"
 	} else {
 		log.Info("docker not available or disabled, using local runner (no isolation)")
-		runner = worker.LocalClaude{Effort: f.effort, FullClone: f.fullClone()}
+		runner = worker.LocalClaude{Effort: f.effort, FullClone: f.fullClone(), MaxTurns: f.maxTurns}
 	}
 
 	w := &worker.Worker{
-		DB:      gdb,
-		Log:     log,
-		DataDir: filepath.Join(f.dataDir, "work"),
-		APIBase: apiBase,
-		Runner:  runner,
+		DB:          gdb,
+		Log:         log,
+		DataDir:     filepath.Join(f.dataDir, "work"),
+		APIBase:     apiBase,
+		Runner:      runner,
+		ScanTimeout: f.scanTimeout,
 		OnEvent: func(scanID, repoID uint, name, data string) {
 			broker.Publish(web.Event{Name: name, Data: data, ScanID: scanID, RepoID: repoID})
 		},

--- a/cmd/scrutineer/main_test.go
+++ b/cmd/scrutineer/main_test.go
@@ -7,9 +7,9 @@ import (
 	"scrutineer/internal/config"
 )
 
-func TestFlagsMerge(t *testing.T) {
+func fullConfig() *config.Config {
 	yes := true
-	cfg := &config.Config{
+	return &config.Config{
 		Addr:        "0.0.0.0:9090",
 		Data:        "/var/lib/scrutineer",
 		Effort:      "medium",
@@ -22,68 +22,70 @@ func TestFlagsMerge(t *testing.T) {
 		ScanTimeout: "30m",
 		MaxTurns:    200,
 	}
+}
 
-	t.Run("config fills unset flags", func(t *testing.T) {
-		f := &flags{addr: "127.0.0.1:8080", cloneMode: "shallow", set: map[string]bool{}}
-		f.merge(cfg)
-		if f.addr != cfg.Addr {
-			t.Errorf("addr = %q, want %q", f.addr, cfg.Addr)
-		}
-		if f.dataDir != cfg.Data {
-			t.Errorf("dataDir = %q", f.dataDir)
-		}
-		if !f.noDocker {
-			t.Errorf("noDocker not applied")
-		}
-		if f.concurrency != 8 {
-			t.Errorf("concurrency = %d", f.concurrency)
-		}
-		if !f.fullClone() {
-			t.Errorf("cloneMode = %q, want full", f.cloneMode)
-		}
-		if len(f.skillLocal) != 1 || f.skillLocal[0] != "/etc/skills" {
-			t.Errorf("skillLocal = %v", f.skillLocal)
-		}
-		if f.scanTimeout != 30*time.Minute {
-			t.Errorf("scanTimeout = %v", f.scanTimeout)
-		}
-		if f.maxTurns != 200 {
-			t.Errorf("maxTurns = %d", f.maxTurns)
-		}
-	})
+func TestFlagsMerge_configFillsUnset(t *testing.T) {
+	cfg := fullConfig()
+	f := &flags{addr: "127.0.0.1:8080", cloneMode: "shallow", set: map[string]bool{}}
+	f.merge(cfg)
+	if f.addr != cfg.Addr {
+		t.Errorf("addr = %q, want %q", f.addr, cfg.Addr)
+	}
+	if f.dataDir != cfg.Data {
+		t.Errorf("dataDir = %q", f.dataDir)
+	}
+	if !f.noDocker {
+		t.Errorf("noDocker not applied")
+	}
+	if f.concurrency != 8 {
+		t.Errorf("concurrency = %d", f.concurrency)
+	}
+	if !f.fullClone() {
+		t.Errorf("cloneMode = %q, want full", f.cloneMode)
+	}
+	if len(f.skillLocal) != 1 || f.skillLocal[0] != "/etc/skills" {
+		t.Errorf("skillLocal = %v", f.skillLocal)
+	}
+	if f.scanTimeout != 30*time.Minute {
+		t.Errorf("scanTimeout = %v", f.scanTimeout)
+	}
+	if f.maxTurns != 200 {
+		t.Errorf("maxTurns = %d", f.maxTurns)
+	}
+}
 
-	t.Run("explicit CLI flag wins over config", func(t *testing.T) {
-		f := &flags{
-			addr: "127.0.0.1:8080", cloneMode: "shallow", concurrency: 2,
-			set: map[string]bool{"addr": true, "clone": true, "concurrency": true},
-		}
-		f.merge(cfg)
-		if f.addr != "127.0.0.1:8080" {
-			t.Errorf("addr overridden despite explicit flag: %q", f.addr)
-		}
-		if f.cloneMode != "shallow" {
-			t.Errorf("cloneMode overridden despite explicit flag: %q", f.cloneMode)
-		}
-		if f.concurrency != 2 {
-			t.Errorf("concurrency overridden despite explicit flag: %d", f.concurrency)
-		}
-		// effort wasn't in set, so config still applies
-		if f.effort != cfg.Effort {
-			t.Errorf("effort = %q, want %q", f.effort, cfg.Effort)
-		}
-	})
+func TestFlagsMerge_cliFlagWins(t *testing.T) {
+	cfg := fullConfig()
+	f := &flags{
+		addr: "127.0.0.1:8080", cloneMode: "shallow", concurrency: 2,
+		set: map[string]bool{"addr": true, "clone": true, "concurrency": true},
+	}
+	f.merge(cfg)
+	if f.addr != "127.0.0.1:8080" {
+		t.Errorf("addr overridden despite explicit flag: %q", f.addr)
+	}
+	if f.cloneMode != "shallow" {
+		t.Errorf("cloneMode overridden despite explicit flag: %q", f.cloneMode)
+	}
+	if f.concurrency != 2 {
+		t.Errorf("concurrency overridden despite explicit flag: %d", f.concurrency)
+	}
+	// effort wasn't in set, so config still applies
+	if f.effort != cfg.Effort {
+		t.Errorf("effort = %q, want %q", f.effort, cfg.Effort)
+	}
+}
 
-	t.Run("zero-value config fields leave defaults alone", func(t *testing.T) {
-		f := &flags{addr: "127.0.0.1:8080", concurrency: 4, scanTimeout: time.Hour, set: map[string]bool{}}
-		f.merge(&config.Config{})
-		if f.addr != "127.0.0.1:8080" {
-			t.Errorf("empty config clobbered addr: %q", f.addr)
-		}
-		if f.concurrency != 4 {
-			t.Errorf("zero concurrency clobbered default: %d", f.concurrency)
-		}
-		if f.scanTimeout != time.Hour {
-			t.Errorf("empty scan_timeout clobbered default: %v", f.scanTimeout)
-		}
-	})
+func TestFlagsMerge_zeroConfigLeavesDefaults(t *testing.T) {
+	f := &flags{addr: "127.0.0.1:8080", concurrency: 4, scanTimeout: time.Hour, set: map[string]bool{}}
+	f.merge(&config.Config{})
+	if f.addr != "127.0.0.1:8080" {
+		t.Errorf("empty config clobbered addr: %q", f.addr)
+	}
+	if f.concurrency != 4 {
+		t.Errorf("zero concurrency clobbered default: %d", f.concurrency)
+	}
+	if f.scanTimeout != time.Hour {
+		t.Errorf("empty scan_timeout clobbered default: %v", f.scanTimeout)
+	}
 }

--- a/cmd/scrutineer/main_test.go
+++ b/cmd/scrutineer/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"testing"
+	"time"
 
 	"scrutineer/internal/config"
 )
@@ -18,6 +19,8 @@ func TestFlagsMerge(t *testing.T) {
 		Skills:      []string{"/etc/skills"},
 		Concurrency: 8,
 		Clone:       "full",
+		ScanTimeout: "30m",
+		MaxTurns:    200,
 	}
 
 	t.Run("config fills unset flags", func(t *testing.T) {
@@ -40,6 +43,12 @@ func TestFlagsMerge(t *testing.T) {
 		}
 		if len(f.skillLocal) != 1 || f.skillLocal[0] != "/etc/skills" {
 			t.Errorf("skillLocal = %v", f.skillLocal)
+		}
+		if f.scanTimeout != 30*time.Minute {
+			t.Errorf("scanTimeout = %v", f.scanTimeout)
+		}
+		if f.maxTurns != 200 {
+			t.Errorf("maxTurns = %d", f.maxTurns)
 		}
 	})
 
@@ -65,13 +74,16 @@ func TestFlagsMerge(t *testing.T) {
 	})
 
 	t.Run("zero-value config fields leave defaults alone", func(t *testing.T) {
-		f := &flags{addr: "127.0.0.1:8080", concurrency: 4, set: map[string]bool{}}
+		f := &flags{addr: "127.0.0.1:8080", concurrency: 4, scanTimeout: time.Hour, set: map[string]bool{}}
 		f.merge(&config.Config{})
 		if f.addr != "127.0.0.1:8080" {
 			t.Errorf("empty config clobbered addr: %q", f.addr)
 		}
 		if f.concurrency != 4 {
 			t.Errorf("zero concurrency clobbered default: %d", f.concurrency)
+		}
+		if f.scanTimeout != time.Hour {
+			t.Errorf("empty scan_timeout clobbered default: %v", f.scanTimeout)
 		}
 	})
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
+	"time"
 
 	"gopkg.in/yaml.v3"
 )
@@ -39,6 +40,28 @@ type Config struct {
 	// Clone selects the clone-depth strategy: "shallow" (default, --depth 1)
 	// or "full" (no depth limit). Empty means use the built-in default.
 	Clone string `yaml:"clone"`
+	// ScanTimeout is the wall-clock limit for a single scan, as a Go
+	// duration string ("30m", "1h"). Empty leaves the built-in default.
+	ScanTimeout string `yaml:"scan_timeout"`
+	// MaxTurns is passed as --max-turns to claude-code. 0 means no limit.
+	MaxTurns int `yaml:"max_turns"`
+}
+
+// ParseScanTimeout validates and parses a scan_timeout string. Empty
+// returns 0 (caller keeps its default); anything else must be a positive
+// time.Duration.
+func ParseScanTimeout(s string) (time.Duration, error) {
+	if s == "" {
+		return 0, nil
+	}
+	d, err := time.ParseDuration(s)
+	if err != nil {
+		return 0, fmt.Errorf("scan_timeout: %w", err)
+	}
+	if d <= 0 {
+		return 0, fmt.Errorf("scan_timeout: must be positive, got %q", s)
+	}
+	return d, nil
 }
 
 // ValidateClone returns an error when s is neither empty, "shallow", nor
@@ -80,6 +103,9 @@ func Load(path string) (*Config, error) {
 		return nil, fmt.Errorf("parse config %s: %w", path, err)
 	}
 	if err := ValidateClone(c.Clone); err != nil {
+		return nil, fmt.Errorf("parse config %s: %w", path, err)
+	}
+	if _, err := ParseScanTimeout(c.ScanTimeout); err != nil {
 		return nil, fmt.Errorf("parse config %s: %w", path, err)
 	}
 	return &c, nil

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 func write(t *testing.T, content string) string {
@@ -62,6 +63,8 @@ egress_allow:
   - "*.mycorp.net"
 concurrency: 8
 clone: full
+scan_timeout: 30m
+max_turns: 200
 `)
 	c, err := Load(path)
 	if err != nil {
@@ -87,6 +90,41 @@ clone: full
 	}
 	if c.Clone != "full" {
 		t.Errorf("clone: %q, want full", c.Clone)
+	}
+	if c.ScanTimeout != "30m" || c.MaxTurns != 200 {
+		t.Errorf("scan_timeout=%q max_turns=%d", c.ScanTimeout, c.MaxTurns)
+	}
+}
+
+func TestParseScanTimeout(t *testing.T) {
+	tests := []struct {
+		in      string
+		want    time.Duration
+		wantErr bool
+	}{
+		{"", 0, false},
+		{"1h", time.Hour, false},
+		{"30m", 30 * time.Minute, false},
+		{"1h30m", 90 * time.Minute, false},
+		{"0", 0, true},
+		{"-5m", 0, true},
+		{"banana", 0, true},
+	}
+	for _, tt := range tests {
+		got, err := ParseScanTimeout(tt.in)
+		if (err != nil) != tt.wantErr {
+			t.Errorf("ParseScanTimeout(%q) err = %v", tt.in, err)
+		}
+		if got != tt.want {
+			t.Errorf("ParseScanTimeout(%q) = %v, want %v", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestLoad_rejectsInvalidScanTimeout(t *testing.T) {
+	path := write(t, "scan_timeout: nope\n")
+	if _, err := Load(path); err == nil {
+		t.Error("expected error for invalid scan_timeout value")
 	}
 }
 

--- a/internal/worker/claude.go
+++ b/internal/worker/claude.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"syscall"
 
 	"scrutineer/internal/db"
@@ -45,6 +46,7 @@ type SkillResult struct {
 type LocalClaude struct {
 	Effort    string
 	FullClone bool
+	MaxTurns  int
 }
 
 // RunSkill runs claude against a staged skill in a local workspace. The
@@ -77,6 +79,9 @@ func (l LocalClaude) RunSkill(ctx context.Context, sj SkillJob, emit func(Event)
 	}
 	if l.Effort != "" {
 		args = append(args, "--effort", l.Effort)
+	}
+	if l.MaxTurns > 0 {
+		args = append(args, "--max-turns", strconv.Itoa(l.MaxTurns))
 	}
 	args = append(args, prompt)
 

--- a/internal/worker/docker.go
+++ b/internal/worker/docker.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"syscall"
 )
 
@@ -23,6 +24,7 @@ type DockerRunner struct {
 	Effort    string
 	ProxyURL  string // http://user:token@host.docker.internal:port; "" disables egress
 	FullClone bool
+	MaxTurns  int
 }
 
 func (d DockerRunner) image() string {
@@ -61,6 +63,9 @@ func (d DockerRunner) RunSkill(ctx context.Context, sj SkillJob, emit func(Event
 	}
 	if d.Effort != "" {
 		claudeArgs = append(claudeArgs, "--effort", d.Effort)
+	}
+	if d.MaxTurns > 0 {
+		claudeArgs = append(claudeArgs, "--max-turns", strconv.Itoa(d.MaxTurns))
 	}
 	claudeArgs = append(claudeArgs, buildSkillPrompt(sj.Name, sj.OutputFile))
 

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -26,13 +26,19 @@ const (
 	PrioMetadata = 10
 )
 
+// DefaultScanTimeout is the wall-clock limit applied to each scan when no
+// override is configured. Model-backed audits on large repos rarely need
+// more than this; a scan that does is almost always wedged.
+const DefaultScanTimeout = time.Hour
+
 type Worker struct {
-	DB      *gorm.DB
-	Log     *slog.Logger
-	DataDir string // workspace root for clones
-	APIBase string // base URL for the scrutineer skill API (http://host:port/api)
-	Runner  SkillRunner
-	OnEvent func(scanID, repoID uint, name, data string) // optional SSE bridge
+	DB          *gorm.DB
+	Log         *slog.Logger
+	DataDir     string // workspace root for clones
+	APIBase     string // base URL for the scrutineer skill API (http://host:port/api)
+	Runner      SkillRunner
+	OnEvent     func(scanID, repoID uint, name, data string) // optional SSE bridge
+	ScanTimeout time.Duration
 
 	mu      sync.Mutex
 	running map[uint]context.CancelFunc
@@ -85,7 +91,11 @@ func (w *Worker) wrap(h handler) func(context.Context, []byte) error {
 			return nil
 		}
 
-		ctx, cancel := context.WithCancel(ctx)
+		timeout := w.ScanTimeout
+		if timeout <= 0 {
+			timeout = DefaultScanTimeout
+		}
+		ctx, cancel := context.WithTimeout(ctx, timeout)
 		defer cancel()
 		w.mu.Lock()
 		if w.running == nil {
@@ -128,6 +138,10 @@ func (w *Worker) wrap(h handler) func(context.Context, []byte) error {
 		fin := time.Now()
 		scan.FinishedAt = &fin
 		switch {
+		case errors.Is(ctx.Err(), context.DeadlineExceeded):
+			scan.Status = db.ScanFailed
+			scan.Error = fmt.Sprintf("scan timed out after %s", timeout)
+			emit(Event{Kind: KindError, Text: scan.Error})
 		case errors.Is(ctx.Err(), context.Canceled):
 			scan.Status = db.ScanCancelled
 			scan.Error = "cancelled by user"

--- a/scrutineer.sample.yaml
+++ b/scrutineer.sample.yaml
@@ -45,6 +45,15 @@
 # lower if you want model calls serialised.
 # concurrency: 4
 
+# Wall-clock limit for one scan. Scans that exceed this are killed and
+# marked failed. Go duration syntax ("30m", "1h30m", "2h").
+# scan_timeout: 1h
+
+# Pass --max-turns to claude-code so a scan that loops gets cut off.
+# 0 (default) means no limit. The longest observed completed deep-dive
+# is ~140 turns, so 200 is a safe ceiling if you want one.
+# max_turns: 0
+
 # The model picker in the UI. Replacing this list replaces the built-in
 # set (Sonnet, Opus). Leave it out to keep the built-in list.
 # models:


### PR DESCRIPTION
Three `maintainers` scans on my instance had been running for 4-22 hours with zero turns recorded, i.e. the claude process was wedged before producing anything rather than looping. This adds two knobs:

`scan_timeout` (default `1h`, `-scan-timeout` flag, `scan_timeout:` in YAML) wraps each scan's context with `WithTimeout` instead of `WithCancel`. A scan that exceeds it is killed and marked failed with "scan timed out after 1h0m0s". The cancel button still works since `WithTimeout` returns a `CancelFunc` too. Longest observed successful scan in my DB is 43 min (security-deep-dive, 115 turns), so 1h has headroom.

`max_turns` (default `0` = unlimited, `-max-turns` flag, `max_turns:` in YAML) is passed as `--max-turns N` to claude-code on both runners. The stream parser already handles `error_max_turns` so a scan that hits the cap finishes as failed with "hit max turns". Max observed completed run is 142 turns, so 200 is the suggested ceiling in the sample yaml.

Also adds the `-clone` row that #85 forgot in the README flags table, and splits `TestFlagsMerge` into three top-level tests to stay under gocognit after adding the new assertions.