### PR TITLE
config: add anthropic_base_url for custom API endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ You need [Go 1.26+](https://go.dev/dl/), [Docker](https://docs.docker.com/get-do
     git clone https://github.com/alpha-omega-security/scrutineer
     cd scrutineer
     export ANTHROPIC_API_KEY=sk-ant-...
+    export ANTHROPIC_API_URL=https://...  # optional: custom API endpoint
     go run ./cmd/scrutineer -skills ./skills
 
 Then open http://127.0.0.1:8080.
@@ -117,7 +118,7 @@ The same applies to the Dependents tab -- you can import any dependent's reposit
 ## Docker
 
     docker build -t scrutineer .
-    docker run -p 127.0.0.1:8080:8080 -v scrutineer-data:/data -e ANTHROPIC_API_KEY=sk-... scrutineer
+    docker run -p 127.0.0.1:8080:8080 -v scrutineer-data:/data -e ANTHROPIC_API_KEY=sk-... -e ANTHROPIC_API_URL=https://... scrutineer
 
 Always bind to `127.0.0.1`. The UI has no authentication; binding to `0.0.0.0` exposes your findings database to anyone on the network.
 
@@ -130,7 +131,7 @@ Use `--no-docker` to disable containerised execution, or `--runner-image` to spe
     docker build -t scrutineer-runner -f Dockerfile.runner .
     go run ./cmd/scrutineer -skills ./skills --runner-image scrutineer-runner
 
-When the docker runner is active, scrutineer starts an authenticated egress proxy on the host and points `HTTPS_PROXY`/`HTTP_PROXY` inside the container at it. The proxy only tunnels to an allowlist of hosts: the Anthropic API, `*.ecosyste.ms`, the major forges (GitHub, GitLab, Codeberg, Bitbucket), common package registries (npm, PyPI, RubyGems, crates.io, Go module proxy, Packagist, Hex, NuGet), advisory sources (semgrep.dev, OSV, NVD, cwe.mitre.org), and `host.docker.internal` for the local skill API. Requests to anything else get a 403 and are logged. Extend the list with `egress_allow` in the config file. The proxy uses a per-process random token so it isn't an open relay; tools that ignore the proxy env are not blocked at the network layer (see `threatmodel.md`).
+When the docker runner is active, scrutineer starts an authenticated egress proxy on the host and points `HTTPS_PROXY`/`HTTP_PROXY` inside the container at it. The proxy only tunnels to an allowlist of hosts: the Anthropic API, `*.ecosyste.ms`, the major forges (GitHub, GitLab, Codeberg, Bitbucket), common package registries (npm, PyPI, RubyGems, crates.io, Go module proxy, Packagist, Hex, NuGet), advisory sources (semgrep.dev, OSV, NVD, cwe.mitre.org), and `host.docker.internal` for the local skill API. Requests to anything else get a 403 and are logged. Extend the list with `egress_allow` in the config file. When `-anthropic-api-url` is set (or falls back to the `ANTHROPIC_API_URL` env var), its hostname is automatically added to the allowlist. The proxy uses a per-process random token so it isn't an open relay; tools that ignore the proxy env are not blocked at the network layer (see `threatmodel.md`).
 
 ## Flags
 
@@ -148,6 +149,7 @@ When the docker runner is active, scrutineer starts an authenticated egress prox
 | `-clone` | `shallow` | Clone depth: `shallow` (`--depth 1`) or `full` |
 | `-scan-timeout` | `1h` | Wall-clock limit per scan; exceeded scans fail |
 | `-max-turns` | `0` | Passed as `--max-turns` to claude-code (0 = unlimited) |
+| `-anthropic-api-url` | - | Custom Anthropic API base URL (env: `ANTHROPIC_API_URL`) |
 
 ## Config file
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ You need [Go 1.26+](https://go.dev/dl/), [Docker](https://docs.docker.com/get-do
     git clone https://github.com/alpha-omega-security/scrutineer
     cd scrutineer
     export ANTHROPIC_API_KEY=sk-ant-...
-    export ANTHROPIC_API_URL=https://...  # optional: custom API endpoint
+    export ANTHROPIC_BASE_URL=https://...  # optional: custom API endpoint
     go run ./cmd/scrutineer -skills ./skills
 
 Then open http://127.0.0.1:8080.
@@ -118,7 +118,7 @@ The same applies to the Dependents tab -- you can import any dependent's reposit
 ## Docker
 
     docker build -t scrutineer .
-    docker run -p 127.0.0.1:8080:8080 -v scrutineer-data:/data -e ANTHROPIC_API_KEY=sk-... -e ANTHROPIC_API_URL=https://... scrutineer
+    docker run -p 127.0.0.1:8080:8080 -v scrutineer-data:/data -e ANTHROPIC_API_KEY=sk-... -e ANTHROPIC_BASE_URL=https://... scrutineer
 
 Always bind to `127.0.0.1`. The UI has no authentication; binding to `0.0.0.0` exposes your findings database to anyone on the network.
 
@@ -131,7 +131,7 @@ Use `--no-docker` to disable containerised execution, or `--runner-image` to spe
     docker build -t scrutineer-runner -f Dockerfile.runner .
     go run ./cmd/scrutineer -skills ./skills --runner-image scrutineer-runner
 
-When the docker runner is active, scrutineer starts an authenticated egress proxy on the host and points `HTTPS_PROXY`/`HTTP_PROXY` inside the container at it. The proxy only tunnels to an allowlist of hosts: the Anthropic API, `*.ecosyste.ms`, the major forges (GitHub, GitLab, Codeberg, Bitbucket), common package registries (npm, PyPI, RubyGems, crates.io, Go module proxy, Packagist, Hex, NuGet), advisory sources (semgrep.dev, OSV, NVD, cwe.mitre.org), and `host.docker.internal` for the local skill API. Requests to anything else get a 403 and are logged. Extend the list with `egress_allow` in the config file. When `-anthropic-api-url` is set (or falls back to the `ANTHROPIC_API_URL` env var), its hostname is automatically added to the allowlist. The proxy uses a per-process random token so it isn't an open relay; tools that ignore the proxy env are not blocked at the network layer (see `threatmodel.md`).
+When the docker runner is active, scrutineer starts an authenticated egress proxy on the host and points `HTTPS_PROXY`/`HTTP_PROXY` inside the container at it. The proxy only tunnels to an allowlist of hosts: the Anthropic API, `*.ecosyste.ms`, the major forges (GitHub, GitLab, Codeberg, Bitbucket), common package registries (npm, PyPI, RubyGems, crates.io, Go module proxy, Packagist, Hex, NuGet), advisory sources (semgrep.dev, OSV, NVD, cwe.mitre.org), and `host.docker.internal` for the local skill API. Requests to anything else get a 403 and are logged. Extend the list with `egress_allow` in the config file. When `-anthropic-api-url` is set (or falls back to the `ANTHROPIC_BASE_URL` env var), its hostname is automatically added to the allowlist. The proxy uses a per-process random token so it isn't an open relay; tools that ignore the proxy env are not blocked at the network layer (see `threatmodel.md`).
 
 ## Flags
 
@@ -149,7 +149,7 @@ When the docker runner is active, scrutineer starts an authenticated egress prox
 | `-clone` | `shallow` | Clone depth: `shallow` (`--depth 1`) or `full` |
 | `-scan-timeout` | `1h` | Wall-clock limit per scan; exceeded scans fail |
 | `-max-turns` | `0` | Passed as `--max-turns` to claude-code (0 = unlimited) |
-| `-anthropic-api-url` | - | Custom Anthropic API base URL (env: `ANTHROPIC_API_URL`) |
+| `-anthropic-api-url` | - | Custom Anthropic API base URL (env: `ANTHROPIC_BASE_URL`) |
 
 ## Config file
 

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Use `--no-docker` to disable containerised execution, or `--runner-image` to spe
     docker build -t scrutineer-runner -f Dockerfile.runner .
     go run ./cmd/scrutineer -skills ./skills --runner-image scrutineer-runner
 
-When the docker runner is active, scrutineer starts an authenticated egress proxy on the host and points `HTTPS_PROXY`/`HTTP_PROXY` inside the container at it. The proxy only tunnels to an allowlist of hosts: the Anthropic API, `*.ecosyste.ms`, the major forges (GitHub, GitLab, Codeberg, Bitbucket), common package registries (npm, PyPI, RubyGems, crates.io, Go module proxy, Packagist, Hex, NuGet), advisory sources (semgrep.dev, OSV, NVD, cwe.mitre.org), and `host.docker.internal` for the local skill API. Requests to anything else get a 403 and are logged. Extend the list with `egress_allow` in the config file. When `-anthropic-api-url` is set (or falls back to the `ANTHROPIC_BASE_URL` env var), its hostname is automatically added to the allowlist. The proxy uses a per-process random token so it isn't an open relay; tools that ignore the proxy env are not blocked at the network layer (see `threatmodel.md`).
+When the docker runner is active, scrutineer starts an authenticated egress proxy on the host and points `HTTPS_PROXY`/`HTTP_PROXY` inside the container at it. The proxy only tunnels to an allowlist of hosts: the Anthropic API, `*.ecosyste.ms`, the major forges (GitHub, GitLab, Codeberg, Bitbucket), common package registries (npm, PyPI, RubyGems, crates.io, Go module proxy, Packagist, Hex, NuGet), advisory sources (semgrep.dev, OSV, NVD, cwe.mitre.org), and `host.docker.internal` for the local skill API. Requests to anything else get a 403 and are logged. Extend the list with `egress_allow` in the config file. When `-anthropic-base-url` is set (or falls back to the `ANTHROPIC_BASE_URL` env var), its hostname is automatically added to the allowlist. The proxy uses a per-process random token so it isn't an open relay; tools that ignore the proxy env are not blocked at the network layer (see `threatmodel.md`).
 
 ## Flags
 
@@ -149,7 +149,7 @@ When the docker runner is active, scrutineer starts an authenticated egress prox
 | `-clone` | `shallow` | Clone depth: `shallow` (`--depth 1`) or `full` |
 | `-scan-timeout` | `1h` | Wall-clock limit per scan; exceeded scans fail |
 | `-max-turns` | `0` | Passed as `--max-turns` to claude-code (0 = unlimited) |
-| `-anthropic-api-url` | - | Custom Anthropic API base URL (env: `ANTHROPIC_BASE_URL`) |
+| `-anthropic-base-url` | - | Custom Anthropic API base URL (env: `ANTHROPIC_BASE_URL`) |
 
 ## Config file
 

--- a/cmd/scrutineer/main.go
+++ b/cmd/scrutineer/main.go
@@ -82,7 +82,7 @@ func parseFlags() *flags {
 	flag.StringVar(&f.cloneMode, "clone", "shallow", "clone depth: shallow (--depth 1) or full")
 	flag.DurationVar(&f.scanTimeout, "scan-timeout", worker.DefaultScanTimeout, "wall-clock limit per scan")
 	flag.IntVar(&f.maxTurns, "max-turns", 0, "claude --max-turns limit (0 = unlimited)")
-	flag.StringVar(&f.anthropicAPIURL, "anthropic-api-url", "", "custom Anthropic API base URL (env: ANTHROPIC_API_URL)")
+	flag.StringVar(&f.anthropicAPIURL, "anthropic-api-url", "", "custom Anthropic API base URL (env: ANTHROPIC_BASE_URL)")
 	flag.Var(&f.skillLocal, "skills", "directory to load SKILL.md files from (repeatable)")
 	flag.Parse()
 
@@ -161,10 +161,10 @@ func run(log *slog.Logger) error {
 		return err
 	}
 	if f.anthropicAPIURL == "" {
-		f.anthropicAPIURL = os.Getenv("ANTHROPIC_API_URL")
+		f.anthropicAPIURL = os.Getenv("ANTHROPIC_BASE_URL")
 	}
-	if f.anthropicAPIURL != "" && os.Getenv("ANTHROPIC_API_URL") != f.anthropicAPIURL {
-		os.Setenv("ANTHROPIC_API_URL", f.anthropicAPIURL)
+	if f.anthropicAPIURL != "" && os.Getenv("ANTHROPIC_BASE_URL") != f.anthropicAPIURL {
+		os.Setenv("ANTHROPIC_BASE_URL", f.anthropicAPIURL)
 	}
 
 	if err := os.MkdirAll(f.dataDir, dataPermSecure); err != nil {

--- a/cmd/scrutineer/main.go
+++ b/cmd/scrutineer/main.go
@@ -61,7 +61,7 @@ type flags struct {
 	cloneMode       string
 	scanTimeout     time.Duration
 	maxTurns        int
-	anthropicAPIURL string
+	anthropicBaseURL string
 	skillLocal      skillDirs
 
 	// set records which flags were passed on the command line so merge
@@ -82,7 +82,7 @@ func parseFlags() *flags {
 	flag.StringVar(&f.cloneMode, "clone", "shallow", "clone depth: shallow (--depth 1) or full")
 	flag.DurationVar(&f.scanTimeout, "scan-timeout", worker.DefaultScanTimeout, "wall-clock limit per scan")
 	flag.IntVar(&f.maxTurns, "max-turns", 0, "claude --max-turns limit (0 = unlimited)")
-	flag.StringVar(&f.anthropicAPIURL, "anthropic-api-url", "", "custom Anthropic API base URL (env: ANTHROPIC_BASE_URL)")
+	flag.StringVar(&f.anthropicBaseURL, "anthropic-base-url", "", "custom Anthropic API base URL (env: ANTHROPIC_BASE_URL)")
 	flag.Var(&f.skillLocal, "skills", "directory to load SKILL.md files from (repeatable)")
 	flag.Parse()
 
@@ -128,8 +128,8 @@ func (f *flags) merge(cfg *config.Config) {
 	if cfg.MaxTurns > 0 && !f.set["max-turns"] {
 		f.maxTurns = cfg.MaxTurns
 	}
-	if cfg.AnthropicAPIURL != "" && !f.set["anthropic-api-url"] {
-		f.anthropicAPIURL = cfg.AnthropicAPIURL
+	if cfg.AnthropicBaseURL != "" && !f.set["anthropic-base-url"] {
+		f.anthropicBaseURL = cfg.AnthropicBaseURL
 	}
 
 	if len(cfg.Models) > 0 {
@@ -160,11 +160,11 @@ func run(log *slog.Logger) error {
 	if err := config.ValidateClone(f.cloneMode); err != nil {
 		return err
 	}
-	if f.anthropicAPIURL == "" {
-		f.anthropicAPIURL = os.Getenv("ANTHROPIC_BASE_URL")
+	if f.anthropicBaseURL == "" {
+		f.anthropicBaseURL = os.Getenv("ANTHROPIC_BASE_URL")
 	}
-	if f.anthropicAPIURL != "" && os.Getenv("ANTHROPIC_BASE_URL") != f.anthropicAPIURL {
-		os.Setenv("ANTHROPIC_BASE_URL", f.anthropicAPIURL)
+	if f.anthropicBaseURL != "" && os.Getenv("ANTHROPIC_BASE_URL") != f.anthropicBaseURL {
+		os.Setenv("ANTHROPIC_BASE_URL", f.anthropicBaseURL)
 	}
 
 	if err := os.MkdirAll(f.dataDir, dataPermSecure); err != nil {
@@ -208,9 +208,9 @@ func run(log *slog.Logger) error {
 	if cfg != nil {
 		egressExtra = cfg.EgressAllow
 	}
-	if h := apiURLHost(f.anthropicAPIURL); h != "" {
+	if h := baseURLHost(f.anthropicBaseURL); h != "" {
 		egressExtra = append(egressExtra, h)
-		log.Info("added anthropic API URL host to egress allowlist", "host", h)
+		log.Info("added anthropic base URL host to egress allowlist", "host", h)
 	}
 
 	var runner worker.SkillRunner
@@ -230,7 +230,7 @@ func run(log *slog.Logger) error {
 			ProxyURL:        worker.ProxyURL(token, port),
 			FullClone:       f.fullClone(),
 			MaxTurns:        f.maxTurns,
-			AnthropicAPIURL: f.anthropicAPIURL,
+			AnthropicBaseURL: f.anthropicBaseURL,
 		}
 		// Skills inside the container reach the host via host.docker.internal,
 		// which the egress proxy rewrites to 127.0.0.1 when dialing.
@@ -314,7 +314,7 @@ func hashPath(s string) string {
 	return r.Replace(s)
 }
 
-func apiURLHost(raw string) string {
+func baseURLHost(raw string) string {
 	if raw == "" {
 		return ""
 	}

--- a/cmd/scrutineer/main.go
+++ b/cmd/scrutineer/main.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -49,18 +50,19 @@ func main() {
 // parseFlags fills defaults and CLI overrides; merge layers the config
 // file underneath any flag the user set explicitly.
 type flags struct {
-	configPath  string
-	addr        string
-	dataDir     string
-	effort      string
-	noDocker    bool
-	runnerImage string
-	skillsRepo  string
-	concurrency int
-	cloneMode   string
-	scanTimeout time.Duration
-	maxTurns    int
-	skillLocal  skillDirs
+	configPath      string
+	addr            string
+	dataDir         string
+	effort          string
+	noDocker        bool
+	runnerImage     string
+	skillsRepo      string
+	concurrency     int
+	cloneMode       string
+	scanTimeout     time.Duration
+	maxTurns        int
+	anthropicAPIURL string
+	skillLocal      skillDirs
 
 	// set records which flags were passed on the command line so merge
 	// knows not to let the config file override them.
@@ -80,6 +82,7 @@ func parseFlags() *flags {
 	flag.StringVar(&f.cloneMode, "clone", "shallow", "clone depth: shallow (--depth 1) or full")
 	flag.DurationVar(&f.scanTimeout, "scan-timeout", worker.DefaultScanTimeout, "wall-clock limit per scan")
 	flag.IntVar(&f.maxTurns, "max-turns", 0, "claude --max-turns limit (0 = unlimited)")
+	flag.StringVar(&f.anthropicAPIURL, "anthropic-api-url", "", "custom Anthropic API base URL (env: ANTHROPIC_API_URL)")
 	flag.Var(&f.skillLocal, "skills", "directory to load SKILL.md files from (repeatable)")
 	flag.Parse()
 
@@ -125,6 +128,9 @@ func (f *flags) merge(cfg *config.Config) {
 	if cfg.MaxTurns > 0 && !f.set["max-turns"] {
 		f.maxTurns = cfg.MaxTurns
 	}
+	if cfg.AnthropicAPIURL != "" && !f.set["anthropic-api-url"] {
+		f.anthropicAPIURL = cfg.AnthropicAPIURL
+	}
 
 	if len(cfg.Models) > 0 {
 		models := make([]web.Model, 0, len(cfg.Models))
@@ -153,6 +159,12 @@ func run(log *slog.Logger) error {
 	}
 	if err := config.ValidateClone(f.cloneMode); err != nil {
 		return err
+	}
+	if f.anthropicAPIURL == "" {
+		f.anthropicAPIURL = os.Getenv("ANTHROPIC_API_URL")
+	}
+	if f.anthropicAPIURL != "" && os.Getenv("ANTHROPIC_API_URL") != f.anthropicAPIURL {
+		os.Setenv("ANTHROPIC_API_URL", f.anthropicAPIURL)
 	}
 
 	if err := os.MkdirAll(f.dataDir, dataPermSecure); err != nil {
@@ -196,6 +208,10 @@ func run(log *slog.Logger) error {
 	if cfg != nil {
 		egressExtra = cfg.EgressAllow
 	}
+	if h := apiURLHost(f.anthropicAPIURL); h != "" {
+		egressExtra = append(egressExtra, h)
+		log.Info("added anthropic API URL host to egress allowlist", "host", h)
+	}
 
 	var runner worker.SkillRunner
 	apiBase := "http://" + f.addr + "/api"
@@ -209,11 +225,12 @@ func run(log *slog.Logger) error {
 		log.Info("docker detected, using containerised runner",
 			"image", f.runnerImage, "egress_proxy_port", port, "egress_allow", len(allow))
 		runner = worker.DockerRunner{
-			Image:     f.runnerImage,
-			Effort:    f.effort,
-			ProxyURL:  worker.ProxyURL(token, port),
-			FullClone: f.fullClone(),
-			MaxTurns:  f.maxTurns,
+			Image:           f.runnerImage,
+			Effort:          f.effort,
+			ProxyURL:        worker.ProxyURL(token, port),
+			FullClone:       f.fullClone(),
+			MaxTurns:        f.maxTurns,
+			AnthropicAPIURL: f.anthropicAPIURL,
 		}
 		// Skills inside the container reach the host via host.docker.internal,
 		// which the egress proxy rewrites to 127.0.0.1 when dialing.
@@ -295,6 +312,17 @@ func addrPort(addr string) string {
 func hashPath(s string) string {
 	r := strings.NewReplacer("/", "_", ":", "_", "?", "_", "&", "_", "=", "_")
 	return r.Replace(s)
+}
+
+func apiURLHost(raw string) string {
+	if raw == "" {
+		return ""
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return ""
+	}
+	return u.Hostname()
 }
 
 // cfgPath returns the path the loader actually used for logging.

--- a/cmd/scrutineer/main.go
+++ b/cmd/scrutineer/main.go
@@ -50,19 +50,19 @@ func main() {
 // parseFlags fills defaults and CLI overrides; merge layers the config
 // file underneath any flag the user set explicitly.
 type flags struct {
-	configPath      string
-	addr            string
-	dataDir         string
-	effort          string
-	noDocker        bool
-	runnerImage     string
-	skillsRepo      string
-	concurrency     int
-	cloneMode       string
-	scanTimeout     time.Duration
-	maxTurns        int
+	configPath       string
+	addr             string
+	dataDir          string
+	effort           string
+	noDocker         bool
+	runnerImage      string
+	skillsRepo       string
+	concurrency      int
+	cloneMode        string
+	scanTimeout      time.Duration
+	maxTurns         int
 	anthropicBaseURL string
-	skillLocal      skillDirs
+	skillLocal       skillDirs
 
 	// set records which flags were passed on the command line so merge
 	// knows not to let the config file override them.
@@ -163,8 +163,11 @@ func run(log *slog.Logger) error {
 	if f.anthropicBaseURL == "" {
 		f.anthropicBaseURL = os.Getenv("ANTHROPIC_BASE_URL")
 	}
-	if f.anthropicBaseURL != "" && os.Getenv("ANTHROPIC_BASE_URL") != f.anthropicBaseURL {
-		os.Setenv("ANTHROPIC_BASE_URL", f.anthropicBaseURL)
+	// LocalClaude inherits the host env, so writing the resolved value
+	// back here is what makes flag/config precedence apply on the local
+	// runner path. DockerRunner gets it explicitly via its struct field.
+	if f.anthropicBaseURL != "" {
+		_ = os.Setenv("ANTHROPIC_BASE_URL", f.anthropicBaseURL)
 	}
 
 	if err := os.MkdirAll(f.dataDir, dataPermSecure); err != nil {
@@ -225,11 +228,11 @@ func run(log *slog.Logger) error {
 		log.Info("docker detected, using containerised runner",
 			"image", f.runnerImage, "egress_proxy_port", port, "egress_allow", len(allow))
 		runner = worker.DockerRunner{
-			Image:           f.runnerImage,
-			Effort:          f.effort,
-			ProxyURL:        worker.ProxyURL(token, port),
-			FullClone:       f.fullClone(),
-			MaxTurns:        f.maxTurns,
+			Image:            f.runnerImage,
+			Effort:           f.effort,
+			ProxyURL:         worker.ProxyURL(token, port),
+			FullClone:        f.fullClone(),
+			MaxTurns:         f.maxTurns,
 			AnthropicBaseURL: f.anthropicBaseURL,
 		}
 		// Skills inside the container reach the host via host.docker.internal,

--- a/cmd/scrutineer/main_test.go
+++ b/cmd/scrutineer/main_test.go
@@ -10,17 +10,18 @@ import (
 func fullConfig() *config.Config {
 	yes := true
 	return &config.Config{
-		Addr:        "0.0.0.0:9090",
-		Data:        "/var/lib/scrutineer",
-		Effort:      "medium",
-		NoDocker:    &yes,
-		RunnerImage: "custom:v1",
-		SkillsRepo:  "https://example.com/skills.git",
-		Skills:      []string{"/etc/skills"},
-		Concurrency: 8,
-		Clone:       "full",
-		ScanTimeout: "30m",
-		MaxTurns:    200,
+		Addr:            "0.0.0.0:9090",
+		Data:            "/var/lib/scrutineer",
+		Effort:          "medium",
+		NoDocker:        &yes,
+		RunnerImage:     "custom:v1",
+		SkillsRepo:      "https://example.com/skills.git",
+		Skills:          []string{"/etc/skills"},
+		Concurrency:     8,
+		Clone:           "full",
+		ScanTimeout:     "30m",
+		MaxTurns:        200,
+		AnthropicAPIURL: "https://proxy.corp.com/v1",
 	}
 }
 
@@ -52,13 +53,17 @@ func TestFlagsMerge_configFillsUnset(t *testing.T) {
 	if f.maxTurns != 200 {
 		t.Errorf("maxTurns = %d", f.maxTurns)
 	}
+	if f.anthropicAPIURL != cfg.AnthropicAPIURL {
+		t.Errorf("anthropicAPIURL = %q, want %q", f.anthropicAPIURL, cfg.AnthropicAPIURL)
+	}
 }
 
 func TestFlagsMerge_cliFlagWins(t *testing.T) {
 	cfg := fullConfig()
 	f := &flags{
 		addr: "127.0.0.1:8080", cloneMode: "shallow", concurrency: 2,
-		set: map[string]bool{"addr": true, "clone": true, "concurrency": true},
+		anthropicAPIURL: "https://my-flag.example.com/v1",
+		set:             map[string]bool{"addr": true, "clone": true, "concurrency": true, "anthropic-api-url": true},
 	}
 	f.merge(cfg)
 	if f.addr != "127.0.0.1:8080" {
@@ -74,6 +79,9 @@ func TestFlagsMerge_cliFlagWins(t *testing.T) {
 	if f.effort != cfg.Effort {
 		t.Errorf("effort = %q, want %q", f.effort, cfg.Effort)
 	}
+	if f.anthropicAPIURL != "https://my-flag.example.com/v1" {
+		t.Errorf("anthropicAPIURL overridden despite explicit flag: %q", f.anthropicAPIURL)
+	}
 }
 
 func TestFlagsMerge_zeroConfigLeavesDefaults(t *testing.T) {
@@ -87,5 +95,26 @@ func TestFlagsMerge_zeroConfigLeavesDefaults(t *testing.T) {
 	}
 	if f.scanTimeout != time.Hour {
 		t.Errorf("empty scan_timeout clobbered default: %v", f.scanTimeout)
+	}
+	if f.anthropicAPIURL != "" {
+		t.Errorf("empty config set anthropicAPIURL: %q", f.anthropicAPIURL)
+	}
+}
+
+func TestAPIURLHost(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"", ""},
+		{"https://api.anthropic.com", "api.anthropic.com"},
+		{"https://my-proxy.corp.com/v1", "my-proxy.corp.com"},
+		{"https://my-proxy.corp.com:8443/v1", "my-proxy.corp.com"},
+		{"http://localhost:4000", "localhost"},
+		{"://broken", ""},
+	}
+	for _, tc := range cases {
+		if got := apiURLHost(tc.in); got != tc.want {
+			t.Errorf("apiURLHost(%q) = %q, want %q", tc.in, got, tc.want)
+		}
 	}
 }

--- a/cmd/scrutineer/main_test.go
+++ b/cmd/scrutineer/main_test.go
@@ -21,7 +21,7 @@ func fullConfig() *config.Config {
 		Clone:           "full",
 		ScanTimeout:     "30m",
 		MaxTurns:        200,
-		AnthropicAPIURL: "https://proxy.corp.com/v1",
+		AnthropicBaseURL: "https://proxy.corp.com/v1",
 	}
 }
 
@@ -53,8 +53,8 @@ func TestFlagsMerge_configFillsUnset(t *testing.T) {
 	if f.maxTurns != 200 {
 		t.Errorf("maxTurns = %d", f.maxTurns)
 	}
-	if f.anthropicAPIURL != cfg.AnthropicAPIURL {
-		t.Errorf("anthropicAPIURL = %q, want %q", f.anthropicAPIURL, cfg.AnthropicAPIURL)
+	if f.anthropicBaseURL != cfg.AnthropicBaseURL {
+		t.Errorf("anthropicBaseURL = %q, want %q", f.anthropicBaseURL, cfg.AnthropicBaseURL)
 	}
 }
 
@@ -62,8 +62,8 @@ func TestFlagsMerge_cliFlagWins(t *testing.T) {
 	cfg := fullConfig()
 	f := &flags{
 		addr: "127.0.0.1:8080", cloneMode: "shallow", concurrency: 2,
-		anthropicAPIURL: "https://my-flag.example.com/v1",
-		set:             map[string]bool{"addr": true, "clone": true, "concurrency": true, "anthropic-api-url": true},
+		anthropicBaseURL: "https://my-flag.example.com/v1",
+		set:             map[string]bool{"addr": true, "clone": true, "concurrency": true, "anthropic-base-url": true},
 	}
 	f.merge(cfg)
 	if f.addr != "127.0.0.1:8080" {
@@ -79,8 +79,8 @@ func TestFlagsMerge_cliFlagWins(t *testing.T) {
 	if f.effort != cfg.Effort {
 		t.Errorf("effort = %q, want %q", f.effort, cfg.Effort)
 	}
-	if f.anthropicAPIURL != "https://my-flag.example.com/v1" {
-		t.Errorf("anthropicAPIURL overridden despite explicit flag: %q", f.anthropicAPIURL)
+	if f.anthropicBaseURL != "https://my-flag.example.com/v1" {
+		t.Errorf("anthropicBaseURL overridden despite explicit flag: %q", f.anthropicBaseURL)
 	}
 }
 
@@ -96,12 +96,12 @@ func TestFlagsMerge_zeroConfigLeavesDefaults(t *testing.T) {
 	if f.scanTimeout != time.Hour {
 		t.Errorf("empty scan_timeout clobbered default: %v", f.scanTimeout)
 	}
-	if f.anthropicAPIURL != "" {
-		t.Errorf("empty config set anthropicAPIURL: %q", f.anthropicAPIURL)
+	if f.anthropicBaseURL != "" {
+		t.Errorf("empty config set anthropicBaseURL: %q", f.anthropicBaseURL)
 	}
 }
 
-func TestAPIURLHost(t *testing.T) {
+func TestBaseURLHost(t *testing.T) {
 	cases := []struct {
 		in, want string
 	}{
@@ -113,8 +113,8 @@ func TestAPIURLHost(t *testing.T) {
 		{"://broken", ""},
 	}
 	for _, tc := range cases {
-		if got := apiURLHost(tc.in); got != tc.want {
-			t.Errorf("apiURLHost(%q) = %q, want %q", tc.in, got, tc.want)
+		if got := baseURLHost(tc.in); got != tc.want {
+			t.Errorf("baseURLHost(%q) = %q, want %q", tc.in, got, tc.want)
 		}
 	}
 }

--- a/cmd/scrutineer/main_test.go
+++ b/cmd/scrutineer/main_test.go
@@ -10,17 +10,17 @@ import (
 func fullConfig() *config.Config {
 	yes := true
 	return &config.Config{
-		Addr:            "0.0.0.0:9090",
-		Data:            "/var/lib/scrutineer",
-		Effort:          "medium",
-		NoDocker:        &yes,
-		RunnerImage:     "custom:v1",
-		SkillsRepo:      "https://example.com/skills.git",
-		Skills:          []string{"/etc/skills"},
-		Concurrency:     8,
-		Clone:           "full",
-		ScanTimeout:     "30m",
-		MaxTurns:        200,
+		Addr:             "0.0.0.0:9090",
+		Data:             "/var/lib/scrutineer",
+		Effort:           "medium",
+		NoDocker:         &yes,
+		RunnerImage:      "custom:v1",
+		SkillsRepo:       "https://example.com/skills.git",
+		Skills:           []string{"/etc/skills"},
+		Concurrency:      8,
+		Clone:            "full",
+		ScanTimeout:      "30m",
+		MaxTurns:         200,
 		AnthropicBaseURL: "https://proxy.corp.com/v1",
 	}
 }
@@ -63,7 +63,7 @@ func TestFlagsMerge_cliFlagWins(t *testing.T) {
 	f := &flags{
 		addr: "127.0.0.1:8080", cloneMode: "shallow", concurrency: 2,
 		anthropicBaseURL: "https://my-flag.example.com/v1",
-		set:             map[string]bool{"addr": true, "clone": true, "concurrency": true, "anthropic-base-url": true},
+		set:              map[string]bool{"addr": true, "clone": true, "concurrency": true, "anthropic-base-url": true},
 	}
 	f.merge(cfg)
 	if f.addr != "127.0.0.1:8080" {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -47,8 +47,8 @@ type Config struct {
 	MaxTurns int `yaml:"max_turns"`
 	// AnthropicAPIURL overrides the default Anthropic API endpoint. When
 	// set, the hostname is automatically added to the egress allowlist and
-	// the value is passed as ANTHROPIC_API_URL to the claude-code process.
-	// Falls back to the ANTHROPIC_API_URL environment variable if empty.
+	// the value is passed as ANTHROPIC_BASE_URL to the claude-code process.
+	// Falls back to the ANTHROPIC_BASE_URL environment variable if empty.
 	AnthropicAPIURL string `yaml:"anthropic_api_url"`
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -45,6 +45,11 @@ type Config struct {
 	ScanTimeout string `yaml:"scan_timeout"`
 	// MaxTurns is passed as --max-turns to claude-code. 0 means no limit.
 	MaxTurns int `yaml:"max_turns"`
+	// AnthropicAPIURL overrides the default Anthropic API endpoint. When
+	// set, the hostname is automatically added to the egress allowlist and
+	// the value is passed as ANTHROPIC_API_URL to the claude-code process.
+	// Falls back to the ANTHROPIC_API_URL environment variable if empty.
+	AnthropicAPIURL string `yaml:"anthropic_api_url"`
 }
 
 // ParseScanTimeout validates and parses a scan_timeout string. Empty

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -45,11 +45,11 @@ type Config struct {
 	ScanTimeout string `yaml:"scan_timeout"`
 	// MaxTurns is passed as --max-turns to claude-code. 0 means no limit.
 	MaxTurns int `yaml:"max_turns"`
-	// AnthropicAPIURL overrides the default Anthropic API endpoint. When
+	// AnthropicBaseURL overrides the default Anthropic API endpoint. When
 	// set, the hostname is automatically added to the egress allowlist and
 	// the value is passed as ANTHROPIC_BASE_URL to the claude-code process.
 	// Falls back to the ANTHROPIC_BASE_URL environment variable if empty.
-	AnthropicAPIURL string `yaml:"anthropic_api_url"`
+	AnthropicBaseURL string `yaml:"anthropic_base_url"`
 }
 
 // ParseScanTimeout validates and parses a scan_timeout string. Empty

--- a/internal/worker/docker.go
+++ b/internal/worker/docker.go
@@ -25,7 +25,7 @@ type DockerRunner struct {
 	ProxyURL        string // http://user:token@host.docker.internal:port; "" disables egress
 	FullClone       bool
 	MaxTurns        int
-	AnthropicAPIURL string // passed as ANTHROPIC_API_URL env var to the container
+	AnthropicAPIURL string // passed as ANTHROPIC_BASE_URL env var to the container
 }
 
 func (d DockerRunner) image() string {
@@ -95,7 +95,7 @@ func (d DockerRunner) RunSkill(ctx context.Context, sj SkillJob, emit func(Event
 		dockerArgs = append(dockerArgs, "-e", "CLAUDE_CODE_OAUTH_TOKEN")
 	}
 	if d.AnthropicAPIURL != "" {
-		dockerArgs = append(dockerArgs, "-e", "ANTHROPIC_API_URL="+d.AnthropicAPIURL)
+		dockerArgs = append(dockerArgs, "-e", "ANTHROPIC_BASE_URL="+d.AnthropicAPIURL)
 	}
 	dockerArgs = append(dockerArgs, d.image())
 	dockerArgs = append(dockerArgs, claudeArgs...)
@@ -110,7 +110,11 @@ func (d DockerRunner) RunSkill(ctx context.Context, sj SkillJob, emit func(Event
 	}
 	cmd.Stderr = cmd.Stdout
 
-	emit(Event{Kind: KindText, Text: "$ docker run --rm " + d.image() + " <skill:" + sj.Name + ">"})
+	logLine := "$ docker run --rm " + d.image() + " <skill:" + sj.Name + ">"
+	if d.AnthropicAPIURL != "" {
+		logLine += " [ANTHROPIC_BASE_URL=" + d.AnthropicAPIURL + "]"
+	}
+	emit(Event{Kind: KindText, Text: logLine})
 	if err := cmd.Start(); err != nil {
 		return SkillResult{}, fmt.Errorf("start docker: %w", err)
 	}

--- a/internal/worker/docker.go
+++ b/internal/worker/docker.go
@@ -20,11 +20,12 @@ const DefaultRunnerImage = "ghcr.io/alpha-omega-security/scrutineer-runner:lates
 // workspace (clone + staged skill + output file) mounted at /work. It
 // implements SkillRunner.
 type DockerRunner struct {
-	Image     string
-	Effort    string
-	ProxyURL  string // http://user:token@host.docker.internal:port; "" disables egress
-	FullClone bool
-	MaxTurns  int
+	Image           string
+	Effort          string
+	ProxyURL        string // http://user:token@host.docker.internal:port; "" disables egress
+	FullClone       bool
+	MaxTurns        int
+	AnthropicAPIURL string // passed as ANTHROPIC_API_URL env var to the container
 }
 
 func (d DockerRunner) image() string {
@@ -92,6 +93,9 @@ func (d DockerRunner) RunSkill(ctx context.Context, sj SkillJob, emit func(Event
 	}
 	if os.Getenv("CLAUDE_CODE_OAUTH_TOKEN") != "" {
 		dockerArgs = append(dockerArgs, "-e", "CLAUDE_CODE_OAUTH_TOKEN")
+	}
+	if d.AnthropicAPIURL != "" {
+		dockerArgs = append(dockerArgs, "-e", "ANTHROPIC_API_URL="+d.AnthropicAPIURL)
 	}
 	dockerArgs = append(dockerArgs, d.image())
 	dockerArgs = append(dockerArgs, claudeArgs...)

--- a/internal/worker/docker.go
+++ b/internal/worker/docker.go
@@ -20,11 +20,11 @@ const DefaultRunnerImage = "ghcr.io/alpha-omega-security/scrutineer-runner:lates
 // workspace (clone + staged skill + output file) mounted at /work. It
 // implements SkillRunner.
 type DockerRunner struct {
-	Image           string
-	Effort          string
-	ProxyURL        string // http://user:token@host.docker.internal:port; "" disables egress
-	FullClone       bool
-	MaxTurns        int
+	Image            string
+	Effort           string
+	ProxyURL         string // http://user:token@host.docker.internal:port; "" disables egress
+	FullClone        bool
+	MaxTurns         int
 	AnthropicBaseURL string // passed as ANTHROPIC_BASE_URL env var to the container
 }
 

--- a/internal/worker/docker.go
+++ b/internal/worker/docker.go
@@ -25,7 +25,7 @@ type DockerRunner struct {
 	ProxyURL        string // http://user:token@host.docker.internal:port; "" disables egress
 	FullClone       bool
 	MaxTurns        int
-	AnthropicAPIURL string // passed as ANTHROPIC_BASE_URL env var to the container
+	AnthropicBaseURL string // passed as ANTHROPIC_BASE_URL env var to the container
 }
 
 func (d DockerRunner) image() string {
@@ -94,8 +94,8 @@ func (d DockerRunner) RunSkill(ctx context.Context, sj SkillJob, emit func(Event
 	if os.Getenv("CLAUDE_CODE_OAUTH_TOKEN") != "" {
 		dockerArgs = append(dockerArgs, "-e", "CLAUDE_CODE_OAUTH_TOKEN")
 	}
-	if d.AnthropicAPIURL != "" {
-		dockerArgs = append(dockerArgs, "-e", "ANTHROPIC_BASE_URL="+d.AnthropicAPIURL)
+	if d.AnthropicBaseURL != "" {
+		dockerArgs = append(dockerArgs, "-e", "ANTHROPIC_BASE_URL="+d.AnthropicBaseURL)
 	}
 	dockerArgs = append(dockerArgs, d.image())
 	dockerArgs = append(dockerArgs, claudeArgs...)
@@ -111,8 +111,8 @@ func (d DockerRunner) RunSkill(ctx context.Context, sj SkillJob, emit func(Event
 	cmd.Stderr = cmd.Stdout
 
 	logLine := "$ docker run --rm " + d.image() + " <skill:" + sj.Name + ">"
-	if d.AnthropicAPIURL != "" {
-		logLine += " [ANTHROPIC_BASE_URL=" + d.AnthropicAPIURL + "]"
+	if d.AnthropicBaseURL != "" {
+		logLine += " [ANTHROPIC_BASE_URL=" + d.AnthropicBaseURL + "]"
 	}
 	emit(Event{Kind: KindText, Text: logLine})
 	if err := cmd.Start(); err != nil {

--- a/scrutineer.sample.yaml
+++ b/scrutineer.sample.yaml
@@ -55,7 +55,7 @@
 # max_turns: 0
 
 # Custom Anthropic API base URL. When set, the hostname is automatically
-# added to the egress allowlist. Falls back to the ANTHROPIC_API_URL
+# added to the egress allowlist. Falls back to the ANTHROPIC_BASE_URL
 # environment variable when empty.
 # anthropic_api_url: https://my-proxy.corp.com/v1
 

--- a/scrutineer.sample.yaml
+++ b/scrutineer.sample.yaml
@@ -57,7 +57,7 @@
 # Custom Anthropic API base URL. When set, the hostname is automatically
 # added to the egress allowlist. Falls back to the ANTHROPIC_BASE_URL
 # environment variable when empty.
-# anthropic_api_url: https://my-proxy.corp.com/v1
+# anthropic_base_url: https://my-proxy.corp.com/v1
 
 # The model picker in the UI. Replacing this list replaces the built-in
 # set (Sonnet, Opus). Leave it out to keep the built-in list.

--- a/scrutineer.sample.yaml
+++ b/scrutineer.sample.yaml
@@ -54,6 +54,11 @@
 # is ~140 turns, so 200 is a safe ceiling if you want one.
 # max_turns: 0
 
+# Custom Anthropic API base URL. When set, the hostname is automatically
+# added to the egress allowlist. Falls back to the ANTHROPIC_API_URL
+# environment variable when empty.
+# anthropic_api_url: https://my-proxy.corp.com/v1
+
 # The model picker in the UI. Replacing this list replaces the built-in
 # set (Sonnet, Opus). Leave it out to keep the built-in list.
 # models:


### PR DESCRIPTION
## Summary

This MR adds `-anthropic-base-url` flag and `anthropic_base_url` YAML field so operators can point `scrutineer` at a custom Anthropic API endpoint (e.g. an LLM proxy, like I wanted to!). Falls back to the `ANTHROPIC_BASE_URL` env var when neither the flag nor config is set. This means the resolution order: CLI flag > YAML config > env var > default.

> [!NOTE]
> I wasn't sure if this should be a config option or an env var - I chose to do both, because my understanding is that `ANTHROPIC_BASE_URL` _may_ be set on a local system, but it may not always be. More than happy to update based on feedback, though! 

The resolved URL is passed as `ANTHROPIC_BASE_URL` to Docker containers and its hostname is automatically added to the egress proxy allowlist, so a single config change is all that's needed. The scan log now surfaces the resolved URL so operators can confirm it's being forwarded.

## Test

Tests cover the three merge precedence cases (config fills default, explicit flag wins, zero-value config leaves default alone) plus `baseURLHost` extraction. I also made sure this ran locally, confirming that the `ANTHROPIC_BASE_URL` is passed to the runner container & the requests hit the LLM proxy a-ok. :)