### PR TITLE
fix: highlight SBOM tab when selected

### DIFF
--- a/internal/web/templates/layout.html
+++ b/internal/web/templates/layout.html
@@ -157,6 +157,7 @@
             : p.indexOf('/maintainers') === 0 ? 'maintainers'
             : p.indexOf('/orgs') === 0 ? 'orgs'
             : p.indexOf('/packages') === 0 ? 'packages'
+            : p.indexOf('/sboms') === 0 ? 'sboms'
             : p.indexOf('/advisories') === 0 ? 'advisories'
             : p.indexOf('/findings') === 0 ? 'findings'
             : p.indexOf('/scans') === 0 ? 'scans'


### PR DESCRIPTION
Currently, when on the SBOM tab, the "Repositories" one is highlighted. This fixes this behavior.