### PR TITLE
CNA model + cve.org partner-list sync

### DIFF
--- a/cmd/scrutineer/main.go
+++ b/cmd/scrutineer/main.go
@@ -205,6 +205,14 @@ func run(log *slog.Logger) error {
 		return err
 	}
 
+	go func() {
+		if n, err := worker.SyncCNAs(context.Background(), gdb, ""); err != nil {
+			log.Warn("CNA sync failed", "err", err)
+		} else {
+			log.Info("synced CNA list", "count", n)
+		}
+	}()
+
 	broker := web.NewBroker()
 
 	var egressExtra []string

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -560,7 +560,7 @@ type CNA struct {
 	ID uint `gorm:"primarykey"`
 
 	ShortName    string `gorm:"uniqueIndex;not null"`
-	CNAID        string `gorm:"uniqueIndex"`
+	CNAID        string `gorm:"index"`
 	Organization string
 	Scope        string `gorm:"type:text"`
 	Email        string

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -500,7 +500,7 @@ func Open(dsn string) (*gorm.DB, error) {
 		&FindingCommunication{}, &FindingReference{}, &FindingHistory{},
 		&Dependency{}, &Package{}, &Dependent{}, &Advisory{},
 		&Maintainer{}, &Skill{}, &Subproject{},
-		&SBOMUpload{}, &SBOMPackage{},
+		&SBOMUpload{}, &SBOMPackage{}, &CNA{},
 	); err != nil {
 		return nil, fmt.Errorf("automigrate: %w", err)
 	}
@@ -549,6 +549,32 @@ type SBOMPackage struct {
 	ResolveError string
 
 	CreatedAt time.Time
+}
+
+// CNA is a CVE Numbering Authority from the public cve.org partner list.
+// Stored so the disclosure workflow can route a finding to the CNA whose
+// scope covers the project rather than (or in addition to) the maintainer.
+// Scope is the free-text coverage description as published; matching a
+// repo to a CNA is left to a skill since scopes are prose, not patterns.
+type CNA struct {
+	ID uint `gorm:"primarykey"`
+
+	ShortName    string `gorm:"uniqueIndex;not null"`
+	CNAID        string `gorm:"uniqueIndex"`
+	Organization string
+	Scope        string `gorm:"type:text"`
+	Email        string
+	ContactURL   string
+	PolicyURL    string
+	AdvisoryURL  string
+	Root         string
+	Types        string
+	Country      string
+	Metadata     string `gorm:"type:text"`
+
+	FetchedAt *time.Time
+	CreatedAt time.Time
+	UpdatedAt time.Time
 }
 
 // Subproject is a scannable unit the subprojects skill discovered inside

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -85,4 +85,13 @@ func TestOpenAndMigrate(t *testing.T) {
 	if got.Repository.URL != r.URL {
 		t.Errorf("preload failed: %+v", got.Repository)
 	}
+
+	cna := CNA{ShortName: "apache", CNAID: "CNA-2016-0004", Organization: "Apache Software Foundation",
+		Scope: "All Apache Software Foundation projects", Email: "security@apache.org"}
+	if err := gdb.Create(&cna).Error; err != nil {
+		t.Fatalf("create CNA: %v", err)
+	}
+	if err := gdb.Create(&CNA{ShortName: "apache"}).Error; err == nil {
+		t.Errorf("expected unique-index violation on duplicate ShortName")
+	}
 }

--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -103,6 +103,7 @@ func (s *Server) apiHandler() http.Handler {
 	mux.HandleFunc("PUT /findings/{id}/labels", s.apiSetFindingLabels)
 	mux.HandleFunc("GET /findings/{id}/history", s.apiListFindingHistory)
 	mux.HandleFunc("GET /skills", s.apiListSkills)
+	mux.HandleFunc("GET /cnas", s.apiListCNAs)
 	return http.StripPrefix(apiPrefix, s.apiAuth(mux))
 }
 
@@ -242,6 +243,37 @@ func (s *Server) findingRepoID(findingID uint) (uint, bool) {
 		return 0, false
 	}
 	return repoID, true
+}
+
+// apiListCNAs returns the cached CVE Numbering Authority list. Global
+// (not repo-scoped) since CNA scope is matched against repo metadata by
+// the caller, not by scrutineer. Supports ?q= for a substring match
+// across short_name, organization, and scope so a skill can narrow before
+// reading prose.
+func (s *Server) apiListCNAs(w http.ResponseWriter, r *http.Request) {
+	q := s.DB.Order("short_name")
+	if term := r.URL.Query().Get("q"); term != "" {
+		like := "%" + term + "%"
+		q = q.Where("short_name LIKE ? OR organization LIKE ? OR scope LIKE ?", like, like, like)
+	}
+	var rows []db.CNA
+	q.Find(&rows)
+	out := make([]map[string]any, 0, len(rows))
+	for _, c := range rows {
+		out = append(out, map[string]any{
+			"short_name":   c.ShortName,
+			"cna_id":       c.CNAID,
+			"organization": c.Organization,
+			"scope":        c.Scope,
+			"email":        c.Email,
+			"contact_url":  c.ContactURL,
+			"policy_url":   c.PolicyURL,
+			"advisory_url": c.AdvisoryURL,
+			"root":         c.Root,
+			"types":        c.Types,
+		})
+	}
+	writeJSON(w, http.StatusOK, out)
 }
 
 func (s *Server) apiListSkills(w http.ResponseWriter, r *http.Request) {

--- a/internal/web/api_test.go
+++ b/internal/web/api_test.go
@@ -31,6 +31,43 @@ func seedRunningScan(t *testing.T, s *Server) (db.Repository, db.Scan) {
 	return repo, scan
 }
 
+func TestAPIListCNAs(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	_, scan := seedRunningScan(t, s)
+
+	s.DB.Create(&db.CNA{ShortName: "apache", Organization: "Apache Software Foundation",
+		Scope: "All Apache Software Foundation projects", Email: "security@apache.org"})
+	s.DB.Create(&db.CNA{ShortName: "curl", Organization: "curl", Scope: "curl and libcurl"})
+
+	get := func(q string) []map[string]any {
+		r := httptest.NewRequest("GET", "/api/cnas"+q, nil)
+		r.Host = testHost
+		r.Header.Set("Authorization", "Bearer "+scan.APIToken)
+		w := httptest.NewRecorder()
+		s.Handler().ServeHTTP(w, r)
+		if w.Code != 200 {
+			t.Fatalf("status %d: %s", w.Code, w.Body)
+		}
+		var rows []map[string]any
+		_ = json.NewDecoder(w.Body).Decode(&rows)
+		return rows
+	}
+
+	all := get("")
+	if len(all) != 2 {
+		t.Fatalf("len = %d, want 2", len(all))
+	}
+	if all[0]["short_name"] != "apache" || all[0]["email"] != "security@apache.org" {
+		t.Errorf("first row = %+v", all[0])
+	}
+
+	filtered := get("?q=libcurl")
+	if len(filtered) != 1 || filtered[0]["short_name"] != "curl" {
+		t.Errorf("scope filter: %+v", filtered)
+	}
+}
+
 func TestAPIRejectsMissingBearer(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()

--- a/internal/worker/cna.go
+++ b/internal/worker/cna.go
@@ -74,7 +74,7 @@ type cnaEntry struct {
 		Email   []struct{ EmailAddr string } `json:"email"`
 		Contact []struct{ URL string }       `json:"contact"`
 	} `json:"contact"`
-	DisclosurePolicy []struct{ URL string } `json:"disclosurePolicy"`
+	DisclosurePolicy   []struct{ URL string } `json:"disclosurePolicy"`
 	SecurityAdvisories struct {
 		Advisories []struct{ URL string } `json:"advisories"`
 	} `json:"securityAdvisories"`

--- a/internal/worker/cna.go
+++ b/internal/worker/cna.go
@@ -1,0 +1,148 @@
+package worker
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+
+	"scrutineer/internal/db"
+)
+
+// CNAListURL is the public CVE Program partner list. Served as a static
+// JSON file from the cve.org website repo, so no auth needed.
+const CNAListURL = "https://raw.githubusercontent.com/CVEProject/cve-website/dev/src/assets/data/CNAsList.json"
+
+// SyncCNAs fetches the public CNA partner list and upserts every entry
+// into the cnas table keyed on short_name. Safe to re-run; existing rows
+// are updated in place. The list is ~500 entries and changes slowly, so a
+// once-at-startup call is enough.
+func SyncCNAs(ctx context.Context, gdb *gorm.DB, url string) (int, error) {
+	if url == "" {
+		url = CNAListURL
+	}
+	ctx, cancel := context.WithTimeout(ctx, httpTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return 0, err
+	}
+	req.Header.Set("User-Agent", userAgent)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return 0, fmt.Errorf("fetch CNA list: %s returned %d", url, resp.StatusCode)
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBody))
+	if err != nil {
+		return 0, err
+	}
+
+	rows, err := parseCNAList(body)
+	if err != nil {
+		return 0, err
+	}
+	if len(rows) == 0 {
+		return 0, nil
+	}
+	if err := gdb.Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "short_name"}},
+		UpdateAll: true,
+	}).Create(&rows).Error; err != nil {
+		return 0, fmt.Errorf("upsert CNAs: %w", err)
+	}
+	return len(rows), nil
+}
+
+type cnaEntry struct {
+	ShortName        string `json:"shortName"`
+	CNAID            string `json:"cnaID"`
+	OrganizationName string `json:"organizationName"`
+	Scope            string `json:"scope"`
+	Country          string `json:"country"`
+	Contact          []struct {
+		Email   []struct{ EmailAddr string } `json:"email"`
+		Contact []struct{ URL string }       `json:"contact"`
+	} `json:"contact"`
+	DisclosurePolicy []struct{ URL string } `json:"disclosurePolicy"`
+	SecurityAdvisories struct {
+		Advisories []struct{ URL string } `json:"advisories"`
+	} `json:"securityAdvisories"`
+	CNA struct {
+		Root struct{ ShortName string } `json:"root"`
+		Type []string                   `json:"type"`
+	} `json:"CNA"`
+}
+
+func parseCNAList(data []byte) ([]db.CNA, error) {
+	var entries []cnaEntry
+	if err := json.Unmarshal(data, &entries); err != nil {
+		return nil, fmt.Errorf("parse CNA list: %w", err)
+	}
+	now := time.Now()
+	out := make([]db.CNA, 0, len(entries))
+	for i := range entries {
+		e := &entries[i]
+		if e.ShortName == "" {
+			continue
+		}
+		raw, _ := json.Marshal(e)
+		out = append(out, db.CNA{
+			ShortName:    e.ShortName,
+			CNAID:        e.CNAID,
+			Organization: e.OrganizationName,
+			Scope:        e.Scope,
+			Email:        firstEmail(e),
+			ContactURL:   firstContactURL(e),
+			PolicyURL:    firstURL(e.DisclosurePolicy),
+			AdvisoryURL:  firstURL(e.SecurityAdvisories.Advisories),
+			Root:         e.CNA.Root.ShortName,
+			Types:        strings.Join(e.CNA.Type, ","),
+			Country:      e.Country,
+			Metadata:     string(raw),
+			FetchedAt:    &now,
+		})
+	}
+	return out, nil
+}
+
+func firstEmail(e *cnaEntry) string {
+	for _, c := range e.Contact {
+		for _, em := range c.Email {
+			if em.EmailAddr != "" {
+				return em.EmailAddr
+			}
+		}
+	}
+	return ""
+}
+
+func firstContactURL(e *cnaEntry) string {
+	for _, c := range e.Contact {
+		for _, u := range c.Contact {
+			if u.URL != "" {
+				return u.URL
+			}
+		}
+	}
+	return ""
+}
+
+func firstURL(xs []struct{ URL string }) string {
+	for _, x := range xs {
+		if x.URL != "" {
+			return x.URL
+		}
+	}
+	return ""
+}

