### PR TITLE
skills: add reachability skill + dependency-findings API

### DIFF
--- a/internal/db/ecosystem.go
+++ b/internal/db/ecosystem.go
@@ -1,0 +1,145 @@
+package db
+
+import "gorm.io/gorm"
+
+// dependencyEcosystemAlias maps git-pkgs ecosystem names (as stored on
+// Dependency rows) to packages.ecosyste.ms registry names (as stored on
+// Package rows). The two sources disagree for a handful of registries; the
+// join in DependencyFindings needs them to agree.
+var dependencyEcosystemAlias = map[string]string{
+	"gem":            "rubygems",
+	"golang":         "go",
+	"composer":       "packagist",
+	"github-actions": "actions",
+	"brew":           "homebrew",
+	"swift":          "swiftpm",
+	"nix":            "nixpkgs",
+}
+
+func CanonicalEcosystem(dep string) string {
+	if v, ok := dependencyEcosystemAlias[dep]; ok {
+		return v
+	}
+	return dep
+}
+
+// DependencyFinding is one finding on a library that the given application
+// depends on. Returned by DependencyFindings; consumed by the reachability
+// skill via the /repositories/{id}/dependency-findings API.
+type DependencyFinding struct {
+	Package        string `json:"package"`
+	Ecosystem      string `json:"ecosystem"`
+	Requirement    string `json:"requirement"`
+	ManifestPath   string `json:"manifest_path"`
+	DependencyType string `json:"dependency_type"`
+
+	FindingID  uint             `json:"finding_id"`
+	LibRepoID  uint             `json:"library_repository_id"`
+	LibRepoURL string           `json:"library_repository_url"`
+	Title      string           `json:"title"`
+	Severity   string           `json:"severity"`
+	CWE        string           `json:"cwe"`
+	Location   string           `json:"location"`
+	Sinks      string           `json:"sinks"`
+	Status     FindingLifecycle `json:"status"`
+	Trace      string           `json:"trace"`
+	Boundary   string           `json:"boundary"`
+}
+
+// DependencyFindings joins an application repository's Dependency rows
+// against every Package row in the database (any repository) and returns
+// the live Findings on the matched library repositories. Self-matches and
+// findings already marked fixed/rejected/duplicate are excluded.
+func DependencyFindings(g *gorm.DB, appRepoID uint) ([]DependencyFinding, error) {
+	var deps []Dependency
+	if err := g.Where("repository_id = ?", appRepoID).Find(&deps).Error; err != nil {
+		return nil, err
+	}
+
+	type key struct{ name, eco string }
+	want := map[key]Dependency{}
+	for _, d := range deps {
+		k := key{d.Name, CanonicalEcosystem(d.Ecosystem)}
+		if cur, ok := want[k]; !ok || preferDep(d, cur) {
+			want[k] = d
+		}
+	}
+	if len(want) == 0 {
+		return []DependencyFinding{}, nil
+	}
+
+	type pkgRow struct {
+		Name          string
+		Ecosystem     string
+		RepositoryID  uint
+		RepositoryURL string
+	}
+	var pkgs []pkgRow
+	if err := g.Table("packages").
+		Select("packages.name, packages.ecosystem, packages.repository_id, repositories.url AS repository_url").
+		Joins("JOIN repositories ON repositories.id = packages.repository_id").
+		Where("packages.repository_id <> ?", appRepoID).
+		Scan(&pkgs).Error; err != nil {
+		return nil, err
+	}
+
+	libDeps := map[uint]DependencyFinding{}
+	for _, p := range pkgs {
+		d, ok := want[key{p.Name, p.Ecosystem}]
+		if !ok {
+			continue
+		}
+		libDeps[p.RepositoryID] = DependencyFinding{
+			Package:        p.Name,
+			Ecosystem:      p.Ecosystem,
+			Requirement:    d.Requirement,
+			ManifestPath:   d.ManifestPath,
+			DependencyType: d.DependencyType,
+			LibRepoID:      p.RepositoryID,
+			LibRepoURL:     p.RepositoryURL,
+		}
+	}
+	if len(libDeps) == 0 {
+		return []DependencyFinding{}, nil
+	}
+
+	libIDs := make([]uint, 0, len(libDeps))
+	for id := range libDeps {
+		libIDs = append(libIDs, id)
+	}
+	var findings []Finding
+	if err := g.Where("repository_id IN ?", libIDs).
+		Where("status NOT IN ?", []FindingLifecycle{FindingFixed, FindingRejected, FindingDuplicate}).
+		Order("CASE severity WHEN 'Critical' THEN 0 WHEN 'High' THEN 1 WHEN 'Medium' THEN 2 ELSE 3 END, repository_id").
+		Find(&findings).Error; err != nil {
+		return nil, err
+	}
+
+	out := make([]DependencyFinding, 0, len(findings))
+	for _, f := range findings {
+		base := libDeps[f.RepositoryID]
+		base.FindingID = f.ID
+		base.Title = f.Title
+		base.Severity = f.Severity
+		base.CWE = f.CWE
+		base.Location = f.Location
+		base.Sinks = f.Sinks
+		base.Status = f.Status
+		base.Trace = f.Trace
+		base.Boundary = f.Boundary
+		out = append(out, base)
+	}
+	return out, nil
+}
+
+// preferDep picks the more informative of two Dependency rows for the same
+// package: a lockfile row (concrete requirement) beats a manifest row, and
+// a runtime dependency beats a development one.
+func preferDep(a, b Dependency) bool {
+	const runtime = "runtime"
+	aRT, bRT := a.DependencyType == runtime, b.DependencyType == runtime
+	if aRT != bRT {
+		return aRT
+	}
+	return a.ManifestKind == "lockfile" && b.ManifestKind != "lockfile"
+}

