### PR TITLE
Support branch-scoped scans

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -91,6 +91,10 @@ type Scan struct {
 	FindingID *uint  `gorm:"index"`
 	APIToken  string `gorm:"index"`
 
+	// Ref is the git ref (branch, tag, commit) to checkout after cloning.
+	// Empty means the repository's default branch (origin/HEAD).
+	Ref string
+
 	// SubPath scopes the scan's code analysis to a sub-folder within the
 	// clone (e.g. airflow-core inside apache/airflow). Empty means the
 	// repo root. Skills that walk files honour this through

--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -187,9 +187,13 @@ func (s *Server) apiRunSkill(w http.ResponseWriter, r *http.Request) {
 	}
 	var body struct {
 		Model string `json:"model"`
+		Ref   string `json:"ref"`
 	}
 	_ = json.NewDecoder(r.Body).Decode(&body)
-	scanID, err := s.enqueueSkill(r.Context(), uint(id), skill.ID, body.Model)
+	scanID, err := s.enqueueSkillWith(r.Context(), uint(id), skill.ID, ScanOpts{
+		Model: body.Model,
+		Ref:   body.Ref,
+	})
 	if err != nil {
 		writeAPIError(w, http.StatusInternalServerError, err.Error())
 		return
@@ -301,7 +305,7 @@ func (s *Server) apiListSkills(w http.ResponseWriter, r *http.Request) {
 }
 
 func scanSummary(sc db.Scan) map[string]any {
-	return map[string]any{
+	m := map[string]any{
 		"id":            sc.ID,
 		"repository_id": sc.RepositoryID,
 		"kind":          sc.Kind,
@@ -314,6 +318,10 @@ func scanSummary(sc db.Scan) map[string]any {
 		"finished_at":   sc.FinishedAt,
 		"error":         sc.Error,
 	}
+	if sc.Ref != "" {
+		m["ref"] = sc.Ref
+	}
+	return m
 }
 
 func writeJSON(w http.ResponseWriter, code int, v any) {

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -1315,21 +1315,22 @@ func (s *Server) createOrTriageRepo(ctx context.Context, input RepoInput, model 
 		return repo, false, err
 	}
 	isNew := existing == 0
-	if !isNew {
+	if !isNew && input.Branch == "" && input.SubPath == "" {
 		return repo, false, nil
 	}
 	var skill db.Skill
 	if err := s.DB.Where("name = ? AND active = ?", defaultSkillName, true).First(&skill).Error; err != nil {
 		s.Log.Warn("default skill not found, repo added with no scans", "skill", defaultSkillName)
-		return repo, true, nil
+		return repo, isNew, nil
 	}
 	if _, err := s.enqueueSkillWith(ctx, repo.ID, skill.ID, ScanOpts{
 		Model:   model,
 		SubPath: input.SubPath,
+		Ref:     input.Branch,
 	}); err != nil {
-		return repo, true, err
+		return repo, isNew, err
 	}
-	return repo, true, nil
+	return repo, isNew, nil
 }
 
 func bulkToastCategory(created int, invalid []string) string {
@@ -1545,6 +1546,7 @@ func (s *Server) scanRetry(w http.ResponseWriter, r *http.Request) {
 		Model:     scan.Model,
 		FindingID: scan.FindingID,
 		SubPath:   scan.SubPath,
+		Ref:       scan.Ref,
 	})
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -1600,6 +1602,7 @@ type ScanOpts struct {
 	Model     string
 	FindingID *uint
 	SubPath   string
+	Ref       string
 }
 
 func (s *Server) enqueueSkill(ctx context.Context, repoID, skillID uint, model string) (uint, error) {
@@ -1627,6 +1630,7 @@ func (s *Server) enqueueSkillWith(ctx context.Context, repoID, skillID uint, opt
 		SkillID:      &skillID,
 		FindingID:    opts.FindingID,
 		SubPath:      opts.SubPath,
+		Ref:          opts.Ref,
 		APIToken:     NewAPIToken(),
 	}
 	if err := s.DB.Create(&scan).Error; err != nil {

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -1895,3 +1895,81 @@ func TestMaintainerShow_displaysFindingStatus(t *testing.T) {
 		t.Errorf("finding status not rendered in maintainer findings tab")
 	}
 }
+
+func TestRepoCreate_branchURLTriggersTriageWithRef(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	s.DB.Create(&db.Skill{Name: "triage", Active: true, Source: "test", Body: "test", OutputFile: "report.json", OutputKind: "freeform", Version: 1})
+
+	form := url.Values{"url": {"https://github.com/apache/httpd/tree/2.4.x"}}
+	req := httptest.NewRequest("POST", "/repositories", strings.NewReader(form.Encode()))
+	req.Host = testHost
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Sec-Fetch-Site", "same-origin")
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+
+	var scan db.Scan
+	if err := s.DB.First(&scan).Error; err != nil {
+		t.Fatalf("no scan created: %v", err)
+	}
+	if scan.Ref != "2.4.x" {
+		t.Errorf("scan.Ref = %q, want %q", scan.Ref, "2.4.x")
+	}
+}
+
+func TestRepoCreate_existingRepoWithBranchEnqueuesScan(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	s.DB.Create(&db.Skill{Name: "triage", Active: true, Source: "test", Body: "test", OutputFile: "report.json", OutputKind: "freeform", Version: 1})
+	s.DB.Create(&db.Repository{URL: "https://github.com/apache/httpd.git", Name: "httpd"})
+
+	form := url.Values{"url": {"https://github.com/apache/httpd/tree/2.4.x"}}
+	req := httptest.NewRequest("POST", "/repositories", strings.NewReader(form.Encode()))
+	req.Host = testHost
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Sec-Fetch-Site", "same-origin")
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+
+	var scan db.Scan
+	if err := s.DB.First(&scan).Error; err != nil {
+		t.Fatalf("no scan created for existing repo with branch: %v", err)
+	}
+	if scan.Ref != "2.4.x" {
+		t.Errorf("scan.Ref = %q, want %q", scan.Ref, "2.4.x")
+	}
+}
+
+func TestRepoCreate_existingRepoWithoutBranchDoesNotEnqueue(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	s.DB.Create(&db.Skill{Name: "triage", Active: true, Source: "test", Body: "test", OutputFile: "report.json", OutputKind: "freeform", Version: 1})
+	s.DB.Create(&db.Repository{URL: "https://github.com/apache/httpd.git", Name: "httpd"})
+
+	form := url.Values{"url": {"https://github.com/apache/httpd"}}
+	req := httptest.NewRequest("POST", "/repositories", strings.NewReader(form.Encode()))
+	req.Host = testHost
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Sec-Fetch-Site", "same-origin")
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+
+	var count int64
+	s.DB.Model(&db.Scan{}).Count(&count)
+	if count != 0 {
+		t.Errorf("expected no scan for plain re-add, got %d", count)
+	}
+}

--- a/internal/web/templates/scan_show.html
+++ b/internal/web/templates/scan_show.html
@@ -23,6 +23,10 @@
     <dt class="text-muted-foreground">Model</dt>
     <dd>{{if .Model}}{{.Model}}{{else}}-{{end}}</dd>
   </div>
+  {{if .Ref}}<div>
+    <dt class="text-muted-foreground">Ref</dt>
+    <dd>{{.Ref}}</dd>
+  </div>{{end}}
   <div>
     <dt class="text-muted-foreground">Commit</dt>
     <dd><code>{{if .Commit}}{{short .Commit}}{{else}}-{{end}}</code></dd>

--- a/internal/worker/claude.go
+++ b/internal/worker/claude.go
@@ -36,6 +36,7 @@ type SkillJob struct {
 	Name       string
 	SkillDir   string // host absolute path to the staged skill directory
 	OutputFile string // relative to the scan workspace, e.g. "report.json"
+	Ref        string // git ref to checkout; empty = default branch
 }
 
 type SkillResult struct {
@@ -56,7 +57,7 @@ type LocalClaude struct {
 //	{DataDir}/scan-{id}/.claude/skills/NAME staged skill (read by claude-code)
 //	{DataDir}/scan-{id}/OutputFile          where the skill writes, if any
 func (l LocalClaude) RunSkill(ctx context.Context, sj SkillJob, emit func(Event)) (SkillResult, error) {
-	src, err := ensureClone(ctx, sj.Repo, sj.WorkRoot, l.FullClone, emit)
+	src, err := ensureClone(ctx, sj.Repo, sj.WorkRoot, l.FullClone, sj.Ref, emit)
 	if err != nil {
 		return SkillResult{}, err
 	}

--- a/internal/worker/clone.go
+++ b/internal/worker/clone.go
@@ -20,12 +20,12 @@ const dirPerm = 0o755
 // (scan-{id}) so concurrent scans do not share src or report.json,
 // removing a class of races where skill A's output gets clobbered by
 // skill B removing report.json before A finishes reading it.
-func ensureClone(ctx context.Context, repo db.Repository, work string, fullClone bool, emit func(Event)) (string, error) {
+func ensureClone(ctx context.Context, repo db.Repository, work string, fullClone bool, ref string, emit func(Event)) (string, error) {
 	src := filepath.Join(work, "src")
 	if err := os.MkdirAll(work, dirPerm); err != nil {
 		return "", err
 	}
-	if err := cloneOrFetch(ctx, repo.URL, src, fullClone, emit); err != nil {
+	if err := cloneOrFetch(ctx, repo.URL, src, fullClone, ref, emit); err != nil {
 		return "", fmt.Errorf("clone: %w", err)
 	}
 	return src, nil
@@ -40,9 +40,13 @@ func validateGitURL(u string) error {
 	return nil
 }
 
-func cloneOrFetch(ctx context.Context, url, dst string, fullClone bool, emit func(Event)) error {
+func cloneOrFetch(ctx context.Context, url, dst string, fullClone bool, ref string, emit func(Event)) error {
 	if err := validateGitURL(url); err != nil {
 		return err
+	}
+	resetTarget := "origin/HEAD"
+	if ref != "" {
+		resetTarget = "origin/" + ref
 	}
 	if _, err := os.Stat(filepath.Join(dst, ".git")); err == nil {
 		fetchArgs := []string{"-C", dst, "fetch", "--quiet", "origin"}
@@ -58,18 +62,20 @@ func cloneOrFetch(ctx context.Context, url, dst string, fullClone bool, emit fun
 		if out, err := git(ctx, "", fetchArgs...); err != nil {
 			return fmt.Errorf("%s: %w", out, err)
 		}
-		if out, err := git(ctx, "", "-C", dst, "reset", "--quiet", "--hard", "origin/HEAD"); err != nil {
+		if out, err := git(ctx, "", "-C", dst, "reset", "--quiet", "--hard", resetTarget); err != nil {
 			return fmt.Errorf("%s: %w", out, err)
 		}
 		return nil
 	}
-	// -- stops git option parsing so a URL can't be interpreted as a flag.
-	// GIT_PROTOCOL_FROM_USER=0 blocks ext:: and other user-facing protocol handlers.
 	args := []string{"clone", "--quiet"}
 	msg := "$ git clone " + url
+	if ref != "" {
+		args = append(args, "--branch", ref)
+		msg += " --branch " + ref
+	}
 	if !fullClone {
-		args = []string{"clone", "--depth", "1", "--quiet"}
-		msg = "$ git clone --depth 1 " + url
+		args = append(args, "--depth", "1")
+		msg += " (shallow)"
 	}
 	args = append(args, "--", url, dst)
 	emit(Event{Kind: KindText, Text: msg})

--- a/internal/worker/docker.go
+++ b/internal/worker/docker.go
@@ -44,7 +44,7 @@ func (d DockerRunner) image() string {
 // Egress is routed through scrutineer's allowlisting proxy on the host;
 // see EgressProxy. tmpfs/cap-drop rules mirror the local runner's intent.
 func (d DockerRunner) RunSkill(ctx context.Context, sj SkillJob, emit func(Event)) (SkillResult, error) {
-	src, err := ensureClone(ctx, sj.Repo, sj.WorkRoot, d.FullClone, emit)
+	src, err := ensureClone(ctx, sj.Repo, sj.WorkRoot, d.FullClone, sj.Ref, emit)
 	if err != nil {
 		return SkillResult{}, err
 	}

--- a/internal/worker/skill.go
+++ b/internal/worker/skill.go
@@ -33,6 +33,9 @@ type skillContextScrutineer struct {
 	RepoID    uint   `json:"repository_id"`        // convenience for URL building
 	SkillID   uint   `json:"skill_id,omitempty"`   // the running skill
 	FindingID uint   `json:"finding_id,omitempty"` // set for finding-scoped scans
+	// ScanRef is the git ref (branch/tag) the clone was checked out to.
+	// Empty means the repository's default branch.
+	ScanRef string `json:"scan_ref,omitempty"`
 	// ScanSubPath scopes code analysis to a sub-folder of ./src (monorepo
 	// support). Empty means the repo root. Skills that walk files honour
 	// this; skills that query external APIs ignore it.
@@ -100,6 +103,7 @@ func (w *Worker) doSkill(ctx context.Context, scan *db.Scan, emit func(Event)) (
 		Name:       skill.Name,
 		SkillDir:   skillDir,
 		OutputFile: skill.OutputFile,
+		Ref:        scan.Ref,
 	}
 	res, err := w.Runner.RunSkill(ctx, sj, emit)
 	scan.Commit = res.Commit
@@ -373,6 +377,9 @@ func stageContext(workRoot, apiBase string, scan *db.Scan, repo *db.Repository) 
 	}
 	if scan.FindingID != nil {
 		ctx.Scrutineer.FindingID = *scan.FindingID
+	}
+	if scan.Ref != "" {
+		ctx.Scrutineer.ScanRef = scan.Ref
 	}
 	if scan.SubPath != "" {
 		ctx.Scrutineer.ScanSubPath = scan.SubPath

--- a/internal/worker/skill_test.go
+++ b/internal/worker/skill_test.go
@@ -203,3 +203,39 @@ func TestStageSkill_writesMarkdownAndSchema(t *testing.T) {
 		t.Errorf("schema: %q", string(sch))
 	}
 }
+
+func TestStageContext_includesRef(t *testing.T) {
+	dir := t.TempDir()
+	repo := &db.Repository{URL: "https://example.com/x", Name: "x"}
+	scan := &db.Scan{ID: 1, RepositoryID: 1, APIToken: "t", Ref: "2.4.x"}
+	if err := stageContext(dir, "http://127.0.0.1:8080/api", scan, repo); err != nil {
+		t.Fatal(err)
+	}
+	b, err := os.ReadFile(filepath.Join(dir, "context.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got skillContext
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Scrutineer.ScanRef != "2.4.x" {
+		t.Errorf("scan_ref = %q, want %q", got.Scrutineer.ScanRef, "2.4.x")
+	}
+}
+
+func TestStageContext_omitsRefWhenEmpty(t *testing.T) {
+	dir := t.TempDir()
+	repo := &db.Repository{URL: "https://example.com/x", Name: "x"}
+	scan := &db.Scan{ID: 1, RepositoryID: 1, APIToken: "t"}
+	if err := stageContext(dir, "http://127.0.0.1:8080/api", scan, repo); err != nil {
+		t.Fatal(err)
+	}
+	b, err := os.ReadFile(filepath.Join(dir, "context.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(b), "scan_ref") {
+		t.Errorf("scan_ref should be omitted when empty, got: %s", b)
+	}
+}

--- a/skills/triage/SKILL.md
+++ b/skills/triage/SKILL.md
@@ -36,7 +36,9 @@ A docs repo (markdown only) has neither. An infrastructure repo (terraform, helm
 
 Before enqueueing anything, check what already ran so a re-trigger is idempotent: `GET {api_base}/repositories/{repository_id}/scans` returns every scan on this repository with `skill_name` and `status`. Build a set of skill names with `status="done"` or `status="running"` and skip those.
 
-For every remaining skill in the list below, enqueue it: `POST {api_base}/repositories/{id}/skills/{name}/run` with an `Authorization: Bearer {token}` header. Empty JSON body. Order does not matter; the scrutineer worker runs them as they come in.
+For every remaining skill in the list below, enqueue it: `POST {api_base}/repositories/{id}/skills/{name}/run` with an `Authorization: Bearer {token}` header. Order does not matter; the scrutineer worker runs them as they come in.
+
+If `scrutineer.scan_ref` is set in `context.json`, include it in the POST body as `{"ref": "<value>"}` so child scans clone the same branch. If it is empty, send an empty JSON body or omit the body.
 
 Always:
 


### PR DESCRIPTION
Adds `Scan.Ref` so scans can target a specific branch instead of always cloning the default branch. Addresses #125.

- `Ref` field on `db.Scan` and `SkillJob`; `cloneOrFetch` passes `--branch <ref>` on clone and resets to `origin/<ref>` on fetch
- Adding a `/tree/<branch>` URL (e.g. `https://github.com/apache/httpd/tree/2.4.x`) stores the base URL on the repo row but sets `Ref` on the triage scan
- Re-adding an existing repo with a branch enqueues a new triage instead of silently returning
- `context.json` includes `scrutineer.scan_ref` so triage forwards it to child scans via `POST .../skills/{name}/run` with `{"ref": "..."}` in the body
- `scanSummary` API response includes `ref` when set; scan detail page shows the ref