--- a/internal/worker/cna_test.go
+++ b/internal/worker/cna_test.go
@@ -1,0 +1,119 @@
+package worker
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"scrutineer/internal/db"
+)
+
+const cnaFixture = `[
+  {
+    "shortName": "apache",
+    "cnaID": "CNA-2016-0004",
+    "organizationName": "Apache Software Foundation",
+    "scope": "All Apache Software Foundation projects",
+    "country": "USA",
+    "contact": [{
+      "email": [{"label": "Email", "emailAddr": "security@apache.org"}],
+      "contact": [{"label": "Page", "url": "https://apache.org/security/"}]
+    }],
+    "disclosurePolicy": [{"label": "Policy", "url": "https://apache.org/security/committers.html"}],
+    "securityAdvisories": {"advisories": [{"label": "Advisories", "url": "https://apache.org/security/projects.html"}]},
+    "CNA": {"root": {"shortName": "mitre"}, "type": ["Open Source"]}
+  },
+  {
+    "shortName": "curl",
+    "cnaID": "CNA-2023-0002",
+    "organizationName": "curl",
+    "scope": "curl and libcurl",
+    "contact": [{"email": [], "contact": []}],
+    "disclosurePolicy": [],
+    "securityAdvisories": {"advisories": []},
+    "CNA": {"root": {"shortName": "mitre"}, "type": ["Open Source", "Vendor"]}
+  }
+]`
+
+func TestParseCNAList(t *testing.T) {
+	rows, err := parseCNAList([]byte(cnaFixture))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("rows = %d, want 2", len(rows))
+	}
+	a := rows[0]
+	if a.ShortName != "apache" || a.CNAID != "CNA-2016-0004" {
+		t.Errorf("identity = %s/%s", a.ShortName, a.CNAID)
+	}
+	if a.Email != "security@apache.org" {
+		t.Errorf("email = %q", a.Email)
+	}
+	if a.ContactURL != "https://apache.org/security/" {
+		t.Errorf("contact url = %q", a.ContactURL)
+	}
+	if a.PolicyURL != "https://apache.org/security/committers.html" {
+		t.Errorf("policy url = %q", a.PolicyURL)
+	}
+	if a.AdvisoryURL != "https://apache.org/security/projects.html" {
+		t.Errorf("advisory url = %q", a.AdvisoryURL)
+	}
+	if a.Root != "mitre" || a.Types != "Open Source" {
+		t.Errorf("root/types = %s/%s", a.Root, a.Types)
+	}
+	if a.FetchedAt == nil {
+		t.Errorf("FetchedAt not set")
+	}
+	if a.Metadata == "" {
+		t.Errorf("Metadata not preserved")
+	}
+	c := rows[1]
+	if c.Email != "" || c.PolicyURL != "" {
+		t.Errorf("empty arrays should yield empty strings: %+v", c)
+	}
+	if c.Types != "Open Source,Vendor" {
+		t.Errorf("types = %q", c.Types)
+	}
+}
+
+func TestSyncCNAs_upsertsByShortName(t *testing.T) {
+	gdb, err := db.Open("file::memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(cnaFixture))
+	}))
+	defer srv.Close()
+
+	n, err := SyncCNAs(context.Background(), gdb, srv.URL)
+	if err != nil {
+		t.Fatalf("first sync: %v", err)
+	}
+	if n != 2 {
+		t.Fatalf("n = %d, want 2", n)
+	}
+	var count int64
+	gdb.Model(&db.CNA{}).Count(&count)
+	if count != 2 {
+		t.Fatalf("rows after first sync = %d", count)
+	}
+
+	// Second sync should update in place, not duplicate.
+	if _, err := SyncCNAs(context.Background(), gdb, srv.URL); err != nil {
+		t.Fatalf("second sync: %v", err)
+	}
+	gdb.Model(&db.CNA{}).Count(&count)
+	if count != 2 {
+		t.Errorf("rows after second sync = %d, want 2 (upsert, not insert)", count)
+	}
+
+	var apache db.CNA
+	gdb.Where("short_name = ?", "apache").First(&apache)
+	if apache.Scope != "All Apache Software Foundation projects" {
+		t.Errorf("apache scope = %q", apache.Scope)
+	}
+}

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -479,6 +479,38 @@ paths:
                 type: array
                 items: { $ref: '#/components/schemas/SkillSummary' }
 