--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -89,6 +89,7 @@ func (s *Server) apiHandler() http.Handler {
 	mux.HandleFunc("GET /repositories/{id}/dependents", s.apiListDependents)
 	mux.HandleFunc("GET /repositories/{id}/dependencies", s.apiListDependencies)
 	mux.HandleFunc("GET /repositories/{id}/findings", s.apiListFindings)
+	mux.HandleFunc("GET /repositories/{id}/dependency-findings", s.apiListDependencyFindings)
 	mux.HandleFunc("POST /repositories/{id}/skills/{name}/run", s.apiRunSkill)
 	mux.HandleFunc("POST /findings/{id}/skills/{name}/run", s.apiRunFindingSkill)
 	mux.HandleFunc("GET /scans/{id}", s.apiGetScan)

--- a/internal/web/api_reads.go
+++ b/internal/web/api_reads.go
@@ -139,6 +139,33 @@ func (s *Server) apiListDependencies(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, out)
 }
 
+// apiListDependencyFindings returns findings on any library repository whose
+// published package appears in this repository's dependency list. The skill
+// token still only authorises the caller's own repo; the cross-repo read is
+// derived from that repo's dependencies, not chosen by the caller.
+func (s *Server) apiListDependencyFindings(w http.ResponseWriter, r *http.Request) {
+	id, _ := strconv.Atoi(r.PathValue("id"))
+	if !s.scanOwnsRepo(r, uint(id)) {
+		writeAPIError(w, http.StatusForbidden, "scan may only read its own repository")
+		return
+	}
+	rows, err := db.DependencyFindings(s.DB, uint(id))
+	if err != nil {
+		writeAPIError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	if sev := r.URL.Query().Get("severity"); sev != "" {
+		filtered := rows[:0]
+		for _, row := range rows {
+			if row.Severity == sev {
+				filtered = append(filtered, row)
+			}
+		}
+		rows = filtered
+	}
+	writeJSON(w, http.StatusOK, rows)
+}
+
 // apiListFindings returns the findings for a repository across every scan.
 // Scoped to the authenticated scan's repository; severity filter optional.
 func (s *Server) apiListFindings(w http.ResponseWriter, r *http.Request) {

--- a/internal/web/api_test.go
+++ b/internal/web/api_test.go
@@ -161,6 +161,68 @@ func TestAPIFindingReadsAndFilters(t *testing.T) {
 	}
 }
 
+func TestAPIListDependencyFindings(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	app, scan := seedRunningScan(t, s)
+
+	// App declares roo via Gemfile (ecosystem "gem", git-pkgs naming).
+	s.DB.Create(&db.Dependency{RepositoryID: app.ID, Name: "roo", Ecosystem: "gem", Requirement: "~> 2.10", ManifestPath: "Gemfile", ManifestKind: "manifest", DependencyType: "runtime"})
+	s.DB.Create(&db.Dependency{RepositoryID: app.ID, Name: "roo", Ecosystem: "gem", Requirement: "2.10.1", ManifestPath: "Gemfile.lock", ManifestKind: "lockfile", DependencyType: "runtime"})
+	s.DB.Create(&db.Dependency{RepositoryID: app.ID, Name: "leftpad", Ecosystem: "npm", ManifestPath: "package.json"})
+
+	// Library repo publishes roo to rubygems (ecosyste.ms naming) and has findings.
+	lib := db.Repository{URL: "https://example.com/roo", Name: "roo"}
+	s.DB.Create(&lib)
+	s.DB.Create(&db.Package{RepositoryID: lib.ID, Name: "roo", Ecosystem: "rubygems"})
+	libScan := db.Scan{RepositoryID: lib.ID, Kind: worker.JobSkill, Status: db.ScanDone}
+	s.DB.Create(&libScan)
+	s.DB.Create(&db.Finding{ScanID: libScan.ID, RepositoryID: lib.ID, Title: "xlsx bomb", Severity: sevHigh, CWE: "CWE-770", Location: "lib/roo/excelx.rb:42", Status: db.FindingNew, Trace: "t", Boundary: "b"})
+	s.DB.Create(&db.Finding{ScanID: libScan.ID, RepositoryID: lib.ID, Title: "ods bomb", Severity: "Medium", CWE: "CWE-770", Status: db.FindingNew})
+	s.DB.Create(&db.Finding{ScanID: libScan.ID, RepositoryID: lib.ID, Title: "old", Severity: sevHigh, Status: db.FindingFixed})
+
+	// Self-published package on the app repo must not match its own findings.
+	s.DB.Create(&db.Package{RepositoryID: app.ID, Name: "leftpad", Ecosystem: "npm"})
+	s.DB.Create(&db.Finding{ScanID: scan.ID, RepositoryID: app.ID, Title: "self", Severity: sevHigh, Status: db.FindingNew})
+
+	r := httptest.NewRequest("GET", "/api/repositories/"+strconv.FormatUint(uint64(app.ID), 10)+"/dependency-findings", nil)
+	r.Host = testHost
+	r.Header.Set("Authorization", "Bearer "+scan.APIToken)
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, r)
+	if w.Code != 200 {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+	var rows []db.DependencyFinding
+	if err := json.NewDecoder(w.Body).Decode(&rows); err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("rows=%d want=2 (live roo findings only): %+v", len(rows), rows)
+	}
+	if rows[0].Severity != sevHigh || rows[0].Package != "roo" {
+		t.Errorf("first row should be the High roo finding, got %+v", rows[0])
+	}
+	if rows[0].Requirement != "2.10.1" {
+		t.Errorf("lockfile requirement should win, got %q", rows[0].Requirement)
+	}
+	if rows[0].LibRepoURL != "https://example.com/roo" {
+		t.Errorf("library_repository_url=%q", rows[0].LibRepoURL)
+	}
+
+	// Severity filter
+	r = httptest.NewRequest("GET", "/api/repositories/"+strconv.FormatUint(uint64(app.ID), 10)+"/dependency-findings?severity=High", nil)
+	r.Host = testHost
+	r.Header.Set("Authorization", "Bearer "+scan.APIToken)
+	w = httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, r)
+	rows = nil
+	_ = json.NewDecoder(w.Body).Decode(&rows)
+	if len(rows) != 1 || rows[0].Title != "xlsx bomb" {
+		t.Errorf("severity filter: %+v", rows)
+	}
+}
+
 func TestAPIRunFindingSkill_scopesFindingID(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -168,6 +168,33 @@ paths:
                 items: { $ref: '#/components/schemas/FindingSummary' }
         '403': { $ref: '#/components/responses/Forbidden' }
 
+  /repositories/{id}/dependency-findings:
+    get:
+      summary: List findings on libraries this repository depends on
+      description: >
+        Joins this repository's Dependency rows against every Package row
+        scrutineer knows about and returns the live findings on the matched
+        library repositories. git-pkgs ecosystem names (gem, golang,
+        composer) are normalised to packages.ecosyste.ms names (rubygems,
+        go, packagist) before matching. Findings already marked fixed,
+        rejected or duplicate are excluded. Consumed by the reachability
+        skill.
+      operationId: listRepositoryDependencyFindings
+      parameters:
+        - $ref: '#/components/parameters/RepositoryID'
+        - name: severity
+          in: query
+          schema: { type: string, enum: [Critical, High, Medium, Low] }
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: '#/components/schemas/DependencyFinding' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+
   /repositories/{id}/skills/{name}/run:
     post:
       summary: Enqueue a skill scan against this repository
@@ -717,6 +744,27 @@ components:
         dependency_type: { type: string }
         manifest_path:   { type: string }
         manifest_kind:   { type: string }
+
+    DependencyFinding:
+      type: object
+      required: [package, ecosystem, finding_id, library_repository_id, severity]
+      properties:
+        package:               { type: string }
+        ecosystem:             { type: string }
+        requirement:           { type: string }
+        manifest_path:         { type: string }
+        dependency_type:       { type: string }
+        finding_id:            { type: integer, format: int64 }
+        library_repository_id: { type: integer, format: int64 }
+        library_repository_url: { type: string, format: uri }
+        title:                 { type: string }
+        severity:              { type: string, enum: [Critical, High, Medium, Low] }
+        cwe:                   { type: string }
+        location:              { type: string, description: file:line inside the library }
+        sinks:                 { type: string }
+        status:                { type: string }
+        trace:                 { type: string }
+        boundary:              { type: string }
 
     FindingSummary:
       type: object

--- a/skills/reachability/SKILL.md
+++ b/skills/reachability/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: reachability
+description: Check whether known sinks in this application's dependencies are reachable from its own trust boundaries. Scrutineer already holds findings against the libraries this app uses; this skill traces each one from the app's entry points to the library call and reports the ones an attacker can reach. Use on applications (Gemfile.lock / package-lock.json present), not on libraries.
+license: MIT
+metadata:
+  scrutineer.output_file: report.json
+  scrutineer.output_kind: findings
+---
+
+# reachability
+
+Security-deep-dive on a library finds dangerous sinks but stops at the library boundary: "High if the caller passes untrusted input." This skill picks up on the application side. Scrutineer hands you the list of sinks already found in this app's dependencies; you decide, per sink, whether this app wires untrusted input to it.
+
+A reachable sink in an application is usually one severity step above the same sink in the library, because the boundary discount no longer applies. A library High that this app exposes on an unauthenticated route is an application Critical.
+
+## Workspace
+
+- `./src` — the cloned application
+- `./context.json` — `scrutineer.api_base`, `scrutineer.token`, `scrutineer.repository_id`, optional `scrutineer.scan_subpath`
+- `./report.json` — write findings here
+- `./schema.json` — output shape (same as security-deep-dive)
+
+## Inputs
+
+Fetch the candidate sinks:
+
+```
+GET {api_base}/repositories/{repository_id}/dependency-findings
+Authorization: Bearer {token}
+```
+
+Each entry has `package`, `ecosystem`, `requirement`, `manifest_path`, `dependency_type`, `severity`, `cwe`, `title`, `location` (file:line inside the library), `sinks`, `trace`, `boundary`, `library_repository_url`, and `finding_id`. The list is ordered by severity. If it is empty, either the dependencies skill has not indexed this repo yet or none of its dependencies have findings; write `{"findings": [], "ruled_out": [], "inventory": [], ...}` per the schema and stop.
+
+Work the list top-down. Budget your time toward High and Medium; Low entries are mostly resource-exhaustion in parsers and only worth a quick grep.
+
+## Per-sink procedure
+
+For each candidate, the question is fixed: does untrusted input from one of this application's entry points reach the library call named in `location` / `sinks`?
+
+### 1. Locate the call site
+
+Find where this app calls into `package`. Start from the `boundary` field on the candidate — it names the library entry point that leads to the sink (e.g. `Roo::Spreadsheet.open`, `Icalendar::Calendar.parse`, `PDF::Reader.new`). Grep `./src` for that symbol, the `require`/`import` of `package`, and obvious wrappers around it. If `scan_subpath` is set, scope to that folder.
+
+If the package is only in `Gemfile.lock` as a transitive dependency and nothing in `./src` calls it directly, check whether the app calls the intermediate package in a way that forwards input (e.g. crass via `sanitize`/loofah, sawyer via Octokit). If you cannot find a call path in two hops, rule it out: "transitive, no direct or one-hop call site".
+
+If `dependency_type` is `development` or the only call sites are under `test/`, `spec/`, or `script/`, rule it out: "development-only".
+
+### 2. Trace to a boundary
+
+From each call site, walk backwards to where the argument originates. You are looking for:
+
+- request parameters, uploaded files, request bodies
+- records read from the database whose value an unprivileged user wrote
+- files or URLs fetched from a location an external party controls
+- background-job arguments whose enqueue path is one of the above
+
+Name the route, controller action, job class, or CLI entry point. Quote the line where external data enters and each hop to the library call.
+
+If every call site receives only operator-chosen constants, fixtures, or admin-only input, rule it out and say which. Admin-only still counts if the app has self-service signup that grants the relevant role.
+
+### 3. Confirm the sink behaviour applies
+
+Read the candidate's `trace` and `boundary` prose. They describe the input shape that triggers the library bug. Check the app does not already neutralise it: size limits, content-type allowlists, schema validation, a safe-mode flag on the library call. Cite what you checked either way.
+
+You do not need to re-prove the library bug — that is the upstream finding's job. You do need to show this app's input can take the shape the upstream finding requires.
+
+### 4. Rate
+
+- **Critical** — reachable from an unauthenticated or self-service-authenticated request with no precondition beyond "send the payload", and the upstream sink yields code execution, auth bypass, or data exfiltration.
+- **High** — reachable from an authenticated user, or upstream impact is denial-of-service / resource exhaustion on a public route.
+- **Medium** — reachable but gated by a non-default configuration, an elevated role short of admin, or a multi-step chain.
+- **Low** — reachable only from trusted operator input, or the app's own limits reduce impact to nuisance level.
+
+## Output
+
+Write `./report.json` conforming to `./schema.json`.
+
+- `inventory[]` — one entry per candidate you assessed: `id` `S{n}`, `class` derived from the candidate's CWE (best fit from the schema's `sink_class` enum), `location` `"{package} {requirement} → {candidate.location}"`, `consumes` set to the call-site argument you traced.
+- `findings[]` — each reachable sink. `title` should name both the app entry point and the library sink, e.g. `"Spreadsheet upload at ImportsController#create reaches roo xlsx range expansion (upstream finding #{finding_id})"`. Put the call-site trace in `trace`, the app's boundary in `boundary`, and what you checked for mitigations in `validation`. Reference the upstream finding by `finding_id` and `library_repository_url` in `prior_art`.
+- `ruled_out[]` — every candidate you did not promote to a finding, with `step` 1/2/3 matching the section above where it fell out and a one-line `reason`.
+- `boundaries[]` — the application's actors (anonymous web user, authenticated user, admin, background job feeder) as you found them while tracing.
+
+Set `spec_version` to `10`. Use the repository URL and HEAD commit of `./src` for `repository` and `commit`.

