### PR TITLE
Fix SQLite variable limit on large dependency sets

### DIFF
--- a/internal/worker/skill_parsers.go
+++ b/internal/worker/skill_parsers.go
@@ -128,7 +128,7 @@ func (w *Worker) parsePackagesOutput(scan *db.Scan, report string, emit func(Eve
 		rows = append(rows, row)
 	}
 	if len(rows) > 0 {
-		if err := w.DB.Create(&rows).Error; err != nil {
+		if err := w.DB.CreateInBatches(&rows, 50).Error; err != nil {
 			return fmt.Errorf("save packages: %w", err)
 		}
 	}
@@ -180,7 +180,7 @@ func (w *Worker) parseAdvisoriesOutput(scan *db.Scan, report string, emit func(E
 		rows = append(rows, row)
 	}
 	if len(rows) > 0 {
-		if err := w.DB.Create(&rows).Error; err != nil {
+		if err := w.DB.CreateInBatches(&rows, 50).Error; err != nil {
 			return fmt.Errorf("save advisories: %w", err)
 		}
 	}
@@ -223,7 +223,7 @@ func (w *Worker) parseDependentsOutput(scan *db.Scan, report string, emit func(E
 		})
 	}
 	if len(rows) > 0 {
-		if err := w.DB.Create(&rows).Error; err != nil {
+		if err := w.DB.CreateInBatches(&rows, 50).Error; err != nil {
 			return fmt.Errorf("save dependents: %w", err)
 		}
 	}
@@ -271,7 +271,7 @@ func (w *Worker) parseDependenciesOutput(scan *db.Scan, report string, emit func
 		})
 	}
 	if len(rows) > 0 {
-		if err := w.DB.Create(&rows).Error; err != nil {
+		if err := w.DB.CreateInBatches(&rows, 50).Error; err != nil {
 			return fmt.Errorf("save dependencies: %w", err)
 		}
 	}
@@ -313,7 +313,7 @@ func (w *Worker) parseSubprojectsOutput(scan *db.Scan, report string, emit func(
 		})
 	}
 	if len(rows) > 0 {
-		if err := w.DB.Create(&rows).Error; err != nil {
+		if err := w.DB.CreateInBatches(&rows, 50).Error; err != nil {
 			return fmt.Errorf("save subprojects: %w", err)
 		}
 	}

--- a/internal/worker/skill_parsers.go
+++ b/internal/worker/skill_parsers.go
@@ -9,6 +9,8 @@ import (
 	"scrutineer/internal/db"
 )
 
+const insertBatchSize = 50
+
 // parseRepoMetadataOutput updates the Repository columns that previously
 // came from the metadata Go handler. Shape matches the subset of
 // repos.ecosyste.ms fields scrutineer actually uses; the skill picks them
@@ -128,7 +130,7 @@ func (w *Worker) parsePackagesOutput(scan *db.Scan, report string, emit func(Eve
 		rows = append(rows, row)
 	}
 	if len(rows) > 0 {
-		if err := w.DB.CreateInBatches(&rows, 50).Error; err != nil {
+		if err := w.DB.CreateInBatches(&rows, insertBatchSize).Error; err != nil {
 			return fmt.Errorf("save packages: %w", err)
 		}
 	}
@@ -180,7 +182,7 @@ func (w *Worker) parseAdvisoriesOutput(scan *db.Scan, report string, emit func(E
 		rows = append(rows, row)
 	}
 	if len(rows) > 0 {
-		if err := w.DB.CreateInBatches(&rows, 50).Error; err != nil {
+		if err := w.DB.CreateInBatches(&rows, insertBatchSize).Error; err != nil {
 			return fmt.Errorf("save advisories: %w", err)
 		}
 	}
@@ -223,7 +225,7 @@ func (w *Worker) parseDependentsOutput(scan *db.Scan, report string, emit func(E
 		})
 	}
 	if len(rows) > 0 {
-		if err := w.DB.CreateInBatches(&rows, 50).Error; err != nil {
+		if err := w.DB.CreateInBatches(&rows, insertBatchSize).Error; err != nil {
 			return fmt.Errorf("save dependents: %w", err)
 		}
 	}
@@ -271,7 +273,7 @@ func (w *Worker) parseDependenciesOutput(scan *db.Scan, report string, emit func
 		})
 	}
 	if len(rows) > 0 {
-		if err := w.DB.CreateInBatches(&rows, 50).Error; err != nil {
+		if err := w.DB.CreateInBatches(&rows, insertBatchSize).Error; err != nil {
 			return fmt.Errorf("save dependencies: %w", err)
 		}
 	}
@@ -313,7 +315,7 @@ func (w *Worker) parseSubprojectsOutput(scan *db.Scan, report string, emit func(
 		})
 	}
 	if len(rows) > 0 {
-		if err := w.DB.CreateInBatches(&rows, 50).Error; err != nil {
+		if err := w.DB.CreateInBatches(&rows, insertBatchSize).Error; err != nil {
 			return fmt.Errorf("save subprojects: %w", err)
 		}
 	}

--- a/internal/worker/skill_parsers_test.go
+++ b/internal/worker/skill_parsers_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"log/slog"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -274,5 +275,25 @@ func TestParseDependencies_acceptsTypeOrDependencyType(t *testing.T) {
 	gotTypes := map[string]string{rows[0].Name: rows[0].DependencyType, rows[1].Name: rows[1].DependencyType}
 	if gotTypes["a"] != "runtime" || gotTypes["b"] != "development" {
 		t.Errorf("types: %+v", gotTypes)
+	}
+}
+
+func TestParseDependencies_largeBatchExceedsSQLiteVariableLimit(t *testing.T) {
+	const n = 200
+	deps := make([]map[string]string, n)
+	for i := range n {
+		deps[i] = map[string]string{
+			"name":          "dep-" + strconv.Itoa(i),
+			"ecosystem":     "npm",
+			"type":          "runtime",
+			"manifest_path": "package.json",
+		}
+	}
+	b, _ := json.Marshal(map[string]any{"dependencies": deps})
+	repo, gdb := runSkillWithReport(t, "dependencies", string(b))
+	var count int64
+	gdb.Model(&db.Dependency{}).Where("repository_id = ?", repo.ID).Count(&count)
+	if count != n {
+		t.Fatalf("count = %d, want %d", count, n)
 	}
 }


### PR DESCRIPTION
Repos with 100+ dependencies hit SQLite's 999-variable limit when all rows are inserted in a single statement, failing with `too many SQL variables`.

Switch all five bulk `Create` calls in the skill parsers (packages, advisories, dependents, dependencies, subprojects) to `CreateInBatches(50)`.

Closes #123