+  /cnas:
+    get:
+      summary: List CVE Numbering Authorities
+      description: >
+        Cached copy of the cve.org partner list. Global, not repo-scoped.
+        Use q to substring-match across short_name, organization, and scope.
+      operationId: listCNAs
+      parameters:
+        - name: q
+          in: query
+          schema: { type: string }
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    short_name:   { type: string }
+                    cna_id:       { type: string }
+                    organization: { type: string }
+                    scope:        { type: string }
+                    email:        { type: string }
+                    contact_url:  { type: string }
+                    policy_url:   { type: string }
+                    advisory_url: { type: string }
+                    root:         { type: string }
+                    types:        { type: string }
+
   /v1/repositories/{id}/findings:
     get:
       summary: Export findings for a repository as JSONL

--- a/skills/cna-match/SKILL.md
+++ b/skills/cna-match/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: cna-match
+description: Determine which CVE Numbering Authority (if any) covers this repository, so disclosures can be routed to the CNA's security contact rather than only the maintainer. Reads scrutineer's cached CNA list and matches the repo's owner, project name, and published packages against each CNA's published scope.
+license: MIT
+metadata:
+  scrutineer.output_file: report.json
+  scrutineer.output_kind: maintainers
+---
+
+# cna-match
+
+Decide whether a CVE Numbering Authority covers this repository. When one does, the disclosure should go to that CNA's security contact (and usually the maintainer in CC), because the CNA is who issues the CVE ID and coordinates the advisory.
+
+## Workspace
+
+- `./src` — the cloned repository. Useful mainly for `SECURITY.md`, which sometimes names the CNA directly.
+- `./context.json` — read `repository.url`, `repository.full_name`, `repository.owner`, plus the `scrutineer` block with `api_base`, `token`, `repository_id`.
+- `./report.json` — write your result here.
+- `./schema.json` — the JSON schema your report must validate against.
+
+## Data
+
+Call these with `Authorization: Bearer {token}`:
+
+- `GET {api_base}/repositories/{repository_id}` — owner, full name, html_url.
+- `GET {api_base}/repositories/{repository_id}/packages` — published package names and ecosystems. A CNA scope often names the package, not the repo.
+- `GET {api_base}/cnas` — the full CNA list (short_name, organization, scope, email, contact_url, policy_url, root, types). Pass `?q={term}` to narrow by substring across short_name/organization/scope; useful for checking the obvious candidate first (e.g. `?q=apache` when the owner is `apache`).
+
+Also read `./src/SECURITY.md` and `./src/.github/SECURITY.md` if present. Projects under a CNA usually say so there ("Report to security@apache.org", "We are our own CNA", "Report via GitHub Security Advisories").
+
+## Matching
+
+CNA scopes are free-text prose, not patterns. Match in this order and stop at the first hit:
+
+1. **SECURITY.md names a CNA or its contact directly.** If the file says report to a specific security@ address or names a CNA programme, find that entry in `/cnas` and use it.
+2. **Owner matches a CNA's organization or scope.** Repo owner `apache` → CNA `apache` ("All Apache Software Foundation projects"). Owner `kubernetes` or `kubernetes-sigs` → CNA `kubernetes`. Owner `nodejs` → CNA `nodejs`. Check `?q={owner}` first.
+3. **Package or project name matches a single-project CNA scope.** Package `curl` or `libcurl` → CNA `curl`. Package `openssl` → CNA `openssl`. These CNAs have narrow scopes naming the project explicitly.
+4. **Hosted on github.com with no other match.** GitHub (`GitHub_M`) is the CNA of last resort for public repos on github.com that have no other CNA. Only use this if steps 1-3 found nothing.
+
+A scope like "Vendor X products only" or "issues discovered by our researchers" does not cover an unrelated open-source repo even if a keyword overlaps. Read the scope sentence, not just the keyword.
+
+If nothing matches, that is a valid result: most projects have no CNA and disclosure goes to the maintainer.
+
+## Output
+
+Write `./report.json` matching `./schema.json`. The `output_kind` is `maintainers` so scrutineer's existing parser updates `Repository.DisclosureChannel` from the `disclosure_channel` field; `maintainers` stays an empty array. The `cna` block records which CNA matched and why so an analyst can review the reasoning in the scan report.
+
+When a CNA matched, set `disclosure_channel` to its email if it has one, otherwise its `contact_url`. Append the organization name in parentheses so the repo page shows where the address came from, e.g. `security@apache.org (Apache Software Foundation CNA)`.
+
+When nothing matched, leave `disclosure_channel` empty so any value the `maintainers` skill set earlier is left alone, and set `cna` to `null`.

