### PR TITLE
Warn on OAuth token in ANTHROPIC_API_KEY, document both auth options

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,24 @@ A local tool for scanning open source repositories for security vulnerabilities 
 
 ## Quick start
 
-You need [Go 1.26+](https://go.dev/dl/), [Docker](https://docs.docker.com/get-docker/) running, and an Anthropic API key from [console.anthropic.com](https://console.anthropic.com).
+You need [Go 1.26+](https://go.dev/dl/) and [Docker](https://docs.docker.com/get-docker/) running.
 
     git clone https://github.com/alpha-omega-security/scrutineer
     cd scrutineer
-    export ANTHROPIC_API_KEY=sk-ant-...
+
+Authenticate Claude with one of two options:
+
+**Option A: Claude Code subscription** (Max, Pro, Team, or Enterprise) -- generate a long-lived OAuth token with the [Claude CLI](https://docs.anthropic.com/en/docs/claude-code):
+
+    claude setup-token
+    export CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-...
+
+**Option B: Anthropic API key** from [console.anthropic.com](https://console.anthropic.com):
+
+    export ANTHROPIC_API_KEY=sk-ant-api03-...
+
+Then start scrutineer:
+
     export ANTHROPIC_BASE_URL=https://...  # optional: custom API endpoint
     go run ./cmd/scrutineer -skills ./skills
 
@@ -118,7 +131,16 @@ The same applies to the Dependents tab -- you can import any dependent's reposit
 ## Docker
 
     docker build -t scrutineer .
-    docker run -p 127.0.0.1:8080:8080 -v scrutineer-data:/data -e ANTHROPIC_API_KEY=sk-... -e ANTHROPIC_BASE_URL=https://... scrutineer
+    docker run -p 127.0.0.1:8080:8080 -v scrutineer-data:/data \
+      -e ANTHROPIC_API_KEY=sk-ant-api03-... \
+      -e ANTHROPIC_BASE_URL=https://... \
+      scrutineer
+
+Or with a Claude Code OAuth token instead of an API key:
+
+    docker run -p 127.0.0.1:8080:8080 -v scrutineer-data:/data \
+      -e CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-... \
+      scrutineer
 
 Always bind to `127.0.0.1`. The UI has no authentication; binding to `0.0.0.0` exposes your findings database to anyone on the network.
 

--- a/cmd/scrutineer/main.go
+++ b/cmd/scrutineer/main.go
@@ -229,8 +229,10 @@ func run(log *slog.Logger) error {
 		if err != nil {
 			return fmt.Errorf("start egress proxy: %w", err)
 		}
+		gwIP := worker.ResolveHostGatewayIPv4(f.runnerImage)
 		log.Info("docker detected, using containerised runner",
-			"image", f.runnerImage, "egress_proxy_port", port, "egress_allow", len(allow))
+			"image", f.runnerImage, "egress_proxy_port", port, "egress_allow", len(allow),
+			"host_gateway_ipv4", gwIP)
 		runner = worker.DockerRunner{
 			Image:            f.runnerImage,
 			Effort:           f.effort,
@@ -238,6 +240,7 @@ func run(log *slog.Logger) error {
 			FullClone:        f.fullClone(),
 			MaxTurns:         f.maxTurns,
 			AnthropicBaseURL: f.anthropicBaseURL,
+			HostGatewayIP:    gwIP,
 		}
 		// Skills inside the container reach the host via host.docker.internal,
 		// which the egress proxy rewrites to 127.0.0.1 when dialing.

--- a/cmd/scrutineer/main.go
+++ b/cmd/scrutineer/main.go
@@ -160,6 +160,10 @@ func run(log *slog.Logger) error {
 	if err := config.ValidateClone(f.cloneMode); err != nil {
 		return err
 	}
+	if key := os.Getenv("ANTHROPIC_API_KEY"); strings.HasPrefix(key, "sk-ant-oat") {
+		log.Warn("ANTHROPIC_API_KEY looks like an OAuth token from `claude setup-token`; set it as CLAUDE_CODE_OAUTH_TOKEN instead")
+	}
+
 	if f.anthropicBaseURL == "" {
 		f.anthropicBaseURL = os.Getenv("ANTHROPIC_BASE_URL")
 	}

--- a/internal/worker/docker.go
+++ b/internal/worker/docker.go
@@ -81,6 +81,7 @@ func (d DockerRunner) RunSkill(ctx context.Context, sj SkillJob, emit func(Event
 		"run", "--rm",
 		"--cap-drop", "ALL",
 		"--user", fmt.Sprintf("%d:%d", os.Getuid(), os.Getgid()),
+		"-e", "HOME=/tmp",
 		"--tmpfs", "/tmp:rw,noexec,nosuid,size=256m",
 		"-v", absWork + ":/work",
 		"-w", "/work",

--- a/internal/worker/docker.go
+++ b/internal/worker/docker.go
@@ -7,10 +7,12 @@ package worker
 import (
 	"context"
 	"fmt"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"syscall"
 )
 
@@ -26,6 +28,7 @@ type DockerRunner struct {
 	FullClone        bool
 	MaxTurns         int
 	AnthropicBaseURL string // passed as ANTHROPIC_BASE_URL env var to the container
+	HostGatewayIP    string // IPv4 address for --add-host; falls back to "host-gateway"
 }
 
 func (d DockerRunner) image() string {
@@ -70,6 +73,10 @@ func (d DockerRunner) RunSkill(ctx context.Context, sj SkillJob, emit func(Event
 	}
 	claudeArgs = append(claudeArgs, buildSkillPrompt(sj.Name, sj.OutputFile))
 
+	gwTarget := "host-gateway"
+	if d.HostGatewayIP != "" {
+		gwTarget = d.HostGatewayIP
+	}
 	dockerArgs := []string{
 		"run", "--rm",
 		"--cap-drop", "ALL",
@@ -77,7 +84,7 @@ func (d DockerRunner) RunSkill(ctx context.Context, sj SkillJob, emit func(Event
 		"--tmpfs", "/tmp:rw,noexec,nosuid,size=256m",
 		"-v", absWork + ":/work",
 		"-w", "/work",
-		"--add-host", HostGatewayAlias + ":host-gateway",
+		"--add-host", HostGatewayAlias + ":" + gwTarget,
 	}
 	if d.ProxyURL != "" {
 		dockerArgs = append(dockerArgs,
@@ -140,4 +147,30 @@ func (d DockerRunner) RunSkill(ctx context.Context, sj SkillJob, emit func(Event
 func DockerAvailable() bool {
 	out, err := exec.Command("docker", "info", "--format", "{{.ServerVersion}}").Output()
 	return err == nil && len(out) > 0
+}
+
+// ResolveHostGatewayIPv4 returns the IPv4 address that Docker's
+// host-gateway maps to. Docker adds both IPv4 and IPv6 /etc/hosts
+// entries for host-gateway; tools that prefer IPv6 (like Node's fetch)
+// fail when the server only listens on 127.0.0.1. Using the explicit
+// IPv4 address avoids the dual-stack ambiguity.
+func ResolveHostGatewayIPv4(image string) string {
+	out, err := exec.Command("docker", "run", "--rm",
+		"--add-host", "hgw:host-gateway",
+		"--entrypoint", "grep",
+		image, "hgw", "/etc/hosts").Output()
+	if err != nil {
+		return ""
+	}
+	for line := range strings.SplitSeq(strings.TrimSpace(string(out)), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 1 {
+			continue
+		}
+		ip := net.ParseIP(fields[0])
+		if ip != nil && ip.To4() != nil {
+			return fields[0]
+		}
+	}
+	return ""
 }

--- a/internal/worker/docker.go
+++ b/internal/worker/docker.go
@@ -73,6 +73,7 @@ func (d DockerRunner) RunSkill(ctx context.Context, sj SkillJob, emit func(Event
 	dockerArgs := []string{
 		"run", "--rm",
 		"--cap-drop", "ALL",
+		"--user", fmt.Sprintf("%d:%d", os.Getuid(), os.Getgid()),
 		"--tmpfs", "/tmp:rw,noexec,nosuid,size=256m",
 		"-v", absWork + ":/work",
 		"-w", "/work",


### PR DESCRIPTION
`claude setup-token` produces an OAuth token (`sk-ant-oat01-...`) that only works when set as `CLAUDE_CODE_OAUTH_TOKEN`. Setting it as `ANTHROPIC_API_KEY` causes "invalid API key" errors because the runner passes it directly to the Anthropic API, which rejects OAuth tokens.

- Add a startup warning when `ANTHROPIC_API_KEY` has an `sk-ant-oat` prefix pointing users to use `CLAUDE_CODE_OAUTH_TOKEN` instead
- Update quickstart docs to show both auth paths: Claude Code subscription via `claude setup-token` (Option A) and Anthropic API key from console.anthropic.com (Option B)
- Update Docker section with examples for both env vars

Closes #120