### PR TITLE
Progressive enhancement: htmx, SSE, settings page

### DIFF
--- a/cmd/scrutineer/main.go
+++ b/cmd/scrutineer/main.go
@@ -142,6 +142,9 @@ func (f *flags) merge(cfg *config.Config) {
 	if cfg.DefaultModel != "" {
 		web.SetDefaultModel(cfg.DefaultModel)
 	}
+	if cfg.Theme != "" {
+		web.SetTheme(cfg.Theme)
+	}
 }
 
 func (f *flags) fullClone() bool { return f.cloneMode == "full" }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
+	"slices"
 	"time"
 
 	"gopkg.in/yaml.v3"
@@ -50,6 +51,9 @@ type Config struct {
 	// the value is passed as ANTHROPIC_BASE_URL to the claude-code process.
 	// Falls back to the ANTHROPIC_BASE_URL environment variable if empty.
 	AnthropicBaseURL string `yaml:"anthropic_base_url"`
+	// Theme selects the colour scheme: "claude" (default), "ocean-breeze",
+	// "catppuccin", "sunset-horizon", "midnight-bloom", or "northern-lights".
+	Theme string `yaml:"theme"`
 }
 
 // ParseScanTimeout validates and parses a scan_timeout string. Empty
@@ -88,6 +92,18 @@ type Model struct {
 	ID   string `yaml:"id"`
 }
 
+// Themes lists every valid theme name.
+var Themes = []string{"claude", "ocean-breeze", "catppuccin", "sunset-horizon", "midnight-bloom", "northern-lights"}
+
+// ValidateTheme returns an error when s is not a known theme name.
+// Empty is valid (caller keeps the default).
+func ValidateTheme(s string) error {
+	if s == "" || slices.Contains(Themes, s) {
+		return nil
+	}
+	return fmt.Errorf("theme: unknown %q", s)
+}
+
 // Load reads a YAML config from path. Returns (nil, nil) when the file
 // does not exist and the caller passed "" or DefaultPath — making config
 // fully opt-in. Explicit paths that don't exist are an error.
@@ -111,6 +127,9 @@ func Load(path string) (*Config, error) {
 		return nil, fmt.Errorf("parse config %s: %w", path, err)
 	}
 	if _, err := ParseScanTimeout(c.ScanTimeout); err != nil {
+		return nil, fmt.Errorf("parse config %s: %w", path, err)
+	}
+	if err := ValidateTheme(c.Theme); err != nil {
 		return nil, fmt.Errorf("parse config %s: %w", path, err)
 	}
 	return &c, nil

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -141,3 +141,32 @@ func TestLoad_rejectsUnparseable(t *testing.T) {
 		t.Error("expected parse error")
 	}
 }
+
+func TestValidateTheme(t *testing.T) {
+	for _, name := range []string{"", "claude", "ocean-breeze", "catppuccin", "sunset-horizon", "midnight-bloom", "northern-lights"} {
+		if err := ValidateTheme(name); err != nil {
+			t.Errorf("ValidateTheme(%q) = %v, want nil", name, err)
+		}
+	}
+	if err := ValidateTheme("nope"); err == nil {
+		t.Error("expected error for unknown theme")
+	}
+}
+
+func TestLoad_rejectsInvalidTheme(t *testing.T) {
+	path := write(t, "theme: nope\n")
+	if _, err := Load(path); err == nil {
+		t.Error("expected error for invalid theme value")
+	}
+}
+
+func TestLoad_parsesTheme(t *testing.T) {
+	path := write(t, "theme: catppuccin\n")
+	c, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c.Theme != "catppuccin" {
+		t.Errorf("theme=%q, want catppuccin", c.Theme)
+	}
+}

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -26,8 +26,9 @@ type Payload struct {
 }
 
 type Queue struct {
-	q      *goqite.Queue
-	runner *jobs.Runner
+	q           *goqite.Queue
+	runner      *jobs.Runner
+	Concurrency int
 }
 
 const (
@@ -56,7 +57,7 @@ func New(sqldb *sql.DB, log *slog.Logger, concurrency int) (*Queue, error) {
 		PollInterval: time.Second,
 		Extend:       visibilityTimeout,
 	})
-	return &Queue{q: q, runner: r}, nil
+	return &Queue{q: q, runner: r, Concurrency: concurrency}, nil
 }
 
 func (q *Queue) Register(name string, fn jobs.Func) {

--- a/internal/web/finding_forms.go
+++ b/internal/web/finding_forms.go
@@ -42,8 +42,7 @@ func (s *Server) findingFields(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	w.Header().Set("HX-Redirect", fmt.Sprintf("/findings/%d", f.ID))
-	w.WriteHeader(http.StatusNoContent)
+	s.redirect(w, r, fmt.Sprintf("/findings/%d", f.ID))
 }
 
 func (s *Server) findingCommunications(w http.ResponseWriter, r *http.Request) {
@@ -68,8 +67,7 @@ func (s *Server) findingCommunications(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusUnprocessableEntity)
 		return
 	}
-	w.Header().Set("HX-Redirect", fmt.Sprintf("/findings/%d", f.ID))
-	w.WriteHeader(http.StatusNoContent)
+	s.redirect(w, r, fmt.Sprintf("/findings/%d", f.ID))
 }
 
 func (s *Server) findingReferences(w http.ResponseWriter, r *http.Request) {
@@ -87,8 +85,7 @@ func (s *Server) findingReferences(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusUnprocessableEntity)
 		return
 	}
