### PR TITLE
Log SQL query count and time per HTTP request

### DIFF
--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -42,7 +42,7 @@ func (s *Server) apiAuth(next http.Handler) http.Handler {
 			return
 		}
 		var scan db.Scan
-		if err := s.DB.Where("api_token = ? AND status = ?", token, db.ScanRunning).
+		if err := s.db(r).Where("api_token = ? AND status = ?", token, db.ScanRunning).
 			First(&scan).Error; err != nil {
 			if errors.Is(err, gorm.ErrRecordNotFound) {
 				writeAPIError(w, http.StatusUnauthorized, "token invalid or scan not running")
@@ -114,7 +114,7 @@ func (s *Server) apiGetRepository(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	var repo db.Repository
-	if err := s.DB.First(&repo, id).Error; err != nil {
+	if err := s.db(r).First(&repo, id).Error; err != nil {
 		writeAPIError(w, http.StatusNotFound, "repository not found")
 		return
 	}
@@ -139,7 +139,7 @@ func (s *Server) apiListScans(w http.ResponseWriter, r *http.Request) {
 		writeAPIError(w, http.StatusForbidden, "scan may only list scans on its own repository")
 		return
 	}
-	q := s.DB.Where("repository_id = ?", id).Order("id desc")
+	q := s.db(r).Where("repository_id = ?", id).Order("id desc")
 	if status := r.URL.Query().Get("status"); status != "" {
 		q = q.Where("status = ?", status)
 	}
@@ -158,7 +158,7 @@ func (s *Server) apiListScans(w http.ResponseWriter, r *http.Request) {
 func (s *Server) apiGetScan(w http.ResponseWriter, r *http.Request) {
 	id, _ := strconv.Atoi(r.PathValue("id"))
 	var sc db.Scan
-	if err := s.DB.First(&sc, id).Error; err != nil {
+	if err := s.db(r).First(&sc, id).Error; err != nil {
 		writeAPIError(w, http.StatusNotFound, "scan not found")
 		return
 	}
@@ -180,7 +180,7 @@ func (s *Server) apiRunSkill(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	var skill db.Skill
-	if err := s.DB.Where("name = ? AND active = ?", name, true).First(&skill).Error; err != nil {
+	if err := s.db(r).Where("name = ? AND active = ?", name, true).First(&skill).Error; err != nil {
 		writeAPIError(w, http.StatusNotFound, "skill not found or inactive")
 		return
 	}
@@ -194,7 +194,7 @@ func (s *Server) apiRunSkill(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	var sc db.Scan
-	s.DB.First(&sc, scanID)
+	s.db(r).First(&sc, scanID)
 	writeJSON(w, http.StatusCreated, scanSummary(sc))
 }
 
@@ -214,7 +214,7 @@ func (s *Server) apiRunFindingSkill(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	var skill db.Skill
-	if err := s.DB.Where("name = ? AND active = ?", name, true).First(&skill).Error; err != nil {
+	if err := s.db(r).Where("name = ? AND active = ?", name, true).First(&skill).Error; err != nil {
 		writeAPIError(w, http.StatusNotFound, "skill not found or inactive")
 		return
 	}
@@ -229,7 +229,7 @@ func (s *Server) apiRunFindingSkill(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	var sc db.Scan
-	s.DB.First(&sc, scanID)
+	s.db(r).First(&sc, scanID)
 	writeJSON(w, http.StatusCreated, scanSummary(sc))
 }
 
@@ -246,7 +246,7 @@ func (s *Server) findingRepoID(findingID uint) (uint, bool) {
 }
 
 func (s *Server) apiListSkills(w http.ResponseWriter, r *http.Request) {
-	q := s.DB.Order("name")
+	q := s.db(r).Order("name")
 	if v := r.URL.Query().Get("active"); v != "" {
 		active, _ := strconv.ParseBool(v)
 		q = q.Where("active = ?", active)

--- a/internal/web/api_export.go
+++ b/internal/web/api_export.go
@@ -26,13 +26,13 @@ func (s *Server) apiExportRepoFindings(w http.ResponseWriter, r *http.Request) {
 	}
 	id, _ := strconv.Atoi(r.PathValue("id"))
 	var repo db.Repository
-	if err := s.DB.First(&repo, id).Error; err != nil {
+	if err := s.db(r).First(&repo, id).Error; err != nil {
 		writeAPIError(w, http.StatusNotFound, "repository not found")
 		return
 	}
 
-	q := s.DB.Model(&db.Finding{}).
-		Where("scan_id IN (?)", s.DB.Model(&db.Scan{}).Select("id").Where("repository_id = ?", id)).
+	q := s.db(r).Model(&db.Finding{}).
+		Where("scan_id IN (?)", s.db(r).Model(&db.Scan{}).Select("id").Where("repository_id = ?", id)).
 		Order("id desc")
 	q = applyFindingFilters(q, r)
 	streamJSONL(w, q, findingExport)
@@ -42,7 +42,7 @@ func (s *Server) apiExportFindings(w http.ResponseWriter, r *http.Request) {
 	if !validateExportFormat(w, r) {
 		return
 	}
-	q := applyFindingFilters(s.DB.Model(&db.Finding{}).Order("id desc"), r)
+	q := applyFindingFilters(s.db(r).Model(&db.Finding{}).Order("id desc"), r)
 	streamJSONL(w, q, findingExport)
 }
 
@@ -50,7 +50,7 @@ func (s *Server) apiExportScans(w http.ResponseWriter, r *http.Request) {
 	if !validateExportFormat(w, r) {
 		return
 	}
-	q := s.DB.Model(&db.Scan{}).Order("id desc")
+	q := s.db(r).Model(&db.Scan{}).Order("id desc")
 	if v := r.URL.Query().Get("status"); v != "" {
 		q = q.Where("status = ?", v)
 	}

--- a/internal/web/api_finding_writes.go
+++ b/internal/web/api_finding_writes.go
@@ -70,7 +70,7 @@ func (s *Server) apiListFindingNotes(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	var rows []db.FindingNote
-	s.DB.Where("finding_id = ?", id).Order("created_at desc").Find(&rows)
+	s.db(r).Where("finding_id = ?", id).Order("created_at desc").Find(&rows)
 	writeJSON(w, http.StatusOK, rows)
 }
 
@@ -105,7 +105,7 @@ func (s *Server) apiListFindingCommunications(w http.ResponseWriter, r *http.Req
 		return
 	}
 	var rows []db.FindingCommunication
-	s.DB.Where("finding_id = ?", id).Order("at desc").Find(&rows)
+	s.db(r).Where("finding_id = ?", id).Order("at desc").Find(&rows)
 	writeJSON(w, http.StatusOK, rows)
 }
 
@@ -137,7 +137,7 @@ func (s *Server) apiListFindingReferences(w http.ResponseWriter, r *http.Request
 		return
 	}
 	var rows []db.FindingReference
-	s.DB.Where("finding_id = ?", id).Order("id desc").Find(&rows)
+	s.db(r).Where("finding_id = ?", id).Order("id desc").Find(&rows)
 	writeJSON(w, http.StatusOK, rows)
 }
 
@@ -166,7 +166,7 @@ func (s *Server) apiListFindingHistory(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	var rows []db.FindingHistory
-	s.DB.Where("finding_id = ?", id).Order("created_at desc").Find(&rows)
+	s.db(r).Where("finding_id = ?", id).Order("created_at desc").Find(&rows)
 	writeJSON(w, http.StatusOK, rows)
 }
 

--- a/internal/web/api_reads.go
+++ b/internal/web/api_reads.go
@@ -19,7 +19,7 @@ func (s *Server) apiListMaintainers(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	var rows []db.Maintainer
-	s.DB.Joins("JOIN repository_maintainers rm ON rm.maintainer_id = maintainers.id").
+	s.db(r).Joins("JOIN repository_maintainers rm ON rm.maintainer_id = maintainers.id").
 		Where("rm.repository_id = ?", id).
 		Order("maintainers.login").Find(&rows)
 	out := make([]map[string]any, 0, len(rows))
@@ -44,7 +44,7 @@ func (s *Server) apiListPackages(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	var rows []db.Package
-	s.DB.Where("repository_id = ?", id).Order("dependent_repos desc, downloads desc").Find(&rows)
+	s.db(r).Where("repository_id = ?", id).Order("dependent_repos desc, downloads desc").Find(&rows)
 	out := make([]map[string]any, 0, len(rows))
 	for _, p := range rows {
 		out = append(out, map[string]any{
@@ -71,7 +71,7 @@ func (s *Server) apiListAdvisories(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	var rows []db.Advisory
-	s.DB.Where("repository_id = ?", id).Order("cvss_score desc").Find(&rows)
+	s.db(r).Where("repository_id = ?", id).Order("cvss_score desc").Find(&rows)
 	out := make([]map[string]any, 0, len(rows))
 	for _, a := range rows {
 		out = append(out, map[string]any{
@@ -97,7 +97,7 @@ func (s *Server) apiListDependents(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	var rows []db.Dependent
-	s.DB.Where("repository_id = ?", id).Order("dependent_repos desc").Find(&rows)
+	s.db(r).Where("repository_id = ?", id).Order("dependent_repos desc").Find(&rows)
 	out := make([]map[string]any, 0, len(rows))
 	for _, d := range rows {
 		out = append(out, map[string]any{
@@ -122,7 +122,7 @@ func (s *Server) apiListDependencies(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	var rows []db.Dependency
-	s.DB.Where("repository_id = ?", id).Order("ecosystem, name").Find(&rows)
+	s.db(r).Where("repository_id = ?", id).Order("ecosystem, name").Find(&rows)
 	out := make([]map[string]any, 0, len(rows))
 	for _, d := range rows {
 		out = append(out, map[string]any{
@@ -176,7 +176,7 @@ func (s *Server) apiListFindings(w http.ResponseWriter, r *http.Request) {
 	}
 	// Direct subquery; GORM's Joins("Scan") aliasing doesn't round-trip on
 	// sqlite when the joined struct has its own relations.
-	q := s.DB.Where("scan_id IN (?)", s.DB.Model(&db.Scan{}).Select("id").Where("repository_id = ?", id)).
+	q := s.db(r).Where("scan_id IN (?)", s.db(r).Model(&db.Scan{}).Select("id").Where("repository_id = ?", id)).
 		Order("id desc")
 	if sev := r.URL.Query().Get("severity"); sev != "" {
 		q = q.Where("severity = ?", sev)
@@ -198,7 +198,7 @@ func (s *Server) apiListFindings(w http.ResponseWriter, r *http.Request) {
 func (s *Server) apiGetFinding(w http.ResponseWriter, r *http.Request) {
 	id, _ := strconv.Atoi(r.PathValue("id"))
 	var f db.Finding
-	if err := s.DB.First(&f, id).Error; err != nil {
+	if err := s.db(r).First(&f, id).Error; err != nil {
 		writeAPIError(w, http.StatusNotFound, "finding not found")
 		return
 	}

--- a/internal/web/dbstats.go
+++ b/internal/web/dbstats.go
@@ -1,0 +1,76 @@
+package web
+
+import (
+	"context"
+	"sync/atomic"
+	"time"
+
+	"gorm.io/gorm"
+)
+
+type ctxKey struct{}
+
+type queryStats struct {
+	count   atomic.Int64
+	totalNs atomic.Int64
+}
+
+func (qs *queryStats) record(d time.Duration) {
+	qs.count.Add(1)
+	qs.totalNs.Add(d.Nanoseconds())
+}
+
+func (qs *queryStats) Count() int64            { return qs.count.Load() }
+func (qs *queryStats) Duration() time.Duration { return time.Duration(qs.totalNs.Load()) }
+
+func contextWithStats(ctx context.Context) context.Context {
+	return context.WithValue(ctx, ctxKey{}, &queryStats{})
+}
+
+func statsFromContext(ctx context.Context) *queryStats {
+	qs, _ := ctx.Value(ctxKey{}).(*queryStats)
+	return qs
+}
+
+var startTimeKey = "web:start"
+
+func registerQueryStatsCallback(gdb *gorm.DB) {
+	cb := gdb.Callback()
+	cb.Query().Before("gorm:query").Register("web:before_query", stampStart)
+	cb.Query().After("gorm:query").Register("web:after_query", recordElapsed)
+	cb.Create().Before("gorm:create").Register("web:before_create", stampStart)
+	cb.Create().After("gorm:create").Register("web:after_create", recordElapsed)
+	cb.Update().Before("gorm:update").Register("web:before_update", stampStart)
+	cb.Update().After("gorm:update").Register("web:after_update", recordElapsed)
+	cb.Delete().Before("gorm:delete").Register("web:before_delete", stampStart)
+	cb.Delete().After("gorm:delete").Register("web:after_delete", recordElapsed)
+	cb.Raw().Before("gorm:raw").Register("web:before_raw", stampStart)
+	cb.Raw().After("gorm:raw").Register("web:after_raw", recordElapsed)
+	cb.Row().Before("gorm:row").Register("web:before_row", stampStart)
+	cb.Row().After("gorm:row").Register("web:after_row", recordElapsed)
+}
+
+func stampStart(gdb *gorm.DB) {
+	if gdb.Statement == nil {
+		return
+	}
+	if statsFromContext(gdb.Statement.Context) == nil {
+		return
+	}
+	gdb.Statement.Settings.Store(startTimeKey, time.Now())
+}
+
+func recordElapsed(gdb *gorm.DB) {
+	if gdb.Statement == nil {
+		return
+	}
+	qs := statsFromContext(gdb.Statement.Context)
+	if qs == nil {
+		return
+	}
+	v, ok := gdb.Statement.Settings.Load(startTimeKey)
+	if !ok {
+		return
+	}
+	qs.record(time.Since(v.(time.Time)))
+}

--- a/internal/web/dbstats.go
+++ b/internal/web/dbstats.go
@@ -34,20 +34,28 @@ func statsFromContext(ctx context.Context) *queryStats {
 
 var startTimeKey = "web:start"
 
-func registerQueryStatsCallback(gdb *gorm.DB) {
+func registerQueryStatsCallback(gdb *gorm.DB) error {
 	cb := gdb.Callback()
-	cb.Query().Before("gorm:query").Register("web:before_query", stampStart)
-	cb.Query().After("gorm:query").Register("web:after_query", recordElapsed)
-	cb.Create().Before("gorm:create").Register("web:before_create", stampStart)
-	cb.Create().After("gorm:create").Register("web:after_create", recordElapsed)
-	cb.Update().Before("gorm:update").Register("web:before_update", stampStart)
-	cb.Update().After("gorm:update").Register("web:after_update", recordElapsed)
-	cb.Delete().Before("gorm:delete").Register("web:before_delete", stampStart)
-	cb.Delete().After("gorm:delete").Register("web:after_delete", recordElapsed)
-	cb.Raw().Before("gorm:raw").Register("web:before_raw", stampStart)
-	cb.Raw().After("gorm:raw").Register("web:after_raw", recordElapsed)
-	cb.Row().Before("gorm:row").Register("web:before_row", stampStart)
-	cb.Row().After("gorm:row").Register("web:after_row", recordElapsed)
+	regs := []error{
+		cb.Query().Before("gorm:query").Register("web:before_query", stampStart),
+		cb.Query().After("gorm:query").Register("web:after_query", recordElapsed),
+		cb.Create().Before("gorm:create").Register("web:before_create", stampStart),
+		cb.Create().After("gorm:create").Register("web:after_create", recordElapsed),
+		cb.Update().Before("gorm:update").Register("web:before_update", stampStart),
+		cb.Update().After("gorm:update").Register("web:after_update", recordElapsed),
+		cb.Delete().Before("gorm:delete").Register("web:before_delete", stampStart),
+		cb.Delete().After("gorm:delete").Register("web:after_delete", recordElapsed),
+		cb.Raw().Before("gorm:raw").Register("web:before_raw", stampStart),
+		cb.Raw().After("gorm:raw").Register("web:after_raw", recordElapsed),
+		cb.Row().Before("gorm:row").Register("web:before_row", stampStart),
+		cb.Row().After("gorm:row").Register("web:after_row", recordElapsed),
+	}
+	for _, err := range regs {
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func stampStart(gdb *gorm.DB) {

--- a/internal/web/finding_forms.go
+++ b/internal/web/finding_forms.go
@@ -24,7 +24,7 @@ var analystFields = []string{
 
 func (s *Server) findingFields(w http.ResponseWriter, r *http.Request) {
 	var f db.Finding
-	if err := s.DB.First(&f, r.PathValue("id")).Error; err != nil {
+	if err := s.db(r).First(&f, r.PathValue("id")).Error; err != nil {
 		http.NotFound(w, r)
 		return
 	}
@@ -47,7 +47,7 @@ func (s *Server) findingFields(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) findingCommunications(w http.ResponseWriter, r *http.Request) {
 	var f db.Finding
-	if err := s.DB.First(&f, r.PathValue("id")).Error; err != nil {
+	if err := s.db(r).First(&f, r.PathValue("id")).Error; err != nil {
 		http.NotFound(w, r)
 		return
 	}
@@ -72,7 +72,7 @@ func (s *Server) findingCommunications(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) findingReferences(w http.ResponseWriter, r *http.Request) {
 	var f db.Finding
-	if err := s.DB.First(&f, r.PathValue("id")).Error; err != nil {
+	if err := s.db(r).First(&f, r.PathValue("id")).Error; err != nil {
 		http.NotFound(w, r)
 		return
 	}
@@ -90,7 +90,7 @@ func (s *Server) findingReferences(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) findingLabels(w http.ResponseWriter, r *http.Request) {
 	var f db.Finding
-	if err := s.DB.First(&f, r.PathValue("id")).Error; err != nil {
+	if err := s.db(r).First(&f, r.PathValue("id")).Error; err != nil {
 		http.NotFound(w, r)
 		return
 	}

--- a/internal/web/finding_patch.go
+++ b/internal/web/finding_patch.go
@@ -51,7 +51,7 @@ func (s *Server) latestPatchScan(findingID uint) (*db.Scan, *patchReport, error)
 // file.
 func (s *Server) findingPatchDownload(w http.ResponseWriter, r *http.Request) {
 	var f db.Finding
-	if err := s.DB.First(&f, r.PathValue("id")).Error; err != nil {
+	if err := s.db(r).First(&f, r.PathValue("id")).Error; err != nil {
 		http.NotFound(w, r)
 		return
 	}

--- a/internal/web/org_report.go
+++ b/internal/web/org_report.go
@@ -24,7 +24,7 @@ func (s *Server) orgReport(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	var repos []db.Repository
-	s.DB.Where("owner = ?", owner).Order("name").Find(&repos)
+	s.db(r).Where("owner = ?", owner).Order("name").Find(&repos)
 	if len(repos) == 0 {
 		http.NotFound(w, r)
 		return

--- a/internal/web/org_summary.go
+++ b/internal/web/org_summary.go
@@ -29,7 +29,7 @@ func (s *Server) orgSummary(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	var repos []db.Repository
-	s.DB.Where("owner = ?", owner).Order("name").Find(&repos)
+	s.db(r).Where("owner = ?", owner).Order("name").Find(&repos)
 	if len(repos) == 0 {
 		http.NotFound(w, r)
 		return

--- a/internal/web/repo_report.go
+++ b/internal/web/repo_report.go
@@ -19,7 +19,7 @@ import (
 // a filename hint so clicking the download button saves a file.
 func (s *Server) repoReport(w http.ResponseWriter, r *http.Request) {
 	var repo db.Repository
-	if err := s.DB.First(&repo, r.PathValue("id")).Error; err != nil {
+	if err := s.db(r).First(&repo, r.PathValue("id")).Error; err != nil {
 		http.NotFound(w, r)
 		return
 	}

--- a/internal/web/sboms.go
+++ b/internal/web/sboms.go
@@ -29,7 +29,7 @@ func (s *Server) registerSBOMRoutes(mux *http.ServeMux) {
 
 func (s *Server) sbomList(w http.ResponseWriter, r *http.Request) {
 	var rows []db.SBOMUpload
-	s.DB.Order("id desc").Find(&rows)
+	s.db(r).Order("id desc").Find(&rows)
 	s.render(w, r, "sboms.html", map[string]any{"SBOMs": rows})
 }
 
@@ -77,7 +77,7 @@ func (s *Server) sbomUpload(w http.ResponseWriter, r *http.Request) {
 			Scope:     scope[p.ID],
 		})
 	}
-	if err := s.DB.Create(&up).Error; err != nil {
+	if err := s.db(r).Create(&up).Error; err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -89,7 +89,7 @@ func (s *Server) sbomUpload(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) sbomShow(w http.ResponseWriter, r *http.Request) {
 	var up db.SBOMUpload
-	if err := s.DB.Preload("Packages.Repository").First(&up, r.PathValue("id")).Error; err != nil {
+	if err := s.db(r).Preload("Packages.Repository").First(&up, r.PathValue("id")).Error; err != nil {
 		http.NotFound(w, r)
 		return
 	}
@@ -133,7 +133,7 @@ func (s *Server) sbomShow(w http.ResponseWriter, r *http.Request) {
 	var findings []db.Finding
 	var advisories []db.Advisory
 	if len(repoIDs) > 0 {
-		q := s.DB.Where("repository_id IN ? AND status NOT IN ?", repoIDs,
+		q := s.db(r).Where("repository_id IN ? AND status NOT IN ?", repoIDs,
 			[]db.FindingLifecycle{db.FindingRejected, db.FindingDuplicate})
 		if sev := r.URL.Query().Get("severity"); sev != "" {
 			q = q.Where("severity = ?", sev)
@@ -150,7 +150,7 @@ func (s *Server) sbomShow(w http.ResponseWriter, r *http.Request) {
 		}
 		q.Find(&findings)
 
-		s.DB.Where("repository_id IN ? AND withdrawn_at IS NULL", repoIDs).
+		s.db(r).Where("repository_id IN ? AND withdrawn_at IS NULL", repoIDs).
 			Order("cvss_score desc, published_at desc").Find(&advisories)
 	}
 
@@ -175,7 +175,7 @@ func (s *Server) sbomShow(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) sbomResolve(w http.ResponseWriter, r *http.Request) {
 	var up db.SBOMUpload
-	if err := s.DB.First(&up, r.PathValue("id")).Error; err != nil {
+	if err := s.db(r).First(&up, r.PathValue("id")).Error; err != nil {
 		http.NotFound(w, r)
 		return
 	}
@@ -194,7 +194,7 @@ func (s *Server) goResolve(uploadID uint) {
 }
 
 func (s *Server) sbomDelete(w http.ResponseWriter, r *http.Request) {
-	if err := s.DB.Delete(&db.SBOMUpload{}, r.PathValue("id")).Error; err != nil {
+	if err := s.db(r).Delete(&db.SBOMUpload{}, r.PathValue("id")).Error; err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -143,8 +143,13 @@ func New(gdb *gorm.DB, q *queue.Queue, log *slog.Logger, broker *Broker, w *work
 	if err != nil {
 		return nil, err
 	}
+	registerQueryStatsCallback(gdb)
 	return &Server{DB: gdb, Queue: q, Log: log, Broker: broker, Worker: w, tmpl: t,
 		resolvePURL: resolvePURLRepo}, nil
+}
+
+func (s *Server) db(r *http.Request) *gorm.DB {
+	return s.DB.WithContext(r.Context())
 }
 
 func (s *Server) Handler() http.Handler {
@@ -367,7 +372,7 @@ func distinctLanguages(gdb *gorm.DB) []string {
 }
 
 func (s *Server) repoList(w http.ResponseWriter, r *http.Request) {
-	q := s.DB.Model(&db.Repository{})
+	q := s.db(r).Model(&db.Repository{})
 	lang := r.URL.Query().Get("language")
 	if lang != "" {
 		// languages is a ", "-joined list; wrapping both sides lets one
@@ -421,7 +426,7 @@ func (s *Server) repoList(w http.ResponseWriter, r *http.Request) {
 			N            int
 		}
 		var counts []rowCount
-		s.DB.Model(&db.Finding{}).
+		s.db(r).Model(&db.Finding{}).
 			Select("repository_id, COUNT(*) AS n").
 			Where("repository_id IN ?", repoIDs).
 			Group("repository_id").
@@ -435,7 +440,7 @@ func (s *Server) repoList(w http.ResponseWriter, r *http.Request) {
 		// For each repo, the latest scan. A single query using a grouped
 		// subquery avoids one-query-per-row.
 		var scans []db.Scan
-		s.DB.Raw(`
+		s.db(r).Raw(`
 			SELECT s.* FROM scans s
 			JOIN (SELECT repository_id, MAX(id) AS max_id FROM scans
 				WHERE repository_id IN ? GROUP BY repository_id) latest
@@ -511,7 +516,7 @@ func (s *Server) orgsList(w http.ResponseWriter, r *http.Request) {
 		LastActivity string
 	}
 	var aggs []aggRow
-	q := s.DB.Model(&db.Repository{}).
+	q := s.db(r).Model(&db.Repository{}).
 		Select("owner, COUNT(*) AS repos, MAX(updated_at) AS last_activity").
 		Where("owner != ''").
 		Group("owner")
@@ -528,7 +533,7 @@ func (s *Server) orgsList(w http.ResponseWriter, r *http.Request) {
 			N     int
 		}
 		var counts []c
-		s.DB.Raw(`
+		s.db(r).Raw(`
 			SELECT r.owner, COUNT(f.id) AS n
 			FROM repositories r
 			LEFT JOIN findings f ON f.repository_id = r.id
@@ -596,7 +601,7 @@ func (s *Server) orgShow(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var repos []db.Repository
-	s.DB.Where("owner = ?", owner).Order("name").Find(&repos)
+	s.db(r).Where("owner = ?", owner).Order("name").Find(&repos)
 	if len(repos) == 0 {
 		http.NotFound(w, r)
 		return
@@ -614,7 +619,7 @@ func (s *Server) orgShow(w http.ResponseWriter, r *http.Request) {
 		N            int
 	}
 	var counts []rowCount
-	s.DB.Model(&db.Finding{}).
+	s.db(r).Model(&db.Finding{}).
 		Select("repository_id, COUNT(*) AS n").
 		Where("repository_id IN ?", repoIDs).
 		Group("repository_id").Scan(&counts)
@@ -627,18 +632,18 @@ func (s *Server) orgShow(w http.ResponseWriter, r *http.Request) {
 	// within a severity. Purely alphabetical severity would put Low
 	// before Medium, which misreads for a stakeholder scanning the tab.
 	var findings []db.Finding
-	s.DB.Where("repository_id IN ?", repoIDs).
+	s.db(r).Where("repository_id IN ?", repoIDs).
 		Order(severityOrder).Order("id desc").
 		Limit(orgTabLimit).Find(&findings)
 	reposByID := loadRepoMap(s.DB, findings)
 
 	var advisories []db.Advisory
-	s.DB.Where("repository_id IN ?", repoIDs).Order("cvss_score desc").
+	s.db(r).Where("repository_id IN ?", repoIDs).Order("cvss_score desc").
 		Limit(orgTabLimit).Find(&advisories)
 	advisoryRepos := loadAdvisoryRepoMap(s.DB, advisories)
 
 	var maintainers []db.Maintainer
-	s.DB.Joins("JOIN repository_maintainers rm ON rm.maintainer_id = maintainers.id").
+	s.db(r).Joins("JOIN repository_maintainers rm ON rm.maintainer_id = maintainers.id").
 		Where("rm.repository_id IN ?", repoIDs).
 		Distinct().Order("maintainers.name").Find(&maintainers)
 
@@ -655,7 +660,7 @@ func (s *Server) orgShow(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) maintainersList(w http.ResponseWriter, r *http.Request) {
-	q := s.DB.Model(&db.Maintainer{})
+	q := s.db(r).Model(&db.Maintainer{})
 	status := r.URL.Query().Get("status")
 	if status != "" {
 		q = q.Where("status = ?", status)
@@ -703,7 +708,7 @@ func (s *Server) maintainersList(w http.ResponseWriter, r *http.Request) {
 			N            int
 		}
 		var counts []row
-		s.DB.Raw(`
+		s.db(r).Raw(`
 			SELECT rm.maintainer_id, COUNT(f.id) AS n
 			FROM repository_maintainers rm
 			LEFT JOIN findings f ON f.repository_id = rm.repository_id
@@ -730,12 +735,12 @@ func (s *Server) maintainersList(w http.ResponseWriter, r *http.Request) {
 func (s *Server) maintainerDoNotContact(w http.ResponseWriter, r *http.Request) {
 	id, _ := strconv.Atoi(r.PathValue("id"))
 	var m db.Maintainer
-	if err := s.DB.First(&m, id).Error; err != nil {
+	if err := s.db(r).First(&m, id).Error; err != nil {
 		http.NotFound(w, r)
 		return
 	}
 	value := r.FormValue("value") == "true"
-	if err := s.DB.Model(&db.Maintainer{}).Where("id = ?", m.ID).
+	if err := s.db(r).Model(&db.Maintainer{}).Where("id = ?", m.ID).
 		Update("do_not_contact", value).Error; err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -745,7 +750,7 @@ func (s *Server) maintainerDoNotContact(w http.ResponseWriter, r *http.Request) 
 
 func (s *Server) maintainerShow(w http.ResponseWriter, r *http.Request) {
 	var m db.Maintainer
-	if err := s.DB.Preload("Repositories").First(&m, r.PathValue("id")).Error; err != nil {
+	if err := s.db(r).Preload("Repositories").First(&m, r.PathValue("id")).Error; err != nil {
 		http.NotFound(w, r)
 		return
 	}
@@ -756,7 +761,7 @@ func (s *Server) maintainerShow(w http.ResponseWriter, r *http.Request) {
 	}
 	var findings []db.Finding
 	if len(repoIDs) > 0 {
-		s.DB.Where("repository_id IN ?", repoIDs).Order("id desc").Find(&findings)
+		s.db(r).Where("repository_id IN ?", repoIDs).Order("id desc").Find(&findings)
 	}
 	reposByID := loadRepoMap(s.DB, findings)
 	s.render(w, r, "maintainer_show.html", map[string]any{
@@ -798,7 +803,7 @@ var scanStatusOrder = `CASE scans.status
 	WHEN 'running' THEN 0 WHEN 'queued' THEN 1 ELSE 2 END`
 
 func (s *Server) findings(w http.ResponseWriter, r *http.Request) {
-	q := s.DB.Model(&db.Finding{})
+	q := s.db(r).Model(&db.Finding{})
 	sev := r.URL.Query().Get("severity")
 	if sev != "" {
 		q = q.Where("severity = ?", sev)
@@ -806,7 +811,7 @@ func (s *Server) findings(w http.ResponseWriter, r *http.Request) {
 	owner := r.URL.Query().Get("owner")
 	if owner != "" {
 		q = q.Where("repository_id IN (?)",
-			s.DB.Model(&db.Repository{}).Select("id").Where("owner = ?", owner))
+			s.db(r).Model(&db.Repository{}).Select("id").Where("owner = ?", owner))
 	}
 	search := strings.TrimSpace(r.URL.Query().Get("q"))
 	if search != "" {
@@ -851,7 +856,7 @@ func (s *Server) findings(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) depScan(w http.ResponseWriter, r *http.Request) {
 	var dep db.Dependency
-	if err := s.DB.First(&dep, r.PathValue("id")).Error; err != nil {
+	if err := s.db(r).First(&dep, r.PathValue("id")).Error; err != nil {
 		http.NotFound(w, r)
 		return
 	}
@@ -865,7 +870,7 @@ func (s *Server) depScan(w http.ResponseWriter, r *http.Request) {
 
 	// Find or create
 	repo := db.Repository{URL: repoURL, Name: db.NameFromURL(repoURL)}
-	if err := s.DB.Where(db.Repository{URL: repoURL}).FirstOrCreate(&repo).Error; err != nil {
+	if err := s.db(r).Where(db.Repository{URL: repoURL}).FirstOrCreate(&repo).Error; err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -898,7 +903,7 @@ func resolvePURLRepo(ctx context.Context, purl string) string {
 
 func (s *Server) dependentScan(w http.ResponseWriter, r *http.Request) {
 	var dep db.Dependent
-	if err := s.DB.First(&dep, r.PathValue("id")).Error; err != nil {
+	if err := s.db(r).First(&dep, r.PathValue("id")).Error; err != nil {
 		http.NotFound(w, r)
 		return
 	}
@@ -921,15 +926,15 @@ const (
 
 func (s *Server) addRepoAndScan(w http.ResponseWriter, r *http.Request, repoURL string) {
 	repo := db.Repository{URL: repoURL, Name: db.NameFromURL(repoURL)}
-	if err := s.DB.Where(db.Repository{URL: repoURL}).FirstOrCreate(&repo).Error; err != nil {
+	if err := s.db(r).Where(db.Repository{URL: repoURL}).FirstOrCreate(&repo).Error; err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 	var scanCount int64
-	s.DB.Model(&db.Scan{}).Where("repository_id = ?", repo.ID).Count(&scanCount)
+	s.db(r).Model(&db.Scan{}).Where("repository_id = ?", repo.ID).Count(&scanCount)
 	if scanCount == 0 {
 		var skill db.Skill
-		if err := s.DB.Where("name = ? AND active = ?", defaultSkillName, true).
+		if err := s.db(r).Where("name = ? AND active = ?", defaultSkillName, true).
 			First(&skill).Error; err == nil {
 			_, _ = s.enqueueSkill(r.Context(), repo.ID, skill.ID, "")
 		} else {
@@ -941,7 +946,7 @@ func (s *Server) addRepoAndScan(w http.ResponseWriter, r *http.Request, repoURL 
 
 func (s *Server) findingStatus(w http.ResponseWriter, r *http.Request) {
 	var f db.Finding
-	if err := s.DB.First(&f, r.PathValue("id")).Error; err != nil {
+	if err := s.db(r).First(&f, r.PathValue("id")).Error; err != nil {
 		http.NotFound(w, r)
 		return
 	}
@@ -984,17 +989,17 @@ func (s *Server) findingPatchRun(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) runFindingSkill(w http.ResponseWriter, r *http.Request, name string) {
 	var f db.Finding
-	if err := s.DB.First(&f, r.PathValue("id")).Error; err != nil {
+	if err := s.db(r).First(&f, r.PathValue("id")).Error; err != nil {
 		http.NotFound(w, r)
 		return
 	}
 	var scan db.Scan
-	if err := s.DB.First(&scan, f.ScanID).Error; err != nil {
+	if err := s.db(r).First(&scan, f.ScanID).Error; err != nil {
 		http.Error(w, "scan for finding not found", http.StatusInternalServerError)
 		return
 	}
 	var skill db.Skill
-	if err := s.DB.Where("name = ? AND active = ?", name, true).First(&skill).Error; err != nil {
+	if err := s.db(r).Where("name = ? AND active = ?", name, true).First(&skill).Error; err != nil {
 		http.Error(w, name+" skill is not installed", http.StatusPreconditionFailed)
 		return
 	}
@@ -1009,7 +1014,7 @@ func (s *Server) runFindingSkill(w http.ResponseWriter, r *http.Request, name st
 
 func (s *Server) findingNotes(w http.ResponseWriter, r *http.Request) {
 	var f db.Finding
-	if err := s.DB.First(&f, r.PathValue("id")).Error; err != nil {
+	if err := s.db(r).First(&f, r.PathValue("id")).Error; err != nil {
 		http.NotFound(w, r)
 		return
 	}
@@ -1021,7 +1026,7 @@ func (s *Server) findingNotes(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) packages(w http.ResponseWriter, r *http.Request) {
-	q := s.DB.Model(&db.Package{})
+	q := s.db(r).Model(&db.Package{})
 	eco := r.URL.Query().Get("ecosystem")
 	if eco != "" {
 		q = q.Where("ecosystem = ?", eco)
@@ -1056,7 +1061,7 @@ func (s *Server) packages(w http.ResponseWriter, r *http.Request) {
 	q.Limit(perPage).Offset((page.N - 1) * perPage).Find(&rows)
 
 	var ecosystems []string
-	s.DB.Model(&db.Package{}).Distinct("ecosystem").Order("ecosystem").Pluck("ecosystem", &ecosystems)
+	s.db(r).Model(&db.Package{}).Distinct("ecosystem").Order("ecosystem").Pluck("ecosystem", &ecosystems)
 
 	s.render(w, r, "packages.html", map[string]any{
 		"Pkgs": rows, "Page": page, "Ecosystem": eco, "Sort": sort, "Ecosystems": ecosystems,
@@ -1066,7 +1071,7 @@ func (s *Server) packages(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) packageShow(w http.ResponseWriter, r *http.Request) {
 	var p db.Package
-	if err := s.DB.Preload("Repository").First(&p, r.PathValue("id")).Error; err != nil {
+	if err := s.db(r).Preload("Repository").First(&p, r.PathValue("id")).Error; err != nil {
 		http.NotFound(w, r)
 		return
 	}
@@ -1078,7 +1083,7 @@ func (s *Server) packageShow(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) advisoriesList(w http.ResponseWriter, r *http.Request) {
-	q := s.DB.Model(&db.Advisory{})
+	q := s.db(r).Model(&db.Advisory{})
 	sev := r.URL.Query().Get("severity")
 	if sev != "" {
 		q = q.Where("severity = ?", sev)
@@ -1111,7 +1116,7 @@ func (s *Server) advisoriesList(w http.ResponseWriter, r *http.Request) {
 
 	reposByID := loadAdvisoryRepoMap(s.DB, rows)
 	var severities []string
-	s.DB.Model(&db.Advisory{}).Where("severity != ''").Distinct("severity").
+	s.db(r).Model(&db.Advisory{}).Where("severity != ''").Distinct("severity").
 		Order("severity").Pluck("severity", &severities)
 
 	s.render(w, r, "advisories.html", map[string]any{
@@ -1147,24 +1152,24 @@ func loadAdvisoryRepoMap(gdb *gorm.DB, rows []db.Advisory) map[uint]db.Repositor
 
 func (s *Server) findingShow(w http.ResponseWriter, r *http.Request) {
 	var f db.Finding
-	if err := s.DB.Preload("Labels").First(&f, r.PathValue("id")).Error; err != nil {
+	if err := s.db(r).Preload("Labels").First(&f, r.PathValue("id")).Error; err != nil {
 		http.NotFound(w, r)
 		return
 	}
 	var scan db.Scan
-	s.DB.First(&scan, f.ScanID)
+	s.db(r).First(&scan, f.ScanID)
 	var repo db.Repository
-	s.DB.First(&repo, scan.RepositoryID)
+	s.db(r).First(&repo, scan.RepositoryID)
 	var notes []db.FindingNote
-	s.DB.Where("finding_id = ?", f.ID).Order("created_at desc").Find(&notes)
+	s.db(r).Where("finding_id = ?", f.ID).Order("created_at desc").Find(&notes)
 	var comms []db.FindingCommunication
-	s.DB.Where("finding_id = ?", f.ID).Order("at desc").Find(&comms)
+	s.db(r).Where("finding_id = ?", f.ID).Order("at desc").Find(&comms)
 	var refs []db.FindingReference
-	s.DB.Where("finding_id = ?", f.ID).Order("id desc").Find(&refs)
+	s.db(r).Where("finding_id = ?", f.ID).Order("id desc").Find(&refs)
 	var history []db.FindingHistory
-	s.DB.Where("finding_id = ?", f.ID).Order("created_at desc").Find(&history)
+	s.db(r).Where("finding_id = ?", f.ID).Order("created_at desc").Find(&history)
 	var labels []db.FindingLabel
-	s.DB.Order("name").Find(&labels)
+	s.db(r).Order("name").Find(&labels)
 	selected := make(map[string]bool, len(f.Labels))
 	for _, l := range f.Labels {
 		selected[l.Name] = true
@@ -1192,7 +1197,7 @@ func (s *Server) findingShow(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) jobs(w http.ResponseWriter, r *http.Request) {
-	q := s.DB.Model(&db.Scan{})
+	q := s.db(r).Model(&db.Scan{})
 	skillName := r.URL.Query().Get("skill")
 	if skillName != "" {
 		q = q.Where("skill_name = ?", skillName)
@@ -1224,7 +1229,7 @@ func (s *Server) jobs(w http.ResponseWriter, r *http.Request) {
 		Limit(perPage).Offset((page.N - 1) * perPage).Find(&scans)
 
 	var skillNames []string
-	s.DB.Model(&db.Scan{}).Where("skill_name != ''").Distinct("skill_name").
+	s.db(r).Model(&db.Scan{}).Where("skill_name != ''").Distinct("skill_name").
 		Order("skill_name").Pluck("skill_name", &skillNames)
 
 	anySubPath := false
@@ -1366,7 +1371,7 @@ func bulkToastDescription(invalid []string) string {
 
 func (s *Server) repoShow(w http.ResponseWriter, r *http.Request) {
 	var repo db.Repository
-	if err := s.DB.First(&repo, r.PathValue("id")).Error; err != nil {
+	if err := s.db(r).First(&repo, r.PathValue("id")).Error; err != nil {
 		http.NotFound(w, r)
 		return
 	}
@@ -1375,7 +1380,7 @@ func (s *Server) repoShow(w http.ResponseWriter, r *http.Request) {
 	// page should read like "this is the state of each job on this repo",
 	// not a scroll of every historical attempt. Older runs are still
 	// reachable via /scans/{id} and the global /scans index.
-	s.DB.Raw(`
+	s.db(r).Raw(`
 		SELECT s.* FROM scans s
 		JOIN (
 			SELECT COALESCE(skill_name, '') AS sn, COALESCE(sub_path, '') AS sp, MAX(id) AS max_id
@@ -1395,7 +1400,7 @@ func (s *Server) repoShow(w http.ResponseWriter, r *http.Request) {
 		}
 		if latest == nil {
 			latest = &scans[i]
-			s.DB.Where("scan_id = ?", latest.ID).Find(&latest.Findings)
+			s.db(r).Where("scan_id = ?", latest.ID).Find(&latest.Findings)
 		}
 		if scans[i].Status == db.ScanDone && scans[i].Report != "" && threatModel == nil {
 			var report map[string]any
@@ -1409,7 +1414,7 @@ func (s *Server) repoShow(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var totalCost float64
-	s.DB.Model(&db.Scan{}).Where("repository_id = ?", repo.ID).
+	s.db(r).Model(&db.Scan{}).Where("repository_id = ?", repo.ID).
 		Select("COALESCE(SUM(cost_usd), 0)").Scan(&totalCost)
 
 	// All findings across every scan of this repo, not just the latest
@@ -1417,26 +1422,26 @@ func (s *Server) repoShow(w http.ResponseWriter, r *http.Request) {
 	// stay off the tab; everything else is shown so an empty or failed
 	// latest scan does not hide earlier results (#72).
 	var findings []db.Finding
-	s.DB.Where("repository_id = ? AND status NOT IN ?", repo.ID,
+	s.db(r).Where("repository_id = ? AND status NOT IN ?", repo.ID,
 		[]db.FindingLifecycle{db.FindingRejected, db.FindingDuplicate}).
 		Order(severityOrder).Order("id desc").Find(&findings)
 
 	var maintainers []db.Maintainer
-	s.DB.Joins("JOIN repository_maintainers ON repository_maintainers.maintainer_id = maintainers.id").
+	s.db(r).Joins("JOIN repository_maintainers ON repository_maintainers.maintainer_id = maintainers.id").
 		Where("repository_maintainers.repository_id = ?", repo.ID).Find(&maintainers)
 
 	var rawDeps []db.Dependency
-	s.DB.Where("repository_id = ?", repo.ID).Order("ecosystem, name, manifest_kind desc").Find(&rawDeps)
+	s.db(r).Where("repository_id = ?", repo.ID).Order("ecosystem, name, manifest_kind desc").Find(&rawDeps)
 	deps := groupDeps(rawDeps)
 
 	var pkgs []db.Package
-	s.DB.Where("repository_id = ?", repo.ID).Order("dependent_repos desc, downloads desc").Find(&pkgs)
+	s.db(r).Where("repository_id = ?", repo.ID).Order("dependent_repos desc, downloads desc").Find(&pkgs)
 
 	var dependents []db.Dependent
-	s.DB.Where("repository_id = ?", repo.ID).Order("dependent_repos desc").Find(&dependents)
+	s.db(r).Where("repository_id = ?", repo.ID).Order("dependent_repos desc").Find(&dependents)
 
 	var advisories []db.Advisory
-	s.DB.Where("repository_id = ?", repo.ID).Order("cvss_score desc").Find(&advisories)
+	s.db(r).Where("repository_id = ?", repo.ID).Order("cvss_score desc").Find(&advisories)
 
 	knownURLs := buildKnownURLs(s.DB)
 	knownPURLs := buildKnownPURLs(s.DB)
@@ -1448,17 +1453,17 @@ func (s *Server) repoShow(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var activeSkills []db.Skill
-	s.DB.Where("active = ?", true).Order("name").Find(&activeSkills)
+	s.db(r).Where("active = ?", true).Order("name").Find(&activeSkills)
 
 	var subprojects []db.Subproject
-	s.DB.Where("repository_id = ?", repo.ID).Order("path").Find(&subprojects)
+	s.db(r).Where("repository_id = ?", repo.ID).Order("path").Find(&subprojects)
 	subScanCount := map[string]int{}
 	if len(subprojects) > 0 {
 		rows := make([]struct {
 			SubPath string
 			N       int
 		}, 0)
-		s.DB.Raw(`SELECT sub_path, COUNT(*) AS n FROM scans
+		s.db(r).Raw(`SELECT sub_path, COUNT(*) AS n FROM scans
 			WHERE repository_id = ? AND sub_path != '' GROUP BY sub_path`,
 			repo.ID).Scan(&rows)
 		for _, r := range rows {
@@ -1482,14 +1487,14 @@ func (s *Server) repoShow(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) repoScan(w http.ResponseWriter, r *http.Request) {
 	var repo db.Repository
-	if err := s.DB.First(&repo, r.PathValue("id")).Error; err != nil {
+	if err := s.db(r).First(&repo, r.PathValue("id")).Error; err != nil {
 		http.NotFound(w, r)
 		return
 	}
 	// The "New scan" button enqueues the deep-dive skill; everything else is
 	// triggered either by the triage skill or by the explicit Run skill menu.
 	var skill db.Skill
-	if err := s.DB.Where("name = ? AND active = ?", deepDiveSkillName, true).First(&skill).Error; err != nil {
+	if err := s.db(r).Where("name = ? AND active = ?", deepDiveSkillName, true).First(&skill).Error; err != nil {
 		http.Error(w, deepDiveSkillName+" skill is not installed", http.StatusPreconditionFailed)
 		return
 	}
@@ -1509,12 +1514,12 @@ func (s *Server) repoScan(w http.ResponseWriter, r *http.Request) {
 func (s *Server) repoDisclosureChannel(w http.ResponseWriter, r *http.Request) {
 	id, _ := strconv.Atoi(r.PathValue("id"))
 	var repo db.Repository
-	if err := s.DB.First(&repo, id).Error; err != nil {
+	if err := s.db(r).First(&repo, id).Error; err != nil {
 		http.NotFound(w, r)
 		return
 	}
 	value := strings.TrimSpace(r.FormValue("disclosure_channel"))
-	if err := s.DB.Model(&db.Repository{}).Where("id = ?", repo.ID).
+	if err := s.db(r).Model(&db.Repository{}).Where("id = ?", repo.ID).
 		Update("disclosure_channel", value).Error; err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -1524,7 +1529,7 @@ func (s *Server) repoDisclosureChannel(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) scanShow(w http.ResponseWriter, r *http.Request) {
 	var scan db.Scan
-	if err := s.DB.Preload("Repository").Preload("Findings").First(&scan, r.PathValue("id")).Error; err != nil {
+	if err := s.db(r).Preload("Repository").Preload("Findings").First(&scan, r.PathValue("id")).Error; err != nil {
 		http.NotFound(w, r)
 		return
 	}
@@ -1533,7 +1538,7 @@ func (s *Server) scanShow(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) scanRetry(w http.ResponseWriter, r *http.Request) {
 	var scan db.Scan
-	if err := s.DB.First(&scan, r.PathValue("id")).Error; err != nil {
+	if err := s.db(r).First(&scan, r.PathValue("id")).Error; err != nil {
 		http.NotFound(w, r)
 		return
 	}
@@ -1555,7 +1560,7 @@ func (s *Server) scanRetry(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) scanCancel(w http.ResponseWriter, r *http.Request) {
 	var scan db.Scan
-	if err := s.DB.First(&scan, r.PathValue("id")).Error; err != nil {
+	if err := s.db(r).First(&scan, r.PathValue("id")).Error; err != nil {
 		http.NotFound(w, r)
 		return
 	}
@@ -1566,7 +1571,7 @@ func (s *Server) scanCancel(w http.ResponseWriter, r *http.Request) {
 	if !s.Worker.Cancel(scan.ID) {
 		// Not in flight: mark the row so the queue handler drops it on pickup.
 		now := time.Now()
-		s.DB.Model(&scan).Updates(map[string]any{
+		s.db(r).Model(&scan).Updates(map[string]any{
 			"status":      db.ScanCancelled,
 			"error":       "cancelled by user",
 			"finished_at": &now,
@@ -1579,7 +1584,7 @@ func (s *Server) scanCancel(w http.ResponseWriter, r *http.Request) {
 // hx-trigger while the scan is running so the operator can watch claude work.
 func (s *Server) scanLog(w http.ResponseWriter, r *http.Request) {
 	var scan db.Scan
-	if err := s.DB.First(&scan, r.PathValue("id")).Error; err != nil {
+	if err := s.db(r).First(&scan, r.PathValue("id")).Error; err != nil {
 		http.NotFound(w, r)
 		return
 	}
@@ -1791,8 +1796,15 @@ func securityHeaders(h http.Handler) http.Handler {
 
 func logRequests(log *slog.Logger, h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := contextWithStats(r.Context())
+		r = r.WithContext(ctx)
 		start := time.Now()
 		h.ServeHTTP(w, r)
-		log.Info("http", "method", r.Method, "path", r.URL.Path, "dur", time.Since(start).Round(time.Millisecond))
+		dur := time.Since(start).Round(time.Millisecond)
+		attrs := []any{"method", r.Method, "path", r.URL.Path, "dur", dur}
+		if qs := statsFromContext(ctx); qs != nil && qs.Count() > 0 {
+			attrs = append(attrs, "queries", qs.Count(), "query_time", qs.Duration().Round(time.Millisecond))
+		}
+		log.Info("http", attrs...)
 	})
 }

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -143,7 +143,9 @@ func New(gdb *gorm.DB, q *queue.Queue, log *slog.Logger, broker *Broker, w *work
 	if err != nil {
 		return nil, err
 	}
-	registerQueryStatsCallback(gdb)
+	if err := registerQueryStatsCallback(gdb); err != nil {
+		return nil, err
+	}
 	return &Server{DB: gdb, Queue: q, Log: log, Broker: broker, Worker: w, tmpl: t,
 		resolvePURL: resolvePURLRepo}, nil
 }

--- a/internal/web/skills_handlers.go
+++ b/internal/web/skills_handlers.go
@@ -10,14 +10,14 @@ import (
 
 func (s *Server) skillsList(w http.ResponseWriter, r *http.Request) {
 	var skills []db.Skill
-	s.DB.Order("active desc, name asc").Find(&skills)
+	s.db(r).Order("active desc, name asc").Find(&skills)
 	s.render(w, r, "skills.html", map[string]any{"Skills": skills})
 }
 
 func (s *Server) skillShow(w http.ResponseWriter, r *http.Request) {
 	id, _ := strconv.Atoi(r.PathValue("id"))
 	var skill db.Skill
-	if err := s.DB.First(&skill, id).Error; err != nil {
+	if err := s.db(r).First(&skill, id).Error; err != nil {
 		http.NotFound(w, r)
 		return
 	}
@@ -35,7 +35,7 @@ func (s *Server) skillNew(w http.ResponseWriter, r *http.Request) {
 func (s *Server) skillEdit(w http.ResponseWriter, r *http.Request) {
 	id, _ := strconv.Atoi(r.PathValue("id"))
 	var skill db.Skill
-	if err := s.DB.First(&skill, id).Error; err != nil {
+	if err := s.db(r).First(&skill, id).Error; err != nil {
 		http.NotFound(w, r)
 		return
 	}
@@ -66,7 +66,7 @@ func (s *Server) skillCreate(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "name and description are required", http.StatusBadRequest)
 		return
 	}
-	if err := s.DB.Create(&skill).Error; err != nil {
+	if err := s.db(r).Create(&skill).Error; err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
@@ -76,7 +76,7 @@ func (s *Server) skillCreate(w http.ResponseWriter, r *http.Request) {
 func (s *Server) skillUpdate(w http.ResponseWriter, r *http.Request) {
 	id, _ := strconv.Atoi(r.PathValue("id"))
 	var skill db.Skill
-	if err := s.DB.First(&skill, id).Error; err != nil {
+	if err := s.db(r).First(&skill, id).Error; err != nil {
 		http.NotFound(w, r)
 		return
 	}
@@ -92,7 +92,7 @@ func (s *Server) skillUpdate(w http.ResponseWriter, r *http.Request) {
 	skill.SchemaJSON = r.FormValue("schema_json")
 	skill.Active = r.FormValue("active") == "on"
 	skill.Version++
-	if err := s.DB.Save(&skill).Error; err != nil {
+	if err := s.db(r).Save(&skill).Error; err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
@@ -109,7 +109,7 @@ func (s *Server) skillRun(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	var skill db.Skill
-	if err := s.DB.First(&skill, skillID).Error; err != nil || !skill.Active {
+	if err := s.db(r).First(&skill, skillID).Error; err != nil || !skill.Active {
 		http.Error(w, "skill not found or inactive", http.StatusNotFound)
 		return
 	}

--- a/internal/web/theme.go
+++ b/internal/web/theme.go
@@ -50,19 +50,19 @@ func (s *Server) settingsShow(w http.ResponseWriter, r *http.Request) {
 		Maintainers int64
 		Skills      int64
 	}
-	s.DB.Table("repositories").Count(&stats.Repos)
-	s.DB.Table("scans").Count(&stats.Scans)
-	s.DB.Table("findings").Count(&stats.Findings)
-	s.DB.Table("packages").Count(&stats.Packages)
-	s.DB.Table("advisories").Count(&stats.Advisories)
-	s.DB.Table("maintainers").Count(&stats.Maintainers)
-	s.DB.Table("skills").Count(&stats.Skills)
+	s.db(r).Table("repositories").Count(&stats.Repos)
+	s.db(r).Table("scans").Count(&stats.Scans)
+	s.db(r).Table("findings").Count(&stats.Findings)
+	s.db(r).Table("packages").Count(&stats.Packages)
+	s.db(r).Table("advisories").Count(&stats.Advisories)
+	s.db(r).Table("maintainers").Count(&stats.Maintainers)
+	s.db(r).Table("skills").Count(&stats.Skills)
 
 	var dbSizeBytes int64
-	s.DB.Raw("SELECT page_count * page_size FROM pragma_page_count(), pragma_page_size()").Scan(&dbSizeBytes)
+	s.db(r).Raw("SELECT page_count * page_size FROM pragma_page_count(), pragma_page_size()").Scan(&dbSizeBytes)
 
 	var dbPath string
-	s.DB.Raw("SELECT file FROM pragma_database_list WHERE name = 'main'").Scan(&dbPath)
+	s.db(r).Raw("SELECT file FROM pragma_database_list WHERE name = 'main'").Scan(&dbPath)
 
 	s.render(w, r, "settings.html", map[string]any{
 		"Themes":       config.Themes,

--- a/internal/web/usage.go
+++ b/internal/web/usage.go
@@ -33,7 +33,7 @@ func (s *Server) usage(w http.ResponseWriter, r *http.Request) {
 	// rows have zero cost and would drag the floor down, and failed runs
 	// did still spend tokens so they stay in.
 	var scans []db.Scan
-	s.DB.Select("skill_name", "cost_usd", "turns",
+	s.db(r).Select("skill_name", "cost_usd", "turns",
 		"input_tokens", "output_tokens", "cache_read_tokens", "cache_write_tokens").
 		Where("status IN ?", []db.ScanStatus{db.ScanDone, db.ScanFailed}).
 		Where("skill_name != ''").


### PR DESCRIPTION
Adds per-request SQL observability to the HTTP log lines. Each request now logs the number of queries executed and their total time, e.g.:

```
level=INFO msg=http method=GET path=/repositories dur=45ms queries=5 query_time=32ms
```

GORM before/after callbacks track individual query durations. The `logRequests` middleware injects a stats tracker into the request context, and handlers use `s.db(r)` (which calls `s.DB.WithContext`) to propagate it. Non-handler code (background jobs, SSE renderers) still uses `s.DB` directly and is untracked.