### PR TITLE
web: float running/queued scans to top of /scans

### DIFF
--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -675,6 +675,11 @@ var severityOrder = `CASE severity
 	WHEN 'Critical' THEN 0 WHEN 'High' THEN 1
 	WHEN 'Medium' THEN 2 WHEN 'Low' THEN 3 ELSE 4 END`
 
+// scanStatusOrder floats active work to the top of the scans index so the
+// operator sees what is in flight before the backlog of completed runs.
+var scanStatusOrder = `CASE scans.status
+	WHEN 'running' THEN 0 WHEN 'queued' THEN 1 ELSE 2 END`
+
 func (s *Server) findings(w http.ResponseWriter, r *http.Request) {
 	q := s.DB.Model(&db.Finding{})
 	sev := r.URL.Query().Get("severity")
@@ -1089,7 +1094,7 @@ func (s *Server) jobs(w http.ResponseWriter, r *http.Request) {
 		q = q.Joins("Repository").Order("`Repository`.name, scans.id desc")
 	default:
 		sort = defaultSort
-		q = q.Order("scans.id desc")
+		q = q.Order(scanStatusOrder).Order("scans.id desc")
 	}
 
 	var total int64

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -1493,6 +1493,39 @@ func TestRetry_preservesSubPath(t *testing.T) {
 	}
 }
 
+func TestJobs_defaultSortFloatsActiveFirst(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	repo := db.Repository{URL: "https://example.com/order", Name: "order"}
+	s.DB.Create(&repo)
+	// Created in id order: done, running, queued. Default sort should
+	// surface running, then queued, then done regardless of id.
+	mk := func(st db.ScanStatus) uint {
+		sc := db.Scan{RepositoryID: repo.ID, Kind: "skill", SkillName: "x", Status: st}
+		s.DB.Create(&sc)
+		return sc.ID
+	}
+	doneID := mk(db.ScanDone)
+	runID := mk(db.ScanRunning)
+	queueID := mk(db.ScanQueued)
+
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq("GET", "/scans"))
+	if w.Code != 200 {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+	body := w.Body.String()
+	pos := func(id uint) int { return strings.Index(body, fmt.Sprintf(`hx-get="/scans/%d"`, id)) }
+	r, q, d := pos(runID), pos(queueID), pos(doneID)
+	if r < 0 || q < 0 || d < 0 {
+		t.Fatalf("scan rows not rendered: running=%d queued=%d done=%d", r, q, d)
+	}
+	if r >= q || q >= d {
+		t.Errorf("expected running < queued < done, got running=%d queued=%d done=%d", r, q, d)
+	}
+}
+
 func TestScanCancel_queued(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()


### PR DESCRIPTION
The default sort on `/scans` was newest-first, which buries in-flight work under completed runs once you have a few thousand rows. This prepends a `CASE status` ordering (running, then queued, then everything else) to the default sort so active work is always visible at the top; within each bucket it's still newest-first. The explicit `sort=skill|status|repository` options are unchanged.

`scanStatusOrder` mirrors the existing `severityOrder` pattern. Test asserts row order via the `hx-get="/scans/{id}"` attributes since skill names also appear in the filter dropdown.