--- a/skills/cna-match/schema.json
+++ b/skills/cna-match/schema.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "cna-match report",
+  "type": "object",
+  "required": ["maintainers", "cna"],
+  "additionalProperties": false,
+  "properties": {
+    "maintainers": {
+      "type": "array",
+      "maxItems": 0,
+      "description": "Always empty. Present so output_kind=maintainers parses cleanly."
+    },
+    "disclosure_channel": {
+      "type": "string",
+      "description": "CNA contact (email or URL) with organization name in parentheses. Empty when no CNA matched."
+    },
+    "cna": {
+      "type": ["object", "null"],
+      "description": "The matched CNA, or null when none covers this repository.",
+      "additionalProperties": false,
+      "properties": {
+        "short_name":   { "type": "string" },
+        "organization": { "type": "string" },
+        "email":        { "type": "string" },
+        "contact_url":  { "type": "string" },
+        "policy_url":   { "type": "string" },
+        "scope":        { "type": "string", "description": "The CNA's published scope text, verbatim." },
+        "match_rule":   { "type": "string", "enum": ["security_md", "owner", "package", "github_fallback"] },
+        "match_reason": { "type": "string", "description": "One sentence: which signal matched which part of the scope." }
+      },
+      "required": ["short_name", "organization", "scope", "match_rule", "match_reason"]
+    }
+  }
+}


### PR DESCRIPTION
First piece of CNA-aware disclosure routing: store the CVE Numbering Authority list locally so a later skill can match a repo to the CNA whose scope covers it instead of (or in addition to) the maintainer.

`db.CNA` holds short name, CNA ID, organization, free-text scope, contact email/URL, disclosure-policy URL, advisories URL, root CNA, types, country, plus the raw JSON in `Metadata` like `Repository` does.

`worker.SyncCNAs` fetches the public `CNAsList.json` (~500 entries) from the cve-website repo and upserts by `short_name`. Runs in a background goroutine at startup; failure is a logged warning so offline boot still works. Tests cover the nested-field flattening and verify a second sync updates rather than duplicates.

Also adds `GET {api_base}/cnas` on the skill API and a `cna-match` skill that reads the scope text against the repo's owner + package names and writes a `DisclosureChannel` suggestion.