--- a/skills/reachability/schema.json
+++ b/skills/reachability/schema.json
@@ -1,0 +1,146 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "security-deep-dive report",
+  "description": "Machine-readable form of a deep security audit. Mirrors the prose report: structured inventory and findings, per-step narrative for each finding, and a ruled-out list covering every inventory sink that did not become a finding.",
+  "type": "object",
+  "required": [
+    "repository",
+    "commit",
+    "spec_version",
+    "model",
+    "date",
+    "languages",
+    "boundaries",
+    "inventory",
+    "findings",
+    "ruled_out"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "repository":   { "type": "string", "format": "uri" },
+    "commit":       { "type": "string", "pattern": "^[0-9a-f]{7,40}$" },
+    "artefact":     { "type": "string" },
+    "spec_version": { "type": "integer", "minimum": 1 },
+    "model":        { "type": "string" },
+    "date":         { "type": "string", "format": "date" },
+    "files_reviewed": { "type": "integer", "minimum": 0 },
+    "languages":    { "type": "array", "items": { "type": "string" }, "minItems": 1 },
+
+    "boundaries":           { "type": "array", "items": { "$ref": "#/$defs/boundary" }, "minItems": 1 },
+    "boundaries_narrative": { "$ref": "#/$defs/markdown" },
+
+    "sink_primitives": {
+      "type": "object",
+      "propertyNames": { "$ref": "#/$defs/sink_class" },
+      "additionalProperties": { "type": "array", "items": { "type": "string" } }
+    },
+    "inventory":        { "type": "array", "items": { "$ref": "#/$defs/sink" } },
+    "inventory_notes":  { "$ref": "#/$defs/markdown" },
+
+    "findings":  { "type": "array", "items": { "$ref": "#/$defs/finding" } },
+    "ruled_out": { "type": "array", "items": { "$ref": "#/$defs/ruled_out_entry" } },
+
+    "prior_art": { "$ref": "#/$defs/markdown" },
+    "reach":     { "$ref": "#/$defs/markdown" }
+  },
+
+  "$defs": {
+    "markdown": {
+      "type": "string",
+      "contentMediaType": "text/markdown"
+    },
+    "severity": {
+      "type": "string",
+      "enum": ["Critical", "High", "Medium", "Low"]
+    },
+    "sink_class": {
+      "type": "string",
+      "enum": [
+        "Code execution",
+        "Command execution",
+        "File operations",
+        "Path handling",
+        "Archive extraction",
+        "Deserialisation",
+        "Template",
+        "Network",
+        "Validation",
+        "Cryptography",
+        "Memory safety",
+        "Shared mutable state",
+        "Concurrency",
+        "Resource consumption",
+        "Reflection",
+        "Round-trip integrity"
+      ]
+    },
+    "sink_id":    { "type": "string", "pattern": "^S[0-9]+$" },
+    "finding_id": { "type": "string", "pattern": "^F[0-9]+$" },
+    "step":       { "type": "integer", "minimum": 1, "maximum": 6 },
+    "cwe":        { "type": "string", "pattern": "^CWE-[0-9]+$" },
+    "trusted":    { "type": "string", "enum": ["yes", "no", "conditional"] },
+
+    "boundary": {
+      "type": "object",
+      "required": ["actor", "trusted", "controls", "source"],
+      "additionalProperties": false,
+      "properties": {
+        "actor":    { "type": "string" },
+        "trusted":  { "$ref": "#/$defs/trusted" },
+        "controls": { "type": "string" },
+        "source":   { "type": "string" }
+      }
+    },
+
+    "sink": {
+      "type": "object",
+      "required": ["id", "location", "class", "consumes"],
+      "additionalProperties": false,
+      "properties": {
+        "id":        { "$ref": "#/$defs/sink_id" },
+        "location":  { "type": "string" },
+        "class":     { "$ref": "#/$defs/sink_class" },
+        "primitive": { "type": "string" },
+        "consumes":  { "type": "string" }
+      }
+    },
+
+    "ruled_out_entry": {
+      "type": "object",
+      "required": ["sinks", "step", "reason"],
+      "additionalProperties": false,
+      "properties": {
+        "sinks":   { "type": "array", "items": { "$ref": "#/$defs/sink_id" }, "minItems": 1 },
+        "step":    { "$ref": "#/$defs/step" },
+        "reason":  { "$ref": "#/$defs/markdown" },
+        "summary": { "type": "string" }
+      }
+    },
+
+    "finding": {
+      "type": "object",
+      "required": [
+        "id", "sinks", "title", "severity", "cwe", "location",
+        "trace", "boundary", "validation", "rating"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "id":            { "$ref": "#/$defs/finding_id" },
+        "sinks":         { "type": "array", "items": { "$ref": "#/$defs/sink_id" }, "minItems": 1 },
+        "title":         { "type": "string" },
+        "severity":      { "$ref": "#/$defs/severity" },
+        "cwe":           { "$ref": "#/$defs/cwe" },
+        "location":      { "type": "string" },
+        "affected":      { "type": "string" },
+        "reach_checked": { "type": "integer", "minimum": 0 },
+        "reach_exposed": { "type": "integer", "minimum": 0 },
+        "trace":      { "$ref": "#/$defs/markdown" },
+        "boundary":   { "$ref": "#/$defs/markdown" },
+        "validation": { "$ref": "#/$defs/markdown" },
+        "prior_art":  { "$ref": "#/$defs/markdown" },
+        "reach":      { "$ref": "#/$defs/markdown" },
+        "rating":     { "$ref": "#/$defs/markdown" }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds a `reachability` skill that checks whether known sinks in an application's dependencies are reachable from the app's own entry points. The existing library findings give us the sinks; this skill traces each one from the app side and reports the ones an attacker can actually reach.

To feed it, `GET /api/repositories/{id}/dependency-findings` joins the repo's `dependencies` rows against every `packages` row in the database and returns the live findings on the matched library repos. `db.CanonicalEcosystem` normalises git-pkgs ecosystem names (`gem`, `golang`, `composer`) to the packages.ecosyste.ms names (`rubygems`, `go`, `packagist`) so the join works; without that every Ruby row was missing. Self-matches and findings already marked fixed/rejected/duplicate are excluded, and duplicate dependency rows (Gemfile + Gemfile.lock) collapse to the lockfile entry.

The skill emits `output_kind: findings` so results land in the Findings tab and dedupe by fingerprint alongside `security-deep-dive` output.

Tried it against eight Rails apps that depend on gems with existing High findings (foodsoft, placecal, simple-server, taxonworks, joss, figgy, whitehall, openproject). Five produced findings; placecal's hourly `CalendarImporterJob` reaches the icalendar VTIMEZONE RRULE bomb from any registered feed URL, and foodsoft's `Api::V1::ArticleCategoriesController#index` passes `params[:q]` straight to ransack.