### PR TITLE
feat: implement CSAF document generation and validation for findings

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ toolchain go1.26.2
 require (
 	github.com/git-pkgs/sbom v0.1.0
 	github.com/glebarez/sqlite v1.11.0
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	github.com/yuin/goldmark v1.8.2
 	gopkg.in/yaml.v3 v3.0.1
 	gorm.io/gorm v1.31.1
@@ -22,7 +23,6 @@ require (
 	github.com/mattn/go-isatty v0.0.22 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
-	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
 	golang.org/x/sys v0.43.0 // indirect
 	golang.org/x/text v0.36.0 // indirect
 	modernc.org/libc v1.72.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/mattn/go-isatty v0.0.22 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
 	golang.org/x/sys v0.43.0 // indirect
 	golang.org/x/text v0.36.0 // indirect
 	modernc.org/libc v1.72.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
+github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/git-pkgs/sbom v0.1.0 h1:rMNqpHl8qb2MPHF3g0dlL0RU5r0lfcpI3uXmJR9bd+U=

--- a/go.sum
+++ b/go.sum
@@ -32,6 +32,8 @@ github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOF
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 h1:KRzFb2m7YtdldCEkzs6KqmJw4nqEVZGK7IN2kJkjTuQ=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.2/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
 github.com/yuin/goldmark v1.8.2 h1:kEGpgqJXdgbkhcOgBxkC0X0PmoPG1ZyoZ117rDVp4zE=
 github.com/yuin/goldmark v1.8.2/go.mod h1:ip/1k0VRfGynBgxOz0yCqHrbZXhcjxyuS66Brc7iBKg=
 golang.org/x/crypto v0.45.0 h1:jMBrvKuj23MTlT0bQEOBcAE0mjg8mK9RXFhRH6nyF3Q=

--- a/internal/web/csaf_schemas/README.md
+++ b/internal/web/csaf_schemas/README.md
@@ -1,0 +1,15 @@
+# Vendored JSON Schemas
+
+These schemas are embedded into the binary (`//go:embed csaf_schemas/*.json`) and
+used to validate generated CSAF 2.0 VEX documents at runtime.
+
+| File                     | Source                                                                 | Snapshot date |
+|--------------------------|------------------------------------------------------------------------|---------------|
+| `csaf_json_schema.json`  | https://docs.oasis-open.org/csaf/csaf/v2.0/csaf_json_schema.json       | 2026-04-29    |
+| `cvss-v2.0.json`         | https://www.first.org/cvss/cvss-v2.0.json                              | 2026-04-29    |
+| `cvss-v3.0.json`         | https://www.first.org/cvss/cvss-v3.0.json                              | 2026-04-29    |
+| `cvss-v3.1.json`         | https://www.first.org/cvss/cvss-v3.1.json                              | 2026-04-29    |
+
+Refresh by re-fetching from the source URLs above. The CSAF schema's `$ref`
+entries point to the no-query CVSS URLs; if a CVSS schema is updated upstream
+with a new `$id` query suffix, strip it locally so resolution still works.

--- a/internal/web/csaf_schemas/csaf_json_schema.json
+++ b/internal/web/csaf_schemas/csaf_json_schema.json
@@ -1,0 +1,1414 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://docs.oasis-open.org/csaf/csaf/v2.0/csaf_json_schema.json",
+  "title": "Common Security Advisory Framework",
+  "description": "Representation of security advisory information as a JSON document.",
+  "type": "object",
+  "$defs": {
+    "acknowledgments_t": {
+      "title": "List of acknowledgments",
+      "description": "Contains a list of acknowledgment elements.",
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "title": "Acknowledgment",
+        "description": "Acknowledges contributions by describing those that contributed.",
+        "type": "object",
+        "minProperties": 1,
+        "properties": {
+          "names": {
+            "title": "List of acknowledged names",
+            "description": "Contains the names of contributors being recognized.",
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "title": "Name of the contributor",
+              "description": "Contains the name of a single contributor being recognized.",
+              "type": "string",
+              "minLength": 1,
+              "examples": [
+                "Albert Einstein",
+                "Johann Sebastian Bach"
+              ]
+            }
+          },
+          "organization": {
+            "title": "Contributing organization",
+            "description": "Contains the name of a contributing organization being recognized.",
+            "type": "string",
+            "minLength": 1,
+            "examples": [
+              "CISA",
+              "Google Project Zero",
+              "Talos"
+            ]
+          },
+          "summary": {
+            "title": "Summary of the acknowledgment",
+            "description": "SHOULD represent any contextual details the document producers wish to make known about the acknowledgment or acknowledged parties.",
+            "type": "string",
+            "minLength": 1,
+            "examples": [
+              "First analysis of Coordinated Multi-Stream Attack (CMSA)"
+            ]
+          },
+          "urls": {
+            "title": "List of URLs",
+            "description": "Specifies a list of URLs or location of the reference to be acknowledged.",
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "title": "URL of acknowledgment",
+              "description": "Contains the URL or location of the reference to be acknowledged.",
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        }
+      }
+    },
+    "branches_t": {
+      "title": "List of branches",
+      "description": "Contains branch elements as children of the current element.",
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "title": "Branch",
+        "description": "Is a part of the hierarchical structure of the product tree.",
+        "type": "object",
+        "maxProperties": 3,
+        "minProperties": 3,
+        "required": [
+          "category",
+          "name"
+        ],
+        "properties": {
+          "branches": {
+            "$ref": "#/$defs/branches_t"
+          },
+          "category": {
+            "title": "Category of the branch",
+            "description": "Describes the characteristics of the labeled branch.",
+            "type": "string",
+            "enum": [
+              "architecture",
+              "host_name",
+              "language",
+              "legacy",
+              "patch_level",
+              "product_family",
+              "product_name",
+              "product_version",
+              "product_version_range",
+              "service_pack",
+              "specification",
+              "vendor"
+            ]
+          },
+          "name": {
+            "title": "Name of the branch",
+            "description": "Contains the canonical descriptor or 'friendly name' of the branch.",
+            "type": "string",
+            "minLength": 1,
+            "examples": [
+              "10",
+              "365",
+              "Microsoft",
+              "Office",
+              "PCS 7",
+              "SIMATIC",
+              "Siemens",
+              "Windows"
+            ]
+          },
+          "product": {
+            "$ref": "#/$defs/full_product_name_t"
+          }
+        }
+      }
+    },
+    "full_product_name_t": {
+      "title": "Full product name",
+      "description": "Specifies information about the product and assigns the product_id.",
+      "type": "object",
+      "required": [
+        "name",
+        "product_id"
+      ],
+      "properties": {
+        "name": {
+          "title": "Textual description of the product",
+          "description": "The value should be the product’s full canonical name, including version number and other attributes, as it would be used in a human-friendly document.",
+          "type": "string",
+          "minLength": 1,
+          "examples": [
+            "Cisco AnyConnect Secure Mobility Client 2.3.185",
+            "Microsoft Host Integration Server 2006 Service Pack 1"
+          ]
+        },
+        "product_id": {
+          "$ref": "#/$defs/product_id_t"
+        },
+        "product_identification_helper": {
+          "title": "Helper to identify the product",
+          "description": "Provides at least one method which aids in identifying the product in an asset database.",
+          "type": "object",
+          "minProperties": 1,
+          "properties": {
+            "cpe": {
+              "title": "Common Platform Enumeration representation",
+              "description": "The Common Platform Enumeration (CPE) attribute refers to a method for naming platforms external to this specification.",
+              "type": "string",
+              "pattern": "^(cpe:2\\.3:[aho\\*\\-](:(((\\?*|\\*?)([a-zA-Z0-9\\-\\._]|(\\\\[\\\\\\*\\?!\"#\\$%&'\\(\\)\\+,/:;<=>@\\[\\]\\^`\\{\\|\\}~]))+(\\?*|\\*?))|[\\*\\-])){5}(:(([a-zA-Z]{2,3}(-([a-zA-Z]{2}|[0-9]{3}))?)|[\\*\\-]))(:(((\\?*|\\*?)([a-zA-Z0-9\\-\\._]|(\\\\[\\\\\\*\\?!\"#\\$%&'\\(\\)\\+,/:;<=>@\\[\\]\\^`\\{\\|\\}~]))+(\\?*|\\*?))|[\\*\\-])){4})|([c][pP][eE]:/[AHOaho]?(:[A-Za-z0-9\\._\\-~%]*){0,6})$",
+              "minLength": 5
+            },
+            "hashes": {
+              "title": "List of hashes",
+              "description": "Contains a list of cryptographic hashes usable to identify files.",
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "title": "Cryptographic hashes",
+                "description": "Contains all information to identify a file based on its cryptographic hash values.",
+                "type": "object",
+                "required": [
+                  "file_hashes",
+                  "filename"
+                ],
+                "properties": {
+                  "file_hashes": {
+                    "title": "List of file hashes",
+                    "description": "Contains a list of cryptographic hashes for this file.",
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                      "title": "File hash",
+                      "description": "Contains one hash value and algorithm of the file to be identified.",
+                      "type": "object",
+                      "required": [
+                        "algorithm",
+                        "value"
+                      ],
+                      "properties": {
+                        "algorithm": {
+                          "title": "Algorithm of the cryptographic hash",
+                          "description": "Contains the name of the cryptographic hash algorithm used to calculate the value.",
+                          "type": "string",
+                          "default": "sha256",
+                          "minLength": 1,
+                          "examples": [
+                            "blake2b512",
+                            "sha256",
+                            "sha3-512",
+                            "sha384",
+                            "sha512"
+                          ]
+                        },
+                        "value": {
+                          "title": "Value of the cryptographic hash",
+                          "description": "Contains the cryptographic hash value in hexadecimal representation.",
+                          "type": "string",
+                          "pattern": "^[0-9a-fA-F]{32,}$",
+                          "minLength": 32,
+                          "examples": [
+                            "37df33cb7464da5c7f077f4d56a32bc84987ec1d85b234537c1c1a4d4fc8d09dc29e2e762cb5203677bf849a2855a0283710f1f5fe1d6ce8d5ac85c645d0fcb3",
+                            "4775203615d9534a8bfca96a93dc8b461a489f69124a130d786b42204f3341cc",
+                            "9ea4c8200113d49d26505da0e02e2f49055dc078d1ad7a419b32e291c7afebbb84badfbd46dec42883bea0b2a1fa697c"
+                          ]
+                        }
+                      }
+                    }
+                  },
+                  "filename": {
+                    "title": "Filename",
+                    "description": "Contains the name of the file which is identified by the hash values.",
+                    "type": "string",
+                    "minLength": 1,
+                    "examples": [
+                      "WINWORD.EXE",
+                      "msotadddin.dll",
+                      "sudoers.so"
+                    ]
+                  }
+                }
+              }
+            },
+            "model_numbers": {
+              "title": "List of models",
+              "description": "Contains a list of full or abbreviated (partial) model numbers.",
+              "type": "array",
+              "minItems": 1,
+              "uniqueItems": true,
+              "items": {
+                "title": "Model number",
+                "description": "Contains a full or abbreviated (partial) model number of the component to identify.",
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "purl": {
+              "title": "package URL representation",
+              "description": "The package URL (purl) attribute refers to a method for reliably identifying and locating software packages external to this specification.",
+              "type": "string",
+              "format": "uri",
+              "pattern": "^pkg:[A-Za-z\\.\\-\\+][A-Za-z0-9\\.\\-\\+]*/.+",
+              "minLength": 7
+            },
+            "sbom_urls": {
+              "title": "List of SBOM URLs",
+              "description": "Contains a list of URLs where SBOMs for this product can be retrieved.",
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "title": "SBOM URL",
+                "description": "Contains a URL of one SBOM for this product.",
+                "type": "string",
+                "format": "uri"
+              }
+            },
+            "serial_numbers": {
+              "title": "List of serial numbers",
+              "description": "Contains a list of full or abbreviated (partial) serial numbers.",
+              "type": "array",
+              "minItems": 1,
+              "uniqueItems": true,
+              "items": {
+                "title": "Serial number",
+                "description": "Contains a full or abbreviated (partial) serial number of the component to identify.",
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "skus": {
+              "title": "List of stock keeping units",
+              "description": "Contains a list of full or abbreviated (partial) stock keeping units.",
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "title": "Stock keeping unit",
+                "description": "Contains a full or abbreviated (partial) stock keeping unit (SKU) which is used in the ordering process to identify the component.",
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "x_generic_uris": {
+              "title": "List of generic URIs",
+              "description": "Contains a list of identifiers which are either vendor-specific or derived from a standard not yet supported.",
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "title": "Generic URI",
+                "description": "Provides a generic extension point for any identifier which is either vendor-specific or derived from a standard not yet supported.",
+                "type": "object",
+                "required": [
+                  "namespace",
+                  "uri"
+                ],
+                "properties": {
+                  "namespace": {
+                    "title": "Namespace of the generic URI",
+                    "description": "Refers to a URL which provides the name and knowledge about the specification used or is the namespace in which these values are valid.",
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "uri": {
+                    "title": "URI",
+                    "description": "Contains the identifier itself.",
+                    "type": "string",
+                    "format": "uri"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "lang_t": {
+      "title": "Language type",
+      "description": "Identifies a language, corresponding to IETF BCP 47 / RFC 5646. See IETF language registry: https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry",
+      "type": "string",
+      "pattern": "^(([A-Za-z]{2,3}(-[A-Za-z]{3}(-[A-Za-z]{3}){0,2})?|[A-Za-z]{4,8})(-[A-Za-z]{4})?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-[A-WY-Za-wy-z0-9](-[A-Za-z0-9]{2,8})+)*(-[Xx](-[A-Za-z0-9]{1,8})+)?|[Xx](-[A-Za-z0-9]{1,8})+|[Ii]-[Dd][Ee][Ff][Aa][Uu][Ll][Tt]|[Ii]-[Mm][Ii][Nn][Gg][Oo])$",
+      "examples": [
+        "de",
+        "en",
+        "fr",
+        "frc",
+        "jp"
+      ]
+    },
+    "notes_t": {
+      "title": "List of notes",
+      "description": "Contains notes which are specific to the current context.",
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "title": "Note",
+        "description": "Is a place to put all manner of text blobs related to the current context.",
+        "type": "object",
+        "required": [
+          "category",
+          "text"
+        ],
+        "properties": {
+          "audience": {
+            "title": "Audience of note",
+            "description": "Indicates who is intended to read it.",
+            "type": "string",
+            "minLength": 1,
+            "examples": [
+              "all",
+              "executives",
+              "operational management and system administrators",
+              "safety engineers"
+            ]
+          },
+          "category": {
+            "title": "Note category",
+            "description": "Contains the information of what kind of note this is.",
+            "type": "string",
+            "enum": [
+              "description",
+              "details",
+              "faq",
+              "general",
+              "legal_disclaimer",
+              "other",
+              "summary"
+            ]
+          },
+          "text": {
+            "title": "Note content",
+            "description": "Holds the content of the note. Content varies depending on type.",
+            "type": "string",
+            "minLength": 1
+          },
+          "title": {
+            "title": "Title of note",
+            "description": "Provides a concise description of what is contained in the text of the note.",
+            "type": "string",
+            "minLength": 1,
+            "examples": [
+              "Details",
+              "Executive summary",
+              "Technical summary",
+              "Impact on safety systems"
+            ]
+          }
+        }
+      }
+    },
+    "product_group_id_t": {
+      "title": "Reference token for product group instance",
+      "description": "Token required to identify a group of products so that it can be referred to from other parts in the document. There is no predefined or required format for the product_group_id as long as it uniquely identifies a group in the context of the current document.",
+      "type": "string",
+      "minLength": 1,
+      "examples": [
+        "CSAFGID-0001",
+        "CSAFGID-0002",
+        "CSAFGID-0020"
+      ]
+    },
+    "product_groups_t": {
+      "title": "List of product_group_ids",
+      "description": "Specifies a list of product_group_ids to give context to the parent item.",
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/$defs/product_group_id_t"
+      }
+    },
+    "product_id_t": {
+      "title": "Reference token for product instance",
+      "description": "Token required to identify a full_product_name so that it can be referred to from other parts in the document. There is no predefined or required format for the product_id as long as it uniquely identifies a product in the context of the current document.",
+      "type": "string",
+      "minLength": 1,
+      "examples": [
+        "CSAFPID-0004",
+        "CSAFPID-0008"
+      ]
+    },
+    "products_t": {
+      "title": "List of product_ids",
+      "description": "Specifies a list of product_ids to give context to the parent item.",
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/$defs/product_id_t"
+      }
+    },
+    "references_t": {
+      "title": "List of references",
+      "description": "Holds a list of references.",
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "title": "Reference",
+        "description": "Holds any reference to conferences, papers, advisories, and other resources that are related and considered related to either a surrounding part of or the entire document and to be of value to the document consumer.",
+        "type": "object",
+        "required": [
+          "summary",
+          "url"
+        ],
+        "properties": {
+          "category": {
+            "title": "Category of reference",
+            "description": "Indicates whether the reference points to the same document or vulnerability in focus (depending on scope) or to an external resource.",
+            "type": "string",
+            "default": "external",
+            "enum": [
+              "external",
+              "self"
+            ]
+          },
+          "summary": {
+            "title": "Summary of the reference",
+            "description": "Indicates what this reference refers to.",
+            "type": "string",
+            "minLength": 1
+          },
+          "url": {
+            "title": "URL of reference",
+            "description": "Provides the URL for the reference.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "version_t": {
+      "title": "Version",
+      "description": "Specifies a version string to denote clearly the evolution of the content of the document. Format must be either integer or semantic versioning.",
+      "type": "string",
+      "pattern": "^(0|[1-9][0-9]*)$|^((0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)$",
+      "examples": [
+        "1",
+        "4",
+        "0.9.0",
+        "1.4.3",
+        "2.40.0+21AF26D3"
+      ]
+    }
+  },
+  "required": [
+    "document"
+  ],
+  "properties": {
+    "document": {
+      "title": "Document level meta-data",
+      "description": "Captures the meta-data about this document describing a particular set of security advisories.",
+      "type": "object",
+      "required": [
+        "category",
+        "csaf_version",
+        "publisher",
+        "title",
+        "tracking"
+      ],
+      "properties": {
+        "acknowledgments": {
+          "title": "Document acknowledgments",
+          "description": "Contains a list of acknowledgment elements associated with the whole document.",
+          "$ref": "#/$defs/acknowledgments_t"
+        },
+        "aggregate_severity": {
+          "title": "Aggregate severity",
+          "description": "Is a vehicle that is provided by the document producer to convey the urgency and criticality with which the one or more vulnerabilities reported should be addressed. It is a document-level metric and applied to the document as a whole — not any specific vulnerability. The range of values in this field is defined according to the document producer's policies and procedures.",
+          "type": "object",
+          "required": [
+            "text"
+          ],
+          "properties": {
+            "namespace": {
+              "title": "Namespace of aggregate severity",
+              "description": "Points to the namespace so referenced.",
+              "type": "string",
+              "format": "uri"
+            },
+            "text": {
+              "title": "Text of aggregate severity",
+              "description": "Provides a severity which is independent of - and in addition to - any other standard metric for determining the impact or severity of a given vulnerability (such as CVSS).",
+              "type": "string",
+              "minLength": 1,
+              "examples": [
+                "Critical",
+                "Important",
+                "Moderate"
+              ]
+            }
+          }
+        },
+        "category": {
+          "title": "Document category",
+          "description": "Defines a short canonical name, chosen by the document producer, which will inform the end user as to the category of document.",
+          "type": "string",
+          "pattern": "^[^\\s\\-_\\.](.*[^\\s\\-_\\.])?$",
+          "minLength": 1,
+          "examples": [
+            "csaf_base",
+            "csaf_security_advisory",
+            "csaf_vex",
+            "Example Company Security Notice"
+          ]
+        },
+        "csaf_version": {
+          "title": "CSAF version",
+          "description": "Gives the version of the CSAF specification which the document was generated for.",
+          "type": "string",
+          "enum": [
+            "2.0"
+          ]
+        },
+        "distribution": {
+          "title": "Rules for sharing document",
+          "description": "Describe any constraints on how this document might be shared.",
+          "type": "object",
+          "minProperties": 1,
+          "properties": {
+            "text": {
+              "title": "Textual description",
+              "description": "Provides a textual description of additional constraints.",
+              "type": "string",
+              "minLength": 1,
+              "examples": [
+                "Copyright 2021, Example Company, All Rights Reserved.",
+                "Distribute freely.",
+                "Share only on a need-to-know-basis only."
+              ]
+            },
+            "tlp": {
+              "title": "Traffic Light Protocol (TLP)",
+              "description": "Provides details about the TLP classification of the document.",
+              "type": "object",
+              "required": [
+                "label"
+              ],
+              "properties": {
+                "label": {
+                  "title": "Label of TLP",
+                  "description": "Provides the TLP label of the document.",
+                  "type": "string",
+                  "enum": [
+                    "AMBER",
+                    "GREEN",
+                    "RED",
+                    "WHITE"
+                  ]
+                },
+                "url": {
+                  "title": "URL of TLP version",
+                  "description": "Provides a URL where to find the textual description of the TLP version which is used in this document. Default is the URL to the definition by FIRST.",
+                  "type": "string",
+                  "default": "https://www.first.org/tlp/",
+                  "format": "uri",
+                  "examples": [
+                    "https://www.us-cert.gov/tlp",
+                    "https://www.bsi.bund.de/SharedDocs/Downloads/DE/BSI/Kritis/Merkblatt_TLP.pdf"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "lang": {
+          "title": "Document language",
+          "description": "Identifies the language used by this document, corresponding to IETF BCP 47 / RFC 5646.",
+          "$ref": "#/$defs/lang_t"
+        },
+        "notes": {
+          "title": "Document notes",
+          "description": "Holds notes associated with the whole document.",
+          "$ref": "#/$defs/notes_t"
+        },
+        "publisher": {
+          "title": "Publisher",
+          "description": "Provides information about the publisher of the document.",
+          "type": "object",
+          "required": [
+            "category",
+            "name",
+            "namespace"
+          ],
+          "properties": {
+            "category": {
+              "title": "Category of publisher",
+              "description": "Provides information about the category of publisher releasing the document.",
+              "type": "string",
+              "enum": [
+                "coordinator",
+                "discoverer",
+                "other",
+                "translator",
+                "user",
+                "vendor"
+              ]
+            },
+            "contact_details": {
+              "title": "Contact details",
+              "description": "Information on how to contact the publisher, possibly including details such as web sites, email addresses, phone numbers, and postal mail addresses.",
+              "type": "string",
+              "minLength": 1,
+              "examples": [
+                "Example Company can be reached at contact_us@example.com, or via our website at https://www.example.com/contact."
+              ]
+            },
+            "issuing_authority": {
+              "title": "Issuing authority",
+              "description": "Provides information about the authority of the issuing party to release the document, in particular, the party's constituency and responsibilities or other obligations.",
+              "type": "string",
+              "minLength": 1
+            },
+            "name": {
+              "title": "Name of publisher",
+              "description": "Contains the name of the issuing party.",
+              "type": "string",
+              "minLength": 1,
+              "examples": [
+                "BSI",
+                "Cisco PSIRT",
+                "Siemens ProductCERT"
+              ]
+            },
+            "namespace": {
+              "title": "Namespace of publisher",
+              "description": "Contains a URL which is under control of the issuing party and can be used as a globally unique identifier for that issuing party.",
+              "type": "string",
+              "format": "uri",
+              "examples": [
+                "https://csaf.io",
+                "https://www.example.com"
+              ]
+            }
+          }
+        },
+        "references": {
+          "title": "Document references",
+          "description": "Holds a list of references associated with the whole document.",
+          "$ref": "#/$defs/references_t"
+        },
+        "source_lang": {
+          "title": "Source language",
+          "description": "If this copy of the document is a translation then the value of this property describes from which language this document was translated.",
+          "$ref": "#/$defs/lang_t"
+        },
+        "title": {
+          "title": "Title of this document",
+          "description": "This SHOULD be a canonical name for the document, and sufficiently unique to distinguish it from similar documents.",
+          "type": "string",
+          "minLength": 1,
+          "examples": [
+            "Cisco IPv6 Crafted Packet Denial of Service Vulnerability",
+            "Example Company Cross-Site-Scripting Vulnerability in Example Generator"
+          ]
+        },
+        "tracking": {
+          "title": "Tracking",
+          "description": "Is a container designated to hold all management attributes necessary to track a CSAF document as a whole.",
+          "type": "object",
+          "required": [
+            "current_release_date",
+            "id",
+            "initial_release_date",
+            "revision_history",
+            "status",
+            "version"
+          ],
+          "properties": {
+            "aliases": {
+              "title": "Aliases",
+              "description": "Contains a list of alternate names for the same document.",
+              "type": "array",
+              "minItems": 1,
+              "uniqueItems": true,
+              "items": {
+                "title": "Alternate name",
+                "description": "Specifies a non-empty string that represents a distinct optional alternative ID used to refer to the document.",
+                "type": "string",
+                "minLength": 1,
+                "examples": [
+                  "CVE-2019-12345"
+                ]
+              }
+            },
+            "current_release_date": {
+              "title": "Current release date",
+              "description": "The date when the current revision of this document was released",
+              "type": "string",
+              "format": "date-time"
+            },
+            "generator": {
+              "title": "Document generator",
+              "description": "Is a container to hold all elements related to the generation of the document. These items will reference when the document was actually created, including the date it was generated and the entity that generated it.",
+              "type": "object",
+              "required": [
+                "engine"
+              ],
+              "properties": {
+                "date": {
+                  "title": "Date of document generation",
+                  "description": "This SHOULD be the current date that the document was generated. Because documents are often generated internally by a document producer and exist for a nonzero amount of time before being released, this field MAY be different from the Initial Release Date and Current Release Date.",
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "engine": {
+                  "title": "Engine of document generation",
+                  "description": "Contains information about the engine that generated the CSAF document.",
+                  "type": "object",
+                  "required": [
+                    "name"
+                  ],
+                  "properties": {
+                    "name": {
+                      "title": "Engine name",
+                      "description": "Represents the name of the engine that generated the CSAF document.",
+                      "type": "string",
+                      "minLength": 1,
+                      "examples": [
+                        "Red Hat rhsa-to-cvrf",
+                        "Secvisogram",
+                        "TVCE"
+                      ]
+                    },
+                    "version": {
+                      "title": "Engine version",
+                      "description": "Contains the version of the engine that generated the CSAF document.",
+                      "type": "string",
+                      "minLength": 1,
+                      "examples": [
+                        "0.6.0",
+                        "1.0.0-beta+exp.sha.a1c44f85",
+                        "2"
+                      ]
+                    }
+                  }
+                }
+              }
+            },
+            "id": {
+              "title": "Unique identifier for the document",
+              "description": "The ID is a simple label that provides for a wide range of numbering values, types, and schemes. Its value SHOULD be assigned and maintained by the original document issuing authority.",
+              "type": "string",
+              "pattern": "^[\\S](.*[\\S])?$",
+              "minLength": 1,
+              "examples": [
+                "Example Company - 2019-YH3234",
+                "RHBA-2019:0024",
+                "cisco-sa-20190513-secureboot"
+              ]
+            },
+            "initial_release_date": {
+              "title": "Initial release date",
+              "description": "The date when this document was first published.",
+              "type": "string",
+              "format": "date-time"
+            },
+            "revision_history": {
+              "title": "Revision history",
+              "description": "Holds one revision item for each version of the CSAF document, including the initial one.",
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "title": "Revision",
+                "description": "Contains all the information elements required to track the evolution of a CSAF document.",
+                "type": "object",
+                "required": [
+                  "date",
+                  "number",
+                  "summary"
+                ],
+                "properties": {
+                  "date": {
+                    "title": "Date of the revision",
+                    "description": "The date of the revision entry",
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "legacy_version": {
+                    "title": "Legacy version of the revision",
+                    "description": "Contains the version string used in an existing document with the same content.",
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "number": {
+                    "$ref": "#/$defs/version_t"
+                  },
+                  "summary": {
+                    "title": "Summary of the revision",
+                    "description": "Holds a single non-empty string representing a short description of the changes.",
+                    "type": "string",
+                    "minLength": 1,
+                    "examples": [
+                      "Initial version."
+                    ]
+                  }
+                }
+              }
+            },
+            "status": {
+              "title": "Document status",
+              "description": "Defines the draft status of the document.",
+              "type": "string",
+              "enum": [
+                "draft",
+                "final",
+                "interim"
+              ]
+            },
+            "version": {
+              "$ref": "#/$defs/version_t"
+            }
+          }
+        }
+      }
+    },
+    "product_tree": {
+      "title": "Product tree",
+      "description": "Is a container for all fully qualified product names that can be referenced elsewhere in the document.",
+      "type": "object",
+      "minProperties": 1,
+      "properties": {
+        "branches": {
+          "$ref": "#/$defs/branches_t"
+        },
+        "full_product_names": {
+          "title": "List of full product names",
+          "description": "Contains a list of full product names.",
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/full_product_name_t"
+          }
+        },
+        "product_groups": {
+          "title": "List of product groups",
+          "description": "Contains a list of product groups.",
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "title": "Product group",
+            "description": "Defines a new logical group of products that can then be referred to in other parts of the document to address a group of products with a single identifier.",
+            "type": "object",
+            "required": [
+              "group_id",
+              "product_ids"
+            ],
+            "properties": {
+              "group_id": {
+                "$ref": "#/$defs/product_group_id_t"
+              },
+              "product_ids": {
+                "title": "List of Product IDs",
+                "description": "Lists the product_ids of those products which known as one group in the document.",
+                "type": "array",
+                "minItems": 2,
+                "uniqueItems": true,
+                "items": {
+                  "$ref": "#/$defs/product_id_t"
+                }
+              },
+              "summary": {
+                "title": "Summary of the product group",
+                "description": "Gives a short, optional description of the group.",
+                "type": "string",
+                "minLength": 1,
+                "examples": [
+                  "Products supporting Modbus.",
+                  "The x64 versions of the operating system."
+                ]
+              }
+            }
+          }
+        },
+        "relationships": {
+          "title": "List of relationships",
+          "description": "Contains a list of relationships.",
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "title": "Relationship",
+            "description": "Establishes a link between two existing full_product_name_t elements, allowing the document producer to define a combination of two products that form a new full_product_name entry.",
+            "type": "object",
+            "required": [
+              "category",
+              "full_product_name",
+              "product_reference",
+              "relates_to_product_reference"
+            ],
+            "properties": {
+              "category": {
+                "title": "Relationship category",
+                "description": "Defines the category of relationship for the referenced component.",
+                "type": "string",
+                "enum": [
+                  "default_component_of",
+                  "external_component_of",
+                  "installed_on",
+                  "installed_with",
+                  "optional_component_of"
+                ]
+              },
+              "full_product_name": {
+                "$ref": "#/$defs/full_product_name_t"
+              },
+              "product_reference": {
+                "title": "Product reference",
+                "description": "Holds a Product ID that refers to the Full Product Name element, which is referenced as the first element of the relationship.",
+                "$ref": "#/$defs/product_id_t"
+              },
+              "relates_to_product_reference": {
+                "title": "Relates to product reference",
+                "description": "Holds a Product ID that refers to the Full Product Name element, which is referenced as the second element of the relationship.",
+                "$ref": "#/$defs/product_id_t"
+              }
+            }
+          }
+        }
+      }
+    },
+    "vulnerabilities": {
+      "title": "Vulnerabilities",
+      "description": "Represents a list of all relevant vulnerability information items.",
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "title": "Vulnerability",
+        "description": "Is a container for the aggregation of all fields that are related to a single vulnerability in the document.",
+        "type": "object",
+        "minProperties": 1,
+        "properties": {
+          "acknowledgments": {
+            "title": "Vulnerability acknowledgments",
+            "description": "Contains a list of acknowledgment elements associated with this vulnerability item.",
+            "$ref": "#/$defs/acknowledgments_t"
+          },
+          "cve": {
+            "title": "CVE",
+            "description": "Holds the MITRE standard Common Vulnerabilities and Exposures (CVE) tracking number for the vulnerability.",
+            "type": "string",
+            "pattern": "^CVE-[0-9]{4}-[0-9]{4,}$"
+          },
+          "cwe": {
+            "title": "CWE",
+            "description": "Holds the MITRE standard Common Weakness Enumeration (CWE) for the weakness associated.",
+            "type": "object",
+            "required": [
+              "id",
+              "name"
+            ],
+            "properties": {
+              "id": {
+                "title": "Weakness ID",
+                "description": "Holds the ID for the weakness associated.",
+                "type": "string",
+                "pattern": "^CWE-[1-9]\\d{0,5}$",
+                "examples": [
+                  "CWE-22",
+                  "CWE-352",
+                  "CWE-79"
+                ]
+              },
+              "name": {
+                "title": "Weakness name",
+                "description": "Holds the full name of the weakness as given in the CWE specification.",
+                "type": "string",
+                "minLength": 1,
+                "examples": [
+                  "Cross-Site Request Forgery (CSRF)",
+                  "Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')",
+                  "Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
+                ]
+              }
+            }
+          },
+          "discovery_date": {
+            "title": "Discovery date",
+            "description": "Holds the date and time the vulnerability was originally discovered.",
+            "type": "string",
+            "format": "date-time"
+          },
+          "flags": {
+            "title": "List of flags",
+            "description": "Contains a list of machine readable flags.",
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true,
+            "items": {
+              "title": "Flag",
+              "description": "Contains product specific information in regard to this vulnerability as a single machine readable flag.",
+              "type": "object",
+              "required": [
+                "label"
+              ],
+              "properties": {
+                "date": {
+                  "title": "Date of the flag",
+                  "description": "Contains the date when assessment was done or the flag was assigned.",
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "group_ids": {
+                  "$ref": "#/$defs/product_groups_t"
+                },
+                "label": {
+                  "title": "Label of the flag",
+                  "description": "Specifies the machine readable label.",
+                  "type": "string",
+                  "enum": [
+                    "component_not_present",
+                    "inline_mitigations_already_exist",
+                    "vulnerable_code_cannot_be_controlled_by_adversary",
+                    "vulnerable_code_not_in_execute_path",
+                    "vulnerable_code_not_present"
+                  ]
+                },
+                "product_ids": {
+                  "$ref": "#/$defs/products_t"
+                }
+              }
+            }
+          },
+          "ids": {
+            "title": "List of IDs",
+            "description": "Represents a list of unique labels or tracking IDs for the vulnerability (if such information exists).",
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true,
+            "items": {
+              "title": "ID",
+              "description": "Contains a single unique label or tracking ID for the vulnerability.",
+              "type": "object",
+              "required": [
+                "system_name",
+                "text"
+              ],
+              "properties": {
+                "system_name": {
+                  "title": "System name",
+                  "description": "Indicates the name of the vulnerability tracking or numbering system.",
+                  "type": "string",
+                  "minLength": 1,
+                  "examples": [
+                    "Cisco Bug ID",
+                    "GitHub Issue"
+                  ]
+                },
+                "text": {
+                  "title": "Text",
+                  "description": "Is unique label or tracking ID for the vulnerability (if such information exists).",
+                  "type": "string",
+                  "minLength": 1,
+                  "examples": [
+                    "CSCso66472",
+                    "oasis-tcs/csaf#210"
+                  ]
+                }
+              }
+            }
+          },
+          "involvements": {
+            "title": "List of involvements",
+            "description": "Contains a list of involvements.",
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true,
+            "items": {
+              "title": "Involvement",
+              "description": "Is a container, that allows the document producers to comment on the level of involvement (or engagement) of themselves or third parties in the vulnerability identification, scoping, and remediation process.",
+              "type": "object",
+              "required": [
+                "party",
+                "status"
+              ],
+              "properties": {
+                "date": {
+                  "title": "Date of involvement",
+                  "description": "Holds the date and time of the involvement entry.",
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "party": {
+                  "title": "Party category",
+                  "description": "Defines the category of the involved party.",
+                  "type": "string",
+                  "enum": [
+                    "coordinator",
+                    "discoverer",
+                    "other",
+                    "user",
+                    "vendor"
+                  ]
+                },
+                "status": {
+                  "title": "Party status",
+                  "description": "Defines contact status of the involved party.",
+                  "type": "string",
+                  "enum": [
+                    "completed",
+                    "contact_attempted",
+                    "disputed",
+                    "in_progress",
+                    "not_contacted",
+                    "open"
+                  ]
+                },
+                "summary": {
+                  "title": "Summary of the involvement",
+                  "description": "Contains additional context regarding what is going on.",
+                  "type": "string",
+                  "minLength": 1
+                }
+              }
+            }
+          },
+          "notes": {
+            "title": "Vulnerability notes",
+            "description": "Holds notes associated with this vulnerability item.",
+            "$ref": "#/$defs/notes_t"
+          },
+          "product_status": {
+            "title": "Product status",
+            "description": "Contains different lists of product_ids which provide details on the status of the referenced product related to the current vulnerability. ",
+            "type": "object",
+            "minProperties": 1,
+            "properties": {
+              "first_affected": {
+                "title": "First affected",
+                "description": "These are the first versions of the releases known to be affected by the vulnerability.",
+                "$ref": "#/$defs/products_t"
+              },
+              "first_fixed": {
+                "title": "First fixed",
+                "description": "These versions contain the first fix for the vulnerability but may not be the recommended fixed versions.",
+                "$ref": "#/$defs/products_t"
+              },
+              "fixed": {
+                "title": "Fixed",
+                "description": "These versions contain a fix for the vulnerability but may not be the recommended fixed versions.",
+                "$ref": "#/$defs/products_t"
+              },
+              "known_affected": {
+                "title": "Known affected",
+                "description": "These versions are known to be affected by the vulnerability.",
+                "$ref": "#/$defs/products_t"
+              },
+              "known_not_affected": {
+                "title": "Known not affected",
+                "description": "These versions are known not to be affected by the vulnerability.",
+                "$ref": "#/$defs/products_t"
+              },
+              "last_affected": {
+                "title": "Last affected",
+                "description": "These are the last versions in a release train known to be affected by the vulnerability. Subsequently released versions would contain a fix for the vulnerability.",
+                "$ref": "#/$defs/products_t"
+              },
+              "recommended": {
+                "title": "Recommended",
+                "description": "These versions have a fix for the vulnerability and are the vendor-recommended versions for fixing the vulnerability.",
+                "$ref": "#/$defs/products_t"
+              },
+              "under_investigation": {
+                "title": "Under investigation",
+                "description": "It is not known yet whether these versions are or are not affected by the vulnerability. However, it is still under investigation - the result will be provided in a later release of the document.",
+                "$ref": "#/$defs/products_t"
+              }
+            }
+          },
+          "references": {
+            "title": "Vulnerability references",
+            "description": "Holds a list of references associated with this vulnerability item.",
+            "$ref": "#/$defs/references_t"
+          },
+          "release_date": {
+            "title": "Release date",
+            "description": "Holds the date and time the vulnerability was originally released into the wild.",
+            "type": "string",
+            "format": "date-time"
+          },
+          "remediations": {
+            "title": "List of remediations",
+            "description": "Contains a list of remediations.",
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "title": "Remediation",
+              "description": "Specifies details on how to handle (and presumably, fix) a vulnerability.",
+              "type": "object",
+              "required": [
+                "category",
+                "details"
+              ],
+              "properties": {
+                "category": {
+                  "title": "Category of the remediation",
+                  "description": "Specifies the category which this remediation belongs to.",
+                  "type": "string",
+                  "enum": [
+                    "mitigation",
+                    "no_fix_planned",
+                    "none_available",
+                    "vendor_fix",
+                    "workaround"
+                  ]
+                },
+                "date": {
+                  "title": "Date of the remediation",
+                  "description": "Contains the date from which the remediation is available.",
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "details": {
+                  "title": "Details of the remediation",
+                  "description": "Contains a thorough human-readable discussion of the remediation.",
+                  "type": "string",
+                  "minLength": 1
+                },
+                "entitlements": {
+                  "title": "List of entitlements",
+                  "description": "Contains a list of entitlements.",
+                  "type": "array",
+                  "minItems": 1,
+                  "items": {
+                    "title": "Entitlement of the remediation",
+                    "description": "Contains any possible vendor-defined constraints for obtaining fixed software or hardware that fully resolves the vulnerability.",
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "group_ids": {
+                  "$ref": "#/$defs/product_groups_t"
+                },
+                "product_ids": {
+                  "$ref": "#/$defs/products_t"
+                },
+                "restart_required": {
+                  "title": "Restart required by remediation",
+                  "description": "Provides information on category of restart is required by this remediation to become effective.",
+                  "type": "object",
+                  "required": [
+                    "category"
+                  ],
+                  "properties": {
+                    "category": {
+                      "title": "Category of restart",
+                      "description": "Specifies what category of restart is required by this remediation to become effective.",
+                      "type": "string",
+                      "enum": [
+                        "connected",
+                        "dependencies",
+                        "machine",
+                        "none",
+                        "parent",
+                        "service",
+                        "system",
+                        "vulnerable_component",
+                        "zone"
+                      ]
+                    },
+                    "details": {
+                      "title": "Additional restart information",
+                      "description": "Provides additional information for the restart. This can include details on procedures, scope or impact.",
+                      "type": "string",
+                      "minLength": 1
+                    }
+                  }
+                },
+                "url": {
+                  "title": "URL to the remediation",
+                  "description": "Contains the URL where to obtain the remediation.",
+                  "type": "string",
+                  "format": "uri"
+                }
+              }
+            }
+          },
+          "scores": {
+            "title": "List of scores",
+            "description": "Contains score objects for the current vulnerability.",
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "title": "Score",
+              "description": "Specifies information about (at least one) score of the vulnerability and for which products the given value applies.",
+              "type": "object",
+              "minProperties": 2,
+              "required": [
+                "products"
+              ],
+              "properties": {
+                "cvss_v2": {
+                  "$ref": "https://www.first.org/cvss/cvss-v2.0.json"
+                },
+                "cvss_v3": {
+                  "oneOf": [
+                    {
+                      "$ref": "https://www.first.org/cvss/cvss-v3.0.json"
+                    },
+                    {
+                      "$ref": "https://www.first.org/cvss/cvss-v3.1.json"
+                    }
+                  ]
+                },
+                "products": {
+                  "$ref": "#/$defs/products_t"
+                }
+              }
+            }
+          },
+          "threats": {
+            "title": "List of threats",
+            "description": "Contains information about a vulnerability that can change with time.",
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "title": "Threat",
+              "description": "Contains the vulnerability kinetic information. This information can change as the vulnerability ages and new information becomes available.",
+              "type": "object",
+              "required": [
+                "category",
+                "details"
+              ],
+              "properties": {
+                "category": {
+                  "title": "Category of the threat",
+                  "description": "Categorizes the threat according to the rules of the specification.",
+                  "type": "string",
+                  "enum": [
+                    "exploit_status",
+                    "impact",
+                    "target_set"
+                  ]
+                },
+                "date": {
+                  "title": "Date of the threat",
+                  "description": "Contains the date when the assessment was done or the threat appeared.",
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "details": {
+                  "title": "Details of the threat",
+                  "description": "Represents a thorough human-readable discussion of the threat.",
+                  "type": "string",
+                  "minLength": 1
+                },
+                "group_ids": {
+                  "$ref": "#/$defs/product_groups_t"
+                },
+                "product_ids": {
+                  "$ref": "#/$defs/products_t"
+                }
+              }
+            }
+          },
+          "title": {
+            "title": "Title",
+            "description": "Gives the document producer the ability to apply a canonical name or title to the vulnerability.",
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    }
+  }
+}

--- a/internal/web/csaf_schemas/cvss-v2.0.json
+++ b/internal/web/csaf_schemas/cvss-v2.0.json
@@ -1,0 +1,104 @@
+{
+    "license": [
+        "Copyright (c) 2017, FIRST.ORG, INC.",
+        "All rights reserved.",
+        "",
+        "Redistribution and use in source and binary forms, with or without modification, are permitted provided that the ",
+        "following conditions are met:",
+        "1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following ",
+        "   disclaimer.",
+        "2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the ",
+        "   following disclaimer in the documentation and/or other materials provided with the distribution.",
+        "3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote ",
+        "   products derived from this software without specific prior written permission.",
+        "",
+        "THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 'AS IS' AND ANY EXPRESS OR IMPLIED WARRANTIES, ",
+        "INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE ",
+        "DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, ",
+        "SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR ",
+        "SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, ",
+        "WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE ",
+        "OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+    ],
+
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "JSON Schema for Common Vulnerability Scoring System version 2.0",
+    "id": "https://www.first.org/cvss/cvss-v2.0.json?20170531",
+    "type": "object",
+    "definitions": {
+        "accessVectorType": {
+            "type": "string",
+            "enum": [ "NETWORK", "ADJACENT_NETWORK", "LOCAL" ]
+        },
+        "accessComplexityType": {
+            "type": "string",
+            "enum": [ "HIGH", "MEDIUM", "LOW" ]
+        },
+        "authenticationType": {
+            "type": "string",
+            "enum": [ "MULTIPLE", "SINGLE", "NONE" ]
+        },
+        "ciaType": {
+            "type": "string",
+            "enum": [ "NONE", "PARTIAL", "COMPLETE" ]
+        },
+        "exploitabilityType": {
+            "type": "string",
+            "enum": [ "UNPROVEN", "PROOF_OF_CONCEPT", "FUNCTIONAL", "HIGH", "NOT_DEFINED" ]
+        },
+        "remediationLevelType": {
+            "type": "string",
+            "enum": [ "OFFICIAL_FIX", "TEMPORARY_FIX", "WORKAROUND", "UNAVAILABLE", "NOT_DEFINED" ]
+        },
+        "reportConfidenceType": {
+            "type": "string",
+            "enum": [ "UNCONFIRMED", "UNCORROBORATED", "CONFIRMED", "NOT_DEFINED" ]
+        },
+        "collateralDamagePotentialType": {
+            "type": "string",
+            "enum": [ "NONE", "LOW", "LOW_MEDIUM", "MEDIUM_HIGH", "HIGH", "NOT_DEFINED" ]
+        },
+        "targetDistributionType": {
+            "type": "string",
+            "enum": [ "NONE", "LOW", "MEDIUM", "HIGH", "NOT_DEFINED" ]
+        },
+        "ciaRequirementType": {
+            "type": "string",
+            "enum": [ "LOW", "MEDIUM", "HIGH", "NOT_DEFINED" ]
+        },
+        "scoreType": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 10
+        }
+    },
+    "properties": {
+        "version": {
+            "description": "CVSS Version",
+            "type": "string",
+            "enum": [ "2.0" ]
+        },
+        "vectorString": {
+            "type": "string",
+            "pattern": "^((AV:[NAL]|AC:[LMH]|Au:[MSN]|[CIA]:[NPC]|E:(U|POC|F|H|ND)|RL:(OF|TF|W|U|ND)|RC:(UC|UR|C|ND)|CDP:(N|L|LM|MH|H|ND)|TD:(N|L|M|H|ND)|[CIA]R:(L|M|H|ND))/)*(AV:[NAL]|AC:[LMH]|Au:[MSN]|[CIA]:[NPC]|E:(U|POC|F|H|ND)|RL:(OF|TF|W|U|ND)|RC:(UC|UR|C|ND)|CDP:(N|L|LM|MH|H|ND)|TD:(N|L|M|H|ND)|[CIA]R:(L|M|H|ND))$"
+        },
+        "accessVector":                   { "$ref": "#/definitions/accessVectorType" },
+        "accessComplexity":               { "$ref": "#/definitions/accessComplexityType" },
+        "authentication":                 { "$ref": "#/definitions/authenticationType" },
+        "confidentialityImpact":          { "$ref": "#/definitions/ciaType" },
+        "integrityImpact":                { "$ref": "#/definitions/ciaType" },
+        "availabilityImpact":             { "$ref": "#/definitions/ciaType" },
+        "baseScore":                      { "$ref": "#/definitions/scoreType" },
+        "exploitability":                 { "$ref": "#/definitions/exploitabilityType" },
+        "remediationLevel":               { "$ref": "#/definitions/remediationLevelType" },
+        "reportConfidence":               { "$ref": "#/definitions/reportConfidenceType" },
+        "temporalScore":                  { "$ref": "#/definitions/scoreType" },
+        "collateralDamagePotential":      { "$ref": "#/definitions/collateralDamagePotentialType" },
+        "targetDistribution":             { "$ref": "#/definitions/targetDistributionType" },
+        "confidentialityRequirement":     { "$ref": "#/definitions/ciaRequirementType" },
+        "integrityRequirement":           { "$ref": "#/definitions/ciaRequirementType" },
+        "availabilityRequirement":        { "$ref": "#/definitions/ciaRequirementType" },
+        "environmentalScore":             { "$ref": "#/definitions/scoreType" }
+    },
+    "required": [ "version", "vectorString", "baseScore" ]
+}

--- a/internal/web/csaf_schemas/cvss-v3.0.json
+++ b/internal/web/csaf_schemas/cvss-v3.0.json
@@ -1,0 +1,143 @@
+{
+    "license": [
+        "Copyright (c) 2017, FIRST.ORG, INC.",
+        "All rights reserved.",
+        "",
+        "Redistribution and use in source and binary forms, with or without modification, are permitted provided that the ",
+        "following conditions are met:",
+        "1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following ",
+        "   disclaimer.",
+        "2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the ",
+        "   following disclaimer in the documentation and/or other materials provided with the distribution.",
+        "3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote ",
+        "   products derived from this software without specific prior written permission.",
+        "",
+        "THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 'AS IS' AND ANY EXPRESS OR IMPLIED WARRANTIES, ",
+        "INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE ",
+        "DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, ",
+        "SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR ",
+        "SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, ",
+        "WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE ",
+        "OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+    ],
+
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "JSON Schema for Common Vulnerability Scoring System version 3.0",
+    "id": "https://www.first.org/cvss/cvss-v3.0.json?20170531",
+    "type": "object",
+    "definitions": {
+        "attackVectorType": {
+            "type": "string",
+            "enum": [ "NETWORK", "ADJACENT_NETWORK", "LOCAL", "PHYSICAL" ]
+        },
+        "modifiedAttackVectorType": {
+            "type": "string",
+            "enum": [ "NETWORK", "ADJACENT_NETWORK", "LOCAL", "PHYSICAL", "NOT_DEFINED" ]
+        },
+        "attackComplexityType": {
+            "type": "string",
+            "enum": [ "HIGH", "LOW" ]
+        },
+        "modifiedAttackComplexityType": {
+            "type": "string",
+            "enum": [ "HIGH", "LOW", "NOT_DEFINED" ]
+        },
+        "privilegesRequiredType": {
+            "type": "string",
+            "enum": [ "HIGH", "LOW", "NONE" ]
+        },
+        "modifiedPrivilegesRequiredType": {
+            "type": "string",
+            "enum": [ "HIGH", "LOW", "NONE", "NOT_DEFINED" ]
+        },
+        "userInteractionType": {
+            "type": "string",
+            "enum": [ "NONE", "REQUIRED" ]
+        },
+        "modifiedUserInteractionType": {
+            "type": "string",
+            "enum": [ "NONE", "REQUIRED", "NOT_DEFINED" ]
+        },
+        "scopeType": {
+            "type": "string",
+            "enum": [ "UNCHANGED", "CHANGED" ]
+        },
+        "modifiedScopeType": {
+            "type": "string",
+            "enum": [ "UNCHANGED", "CHANGED", "NOT_DEFINED" ]
+        },
+        "ciaType": {
+            "type": "string",
+            "enum": [ "NONE", "LOW", "HIGH" ]
+        },
+        "modifiedCiaType": {
+            "type": "string",
+            "enum": [ "NONE", "LOW", "HIGH", "NOT_DEFINED" ]
+        },
+        "exploitCodeMaturityType": {
+            "type": "string",
+            "enum": [ "UNPROVEN", "PROOF_OF_CONCEPT", "FUNCTIONAL", "HIGH", "NOT_DEFINED" ]
+        },
+        "remediationLevelType": {
+            "type": "string",
+            "enum": [ "OFFICIAL_FIX", "TEMPORARY_FIX", "WORKAROUND", "UNAVAILABLE", "NOT_DEFINED" ]
+        },
+        "confidenceType": {
+            "type": "string",
+            "enum": [ "UNKNOWN", "REASONABLE", "CONFIRMED", "NOT_DEFINED" ]
+        },
+        "ciaRequirementType": {
+            "type": "string",
+            "enum": [ "LOW", "MEDIUM", "HIGH", "NOT_DEFINED" ]
+        },
+        "scoreType": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 10
+        },
+        "severityType": {
+            "type": "string",
+            "enum": [ "NONE", "LOW", "MEDIUM", "HIGH", "CRITICAL" ]
+        }
+    },
+    "properties": {
+        "version": {
+            "description": "CVSS Version",
+            "type": "string",
+            "enum": [ "3.0" ]
+        },
+        "vectorString": {
+            "type": "string",
+            "pattern": "^CVSS:3[.]0/((AV:[NALP]|AC:[LH]|PR:[NLH]|UI:[NR]|S:[UC]|[CIA]:[NLH]|E:[XUPFH]|RL:[XOTWU]|RC:[XURC]|[CIA]R:[XLMH]|MAV:[XNALP]|MAC:[XLH]|MPR:[XNLH]|MUI:[XNR]|MS:[XUC]|M[CIA]:[XNLH])/)*(AV:[NALP]|AC:[LH]|PR:[NLH]|UI:[NR]|S:[UC]|[CIA]:[NLH]|E:[XUPFH]|RL:[XOTWU]|RC:[XURC]|[CIA]R:[XLMH]|MAV:[XNALP]|MAC:[XLH]|MPR:[XNLH]|MUI:[XNR]|MS:[XUC]|M[CIA]:[XNLH])$"
+        },
+        "attackVector":                   { "$ref": "#/definitions/attackVectorType" },
+        "attackComplexity":               { "$ref": "#/definitions/attackComplexityType" },
+        "privilegesRequired":             { "$ref": "#/definitions/privilegesRequiredType" },
+        "userInteraction":                { "$ref": "#/definitions/userInteractionType" },
+        "scope":                          { "$ref": "#/definitions/scopeType" },
+        "confidentialityImpact":          { "$ref": "#/definitions/ciaType" },
+        "integrityImpact":                { "$ref": "#/definitions/ciaType" },
+        "availabilityImpact":             { "$ref": "#/definitions/ciaType" },
+        "baseScore":                      { "$ref": "#/definitions/scoreType" },
+        "baseSeverity":                   { "$ref": "#/definitions/severityType" },
+        "exploitCodeMaturity":            { "$ref": "#/definitions/exploitCodeMaturityType" },
+        "remediationLevel":               { "$ref": "#/definitions/remediationLevelType" },
+        "reportConfidence":               { "$ref": "#/definitions/confidenceType" },
+        "temporalScore":                  { "$ref": "#/definitions/scoreType" },
+        "temporalSeverity":               { "$ref": "#/definitions/severityType" },
+        "confidentialityRequirement":     { "$ref": "#/definitions/ciaRequirementType" },
+        "integrityRequirement":           { "$ref": "#/definitions/ciaRequirementType" },
+        "availabilityRequirement":        { "$ref": "#/definitions/ciaRequirementType" },
+        "modifiedAttackVector":           { "$ref": "#/definitions/modifiedAttackVectorType" },
+        "modifiedAttackComplexity":       { "$ref": "#/definitions/modifiedAttackComplexityType" },
+        "modifiedPrivilegesRequired":     { "$ref": "#/definitions/modifiedPrivilegesRequiredType" },
+        "modifiedUserInteraction":        { "$ref": "#/definitions/modifiedUserInteractionType" },
+        "modifiedScope":                  { "$ref": "#/definitions/modifiedScopeType" },
+        "modifiedConfidentialityImpact":  { "$ref": "#/definitions/modifiedCiaType" },
+        "modifiedIntegrityImpact":        { "$ref": "#/definitions/modifiedCiaType" },
+        "modifiedAvailabilityImpact":     { "$ref": "#/definitions/modifiedCiaType" },
+        "environmentalScore":             { "$ref": "#/definitions/scoreType" },
+        "environmentalSeverity":          { "$ref": "#/definitions/severityType" }
+    },
+    "required": [ "version", "vectorString", "baseScore", "baseSeverity" ]
+}

--- a/internal/web/csaf_schemas/cvss-v3.1.json
+++ b/internal/web/csaf_schemas/cvss-v3.1.json
@@ -1,0 +1,143 @@
+{
+    "license": [
+        "Copyright (c) 2021, FIRST.ORG, INC.",
+        "All rights reserved.",
+        "",
+        "Redistribution and use in source and binary forms, with or without modification, are permitted provided that the ",
+        "following conditions are met:",
+        "1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following ",
+        "   disclaimer.",
+        "2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the ",
+        "   following disclaimer in the documentation and/or other materials provided with the distribution.",
+        "3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote ",
+        "   products derived from this software without specific prior written permission.",
+        "",
+        "THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 'AS IS' AND ANY EXPRESS OR IMPLIED WARRANTIES, ",
+        "INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE ",
+        "DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, ",
+        "SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR ",
+        "SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, ",
+        "WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE ",
+        "OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+    ],
+
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "JSON Schema for Common Vulnerability Scoring System version 3.1",
+    "$id": "https://www.first.org/cvss/cvss-v3.1.json?20211103",
+    "type": "object",
+    "definitions": {
+        "attackVectorType": {
+            "type": "string",
+            "enum": [ "NETWORK", "ADJACENT_NETWORK", "LOCAL", "PHYSICAL" ]
+        },
+        "modifiedAttackVectorType": {
+            "type": "string",
+            "enum": [ "NETWORK", "ADJACENT_NETWORK", "LOCAL", "PHYSICAL", "NOT_DEFINED" ]
+        },
+        "attackComplexityType": {
+            "type": "string",
+            "enum": [ "HIGH", "LOW" ]
+        },
+        "modifiedAttackComplexityType": {
+            "type": "string",
+            "enum": [ "HIGH", "LOW", "NOT_DEFINED" ]
+        },
+        "privilegesRequiredType": {
+            "type": "string",
+            "enum": [ "HIGH", "LOW", "NONE" ]
+        },
+        "modifiedPrivilegesRequiredType": {
+            "type": "string",
+            "enum": [ "HIGH", "LOW", "NONE", "NOT_DEFINED" ]
+        },
+        "userInteractionType": {
+            "type": "string",
+            "enum": [ "NONE", "REQUIRED" ]
+        },
+        "modifiedUserInteractionType": {
+            "type": "string",
+            "enum": [ "NONE", "REQUIRED", "NOT_DEFINED" ]
+        },
+        "scopeType": {
+            "type": "string",
+            "enum": [ "UNCHANGED", "CHANGED" ]
+        },
+        "modifiedScopeType": {
+            "type": "string",
+            "enum": [ "UNCHANGED", "CHANGED", "NOT_DEFINED" ]
+        },
+        "ciaType": {
+            "type": "string",
+            "enum": [ "NONE", "LOW", "HIGH" ]
+        },
+        "modifiedCiaType": {
+            "type": "string",
+            "enum": [ "NONE", "LOW", "HIGH", "NOT_DEFINED" ]
+        },
+        "exploitCodeMaturityType": {
+            "type": "string",
+            "enum": [ "UNPROVEN", "PROOF_OF_CONCEPT", "FUNCTIONAL", "HIGH", "NOT_DEFINED" ]
+        },
+        "remediationLevelType": {
+            "type": "string",
+            "enum": [ "OFFICIAL_FIX", "TEMPORARY_FIX", "WORKAROUND", "UNAVAILABLE", "NOT_DEFINED" ]
+        },
+        "confidenceType": {
+            "type": "string",
+            "enum": [ "UNKNOWN", "REASONABLE", "CONFIRMED", "NOT_DEFINED" ]
+        },
+        "ciaRequirementType": {
+            "type": "string",
+            "enum": [ "LOW", "MEDIUM", "HIGH", "NOT_DEFINED" ]
+        },
+        "scoreType": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 10
+        },
+        "severityType": {
+            "type": "string",
+            "enum": [ "NONE", "LOW", "MEDIUM", "HIGH", "CRITICAL" ]
+        }
+    },
+    "properties": {
+        "version": {
+            "description": "CVSS Version",
+            "type": "string",
+            "enum": [ "3.1" ]
+        },
+        "vectorString": {
+            "type": "string",
+            "pattern": "^CVSS:3[.]1/((AV:[NALP]|AC:[LH]|PR:[NLH]|UI:[NR]|S:[UC]|[CIA]:[NLH]|E:[XUPFH]|RL:[XOTWU]|RC:[XURC]|[CIA]R:[XLMH]|MAV:[XNALP]|MAC:[XLH]|MPR:[XNLH]|MUI:[XNR]|MS:[XUC]|M[CIA]:[XNLH])/)*(AV:[NALP]|AC:[LH]|PR:[NLH]|UI:[NR]|S:[UC]|[CIA]:[NLH]|E:[XUPFH]|RL:[XOTWU]|RC:[XURC]|[CIA]R:[XLMH]|MAV:[XNALP]|MAC:[XLH]|MPR:[XNLH]|MUI:[XNR]|MS:[XUC]|M[CIA]:[XNLH])$"
+        },
+        "attackVector":                   { "$ref": "#/definitions/attackVectorType" },
+        "attackComplexity":               { "$ref": "#/definitions/attackComplexityType" },
+        "privilegesRequired":             { "$ref": "#/definitions/privilegesRequiredType" },
+        "userInteraction":                { "$ref": "#/definitions/userInteractionType" },
+        "scope":                          { "$ref": "#/definitions/scopeType" },
+        "confidentialityImpact":          { "$ref": "#/definitions/ciaType" },
+        "integrityImpact":                { "$ref": "#/definitions/ciaType" },
+        "availabilityImpact":             { "$ref": "#/definitions/ciaType" },
+        "baseScore":                      { "$ref": "#/definitions/scoreType" },
+        "baseSeverity":                   { "$ref": "#/definitions/severityType" },
+        "exploitCodeMaturity":            { "$ref": "#/definitions/exploitCodeMaturityType" },
+        "remediationLevel":               { "$ref": "#/definitions/remediationLevelType" },
+        "reportConfidence":               { "$ref": "#/definitions/confidenceType" },
+        "temporalScore":                  { "$ref": "#/definitions/scoreType" },
+        "temporalSeverity":               { "$ref": "#/definitions/severityType" },
+        "confidentialityRequirement":     { "$ref": "#/definitions/ciaRequirementType" },
+        "integrityRequirement":           { "$ref": "#/definitions/ciaRequirementType" },
+        "availabilityRequirement":        { "$ref": "#/definitions/ciaRequirementType" },
+        "modifiedAttackVector":           { "$ref": "#/definitions/modifiedAttackVectorType" },
+        "modifiedAttackComplexity":       { "$ref": "#/definitions/modifiedAttackComplexityType" },
+        "modifiedPrivilegesRequired":     { "$ref": "#/definitions/modifiedPrivilegesRequiredType" },
+        "modifiedUserInteraction":        { "$ref": "#/definitions/modifiedUserInteractionType" },
+        "modifiedScope":                  { "$ref": "#/definitions/modifiedScopeType" },
+        "modifiedConfidentialityImpact":  { "$ref": "#/definitions/modifiedCiaType" },
+        "modifiedIntegrityImpact":        { "$ref": "#/definitions/modifiedCiaType" },
+        "modifiedAvailabilityImpact":     { "$ref": "#/definitions/modifiedCiaType" },
+        "environmentalScore":             { "$ref": "#/definitions/scoreType" },
+        "environmentalSeverity":          { "$ref": "#/definitions/severityType" }
+    },
+    "required": [ "version", "vectorString", "baseScore", "baseSeverity" ]
+}

--- a/internal/web/finding_csaf.go
+++ b/internal/web/finding_csaf.go
@@ -1,0 +1,600 @@
+package web
+
+import (
+	"bytes"
+	"embed"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/santhosh-tekuri/jsonschema/v6"
+
+	"scrutineer/internal/db"
+)
+
+//go:embed csaf_schemas/*.json
+var csafSchemaFS embed.FS
+
+const (
+	csafStatusFixed              = "fixed"
+	csafStatusKnownAffected      = "known_affected"
+	csafStatusKnownNotAffected   = "known_not_affected"
+	csafStatusUnderInvestigation = "under_investigation"
+
+	csafJustificationComponentNotPresent    = "component_not_present"
+	csafJustificationControlledByAdversary  = "vulnerable_code_cannot_be_controlled_by_adversary"
+	csafJustificationInlineMitigationsExist = "inline_mitigations_already_exist"
+	csafJustificationNotInExecutePath       = "vulnerable_code_not_in_execute_path"
+
+	csafSeverityCritical = "CRITICAL"
+	csafSeverityHigh     = "HIGH"
+	csafSeverityMedium   = "MEDIUM"
+	csafSeverityLow      = "LOW"
+	csafSeverityNone     = "NONE"
+
+	cvssVersion30 = "3.0"
+	cvssVersion31 = "3.1"
+)
+
+// CVSS v3 base-score severity bands, per the FIRST CVSS specification.
+const (
+	cvssCriticalScore = 9.0
+	cvssHighScore     = 7.0
+	cvssMediumScore   = 4.0
+)
+
+var (
+	csafSchemaOnce sync.Once
+	csafSchemaVal  *jsonschema.Schema
+	csafSchemaErr  error
+)
+
+// getCSAFSchema returns the compiled validator, building it on first call.
+func getCSAFSchema() (*jsonschema.Schema, error) {
+	csafSchemaOnce.Do(func() {
+		c := jsonschema.NewCompiler()
+		files := []struct{ url, file string }{
+			{"https://www.first.org/cvss/cvss-v2.0.json", "cvss-v2.0.json"},
+			{"https://www.first.org/cvss/cvss-v3.0.json", "cvss-v3.0.json"},
+			{"https://www.first.org/cvss/cvss-v3.1.json", "cvss-v3.1.json"},
+			{"https://docs.oasis-open.org/csaf/csaf/v2.0/csaf_json_schema.json", "csaf_json_schema.json"},
+		}
+		for _, f := range files {
+			b, err := csafSchemaFS.ReadFile("csaf_schemas/" + f.file)
+			if err != nil {
+				csafSchemaErr = fmt.Errorf("read %s: %w", f.file, err)
+				return
+			}
+			doc, err := jsonschema.UnmarshalJSON(bytes.NewReader(b))
+			if err != nil {
+				csafSchemaErr = fmt.Errorf("parse %s: %w", f.file, err)
+				return
+			}
+			if err := c.AddResource(f.url, doc); err != nil {
+				csafSchemaErr = fmt.Errorf("add %s: %w", f.file, err)
+				return
+			}
+		}
+		csafSchemaVal, csafSchemaErr = c.Compile("https://docs.oasis-open.org/csaf/csaf/v2.0/csaf_json_schema.json")
+	})
+	return csafSchemaVal, csafSchemaErr
+}
+
+func (s *Server) findingCSAF(w http.ResponseWriter, r *http.Request) {
+	id, _ := strconv.Atoi(r.PathValue("id"))
+	var f db.Finding
+	if err := s.DB.First(&f, id).Error; err != nil {
+		http.NotFound(w, r)
+		return
+	}
+	var repo db.Repository
+	s.DB.First(&repo, f.RepositoryID)
+	var refs []db.FindingReference
+	s.DB.Where("finding_id = ?", f.ID).Order("id desc").Find(&refs)
+
+	raw, err := json.MarshalIndent(buildCSAF(f, repo, refs), "", "  ")
+	if err != nil {
+		s.Log.Error("csaf marshal", "finding", f.ID, "err", err)
+		http.Error(w, "failed to generate CSAF document", http.StatusInternalServerError)
+		return
+	}
+	inst, err := jsonschema.UnmarshalJSON(bytes.NewReader(raw))
+	if err != nil {
+		s.Log.Error("csaf reparse", "finding", f.ID, "err", err)
+		http.Error(w, "failed to generate CSAF document", http.StatusInternalServerError)
+		return
+	}
+	if err := s.csafSchema.Validate(inst); err != nil {
+		s.Log.Error("csaf invalid", "finding", f.ID, "err", err)
+		http.Error(w, "failed to generate valid CSAF document", http.StatusInternalServerError)
+		return
+	}
+
+	filename := fmt.Sprintf("scrutineer-finding-%d-%s.json", f.ID, time.Now().UTC().Format("20060102"))
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.Header().Set("Content-Disposition", `attachment; filename="`+filename+`"`)
+	_, _ = w.Write(raw)
+}
+
+type csafDocument struct {
+	Document        csafDocMeta         `json:"document"`
+	ProductTree     *csafProductTree    `json:"product_tree,omitempty"`
+	Vulnerabilities []csafVulnerability `json:"vulnerabilities,omitempty"`
+}
+
+type csafDocMeta struct {
+	Category     string          `json:"category"`
+	CSAFVersion  string          `json:"csaf_version"`
+	Title        string          `json:"title"`
+	Distribution csafDistrib     `json:"distribution"`
+	Publisher    csafPublisher   `json:"publisher"`
+	Tracking     csafTracking    `json:"tracking"`
+	Notes        []csafNote      `json:"notes,omitempty"`
+	References   []csafReference `json:"references,omitempty"`
+}
+
+type csafDistrib struct {
+	TLP csafTLP `json:"tlp"`
+}
+
+type csafTLP struct {
+	Label string `json:"label"`
+}
+
+type csafPublisher struct {
+	Category  string `json:"category"`
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
+}
+
+type csafTracking struct {
+	ID                 string         `json:"id"`
+	InitialReleaseDate string         `json:"initial_release_date"`
+	CurrentReleaseDate string         `json:"current_release_date"`
+	Status             string         `json:"status"`
+	Version            string         `json:"version"`
+	RevisionHistory    []csafRevision `json:"revision_history"`
+	Generator          *csafGenerator `json:"generator,omitempty"`
+}
+
+type csafRevision struct {
+	Number  string `json:"number"`
+	Date    string `json:"date"`
+	Summary string `json:"summary"`
+}
+
+type csafGenerator struct {
+	Engine csafEngine `json:"engine"`
+}
+
+type csafEngine struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+
+type csafProductTree struct {
+	Branches []csafBranch `json:"branches,omitempty"`
+}
+
+type csafBranch struct {
+	Category string       `json:"category"`
+	Name     string       `json:"name"`
+	Branches []csafBranch `json:"branches,omitempty"`
+	Product  *csafProduct `json:"product,omitempty"`
+}
+
+type csafProduct struct {
+	Name        string                 `json:"name"`
+	ProductID   string                 `json:"product_id"`
+	IdentHelper *csafProductIdentifier `json:"product_identification_helper,omitempty"`
+}
+
+type csafProductIdentifier struct {
+	PURL string `json:"purl,omitempty"`
+}
+
+type csafVulnerability struct {
+	CVE           string             `json:"cve,omitempty"`
+	CWE           *csafCWE           `json:"cwe,omitempty"`
+	Title         string             `json:"title,omitempty"`
+	Notes         []csafNote         `json:"notes,omitempty"`
+	ProductStatus *csafProductStatus `json:"product_status,omitempty"`
+	Scores        []csafScore        `json:"scores,omitempty"`
+	Flags         []csafFlag         `json:"flags,omitempty"`
+	Remediations  []csafRemediation  `json:"remediations,omitempty"`
+	References    []csafReference    `json:"references,omitempty"`
+}
+
+type csafCWE struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+type csafNote struct {
+	Category string `json:"category"`
+	Title    string `json:"title,omitempty"`
+	Text     string `json:"text"`
+}
+
+type csafProductStatus struct {
+	KnownAffected      []string `json:"known_affected,omitempty"`
+	KnownNotAffected   []string `json:"known_not_affected,omitempty"`
+	Fixed              []string `json:"fixed,omitempty"`
+	UnderInvestigation []string `json:"under_investigation,omitempty"`
+}
+
+type csafScore struct {
+	Products []string    `json:"products"`
+	CVSSv3   *csafCVSSv3 `json:"cvss_v3,omitempty"`
+}
+
+type csafCVSSv3 struct {
+	Version               string  `json:"version"`
+	VectorString          string  `json:"vectorString"`
+	BaseScore             float64 `json:"baseScore"`
+	BaseSeverity          string  `json:"baseSeverity"`
+	AttackVector          string  `json:"attackVector,omitempty"`
+	AttackComplexity      string  `json:"attackComplexity,omitempty"`
+	PrivilegesRequired    string  `json:"privilegesRequired,omitempty"`
+	UserInteraction       string  `json:"userInteraction,omitempty"`
+	Scope                 string  `json:"scope,omitempty"`
+	ConfidentialityImpact string  `json:"confidentialityImpact,omitempty"`
+	IntegrityImpact       string  `json:"integrityImpact,omitempty"`
+	AvailabilityImpact    string  `json:"availabilityImpact,omitempty"`
+}
+
+type csafFlag struct {
+	Label      string   `json:"label"`
+	ProductIDs []string `json:"product_ids"`
+}
+
+type csafRemediation struct {
+	Category   string   `json:"category"`
+	Details    string   `json:"details"`
+	ProductIDs []string `json:"product_ids,omitempty"`
+	URL        string   `json:"url,omitempty"`
+}
+
+type csafReference struct {
+	Category string `json:"category"`
+	Summary  string `json:"summary,omitempty"`
+	URL      string `json:"url"`
+}
+
+func buildCSAF(f db.Finding, repo db.Repository, refs []db.FindingReference) csafDocument {
+	productID := fmt.Sprintf("PKG-%d-%s", f.RepositoryID, csafProductSuffix(f))
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	initial := f.CreatedAt.UTC().Format(time.RFC3339)
+	current := f.UpdatedAt.UTC().Format(time.RFC3339)
+	if initial == "" {
+		initial = now
+	}
+	if current == "" {
+		current = initial
+	}
+
+	docStatus := "draft"
+	if f.Status == db.FindingPublished {
+		docStatus = "final"
+	}
+
+	doc := csafDocument{
+		Document: csafDocMeta{
+			Category:    "csaf_vex",
+			CSAFVersion: "2.0",
+			Title:       fmt.Sprintf("Scrutineer VEX: %s", firstNonEmpty(f.Title, "finding "+strconv.Itoa(int(f.ID)))),
+			Distribution: csafDistrib{
+				TLP: csafTLP{Label: "WHITE"},
+			},
+			Publisher: csafPublisher{
+				Category:  "discoverer",
+				Name:      "Scrutineer",
+				Namespace: "https://github.com/alpha-omega-security/scrutineer",
+			},
+			Tracking: csafTracking{
+				ID:                 fmt.Sprintf("scrutineer-finding-%d", f.ID),
+				InitialReleaseDate: initial,
+				CurrentReleaseDate: current,
+				Status:             docStatus,
+				Version:            "1",
+				RevisionHistory: []csafRevision{
+					{Number: "1", Date: initial, Summary: "initial export"},
+				},
+				Generator: &csafGenerator{
+					Engine: csafEngine{Name: "scrutineer", Version: "0"},
+				},
+			},
+		},
+	}
+
+	productName := firstNonEmpty(repo.FullName, repo.Name, "package")
+	productVersion := firstNonEmpty(f.Affected, "unknown")
+	doc.ProductTree = &csafProductTree{
+		Branches: []csafBranch{{
+			Category: "product_name",
+			Name:     productName,
+			Branches: []csafBranch{{
+				Category: "product_version",
+				Name:     productVersion,
+				Product: &csafProduct{
+					Name:      fmt.Sprintf("%s %s", productName, productVersion),
+					ProductID: productID,
+				},
+			}},
+		}},
+	}
+
+	v := csafVulnerability{
+		CVE:           f.CVEID,
+		Title:         f.Title,
+		ProductStatus: buildProductStatus(f, productID),
+		References:    buildReferences(refs),
+		Notes:         buildAuditNotes(f),
+	}
+	if cwe := buildCWE(f.CWE); cwe != nil {
+		v.CWE = cwe
+	}
+	if score := buildScore(f, productID); score != nil {
+		v.Scores = []csafScore{*score}
+	}
+	if flag := buildFlag(f, productID); flag != nil {
+		v.Flags = []csafFlag{*flag}
+	}
+	if rem := buildRemediations(f, repo, productID); len(rem) > 0 {
+		v.Remediations = rem
+	}
+	doc.Vulnerabilities = []csafVulnerability{v}
+
+	return doc
+}
+
+func csafProductSuffix(f db.Finding) string {
+	if f.FindingID != "" {
+		return f.FindingID
+	}
+	return strconv.Itoa(int(f.ID))
+}
+
+func mapProductStatus(f db.Finding) string {
+	switch f.Status {
+	case db.FindingFixed, db.FindingPublished:
+		return csafStatusFixed
+	case db.FindingRejected, db.FindingDuplicate:
+		return csafStatusKnownNotAffected
+	case db.FindingNew, db.FindingEnriched:
+		return csafStatusUnderInvestigation
+	case db.FindingTriaged, db.FindingReady, db.FindingReported, db.FindingAcknowledged:
+		if f.Resolution == db.ResolutionWontfix {
+			return csafStatusKnownNotAffected
+		}
+		return csafStatusKnownAffected
+	}
+	if f.Resolution == db.ResolutionWontfix {
+		return csafStatusKnownNotAffected
+	}
+	return csafStatusUnderInvestigation
+}
+
+func buildProductStatus(f db.Finding, productID string) *csafProductStatus {
+	ps := &csafProductStatus{}
+	switch mapProductStatus(f) {
+	case csafStatusFixed:
+		ps.Fixed = []string{productID}
+	case csafStatusKnownNotAffected:
+		ps.KnownNotAffected = []string{productID}
+	case csafStatusKnownAffected:
+		ps.KnownAffected = []string{productID}
+	default:
+		ps.UnderInvestigation = []string{productID}
+	}
+	return ps
+}
+
+func pickJustification(f db.Finding) string {
+	switch {
+	case f.Boundary != "":
+		return csafJustificationControlledByAdversary
+	case f.Validation != "":
+		return csafJustificationInlineMitigationsExist
+	case f.Reach != "":
+		return csafJustificationNotInExecutePath
+	default:
+		return csafJustificationComponentNotPresent
+	}
+}
+
+func buildFlag(f db.Finding, productID string) *csafFlag {
+	if mapProductStatus(f) != csafStatusKnownNotAffected {
+		return nil
+	}
+	return &csafFlag{Label: pickJustification(f), ProductIDs: []string{productID}}
+}
+
+func buildCWE(id string) *csafCWE {
+	if id == "" {
+		return nil
+	}
+	if _, c, ok := LookupCWE(id); ok {
+		return &csafCWE{ID: id, Name: c.Name}
+	}
+	return &csafCWE{ID: id, Name: id}
+}
+
+func buildAuditNotes(f db.Finding) []csafNote {
+	steps := []struct{ title, text string }{
+		{"trace", f.Trace},
+		{"boundary", f.Boundary},
+		{"validation", f.Validation},
+		{"prior_art", f.PriorArt},
+		{"reach", f.Reach},
+		{"rating", f.Rating},
+	}
+	var out []csafNote
+	for _, s := range steps {
+		if s.text == "" {
+			continue
+		}
+		out = append(out, csafNote{Category: "details", Title: s.title, Text: s.text})
+	}
+	return out
+}
+
+func buildReferences(refs []db.FindingReference) []csafReference {
+	if len(refs) == 0 {
+		return nil
+	}
+	out := make([]csafReference, 0, len(refs))
+	for _, r := range refs {
+		summary := r.Summary
+		if summary == "" {
+			summary = r.Tags
+		}
+		out = append(out, csafReference{Category: "external", Summary: summary, URL: r.URL})
+	}
+	return out
+}
+
+func buildRemediations(f db.Finding, repo db.Repository, productID string) []csafRemediation {
+	var out []csafRemediation
+	if f.FixVersion != "" || f.FixCommit != "" {
+		details := "Fix available"
+		if f.FixVersion != "" {
+			details = "Fixed in " + f.FixVersion
+		} else if f.FixCommit != "" {
+			details = "Fixed in commit " + f.FixCommit
+		}
+		url := ""
+		if repo.HTMLURL != "" && f.FixCommit != "" {
+			url = strings.TrimSuffix(repo.HTMLURL, "/") + "/commit/" + f.FixCommit
+		}
+		out = append(out, csafRemediation{
+			Category:   "vendor_fix",
+			Details:    details,
+			ProductIDs: []string{productID},
+			URL:        url,
+		})
+	}
+	if f.Resolution == db.ResolutionWorkaround {
+		details := f.Trace
+		if details == "" {
+			details = "Workaround available; see finding details."
+		}
+		out = append(out, csafRemediation{
+			Category:   "workaround",
+			Details:    details,
+			ProductIDs: []string{productID},
+		})
+	}
+	return out
+}
+
+// buildScore emits nothing when the CVSS vector is missing or malformed:
+// CSAF requires every score's vectorString to match a strict regex, and
+// faking one from a bare numeric score would produce an invalid document.
+func buildScore(f db.Finding, productID string) *csafScore {
+	cvss := parseCVSSv3Vector(f.CVSSVector)
+	if cvss == nil {
+		return nil
+	}
+	cvss.BaseScore = f.CVSSScore
+	cvss.BaseSeverity = severityLabel(f.Severity, f.CVSSScore)
+	cvss.VectorString = f.CVSSVector
+	return &csafScore{Products: []string{productID}, CVSSv3: cvss}
+}
+
+func parseCVSSv3Vector(vec string) *csafCVSSv3 {
+	if !strings.HasPrefix(vec, "CVSS:") {
+		return nil
+	}
+	parts := strings.Split(vec, "/")
+	const minParts = 2
+	if len(parts) < minParts {
+		return nil
+	}
+	version := strings.TrimPrefix(parts[0], "CVSS:")
+	if version != cvssVersion30 && version != cvssVersion31 {
+		version = cvssVersion31
+	}
+	out := &csafCVSSv3{Version: version}
+	got := 0
+	for _, kv := range parts[1:] {
+		k, v, ok := strings.Cut(kv, ":")
+		if !ok {
+			continue
+		}
+		val, ok := cvssValue(k, v)
+		if !ok {
+			continue
+		}
+		switch k {
+		case "AV":
+			out.AttackVector = val
+		case "AC":
+			out.AttackComplexity = val
+		case "PR":
+			out.PrivilegesRequired = val
+		case "UI":
+			out.UserInteraction = val
+		case "S":
+			out.Scope = val
+		case "C":
+			out.ConfidentialityImpact = val
+		case "I":
+			out.IntegrityImpact = val
+		case "A":
+			out.AvailabilityImpact = val
+		}
+		got++
+	}
+	if got == 0 {
+		return nil
+	}
+	return out
+}
+
+func cvssValue(k, v string) (string, bool) {
+	var m map[string]string
+	switch k {
+	case "AV":
+		m = map[string]string{"N": "NETWORK", "A": "ADJACENT_NETWORK", "L": "LOCAL", "P": "PHYSICAL"}
+	case "AC":
+		m = map[string]string{"L": "LOW", "H": "HIGH"}
+	case "PR":
+		m = map[string]string{"N": "NONE", "L": "LOW", "H": "HIGH"}
+	case "UI":
+		m = map[string]string{"N": "NONE", "R": "REQUIRED"}
+	case "S":
+		m = map[string]string{"U": "UNCHANGED", "C": "CHANGED"}
+	case "C", "I", "A":
+		m = map[string]string{"H": "HIGH", "L": "LOW", "N": "NONE"}
+	default:
+		return "", false
+	}
+	val, ok := m[v]
+	return val, ok
+}
+
+func severityLabel(severity string, score float64) string {
+	if s := strings.ToUpper(strings.TrimSpace(severity)); s != "" {
+		switch s {
+		case csafSeverityCritical, csafSeverityHigh, csafSeverityMedium, csafSeverityLow, csafSeverityNone:
+			return s
+		}
+	}
+	switch {
+	case score >= cvssCriticalScore:
+		return csafSeverityCritical
+	case score >= cvssHighScore:
+		return csafSeverityHigh
+	case score >= cvssMediumScore:
+		return csafSeverityMedium
+	case score > 0:
+		return csafSeverityLow
+	}
+	return csafSeverityNone
+}

--- a/internal/web/finding_csaf.go
+++ b/internal/web/finding_csaf.go
@@ -25,11 +25,6 @@ const (
 	csafStatusKnownNotAffected   = "known_not_affected"
 	csafStatusUnderInvestigation = "under_investigation"
 
-	csafJustificationComponentNotPresent    = "component_not_present"
-	csafJustificationControlledByAdversary  = "vulnerable_code_cannot_be_controlled_by_adversary"
-	csafJustificationInlineMitigationsExist = "inline_mitigations_already_exist"
-	csafJustificationNotInExecutePath       = "vulnerable_code_not_in_execute_path"
-
 	csafSeverityCritical = "CRITICAL"
 	csafSeverityHigh     = "HIGH"
 	csafSeverityMedium   = "MEDIUM"
@@ -91,6 +86,16 @@ func (s *Server) findingCSAF(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 		return
 	}
+	if f.Status == db.FindingDuplicate {
+		http.Error(w, "finding is a duplicate; export not available", http.StatusGone)
+		return
+	}
+	schema, err := getCSAFSchema()
+	if err != nil {
+		s.Log.Error("csaf schema", "err", err)
+		http.Error(w, "failed to load CSAF schema", http.StatusInternalServerError)
+		return
+	}
 	var repo db.Repository
 	s.DB.First(&repo, f.RepositoryID)
 	var refs []db.FindingReference
@@ -108,7 +113,7 @@ func (s *Server) findingCSAF(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "failed to generate CSAF document", http.StatusInternalServerError)
 		return
 	}
-	if err := s.csafSchema.Validate(inst); err != nil {
+	if err := schema.Validate(inst); err != nil {
 		s.Log.Error("csaf invalid", "finding", f.ID, "err", err)
 		http.Error(w, "failed to generate valid CSAF document", http.StatusInternalServerError)
 		return
@@ -204,7 +209,6 @@ type csafVulnerability struct {
 	Notes         []csafNote         `json:"notes,omitempty"`
 	ProductStatus *csafProductStatus `json:"product_status,omitempty"`
 	Scores        []csafScore        `json:"scores,omitempty"`
-	Flags         []csafFlag         `json:"flags,omitempty"`
 	Remediations  []csafRemediation  `json:"remediations,omitempty"`
 	References    []csafReference    `json:"references,omitempty"`
 }
@@ -247,11 +251,6 @@ type csafCVSSv3 struct {
 	AvailabilityImpact    string  `json:"availabilityImpact,omitempty"`
 }
 
-type csafFlag struct {
-	Label      string   `json:"label"`
-	ProductIDs []string `json:"product_ids"`
-}
-
 type csafRemediation struct {
 	Category   string   `json:"category"`
 	Details    string   `json:"details"`
@@ -261,7 +260,7 @@ type csafRemediation struct {
 
 type csafReference struct {
 	Category string `json:"category"`
-	Summary  string `json:"summary,omitempty"`
+	Summary  string `json:"summary"`
 	URL      string `json:"url"`
 }
 
@@ -269,13 +268,13 @@ func buildCSAF(f db.Finding, repo db.Repository, refs []db.FindingReference) csa
 	productID := fmt.Sprintf("PKG-%d-%s", f.RepositoryID, csafProductSuffix(f))
 
 	now := time.Now().UTC().Format(time.RFC3339)
-	initial := f.CreatedAt.UTC().Format(time.RFC3339)
-	current := f.UpdatedAt.UTC().Format(time.RFC3339)
-	if initial == "" {
-		initial = now
+	initial := now
+	if !f.CreatedAt.IsZero() {
+		initial = f.CreatedAt.UTC().Format(time.RFC3339)
 	}
-	if current == "" {
-		current = initial
+	current := initial
+	if !f.UpdatedAt.IsZero() {
+		current = f.UpdatedAt.UTC().Format(time.RFC3339)
 	}
 
 	docStatus := "draft"
@@ -342,9 +341,6 @@ func buildCSAF(f db.Finding, repo db.Repository, refs []db.FindingReference) csa
 	if score := buildScore(f, productID); score != nil {
 		v.Scores = []csafScore{*score}
 	}
-	if flag := buildFlag(f, productID); flag != nil {
-		v.Flags = []csafFlag{*flag}
-	}
 	if rem := buildRemediations(f, repo, productID); len(rem) > 0 {
 		v.Remediations = rem
 	}
@@ -360,15 +356,21 @@ func csafProductSuffix(f db.Finding) string {
 	return strconv.Itoa(int(f.ID))
 }
 
+// mapProductStatus picks the CSAF product_status bucket. FindingPublished
+// means the advisory went out, not that the bug is fixed; only emit "fixed"
+// when a fix is actually pinned via FixVersion/FixCommit.
 func mapProductStatus(f db.Finding) string {
-	switch f.Status {
-	case db.FindingFixed, db.FindingPublished:
+	if f.FixVersion != "" || f.FixCommit != "" {
 		return csafStatusFixed
-	case db.FindingRejected, db.FindingDuplicate:
+	}
+	switch f.Status {
+	case db.FindingFixed:
+		return csafStatusFixed
+	case db.FindingRejected:
 		return csafStatusKnownNotAffected
 	case db.FindingNew, db.FindingEnriched:
 		return csafStatusUnderInvestigation
-	case db.FindingTriaged, db.FindingReady, db.FindingReported, db.FindingAcknowledged:
+	case db.FindingTriaged, db.FindingReady, db.FindingReported, db.FindingAcknowledged, db.FindingPublished:
 		if f.Resolution == db.ResolutionWontfix {
 			return csafStatusKnownNotAffected
 		}
@@ -393,26 +395,6 @@ func buildProductStatus(f db.Finding, productID string) *csafProductStatus {
 		ps.UnderInvestigation = []string{productID}
 	}
 	return ps
-}
-
-func pickJustification(f db.Finding) string {
-	switch {
-	case f.Boundary != "":
-		return csafJustificationControlledByAdversary
-	case f.Validation != "":
-		return csafJustificationInlineMitigationsExist
-	case f.Reach != "":
-		return csafJustificationNotInExecutePath
-	default:
-		return csafJustificationComponentNotPresent
-	}
-}
-
-func buildFlag(f db.Finding, productID string) *csafFlag {
-	if mapProductStatus(f) != csafStatusKnownNotAffected {
-		return nil
-	}
-	return &csafFlag{Label: pickJustification(f), ProductIDs: []string{productID}}
 }
 
 func buildCWE(id string) *csafCWE {
@@ -450,10 +432,7 @@ func buildReferences(refs []db.FindingReference) []csafReference {
 	}
 	out := make([]csafReference, 0, len(refs))
 	for _, r := range refs {
-		summary := r.Summary
-		if summary == "" {
-			summary = r.Tags
-		}
+		summary := firstNonEmpty(r.Summary, r.Tags, r.URL)
 		out = append(out, csafReference{Category: "external", Summary: summary, URL: r.URL})
 	}
 	return out
@@ -480,13 +459,9 @@ func buildRemediations(f db.Finding, repo db.Repository, productID string) []csa
 		})
 	}
 	if f.Resolution == db.ResolutionWorkaround {
-		details := f.Trace
-		if details == "" {
-			details = "Workaround available; see finding details."
-		}
 		out = append(out, csafRemediation{
 			Category:   "workaround",
-			Details:    details,
+			Details:    "Workaround available; see finding details.",
 			ProductIDs: []string{productID},
 		})
 	}
@@ -502,7 +477,7 @@ func buildScore(f db.Finding, productID string) *csafScore {
 		return nil
 	}
 	cvss.BaseScore = f.CVSSScore
-	cvss.BaseSeverity = severityLabel(f.Severity, f.CVSSScore)
+	cvss.BaseSeverity = severityLabel(f.CVSSScore)
 	cvss.VectorString = f.CVSSVector
 	return &csafScore{Products: []string{productID}, CVSSv3: cvss}
 }
@@ -518,7 +493,7 @@ func parseCVSSv3Vector(vec string) *csafCVSSv3 {
 	}
 	version := strings.TrimPrefix(parts[0], "CVSS:")
 	if version != cvssVersion30 && version != cvssVersion31 {
-		version = cvssVersion31
+		return nil
 	}
 	out := &csafCVSSv3{Version: version}
 	got := 0
@@ -579,13 +554,11 @@ func cvssValue(k, v string) (string, bool) {
 	return val, ok
 }
 
-func severityLabel(severity string, score float64) string {
-	if s := strings.ToUpper(strings.TrimSpace(severity)); s != "" {
-		switch s {
-		case csafSeverityCritical, csafSeverityHigh, csafSeverityMedium, csafSeverityLow, csafSeverityNone:
-			return s
-		}
-	}
+// severityLabel derives the CVSS base severity from the numeric score per
+// the FIRST spec. The textual Finding.Severity is intentionally ignored:
+// analyst free-form values can drift from the score (e.g. score 9.8 marked
+// "High" instead of "Critical"), and CSAF tooling expects strict bands.
+func severityLabel(score float64) string {
 	switch {
 	case score >= cvssCriticalScore:
 		return csafSeverityCritical

--- a/internal/web/finding_csaf.go
+++ b/internal/web/finding_csaf.go
@@ -100,8 +100,10 @@ func (s *Server) findingCSAF(w http.ResponseWriter, r *http.Request) {
 	s.DB.First(&repo, f.RepositoryID)
 	var refs []db.FindingReference
 	s.DB.Where("finding_id = ?", f.ID).Order("id desc").Find(&refs)
+	var pkgs []db.Package
+	s.DB.Where("repository_id = ?", f.RepositoryID).Find(&pkgs)
 
-	raw, err := json.MarshalIndent(buildCSAF(f, repo, refs), "", "  ")
+	raw, err := json.MarshalIndent(buildCSAF(f, repo, refs, pkgs), "", "  ")
 	if err != nil {
 		s.Log.Error("csaf marshal", "finding", f.ID, "err", err)
 		http.Error(w, "failed to generate CSAF document", http.StatusInternalServerError)
@@ -208,9 +210,15 @@ type csafVulnerability struct {
 	Title         string             `json:"title,omitempty"`
 	Notes         []csafNote         `json:"notes,omitempty"`
 	ProductStatus *csafProductStatus `json:"product_status,omitempty"`
+	Flags         []csafFlag         `json:"flags,omitempty"`
 	Scores        []csafScore        `json:"scores,omitempty"`
 	Remediations  []csafRemediation  `json:"remediations,omitempty"`
 	References    []csafReference    `json:"references,omitempty"`
+}
+
+type csafFlag struct {
+	Label      string   `json:"label"`
+	ProductIDs []string `json:"product_ids,omitempty"`
 }
 
 type csafCWE struct {
@@ -264,7 +272,7 @@ type csafReference struct {
 	URL      string `json:"url"`
 }
 
-func buildCSAF(f db.Finding, repo db.Repository, refs []db.FindingReference) csafDocument {
+func buildCSAF(f db.Finding, repo db.Repository, refs []db.FindingReference, pkgs []db.Package) csafDocument {
 	productID := fmt.Sprintf("PKG-%d-%s", f.RepositoryID, csafProductSuffix(f))
 
 	now := time.Now().UTC().Format(time.RFC3339)
@@ -313,40 +321,140 @@ func buildCSAF(f db.Finding, repo db.Repository, refs []db.FindingReference) csa
 
 	productName := firstNonEmpty(repo.FullName, repo.Name, "package")
 	productVersion := firstNonEmpty(f.Affected, "unknown")
-	doc.ProductTree = &csafProductTree{
-		Branches: []csafBranch{{
-			Category: "product_name",
-			Name:     productName,
-			Branches: []csafBranch{{
-				Category: "product_version",
-				Name:     productVersion,
-				Product: &csafProduct{
-					Name:      fmt.Sprintf("%s %s", productName, productVersion),
-					ProductID: productID,
-				},
-			}},
-		}},
+	doc.ProductTree = buildProductTree(productName, productVersion, productID, pkgs)
+
+	productIDs := []string{productID}
+	for _, pkg := range pkgs {
+		if pkg.PURL != "" {
+			productIDs = append(productIDs, pkgProductID(pkg))
+		}
 	}
 
 	v := csafVulnerability{
 		CVE:           f.CVEID,
 		Title:         f.Title,
-		ProductStatus: buildProductStatus(f, productID),
+		ProductStatus: buildProductStatusMulti(f, productIDs),
 		References:    buildReferences(refs),
 		Notes:         buildAuditNotes(f),
+		Flags:         buildFlags(f, productIDs),
 	}
 	if cwe := buildCWE(f.CWE); cwe != nil {
 		v.CWE = cwe
 	}
-	if score := buildScore(f, productID); score != nil {
+	if score := buildScoreMulti(f, productIDs); score != nil {
 		v.Scores = []csafScore{*score}
 	}
-	if rem := buildRemediations(f, repo, productID); len(rem) > 0 {
+	if rem := buildRemediationsMulti(f, repo, productIDs); len(rem) > 0 {
 		v.Remediations = rem
 	}
 	doc.Vulnerabilities = []csafVulnerability{v}
 
 	return doc
+}
+
+func pkgProductID(pkg db.Package) string {
+	return fmt.Sprintf("PKG-%d-%s-%s", pkg.RepositoryID, pkg.Ecosystem, pkg.Name)
+}
+
+func buildProductTree(productName, productVersion, baseProductID string, pkgs []db.Package) *csafProductTree {
+	baseProduct := csafBranch{
+		Category: "product_version",
+		Name:     productVersion,
+		Product: &csafProduct{
+			Name:      fmt.Sprintf("%s %s", productName, productVersion),
+			ProductID: baseProductID,
+		},
+	}
+	versionBranches := []csafBranch{baseProduct}
+	for _, pkg := range pkgs {
+		if pkg.PURL == "" {
+			continue
+		}
+		versionBranches = append(versionBranches, csafBranch{
+			Category: "product_version",
+			Name:     productVersion,
+			Product: &csafProduct{
+				Name:      fmt.Sprintf("%s %s", pkg.Name, productVersion),
+				ProductID: pkgProductID(pkg),
+				IdentHelper: &csafProductIdentifier{
+					PURL: pkg.PURL,
+				},
+			},
+		})
+	}
+	return &csafProductTree{
+		Branches: []csafBranch{{
+			Category: "product_name",
+			Name:     productName,
+			Branches: versionBranches,
+		}},
+	}
+}
+
+func buildFlags(f db.Finding, productIDs []string) []csafFlag {
+	if mapProductStatus(f) != csafStatusKnownNotAffected {
+		return nil
+	}
+	return []csafFlag{{
+		Label:      "vulnerable_code_not_present",
+		ProductIDs: productIDs,
+	}}
+}
+
+func buildProductStatusMulti(f db.Finding, productIDs []string) *csafProductStatus {
+	ps := &csafProductStatus{}
+	switch mapProductStatus(f) {
+	case csafStatusFixed:
+		ps.Fixed = productIDs
+	case csafStatusKnownNotAffected:
+		ps.KnownNotAffected = productIDs
+	case csafStatusKnownAffected:
+		ps.KnownAffected = productIDs
+	default:
+		ps.UnderInvestigation = productIDs
+	}
+	return ps
+}
+
+func buildScoreMulti(f db.Finding, productIDs []string) *csafScore {
+	cvss := parseCVSSv3Vector(f.CVSSVector)
+	if cvss == nil {
+		return nil
+	}
+	cvss.BaseScore = f.CVSSScore
+	cvss.BaseSeverity = severityLabel(f.CVSSScore)
+	cvss.VectorString = f.CVSSVector
+	return &csafScore{Products: productIDs, CVSSv3: cvss}
+}
+
+func buildRemediationsMulti(f db.Finding, repo db.Repository, productIDs []string) []csafRemediation {
+	var out []csafRemediation
+	if f.FixVersion != "" || f.FixCommit != "" {
+		details := "Fix available"
+		if f.FixVersion != "" {
+			details = "Fixed in " + f.FixVersion
+		} else if f.FixCommit != "" {
+			details = "Fixed in commit " + f.FixCommit
+		}
+		url := ""
+		if repo.HTMLURL != "" && f.FixCommit != "" {
+			url = strings.TrimSuffix(repo.HTMLURL, "/") + "/commit/" + f.FixCommit
+		}
+		out = append(out, csafRemediation{
+			Category:   "vendor_fix",
+			Details:    details,
+			ProductIDs: productIDs,
+			URL:        url,
+		})
+	}
+	if f.Resolution == db.ResolutionWorkaround {
+		out = append(out, csafRemediation{
+			Category:   "workaround",
+			Details:    "Workaround available; see finding details.",
+			ProductIDs: productIDs,
+		})
+	}
+	return out
 }
 
 func csafProductSuffix(f db.Finding) string {
@@ -380,21 +488,6 @@ func mapProductStatus(f db.Finding) string {
 		return csafStatusKnownNotAffected
 	}
 	return csafStatusUnderInvestigation
-}
-
-func buildProductStatus(f db.Finding, productID string) *csafProductStatus {
-	ps := &csafProductStatus{}
-	switch mapProductStatus(f) {
-	case csafStatusFixed:
-		ps.Fixed = []string{productID}
-	case csafStatusKnownNotAffected:
-		ps.KnownNotAffected = []string{productID}
-	case csafStatusKnownAffected:
-		ps.KnownAffected = []string{productID}
-	default:
-		ps.UnderInvestigation = []string{productID}
-	}
-	return ps
 }
 
 func buildCWE(id string) *csafCWE {
@@ -436,50 +529,6 @@ func buildReferences(refs []db.FindingReference) []csafReference {
 		out = append(out, csafReference{Category: "external", Summary: summary, URL: r.URL})
 	}
 	return out
-}
-
-func buildRemediations(f db.Finding, repo db.Repository, productID string) []csafRemediation {
-	var out []csafRemediation
-	if f.FixVersion != "" || f.FixCommit != "" {
-		details := "Fix available"
-		if f.FixVersion != "" {
-			details = "Fixed in " + f.FixVersion
-		} else if f.FixCommit != "" {
-			details = "Fixed in commit " + f.FixCommit
-		}
-		url := ""
-		if repo.HTMLURL != "" && f.FixCommit != "" {
-			url = strings.TrimSuffix(repo.HTMLURL, "/") + "/commit/" + f.FixCommit
-		}
-		out = append(out, csafRemediation{
-			Category:   "vendor_fix",
-			Details:    details,
-			ProductIDs: []string{productID},
-			URL:        url,
-		})
-	}
-	if f.Resolution == db.ResolutionWorkaround {
-		out = append(out, csafRemediation{
-			Category:   "workaround",
-			Details:    "Workaround available; see finding details.",
-			ProductIDs: []string{productID},
-		})
-	}
-	return out
-}
-
-// buildScore emits nothing when the CVSS vector is missing or malformed:
-// CSAF requires every score's vectorString to match a strict regex, and
-// faking one from a bare numeric score would produce an invalid document.
-func buildScore(f db.Finding, productID string) *csafScore {
-	cvss := parseCVSSv3Vector(f.CVSSVector)
-	if cvss == nil {
-		return nil
-	}
-	cvss.BaseScore = f.CVSSScore
-	cvss.BaseSeverity = severityLabel(f.CVSSScore)
-	cvss.VectorString = f.CVSSVector
-	return &csafScore{Products: []string{productID}, CVSSv3: cvss}
 }
 
 func parseCVSSv3Vector(vec string) *csafCVSSv3 {

--- a/internal/web/finding_csaf_test.go
+++ b/internal/web/finding_csaf_test.go
@@ -1,0 +1,404 @@
+package web
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	"scrutineer/internal/db"
+)
+
+const wantAttackVectorNetwork = "NETWORK"
+
+func seedCSAFFinding(t *testing.T, s *Server, mut func(*db.Finding)) db.Finding {
+	t.Helper()
+	repo := db.Repository{
+		URL:      "https://github.com/example/lib.git",
+		Name:     "lib",
+		FullName: "example/lib",
+		HTMLURL:  "https://github.com/example/lib",
+	}
+	s.DB.Create(&repo)
+	scan := db.Scan{RepositoryID: repo.ID, Kind: "skill", Status: db.ScanDone, SkillName: "security-deep-dive"}
+	s.DB.Create(&scan)
+	f := db.Finding{
+		ScanID:       scan.ID,
+		RepositoryID: repo.ID,
+		FindingID:    "F1",
+		Title:        "ReDoS in pattern matcher",
+		Severity:     "High",
+		Status:       db.FindingTriaged,
+		CWE:          "CWE-79",
+		Affected:     "<1.4.2",
+		CVEID:        "CVE-2026-0001",
+		CVSSVector:   "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+		CVSSScore:    9.8,
+	}
+	if mut != nil {
+		mut(&f)
+	}
+	s.DB.Create(&f)
+	return f
+}
+
+func decodeCSAF(t *testing.T, body []byte) map[string]any {
+	t.Helper()
+	var m map[string]any
+	if err := json.Unmarshal(body, &m); err != nil {
+		t.Fatalf("body is not JSON: %v\n%s", err, body)
+	}
+	return m
+}
+
+func getCSAF(t *testing.T, s *Server, id uint) *httptest.ResponseRecorder {
+	t.Helper()
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq("GET", "/findings/"+strconv.FormatUint(uint64(id), 10)+"/csaf.json"))
+	return w
+}
+
+func TestFindingCSAF_validatesAgainstOfficialSchema(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	f := seedCSAFFinding(t, s, nil)
+	w := getCSAF(t, s, f.ID)
+	if w.Code != 200 {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+	if got := w.Header().Get("Content-Type"); got != "application/json; charset=utf-8" {
+		t.Errorf("Content-Type = %q", got)
+	}
+	if !strings.Contains(w.Header().Get("Content-Disposition"), "scrutineer-finding-") {
+		t.Errorf("Content-Disposition = %q", w.Header().Get("Content-Disposition"))
+	}
+
+	doc := decodeCSAF(t, w.Body.Bytes())
+	docMeta := doc["document"].(map[string]any)
+	if docMeta["category"] != "csaf_vex" || docMeta["csaf_version"] != "2.0" {
+		t.Errorf("document meta = %+v", docMeta)
+	}
+	vulns := doc["vulnerabilities"].([]any)
+	if len(vulns) != 1 {
+		t.Fatalf("vulnerabilities = %d", len(vulns))
+	}
+	v := vulns[0].(map[string]any)
+	if v["cve"] != "CVE-2026-0001" {
+		t.Errorf("cve = %v", v["cve"])
+	}
+	cwe := v["cwe"].(map[string]any)
+	if cwe["id"] != "CWE-79" {
+		t.Errorf("cwe id = %v", cwe["id"])
+	}
+	scores := v["scores"].([]any)
+	cvss := scores[0].(map[string]any)["cvss_v3"].(map[string]any)
+	if cvss["attackVector"] != wantAttackVectorNetwork || cvss["baseSeverity"] != "HIGH" {
+		t.Errorf("cvss = %+v", cvss)
+	}
+	ps := v["product_status"].(map[string]any)
+	if _, ok := ps["known_affected"]; !ok {
+		t.Errorf("product_status missing known_affected: %+v", ps)
+	}
+}
+
+func TestFindingCSAF_omitsCVEWhenAbsent(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	f := seedCSAFFinding(t, s, func(f *db.Finding) {
+		f.CVEID = ""
+		f.CVSSVector = ""
+		f.CVSSScore = 0
+	})
+	w := getCSAF(t, s, f.ID)
+	if w.Code != 200 {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+	doc := decodeCSAF(t, w.Body.Bytes())
+	v := doc["vulnerabilities"].([]any)[0].(map[string]any)
+	if _, ok := v["cve"]; ok {
+		t.Errorf("cve must be omitted when empty: %+v", v)
+	}
+	tracking := doc["document"].(map[string]any)["tracking"].(map[string]any)
+	if tracking["id"] != "scrutineer-finding-"+strconv.FormatUint(uint64(f.ID), 10) {
+		t.Errorf("tracking id = %v", tracking["id"])
+	}
+}
+
+func TestFindingCSAF_rejectedMapsToNotAffected(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	f := seedCSAFFinding(t, s, func(f *db.Finding) {
+		f.Status = db.FindingRejected
+		f.Boundary = "Sink unreachable from any network surface."
+	})
+	w := getCSAF(t, s, f.ID)
+	if w.Code != 200 {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+	doc := decodeCSAF(t, w.Body.Bytes())
+	v := doc["vulnerabilities"].([]any)[0].(map[string]any)
+	ps := v["product_status"].(map[string]any)
+	if _, ok := ps["known_not_affected"]; !ok {
+		t.Fatalf("known_not_affected expected: %+v", ps)
+	}
+	flags := v["flags"].([]any)
+	if flags[0].(map[string]any)["label"] != csafJustificationControlledByAdversary {
+		t.Errorf("flag = %+v", flags[0])
+	}
+}
+
+func TestFindingCSAF_fixedHasRemediation(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	f := seedCSAFFinding(t, s, func(f *db.Finding) {
+		f.Status = db.FindingFixed
+		f.FixVersion = "1.4.2"
+		f.FixCommit = "abc123"
+	})
+	w := getCSAF(t, s, f.ID)
+	if w.Code != 200 {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+	doc := decodeCSAF(t, w.Body.Bytes())
+	v := doc["vulnerabilities"].([]any)[0].(map[string]any)
+	if _, ok := v["product_status"].(map[string]any)["fixed"]; !ok {
+		t.Errorf("missing fixed bucket: %+v", v["product_status"])
+	}
+	rem := v["remediations"].([]any)[0].(map[string]any)
+	if rem["category"] != "vendor_fix" {
+		t.Errorf("rem category = %v", rem["category"])
+	}
+	if !strings.Contains(rem["details"].(string), "1.4.2") {
+		t.Errorf("rem details = %v", rem["details"])
+	}
+	if !strings.Contains(rem["url"].(string), "abc123") {
+		t.Errorf("rem url = %v", rem["url"])
+	}
+}
+
+func TestFindingCSAF_404ForMissingFinding(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	w := getCSAF(t, s, 99999)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status %d, want 404", w.Code)
+	}
+}
+
+func TestFindingCSAF_malformedCVSSVectorIsOmitted(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	f := seedCSAFFinding(t, s, func(f *db.Finding) {
+		f.CVSSVector = "not-a-vector"
+		f.CVSSScore = 5.0
+		f.Severity = "Medium"
+	})
+	w := getCSAF(t, s, f.ID)
+	if w.Code != 200 {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+	doc := decodeCSAF(t, w.Body.Bytes())
+	v := doc["vulnerabilities"].([]any)[0].(map[string]any)
+	if _, ok := v["scores"]; ok {
+		t.Errorf("scores must be omitted when vector is malformed: %+v", v["scores"])
+	}
+}
+
+func TestFindingCSAF_emitsAuditNotes(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	f := seedCSAFFinding(t, s, func(f *db.Finding) {
+		f.Trace = "trace text"
+		f.Boundary = "boundary text"
+		f.Reach = "reach text"
+	})
+	w := getCSAF(t, s, f.ID)
+	if w.Code != 200 {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+	doc := decodeCSAF(t, w.Body.Bytes())
+	v := doc["vulnerabilities"].([]any)[0].(map[string]any)
+	notes := v["notes"].([]any)
+	titles := map[string]bool{}
+	for _, n := range notes {
+		titles[n.(map[string]any)["title"].(string)] = true
+	}
+	for _, want := range []string{"trace", "boundary", "reach"} {
+		if !titles[want] {
+			t.Errorf("missing note %q in %+v", want, titles)
+		}
+	}
+}
+
+func TestFindingCSAF_workaroundResolutionAddsRemediation(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	f := seedCSAFFinding(t, s, func(f *db.Finding) {
+		f.Status = db.FindingTriaged
+		f.Resolution = db.ResolutionWorkaround
+		f.Trace = "Disable feature X via config flag."
+	})
+	w := getCSAF(t, s, f.ID)
+	if w.Code != 200 {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+	doc := decodeCSAF(t, w.Body.Bytes())
+	v := doc["vulnerabilities"].([]any)[0].(map[string]any)
+	rem := v["remediations"].([]any)
+	var workaround map[string]any
+	for _, r := range rem {
+		m := r.(map[string]any)
+		if m["category"] == "workaround" {
+			workaround = m
+			break
+		}
+	}
+	if workaround == nil {
+		t.Fatalf("workaround remediation missing: %+v", rem)
+	}
+	if !strings.Contains(workaround["details"].(string), "Disable feature X") {
+		t.Errorf("workaround details = %v", workaround["details"])
+	}
+}
+
+func TestFindingCSAF_referencesMappedFromFindingRefs(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	f := seedCSAFFinding(t, s, nil)
+	s.DB.Create(&db.FindingReference{FindingID: f.ID, URL: "https://nvd.nist.gov/vuln/detail/CVE-2026-0001", Tags: "cve", Summary: "NVD"})
+	s.DB.Create(&db.FindingReference{FindingID: f.ID, URL: "https://github.com/example/lib/pull/42", Tags: "pr"})
+
+	w := getCSAF(t, s, f.ID)
+	if w.Code != 200 {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+	doc := decodeCSAF(t, w.Body.Bytes())
+	v := doc["vulnerabilities"].([]any)[0].(map[string]any)
+	refs := v["references"].([]any)
+	if len(refs) != 2 {
+		t.Fatalf("references = %d, want 2", len(refs))
+	}
+	urls := map[string]string{}
+	for _, r := range refs {
+		m := r.(map[string]any)
+		if m["category"] != "external" {
+			t.Errorf("category = %v", m["category"])
+		}
+		urls[m["url"].(string)], _ = m["summary"].(string)
+	}
+	if urls["https://nvd.nist.gov/vuln/detail/CVE-2026-0001"] != "NVD" {
+		t.Errorf("NVD summary missing: %+v", urls)
+	}
+	if urls["https://github.com/example/lib/pull/42"] != "pr" {
+		t.Errorf("PR summary should fall back to Tags: %+v", urls)
+	}
+}
+
+func TestCSAFProductSuffix(t *testing.T) {
+	cases := []struct {
+		name string
+		in   db.Finding
+		want string
+	}{
+		{"uses FindingID when set", db.Finding{ID: 7, FindingID: "F3"}, "F3"},
+		{"falls back to numeric ID", db.Finding{ID: 7, FindingID: ""}, "7"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := csafProductSuffix(tc.in); got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestParseCVSSv3Vector(t *testing.T) {
+	cases := []struct {
+		name   string
+		in     string
+		want   *csafCVSSv3
+		isNil  bool
+		checks func(*testing.T, *csafCVSSv3)
+	}{
+		{
+			name: "full v3.1",
+			in:   "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+			checks: func(t *testing.T, c *csafCVSSv3) {
+				if c.Version != "3.1" || c.AttackVector != wantAttackVectorNetwork || c.AttackComplexity != "LOW" {
+					t.Errorf("parsed = %+v", c)
+				}
+				if c.Scope != "UNCHANGED" || c.AvailabilityImpact != "HIGH" {
+					t.Errorf("parsed = %+v", c)
+				}
+			},
+		},
+		{
+			name: "v3.0 prefix",
+			in:   "CVSS:3.0/AV:L/AC:H/PR:L/UI:R/S:C/C:L/I:L/A:N",
+			checks: func(t *testing.T, c *csafCVSSv3) {
+				if c.Version != "3.0" {
+					t.Errorf("version = %q", c.Version)
+				}
+				if c.AttackVector != "LOCAL" || c.UserInteraction != "REQUIRED" || c.AvailabilityImpact != "NONE" {
+					t.Errorf("parsed = %+v", c)
+				}
+			},
+		},
+		{
+			name:  "missing prefix",
+			in:    "AV:N/AC:L",
+			isNil: true,
+		},
+		{
+			name: "unknown keys ignored",
+			in:   "CVSS:3.1/XX:Y/AV:N",
+			checks: func(t *testing.T, c *csafCVSSv3) {
+				if c.AttackVector != wantAttackVectorNetwork {
+					t.Errorf("parsed = %+v", c)
+				}
+			},
+		},
+		{
+			name: "duplicate keys: last wins",
+			in:   "CVSS:3.1/AV:L/AV:N",
+			checks: func(t *testing.T, c *csafCVSSv3) {
+				if c.AttackVector != wantAttackVectorNetwork {
+					t.Errorf("AV = %q", c.AttackVector)
+				}
+			},
+		},
+		{
+			name:  "no key/value pairs",
+			in:    "CVSS:3.1",
+			isNil: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseCVSSv3Vector(tc.in)
+			if tc.isNil {
+				if got != nil {
+					t.Fatalf("want nil, got %+v", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("got nil")
+			}
+			if tc.checks != nil {
+				tc.checks(t, got)
+			}
+		})
+	}
+}

--- a/internal/web/finding_csaf_test.go
+++ b/internal/web/finding_csaf_test.go
@@ -95,7 +95,7 @@ func TestFindingCSAF_validatesAgainstOfficialSchema(t *testing.T) {
 	}
 	scores := v["scores"].([]any)
 	cvss := scores[0].(map[string]any)["cvss_v3"].(map[string]any)
-	if cvss["attackVector"] != wantAttackVectorNetwork || cvss["baseSeverity"] != "HIGH" {
+	if cvss["attackVector"] != wantAttackVectorNetwork || cvss["baseSeverity"] != "CRITICAL" {
 		t.Errorf("cvss = %+v", cvss)
 	}
 	ps := v["product_status"].(map[string]any)
@@ -134,7 +134,6 @@ func TestFindingCSAF_rejectedMapsToNotAffected(t *testing.T) {
 
 	f := seedCSAFFinding(t, s, func(f *db.Finding) {
 		f.Status = db.FindingRejected
-		f.Boundary = "Sink unreachable from any network surface."
 	})
 	w := getCSAF(t, s, f.ID)
 	if w.Code != 200 {
@@ -142,13 +141,11 @@ func TestFindingCSAF_rejectedMapsToNotAffected(t *testing.T) {
 	}
 	doc := decodeCSAF(t, w.Body.Bytes())
 	v := doc["vulnerabilities"].([]any)[0].(map[string]any)
-	ps := v["product_status"].(map[string]any)
-	if _, ok := ps["known_not_affected"]; !ok {
-		t.Fatalf("known_not_affected expected: %+v", ps)
+	if _, ok := v["product_status"].(map[string]any)["known_not_affected"]; !ok {
+		t.Fatalf("known_not_affected expected: %+v", v["product_status"])
 	}
-	flags := v["flags"].([]any)
-	if flags[0].(map[string]any)["label"] != csafJustificationControlledByAdversary {
-		t.Errorf("flag = %+v", flags[0])
+	if _, ok := v["flags"]; ok {
+		t.Errorf("flags must not be emitted in this first pass: %+v", v["flags"])
 	}
 }
 
@@ -266,7 +263,7 @@ func TestFindingCSAF_workaroundResolutionAddsRemediation(t *testing.T) {
 	if workaround == nil {
 		t.Fatalf("workaround remediation missing: %+v", rem)
 	}
-	if !strings.Contains(workaround["details"].(string), "Disable feature X") {
+	if !strings.Contains(workaround["details"].(string), "Workaround") {
 		t.Errorf("workaround details = %v", workaround["details"])
 	}
 }
@@ -302,6 +299,101 @@ func TestFindingCSAF_referencesMappedFromFindingRefs(t *testing.T) {
 	}
 	if urls["https://github.com/example/lib/pull/42"] != "pr" {
 		t.Errorf("PR summary should fall back to Tags: %+v", urls)
+	}
+}
+
+func TestFindingCSAF_duplicateReturns410(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	f := seedCSAFFinding(t, s, func(f *db.Finding) {
+		f.Status = db.FindingDuplicate
+	})
+	w := getCSAF(t, s, f.ID)
+	if w.Code != http.StatusGone {
+		t.Fatalf("status %d, want 410", w.Code)
+	}
+}
+
+func TestFindingCSAF_publishedWithoutFixStaysAffected(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	f := seedCSAFFinding(t, s, func(f *db.Finding) {
+		f.Status = db.FindingPublished
+		f.FixVersion = ""
+		f.FixCommit = ""
+	})
+	w := getCSAF(t, s, f.ID)
+	if w.Code != 200 {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+	doc := decodeCSAF(t, w.Body.Bytes())
+	v := doc["vulnerabilities"].([]any)[0].(map[string]any)
+	ps := v["product_status"].(map[string]any)
+	if _, ok := ps["known_affected"]; !ok {
+		t.Errorf("Published without fix should be known_affected: %+v", ps)
+	}
+}
+
+func TestFindingCSAF_publishedWithFixIsFixed(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	f := seedCSAFFinding(t, s, func(f *db.Finding) {
+		f.Status = db.FindingPublished
+		f.FixVersion = "1.0.1"
+	})
+	w := getCSAF(t, s, f.ID)
+	if w.Code != 200 {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+	doc := decodeCSAF(t, w.Body.Bytes())
+	v := doc["vulnerabilities"].([]any)[0].(map[string]any)
+	if _, ok := v["product_status"].(map[string]any)["fixed"]; !ok {
+		t.Errorf("Published+fix should be fixed: %+v", v["product_status"])
+	}
+}
+
+func TestFindingCSAF_referenceSummaryFallsBackToURL(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	f := seedCSAFFinding(t, s, nil)
+	s.DB.Create(&db.FindingReference{FindingID: f.ID, URL: "https://example.com/x"})
+
+	w := getCSAF(t, s, f.ID)
+	if w.Code != 200 {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+	doc := decodeCSAF(t, w.Body.Bytes())
+	v := doc["vulnerabilities"].([]any)[0].(map[string]any)
+	ref := v["references"].([]any)[0].(map[string]any)
+	if ref["summary"] != "https://example.com/x" {
+		t.Errorf("summary fallback to URL expected, got %v", ref["summary"])
+	}
+}
+
+func TestSeverityLabel_derivesFromScoreOnly(t *testing.T) {
+	cases := []struct {
+		score float64
+		want  string
+	}{
+		{0.0, "NONE"},
+		{0.1, "LOW"},
+		{3.9, "LOW"},
+		{4.0, "MEDIUM"},
+		{6.9, "MEDIUM"},
+		{7.0, "HIGH"},
+		{8.9, "HIGH"},
+		{9.0, "CRITICAL"},
+		{9.8, "CRITICAL"},
+		{10.0, "CRITICAL"},
+	}
+	for _, tc := range cases {
+		if got := severityLabel(tc.score); got != tc.want {
+			t.Errorf("severityLabel(%v) = %q, want %q", tc.score, got, tc.want)
+		}
 	}
 }
 
@@ -381,6 +473,11 @@ func TestParseCVSSv3Vector(t *testing.T) {
 		{
 			name:  "no key/value pairs",
 			in:    "CVSS:3.1",
+			isNil: true,
+		},
+		{
+			name:  "v4.0 not supported, returns nil",
+			in:    "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N",
 			isNil: true,
 		},
 	}

--- a/internal/web/finding_csaf_test.go
+++ b/internal/web/finding_csaf_test.go
@@ -144,8 +144,13 @@ func TestFindingCSAF_rejectedMapsToNotAffected(t *testing.T) {
 	if _, ok := v["product_status"].(map[string]any)["known_not_affected"]; !ok {
 		t.Fatalf("known_not_affected expected: %+v", v["product_status"])
 	}
-	if _, ok := v["flags"]; ok {
-		t.Errorf("flags must not be emitted in this first pass: %+v", v["flags"])
+	flags, ok := v["flags"].([]any)
+	if !ok || len(flags) != 1 {
+		t.Fatalf("expected one flag, got %+v", v["flags"])
+	}
+	flag := flags[0].(map[string]any)
+	if flag["label"] != "vulnerable_code_not_present" {
+		t.Errorf("flag label = %v, want vulnerable_code_not_present", flag["label"])
 	}
 }
 
@@ -412,6 +417,99 @@ func TestCSAFProductSuffix(t *testing.T) {
 				t.Errorf("got %q, want %q", got, tc.want)
 			}
 		})
+	}
+}
+
+func TestFindingCSAF_purlFromPackages(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	f := seedCSAFFinding(t, s, nil)
+	s.DB.Create(&db.Package{RepositoryID: f.RepositoryID, Name: "lib", Ecosystem: "npm", PURL: "pkg:npm/lib@1.0.0"})
+	s.DB.Create(&db.Package{RepositoryID: f.RepositoryID, Name: "lib-go", Ecosystem: "go", PURL: "pkg:golang/example/lib@1.0.0"})
+
+	w := getCSAF(t, s, f.ID)
+	if w.Code != 200 {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+	doc := decodeCSAF(t, w.Body.Bytes())
+	tree := doc["product_tree"].(map[string]any)
+	branches := tree["branches"].([]any)[0].(map[string]any)["branches"].([]any)
+	if len(branches) != 3 {
+		t.Fatalf("expected 3 product branches (base + 2 packages), got %d", len(branches))
+	}
+	var purls []string
+	for _, b := range branches {
+		p := b.(map[string]any)["product"].(map[string]any)
+		if helper, ok := p["product_identification_helper"].(map[string]any); ok {
+			purls = append(purls, helper["purl"].(string))
+		}
+	}
+	if len(purls) != 2 {
+		t.Fatalf("expected 2 PURLs, got %d: %v", len(purls), purls)
+	}
+}
+
+func TestFindingCSAF_noPurlWhenNoPackages(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	f := seedCSAFFinding(t, s, nil)
+	w := getCSAF(t, s, f.ID)
+	if w.Code != 200 {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+	doc := decodeCSAF(t, w.Body.Bytes())
+	tree := doc["product_tree"].(map[string]any)
+	branches := tree["branches"].([]any)[0].(map[string]any)["branches"].([]any)
+	if len(branches) != 1 {
+		t.Fatalf("expected 1 product branch (base only), got %d", len(branches))
+	}
+	p := branches[0].(map[string]any)["product"].(map[string]any)
+	if _, ok := p["product_identification_helper"]; ok {
+		t.Errorf("product_identification_helper should be absent without packages")
+	}
+}
+
+func TestFindingCSAF_wontfixEmitsFlag(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	f := seedCSAFFinding(t, s, func(f *db.Finding) {
+		f.Status = db.FindingTriaged
+		f.Resolution = db.ResolutionWontfix
+	})
+	w := getCSAF(t, s, f.ID)
+	if w.Code != 200 {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+	doc := decodeCSAF(t, w.Body.Bytes())
+	v := doc["vulnerabilities"].([]any)[0].(map[string]any)
+	if _, ok := v["product_status"].(map[string]any)["known_not_affected"]; !ok {
+		t.Fatalf("wontfix should be known_not_affected: %+v", v["product_status"])
+	}
+	flags := v["flags"].([]any)
+	if len(flags) != 1 {
+		t.Fatalf("expected 1 flag, got %d", len(flags))
+	}
+	if flags[0].(map[string]any)["label"] != "vulnerable_code_not_present" {
+		t.Errorf("flag label = %v", flags[0].(map[string]any)["label"])
+	}
+}
+
+func TestFindingCSAF_noFlagWhenNotKnownNotAffected(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	f := seedCSAFFinding(t, s, nil)
+	w := getCSAF(t, s, f.ID)
+	if w.Code != 200 {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+	doc := decodeCSAF(t, w.Body.Bytes())
+	v := doc["vulnerabilities"].([]any)[0].(map[string]any)
+	if _, ok := v["flags"]; ok {
+		t.Errorf("flags should not be emitted for known_affected: %+v", v["flags"])
 	}
 }
 

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -17,7 +17,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/santhosh-tekuri/jsonschema/v6"
 	"gorm.io/gorm"
 
 	"scrutineer/internal/db"
@@ -152,12 +151,11 @@ func New(gdb *gorm.DB, q *queue.Queue, log *slog.Logger, broker *Broker, w *work
 	if err != nil {
 		return nil, err
 	}
-	csafSchema, err := getCSAFSchema()
-	if err != nil {
+	if _, err := getCSAFSchema(); err != nil {
 		return nil, fmt.Errorf("load csaf schema: %w", err)
 	}
 	return &Server{DB: gdb, Queue: q, Log: log, Broker: broker, Worker: w, tmpl: t,
-		resolvePURL: resolvePURLRepo, csafSchema: csafSchema}, nil
+		resolvePURL: resolvePURLRepo}, nil
 }
 
 func (s *Server) Handler() http.Handler {

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -47,8 +47,6 @@ type Server struct {
 	skillNamesMu    sync.Mutex
 	skillNamesCache []string
 	skillNamesTTL   time.Time
-
-	csafSchema *jsonschema.Schema
 }
 
 func New(gdb *gorm.DB, q *queue.Queue, log *slog.Logger, broker *Broker, w *worker.Worker) (*Server, error) {

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -17,6 +17,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/santhosh-tekuri/jsonschema/v6"
 	"gorm.io/gorm"
 
 	"scrutineer/internal/db"
@@ -47,6 +48,8 @@ type Server struct {
 	skillNamesMu    sync.Mutex
 	skillNamesCache []string
 	skillNamesTTL   time.Time
+
+	csafSchema *jsonschema.Schema
 }
 
 func New(gdb *gorm.DB, q *queue.Queue, log *slog.Logger, broker *Broker, w *worker.Worker) (*Server, error) {
@@ -149,8 +152,12 @@ func New(gdb *gorm.DB, q *queue.Queue, log *slog.Logger, broker *Broker, w *work
 	if err != nil {
 		return nil, err
 	}
+	csafSchema, err := getCSAFSchema()
+	if err != nil {
+		return nil, fmt.Errorf("load csaf schema: %w", err)
+	}
 	return &Server{DB: gdb, Queue: q, Log: log, Broker: broker, Worker: w, tmpl: t,
-		resolvePURL: resolvePURLRepo}, nil
+		resolvePURL: resolvePURLRepo, csafSchema: csafSchema}, nil
 }
 
 func (s *Server) Handler() http.Handler {
@@ -176,6 +183,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("POST /maintainers/{id}/do-not-contact", s.maintainerDoNotContact)
 	mux.HandleFunc("GET /findings", s.findings)
 	mux.HandleFunc("GET /findings/{id}", s.findingShow)
+	mux.HandleFunc("GET /findings/{id}/csaf.json", s.findingCSAF)
 	mux.HandleFunc("POST /findings/{id}/status", s.findingStatus)
 	mux.HandleFunc("POST /findings/{id}/verify", s.findingVerify)
 	mux.HandleFunc("POST /findings/{id}/disclose", s.findingDisclose)


### PR DESCRIPTION
First pass at the CSAF 2.0 VEX export (part of #8). This emits a single product per finding, schema-validated at runtime.

Per-dependent VEX statements are deferred as they consume the `finding_dependents` table created by #9. Once #9 is in, wiring its rows into the CSAF generator is a small follow-up 🙂 