-	w.Header().Set("HX-Redirect", fmt.Sprintf("/findings/%d", f.ID))
-	w.WriteHeader(http.StatusNoContent)
+	s.redirect(w, r, fmt.Sprintf("/findings/%d", f.ID))
 }
 
 func (s *Server) findingLabels(w http.ResponseWriter, r *http.Request) {
@@ -118,6 +115,5 @@ func (s *Server) findingLabels(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	w.Header().Set("HX-Redirect", fmt.Sprintf("/findings/%d", f.ID))
-	w.WriteHeader(http.StatusNoContent)
+	s.redirect(w, r, fmt.Sprintf("/findings/%d", f.ID))
 }

--- a/internal/web/sboms.go
+++ b/internal/web/sboms.go
@@ -20,6 +20,7 @@ const (
 
 func (s *Server) registerSBOMRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /sboms", s.sbomList)
+	mux.HandleFunc("GET /sboms/new", s.sbomNew)
 	mux.HandleFunc("POST /sboms", s.sbomUpload)
 	mux.HandleFunc("GET /sboms/{id}", s.sbomShow)
 	mux.HandleFunc("POST /sboms/{id}/resolve", s.sbomResolve)
@@ -30,6 +31,10 @@ func (s *Server) sbomList(w http.ResponseWriter, r *http.Request) {
 	var rows []db.SBOMUpload
 	s.DB.Order("id desc").Find(&rows)
 	s.render(w, r, "sboms.html", map[string]any{"SBOMs": rows})
+}
+
+func (s *Server) sbomNew(w http.ResponseWriter, r *http.Request) {
+	s.render(w, r, "sbom_new.html", nil)
 }
 
 func (s *Server) sbomUpload(w http.ResponseWriter, r *http.Request) {

--- a/internal/web/sboms.go
+++ b/internal/web/sboms.go
@@ -29,7 +29,7 @@ func (s *Server) registerSBOMRoutes(mux *http.ServeMux) {
 func (s *Server) sbomList(w http.ResponseWriter, r *http.Request) {
 	var rows []db.SBOMUpload
 	s.DB.Order("id desc").Find(&rows)
-	s.render(w, "sboms.html", map[string]any{"SBOMs": rows})
+	s.render(w, r, "sboms.html", map[string]any{"SBOMs": rows})
 }
 
 func (s *Server) sbomUpload(w http.ResponseWriter, r *http.Request) {
@@ -159,7 +159,7 @@ func (s *Server) sbomShow(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	s.render(w, "sbom_show.html", map[string]any{
+	s.render(w, r, "sbom_show.html", map[string]any{
 		"SBOM": up, "Packages": pkgs,
 		"Findings": findings, "Advisories": advisories, "Repos": reposByID,
 		"Resolved": resolved, "WithRepo": withRepo,

--- a/internal/web/sboms.go
+++ b/internal/web/sboms.go
@@ -79,8 +79,7 @@ func (s *Server) sbomUpload(w http.ResponseWriter, r *http.Request) {
 
 	s.goResolve(up.ID)
 
-	w.Header().Set("HX-Redirect", fmt.Sprintf("/sboms/%d", up.ID))
-	w.WriteHeader(http.StatusNoContent)
+	s.redirect(w, r, fmt.Sprintf("/sboms/%d", up.ID))
 }
 
 func (s *Server) sbomShow(w http.ResponseWriter, r *http.Request) {
@@ -176,8 +175,7 @@ func (s *Server) sbomResolve(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	s.goResolve(up.ID)
-	w.Header().Set("HX-Redirect", fmt.Sprintf("/sboms/%d", up.ID))
-	w.WriteHeader(http.StatusNoContent)
+	s.redirect(w, r, fmt.Sprintf("/sboms/%d", up.ID))
 }
 
 // goResolve launches resolveSBOMPackages. Indirected so tests can run it
@@ -195,8 +193,7 @@ func (s *Server) sbomDelete(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	w.Header().Set("HX-Redirect", "/sboms")
-	w.WriteHeader(http.StatusNoContent)
+	s.redirect(w, r, "/sboms")
 }
 
 // resolveSBOMPackages walks every unresolved package in the upload, looks up

--- a/internal/web/sboms_test.go
+++ b/internal/web/sboms_test.go
@@ -51,11 +51,11 @@ func TestSBOMUpload_parsesAndStores(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	s.Handler().ServeHTTP(w, multipartReq(t, "/sboms", "file", "demo.cdx.json", cdxFixture))
-	if w.Code != http.StatusNoContent {
+	if w.Code != http.StatusSeeOther {
 		t.Fatalf("status %d: %s", w.Code, w.Body)
 	}
-	if !strings.HasPrefix(w.Header().Get("HX-Redirect"), "/sboms/") {
-		t.Errorf("missing HX-Redirect, got %q", w.Header().Get("HX-Redirect"))
+	if !strings.HasPrefix(w.Header().Get("Location"), "/sboms/") {
+		t.Errorf("missing redirect, got %q", w.Header().Get("Location"))
 	}
 
 	var up db.SBOMUpload

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -1367,14 +1367,6 @@ func (s *Server) repoShow(w http.ResponseWriter, r *http.Request) {
 		ORDER BY s.id DESC
 	`, repo.ID).Scan(&scans)
 
-	active := false
-	for _, sc := range scans {
-		if !sc.Status.Terminal() {
-			active = true
-			break
-		}
-	}
-
 	// The security-deep-dive skill owns the structured audit report; everything
 	// the Summary/Threat Model/Findings tabs render comes from its scans.
 	var latest *db.Scan
@@ -1457,7 +1449,7 @@ func (s *Server) repoShow(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := map[string]any{
-		"Repo": repo, "Scans": scans, "Active": active, "Latest": latest,
+		"Repo": repo, "Scans": scans, "Latest": latest,
 		"Findings":  findings,
 		"TotalCost": totalCost,
 		"TMCommit":  tmCommit,
@@ -1466,15 +1458,6 @@ func (s *Server) repoShow(w http.ResponseWriter, r *http.Request) {
 		"Skills":       activeSkills,
 		"Subprojects":  subprojects,
 		"SubScanCount": subScanCount,
-	}
-	if r.Header.Get("HX-Target") == "scan-rows" {
-		if !active {
-			// All jobs settled since the page loaded; full refresh so the
-			// Summary, Findings and metadata sections pick up results.
-			w.Header().Set("HX-Refresh", "true")
-		}
-		s.render(w, r, "scan_rows", data)
-		return
 	}
 	s.render(w, r, "repo_show.html", data)
 }

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -3,6 +3,7 @@ package web
 import (
 	"context"
 	"embed"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"html/template"
@@ -196,12 +197,71 @@ func (s *Server) Handler() http.Handler {
 	return logRequests(s.Log, root)
 }
 
-func (s *Server) render(w http.ResponseWriter, name string, data any) {
+func (s *Server) render(w http.ResponseWriter, r *http.Request, name string, data map[string]any) {
+	if data == nil {
+		data = map[string]any{}
+	}
+	data["Nav"] = navKey(r.URL.Path)
+	data["Flash"] = popFlash(w, r)
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	if err := s.tmpl.ExecuteTemplate(w, name, data); err != nil {
 		s.Log.Error("render", "tmpl", name, "err", err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}
+}
+
+// Flash is a one-shot message carried across a redirect via the "flash"
+// cookie and rendered server-side into #toaster on the next page load.
+type Flash struct {
+	Category    string `json:"c"`
+	Title       string `json:"t"`
+	Description string `json:"d,omitempty"`
+	Href        string `json:"h,omitempty"`
+	Label       string `json:"l,omitempty"`
+}
+
+func setFlash(w http.ResponseWriter, f Flash) {
+	b, _ := json.Marshal(f)
+	http.SetCookie(w, &http.Cookie{
+		Name:     "flash",
+		Value:    base64.RawURLEncoding.EncodeToString(b),
+		Path:     "/",
+		HttpOnly: true,
+		SameSite: http.SameSiteStrictMode,
+	})
+}
+
+func popFlash(w http.ResponseWriter, r *http.Request) *Flash {
+	c, err := r.Cookie("flash")
+	if err != nil || c.Value == "" {
+		return nil
+	}
+	http.SetCookie(w, &http.Cookie{Name: "flash", Path: "/", MaxAge: -1})
+	raw, err := base64.RawURLEncoding.DecodeString(c.Value)
+	if err != nil {
+		return nil
+	}
+	var f Flash
+	if json.Unmarshal(raw, &f) != nil {
+		return nil
+	}
+	return &f
+}
+
+// navKey maps a request path to the sidebar item that should be marked
+// aria-current. Paths not in the table fall through to the repositories
+// index, which is also the home page.
+func navKey(path string) string {
+	for _, p := range []struct{ prefix, key string }{
+		{"/usage", "usage"}, {"/skills", "skills"}, {"/maintainers", "maintainers"},
+		{"/orgs", "orgs"}, {"/packages", "packages"}, {"/advisories", "advisories"},
+		{"/findings", "findings"}, {"/scans", "scans"}, {"/sboms", "sboms"},
+	} {
+		if strings.HasPrefix(path, p.prefix) {
+			return p.key
+		}
+	}
+	return "repos"
 }
 
 func isHX(r *http.Request) bool { return r.Header.Get("HX-Request") != "" }
@@ -382,9 +442,9 @@ func (s *Server) repoList(w http.ResponseWriter, r *http.Request) {
 		"Q": search,
 	}
 	if isHX(r) {
-		s.render(w, "repo_list.html", data)
+		s.render(w, r, "repo_list.html", data)
 	} else {
-		s.render(w, "index.html", data)
+		s.render(w, r, "index.html", data)
 	}
 }
 
@@ -498,7 +558,7 @@ func (s *Server) orgsList(w http.ResponseWriter, r *http.Request) {
 		})
 	}
 
-	s.render(w, "orgs.html", map[string]any{
+	s.render(w, r, "orgs.html", map[string]any{
 		"Orgs": rows, "Q": search, "Sort": sort,
 	})
 }
@@ -563,7 +623,7 @@ func (s *Server) orgShow(w http.ResponseWriter, r *http.Request) {
 		Where("rm.repository_id IN ?", repoIDs).
 		Distinct().Order("maintainers.name").Find(&maintainers)
 
-	s.render(w, "org_show.html", map[string]any{
+	s.render(w, r, "org_show.html", map[string]any{
 		"Owner":         owner,
 		"Repos":         repos,
 		"FindingCounts": findingCounts,
@@ -636,7 +696,7 @@ func (s *Server) maintainersList(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	s.render(w, "maintainers.html", map[string]any{
+	s.render(w, r, "maintainers.html", map[string]any{
 		"Maintainers":   rows,
 		"Page":          page,
 		"Status":        status,
@@ -680,7 +740,7 @@ func (s *Server) maintainerShow(w http.ResponseWriter, r *http.Request) {
 		s.DB.Where("repository_id IN ?", repoIDs).Order("id desc").Find(&findings)
 	}
 	reposByID := loadRepoMap(s.DB, findings)
-	s.render(w, "maintainer_show.html", map[string]any{
+	s.render(w, r, "maintainer_show.html", map[string]any{
 		"M": m, "Findings": findings, "Repos": reposByID,
 	})
 }
@@ -763,7 +823,7 @@ func (s *Server) findings(w http.ResponseWriter, r *http.Request) {
 			break
 		}
 	}
-	s.render(w, "findings.html", map[string]any{
+	s.render(w, r, "findings.html", map[string]any{
 		"Findings": rows, "Page": page, "Severity": sev, "Sort": sort,
 		"Repos": reposByID, "Q": search, "AnySubPath": anySubPath,
 		"Owner": owner,
@@ -979,7 +1039,7 @@ func (s *Server) packages(w http.ResponseWriter, r *http.Request) {
 	var ecosystems []string
 	s.DB.Model(&db.Package{}).Distinct("ecosystem").Order("ecosystem").Pluck("ecosystem", &ecosystems)
 
-	s.render(w, "packages.html", map[string]any{
+	s.render(w, r, "packages.html", map[string]any{
 		"Pkgs": rows, "Page": page, "Ecosystem": eco, "Sort": sort, "Ecosystems": ecosystems,
 		"Q": search,
 	})
@@ -995,7 +1055,7 @@ func (s *Server) packageShow(w http.ResponseWriter, r *http.Request) {
 	if p.Metadata != "" {
 		data["Meta"] = p.Metadata
 	}
-	s.render(w, "package_show.html", data)
+	s.render(w, r, "package_show.html", data)
 }
 
 func (s *Server) advisoriesList(w http.ResponseWriter, r *http.Request) {
@@ -1035,7 +1095,7 @@ func (s *Server) advisoriesList(w http.ResponseWriter, r *http.Request) {
 	s.DB.Model(&db.Advisory{}).Where("severity != ''").Distinct("severity").
 		Order("severity").Pluck("severity", &severities)
 
-	s.render(w, "advisories.html", map[string]any{
+	s.render(w, r, "advisories.html", map[string]any{
 		"Advisories": rows, "Page": page, "Severity": sev, "Sort": sort,
 		"Severities": severities, "Repos": reposByID, "Q": search,
 	})
@@ -1109,7 +1169,7 @@ func (s *Server) findingShow(w http.ResponseWriter, r *http.Request) {
 		data["PatchScan"] = patchScan
 		data["Patch"] = patchRep
 	}
-	s.render(w, "finding_show.html", data)
+	s.render(w, r, "finding_show.html", data)
 }
 
 func (s *Server) jobs(w http.ResponseWriter, r *http.Request) {
@@ -1155,7 +1215,7 @@ func (s *Server) jobs(w http.ResponseWriter, r *http.Request) {
 			break
 		}
 	}
-	s.render(w, "jobs.html", map[string]any{
+	s.render(w, r, "jobs.html", map[string]any{
 		"Scans": scans, "Page": page,
 		"Skill": skillName, "Status": status, "Sort": sort, "Skills": skillNames,
 		"AnySubPath": anySubPath,
@@ -1179,8 +1239,8 @@ func (s *Server) repoCreate(w http.ResponseWriter, r *http.Request) {
 // repoBulkCreate accepts a newline-separated list of repository URLs,
 // creates each one that is not already in the database, and enqueues the
 // default skill for every new row. Duplicates and unparseable lines are
-// reported back via an HX-Trigger toast rather than failing the whole
-// submission — partial success is the expected case for a pasted list.
+// reported back via a flash toast rather than failing the whole submission;
+// partial success is the expected case for a pasted list.
 func (s *Server) repoBulkCreate(w http.ResponseWriter, r *http.Request) {
 	raw := r.FormValue("urls")
 	lines := strings.Split(raw, "\n")
@@ -1211,13 +1271,11 @@ func (s *Server) repoBulkCreate(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "no URLs supplied", http.StatusUnprocessableEntity)
 		return
 	}
-	toast := map[string]any{
-		"category":    bulkToastCategory(created, invalid),
-		"title":       bulkToastTitle(created, skipped, len(invalid)),
-		"description": bulkToastDescription(invalid),
-	}
-	payload, _ := json.Marshal(map[string]any{"basecoat:toast": map[string]any{"config": toast}})
-	w.Header().Set("HX-Trigger", string(payload))
+	setFlash(w, Flash{
+		Category:    bulkToastCategory(created, invalid),
+		Title:       bulkToastTitle(created, skipped, len(invalid)),
+		Description: bulkToastDescription(invalid),
+	})
 	s.redirect(w, r, "/")
 }
 
@@ -1404,16 +1462,15 @@ func (s *Server) repoShow(w http.ResponseWriter, r *http.Request) {
 		"SubScanCount": subScanCount,
 	}
 	if r.Header.Get("HX-Target") == "scan-rows" {
-		s.maybeToast(w, r, repo.Name, scans)
 		if !active {
 			// All jobs settled since the page loaded; full refresh so the
 			// Summary, Findings and metadata sections pick up results.
 			w.Header().Set("HX-Refresh", "true")
 		}
-		s.render(w, "scan_rows", data)
+		s.render(w, r, "scan_rows", data)
 		return
 	}
-	s.render(w, "repo_show.html", data)
+	s.render(w, r, "repo_show.html", data)
 }
 
 func (s *Server) repoScan(w http.ResponseWriter, r *http.Request) {
@@ -1464,7 +1521,7 @@ func (s *Server) scanShow(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 		return
 	}
-	s.render(w, "scan_show.html", scan)
+	s.render(w, r, "scan_show.html", map[string]any{"Scan": scan})
 }
 
 func (s *Server) scanRetry(w http.ResponseWriter, r *http.Request) {
@@ -1573,33 +1630,6 @@ func (s *Server) enqueueSkillWith(ctx context.Context, repoID, skillID uint, opt
 	}
 	s.DB.Model(&db.Repository{}).Where("id = ?", repoID).Update("updated_at", time.Now())
 	return scan.ID, nil
-}
-
-// maybeToast compares scan statuses against the "seen" cookie and emits an
-// HX-Trigger header for the first scan that has moved to a terminal state
-// since the client last polled. The cookie stores id:status pairs so a page
-// reload does not re-toast.
-func (s *Server) maybeToast(w http.ResponseWriter, r *http.Request, name string, scans []db.Scan) {
-	prev := map[string]string{}
-	if c, err := r.Cookie("scanstate"); err == nil {
-		for pair := range strings.SplitSeq(c.Value, ",") {
-			if k, v, ok := strings.Cut(pair, ":"); ok {
-				prev[k] = v
-			}
-		}
-	}
-	var cur []string
-	for _, sc := range scans {
-		id := strconv.Itoa(int(sc.ID))
-		cur = append(cur, id+":"+string(sc.Status))
-		if sc.Status.Terminal() && prev[id] != "" && prev[id] != string(sc.Status) {
-			payload, _ := json.Marshal(map[string]any{"scanStatus": map[string]any{
-				"id": sc.ID, "status": sc.Status, "name": name,
-			}})
-			w.Header().Set("HX-Trigger", string(payload))
-		}
-	}
-	http.SetCookie(w, &http.Cookie{Name: "scanstate", Value: strings.Join(cur, ","), Path: "/", SameSite: http.SameSiteStrictMode})
 }
 
 const (

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -126,6 +126,18 @@ func New(gdb *gorm.DB, q *queue.Queue, log *slog.Logger, broker *Broker, w *work
 			}
 			return s
 		},
+		"bytes": func(b int64) string {
+			const unit = 1024
+			if b < unit {
+				return fmt.Sprintf("%d B", b)
+			}
+			div, exp := int64(unit), 0
+			for n := b / unit; n >= unit; n /= unit {
+				div *= unit
+				exp++
+			}
+			return fmt.Sprintf("%.1f %cB", float64(b)/float64(div), "KMGTPE"[exp])
+		},
 	}
 	t, err := template.New("").Funcs(funcs).ParseFS(tmplFS, "templates/*.html")
 	if err != nil {
@@ -186,6 +198,10 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("GET /skills/{id}/edit", s.skillEdit)
 	mux.HandleFunc("POST /skills/{id}", s.skillUpdate)
 	mux.HandleFunc("POST /repositories/{id}/skill-scan", s.skillRun)
+	mux.HandleFunc("GET /settings", s.settingsShow)
+	mux.HandleFunc("POST /settings/theme", s.settingsUpdateTheme)
+	mux.HandleFunc("POST /settings/model", s.settingsUpdateModel)
+	mux.HandleFunc("POST /settings/color-scheme", s.settingsUpdateColorScheme)
 
 	// API routes get bearer-auth middleware and skip the browser CSRF checks;
 	// skills call these from inside a scan workspace, not from a browser.
@@ -203,6 +219,8 @@ func (s *Server) render(w http.ResponseWriter, r *http.Request, name string, dat
 		data = map[string]any{}
 	}
 	data["Nav"] = navKey(r.URL.Path)
+	data["Theme"] = resolveTheme(r)
+	data["ColorScheme"] = resolveColorScheme(r)
 	data["Flash"] = popFlash(w, r)
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	if err := s.tmpl.ExecuteTemplate(w, name, data); err != nil {
@@ -254,7 +272,7 @@ func popFlash(w http.ResponseWriter, r *http.Request) *Flash {
 // index, which is also the home page.
 func navKey(path string) string {
 	for _, p := range []struct{ prefix, key string }{
-		{"/usage", "usage"}, {"/skills", "skills"}, {"/maintainers", "maintainers"},
+		{"/settings", "settings"}, {"/usage", "usage"}, {"/skills", "skills"}, {"/maintainers", "maintainers"},
 		{"/orgs", "orgs"}, {"/packages", "packages"}, {"/advisories", "advisories"},
 		{"/findings", "findings"}, {"/scans", "scans"}, {"/sboms", "sboms"},
 	} {

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -204,6 +204,19 @@ func (s *Server) render(w http.ResponseWriter, name string, data any) {
 	}
 }
 
+func isHX(r *http.Request) bool { return r.Header.Get("HX-Request") != "" }
+
+// redirect sends a 303 for plain form posts and HX-Redirect for htmx
+// requests, so every POST handler works with or without javascript.
+func (s *Server) redirect(w http.ResponseWriter, r *http.Request, path string) {
+	if isHX(r) {
+		w.Header().Set("HX-Redirect", path)
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+	http.Redirect(w, r, path, http.StatusSeeOther)
+}
+
 func (s *Server) index(w http.ResponseWriter, r *http.Request) {
 	s.repoList(w, r)
 }
@@ -368,7 +381,7 @@ func (s *Server) repoList(w http.ResponseWriter, r *http.Request) {
 		"Rows": rows, "Page": page, "Language": lang, "Sort": sort, "Languages": languages,
 		"Q": search,
 	}
-	if r.Header.Get("HX-Request") != "" {
+	if isHX(r) {
 		s.render(w, "repo_list.html", data)
 	} else {
 		s.render(w, "index.html", data)
@@ -648,8 +661,7 @@ func (s *Server) maintainerDoNotContact(w http.ResponseWriter, r *http.Request) 
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	w.Header().Set("HX-Redirect", fmt.Sprintf("/maintainers/%d", m.ID))
-	w.WriteHeader(http.StatusNoContent)
+	s.redirect(w, r, fmt.Sprintf("/maintainers/%d", m.ID))
 }
 
 func (s *Server) maintainerShow(w http.ResponseWriter, r *http.Request) {
@@ -845,8 +857,7 @@ func (s *Server) addRepoAndScan(w http.ResponseWriter, r *http.Request, repoURL 
 			s.Log.Warn("default skill not found, repo added with no scans", "skill", defaultSkillName)
 		}
 	}
-	w.Header().Set("HX-Redirect", fmt.Sprintf("/repositories/%d", repo.ID))
-	w.WriteHeader(http.StatusNoContent)
+	s.redirect(w, r, fmt.Sprintf("/repositories/%d", repo.ID))
 }
 
 func (s *Server) findingStatus(w http.ResponseWriter, r *http.Request) {
@@ -868,8 +879,7 @@ func (s *Server) findingStatus(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "invalid status", http.StatusUnprocessableEntity)
 		return
 	}
-	w.Header().Set("HX-Redirect", fmt.Sprintf("/findings/%d", f.ID))
-	w.WriteHeader(http.StatusNoContent)
+	s.redirect(w, r, fmt.Sprintf("/findings/%d", f.ID))
 }
 
 // verifySkillName is the skill the Verify button on the finding page runs.
@@ -915,8 +925,7 @@ func (s *Server) runFindingSkill(w http.ResponseWriter, r *http.Request, name st
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	w.Header().Set("HX-Redirect", fmt.Sprintf("/scans/%d", scanID))
-	w.WriteHeader(http.StatusNoContent)
+	s.redirect(w, r, fmt.Sprintf("/scans/%d", scanID))
 }
 
 func (s *Server) findingNotes(w http.ResponseWriter, r *http.Request) {
@@ -929,8 +938,7 @@ func (s *Server) findingNotes(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusUnprocessableEntity)
 		return
 	}
-	w.Header().Set("HX-Redirect", fmt.Sprintf("/findings/%d", f.ID))
-	w.WriteHeader(http.StatusNoContent)
+	s.redirect(w, r, fmt.Sprintf("/findings/%d", f.ID))
 }
 
 func (s *Server) packages(w http.ResponseWriter, r *http.Request) {
@@ -1165,8 +1173,7 @@ func (s *Server) repoCreate(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	w.Header().Set("HX-Redirect", fmt.Sprintf("/repositories/%d", repo.ID))
-	w.WriteHeader(http.StatusNoContent)
+	s.redirect(w, r, fmt.Sprintf("/repositories/%d", repo.ID))
 }
 
 // repoBulkCreate accepts a newline-separated list of repository URLs,
@@ -1211,8 +1218,7 @@ func (s *Server) repoBulkCreate(w http.ResponseWriter, r *http.Request) {
 	}
 	payload, _ := json.Marshal(map[string]any{"basecoat:toast": map[string]any{"config": toast}})
 	w.Header().Set("HX-Trigger", string(payload))
-	w.Header().Set("HX-Redirect", "/")
-	w.WriteHeader(http.StatusNoContent)
+	s.redirect(w, r, "/")
 }
 
 // createOrTriageRepo is the shared path for both single-add and bulk-add.
@@ -1430,8 +1436,7 @@ func (s *Server) repoScan(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	w.Header().Set("HX-Redirect", fmt.Sprintf("/repositories/%d", repo.ID))
-	w.WriteHeader(http.StatusNoContent)
+	s.redirect(w, r, fmt.Sprintf("/repositories/%d", repo.ID))
 }
 
 // repoDisclosureChannel lets the analyst overwrite (or clear) the
@@ -1450,8 +1455,7 @@ func (s *Server) repoDisclosureChannel(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	w.Header().Set("HX-Redirect", fmt.Sprintf("/repositories/%d", repo.ID))
-	w.WriteHeader(http.StatusNoContent)
+	s.redirect(w, r, fmt.Sprintf("/repositories/%d", repo.ID))
 }
 
 func (s *Server) scanShow(w http.ResponseWriter, r *http.Request) {
@@ -1482,8 +1486,7 @@ func (s *Server) scanRetry(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	w.Header().Set("HX-Redirect", fmt.Sprintf("/scans/%d", newID))
-	w.WriteHeader(http.StatusNoContent)
+	s.redirect(w, r, fmt.Sprintf("/scans/%d", newID))
 }
 
 func (s *Server) scanCancel(w http.ResponseWriter, r *http.Request) {
@@ -1505,8 +1508,7 @@ func (s *Server) scanCancel(w http.ResponseWriter, r *http.Request) {
 			"finished_at": &now,
 		})
 	}
-	w.Header().Set("HX-Refresh", "true")
-	w.WriteHeader(http.StatusNoContent)
+	s.redirect(w, r, fmt.Sprintf("/scans/%d", scan.ID))
 }
 
 // scanLog returns just the <pre> log block. The scan page polls this with

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -141,6 +141,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("GET /events", s.events)
 	mux.HandleFunc("GET /{$}", s.index)
 	mux.HandleFunc("GET /repositories", s.repoList)
+	mux.HandleFunc("GET /repositories/new", s.repoNew)
 	mux.HandleFunc("POST /repositories", s.repoCreate)
 	mux.HandleFunc("POST /repositories/bulk", s.repoBulkCreate)
 	mux.HandleFunc("GET /repositories/{id}", s.repoShow)
@@ -1234,6 +1235,11 @@ func (s *Server) repoCreate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	s.redirect(w, r, fmt.Sprintf("/repositories/%d", repo.ID))
+}
+
+// repoNew is the no-javascript fallback for the Add Repository dialog.
+func (s *Server) repoNew(w http.ResponseWriter, r *http.Request) {
+	s.render(w, r, "repo_new.html", map[string]any{"Bulk": r.FormValue("bulk") != ""})
 }
 
 // repoBulkCreate accepts a newline-separated list of repository URLs,

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -139,6 +139,35 @@ func flashFrom(t *testing.T, w *httptest.ResponseRecorder) Flash {
 	return f
 }
 
+func TestRenderScanStatus_OOBRowAndToast(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	repo := db.Repository{URL: "https://github.com/foo/bar.git", Name: "bar"}
+	s.DB.Create(&repo)
+	scan := db.Scan{RepositoryID: repo.ID, Kind: "skill", SkillName: "audit", Status: db.ScanDone}
+	s.DB.Create(&scan)
+	s.DB.Create(&db.Finding{ScanID: scan.ID, RepositoryID: repo.ID, FindingID: "F1", Title: "x", Severity: "High"})
+
+	out := s.renderScanStatus(scan.ID)
+
+	if !strings.Contains(out, fmt.Sprintf(`id="scan-%d"`, scan.ID)) {
+		t.Errorf("missing row id: %s", out)
+	}
+	if !strings.Contains(out, `hx-swap-oob="true"`) {
+		t.Error("row not marked for OOB swap")
+	}
+	if !strings.Contains(out, `hx-swap-oob="afterbegin:#toaster"`) {
+		t.Error("toast not targeted at #toaster")
+	}
+	if !strings.Contains(out, "audit done") {
+		t.Errorf("toast title missing skill+status: %s", out)
+	}
+	if !strings.Contains(out, "bar") {
+		t.Error("toast missing repo name")
+	}
+}
+
 func TestRepoNew_fallbackPages(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -2,6 +2,8 @@ package web
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -119,6 +121,86 @@ func TestMaintainersIndex_rendersFindingsCountAndDNCBadge(t *testing.T) {
 	// Alice carries the DNC badge; Bob should not.
 	if !strings.Contains(body, `data-tooltip="Do not contact">DNC`) {
 		t.Errorf("missing DNC badge for alice")
+	}
+}
+
+func flashFrom(t *testing.T, w *httptest.ResponseRecorder) Flash {
+	t.Helper()
+	r := &http.Request{Header: http.Header{"Cookie": w.Header().Values("Set-Cookie")}}
+	c, err := r.Cookie("flash")
+	if err != nil {
+		t.Fatalf("no flash cookie set: %v", err)
+	}
+	raw, _ := base64.RawURLEncoding.DecodeString(c.Value)
+	var f Flash
+	if err := json.Unmarshal(raw, &f); err != nil {
+		t.Fatalf("decode flash: %v", err)
+	}
+	return f
+}
+
+func TestFlash_roundtrip(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	rec := httptest.NewRecorder()
+	setFlash(rec, Flash{Category: "success", Title: "Imported", Description: "3 added"})
+
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Host = testHost
+	req.Header.Set("Cookie", rec.Header().Get("Set-Cookie"))
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+
+	body := w.Body.String()
+	if !strings.Contains(body, "Imported") || !strings.Contains(body, "3 added") {
+		t.Error("flash not rendered into page body")
+	}
+	var cleared bool
+	for _, sc := range w.Header().Values("Set-Cookie") {
+		if strings.HasPrefix(sc, "flash=") && strings.Contains(sc, "Max-Age=0") {
+			cleared = true
+		}
+	}
+	if !cleared {
+		t.Error("flash cookie not cleared after render")
+	}
+}
+
+func TestNavKey(t *testing.T) {
+	cases := map[string]string{
+		"/":               "repos",
+		"/repositories/7": "repos",
+		"/findings":       "findings",
+		"/findings/42":    "findings",
+		"/scans/1":        "scans",
+		"/sboms":          "sboms",
+		"/usage":          "usage",
+	}
+	for path, want := range cases {
+		if got := navKey(path); got != want {
+			t.Errorf("navKey(%q) = %q, want %q", path, got, want)
+		}
+	}
+}
+
+func TestSidebar_rendersAriaCurrent(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	req := httptest.NewRequest("GET", "/findings", nil)
+	req.Host = testHost
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status %d", w.Code)
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, `href="/findings" aria-current="page"`) {
+		t.Error("findings link missing aria-current")
+	}
+	if strings.Contains(body, `href="/" aria-current="page"`) {
+		t.Error("repos link should not be current on /findings")
 	}
 }
 
@@ -1316,9 +1398,9 @@ func TestBulkImport_dedupesNormalisedURLs(t *testing.T) {
 	if w.Code != http.StatusSeeOther {
 		t.Fatalf("status %d: %s", w.Code, w.Body)
 	}
-	trigger := w.Header().Get("HX-Trigger")
-	if !strings.Contains(trigger, "1 added") || !strings.Contains(trigger, "3 already present") {
-		t.Errorf("toast = %s, want 1 added / 3 already present", trigger)
+	f := flashFrom(t, w)
+	if !strings.Contains(f.Title, "1 added") || !strings.Contains(f.Title, "3 already present") {
+		t.Errorf("flash title = %q, want 1 added / 3 already present", f.Title)
 	}
 
 	var repos []db.Repository
@@ -1348,9 +1430,9 @@ func TestBulkImport_createsAndEnqueues(t *testing.T) {
 	if w.Header().Get("Location") != "/" {
 		t.Errorf("Location = %q", w.Header().Get("Location"))
 	}
-	trigger := w.Header().Get("HX-Trigger")
-	if !strings.Contains(trigger, "2 added") {
-		t.Errorf("HX-Trigger toast missing '2 added': %s", trigger)
+	f := flashFrom(t, w)
+	if !strings.Contains(f.Title, "2 added") {
+		t.Errorf("flash missing '2 added': %+v", f)
 	}
 
 	var repos []db.Repository
@@ -1382,9 +1464,9 @@ func TestBulkImport_skipsDuplicates(t *testing.T) {
 	if w.Code != http.StatusSeeOther {
 		t.Fatalf("status %d: %s", w.Code, w.Body)
 	}
-	trigger := w.Header().Get("HX-Trigger")
-	if !strings.Contains(trigger, "1 added") || !strings.Contains(trigger, "1 already present") {
-		t.Errorf("toast missing expected counts: %s", trigger)
+	f := flashFrom(t, w)
+	if !strings.Contains(f.Title, "1 added") || !strings.Contains(f.Title, "1 already present") {
+		t.Errorf("flash missing expected counts: %+v", f)
 	}
 
 	var scans []db.Scan
@@ -1419,9 +1501,9 @@ func TestBulkImport_rejectsNonHTTPS(t *testing.T) {
 	if len(repos) != 1 {
 		t.Errorf("want 1 repo (only the https one), got %d", len(repos))
 	}
-	trigger := w.Header().Get("HX-Trigger")
-	if !strings.Contains(trigger, "1 added") || !strings.Contains(trigger, "3 invalid") {
-		t.Errorf("toast missing counts: %s", trigger)
+	f := flashFrom(t, w)
+	if !strings.Contains(f.Title, "1 added") || !strings.Contains(f.Title, "3 invalid") {
+		t.Errorf("flash missing counts: %+v", f)
 	}
 }
 

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -139,6 +139,29 @@ func flashFrom(t *testing.T, w *httptest.ResponseRecorder) Flash {
 	return f
 }
 
+func TestRepoNew_fallbackPages(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	h := s.Handler()
+
+	for _, tc := range []struct{ path, want string }{
+		{"/repositories/new", "Add repository"},
+		{"/repositories/new?bulk=1", "Bulk import"},
+		{"/sboms/new", "Upload SBOM"},
+	} {
+		req := httptest.NewRequest("GET", tc.path, nil)
+		req.Host = testHost
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Errorf("%s: status %d", tc.path, w.Code)
+		}
+		if !strings.Contains(w.Body.String(), tc.want) {
+			t.Errorf("%s: body missing %q", tc.path, tc.want)
+		}
+	}
+}
+
 func TestFlash_roundtrip(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()
@@ -1538,8 +1561,8 @@ func TestBulkImport_dialogRendered(t *testing.T) {
 	if !strings.Contains(body, "Add multiple") {
 		t.Error("add-repo dialog missing 'Add multiple' link to bulk dialog")
 	}
-	if !strings.Contains(body, "getElementById('bulk-add-repo').showModal()") {
-		t.Error("'Add multiple' button does not open bulk dialog")
+	if !strings.Contains(body, `data-dialog="bulk-add-repo"`) {
+		t.Error("'Add multiple' link not wired to bulk dialog")
 	}
 }
 

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -1794,6 +1794,86 @@ func TestScanShowRenders(t *testing.T) {
 	}
 }
 
+func TestSettingsShow_rendersThemeOptions(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq("GET", "/settings"))
+	if w.Code != 200 {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+	body := w.Body.String()
+	for _, theme := range []string{"claude", "ocean-breeze", "catppuccin", "sunset-horizon", "midnight-bloom", "northern-lights"} {
+		if !strings.Contains(body, `value="`+theme+`"`) {
+			t.Errorf("settings page missing theme option %q", theme)
+		}
+	}
+}
+
+func TestSettingsUpdateTheme_setsCookie(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	form := url.Values{"theme": {"catppuccin"}}
+	req := httptest.NewRequest("POST", "/settings/theme", strings.NewReader(form.Encode()))
+	req.Host = testHost
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+
+	var found bool
+	for _, sc := range w.Header().Values("Set-Cookie") {
+		if strings.HasPrefix(sc, "theme=catppuccin") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("theme cookie not set; cookies: %v", w.Header().Values("Set-Cookie"))
+	}
+}
+
+func TestSettingsUpdateTheme_rejectsInvalid(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	form := url.Values{"theme": {"nope"}}
+	req := httptest.NewRequest("POST", "/settings/theme", strings.NewReader(form.Encode()))
+	req.Host = testHost
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Sec-Fetch-Site", "same-origin")
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Errorf("want 422 for invalid theme, got %d", w.Code)
+	}
+}
+
+func TestThemeCookie_appliedToRenderedPage(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	req := localReq("GET", "/")
+	req.AddCookie(&http.Cookie{Name: "theme", Value: "ocean-breeze"})
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+	if w.Code != 200 {
+		t.Fatalf("status %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), `data-theme="ocean-breeze"`) {
+		t.Error("theme cookie not reflected in data-theme attribute")
+	}
+}
+
+func TestNavKey_settings(t *testing.T) {
+	if got := navKey("/settings"); got != "settings" {
+		t.Errorf("navKey(/settings) = %q, want settings", got)
+	}
+}
+
 func TestMaintainerShow_displaysFindingStatus(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -122,6 +122,29 @@ func TestMaintainersIndex_rendersFindingsCountAndDNCBadge(t *testing.T) {
 	}
 }
 
+func TestRedirect_branchesOnHXRequest(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	plain := httptest.NewRequest("POST", "/x", nil)
+	w := httptest.NewRecorder()
+	s.redirect(w, plain, "/target")
+	if w.Code != http.StatusSeeOther || w.Header().Get("Location") != "/target" {
+		t.Errorf("plain: code=%d Location=%q", w.Code, w.Header().Get("Location"))
+	}
+
+	hx := httptest.NewRequest("POST", "/x", nil)
+	hx.Header.Set("HX-Request", "true")
+	w = httptest.NewRecorder()
+	s.redirect(w, hx, "/target")
+	if w.Code != http.StatusNoContent || w.Header().Get("HX-Redirect") != "/target" {
+		t.Errorf("hx: code=%d HX-Redirect=%q", w.Code, w.Header().Get("HX-Redirect"))
+	}
+	if w.Header().Get("Location") != "" {
+		t.Errorf("hx: unexpected Location %q", w.Header().Get("Location"))
+	}
+}
+
 func TestMaintainerDoNotContactToggle(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()
@@ -136,7 +159,7 @@ func TestMaintainerDoNotContactToggle(t *testing.T) {
 		r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 		w := httptest.NewRecorder()
 		s.Handler().ServeHTTP(w, r)
-		if w.Code != http.StatusNoContent {
+		if w.Code != http.StatusSeeOther {
 			t.Fatalf("value=%s status %d: %s", value, w.Code, w.Body)
 		}
 	}
@@ -167,7 +190,7 @@ func TestRepoDisclosureChannel_setAndClear(t *testing.T) {
 		r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 		w := httptest.NewRecorder()
 		s.Handler().ServeHTTP(w, r)
-		if w.Code != http.StatusNoContent {
+		if w.Code != http.StatusSeeOther {
 			t.Fatalf("status %d: %s", w.Code, w.Body)
 		}
 	}
@@ -1016,11 +1039,11 @@ func TestCreateRepoEnqueuesTriageSkill(t *testing.T) {
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, req)
-	if w.Code != 204 {
+	if w.Code != http.StatusSeeOther {
 		t.Fatalf("create status %d: %s", w.Code, w.Body)
 	}
-	if w.Header().Get("HX-Redirect") == "" {
-		t.Error("expected HX-Redirect")
+	if w.Header().Get("Location") == "" {
+		t.Error("expected Location redirect")
 	}
 
 	var repo db.Repository
@@ -1055,11 +1078,11 @@ func TestFindingDiscloseEnqueuesDiscloseSkill(t *testing.T) {
 	req.Header.Set("Sec-Fetch-Site", "same-origin")
 	w := httptest.NewRecorder()
 	s.Handler().ServeHTTP(w, req)
-	if w.Code != http.StatusNoContent {
+	if w.Code != http.StatusSeeOther {
 		t.Fatalf("status %d: %s", w.Code, w.Body)
 	}
-	if !strings.HasPrefix(w.Header().Get("HX-Redirect"), "/scans/") {
-		t.Errorf("expected HX-Redirect to scan, got %q", w.Header().Get("HX-Redirect"))
+	if !strings.HasPrefix(w.Header().Get("Location"), "/scans/") {
+		t.Errorf("expected redirect to scan, got %q", w.Header().Get("Location"))
 	}
 
 	var row db.Scan
@@ -1090,7 +1113,7 @@ func TestFindingPatchRunEnqueuesPatchSkill(t *testing.T) {
 	req.Header.Set("Sec-Fetch-Site", "same-origin")
 	w := httptest.NewRecorder()
 	s.Handler().ServeHTTP(w, req)
-	if w.Code != http.StatusNoContent {
+	if w.Code != http.StatusSeeOther {
 		t.Fatalf("status %d: %s", w.Code, w.Body)
 	}
 
@@ -1290,7 +1313,7 @@ func TestBulkImport_dedupesNormalisedURLs(t *testing.T) {
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	w := httptest.NewRecorder()
 	s.Handler().ServeHTTP(w, req)
-	if w.Code != http.StatusNoContent {
+	if w.Code != http.StatusSeeOther {
 		t.Fatalf("status %d: %s", w.Code, w.Body)
 	}
 	trigger := w.Header().Get("HX-Trigger")
@@ -1319,11 +1342,11 @@ func TestBulkImport_createsAndEnqueues(t *testing.T) {
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	w := httptest.NewRecorder()
 	s.Handler().ServeHTTP(w, req)
-	if w.Code != http.StatusNoContent {
+	if w.Code != http.StatusSeeOther {
 		t.Fatalf("status %d: %s", w.Code, w.Body)
 	}
-	if w.Header().Get("HX-Redirect") != "/" {
-		t.Errorf("HX-Redirect = %q", w.Header().Get("HX-Redirect"))
+	if w.Header().Get("Location") != "/" {
+		t.Errorf("Location = %q", w.Header().Get("Location"))
 	}
 	trigger := w.Header().Get("HX-Trigger")
 	if !strings.Contains(trigger, "2 added") {
@@ -1356,7 +1379,7 @@ func TestBulkImport_skipsDuplicates(t *testing.T) {
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	w := httptest.NewRecorder()
 	s.Handler().ServeHTTP(w, req)
-	if w.Code != http.StatusNoContent {
+	if w.Code != http.StatusSeeOther {
 		t.Fatalf("status %d: %s", w.Code, w.Body)
 	}
 	trigger := w.Header().Get("HX-Trigger")
@@ -1387,7 +1410,7 @@ func TestBulkImport_rejectsNonHTTPS(t *testing.T) {
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	w := httptest.NewRecorder()
 	s.Handler().ServeHTTP(w, req)
-	if w.Code != http.StatusNoContent {
+	if w.Code != http.StatusSeeOther {
 		t.Fatalf("status %d: %s", w.Code, w.Body)
 	}
 
@@ -1450,7 +1473,7 @@ func TestCreateRepo_parsesGitHubTreeURL(t *testing.T) {
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	w := httptest.NewRecorder()
 	s.Handler().ServeHTTP(w, req)
-	if w.Code != http.StatusNoContent {
+	if w.Code != http.StatusSeeOther {
 		t.Fatalf("status %d: %s", w.Code, w.Body)
 	}
 
@@ -1489,7 +1512,7 @@ func TestRetry_preservesSubPath(t *testing.T) {
 	req.Header.Set("Sec-Fetch-Site", "same-origin")
 	w := httptest.NewRecorder()
 	s.Handler().ServeHTTP(w, req)
-	if w.Code != http.StatusNoContent {
+	if w.Code != http.StatusSeeOther {
 		t.Fatalf("retry status %d: %s", w.Code, w.Body)
 	}
 
@@ -1547,7 +1570,7 @@ func TestScanCancel_queued(t *testing.T) {
 	req.Header.Set("Sec-Fetch-Site", "same-origin")
 	w := httptest.NewRecorder()
 	s.Handler().ServeHTTP(w, req)
-	if w.Code != http.StatusNoContent {
+	if w.Code != http.StatusSeeOther {
 		t.Fatalf("cancel status %d: %s", w.Code, w.Body)
 	}
 

--- a/internal/web/skills_handlers.go
+++ b/internal/web/skills_handlers.go
@@ -11,7 +11,7 @@ import (
 func (s *Server) skillsList(w http.ResponseWriter, r *http.Request) {
 	var skills []db.Skill
 	s.DB.Order("active desc, name asc").Find(&skills)
-	s.render(w, "skills.html", map[string]any{"Skills": skills})
+	s.render(w, r, "skills.html", map[string]any{"Skills": skills})
 }
 
 func (s *Server) skillShow(w http.ResponseWriter, r *http.Request) {
@@ -21,11 +21,11 @@ func (s *Server) skillShow(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 		return
 	}
-	s.render(w, "skill_show.html", map[string]any{"S": skill})
+	s.render(w, r, "skill_show.html", map[string]any{"S": skill})
 }
 
 func (s *Server) skillNew(w http.ResponseWriter, r *http.Request) {
-	s.render(w, "skill_form.html", map[string]any{
+	s.render(w, r, "skill_form.html", map[string]any{
 		"S":      db.Skill{Active: true, Source: "ui"},
 		"Action": "/skills",
 		"Verb":   "Create",
@@ -39,7 +39,7 @@ func (s *Server) skillEdit(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 		return
 	}
-	s.render(w, "skill_form.html", map[string]any{
+	s.render(w, r, "skill_form.html", map[string]any{
 		"S":      skill,
 		"Action": "/skills/" + strconv.Itoa(int(skill.ID)),
 		"Verb":   "Save",

--- a/internal/web/skills_handlers_test.go
+++ b/internal/web/skills_handlers_test.go
@@ -1,6 +1,7 @@
 package web
 
 import (
+	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"strconv"
@@ -111,7 +112,7 @@ func TestSkillRetry_preservesSkillID(t *testing.T) {
 	req.Header.Set("Sec-Fetch-Site", "same-origin")
 	w = httptest.NewRecorder()
 	h.ServeHTTP(w, req)
-	if w.Code != 204 {
+	if w.Code != http.StatusSeeOther {
 		t.Fatalf("retry status %d: %s", w.Code, w.Body)
 	}
 

--- a/internal/web/sse.go
+++ b/internal/web/sse.go
@@ -1,11 +1,14 @@
 package web
 
 import (
+	"fmt"
 	"io"
 	"net/http"
 	"strconv"
 	"strings"
 	"sync"
+
+	"scrutineer/internal/db"
 )
 
 // Event is one SSE message. Name maps to the htmx sse-swap attribute;
@@ -99,10 +102,46 @@ func (s *Server) events(w http.ResponseWriter, r *http.Request) {
 		case <-ctx.Done():
 			return
 		case e := <-c.ch:
-			writeSSEEvent(w, e.Name, e.Data)
+			data := e.Data
+			if e.Name == "scan-status" {
+				data = s.renderScanStatus(e.ScanID)
+			}
+			writeSSEEvent(w, e.Name, data)
 			flusher.Flush()
 		}
 	}
+}
+
+// renderScanStatus loads a scan and renders the OOB row + toast fragment
+// pushed to repo_show via the scan-status SSE event.
+func (s *Server) renderScanStatus(scanID uint) string {
+	var scan db.Scan
+	if err := s.DB.Preload("Repository").First(&scan, scanID).Error; err != nil {
+		return ""
+	}
+	var n int64
+	s.DB.Model(&db.Finding{}).Where("scan_id = ?", scan.ID).Count(&n)
+	scan.FindingsCount = int(n)
+
+	cat := "success"
+	if scan.Status != db.ScanDone {
+		cat = "error"
+	}
+	flash := Flash{
+		Category:    cat,
+		Title:       fmt.Sprintf("%s %s", scan.SkillName, scan.Status),
+		Description: scan.Repository.Name,
+		Href:        fmt.Sprintf("/scans/%d", scan.ID),
+		Label:       "View",
+	}
+	var buf strings.Builder
+	if err := s.tmpl.ExecuteTemplate(&buf, "scan-status-sse", map[string]any{
+		"Scan": scan, "Flash": flash,
+	}); err != nil {
+		s.Log.Error("render scan-status-sse", "scan", scanID, "err", err)
+		return ""
+	}
+	return buf.String()
 }
 
 // writeSSEEvent emits one SSE event per the spec. Embedded newlines in data

--- a/internal/web/static/app.js
+++ b/internal/web/static/app.js
@@ -1,0 +1,56 @@
+(function () {
+  'use strict';
+
+  function icons() {
+    if (window.lucide) lucide.createIcons();
+  }
+
+  function restoreTab() {
+    var h = location.hash.slice(1);
+    if (!h) return;
+    var tab = document.getElementById(h);
+    if (!tab || tab.getAttribute('role') !== 'tab') return;
+    var list = tab.closest('[role="tablist"]');
+    if (!list) return;
+    list.querySelectorAll('[role="tab"]').forEach(function (t) {
+      var sel = t.id === h;
+      t.setAttribute('aria-selected', sel);
+      var p = document.getElementById(t.getAttribute('aria-controls'));
+      if (p) p.hidden = !sel;
+    });
+  }
+
+  function init() {
+    icons();
+    restoreTab();
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', icons);
+    window.addEventListener('load', restoreTab);
+  } else {
+    init();
+  }
+
+  document.addEventListener('htmx:afterSwap', icons);
+  document.addEventListener('htmx:historyRestore', init);
+  document.addEventListener('htmx:oobAfterSwap', icons);
+
+  document.addEventListener('click', function (e) {
+    var tab = e.target.closest('[role="tab"]');
+    if (tab && tab.id) history.replaceState(null, '', '#' + tab.id);
+
+    if (e.target.nodeName === 'DIALOG') e.target.close();
+
+    var opener = e.target.closest('[data-dialog]');
+    if (opener) {
+      var dlg = document.getElementById(opener.getAttribute('data-dialog'));
+      if (dlg && dlg.showModal) {
+        e.preventDefault();
+        var cur = opener.closest('dialog');
+        if (cur) cur.close();
+        dlg.showModal();
+      }
+    }
+  });
+})();

--- a/internal/web/static/theme.css
+++ b/internal/web/static/theme.css
@@ -1,5 +1,7 @@
-/* claude theme for basecoat (shadcn-compatible variables, via tweakcn) */
-:root {
+/* Theme variables (shadcn-compatible, via tweakcn) */
+
+/* ── claude (default) ── */
+:root, [data-theme="claude"] {
   --background: oklch(0.9818 0.0054 95.0986);
   --foreground: oklch(0.3438 0.0269 95.7226);
   --card: oklch(0.9818 0.0054 95.0986);
@@ -29,8 +31,7 @@
   --sidebar-border: oklch(0.9401 0 0);
   --sidebar-ring: oklch(0.7731 0 0);
 }
-
-.dark {
+.dark, [data-theme="claude"].dark {
   --background: oklch(0.2679 0.0036 106.6427);
   --foreground: oklch(0.8074 0.0142 93.0137);
   --card: oklch(0.2679 0.0036 106.6427);
@@ -60,6 +61,312 @@
   --sidebar-ring: oklch(0.7731 0 0);
 }
 
+/* ── ocean-breeze ── */
+[data-theme="ocean-breeze"] {
+  --background: oklch(0.98 0.01 244.25);
+  --foreground: oklch(0.37 0.03 259.73);
+  --card: oklch(1 0 0);
+  --card-foreground: oklch(0.37 0.03 259.73);
+  --popover: oklch(1 0 0);
+  --popover-foreground: oklch(0.37 0.03 259.73);
+  --primary: oklch(0.72 0.19 149.58);
+  --primary-foreground: oklch(1 0 0);
+  --secondary: oklch(0.95 0.03 236.82);
+  --secondary-foreground: oklch(0.45 0.03 256.8);
+  --muted: oklch(0.97 0 264.54);
+  --muted-foreground: oklch(0.55 0.02 264.36);
+  --accent: oklch(0.95 0.05 163.05);
+  --accent-foreground: oklch(0.37 0.03 259.73);
+  --destructive: oklch(0.64 0.21 25.33);
+  --destructive-foreground: oklch(1 0 0);
+  --border: oklch(0.93 0.01 264.53);
+  --input: oklch(0.93 0.01 264.53);
+  --ring: oklch(0.72 0.19 149.58);
+  --radius: 0.5rem;
+  --sidebar: oklch(0.95 0.03 236.82);
+  --sidebar-foreground: oklch(0.37 0.03 259.73);
+  --sidebar-primary: oklch(0.72 0.19 149.58);
+  --sidebar-primary-foreground: oklch(1 0 0);
+  --sidebar-accent: oklch(0.95 0.05 163.05);
+  --sidebar-accent-foreground: oklch(0.37 0.03 259.73);
+  --sidebar-border: oklch(0.93 0.01 264.53);
+  --sidebar-ring: oklch(0.72 0.19 149.58);
+}
+[data-theme="ocean-breeze"].dark {
+  --background: oklch(0.21 0.04 265.75);
+  --foreground: oklch(0.87 0.01 258.34);
+  --card: oklch(0.28 0.04 260.03);
+  --card-foreground: oklch(0.87 0.01 258.34);
+  --popover: oklch(0.28 0.04 260.03);
+  --popover-foreground: oklch(0.87 0.01 258.34);
+  --primary: oklch(0.77 0.15 163.22);
+  --primary-foreground: oklch(0.21 0.04 265.75);
+  --secondary: oklch(0.34 0.03 260.91);
+  --secondary-foreground: oklch(0.71 0.01 286.07);
+  --muted: oklch(0.28 0.04 260.03);
+  --muted-foreground: oklch(0.55 0.02 264.36);
+  --accent: oklch(0.37 0.03 259.73);
+  --accent-foreground: oklch(0.71 0.01 286.07);
+  --destructive: oklch(0.64 0.21 25.33);
+  --destructive-foreground: oklch(0.21 0.04 265.75);
+  --border: oklch(0.45 0.03 256.8);
+  --input: oklch(0.45 0.03 256.8);
+  --ring: oklch(0.77 0.15 163.22);
+  --sidebar: oklch(0.28 0.04 260.03);
+  --sidebar-foreground: oklch(0.87 0.01 258.34);
+  --sidebar-primary: oklch(0.77 0.15 163.22);
+  --sidebar-primary-foreground: oklch(0.21 0.04 265.75);
+  --sidebar-accent: oklch(0.37 0.03 259.73);
+  --sidebar-accent-foreground: oklch(0.71 0.01 286.07);
+  --sidebar-border: oklch(0.45 0.03 256.8);
+  --sidebar-ring: oklch(0.77 0.15 163.22);
+}
+
+/* ── catppuccin ── */
+[data-theme="catppuccin"] {
+  --background: oklch(0.96 0.01 264.53);
+  --foreground: oklch(0.44 0.04 279.33);
+  --card: oklch(1 0 0);
+  --card-foreground: oklch(0.44 0.04 279.33);
+  --popover: oklch(0.86 0.01 268.48);
+  --popover-foreground: oklch(0.44 0.04 279.33);
+  --primary: oklch(0.55 0.25 297.02);
+  --primary-foreground: oklch(1 0 0);
+  --secondary: oklch(0.86 0.01 268.48);
+  --secondary-foreground: oklch(0.44 0.04 279.33);
+  --muted: oklch(0.91 0.01 264.51);
+  --muted-foreground: oklch(0.55 0.03 279.08);
+  --accent: oklch(0.68 0.14 235.38);
+  --accent-foreground: oklch(1 0 0);
+  --destructive: oklch(0.55 0.22 19.81);
+  --destructive-foreground: oklch(1 0 0);
+  --border: oklch(0.81 0.02 271.2);
+  --input: oklch(0.86 0.01 268.48);
+  --ring: oklch(0.55 0.25 297.02);
+  --radius: 0.35rem;
+  --sidebar: oklch(0.93 0.01 264.52);
+  --sidebar-foreground: oklch(0.44 0.04 279.33);
+  --sidebar-primary: oklch(0.55 0.25 297.02);
+  --sidebar-primary-foreground: oklch(1 0 0);
+  --sidebar-accent: oklch(0.68 0.14 235.38);
+  --sidebar-accent-foreground: oklch(1 0 0);
+  --sidebar-border: oklch(0.81 0.02 271.2);
+  --sidebar-ring: oklch(0.55 0.25 297.02);
+}
+[data-theme="catppuccin"].dark {
+  --background: oklch(0.22 0.03 284.06);
+  --foreground: oklch(0.88 0.04 272.28);
+  --card: oklch(0.24 0.03 283.91);
+  --card-foreground: oklch(0.88 0.04 272.28);
+  --popover: oklch(0.4 0.03 280.15);
+  --popover-foreground: oklch(0.88 0.04 272.28);
+  --primary: oklch(0.79 0.12 304.77);
+  --primary-foreground: oklch(0.24 0.03 283.91);
+  --secondary: oklch(0.48 0.03 278.64);
+  --secondary-foreground: oklch(0.88 0.04 272.28);
+  --muted: oklch(0.3 0.03 276.21);
+  --muted-foreground: oklch(0.75 0.04 273.93);
+  --accent: oklch(0.85 0.08 210.25);
+  --accent-foreground: oklch(0.24 0.03 283.91);
+  --destructive: oklch(0.76 0.13 2.76);
+  --destructive-foreground: oklch(0.24 0.03 283.91);
+  --border: oklch(0.32 0.03 281.98);
+  --input: oklch(0.32 0.03 281.98);
+  --ring: oklch(0.79 0.12 304.77);
+  --sidebar: oklch(0.18 0.02 284.2);
+  --sidebar-foreground: oklch(0.88 0.04 272.28);
+  --sidebar-primary: oklch(0.79 0.12 304.77);
+  --sidebar-primary-foreground: oklch(0.24 0.03 283.91);
+  --sidebar-accent: oklch(0.85 0.08 210.25);
+  --sidebar-accent-foreground: oklch(0.24 0.03 283.91);
+  --sidebar-border: oklch(0.4 0.03 280.15);
+  --sidebar-ring: oklch(0.79 0.12 304.77);
+}
+
+/* ── sunset-horizon ── */
+[data-theme="sunset-horizon"] {
+  --background: oklch(0.99 0.01 56.32);
+  --foreground: oklch(0.34 0.01 2.77);
+  --card: oklch(1 0 0);
+  --card-foreground: oklch(0.34 0.01 2.77);
+  --popover: oklch(1 0 0);
+  --popover-foreground: oklch(0.34 0.01 2.77);
+  --primary: oklch(0.74 0.16 34.71);
+  --primary-foreground: oklch(1 0 0);
+  --secondary: oklch(0.96 0.02 28.9);
+  --secondary-foreground: oklch(0.56 0.13 32.74);
+  --muted: oklch(0.97 0.02 39.4);
+  --muted-foreground: oklch(0.55 0.01 58.07);
+  --accent: oklch(0.83 0.11 58);
+  --accent-foreground: oklch(0.34 0.01 2.77);
+  --destructive: oklch(0.61 0.21 22.24);
+  --destructive-foreground: oklch(1 0 0);
+  --border: oklch(0.93 0.04 38.69);
+  --input: oklch(0.93 0.04 38.69);
+  --ring: oklch(0.74 0.16 34.71);
+  --radius: 0.625rem;
+  --sidebar: oklch(0.97 0.02 39.4);
+  --sidebar-foreground: oklch(0.34 0.01 2.77);
+  --sidebar-primary: oklch(0.74 0.16 34.71);
+  --sidebar-primary-foreground: oklch(1 0 0);
+  --sidebar-accent: oklch(0.83 0.11 58);
+  --sidebar-accent-foreground: oklch(0.34 0.01 2.77);
+  --sidebar-border: oklch(0.93 0.04 38.69);
+  --sidebar-ring: oklch(0.74 0.16 34.71);
+}
+[data-theme="sunset-horizon"].dark {
+  --background: oklch(0.26 0.02 352.4);
+  --foreground: oklch(0.94 0.01 51.32);
+  --card: oklch(0.32 0.02 341.45);
+  --card-foreground: oklch(0.94 0.01 51.32);
+  --popover: oklch(0.32 0.02 341.45);
+  --popover-foreground: oklch(0.94 0.01 51.32);
+  --primary: oklch(0.74 0.16 34.71);
+  --primary-foreground: oklch(1 0 0);
+  --secondary: oklch(0.36 0.02 342.27);
+  --secondary-foreground: oklch(0.94 0.01 51.32);
+  --muted: oklch(0.32 0.02 341.45);
+  --muted-foreground: oklch(0.84 0.02 52.63);
+  --accent: oklch(0.83 0.11 58);
+  --accent-foreground: oklch(0.26 0.02 352.4);
+  --destructive: oklch(0.61 0.21 22.24);
+  --destructive-foreground: oklch(1 0 0);
+  --border: oklch(0.36 0.02 342.27);
+  --input: oklch(0.36 0.02 342.27);
+  --ring: oklch(0.74 0.16 34.71);
+  --sidebar: oklch(0.26 0.02 352.4);
+  --sidebar-foreground: oklch(0.94 0.01 51.32);
+  --sidebar-primary: oklch(0.74 0.16 34.71);
+  --sidebar-primary-foreground: oklch(1 0 0);
+  --sidebar-accent: oklch(0.83 0.11 58);
+  --sidebar-accent-foreground: oklch(0.26 0.02 352.4);
+  --sidebar-border: oklch(0.36 0.02 342.27);
+  --sidebar-ring: oklch(0.74 0.16 34.71);
+}
+
+/* ── midnight-bloom ── */
+[data-theme="midnight-bloom"] {
+  --background: oklch(0.98 0 0);
+  --foreground: oklch(0.32 0 0);
+  --card: oklch(1 0 0);
+  --card-foreground: oklch(0.32 0 0);
+  --popover: oklch(1 0 0);
+  --popover-foreground: oklch(0.32 0 0);
+  --primary: oklch(0.57 0.2 283.08);
+  --primary-foreground: oklch(1 0 0);
+  --secondary: oklch(0.82 0.07 249.35);
+  --secondary-foreground: oklch(0.32 0 0);
+  --muted: oklch(0.82 0.02 91.62);
+  --muted-foreground: oklch(0.54 0 0);
+  --accent: oklch(0.65 0.06 117.43);
+  --accent-foreground: oklch(1 0 0);
+  --destructive: oklch(0.64 0.21 25.33);
+  --destructive-foreground: oklch(1 0 0);
+  --border: oklch(0.87 0 0);
+  --input: oklch(0.87 0 0);
+  --ring: oklch(0.57 0.2 283.08);
+  --radius: 0.5rem;
+  --sidebar: oklch(0.98 0 0);
+  --sidebar-foreground: oklch(0.32 0 0);
+  --sidebar-primary: oklch(0.57 0.2 283.08);
+  --sidebar-primary-foreground: oklch(1 0 0);
+  --sidebar-accent: oklch(0.65 0.06 117.43);
+  --sidebar-accent-foreground: oklch(1 0 0);
+  --sidebar-border: oklch(0.87 0 0);
+  --sidebar-ring: oklch(0.57 0.2 283.08);
+}
+[data-theme="midnight-bloom"].dark {
+  --background: oklch(0.23 0.01 264.29);
+  --foreground: oklch(0.92 0 0);
+  --card: oklch(0.32 0.01 223.67);
+  --card-foreground: oklch(0.92 0 0);
+  --popover: oklch(0.32 0.01 223.67);
+  --popover-foreground: oklch(0.92 0 0);
+  --primary: oklch(0.57 0.2 283.08);
+  --primary-foreground: oklch(1 0 0);
+  --secondary: oklch(0.34 0.18 301.68);
+  --secondary-foreground: oklch(0.92 0 0);
+  --muted: oklch(0.39 0 0);
+  --muted-foreground: oklch(0.72 0 0);
+  --accent: oklch(0.67 0.14 261.34);
+  --accent-foreground: oklch(0.92 0 0);
+  --destructive: oklch(0.64 0.21 25.33);
+  --destructive-foreground: oklch(1 0 0);
+  --border: oklch(0.39 0 0);
+  --input: oklch(0.39 0 0);
+  --ring: oklch(0.57 0.2 283.08);
+  --sidebar: oklch(0.23 0.01 264.29);
+  --sidebar-foreground: oklch(0.92 0 0);
+  --sidebar-primary: oklch(0.57 0.2 283.08);
+  --sidebar-primary-foreground: oklch(1 0 0);
+  --sidebar-accent: oklch(0.67 0.14 261.34);
+  --sidebar-accent-foreground: oklch(0.92 0 0);
+  --sidebar-border: oklch(0.39 0 0);
+  --sidebar-ring: oklch(0.57 0.2 283.08);
+}
+
+/* ── northern-lights ── */
+[data-theme="northern-lights"] {
+  --background: oklch(0.98 0 286.38);
+  --foreground: oklch(0.32 0 0);
+  --card: oklch(1 0 0);
+  --card-foreground: oklch(0.32 0 0);
+  --popover: oklch(1 0 0);
+  --popover-foreground: oklch(0.32 0 0);
+  --primary: oklch(0.65 0.15 150.31);
+  --primary-foreground: oklch(1 0 0);
+  --secondary: oklch(0.67 0.14 261.34);
+  --secondary-foreground: oklch(1 0 0);
+  --muted: oklch(0.88 0.03 98.1);
+  --muted-foreground: oklch(0.54 0 0);
+  --accent: oklch(0.83 0.11 211.96);
+  --accent-foreground: oklch(0.32 0 0);
+  --destructive: oklch(0.64 0.21 25.33);
+  --destructive-foreground: oklch(1 0 0);
+  --border: oklch(0.87 0 0);
+  --input: oklch(0.87 0 0);
+  --ring: oklch(0.65 0.15 150.31);
+  --radius: 0.5rem;
+  --sidebar: oklch(0.98 0 286.38);
+  --sidebar-foreground: oklch(0.32 0 0);
+  --sidebar-primary: oklch(0.65 0.15 150.31);
+  --sidebar-primary-foreground: oklch(1 0 0);
+  --sidebar-accent: oklch(0.83 0.11 211.96);
+  --sidebar-accent-foreground: oklch(0.32 0 0);
+  --sidebar-border: oklch(0.87 0 0);
+  --sidebar-ring: oklch(0.65 0.15 150.31);
+}
+[data-theme="northern-lights"].dark {
+  --background: oklch(0.23 0.01 264.29);
+  --foreground: oklch(0.92 0 0);
+  --card: oklch(0.32 0.01 223.67);
+  --card-foreground: oklch(0.92 0 0);
+  --popover: oklch(0.32 0.01 223.67);
+  --popover-foreground: oklch(0.92 0 0);
+  --primary: oklch(0.65 0.15 150.31);
+  --primary-foreground: oklch(1 0 0);
+  --secondary: oklch(0.59 0.1 245.74);
+  --secondary-foreground: oklch(0.92 0 0);
+  --muted: oklch(0.39 0 0);
+  --muted-foreground: oklch(0.72 0 0);
+  --accent: oklch(0.67 0.14 261.34);
+  --accent-foreground: oklch(0.92 0 0);
+  --destructive: oklch(0.64 0.21 25.33);
+  --destructive-foreground: oklch(1 0 0);
+  --border: oklch(0.39 0 0);
+  --input: oklch(0.39 0 0);
+  --ring: oklch(0.65 0.15 150.31);
+  --sidebar: oklch(0.23 0.01 264.29);
+  --sidebar-foreground: oklch(0.92 0 0);
+  --sidebar-primary: oklch(0.65 0.15 150.31);
+  --sidebar-primary-foreground: oklch(1 0 0);
+  --sidebar-accent: oklch(0.67 0.14 261.34);
+  --sidebar-accent-foreground: oklch(0.92 0 0);
+  --sidebar-border: oklch(0.39 0 0);
+  --sidebar-ring: oklch(0.65 0.15 150.31);
+}
+
+/* ── shared ── */
 body { background: var(--background); color: var(--foreground);
        font-family: ui-sans-serif, system-ui, sans-serif; }
 pre.log { background: var(--muted); padding: 1rem; border-radius: var(--radius);

--- a/internal/web/templates/advisories.html
+++ b/internal/web/templates/advisories.html
@@ -1,4 +1,4 @@
-{{template "head"}}
+{{template "head" .}}
 
 <div class="flex items-center justify-between gap-4 mb-6">
   <h2 class="text-2xl font-semibold flex items-center gap-2">
@@ -87,4 +87,4 @@
   {{template "empty" (dict "Icon" "shield-alert" "Title" "No advisories" "Body" "Advisories appear here after the advisories skill runs on a repository.")}}
 {{end}}
 
-{{template "foot"}}
+{{template "foot" .}}

--- a/internal/web/templates/advisories.html
+++ b/internal/web/templates/advisories.html
@@ -59,7 +59,7 @@
     {{$repos := .Repos}}
     {{range .Advisories}}
       {{$repo := index $repos .RepositoryID}}
-      <tr class="cursor-pointer" onclick="window.open('{{.URL}}', '_blank', 'noopener')">
+      <tr>
         <td>
           {{if eq .Severity "CRITICAL"}}<span class="badge-destructive">Critical</span>
           {{else if eq .Severity "HIGH"}}<span class="badge-destructive">High</span>
@@ -68,12 +68,11 @@
         </td>
         <td class="text-muted-foreground">{{if .CVSSScore}}{{printf "%.1f" .CVSSScore}}{{end}}</td>
         <td class="min-w-0 whitespace-normal">
-          <div class="font-medium">{{.Title}}</div>
+          <a href="{{.URL}}" target="_blank" rel="noopener" class="font-medium hover:underline">{{.Title}}</a>
           {{if .Classification}}<div class="text-xs text-muted-foreground">{{.Classification}}</div>{{end}}
         </td>
         <td class="truncate">
-          <a href="/repositories/{{$repo.ID}}" class="hover:underline"
-             onclick="event.stopPropagation()">{{$repo.Name}}</a>
+          <a href="/repositories/{{$repo.ID}}" class="hover:underline">{{$repo.Name}}</a>
         </td>
         <td class="text-muted-foreground whitespace-normal text-xs">{{.Packages}}</td>
         <td class="text-muted-foreground">{{if .PublishedAt}}{{.PublishedAt.Format "2006-01-02"}}{{end}}</td>

--- a/internal/web/templates/finding_show.html
+++ b/internal/web/templates/finding_show.html
@@ -1,4 +1,4 @@
-{{template "head"}}
+{{template "head" .}}
 {{$f := .F}}
 {{$scan := .Scan}}
 {{$repo := .Repo}}
@@ -470,4 +470,4 @@ git commit -m "fix: {{$f.Title}}"</pre>
   {{end}}
 </section>
 
-{{template "foot"}}
+{{template "foot" .}}

--- a/internal/web/templates/finding_workflow.html
+++ b/internal/web/templates/finding_workflow.html
@@ -38,66 +38,81 @@
       {{end}}
     </div>
 
-    <div class="flex items-center gap-2 shrink-0">
+    <form method="post" action="/findings/{{$id}}/status" hx-swap="none"
+          class="flex items-center gap-2 shrink-0">
       {{if eq $s "new"}}
-        <button class="btn" hx-post="/findings/{{$id}}/verify" hx-swap="none">
+        <button type="submit" class="btn" formaction="/findings/{{$id}}/verify"
+                hx-post="/findings/{{$id}}/verify">
           <i data-lucide="shield-check"></i> Verify
         </button>
-        <button class="btn-outline" hx-post="/findings/{{$id}}/status" hx-vals='{"status":"triaged"}' hx-swap="none">
+        <button type="submit" name="status" value="triaged" class="btn-outline"
+                hx-post="/findings/{{$id}}/status">
           Skip to triage
         </button>
-        <button class="btn-ghost" hx-post="/findings/{{$id}}/status" hx-vals='{"status":"rejected"}' hx-swap="none">
+        <button type="submit" name="status" value="rejected" class="btn-ghost"
+                hx-post="/findings/{{$id}}/status">
           Reject
         </button>
 
       {{else if eq $s "enriched"}}
-        <button class="btn" hx-post="/findings/{{$id}}/status" hx-vals='{"status":"triaged"}' hx-swap="none">
+        <button type="submit" name="status" value="triaged" class="btn"
+                hx-post="/findings/{{$id}}/status">
           <i data-lucide="check"></i> Triage
         </button>
-        <button class="btn-ghost" hx-post="/findings/{{$id}}/status" hx-vals='{"status":"rejected"}' hx-swap="none">
+        <button type="submit" name="status" value="rejected" class="btn-ghost"
+                hx-post="/findings/{{$id}}/status">
           Reject
         </button>
 
       {{else if eq $s "triaged"}}
-        <button class="btn" hx-post="/findings/{{$id}}/disclose" hx-swap="none">
+        <button type="submit" class="btn" formaction="/findings/{{$id}}/disclose"
+                hx-post="/findings/{{$id}}/disclose">
           <i data-lucide="file-pen"></i> Draft disclosure
         </button>
-        <button class="btn-outline" hx-post="/findings/{{$id}}/patch" hx-swap="none">
+        <button type="submit" class="btn-outline" formaction="/findings/{{$id}}/patch"
+                hx-post="/findings/{{$id}}/patch">
           <i data-lucide="wrench"></i> Propose patch
         </button>
-        <button class="btn-outline" hx-post="/findings/{{$id}}/status" hx-vals='{"status":"ready"}' hx-swap="none">
+        <button type="submit" name="status" value="ready" class="btn-outline"
+                hx-post="/findings/{{$id}}/status">
           Mark ready
         </button>
-        <button class="btn-ghost" hx-post="/findings/{{$id}}/status" hx-vals='{"status":"rejected"}' hx-swap="none">
+        <button type="submit" name="status" value="rejected" class="btn-ghost"
+                hx-post="/findings/{{$id}}/status">
           Reject
         </button>
 
       {{else if eq $s "ready"}}
-        <button class="btn" hx-post="/findings/{{$id}}/status" hx-vals='{"status":"reported"}' hx-swap="none">
+        <button type="submit" name="status" value="reported" class="btn"
+                hx-post="/findings/{{$id}}/status">
           <i data-lucide="send"></i> Mark as reported
         </button>
 
       {{else if eq $s "reported"}}
-        <button class="btn" hx-post="/findings/{{$id}}/status" hx-vals='{"status":"acknowledged"}' hx-swap="none">
+        <button type="submit" name="status" value="acknowledged" class="btn"
+                hx-post="/findings/{{$id}}/status">
           <i data-lucide="message-circle"></i> Acknowledged
         </button>
 
       {{else if eq $s "acknowledged"}}
-        <button class="btn" hx-post="/findings/{{$id}}/status" hx-vals='{"status":"fixed"}' hx-swap="none">
+        <button type="submit" name="status" value="fixed" class="btn"
+                hx-post="/findings/{{$id}}/status">
           <i data-lucide="wrench"></i> Mark fixed
         </button>
 
       {{else if eq $s "fixed"}}
-        <button class="btn" hx-post="/findings/{{$id}}/status" hx-vals='{"status":"published"}' hx-swap="none">
+        <button type="submit" name="status" value="published" class="btn"
+                hx-post="/findings/{{$id}}/status">
           <i data-lucide="globe"></i> Publish
         </button>
 
       {{else if or (eq $s "rejected") (eq $s "duplicate")}}
-        <button class="btn-outline" hx-post="/findings/{{$id}}/status" hx-vals='{"status":"new"}' hx-swap="none">
+        <button type="submit" name="status" value="new" class="btn-outline"
+                hx-post="/findings/{{$id}}/status">
           <i data-lucide="rotate-ccw"></i> Reopen
         </button>
       {{end}}
-    </div>
+    </form>
   </section>
 </div>
 {{end}}

--- a/internal/web/templates/findings.html
+++ b/internal/web/templates/findings.html
@@ -59,10 +59,10 @@
     {{$showSub := .AnySubPath}}
     {{range .Findings}}
       {{$repo := index $repos .RepositoryID}}
-      <tr class="cursor-pointer" hx-get="/findings/{{.ID}}" hx-target="body" hx-push-url="true">
+      <tr id="finding-{{.ID}}" class="cursor-pointer" hx-get="/findings/{{.ID}}" hx-push-url="true">
         <td>{{template "severity-badge" .Severity}}</td>
         <td class="min-w-0 whitespace-normal">
-          <div class="font-medium">{{.Title}}</div>
+          <a href="/findings/{{.ID}}" class="font-medium" hx-on:click="event.stopPropagation()">{{.Title}}</a>
           <div class="text-xs text-muted-foreground line-clamp-2">{{.Summary}}</div>
         </td>
         <td>{{template "finding-status" (fstatus .Status)}}</td>

--- a/internal/web/templates/findings.html
+++ b/internal/web/templates/findings.html
@@ -1,4 +1,4 @@
-{{template "head"}}
+{{template "head" .}}
 
 <div class="flex items-center justify-between gap-4 mb-6">
   <h2 class="text-2xl font-semibold flex items-center gap-2">
@@ -86,4 +86,4 @@
   {{template "empty" (dict "Icon" "bug" "Title" "No findings" "Body" "Findings appear here once a scan reports vulnerabilities.")}}
 {{end}}
 
-{{template "foot"}}
+{{template "foot" .}}

--- a/internal/web/templates/index.html
+++ b/internal/web/templates/index.html
@@ -1,4 +1,4 @@
-{{template "head"}}
+{{template "head" .}}
 
 <h2 class="text-2xl font-semibold mb-6 flex items-center gap-2">
   <i data-lucide="folder-git-2"></i> Repositories
@@ -6,4 +6,4 @@
 
 {{template "repo_list.html" .}}
 
-{{template "foot"}}
+{{template "foot" .}}

--- a/internal/web/templates/jobs.html
+++ b/internal/web/templates/jobs.html
@@ -67,8 +67,8 @@
     <tbody>
     {{$showSub := .AnySubPath}}
     {{range .Scans}}
-      <tr class="cursor-pointer" hx-get="/scans/{{.ID}}" hx-target="body" hx-push-url="true">
-        <td>{{.ID}}</td>
+      <tr id="scan-{{.ID}}" class="cursor-pointer" hx-get="/scans/{{.ID}}" hx-push-url="true">
+        <td><a href="/scans/{{.ID}}" hx-on:click="event.stopPropagation()">{{.ID}}</a></td>
         <td>{{.Repository.Name}}</td>
         {{if $showSub}}
           <td class="text-xs text-muted-foreground">{{if .SubPath}}<code>{{.SubPath}}</code>{{else}}<span>root</span>{{end}}</td>

--- a/internal/web/templates/jobs.html
+++ b/internal/web/templates/jobs.html
@@ -1,4 +1,4 @@
-{{template "head"}}
+{{template "head" .}}
 
 <div class="flex items-center justify-between gap-4 mb-6">
   <h2 class="text-2xl font-semibold flex items-center gap-2">
@@ -90,4 +90,4 @@
   {{template "empty" (dict "Icon" "list-checks" "Title" "No jobs yet" "Body" "Jobs appear here once a repository has been queued.")}}
 {{end}}
 
-{{template "foot"}}
+{{template "foot" .}}

--- a/internal/web/templates/layout.html
+++ b/internal/web/templates/layout.html
@@ -21,7 +21,7 @@
   <script src="https://cdn.jsdelivr.net/npm/htmx-ext-sse@2.2.4/sse.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/lucide@0.545.0/dist/umd/lucide.min.js"></script>
 </head>
-<body hx-on::after-swap="lucide.createIcons()">
+<body hx-on::after-swap="lucide.createIcons()" hx-on::history-restore="lucide.createIcons()">
 
 <aside class="sidebar" data-side="left" aria-hidden="false">
   <nav aria-label="Sidebar">
@@ -61,7 +61,9 @@
   </nav>
 </aside>
 
-<main id="content" class="min-h-screen">
+<main id="content" class="min-h-screen"
+      hx-history-elt
+      hx-target="#content" hx-select="#content" hx-swap="outerHTML">
   <div class="p-4 md:p-6 xl:p-12">
 {{end}}
 

--- a/internal/web/templates/layout.html
+++ b/internal/web/templates/layout.html
@@ -20,8 +20,9 @@
   <script src="https://cdn.jsdelivr.net/npm/htmx.org@2.0.6/dist/htmx.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/htmx-ext-sse@2.2.4/sse.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/lucide@0.545.0/dist/umd/lucide.min.js"></script>
+  <script src="/static/app.js" defer></script>
 </head>
-<body hx-on::after-swap="lucide.createIcons()" hx-on::history-restore="lucide.createIcons()">
+<body>
 
 <aside class="sidebar" data-side="left" aria-hidden="false">
   <nav aria-label="Sidebar">
@@ -54,10 +55,9 @@
       </div>
     </section>
     <footer>
-      <button type="button" class="btn w-full"
-              onclick="document.getElementById('add-repo').showModal()">
+      <a href="/repositories/new" data-dialog="add-repo" class="btn w-full">
         <i data-lucide="plus"></i> Add repository
-      </button>
+      </a>
     </footer>
   </nav>
 </aside>
@@ -72,8 +72,7 @@
   </div>
 </main>
 
-<dialog id="add-repo" class="dialog w-full sm:max-w-md"
-        onclick="if (event.target === this) this.close()">
+<dialog id="add-repo" class="dialog w-full sm:max-w-md">
   <div>
     <header><h2>Add repository</h2></header>
     <section>
@@ -81,10 +80,9 @@
         <input class="input" type="text" name="url"
                placeholder="https://github.com/maragudk/goqite.git" required>
         <footer class="flex justify-between items-center gap-2">
-          <button type="button" class="btn-ghost-sm"
-                  onclick="this.closest('dialog').close(); document.getElementById('bulk-add-repo').showModal()">
+          <a href="/repositories/new?bulk=1" data-dialog="bulk-add-repo" class="btn-ghost-sm">
             <i data-lucide="list-plus"></i> Add multiple
-          </button>
+          </a>
           <div class="flex gap-2">
             <button type="submit" class="btn-outline" formmethod="dialog" formnovalidate>Cancel</button>
             <button type="submit" class="btn" hx-post="/repositories" hx-swap="none">
@@ -98,8 +96,7 @@
   </div>
 </dialog>
 
-<dialog id="bulk-add-repo" class="dialog w-full sm:max-w-lg"
-        onclick="if (event.target === this) this.close()">
+<dialog id="bulk-add-repo" class="dialog w-full sm:max-w-lg">
   <div>
     <header>
       <h2>Bulk import repositories</h2>
@@ -127,31 +124,6 @@
 <div id="toaster" class="toaster">
   {{with .Flash}}{{template "toast" .}}{{end}}
 </div>
-<script>
-  lucide.createIcons();
-  // Persist active tab in URL hash
-  document.addEventListener('click', function (e) {
-    var tab = e.target.closest('[role="tab"]');
-    if (tab && tab.id) history.replaceState(null, '', '#' + tab.id);
-  });
-  // Restore tab after basecoat initialises. Use rAF to yield to deferred scripts.
-  function restoreTab() {
-    var h = location.hash.slice(1);
-    if (!h) return;
-    var tab = document.getElementById(h);
-    if (!tab || tab.getAttribute('role') !== 'tab') return;
-    var tablist = tab.closest('[role="tablist"]');
-    if (!tablist) return;
-    tablist.querySelectorAll('[role="tab"]').forEach(function (t) {
-      var selected = t.id === h;
-      t.setAttribute('aria-selected', selected);
-      var panel = document.getElementById(t.getAttribute('aria-controls'));
-      if (panel) panel.hidden = !selected;
-    });
-  }
-  if (document.readyState === 'complete') restoreTab();
-  else window.addEventListener('load', restoreTab);
-</script>
 </body>
 </html>
 {{end}}

--- a/internal/web/templates/layout.html
+++ b/internal/web/templates/layout.html
@@ -38,17 +38,18 @@
     </header>
     <section>
       <div role="group">
-        <ul>
-          <li><a href="/" data-nav="repos"><i data-lucide="folder-git-2"></i><span>Repositories</span></a></li>
-          <li><a href="/orgs" data-nav="orgs"><i data-lucide="building"></i><span>Organizations</span></a></li>
-          <li><a href="/findings" data-nav="findings"><i data-lucide="bug"></i><span>Findings</span></a></li>
-          <li><a href="/packages" data-nav="packages"><i data-lucide="package"></i><span>Packages</span></a></li>
-          <li><a href="/sboms" data-nav="sboms"><i data-lucide="file-box"></i><span>SBOMs</span></a></li>
-          <li><a href="/advisories" data-nav="advisories"><i data-lucide="shield-alert"></i><span>Advisories</span></a></li>
-          <li><a href="/maintainers" data-nav="maintainers"><i data-lucide="users"></i><span>Maintainers</span></a></li>
-          <li><a href="/scans" data-nav="scans"><i data-lucide="list-checks"></i><span>Scans</span></a></li>
-          <li><a href="/skills" data-nav="skills"><i data-lucide="sparkles"></i><span>Skills</span></a></li>
-          <li><a href="/usage" data-nav="usage"><i data-lucide="coins"></i><span>Usage</span></a></li>
+        <ul id="nav">
+          {{$nav := .Nav}}
+          <li><a href="/"{{if eq $nav "repos"}} aria-current="page"{{end}}><i data-lucide="folder-git-2"></i><span>Repositories</span></a></li>
+          <li><a href="/orgs"{{if eq $nav "orgs"}} aria-current="page"{{end}}><i data-lucide="building"></i><span>Organizations</span></a></li>
+          <li><a href="/findings"{{if eq $nav "findings"}} aria-current="page"{{end}}><i data-lucide="bug"></i><span>Findings</span></a></li>
+          <li><a href="/packages"{{if eq $nav "packages"}} aria-current="page"{{end}}><i data-lucide="package"></i><span>Packages</span></a></li>
+          <li><a href="/sboms"{{if eq $nav "sboms"}} aria-current="page"{{end}}><i data-lucide="file-box"></i><span>SBOMs</span></a></li>
+          <li><a href="/advisories"{{if eq $nav "advisories"}} aria-current="page"{{end}}><i data-lucide="shield-alert"></i><span>Advisories</span></a></li>
+          <li><a href="/maintainers"{{if eq $nav "maintainers"}} aria-current="page"{{end}}><i data-lucide="users"></i><span>Maintainers</span></a></li>
+          <li><a href="/scans"{{if eq $nav "scans"}} aria-current="page"{{end}}><i data-lucide="list-checks"></i><span>Scans</span></a></li>
+          <li><a href="/skills"{{if eq $nav "skills"}} aria-current="page"{{end}}><i data-lucide="sparkles"></i><span>Skills</span></a></li>
+          <li><a href="/usage"{{if eq $nav "usage"}} aria-current="page"{{end}}><i data-lucide="coins"></i><span>Usage</span></a></li>
         </ul>
       </div>
     </section>
@@ -63,7 +64,7 @@
 
 <main id="content" class="min-h-screen"
       hx-history-elt
-      hx-target="#content" hx-select="#content" hx-swap="outerHTML">
+      hx-target="#content" hx-select="#content" hx-select-oob="#nav" hx-swap="outerHTML">
   <div class="p-4 md:p-6 xl:p-12">
 {{end}}
 
@@ -123,7 +124,9 @@
   </div>
 </dialog>
 
-<div id="toaster" class="toaster"></div>
+<div id="toaster" class="toaster">
+  {{with .Flash}}{{template "toast" .}}{{end}}
+</div>
 <script>
   lucide.createIcons();
   // Persist active tab in URL hash
@@ -148,31 +151,6 @@
   }
   if (document.readyState === 'complete') restoreTab();
   else window.addEventListener('load', restoreTab);
-  (function () {
-    var p = location.pathname;
-    var key = p.indexOf('/usage') === 0 ? 'usage'
-            : p.indexOf('/skills') === 0 ? 'skills'
-            : p.indexOf('/maintainers') === 0 ? 'maintainers'
-            : p.indexOf('/orgs') === 0 ? 'orgs'
-            : p.indexOf('/packages') === 0 ? 'packages'
-            : p.indexOf('/sboms') === 0 ? 'sboms'
-            : p.indexOf('/advisories') === 0 ? 'advisories'
-            : p.indexOf('/findings') === 0 ? 'findings'
-            : p.indexOf('/scans') === 0 ? 'scans'
-            : 'repos';
-    var a = document.querySelector('.sidebar a[data-nav="' + key + '"]');
-    if (a) a.setAttribute('aria-current', 'page');
-  })();
-  document.body.addEventListener('scanStatus', function (e) {
-    var d = e.detail || {};
-    var ok = d.status === 'done';
-    document.dispatchEvent(new CustomEvent('basecoat:toast', { detail: { config: {
-      category: ok ? 'success' : 'error',
-      title: d.name + ' scan ' + (ok ? 'complete' : d.status),
-      description: 'scan #' + d.id,
-      action: { href: '/scans/' + d.id, label: 'View' }
-    }}}));
-  });
 </script>
 </body>
 </html>
@@ -216,6 +194,19 @@
       <button type="submit" class="btn-sm-ghost" data-tooltip="Retry"><i data-lucide="refresh-cw"></i></button>
     </form>
   {{end}}
+{{end}}
+
+{{define "toast"}}
+<div class="toast" role="status" aria-atomic="true" aria-hidden="false"
+     data-category="{{.Category}}" data-duration="6000">
+  <div class="toast-content">
+    <section>
+      <h2>{{.Title}}</h2>
+      {{if .Description}}<p>{{.Description}}</p>{{end}}
+    </section>
+    {{if .Href}}<footer><a href="{{.Href}}" class="btn-sm">{{.Label}}</a></footer>{{end}}
+  </div>
+</div>
 {{end}}
 
 {{define "status-badge"}}

--- a/internal/web/templates/layout.html
+++ b/internal/web/templates/layout.html
@@ -16,6 +16,7 @@
   <link rel="icon" type="image/svg+xml" href="/static/favicon.svg">
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="htmx-config" content='{"historyCacheSize": 0}'>
   <title>scrutineer</title>
   <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/basecoat-css@0.3.11/dist/basecoat.cdn.min.css">

--- a/internal/web/templates/layout.html
+++ b/internal/web/templates/layout.html
@@ -76,9 +76,7 @@
   <div>
     <header><h2>Add repository</h2></header>
     <section>
-      <form hx-post="/repositories"
-            hx-on::after-request="if(event.detail.successful){this.reset();this.closest('dialog').close()}"
-            class="form grid gap-3">
+      <form method="post" action="/repositories" class="form grid gap-3">
         <input class="input" type="text" name="url"
                placeholder="https://github.com/maragudk/goqite.git" required>
         <footer class="flex justify-between items-center gap-2">
@@ -87,15 +85,15 @@
             <i data-lucide="list-plus"></i> Add multiple
           </button>
           <div class="flex gap-2">
-            <button type="button" class="btn-outline" onclick="this.closest('dialog').close()">Cancel</button>
-            <button type="submit" class="btn"><i data-lucide="play"></i> Scan</button>
+            <button type="submit" class="btn-outline" formmethod="dialog" formnovalidate>Cancel</button>
+            <button type="submit" class="btn" hx-post="/repositories" hx-swap="none">
+              <i data-lucide="play"></i> Scan
+            </button>
           </div>
         </footer>
       </form>
     </section>
-    <button type="button" aria-label="Close" onclick="this.closest('dialog').close()">
-      <i data-lucide="x"></i>
-    </button>
+    <form method="dialog"><button aria-label="Close"><i data-lucide="x"></i></button></form>
   </div>
 </dialog>
 
@@ -110,20 +108,18 @@
       </p>
     </header>
     <section>
-      <form hx-post="/repositories/bulk"
-            hx-on::after-request="if(event.detail.successful){this.reset();this.closest('dialog').close()}"
-            class="form grid gap-3">
+      <form method="post" action="/repositories/bulk" class="form grid gap-3">
         <textarea class="input font-mono text-xs" name="urls" rows="10" required
                   placeholder="https://github.com/maragudk/goqite.git&#10;https://github.com/spf13/cobra.git&#10;https://github.com/stretchr/testify.git"></textarea>
         <footer class="flex justify-end gap-2">
-          <button type="button" class="btn-outline" onclick="this.closest('dialog').close()">Cancel</button>
-          <button type="submit" class="btn"><i data-lucide="play"></i> Import</button>
+          <button type="submit" class="btn-outline" formmethod="dialog" formnovalidate>Cancel</button>
+          <button type="submit" class="btn" hx-post="/repositories/bulk" hx-swap="none">
+            <i data-lucide="play"></i> Import
+          </button>
         </footer>
       </form>
     </section>
-    <button type="button" aria-label="Close" onclick="this.closest('dialog').close()">
-      <i data-lucide="x"></i>
-    </button>
+    <form method="dialog"><button aria-label="Close"><i data-lucide="x"></i></button></form>
   </div>
 </dialog>
 
@@ -209,14 +205,17 @@
 {{end}}
 
 {{define "scan-actions"}}
-  {{if or (eq (status .Status) "queued") (eq (status .Status) "running")}}<button class="btn-sm-ghost"
-    hx-post="/scans/{{.ID}}/cancel" hx-swap="none"
-    hx-on:click="event.stopPropagation()"
-    data-tooltip="Cancel"><i data-lucide="x"></i></button>
-  {{else if and (or (eq (status .Status) "failed") (eq (status .Status) "cancelled")) .SkillID}}<button class="btn-sm-ghost"
-    hx-post="/scans/{{.ID}}/retry" hx-swap="none"
-    hx-on:click="event.stopPropagation()"
-    data-tooltip="Retry"><i data-lucide="refresh-cw"></i></button>{{end}}
+  {{if or (eq (status .Status) "queued") (eq (status .Status) "running")}}
+    <form method="post" action="/scans/{{.ID}}/cancel" hx-post="/scans/{{.ID}}/cancel"
+          hx-swap="none" hx-on:click="event.stopPropagation()">
+      <button type="submit" class="btn-sm-ghost" data-tooltip="Cancel"><i data-lucide="x"></i></button>
+    </form>
+  {{else if and (or (eq (status .Status) "failed") (eq (status .Status) "cancelled")) .SkillID}}
+    <form method="post" action="/scans/{{.ID}}/retry" hx-post="/scans/{{.ID}}/retry"
+          hx-swap="none" hx-on:click="event.stopPropagation()">
+      <button type="submit" class="btn-sm-ghost" data-tooltip="Retry"><i data-lucide="refresh-cw"></i></button>
+    </form>
+  {{end}}
 {{end}}
 
 {{define "status-badge"}}

--- a/internal/web/templates/layout.html
+++ b/internal/web/templates/layout.html
@@ -1,11 +1,15 @@
 {{define "head"}}
 <!doctype html>
-<html lang="en">
+<html lang="en" data-theme="{{.Theme}}">
 <head>
   <script>
     (function () {
+      var scheme = (document.cookie.match(/(?:^|; )color_scheme=(\w+)/) || [])[1] || 'system';
       var mq = matchMedia('(prefers-color-scheme: dark)');
-      var apply = function () { document.documentElement.classList.toggle('dark', mq.matches); };
+      var apply = function () {
+        var dark = scheme === 'dark' || (scheme === 'system' && mq.matches);
+        document.documentElement.classList.toggle('dark', dark);
+      };
       apply(); mq.addEventListener('change', apply);
     })();
   </script>
@@ -27,15 +31,20 @@
 <aside class="sidebar" data-side="left" aria-hidden="false">
   <nav aria-label="Sidebar">
     <header>
-      <a href="/" class="btn-ghost p-2 h-14 w-full justify-start">
-        <span class="bg-primary text-primary-foreground flex aspect-square size-10 items-center justify-center rounded-lg">
-          <i data-lucide="brick-wall-shield" class="size-6"></i>
-        </span>
-        <span class="grid flex-1 text-left leading-tight">
-          <span class="truncate font-medium">scrutineer</span>
-          <span class="truncate text-xs text-muted-foreground">local</span>
-        </span>
-      </a>
+      <div class="flex items-center w-full gap-1">
+        <a href="/" class="btn-ghost p-2 h-14 flex-1 justify-start">
+          <span class="bg-primary text-primary-foreground flex aspect-square size-10 items-center justify-center rounded-lg">
+            <i data-lucide="brick-wall-shield" class="size-6"></i>
+          </span>
+          <span class="grid flex-1 text-left leading-tight">
+            <span class="truncate font-medium">scrutineer</span>
+            <span class="truncate text-xs text-muted-foreground">local</span>
+          </span>
+        </a>
+        <a href="/settings" class="btn-ghost p-2 size-10 flex items-center justify-center rounded-lg text-muted-foreground hover:text-foreground" data-tooltip="Settings">
+          <i data-lucide="settings" class="size-4"></i>
+        </a>
+      </div>
     </header>
     <section>
       <div role="group">

--- a/internal/web/templates/maintainer_show.html
+++ b/internal/web/templates/maintainer_show.html
@@ -1,4 +1,4 @@
-{{template "head"}}
+{{template "head" .}}
 {{$m := .M}}
 
 {{template "crumbs" (crumbs "Maintainers" "/maintainers" $m.Login "")}}
@@ -93,4 +93,4 @@
   {{end}}
 </div>
 
-{{template "foot"}}
+{{template "foot" .}}

--- a/internal/web/templates/maintainer_show.html
+++ b/internal/web/templates/maintainer_show.html
@@ -15,19 +15,21 @@
     {{if $m.Email}}<p class="text-sm text-muted-foreground">{{$m.Email}}</p>{{end}}
   </div>
   <span class="ml-auto flex items-center gap-2">
+    <form method="post" action="/maintainers/{{$m.ID}}/do-not-contact"
+          hx-post="/maintainers/{{$m.ID}}/do-not-contact" hx-swap="none"
+          class="contents">
     {{if $m.DoNotContact}}
       <span class="badge-destructive" data-tooltip="Maintainer has asked not to be contacted, or routing is known to leak">Do not contact</span>
-      <button class="btn-outline-sm" hx-post="/maintainers/{{$m.ID}}/do-not-contact"
-              hx-vals='{"value":"false"}' hx-swap="none">
+      <button type="submit" name="value" value="false" class="btn-outline-sm">
         Clear flag
       </button>
     {{else}}
-      <button class="btn-outline-sm" hx-post="/maintainers/{{$m.ID}}/do-not-contact"
-              hx-vals='{"value":"true"}' hx-swap="none"
+      <button type="submit" name="value" value="true" class="btn-outline-sm"
               data-tooltip="Suppress from disclosure routing">
         <i data-lucide="ban"></i> Do not contact
       </button>
     {{end}}
+    </form>
     {{template "status-badge" (printf "%s" $m.Status)}}
   </span>
 </div>

--- a/internal/web/templates/maintainer_show.html
+++ b/internal/web/templates/maintainer_show.html
@@ -48,8 +48,8 @@
         <thead><tr><th>Repository</th><th>Language</th><th>Stars</th></tr></thead>
         <tbody>
         {{range $m.Repositories}}
-          <tr class="cursor-pointer" hx-get="/repositories/{{.ID}}" hx-target="body" hx-push-url="true">
-            <td class="font-medium">{{trimscheme .URL}}</td>
+          <tr id="repo-{{.ID}}" class="cursor-pointer" hx-get="/repositories/{{.ID}}" hx-push-url="true">
+            <td><a href="/repositories/{{.ID}}" class="font-medium" hx-on:click="event.stopPropagation()">{{trimscheme .URL}}</a></td>
             <td class="text-muted-foreground">{{.Languages}}</td>
             <td class="text-muted-foreground">{{if .Stars}}{{bignum .Stars}}{{end}}</td>
           </tr>
@@ -72,10 +72,10 @@
       {{$repos := .Repos}}
       {{range .Findings}}
         {{$repo := index $repos .RepositoryID}}
-        <tr class="cursor-pointer" hx-get="/findings/{{.ID}}" hx-target="body" hx-push-url="true">
+        <tr id="finding-{{.ID}}" class="cursor-pointer" hx-get="/findings/{{.ID}}" hx-push-url="true">
           <td>{{template "severity-badge" .Severity}}</td>
           <td class="min-w-0 whitespace-normal">
-            <div class="font-medium">{{.Title}}</div>
+            <a href="/findings/{{.ID}}" class="font-medium" hx-on:click="event.stopPropagation()">{{.Title}}</a>
             <div class="text-xs text-muted-foreground line-clamp-1">{{.Summary}}</div>
           </td>
           <td class="truncate">{{$repo.Name}}</td>

--- a/internal/web/templates/maintainers.html
+++ b/internal/web/templates/maintainers.html
@@ -53,9 +53,9 @@
     <tbody>
     {{$counts := .FindingCounts}}
     {{range .Maintainers}}
-      <tr class="cursor-pointer" hx-get="/maintainers/{{.ID}}" hx-target="body" hx-push-url="true">
-        <td class="font-medium">
-          {{.Name}}
+      <tr id="maintainer-{{.ID}}" class="cursor-pointer" hx-get="/maintainers/{{.ID}}" hx-push-url="true">
+        <td>
+          <a href="/maintainers/{{.ID}}" class="font-medium" hx-on:click="event.stopPropagation()">{{.Name}}</a>
           {{if .DoNotContact}}<span class="badge-destructive ml-1" data-tooltip="Do not contact">DNC</span>{{end}}
         </td>
         <td class="text-muted-foreground">{{.Login}}</td>

--- a/internal/web/templates/maintainers.html
+++ b/internal/web/templates/maintainers.html
@@ -1,4 +1,4 @@
-{{template "head"}}
+{{template "head" .}}
 
 <div class="flex items-center justify-between gap-4 mb-6">
   <h2 class="text-2xl font-semibold flex items-center gap-2">
@@ -75,4 +75,4 @@
   {{template "empty" (dict "Icon" "users" "Title" "No maintainers" "Body" "Maintainers are populated from the commits job when repositories are scanned.")}}
 {{end}}
 
-{{template "foot"}}
+{{template "foot" .}}

--- a/internal/web/templates/org_show.html
+++ b/internal/web/templates/org_show.html
@@ -102,7 +102,7 @@
       {{$repos := .AdvisoryRepos}}
       {{range .Advisories}}
         {{$repo := index $repos .RepositoryID}}
-        <tr class="cursor-pointer" onclick="window.open('{{.URL}}', '_blank', 'noopener')">
+        <tr>
           <td>
             {{if eq .Severity "CRITICAL"}}<span class="badge-destructive">Critical</span>
             {{else if eq .Severity "HIGH"}}<span class="badge-destructive">High</span>
@@ -110,7 +110,7 @@
             {{else}}<span class="badge-secondary">{{.Severity}}</span>{{end}}
           </td>
           <td class="text-muted-foreground">{{if .CVSSScore}}{{printf "%.1f" .CVSSScore}}{{end}}</td>
-          <td class="min-w-0 whitespace-normal font-medium">{{.Title}}</td>
+          <td class="min-w-0 whitespace-normal"><a href="{{.URL}}" target="_blank" rel="noopener" class="font-medium hover:underline">{{.Title}}</a></td>
           <td class="truncate">{{$repo.Name}}</td>
           <td class="text-muted-foreground">{{if .PublishedAt}}{{.PublishedAt.Format "2006-01-02"}}{{end}}</td>
         </tr>

--- a/internal/web/templates/org_show.html
+++ b/internal/web/templates/org_show.html
@@ -51,8 +51,8 @@
       <tbody>
       {{$counts := .FindingCounts}}
       {{range .Repos}}
-        <tr class="cursor-pointer" hx-get="/repositories/{{.ID}}" hx-target="body" hx-push-url="true">
-          <td class="font-medium">{{.Name}}</td>
+        <tr id="repo-{{.ID}}" class="cursor-pointer" hx-get="/repositories/{{.ID}}" hx-push-url="true">
+          <td><a href="/repositories/{{.ID}}" class="font-medium" hx-on:click="event.stopPropagation()">{{.Name}}</a></td>
           <td class="text-muted-foreground">{{.Languages}}</td>
           <td class="text-right text-muted-foreground">{{if .Stars}}{{bignum .Stars}}{{end}}</td>
           <td class="text-right">{{template "findings-badge" (index $counts .ID)}}</td>
@@ -78,9 +78,9 @@
       {{$repos := .FindingRepos}}
       {{range .Findings}}
         {{$repo := index $repos .RepositoryID}}
-        <tr class="cursor-pointer" hx-get="/findings/{{.ID}}" hx-target="body" hx-push-url="true">
+        <tr id="finding-{{.ID}}" class="cursor-pointer" hx-get="/findings/{{.ID}}" hx-push-url="true">
           <td>{{template "severity-badge" .Severity}}</td>
-          <td class="min-w-0 whitespace-normal font-medium">{{.Title}}</td>
+          <td class="min-w-0 whitespace-normal"><a href="/findings/{{.ID}}" class="font-medium" hx-on:click="event.stopPropagation()">{{.Title}}</a></td>
           <td class="truncate">{{$repo.Name}}</td>
           <td>{{template "finding-status" (fstatus .Status)}}</td>
           <td class="text-muted-foreground">{{.CWE}}</td>
@@ -128,8 +128,8 @@
       </tr></thead>
       <tbody>
       {{range .Maintainers}}
-        <tr class="cursor-pointer" hx-get="/maintainers/{{.ID}}" hx-target="body" hx-push-url="true">
-          <td class="font-medium">{{.Name}}</td>
+        <tr id="maintainer-{{.ID}}" class="cursor-pointer" hx-get="/maintainers/{{.ID}}" hx-push-url="true">
+          <td><a href="/maintainers/{{.ID}}" class="font-medium" hx-on:click="event.stopPropagation()">{{.Name}}</a></td>
           <td class="text-muted-foreground">{{.Login}}</td>
           <td class="text-muted-foreground">{{.Email}}</td>
           <td>{{template "status-badge" (printf "%s" .Status)}}</td>

--- a/internal/web/templates/org_show.html
+++ b/internal/web/templates/org_show.html
@@ -1,4 +1,4 @@
-{{template "head"}}
+{{template "head" .}}
 {{$owner := .Owner}}
 
 {{template "crumbs" (crumbs "Organizations" "/orgs" $owner "")}}
@@ -141,4 +141,4 @@
   {{end}}
 </div>
 
-{{template "foot"}}
+{{template "foot" .}}

--- a/internal/web/templates/orgs.html
+++ b/internal/web/templates/orgs.html
@@ -1,4 +1,4 @@
-{{template "head"}}
+{{template "head" .}}
 
 <div class="flex items-center justify-between gap-4 mb-6">
   <h2 class="text-2xl font-semibold flex items-center gap-2">
@@ -53,4 +53,4 @@
   {{template "empty" (dict "Icon" "building" "Title" "No organizations yet" "Body" "The metadata skill populates the Owner field on each repository; organizations appear here once at least one repo has been enriched.")}}
 {{end}}
 
-{{template "foot"}}
+{{template "foot" .}}

--- a/internal/web/templates/orgs.html
+++ b/internal/web/templates/orgs.html
@@ -38,8 +38,8 @@
     </tr></thead>
     <tbody>
     {{range .Orgs}}
-      <tr class="cursor-pointer" hx-get="/orgs/{{.Owner}}" hx-target="body" hx-push-url="true">
-        <td class="font-medium">{{.Owner}}</td>
+      <tr id="org-{{.Owner}}" class="cursor-pointer" hx-get="/orgs/{{.Owner}}" hx-push-url="true">
+        <td><a href="/orgs/{{.Owner}}" class="font-medium" hx-on:click="event.stopPropagation()">{{.Owner}}</a></td>
         <td class="text-right text-muted-foreground">{{.Repos}}</td>
         <td class="text-right">{{template "findings-badge" .FindingsTotal}}</td>
         <td class="text-muted-foreground">{{if .LastActivity}}{{since .LastActivity}}{{end}}</td>

--- a/internal/web/templates/package_show.html
+++ b/internal/web/templates/package_show.html
@@ -1,4 +1,4 @@
-{{template "head"}}
+{{template "head" .}}
 {{$p := .Pkg}}
 
 {{template "crumbs" (crumbs
@@ -72,4 +72,4 @@
 </section>
 {{end}}
 
-{{template "foot"}}
+{{template "foot" .}}

--- a/internal/web/templates/packages.html
+++ b/internal/web/templates/packages.html
@@ -1,4 +1,4 @@
-{{template "head"}}
+{{template "head" .}}
 
 <div class="flex items-center justify-between gap-4 mb-6">
   <h2 class="text-2xl font-semibold flex items-center gap-2">
@@ -72,4 +72,4 @@
   {{template "empty" (dict "Icon" "package" "Title" "No packages" "Body" "Package data appears here once the packages job runs for a repository.")}}
 {{end}}
 
-{{template "foot"}}
+{{template "foot" .}}

--- a/internal/web/templates/packages.html
+++ b/internal/web/templates/packages.html
@@ -54,8 +54,8 @@
     </tr></thead>
     <tbody>
     {{range .Pkgs}}
-      <tr class="cursor-pointer" hx-get="/packages/{{.ID}}" hx-target="body" hx-push-url="true">
-        <td class="whitespace-normal font-medium">{{.Name}}</td>
+      <tr id="package-{{.ID}}" class="cursor-pointer" hx-get="/packages/{{.ID}}" hx-push-url="true">
+        <td class="whitespace-normal"><a href="/packages/{{.ID}}" class="font-medium" hx-on:click="event.stopPropagation()">{{.Name}}</a></td>
         <td><span class="badge-outline">{{.Ecosystem}}</span></td>
         <td class="text-muted-foreground">{{if .RegistryURL}}{{domain .RegistryURL}}{{end}}</td>
         <td class="text-muted-foreground">{{.LatestVersion}}</td>

--- a/internal/web/templates/repo_list.html
+++ b/internal/web/templates/repo_list.html
@@ -45,8 +45,8 @@
     </thead>
     <tbody>
     {{range .Rows}}
-      <tr class="cursor-pointer" hx-get="/repositories/{{.ID}}" hx-target="body" hx-push-url="true">
-        <td>{{trimscheme .URL}}</td>
+      <tr id="repo-{{.ID}}" class="cursor-pointer" hx-get="/repositories/{{.ID}}" hx-push-url="true">
+        <td><a href="/repositories/{{.ID}}" hx-on:click="event.stopPropagation()">{{trimscheme .URL}}</a></td>
         <td class="text-muted-foreground">{{if .Languages}}{{.Languages}}{{else}}-{{end}}</td>
         <td>{{if .LastScan}}{{.LastScan.CreatedAt.Format "15:04:05"}}{{else}}never{{end}}</td>
         <td>{{if .LastScan}}{{template "status-badge" (status .LastScan.Status)}}{{end}}</td>

--- a/internal/web/templates/repo_list.html
+++ b/internal/web/templates/repo_list.html
@@ -52,9 +52,11 @@
         <td>{{if .LastScan}}{{template "status-badge" (status .LastScan.Status)}}{{end}}</td>
         <td>{{template "findings-badge" .FindingsTotal}}</td>
         <td>
-          <button class="btn-sm-outline"
-                  hx-post="/repositories/{{.ID}}/scan"
-                  hx-on:click="event.stopPropagation()"><i data-lucide="refresh-cw"></i> Rescan</button>
+          <form method="post" action="/repositories/{{.ID}}/scan"
+                hx-post="/repositories/{{.ID}}/scan" hx-swap="none"
+                hx-on:click="event.stopPropagation()">
+            <button type="submit" class="btn-sm-outline"><i data-lucide="refresh-cw"></i> Rescan</button>
+          </form>
         </td>
       </tr>
     {{end}}

--- a/internal/web/templates/repo_list.html
+++ b/internal/web/templates/repo_list.html
@@ -1,4 +1,4 @@
-<div id="repos" hx-get="/repositories?q={{.Q}}&page={{.Page.N}}&language={{.Language}}&sort={{.Sort}}" hx-trigger="every 5s" hx-swap="outerHTML">
+<div id="repos" hx-get="/repositories?q={{.Q}}&page={{.Page.N}}&language={{.Language}}&sort={{.Sort}}" hx-trigger="every 5s" hx-target="this" hx-select="#repos" hx-swap="outerHTML">
 <div class="flex items-center justify-end gap-2 mb-4">
   <form method="get" action="/" class="inline-flex">
     <input class="input" type="search" name="q" value="{{.Q}}" placeholder="Search repositories"

--- a/internal/web/templates/repo_list.html
+++ b/internal/web/templates/repo_list.html
@@ -1,4 +1,4 @@
-<div id="repos" hx-get="/repositories?q={{.Q}}&page={{.Page.N}}&language={{.Language}}&sort={{.Sort}}" hx-trigger="every 5s" hx-target="this" hx-select="#repos" hx-swap="outerHTML">
+<div id="repos" hx-get="/repositories?q={{.Q}}&page={{.Page.N}}&language={{.Language}}&sort={{.Sort}}" hx-trigger="every 5s[document.visibilityState==='visible']" hx-target="this" hx-select="#repos" hx-swap="outerHTML">
 <div class="flex items-center justify-end gap-2 mb-4">
   <form method="get" action="/" class="inline-flex">
     <input class="input" type="search" name="q" value="{{.Q}}" placeholder="Search repositories"

--- a/internal/web/templates/repo_new.html
+++ b/internal/web/templates/repo_new.html
@@ -1,0 +1,36 @@
+{{template "head" .}}
+
+<div class="max-w-lg">
+{{if .Bulk}}
+  <h2 class="text-2xl font-semibold mb-2">Bulk import repositories</h2>
+  <p class="text-sm text-muted-foreground mb-4">
+    One URL per line. Only <code>https://</code> URLs are accepted.
+    Duplicates are skipped; each new repo is queued with the default scan set.
+  </p>
+  <form method="post" action="/repositories/bulk" class="form grid gap-3">
+    <textarea class="input font-mono text-xs" name="urls" rows="10" required
+              placeholder="https://github.com/maragudk/goqite.git&#10;https://github.com/spf13/cobra.git"></textarea>
+    <footer class="flex justify-end gap-2">
+      <a href="/" class="btn-outline">Cancel</a>
+      <button type="submit" class="btn"><i data-lucide="play"></i> Import</button>
+    </footer>
+  </form>
+{{else}}
+  <h2 class="text-2xl font-semibold mb-4">Add repository</h2>
+  <form method="post" action="/repositories" class="form grid gap-3">
+    <input class="input" type="text" name="url"
+           placeholder="https://github.com/maragudk/goqite.git" required>
+    <footer class="flex justify-between items-center gap-2">
+      <a href="/repositories/new?bulk=1" class="btn-ghost-sm">
+        <i data-lucide="list-plus"></i> Add multiple
+      </a>
+      <div class="flex gap-2">
+        <a href="/" class="btn-outline">Cancel</a>
+        <button type="submit" class="btn"><i data-lucide="play"></i> Scan</button>
+      </div>
+    </footer>
+  </form>
+{{end}}
+</div>
+
+{{template "foot" .}}

--- a/internal/web/templates/repo_show.html
+++ b/internal/web/templates/repo_show.html
@@ -346,20 +346,20 @@
     </table>
   </div>
 
-  {{if .Active}}
-    <div hx-ext="sse" sse-connect="/events?repo={{.Repo.ID}}"
-         sse-swap="scan-status" hx-swap="none"
-         hx-on::sse-message="if(event.detail.type==='scan-status') location.reload()"
-         hidden></div>
-  {{end}}
+  <div hx-ext="sse" sse-connect="/events?repo={{.Repo.ID}}"
+       sse-swap="scan-status" hx-swap="none" hidden></div>
 </div>
 
 {{template "foot" .}}
 
 {{define "scan_rows"}}
 <tbody id="scan-rows">
-{{range .Scans}}
-  <tr id="scan-{{.ID}}" class="cursor-pointer" hx-get="/scans/{{.ID}}" hx-push-url="true">
+{{range .Scans}}{{template "scan-row" (dict "S" .)}}{{end}}
+</tbody>
+{{end}}
+
+{{define "scan-row"}}{{with .S}}
+  <tr id="scan-{{.ID}}" class="cursor-pointer" hx-get="/scans/{{.ID}}" hx-push-url="true"{{if $.OOB}} hx-swap-oob="true"{{end}}>
     <td><a href="/scans/{{.ID}}" hx-on:click="event.stopPropagation()">{{.ID}}</a></td>
     <td>{{if .SkillName}}{{.SkillName}}{{else}}{{.Kind}}{{end}}</td>
     <td>{{template "status-badge" (status .Status)}}</td>
@@ -371,6 +371,9 @@
     <td>{{if .FinishedAt}}{{dur .Duration}}{{end}}</td>
     <td>{{template "scan-actions" .}}</td>
   </tr>
-{{end}}
-</tbody>
+{{end}}{{end}}
+
+{{define "scan-status-sse"}}
+{{template "scan-row" (dict "S" .Scan "OOB" true)}}
+<div hx-swap-oob="afterbegin:#toaster">{{template "toast" .Flash}}</div>
 {{end}}

--- a/internal/web/templates/repo_show.html
+++ b/internal/web/templates/repo_show.html
@@ -1,4 +1,4 @@
-{{template "head"}}
+{{template "head" .}}
 
 <div class="flex items-start justify-between gap-4 mb-6">
   <div>
@@ -354,7 +354,7 @@
   {{end}}
 </div>
 
-{{template "foot"}}
+{{template "foot" .}}
 
 {{define "scan_rows"}}
 <tbody id="scan-rows">

--- a/internal/web/templates/repo_show.html
+++ b/internal/web/templates/repo_show.html
@@ -36,7 +36,8 @@
     <a href="/repositories/{{.Repo.ID}}/report.md" class="btn-outline" download>
       <i data-lucide="download"></i> Export report
     </a>
-    <form hx-post="/repositories/{{.Repo.ID}}/scan">
+    <form method="post" action="/repositories/{{.Repo.ID}}/scan"
+          hx-post="/repositories/{{.Repo.ID}}/scan" hx-swap="none">
       <button class="btn" type="submit"><i data-lucide="play"></i> New scan</button>
     </form>
   </div>
@@ -239,8 +240,7 @@
             <td class="text-muted-foreground whitespace-normal break-all">{{if .Requirement}}{{.Requirement}}{{else}}-{{end}}</td>
             <td class="text-muted-foreground">{{.DependencyType}}</td>
             <td class="whitespace-normal text-muted-foreground text-xs">{{range $i, $m := .Manifests}}{{if $i}}, {{end}}{{$m}}{{end}}</td>
-            <td>{{if .PURL}}{{$rid := lookup $.KnownPURLs .PURL}}{{if $rid}}<a href="/repositories/{{$rid}}" class="btn-sm-ghost" data-tooltip="View repository"><i data-lucide="external-link"></i></a>{{else}}<button class="btn-sm-ghost" hx-post="/dependencies/{{.ID}}/scan" hx-swap="none"
-                data-tooltip="Import repository"><i data-lucide="import"></i></button>{{end}}{{end}}</td>
+            <td>{{if .PURL}}{{$rid := lookup $.KnownPURLs .PURL}}{{if $rid}}<a href="/repositories/{{$rid}}" class="btn-sm-ghost" data-tooltip="View repository"><i data-lucide="external-link"></i></a>{{else}}<form method="post" action="/dependencies/{{.ID}}/scan" hx-post="/dependencies/{{.ID}}/scan" hx-swap="none"><button type="submit" class="btn-sm-ghost" data-tooltip="Import repository"><i data-lucide="import"></i></button></form>{{end}}{{end}}</td>
           </tr>
         {{end}}
         </tbody>
@@ -297,8 +297,7 @@
           <td class="text-muted-foreground">{{.LatestVersion}}</td>
           <td class="text-muted-foreground">{{bignum .Downloads}}</td>
           <td class="text-muted-foreground">{{bignum .DependentRepos}} repos</td>
-          <td>{{if .RepositoryURL}}{{$rid := lookup $.KnownURLs .RepositoryURL}}{{if $rid}}<a href="/repositories/{{$rid}}" class="btn-sm-ghost" data-tooltip="View repository"><i data-lucide="external-link"></i></a>{{else}}<button class="btn-sm-ghost" hx-post="/dependents/{{.ID}}/scan" hx-swap="none"
-              data-tooltip="Import repository"><i data-lucide="import"></i></button>{{end}}{{end}}</td>
+          <td>{{if .RepositoryURL}}{{$rid := lookup $.KnownURLs .RepositoryURL}}{{if $rid}}<a href="/repositories/{{$rid}}" class="btn-sm-ghost" data-tooltip="View repository"><i data-lucide="external-link"></i></a>{{else}}<form method="post" action="/dependents/{{.ID}}/scan" hx-post="/dependents/{{.ID}}/scan" hx-swap="none"><button type="submit" class="btn-sm-ghost" data-tooltip="Import repository"><i data-lucide="import"></i></button></form>{{end}}{{end}}</td>
         </tr>
       {{end}}
       </tbody>

--- a/internal/web/templates/repo_show.html
+++ b/internal/web/templates/repo_show.html
@@ -155,9 +155,9 @@
           </tr></thead>
           <tbody>
           {{range .Latest.Findings}}
-            <tr class="cursor-pointer" hx-get="/findings/{{.ID}}" hx-target="body" hx-push-url="true">
+            <tr id="finding-{{.ID}}" class="cursor-pointer" hx-get="/findings/{{.ID}}" hx-push-url="true">
               <td>{{template "severity-badge" .Severity}}</td>
-              <td class="min-w-0 whitespace-normal">{{.Title}}</td>
+              <td class="min-w-0 whitespace-normal"><a href="/findings/{{.ID}}" hx-on:click="event.stopPropagation()">{{.Title}}</a></td>
               <td>{{template "finding-status" (fstatus .Status)}}</td>
               <td class="whitespace-normal"><code class="text-xs break-all">{{.Location}}</code></td>
             </tr>
@@ -178,12 +178,12 @@
     </p>
     <div class="grid gap-4">
       {{range .Findings}}
-        <div class="card cursor-pointer" hx-get="/findings/{{.ID}}" hx-target="body" hx-push-url="true">
+        <div id="finding-card-{{.ID}}" class="card cursor-pointer" hx-get="/findings/{{.ID}}" hx-push-url="true">
           <header>
             <div class="flex items-center gap-2">
               {{template "severity-badge" .Severity}}
               {{template "finding-status" (fstatus .Status)}}
-              <h3>{{.Title}}</h3>
+              <h3><a href="/findings/{{.ID}}" hx-on:click="event.stopPropagation()">{{.Title}}</a></h3>
               {{if .CWE}}<span class="badge-outline ml-auto" data-tooltip="{{cwename .CWE}}">{{.CWE}}</span>{{end}}
             </div>
             <p>
@@ -210,8 +210,8 @@
       </tr></thead>
       <tbody>
       {{range .Pkgs}}
-        <tr class="cursor-pointer" hx-get="/packages/{{.ID}}" hx-target="body" hx-push-url="true">
-          <td class="whitespace-normal font-medium">{{.Name}}</td>
+        <tr id="package-{{.ID}}" class="cursor-pointer" hx-get="/packages/{{.ID}}" hx-push-url="true">
+          <td class="whitespace-normal"><a href="/packages/{{.ID}}" class="font-medium" hx-on:click="event.stopPropagation()">{{.Name}}</a></td>
           <td><span class="badge-outline">{{.Ecosystem}}</span></td>
           <td class="text-muted-foreground">{{if .RegistryURL}}{{domain .RegistryURL}}{{end}}</td>
           <td class="text-muted-foreground">{{.LatestVersion}}</td>
@@ -312,8 +312,8 @@
       <thead><tr><th>Login</th><th>Name</th><th>Email</th><th>Status</th></tr></thead>
       <tbody>
       {{range .Maintainers}}
-        <tr class="cursor-pointer" hx-get="/maintainers/{{.ID}}" hx-target="body" hx-push-url="true">
-          <td class="font-medium">{{.Login}}</td>
+        <tr id="maintainer-{{.ID}}" class="cursor-pointer" hx-get="/maintainers/{{.ID}}" hx-push-url="true">
+          <td><a href="/maintainers/{{.ID}}" class="font-medium" hx-on:click="event.stopPropagation()">{{.Login}}</a></td>
           <td>{{.Name}}</td>
           <td class="text-muted-foreground">{{.Email}}</td>
           <td>{{template "status-badge" (printf "%s" .Status)}}</td>
@@ -360,8 +360,8 @@
 {{define "scan_rows"}}
 <tbody id="scan-rows">
 {{range .Scans}}
-  <tr class="cursor-pointer" hx-get="/scans/{{.ID}}" hx-target="body" hx-push-url="true">
-    <td>{{.ID}}</td>
+  <tr id="scan-{{.ID}}" class="cursor-pointer" hx-get="/scans/{{.ID}}" hx-push-url="true">
+    <td><a href="/scans/{{.ID}}" hx-on:click="event.stopPropagation()">{{.ID}}</a></td>
     <td>{{if .SkillName}}{{.SkillName}}{{else}}{{.Kind}}{{end}}</td>
     <td>{{template "status-badge" (status .Status)}}</td>
     <td>{{if gt .FindingsCount 0}}{{template "findings-badge" .FindingsCount}}{{end}}</td>

--- a/internal/web/templates/sbom_new.html
+++ b/internal/web/templates/sbom_new.html
@@ -1,0 +1,15 @@
+{{template "head" .}}
+
+<div class="max-w-md">
+  <h2 class="text-2xl font-semibold mb-2">Upload SBOM</h2>
+  <p class="text-sm text-muted-foreground mb-4">CycloneDX or SPDX, JSON only.</p>
+  <form method="post" action="/sboms" enctype="multipart/form-data" class="form grid gap-4">
+    <input class="input" type="file" name="file" accept=".json,application/json" required>
+    <footer class="flex justify-end gap-2">
+      <a href="/sboms" class="btn-outline">Cancel</a>
+      <button type="submit" class="btn">Upload</button>
+    </footer>
+  </form>
+</div>
+
+{{template "foot" .}}

--- a/internal/web/templates/sbom_show.html
+++ b/internal/web/templates/sbom_show.html
@@ -12,10 +12,13 @@
     </p>
   </div>
   <div class="flex items-center gap-2">
-    <form hx-post="/sboms/{{.SBOM.ID}}/resolve">
+    <form method="post" action="/sboms/{{.SBOM.ID}}/resolve"
+          hx-post="/sboms/{{.SBOM.ID}}/resolve" hx-swap="none">
       <button class="btn-outline" type="submit"><i data-lucide="refresh-cw"></i> Re-resolve</button>
     </form>
-    <form hx-post="/sboms/{{.SBOM.ID}}/delete" hx-confirm="Delete this SBOM and its package list?">
+    <form method="post" action="/sboms/{{.SBOM.ID}}/delete"
+          hx-post="/sboms/{{.SBOM.ID}}/delete" hx-swap="none"
+          hx-confirm="Delete this SBOM and its package list?">
       <button class="btn-outline" type="submit"><i data-lucide="trash"></i> Delete</button>
     </form>
   </div>

--- a/internal/web/templates/sbom_show.html
+++ b/internal/web/templates/sbom_show.html
@@ -150,9 +150,9 @@
       {{$repos := .Repos}}
       {{range .Findings}}
         {{$repo := index $repos .RepositoryID}}
-        <tr class="cursor-pointer" hx-get="/findings/{{.ID}}" hx-target="body" hx-push-url="true">
+        <tr id="finding-{{.ID}}" class="cursor-pointer" hx-get="/findings/{{.ID}}" hx-push-url="true">
           <td>{{template "severity-badge" .Severity}}</td>
-          <td class="min-w-0 whitespace-normal font-medium">{{.Title}}</td>
+          <td class="min-w-0 whitespace-normal"><a href="/findings/{{.ID}}" class="font-medium" hx-on:click="event.stopPropagation()">{{.Title}}</a></td>
           <td class="truncate">{{$repo.Name}}</td>
           <td>{{template "finding-status" (fstatus .Status)}}</td>
           <td class="text-muted-foreground">{{.CWE}}</td>

--- a/internal/web/templates/sbom_show.html
+++ b/internal/web/templates/sbom_show.html
@@ -1,4 +1,4 @@
-{{template "head"}}
+{{template "head" .}}
 
 {{template "crumbs" (crumbs "SBOMs" "/sboms" .SBOM.Name "")}}
 
@@ -196,4 +196,4 @@
   {{end}}
 </div>
 
-{{template "foot"}}
+{{template "foot" .}}

--- a/internal/web/templates/sboms.html
+++ b/internal/web/templates/sboms.html
@@ -15,12 +15,12 @@
       <h2>Upload SBOM</h2>
       <p class="text-sm text-muted-foreground">CycloneDX or SPDX, JSON only.</p>
     </header>
-    <form method="post" action="/sboms" enctype="multipart/form-data"
-          hx-post="/sboms" hx-encoding="multipart/form-data" class="form grid gap-4">
+    <form method="post" action="/sboms" enctype="multipart/form-data" class="form grid gap-4">
       <input class="input" type="file" name="file" accept=".json,application/json" required>
       <footer class="flex justify-end gap-2">
-        <button type="button" class="btn-outline" onclick="this.closest('dialog').close()">Cancel</button>
-        <button type="submit" class="btn">Upload</button>
+        <button type="submit" class="btn-outline" formmethod="dialog" formnovalidate>Cancel</button>
+        <button type="submit" class="btn"
+                hx-post="/sboms" hx-encoding="multipart/form-data" hx-swap="none">Upload</button>
       </footer>
     </form>
   </article>

--- a/internal/web/templates/sboms.html
+++ b/internal/web/templates/sboms.html
@@ -4,9 +4,9 @@
   <h2 class="text-2xl font-semibold flex items-center gap-2">
     <i data-lucide="file-box"></i> SBOMs
   </h2>
-  <button type="button" class="btn" onclick="document.getElementById('sbom-upload').showModal()">
+  <a href="/sboms/new" data-dialog="sbom-upload" class="btn">
     <i data-lucide="upload"></i> Upload SBOM
-  </button>
+  </a>
 </div>
 
 <dialog id="sbom-upload" class="dialog">

--- a/internal/web/templates/sboms.html
+++ b/internal/web/templates/sboms.html
@@ -1,4 +1,4 @@
-{{template "head"}}
+{{template "head" .}}
 
 <div class="flex items-center justify-between gap-4 mb-6">
   <h2 class="text-2xl font-semibold flex items-center gap-2">
@@ -47,4 +47,4 @@
   {{template "empty" (dict "Icon" "file-box" "Title" "No SBOMs yet" "Body" "Upload a CycloneDX or SPDX JSON document to scan every package it lists.")}}
 {{end}}
 
-{{template "foot"}}
+{{template "foot" .}}

--- a/internal/web/templates/sboms.html
+++ b/internal/web/templates/sboms.html
@@ -34,8 +34,8 @@
     </tr></thead>
     <tbody>
     {{range .SBOMs}}
-      <tr class="cursor-pointer" hx-get="/sboms/{{.ID}}" hx-target="body" hx-push-url="true">
-        <td class="font-medium">{{.Name}}<div class="text-xs text-muted-foreground">{{.Filename}}</div></td>
+      <tr id="sbom-{{.ID}}" class="cursor-pointer" hx-get="/sboms/{{.ID}}" hx-push-url="true">
+        <td><a href="/sboms/{{.ID}}" class="font-medium" hx-on:click="event.stopPropagation()">{{.Name}}</a><div class="text-xs text-muted-foreground">{{.Filename}}</div></td>
         <td><span class="badge-outline">{{.Format}} {{.SpecVersion}}</span></td>
         <td class="text-right text-muted-foreground">{{.PackageCount}}</td>
         <td class="text-muted-foreground">{{since .CreatedAt}}</td>

--- a/internal/web/templates/scan_show.html
+++ b/internal/web/templates/scan_show.html
@@ -11,9 +11,10 @@
     {{template "status-badge" (status .Status)}}
   </h2>
   {{if and (eq .Kind "skill") .SkillID}}
-    <button class="btn-outline" hx-post="/scans/{{.ID}}/retry">
-      <i data-lucide="refresh-cw"></i> Retry
-    </button>
+    <form method="post" action="/scans/{{.ID}}/retry"
+          hx-post="/scans/{{.ID}}/retry" hx-swap="none">
+      <button type="submit" class="btn-outline"><i data-lucide="refresh-cw"></i> Retry</button>
+    </form>
   {{end}}
 </div>
 

--- a/internal/web/templates/scan_show.html
+++ b/internal/web/templates/scan_show.html
@@ -1,5 +1,5 @@
-{{template "head"}}
-
+{{template "head" .}}
+{{with .Scan}}
 {{template "crumbs" (crumbs
   "Repositories" "/"
   .Repository.Name (printf "/repositories/%d" .Repository.ID)
@@ -97,7 +97,7 @@
             <td class="text-muted-foreground">
               {{if .CWE}}<span data-tooltip="{{cwename .CWE}}">{{.CWE}}</span>{{end}}
             </td>
-            <td class="whitespace-normal">{{template "loc-link" (dict "HTMLURL" $.Repository.HTMLURL "Commit" $.Commit "Location" .Location)}}</td>
+            <td class="whitespace-normal">{{template "loc-link" (dict "HTMLURL" $.Scan.Repository.HTMLURL "Commit" $.Scan.Commit "Location" .Location)}}</td>
           </tr>
         {{end}}
         </tbody>
@@ -131,5 +131,5 @@
   </div>
   {{end}}
 </div>
-
-{{template "foot"}}
+{{end}}
+{{template "foot" .}}

--- a/internal/web/templates/scan_show.html
+++ b/internal/web/templates/scan_show.html
@@ -86,10 +86,10 @@
         </tr></thead>
         <tbody>
         {{range .Findings}}
-          <tr class="cursor-pointer" hx-get="/findings/{{.ID}}" hx-target="body" hx-push-url="true">
+          <tr id="finding-{{.ID}}" class="cursor-pointer" hx-get="/findings/{{.ID}}" hx-push-url="true">
             <td>{{template "severity-badge" .Severity}}</td>
             <td class="min-w-0 whitespace-normal">
-              <div class="font-medium">{{.Title}}</div>
+              <a href="/findings/{{.ID}}" class="font-medium" hx-on:click="event.stopPropagation()">{{.Title}}</a>
               <div class="text-xs text-muted-foreground line-clamp-2">{{.Summary}}</div>
             </td>
             <td>{{template "finding-status" (fstatus .Status)}}</td>

--- a/internal/web/templates/settings.html
+++ b/internal/web/templates/settings.html
@@ -1,0 +1,145 @@
+{{template "head" .}}
+
+<h1 class="text-2xl font-semibold mb-6">Settings</h1>
+
+<div class="grid gap-6">
+
+<section class="card">
+  <header><h2>Theme</h2></header>
+  <section>
+    <div class="flex flex-wrap gap-3">
+      {{$current := .Theme}}
+      {{range .Themes}}
+      <form method="post" action="/settings/theme" hx-post="/settings/theme" hx-swap="none">
+        <input type="hidden" name="theme" value="{{.}}">
+        <button type="submit" class="rounded-lg border px-4 py-3 text-center hover:bg-muted transition-colors cursor-pointer {{if eq . $current}}border-primary bg-muted/50{{else}}border-transparent{{end}}">
+          <div class="flex justify-center gap-1 mb-2">
+            <span class="w-4 h-4 rounded-full theme-swatch-primary" data-swatch="{{.}}"></span>
+            <span class="w-4 h-4 rounded-full theme-swatch-accent" data-swatch="{{.}}"></span>
+            <span class="w-4 h-4 rounded-full theme-swatch-muted" data-swatch="{{.}}"></span>
+          </div>
+          <span class="text-sm font-medium">{{.}}</span>
+        </button>
+      </form>
+      {{end}}
+    </div>
+  </section>
+</section>
+
+<section class="card">
+  <header><h2>Color scheme</h2></header>
+  <section>
+    <div class="flex flex-wrap gap-3">
+      {{$scheme := .ColorScheme}}
+      {{range $val := list "system" "light" "dark"}}
+      <form method="post" action="/settings/color-scheme" hx-post="/settings/color-scheme" hx-swap="none">
+        <input type="hidden" name="color_scheme" value="{{$val}}">
+        <button type="submit" class="rounded-lg border px-4 py-3 text-center hover:bg-muted transition-colors cursor-pointer {{if eq $val $scheme}}border-primary bg-muted/50{{else}}border-transparent{{end}}">
+          <span class="text-sm font-medium">{{$val}}</span>
+        </button>
+      </form>
+      {{end}}
+    </div>
+  </section>
+</section>
+
+<section class="card">
+  <header><h2>Default model</h2></header>
+  <section>
+    <div class="flex flex-wrap gap-3">
+      {{$model := .DefaultModel}}
+      {{range .Models}}
+      <form method="post" action="/settings/model" hx-post="/settings/model" hx-swap="none">
+        <input type="hidden" name="model" value="{{.ID}}">
+        <button type="submit" class="rounded-lg border px-4 py-3 text-center hover:bg-muted transition-colors cursor-pointer {{if eq .ID $model}}border-primary bg-muted/50{{else}}border-transparent{{end}}">
+          <span class="text-sm font-medium">{{.Name}}</span>
+        </button>
+      </form>
+      {{end}}
+    </div>
+  </section>
+</section>
+
+<section class="card">
+  <header><h2>System</h2></header>
+  <section>
+    <div class="grid grid-cols-3 sm:grid-cols-4 lg:grid-cols-7 gap-3 text-sm">
+      <div class="bg-muted/50 rounded-lg px-3 py-2">
+        <div class="text-muted-foreground text-xs">Repositories</div>
+        <div class="font-medium text-lg">{{bignum .Stats.Repos}}</div>
+      </div>
+      <div class="bg-muted/50 rounded-lg px-3 py-2">
+        <div class="text-muted-foreground text-xs">Scans</div>
+        <div class="font-medium text-lg">{{bignum .Stats.Scans}}</div>
+      </div>
+      <div class="bg-muted/50 rounded-lg px-3 py-2">
+        <div class="text-muted-foreground text-xs">Findings</div>
+        <div class="font-medium text-lg">{{bignum .Stats.Findings}}</div>
+      </div>
+      <div class="bg-muted/50 rounded-lg px-3 py-2">
+        <div class="text-muted-foreground text-xs">Packages</div>
+        <div class="font-medium text-lg">{{bignum .Stats.Packages}}</div>
+      </div>
+      <div class="bg-muted/50 rounded-lg px-3 py-2">
+        <div class="text-muted-foreground text-xs">Advisories</div>
+        <div class="font-medium text-lg">{{bignum .Stats.Advisories}}</div>
+      </div>
+      <div class="bg-muted/50 rounded-lg px-3 py-2">
+        <div class="text-muted-foreground text-xs">Maintainers</div>
+        <div class="font-medium text-lg">{{bignum .Stats.Maintainers}}</div>
+      </div>
+      <div class="bg-muted/50 rounded-lg px-3 py-2">
+        <div class="text-muted-foreground text-xs">Skills</div>
+        <div class="font-medium text-lg">{{bignum .Stats.Skills}}</div>
+      </div>
+    </div>
+    <div class="grid grid-cols-2 gap-3 text-sm mt-3">
+      <div class="bg-muted/50 rounded-lg px-3 py-2">
+        <div class="text-muted-foreground text-xs">Concurrency</div>
+        <div class="font-medium text-lg">{{.Concurrency}}</div>
+      </div>
+      <div class="bg-muted/50 rounded-lg px-3 py-2">
+        <div class="text-muted-foreground text-xs">Database size</div>
+        <div class="font-medium text-lg">{{bytes .DBSize}}</div>
+      </div>
+      <div class="bg-muted/50 rounded-lg px-3 py-2 col-span-2">
+        <div class="text-muted-foreground text-xs">Database path</div>
+        <div class="font-mono text-sm truncate" title="{{.DBPath}}">{{.DBPath}}</div>
+      </div>
+      <div class="bg-muted/50 rounded-lg px-3 py-2 col-span-2">
+        <div class="text-muted-foreground text-xs">Work directory</div>
+        <div class="font-mono text-sm truncate" title="{{.WorkDir}}">{{.WorkDir}}</div>
+      </div>
+    </div>
+  </section>
+</section>
+
+</div>
+
+<style>
+  .theme-swatch-primary[data-swatch="claude"]          { background: oklch(0.6171 0.1375 39.0427); }
+  .theme-swatch-accent[data-swatch="claude"]           { background: oklch(0.9245 0.0138 92.9892); }
+  .theme-swatch-muted[data-swatch="claude"]            { background: oklch(0.9341 0.0153 90.2390); }
+
+  .theme-swatch-primary[data-swatch="ocean-breeze"]    { background: oklch(0.72 0.19 149.58); }
+  .theme-swatch-accent[data-swatch="ocean-breeze"]     { background: oklch(0.95 0.05 163.05); }
+  .theme-swatch-muted[data-swatch="ocean-breeze"]      { background: oklch(0.97 0 264.54); }
+
+  .theme-swatch-primary[data-swatch="catppuccin"]      { background: oklch(0.55 0.25 297.02); }
+  .theme-swatch-accent[data-swatch="catppuccin"]       { background: oklch(0.68 0.14 235.38); }
+  .theme-swatch-muted[data-swatch="catppuccin"]        { background: oklch(0.91 0.01 264.51); }
+
+  .theme-swatch-primary[data-swatch="sunset-horizon"]  { background: oklch(0.74 0.16 34.71); }
+  .theme-swatch-accent[data-swatch="sunset-horizon"]   { background: oklch(0.83 0.11 58); }
+  .theme-swatch-muted[data-swatch="sunset-horizon"]    { background: oklch(0.97 0.02 39.4); }
+
+  .theme-swatch-primary[data-swatch="midnight-bloom"]  { background: oklch(0.57 0.2 283.08); }
+  .theme-swatch-accent[data-swatch="midnight-bloom"]   { background: oklch(0.65 0.06 117.43); }
+  .theme-swatch-muted[data-swatch="midnight-bloom"]    { background: oklch(0.82 0.02 91.62); }
+
+  .theme-swatch-primary[data-swatch="northern-lights"] { background: oklch(0.65 0.15 150.31); }
+  .theme-swatch-accent[data-swatch="northern-lights"]  { background: oklch(0.83 0.11 211.96); }
+  .theme-swatch-muted[data-swatch="northern-lights"]   { background: oklch(0.88 0.03 98.1); }
+</style>
+
+{{template "foot" .}}

--- a/internal/web/templates/skill_form.html
+++ b/internal/web/templates/skill_form.html
@@ -1,4 +1,4 @@
-{{template "head"}}
+{{template "head" .}}
 
 {{with .S}}
 <div class="mb-6">
@@ -69,4 +69,4 @@ Describe what the model should do here.">{{.Body}}</textarea>
 </form>
 {{end}}
 
-{{template "foot"}}
+{{template "foot" .}}

--- a/internal/web/templates/skill_show.html
+++ b/internal/web/templates/skill_show.html
@@ -1,4 +1,4 @@
-{{template "head"}}
+{{template "head" .}}
 
 {{with .S}}
 <div class="flex items-center justify-between gap-4 mb-6">
@@ -37,4 +37,4 @@
 {{end}}
 {{end}}
 
-{{template "foot"}}
+{{template "foot" .}}

--- a/internal/web/templates/skills.html
+++ b/internal/web/templates/skills.html
@@ -1,4 +1,4 @@
-{{template "head"}}
+{{template "head" .}}
 
 <div class="flex items-center justify-between gap-4 mb-6">
   <h2 class="text-2xl font-semibold flex items-center gap-2">
@@ -29,4 +29,4 @@
   {{template "empty" (dict "Icon" "sparkles" "Title" "No skills" "Body" "Seed skills from a directory with -skills ./path, from a git repo with -skills-repo https://github.com/org/skills, or create one in the UI.")}}
 {{end}}
 
-{{template "foot"}}
+{{template "foot" .}}

--- a/internal/web/templates/skills.html
+++ b/internal/web/templates/skills.html
@@ -14,8 +14,8 @@
     </tr></thead>
     <tbody>
     {{range .Skills}}
-      <tr class="cursor-pointer" hx-get="/skills/{{.ID}}" hx-target="body" hx-push-url="true">
-        <td class="font-medium">{{.Name}}</td>
+      <tr id="skill-{{.ID}}" class="cursor-pointer" hx-get="/skills/{{.ID}}" hx-push-url="true">
+        <td><a href="/skills/{{.ID}}" class="font-medium" hx-on:click="event.stopPropagation()">{{.Name}}</a></td>
         <td class="text-muted-foreground whitespace-normal">{{.Description}}</td>
         <td>{{if .OutputKind}}<span class="badge-outline">{{.OutputKind}}</span>{{end}}</td>
         <td class="text-muted-foreground">{{.Source}}</td>

--- a/internal/web/templates/usage.html
+++ b/internal/web/templates/usage.html
@@ -1,4 +1,4 @@
-{{template "head"}}
+{{template "head" .}}
 
 <div class="flex items-center justify-between gap-4 mb-2">
   <h2 class="text-2xl font-semibold flex items-center gap-2">
@@ -51,4 +51,4 @@
   {{template "empty" (dict "Icon" "coins" "Title" "No usage yet" "Body" "Cost data appears here once scans have completed.")}}
 {{end}}
 
-{{template "foot"}}
+{{template "foot" .}}

--- a/internal/web/theme.go
+++ b/internal/web/theme.go
@@ -7,6 +7,8 @@ import (
 	"scrutineer/internal/config"
 )
 
+const cookieMaxAge = 365 * 24 * 60 * 60 //nolint:mnd
+
 var defaultTheme = "claude"
 
 func SetTheme(name string) {
@@ -85,7 +87,7 @@ func (s *Server) settingsUpdateTheme(w http.ResponseWriter, r *http.Request) {
 		Name:     "theme",
 		Value:    theme,
 		Path:     "/",
-		MaxAge:   365 * 24 * 60 * 60,
+		MaxAge:   cookieMaxAge,
 		HttpOnly: true,
 		SameSite: http.SameSiteStrictMode,
 	})
@@ -114,7 +116,7 @@ func (s *Server) settingsUpdateColorScheme(w http.ResponseWriter, r *http.Reques
 		Name:     "color_scheme",
 		Value:    scheme,
 		Path:     "/",
-		MaxAge:   365 * 24 * 60 * 60,
+		MaxAge:   cookieMaxAge,
 		SameSite: http.SameSiteStrictMode,
 	})
 	setFlash(w, Flash{Category: "success", Title: "Color scheme updated"})

--- a/internal/web/theme.go
+++ b/internal/web/theme.go
@@ -1,0 +1,122 @@
+package web
+
+import (
+	"net/http"
+	"slices"
+
+	"scrutineer/internal/config"
+)
+
+var defaultTheme = "claude"
+
+func SetTheme(name string) {
+	if name == "" {
+		return
+	}
+	defaultTheme = name
+}
+
+func resolveTheme(r *http.Request) string {
+	if c, err := r.Cookie("theme"); err == nil && c.Value != "" {
+		if config.ValidateTheme(c.Value) == nil {
+			return c.Value
+		}
+	}
+	return defaultTheme
+}
+
+var colorSchemes = []string{"system", "light", "dark"}
+
+func resolveColorScheme(r *http.Request) string {
+	if c, err := r.Cookie("color_scheme"); err == nil && c.Value != "" {
+		for _, s := range colorSchemes {
+			if c.Value == s {
+				return s
+			}
+		}
+	}
+	return "system"
+}
+
+func (s *Server) settingsShow(w http.ResponseWriter, r *http.Request) {
+	var stats struct {
+		Repos       int64
+		Scans       int64
+		Findings    int64
+		Packages    int64
+		Advisories  int64
+		Maintainers int64
+		Skills      int64
+	}
+	s.DB.Table("repositories").Count(&stats.Repos)
+	s.DB.Table("scans").Count(&stats.Scans)
+	s.DB.Table("findings").Count(&stats.Findings)
+	s.DB.Table("packages").Count(&stats.Packages)
+	s.DB.Table("advisories").Count(&stats.Advisories)
+	s.DB.Table("maintainers").Count(&stats.Maintainers)
+	s.DB.Table("skills").Count(&stats.Skills)
+
+	var dbSizeBytes int64
+	s.DB.Raw("SELECT page_count * page_size FROM pragma_page_count(), pragma_page_size()").Scan(&dbSizeBytes)
+
+	var dbPath string
+	s.DB.Raw("SELECT file FROM pragma_database_list WHERE name = 'main'").Scan(&dbPath)
+
+	s.render(w, r, "settings.html", map[string]any{
+		"Themes":       config.Themes,
+		"Models":       Models,
+		"DefaultModel": DefaultModel(),
+		"ColorScheme":  resolveColorScheme(r),
+		"Concurrency":  s.Queue.Concurrency,
+		"Stats":        stats,
+		"DBSize":       dbSizeBytes,
+		"DBPath":       dbPath,
+		"WorkDir":      s.Worker.DataDir,
+	})
+}
+
+func (s *Server) settingsUpdateTheme(w http.ResponseWriter, r *http.Request) {
+	theme := r.FormValue("theme")
+	if config.ValidateTheme(theme) != nil {
+		http.Error(w, "unknown theme", http.StatusUnprocessableEntity)
+		return
+	}
+	http.SetCookie(w, &http.Cookie{
+		Name:     "theme",
+		Value:    theme,
+		Path:     "/",
+		MaxAge:   365 * 24 * 60 * 60,
+		HttpOnly: true,
+		SameSite: http.SameSiteStrictMode,
+	})
+	setFlash(w, Flash{Category: "success", Title: "Theme updated"})
+	s.redirect(w, r, "/settings")
+}
+
+func (s *Server) settingsUpdateModel(w http.ResponseWriter, r *http.Request) {
+	model := r.FormValue("model")
+	if !ValidModel(model) {
+		http.Error(w, "unknown model", http.StatusUnprocessableEntity)
+		return
+	}
+	SetDefaultModel(model)
+	setFlash(w, Flash{Category: "success", Title: "Default model updated"})
+	s.redirect(w, r, "/settings")
+}
+
+func (s *Server) settingsUpdateColorScheme(w http.ResponseWriter, r *http.Request) {
+	scheme := r.FormValue("color_scheme")
+	if !slices.Contains(colorSchemes, scheme) {
+		http.Error(w, "unknown color scheme", http.StatusUnprocessableEntity)
+		return
+	}
+	http.SetCookie(w, &http.Cookie{
+		Name:     "color_scheme",
+		Value:    scheme,
+		Path:     "/",
+		MaxAge:   365 * 24 * 60 * 60,
+		SameSite: http.SameSiteStrictMode,
+	})
+	setFlash(w, Flash{Category: "success", Title: "Color scheme updated"})
+	s.redirect(w, r, "/settings")
+}

--- a/internal/web/usage.go
+++ b/internal/web/usage.go
@@ -68,7 +68,7 @@ func (s *Server) usage(w http.ResponseWriter, r *http.Request) {
 	}
 	sort.Slice(rows, func(i, j int) bool { return rows[i].Cost.Sum > rows[j].Cost.Sum })
 
-	s.render(w, "usage.html", map[string]any{
+	s.render(w, r, "usage.html", map[string]any{
 		"Rows":      rows,
 		"TotalCost": totalCost,
 		"TotalRuns": totalRuns,


### PR DESCRIPTION
Server-rendered HTML with htmx progressive enhancement so the UI works without JavaScript.

- Wrap all `hx-post` actions in real `<form>` elements with `method="post"` and `action` attributes
- Server-rendered nav highlight via `aria-current="page"` and flash toasts via cookies
- Extract shared JS to `app.js`, add `/repositories/new` and `/sboms/new` fallback pages
- SSE scan-status pushes OOB row updates and toasts instead of full-page reloads
- Fix repo list poll blanking the page on empty response
- Add settings page with six switchable themes (oklch CSS custom properties), color scheme toggle (system/light/dark), default model selector, and system stats (record counts, DB size, concurrency, paths)