### PR TITLE
skills/triage: gate scan set on brief output to skip non-code repos

### DIFF
--- a/skills/triage/SKILL.md
+++ b/skills/triage/SKILL.md
@@ -2,7 +2,7 @@
 name: triage
 description: Default pipeline scrutineer runs when a repository is added. Triggers a standard set of other skills in parallel, then writes a short summary of what was enqueued. Edit the list below to change the default scan coverage without touching scrutineer's Go code.
 license: MIT
-compatibility: Needs network access to the scrutineer API (http://host:port/api).
+compatibility: Needs network access to the scrutineer API (http://host:port/api). Uses `brief` (github.com/git-pkgs/brief) to classify the repository before deciding which scans to enqueue; falls back to enqueueing everything if brief is unavailable.
 metadata:
   scrutineer.output_file: report.json
   scrutineer.output_kind: freeform
@@ -17,23 +17,46 @@ Kick off the standard set of scans against a freshly-added repository.
 - `./context.json` — has `scrutineer.api_base`, `scrutineer.token`, and `scrutineer.repository_id`. Required.
 - `./report.json` — write a short summary of what you enqueued.
 
+## Classify the repository
+
+Run `brief ./src` and read its JSON. Three fields decide which scans are worth queueing:
+
+- `languages` — programming languages detected; `null` or empty means no source
+- `package_managers` — manifest/lockfile ecosystems detected; `null` or empty means nothing publishes or consumes packages here
+- `layout.source_dirs` — where application/library code lives; `null` or empty means any detected language is incidental scripts
+
+From those, set two flags:
+
+- `has_packages` = `package_managers` is present and non-empty
+- `has_code` = `languages` is non-empty AND (`layout.source_dirs` is non-empty OR `has_packages`)
+
+A docs repo (markdown only) has neither. An infrastructure repo (terraform, helm, cloudformation) typically has stray script languages but neither `source_dirs` nor `package_managers`, so `has_code` is false. A real application or library has both. If `brief` is not on PATH or exits non-zero, set both flags true and carry on.
+
 ## The scan set
 
 Before enqueueing anything, check what already ran so a re-trigger is idempotent: `GET {api_base}/repositories/{repository_id}/scans` returns every scan on this repository with `skill_name` and `status`. Build a set of skill names with `status="done"` or `status="running"` and skip those.
 
 For every remaining skill in the list below, enqueue it: `POST {api_base}/repositories/{id}/skills/{name}/run` with an `Authorization: Bearer {token}` header. Empty JSON body. Order does not matter; the scrutineer worker runs them as they come in.
 
+Always:
+
 - `metadata`
+- `maintainers`
+- `repo-overview`
+- `zizmor`
+
+Only when `has_packages`:
+
 - `packages`
 - `advisories`
 - `dependents`
 - `dependencies`
 - `sbom`
-- `maintainers`
+
+Only when `has_code`:
+
 - `subprojects`
-- `repo-overview`
 - `semgrep`
-- `zizmor`
 - `security-deep-dive`
 
 If a skill name comes back `404 skill not found or inactive`, skip it and note which one in your report; the operator may have disabled it on purpose.
@@ -44,14 +67,18 @@ Write `./report.json` as:
 
 ```json
 {
+  "has_code": true,
+  "has_packages": true,
+  "brief": {"languages": ["Ruby"], "package_managers": ["Bundler"], "source_dirs": ["lib", "app"]},
   "triggered": ["metadata", "packages", ...],
   "skipped":   ["semgrep"],
+  "gated":     [],
   "already_done": ["metadata"],
   "errors":    []
 }
 ```
 
-`already_done` holds skills that were skipped because a done/running scan was already present. `skipped` is for skills that came back `404 skill not found or inactive`.
+`gated` lists skills that were not enqueued because `has_code` or `has_packages` was false. `already_done` holds skills that were skipped because a done/running scan was already present. `skipped` is for skills that came back `404 skill not found or inactive`. `brief` is the subset of brief's output the gates were derived from, so an operator can see why a repo got the short treatment and re-run triage manually if the classification was wrong.
 
 Do not wait for any of the scans to finish. The API returns a scan id immediately; your job is to fire them off and exit.
 


### PR DESCRIPTION
The triage skill currently fires all twelve downstream skills regardless of what the repository contains, so a docs repo or a terraform/helm repo gets a full `security-deep-dive` and `semgrep` run that finds nothing.

This runs `brief ./src` first and derives two flags from its `languages`, `package_managers` and `layout.source_dirs` fields. `has_packages` gates the package-ecosystem skills (`packages`, `advisories`, `dependents`, `dependencies`, `sbom`); `has_code` gates the source-analysis skills (`subprojects`, `semgrep`, `security-deep-dive`). `metadata`, `maintainers`, `repo-overview` and `zizmor` always run. If brief is missing or errors, both flags default to true so behaviour is unchanged.

Checked against four alphagov repos: `govuk-rfcs` (markdown only) and `govuk-helm-charts` / `govuk-infrastructure` (terraform/helm with stray scripts) all come out `has_code=false has_packages=false`; `publishing-api` (Rails) comes out true for both. The report records the brief subset and a `gated` list so it's visible why a repo got the short treatment.

brief is already in both runner images at v0.6.0.