### PR TITLE
Fix path traversal in skill name/output and egress proxy port restriction

### DIFF
--- a/cmd/scrutineer/main.go
+++ b/cmd/scrutineer/main.go
@@ -225,7 +225,7 @@ func run(log *slog.Logger) error {
 	if !f.noDocker && worker.DockerAvailable() {
 		allow := append(append([]string{}, worker.DefaultEgressAllow...), egressExtra...)
 		token := worker.NewProxyToken()
-		port, err := worker.StartEgressProxy(&worker.EgressProxy{Allow: allow, Token: token, Log: log})
+		port, err := worker.StartEgressProxy(&worker.EgressProxy{Allow: allow, Token: token, APIPort: addrPort(f.addr), Log: log})
 		if err != nil {
 			return fmt.Errorf("start egress proxy: %w", err)
 		}

--- a/internal/web/skills_handlers.go
+++ b/internal/web/skills_handlers.go
@@ -2,11 +2,26 @@ package web
 
 import (
 	"net/http"
+	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 
 	"scrutineer/internal/db"
 )
+
+var skillNameRE = regexp.MustCompile(`^[a-z0-9]+(-[a-z0-9]+)*$`)
+
+func validateSkillName(name string) bool {
+	return skillNameRE.MatchString(name)
+}
+
+func validateOutputFile(f string) bool {
+	if f == "" {
+		return true
+	}
+	return f == filepath.Base(f) && filepath.IsLocal(f) && !strings.Contains(f, "..")
+}
 
 func (s *Server) skillsList(w http.ResponseWriter, r *http.Request) {
 	var skills []db.Skill
@@ -66,6 +81,14 @@ func (s *Server) skillCreate(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "name and description are required", http.StatusBadRequest)
 		return
 	}
+	if !validateSkillName(skill.Name) {
+		http.Error(w, "name must be lowercase alphanumeric with hyphens (e.g. my-skill-1)", http.StatusBadRequest)
+		return
+	}
+	if !validateOutputFile(skill.OutputFile) {
+		http.Error(w, "output_file must be a plain filename with no path separators", http.StatusBadRequest)
+		return
+	}
 	if err := s.DB.Create(&skill).Error; err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
@@ -91,6 +114,14 @@ func (s *Server) skillUpdate(w http.ResponseWriter, r *http.Request) {
 	skill.OutputKind = strings.TrimSpace(r.FormValue("output_kind"))
 	skill.SchemaJSON = r.FormValue("schema_json")
 	skill.Active = r.FormValue("active") == "on"
+	if !validateSkillName(skill.Name) {
+		http.Error(w, "name must be lowercase alphanumeric with hyphens (e.g. my-skill-1)", http.StatusBadRequest)
+		return
+	}
+	if !validateOutputFile(skill.OutputFile) {
+		http.Error(w, "output_file must be a plain filename with no path separators", http.StatusBadRequest)
+		return
+	}
 	skill.Version++
 	if err := s.DB.Save(&skill).Error; err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)

--- a/internal/web/skills_handlers_test.go
+++ b/internal/web/skills_handlers_test.go
@@ -65,6 +65,74 @@ func TestSkillsCreateAndShow(t *testing.T) {
 	}
 }
 
+func TestSkillCreate_rejectsTraversalName(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	h := s.Handler()
+
+	for _, name := range []string{"../../etc", "a/b", "A_B", "has spaces", "..", "../x"} {
+		form := url.Values{
+			"name":        {name},
+			"description": {"d"},
+			"body":        {"b"},
+		}
+		req := localReq("POST", "/skills")
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		req.Body = httptest.NewRequest("POST", "/skills", strings.NewReader(form.Encode())).Body
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+		if w.Code != 400 {
+			t.Errorf("name=%q: got status %d, want 400", name, w.Code)
+		}
+	}
+}
+
+func TestSkillCreate_rejectsTraversalOutputFile(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	h := s.Handler()
+
+	for _, of := range []string{"../scrutineer.db", "../../etc/passwd", "sub/report.json"} {
+		form := url.Values{
+			"name":        {"good-name"},
+			"description": {"d"},
+			"body":        {"b"},
+			"output_file": {of},
+		}
+		req := localReq("POST", "/skills")
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		req.Body = httptest.NewRequest("POST", "/skills", strings.NewReader(form.Encode())).Body
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+		if w.Code != 400 {
+			t.Errorf("output_file=%q: got status %d, want 400", of, w.Code)
+		}
+	}
+}
+
+func TestSkillCreate_acceptsValidNames(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	h := s.Handler()
+
+	for _, name := range []string{"triage", "my-skill", "scan-2"} {
+		form := url.Values{
+			"name":        {name},
+			"description": {"d"},
+			"body":        {"b"},
+			"output_file": {"report.json"},
+		}
+		req := localReq("POST", "/skills")
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		req.Body = httptest.NewRequest("POST", "/skills", strings.NewReader(form.Encode())).Body
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+		if w.Code != 303 {
+			t.Errorf("name=%q: got status %d, want 303; body=%s", name, w.Code, w.Body)
+		}
+	}
+}
+
 func TestSkillRetry_preservesSkillID(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()

--- a/internal/worker/egress.go
+++ b/internal/worker/egress.go
@@ -79,9 +79,10 @@ var DefaultEgressAllow = []string{
 // the proxy listens on all interfaces so the docker bridge can reach it,
 // and the token stops it being an open relay on the LAN.
 type EgressProxy struct {
-	Allow []string
-	Token string
-	Log   *slog.Logger
+	Allow   []string
+	Token   string
+	APIPort string // only this port is allowed for HostGatewayAlias
+	Log     *slog.Logger
 
 	transport *http.Transport
 	once      sync.Once
@@ -137,6 +138,11 @@ func (p *EgressProxy) serveConnect(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "egress to "+host+" is not on the allowlist", http.StatusForbidden)
 		return
 	}
+	if strings.EqualFold(host, HostGatewayAlias) && p.APIPort != "" && port != p.APIPort {
+		p.Log.Warn("egress denied", "method", "CONNECT", "host", host, "port", port, "allowed_port", p.APIPort)
+		http.Error(w, "egress to "+host+" is only allowed on port "+p.APIPort, http.StatusForbidden)
+		return
+	}
 	upstream, err := net.DialTimeout("tcp", dialTarget(host, port), egressDialTimeout)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadGateway)
@@ -167,6 +173,11 @@ func (p *EgressProxy) serveForward(w http.ResponseWriter, r *http.Request) {
 	if !HostAllowed(p.Allow, host) {
 		p.Log.Warn("egress denied", "method", r.Method, "host", host)
 		http.Error(w, "egress to "+host+" is not on the allowlist", http.StatusForbidden)
+		return
+	}
+	if strings.EqualFold(host, HostGatewayAlias) && p.APIPort != "" && port != p.APIPort {
+		p.Log.Warn("egress denied", "method", r.Method, "host", host, "port", port, "allowed_port", p.APIPort)
+		http.Error(w, "egress to "+host+" is only allowed on port "+p.APIPort, http.StatusForbidden)
 		return
 	}
 	out := r.Clone(r.Context())

--- a/internal/worker/egress_test.go
+++ b/internal/worker/egress_test.go
@@ -167,6 +167,59 @@ func TestEgressProxy_ConnectEndToEnd(t *testing.T) {
 	}
 }
 
+func TestEgressProxy_DeniesGatewayOnWrongPort(t *testing.T) {
+	p := &EgressProxy{
+		Allow:   []string{HostGatewayAlias},
+		APIPort: "8080",
+		Log:     quietLog(),
+	}
+
+	// CONNECT to allowed port should work (as far as allowlist goes)
+	r := httptest.NewRequest(http.MethodConnect, HostGatewayAlias+":8080", nil)
+	w := httptest.NewRecorder()
+	p.ServeHTTP(w, r)
+	// Will fail with 502 (no upstream listener) but NOT 403
+	if w.Code == http.StatusForbidden {
+		t.Fatalf("CONNECT to API port should not be forbidden: %s", w.Body)
+	}
+
+	// CONNECT to a different port should be denied
+	r = httptest.NewRequest(http.MethodConnect, HostGatewayAlias+":9090", nil)
+	w = httptest.NewRecorder()
+	p.ServeHTTP(w, r)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("CONNECT to non-API port: got %d, want 403", w.Code)
+	}
+
+	// Forward (non-CONNECT) to a different port should also be denied
+	r = httptest.NewRequest("GET", "http://"+HostGatewayAlias+":9090/secrets", nil)
+	w = httptest.NewRecorder()
+	p.ServeHTTP(w, r)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("forward to non-API port: got %d, want 403", w.Code)
+	}
+}
+
+func TestEgressProxy_NoPortRestrictionForOtherHosts(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, "ok")
+	}))
+	defer upstream.Close()
+	_, port, _ := net.SplitHostPort(upstream.Listener.Addr().String())
+
+	p := &EgressProxy{
+		Allow:   []string{"127.0.0.1"},
+		APIPort: "8080",
+		Log:     quietLog(),
+	}
+	r := httptest.NewRequest("GET", "http://127.0.0.1:"+port+"/foo", nil)
+	w := httptest.NewRecorder()
+	p.ServeHTTP(w, r)
+	if w.Code != http.StatusOK {
+		t.Fatalf("non-gateway host on any port should be allowed: got %d", w.Code)
+	}
+}
+
 func TestProxyURLShape(t *testing.T) {
 	got := ProxyURL("abc", 1234)
 	want := "http://scrutineer:abc@host.docker.internal:1234"

--- a/internal/worker/skill.go
+++ b/internal/worker/skill.go
@@ -78,6 +78,12 @@ func (w *Worker) doSkill(ctx context.Context, scan *db.Scan, emit func(Event)) (
 	// successful completion; failed/cancelled dirs are left so the
 	// operator can inspect what the skill saw.
 	workRoot := w.workRoot(scan.ID)
+	if !filepath.IsLocal(skill.Name) || strings.Contains(skill.Name, "/") {
+		return "", fmt.Errorf("skill name %q contains path separators", skill.Name)
+	}
+	if skill.OutputFile != "" && (skill.OutputFile != filepath.Base(skill.OutputFile) || !filepath.IsLocal(skill.OutputFile)) {
+		return "", fmt.Errorf("skill output_file %q contains path separators", skill.OutputFile)
+	}
 	skillDir := filepath.Join(workRoot, ".claude", "skills", skill.Name)
 	if err := stageSkill(&skill, skillDir); err != nil {
 		return "", fmt.Errorf("stage skill: %w", err)

--- a/internal/worker/skill.go
+++ b/internal/worker/skill.go
@@ -78,11 +78,8 @@ func (w *Worker) doSkill(ctx context.Context, scan *db.Scan, emit func(Event)) (
 	// successful completion; failed/cancelled dirs are left so the
 	// operator can inspect what the skill saw.
 	workRoot := w.workRoot(scan.ID)
-	if !filepath.IsLocal(skill.Name) || strings.Contains(skill.Name, "/") {
-		return "", fmt.Errorf("skill name %q contains path separators", skill.Name)
-	}
-	if skill.OutputFile != "" && (skill.OutputFile != filepath.Base(skill.OutputFile) || !filepath.IsLocal(skill.OutputFile)) {
-		return "", fmt.Errorf("skill output_file %q contains path separators", skill.OutputFile)
+	if err := validateSkillPaths(skill.Name, skill.OutputFile); err != nil {
+		return "", err
 	}
 	skillDir := filepath.Join(workRoot, ".claude", "skills", skill.Name)
 	if err := stageSkill(&skill, skillDir); err != nil {
@@ -273,6 +270,16 @@ func (w *Worker) parseMaintainersOutput(scan *db.Scan, report string, emit func(
 		_ = w.DB.Model(&repo).Association("Maintainers").Replace(linked)
 	}
 	emit(Event{Kind: KindText, Text: fmt.Sprintf("identified %d maintainer(s)", len(result.Maintainers))})
+	return nil
+}
+
+func validateSkillPaths(name, outputFile string) error {
+	if !filepath.IsLocal(name) || strings.Contains(name, "/") {
+		return fmt.Errorf("skill name %q contains path separators", name)
+	}
+	if outputFile != "" && (outputFile != filepath.Base(outputFile) || !filepath.IsLocal(outputFile)) {
+		return fmt.Errorf("skill output_file %q contains path separators", outputFile)
+	}
 	return nil
 }
 


### PR DESCRIPTION
Fixes three findings from a self-scan (#2446, #2447, #2448).

- Validate `Skill.Name` against `^[a-z0-9]+(-[a-z0-9]+)*$` on create and update, preventing path traversal via `os.RemoveAll` in `stageSkill`
- Validate `Skill.OutputFile` is a bare filename (no `/`, no `..`), preventing arbitrary file delete/read via `os.Remove`/`readCappedReport`
- Add defence-in-depth checks in the worker before computing filesystem paths, guarding against direct DB edits
- Restrict the egress proxy to only tunnel `host.docker.internal` on the configured API port, preventing a sandboxed container from reaching the unauthenticated web UI or other loopback services