### PR TITLE
Fix container write permissions on mounted workspace

### DIFF
--- a/internal/worker/docker.go
+++ b/internal/worker/docker.go
@@ -73,6 +73,7 @@ func (d DockerRunner) RunSkill(ctx context.Context, sj SkillJob, emit func(Event
 	dockerArgs := []string{
 		"run", "--rm",
 		"--cap-drop", "ALL",
+		"--user", fmt.Sprintf("%d:%d", os.Getuid(), os.Getgid()),
 		"--tmpfs", "/tmp:rw,noexec,nosuid,size=256m",
 		"-v", absWork + ":/work",
 		"-w", "/work",


### PR DESCRIPTION
The switch to the semgrep base image (#103) added a `runner` user at UID 1001, but the workspace mounted at `/work` is owned by the host user. The container couldn't write `report.json` or any other skill output, causing scans to fail with permission errors or burn turns trying workarounds.

Pass `--user UID:GID` matching the host process so the container user matches the mounted directory ownership.

Verified with `docker run --user $(id -u):$(id -g)` -- the container can write to `/work` as expected.