### PR TITLE
worker: remove scan workspace after successful completion

### DIFF
--- a/internal/worker/skill.go
+++ b/internal/worker/skill.go
@@ -74,10 +74,10 @@ func (w *Worker) doSkill(ctx context.Context, scan *db.Scan, emit func(Event)) (
 	})
 
 	// Per-scan workspace keeps concurrent skills on the same repo from
-	// clobbering each other's src/ and report.json. Cleaned at scan
-	// completion so we don't accumulate disk; failed-scan dirs are left
-	// behind so the operator can inspect them.
-	workRoot := filepath.Join(w.DataDir, fmt.Sprintf("scan-%d", scan.ID))
+	// clobbering each other's src/ and report.json. wrap() removes it on
+	// successful completion; failed/cancelled dirs are left so the
+	// operator can inspect what the skill saw.
+	workRoot := w.workRoot(scan.ID)
 	skillDir := filepath.Join(workRoot, ".claude", "skills", skill.Name)
 	if err := stageSkill(&skill, skillDir); err != nil {
 		return "", fmt.Errorf("stage skill: %w", err)

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -8,6 +8,8 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"os"
+	"path/filepath"
 	"sync"
 	"time"
 
@@ -61,6 +63,11 @@ func (w *Worker) publish(scanID, repoID uint, name, data string) {
 	if w.OnEvent != nil {
 		w.OnEvent(scanID, repoID, name, data)
 	}
+}
+
+// workRoot returns the per-scan workspace directory under DataDir.
+func (w *Worker) workRoot(scanID uint) string {
+	return filepath.Join(w.DataDir, fmt.Sprintf("scan-%d", scanID))
 }
 
 func (w *Worker) Register(q *queue.Queue) {
@@ -156,6 +163,11 @@ func (w *Worker) wrap(h handler) func(context.Context, []byte) error {
 		}
 		if saveErr := w.DB.Save(&scan).Error; saveErr != nil {
 			return saveErr
+		}
+		if scan.Status == db.ScanDone {
+			if rmErr := os.RemoveAll(w.workRoot(scan.ID)); rmErr != nil {
+				w.Log.Warn("workspace cleanup failed", "scan", scan.ID, "err", rmErr)
+			}
 		}
 		w.publish(scan.ID, scan.RepositoryID, "scan-status", string(scan.Status))
 		w.Log.Info("job finished", "scan", scan.ID, "kind", scan.Kind, "status", scan.Status)

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -3,8 +3,10 @@ package worker
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"log/slog"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -80,5 +82,52 @@ func TestWorker_CancelStopsRunningScan(t *testing.T) {
 	}
 	if w.Cancel(scan.ID) {
 		t.Error("Cancel returned true after job finished")
+	}
+}
+
+func TestWorker_workspaceCleanup(t *testing.T) {
+	gdb, err := db.Open(filepath.Join(t.TempDir(), "wc.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo := db.Repository{URL: "https://example.com/x", Name: "x"}
+	gdb.Create(&repo)
+	skill := db.Skill{Name: "noop", Body: "b", Active: true, Source: "ui", Version: 1}
+	gdb.Create(&skill)
+
+	dataDir := t.TempDir()
+	run := func(r SkillRunner) (db.Scan, string) {
+		scan := db.Scan{RepositoryID: repo.ID, Kind: JobSkill, Status: db.ScanQueued, SkillID: &skill.ID}
+		gdb.Create(&scan)
+		w := &Worker{
+			DB:      gdb,
+			Log:     slog.New(slog.NewTextHandler(io.Discard, nil)),
+			DataDir: dataDir,
+			Runner:  r,
+		}
+		body, _ := json.Marshal(queue.Payload{ScanID: scan.ID})
+		if err := w.wrap(w.doSkill)(context.Background(), body); err != nil {
+			t.Fatalf("wrap: %v", err)
+		}
+		gdb.First(&scan, scan.ID)
+		return scan, w.workRoot(scan.ID)
+	}
+
+	// Successful scan: workspace removed.
+	ok, okRoot := run(fakeRunner{skillRes: SkillResult{Report: ""}})
+	if ok.Status != db.ScanDone {
+		t.Fatalf("status = %s, want done (err=%q)", ok.Status, ok.Error)
+	}
+	if _, err := os.Stat(okRoot); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("workspace %s not removed after successful scan", okRoot)
+	}
+
+	// Failed scan: workspace kept for inspection.
+	fail, failRoot := run(fakeRunner{skillErr: errors.New("boom")})
+	if fail.Status != db.ScanFailed {
+		t.Fatalf("status = %s, want failed", fail.Status)
+	}
+	if _, err := os.Stat(failRoot); err != nil {
+		t.Errorf("workspace %s should be kept after failed scan: %v", failRoot, err)
 	}
 }


### PR DESCRIPTION
The comment at `skill.go` claimed "Cleaned at scan completion so we don't accumulate disk; failed-scan dirs are left behind" but the `os.RemoveAll(workRoot)` was never there. Every scan, successful or not, left its `data/work/scan-{id}/` directory behind. With ~12 skills × ~370 repos × a clone each, my instance hit 70 GB in `data/work/` and ran the host disk out of space.

This adds the missing cleanup in `wrap()` after the scan is saved as `ScanDone`. Failed and cancelled scans still keep their workspace as the comment intends. `workRoot()` is extracted so the path is computed once and shared between `doSkill` and the cleanup. Test runs both a successful and a failed scan through `wrap` and asserts the dir is removed/kept respectively.

Existing instances will still have accumulated `scan-*` and legacy `repo-*` dirs under `data/work/`; those can be cleared manually with `rm -rf data/work/scan-* data/work/repo-*`.