### PR TITLE
Fix slow /scans sort and /repositories packages query

### DIFF
--- a/cmd/scrutineer/main.go
+++ b/cmd/scrutineer/main.go
@@ -192,6 +192,7 @@ func run(log *slog.Logger) error {
 	db.BackfillFindings(gdb)
 	db.BackfillFindingRepository(gdb)
 	db.BackfillFindingFingerprints(gdb)
+	db.BackfillStatusPriority(gdb)
 	if err := db.SeedDefaultLabels(gdb); err != nil {
 		return fmt.Errorf("seed labels: %w", err)
 	}

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -91,6 +91,11 @@ type Scan struct {
 	FindingID *uint  `gorm:"index"`
 	APIToken  string `gorm:"index"`
 
+	// StatusPriority is a denormalised sort key so the scans index can use
+	// an index instead of evaluating a CASE on every row. 0 = running,
+	// 1 = queued, 2 = everything else. Set by StatusPriorityFor().
+	StatusPriority int
+
 	// Ref is the git ref (branch, tag, commit) to checkout after cloning.
 	// Empty means the repository's default branch (origin/HEAD).
 	Ref string
@@ -486,6 +491,17 @@ func (s ScanStatus) Terminal() bool {
 	return s == ScanDone || s == ScanFailed || s == ScanCancelled
 }
 
+func StatusPriorityFor(s ScanStatus) int {
+	switch s {
+	case ScanRunning:
+		return 0
+	case ScanQueued:
+		return 1
+	default:
+		return 2 //nolint:mnd
+	}
+}
+
 func Open(dsn string) (*gorm.DB, error) {
 	cfg := &gorm.Config{
 		Logger: logger.Default.LogMode(logger.Warn),
@@ -508,6 +524,7 @@ func Open(dsn string) (*gorm.DB, error) {
 	); err != nil {
 		return nil, fmt.Errorf("automigrate: %w", err)
 	}
+	gdb.Exec(`CREATE INDEX IF NOT EXISTS idx_scans_priority_id ON scans (status_priority, id DESC)`)
 	return gdb, nil
 }
 
@@ -604,6 +621,12 @@ type Subproject struct {
 
 	CreatedAt time.Time
 	UpdatedAt time.Time
+}
+
+func BackfillStatusPriority(gdb *gorm.DB) {
+	gdb.Exec(`UPDATE scans SET status_priority = 0 WHERE status = 'running' AND (status_priority IS NULL OR status_priority != 0)`)
+	gdb.Exec(`UPDATE scans SET status_priority = 1 WHERE status = 'queued' AND (status_priority IS NULL OR status_priority != 1)`)
+	gdb.Exec(`UPDATE scans SET status_priority = 2 WHERE status NOT IN ('running', 'queued') AND (status_priority IS NULL OR status_priority != 2)`)
 }
 
 // BackfillFindingRepository copies Scan.RepositoryID onto Finding rows

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -91,6 +91,10 @@ type Scan struct {
 	FindingID *uint  `gorm:"index"`
 	APIToken  string `gorm:"index"`
 
+	// Ref is the git ref (branch, tag, commit) to checkout after cloning.
+	// Empty means the repository's default branch (origin/HEAD).
+	Ref string
+
 	// SubPath scopes the scan's code analysis to a sub-folder within the
 	// clone (e.g. airflow-core inside apache/airflow). Empty means the
 	// repo root. Skills that walk files honour this through

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -95,3 +95,38 @@ func TestOpenAndMigrate(t *testing.T) {
 		t.Errorf("expected unique-index violation on duplicate ShortName")
 	}
 }
+
+func TestStatusPriority_sortOrder(t *testing.T) {
+	gdb, err := Open("file::memory:?cache=shared&_busy_timeout=5000")
+	if err != nil {
+		t.Fatal(err)
+	}
+	sqldb, _ := gdb.DB()
+	defer func() { _ = sqldb.Close() }()
+
+	repo := Repository{URL: "https://example.com/sort-test", Name: "sort-test"}
+	gdb.Create(&repo)
+
+	for _, st := range []ScanStatus{ScanDone, ScanRunning, ScanQueued} {
+		sc := Scan{RepositoryID: repo.ID, Kind: "skill", Status: st, StatusPriority: StatusPriorityFor(st)}
+		gdb.Create(&sc)
+	}
+
+	var scans []Scan
+	gdb.Order("status_priority, id desc").Find(&scans)
+	if len(scans) != 3 {
+		t.Fatalf("got %d scans", len(scans))
+	}
+	if scans[0].Status != ScanRunning {
+		t.Errorf("first scan status = %s, want running", scans[0].Status)
+	}
+	if scans[1].Status != ScanQueued {
+		t.Errorf("second scan status = %s, want queued", scans[1].Status)
+	}
+	if scans[2].Status != ScanDone {
+		t.Errorf("third scan status = %s, want done", scans[2].Status)
+	}
+	for _, sc := range scans {
+		t.Logf("id=%d status=%s priority=%d", sc.ID, sc.Status, sc.StatusPriority)
+	}
+}

--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -187,9 +187,13 @@ func (s *Server) apiRunSkill(w http.ResponseWriter, r *http.Request) {
 	}
 	var body struct {
 		Model string `json:"model"`
+		Ref   string `json:"ref"`
 	}
 	_ = json.NewDecoder(r.Body).Decode(&body)
-	scanID, err := s.enqueueSkill(r.Context(), uint(id), skill.ID, body.Model)
+	scanID, err := s.enqueueSkillWith(r.Context(), uint(id), skill.ID, ScanOpts{
+		Model: body.Model,
+		Ref:   body.Ref,
+	})
 	if err != nil {
 		writeAPIError(w, http.StatusInternalServerError, err.Error())
 		return
@@ -301,7 +305,7 @@ func (s *Server) apiListSkills(w http.ResponseWriter, r *http.Request) {
 }
 
 func scanSummary(sc db.Scan) map[string]any {
-	return map[string]any{
+	m := map[string]any{
 		"id":            sc.ID,
 		"repository_id": sc.RepositoryID,
 		"kind":          sc.Kind,
@@ -314,6 +318,10 @@ func scanSummary(sc db.Scan) map[string]any {
 		"finished_at":   sc.FinishedAt,
 		"error":         sc.Error,
 	}
+	if sc.Ref != "" {
+		m["ref"] = sc.Ref
+	}
+	return m
 }
 
 func writeJSON(w http.ResponseWriter, code int, v any) {

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -792,11 +792,6 @@ var severityOrder = `CASE severity
 	WHEN 'Critical' THEN 0 WHEN 'High' THEN 1
 	WHEN 'Medium' THEN 2 WHEN 'Low' THEN 3 ELSE 4 END`
 
-// scanStatusOrder floats active work to the top of the scans index so the
-// operator sees what is in flight before the backlog of completed runs.
-var scanStatusOrder = `CASE scans.status
-	WHEN 'running' THEN 0 WHEN 'queued' THEN 1 ELSE 2 END`
-
 func (s *Server) findings(w http.ResponseWriter, r *http.Request) {
 	q := s.DB.Model(&db.Finding{})
 	sev := r.URL.Query().Get("severity")
@@ -1212,7 +1207,7 @@ func (s *Server) jobs(w http.ResponseWriter, r *http.Request) {
 		q = q.Joins("Repository").Order("`Repository`.name, scans.id desc")
 	default:
 		sort = defaultSort
-		q = q.Order(scanStatusOrder).Order("scans.id desc")
+		q = q.Order("status_priority, scans.id desc")
 	}
 
 	var total int64
@@ -1623,15 +1618,16 @@ func (s *Server) enqueueSkillWith(ctx context.Context, repoID, skillID uint, opt
 		opts.Model = DefaultModel()
 	}
 	scan := db.Scan{
-		RepositoryID: repoID,
-		Kind:         worker.JobSkill,
-		Status:       db.ScanQueued,
-		Model:        opts.Model,
-		SkillID:      &skillID,
-		FindingID:    opts.FindingID,
-		SubPath:      opts.SubPath,
-		Ref:          opts.Ref,
-		APIToken:     NewAPIToken(),
+		RepositoryID:   repoID,
+		Kind:           worker.JobSkill,
+		Status:         db.ScanQueued,
+		StatusPriority: db.StatusPriorityFor(db.ScanQueued),
+		Model:          opts.Model,
+		SkillID:        &skillID,
+		FindingID:      opts.FindingID,
+		SubPath:        opts.SubPath,
+		Ref:            opts.Ref,
+		APIToken:       NewAPIToken(),
 	}
 	if err := s.DB.Create(&scan).Error; err != nil {
 		return 0, err
@@ -1716,8 +1712,11 @@ func buildKnownURLs(gdb *gorm.DB) map[string]uint {
 
 func buildKnownPURLs(gdb *gorm.DB) map[string]uint {
 	m := map[string]uint{}
-	var rows []db.Package
-	gdb.Find(&rows)
+	var rows []struct {
+		PURL         string
+		RepositoryID uint
+	}
+	gdb.Model(&db.Package{}).Select("p_url, repository_id").Find(&rows)
 	for _, p := range rows {
 		m[p.PURL] = p.RepositoryID
 		if base, _, ok := strings.Cut(p.PURL, "?"); ok {

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -1315,21 +1315,22 @@ func (s *Server) createOrTriageRepo(ctx context.Context, input RepoInput, model 
 		return repo, false, err
 	}
 	isNew := existing == 0
-	if !isNew {
+	if !isNew && input.Branch == "" && input.SubPath == "" {
 		return repo, false, nil
 	}
 	var skill db.Skill
 	if err := s.DB.Where("name = ? AND active = ?", defaultSkillName, true).First(&skill).Error; err != nil {
 		s.Log.Warn("default skill not found, repo added with no scans", "skill", defaultSkillName)
-		return repo, true, nil
+		return repo, isNew, nil
 	}
 	if _, err := s.enqueueSkillWith(ctx, repo.ID, skill.ID, ScanOpts{
 		Model:   model,
 		SubPath: input.SubPath,
+		Ref:     input.Branch,
 	}); err != nil {
-		return repo, true, err
+		return repo, isNew, err
 	}
-	return repo, true, nil
+	return repo, isNew, nil
 }
 
 func bulkToastCategory(created int, invalid []string) string {
@@ -1545,6 +1546,7 @@ func (s *Server) scanRetry(w http.ResponseWriter, r *http.Request) {
 		Model:     scan.Model,
 		FindingID: scan.FindingID,
 		SubPath:   scan.SubPath,
+		Ref:       scan.Ref,
 	})
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -1600,6 +1602,7 @@ type ScanOpts struct {
 	Model     string
 	FindingID *uint
 	SubPath   string
+	Ref       string
 }
 
 func (s *Server) enqueueSkill(ctx context.Context, repoID, skillID uint, model string) (uint, error) {
@@ -1627,6 +1630,7 @@ func (s *Server) enqueueSkillWith(ctx context.Context, repoID, skillID uint, opt
 		SkillID:      &skillID,
 		FindingID:    opts.FindingID,
 		SubPath:      opts.SubPath,
+		Ref:          opts.Ref,
 		APIToken:     NewAPIToken(),
 	}
 	if err := s.DB.Create(&scan).Error; err != nil {

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -1666,7 +1666,7 @@ func TestJobs_defaultSortFloatsActiveFirst(t *testing.T) {
 	// Created in id order: done, running, queued. Default sort should
 	// surface running, then queued, then done regardless of id.
 	mk := func(st db.ScanStatus) uint {
-		sc := db.Scan{RepositoryID: repo.ID, Kind: "skill", SkillName: "x", Status: st}
+		sc := db.Scan{RepositoryID: repo.ID, Kind: "skill", SkillName: "x", Status: st, StatusPriority: db.StatusPriorityFor(st)}
 		s.DB.Create(&sc)
 		return sc.ID
 	}

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -1895,3 +1895,81 @@ func TestMaintainerShow_displaysFindingStatus(t *testing.T) {
 		t.Errorf("finding status not rendered in maintainer findings tab")
 	}
 }
+
+func TestRepoCreate_branchURLTriggersTriageWithRef(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	s.DB.Create(&db.Skill{Name: "triage", Active: true, Source: "test", Body: "test", OutputFile: "report.json", OutputKind: "freeform", Version: 1})
+
+	form := url.Values{"url": {"https://github.com/apache/httpd/tree/2.4.x"}}
+	req := httptest.NewRequest("POST", "/repositories", strings.NewReader(form.Encode()))
+	req.Host = testHost
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Sec-Fetch-Site", "same-origin")
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+
+	var scan db.Scan
+	if err := s.DB.First(&scan).Error; err != nil {
+		t.Fatalf("no scan created: %v", err)
+	}
+	if scan.Ref != "2.4.x" {
+		t.Errorf("scan.Ref = %q, want %q", scan.Ref, "2.4.x")
+	}
+}
+
+func TestRepoCreate_existingRepoWithBranchEnqueuesScan(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	s.DB.Create(&db.Skill{Name: "triage", Active: true, Source: "test", Body: "test", OutputFile: "report.json", OutputKind: "freeform", Version: 1})
+	s.DB.Create(&db.Repository{URL: "https://github.com/apache/httpd.git", Name: "httpd"})
+
+	form := url.Values{"url": {"https://github.com/apache/httpd/tree/2.4.x"}}
+	req := httptest.NewRequest("POST", "/repositories", strings.NewReader(form.Encode()))
+	req.Host = testHost
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Sec-Fetch-Site", "same-origin")
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+
+	var scan db.Scan
+	if err := s.DB.First(&scan).Error; err != nil {
+		t.Fatalf("no scan created for existing repo with branch: %v", err)
+	}
+	if scan.Ref != "2.4.x" {
+		t.Errorf("scan.Ref = %q, want %q", scan.Ref, "2.4.x")
+	}
+}
+
+func TestRepoCreate_existingRepoWithoutBranchDoesNotEnqueue(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	s.DB.Create(&db.Skill{Name: "triage", Active: true, Source: "test", Body: "test", OutputFile: "report.json", OutputKind: "freeform", Version: 1})
+	s.DB.Create(&db.Repository{URL: "https://github.com/apache/httpd.git", Name: "httpd"})
+
+	form := url.Values{"url": {"https://github.com/apache/httpd"}}
+	req := httptest.NewRequest("POST", "/repositories", strings.NewReader(form.Encode()))
+	req.Host = testHost
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Sec-Fetch-Site", "same-origin")
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+
+	var count int64
+	s.DB.Model(&db.Scan{}).Count(&count)
+	if count != 0 {
+		t.Errorf("expected no scan for plain re-add, got %d", count)
+	}
+}

--- a/internal/web/templates/scan_show.html
+++ b/internal/web/templates/scan_show.html
@@ -23,6 +23,10 @@
     <dt class="text-muted-foreground">Model</dt>
     <dd>{{if .Model}}{{.Model}}{{else}}-{{end}}</dd>
   </div>
+  {{if .Ref}}<div>
+    <dt class="text-muted-foreground">Ref</dt>
+    <dd>{{.Ref}}</dd>
+  </div>{{end}}
   <div>
     <dt class="text-muted-foreground">Commit</dt>
     <dd><code>{{if .Commit}}{{short .Commit}}{{else}}-{{end}}</code></dd>

--- a/internal/worker/claude.go
+++ b/internal/worker/claude.go
@@ -36,6 +36,7 @@ type SkillJob struct {
 	Name       string
 	SkillDir   string // host absolute path to the staged skill directory
 	OutputFile string // relative to the scan workspace, e.g. "report.json"
+	Ref        string // git ref to checkout; empty = default branch
 }
 
 type SkillResult struct {
@@ -56,7 +57,7 @@ type LocalClaude struct {
 //	{DataDir}/scan-{id}/.claude/skills/NAME staged skill (read by claude-code)
 //	{DataDir}/scan-{id}/OutputFile          where the skill writes, if any
 func (l LocalClaude) RunSkill(ctx context.Context, sj SkillJob, emit func(Event)) (SkillResult, error) {
-	src, err := ensureClone(ctx, sj.Repo, sj.WorkRoot, l.FullClone, emit)
+	src, err := ensureClone(ctx, sj.Repo, sj.WorkRoot, l.FullClone, sj.Ref, emit)
 	if err != nil {
 		return SkillResult{}, err
 	}

--- a/internal/worker/clone.go
+++ b/internal/worker/clone.go
@@ -20,12 +20,12 @@ const dirPerm = 0o755
 // (scan-{id}) so concurrent scans do not share src or report.json,
 // removing a class of races where skill A's output gets clobbered by
 // skill B removing report.json before A finishes reading it.
-func ensureClone(ctx context.Context, repo db.Repository, work string, fullClone bool, emit func(Event)) (string, error) {
+func ensureClone(ctx context.Context, repo db.Repository, work string, fullClone bool, ref string, emit func(Event)) (string, error) {
 	src := filepath.Join(work, "src")
 	if err := os.MkdirAll(work, dirPerm); err != nil {
 		return "", err
 	}
-	if err := cloneOrFetch(ctx, repo.URL, src, fullClone, emit); err != nil {
+	if err := cloneOrFetch(ctx, repo.URL, src, fullClone, ref, emit); err != nil {
 		return "", fmt.Errorf("clone: %w", err)
 	}
 	return src, nil
@@ -40,9 +40,13 @@ func validateGitURL(u string) error {
 	return nil
 }
 
-func cloneOrFetch(ctx context.Context, url, dst string, fullClone bool, emit func(Event)) error {
+func cloneOrFetch(ctx context.Context, url, dst string, fullClone bool, ref string, emit func(Event)) error {
 	if err := validateGitURL(url); err != nil {
 		return err
+	}
+	resetTarget := "origin/HEAD"
+	if ref != "" {
+		resetTarget = "origin/" + ref
 	}
 	if _, err := os.Stat(filepath.Join(dst, ".git")); err == nil {
 		fetchArgs := []string{"-C", dst, "fetch", "--quiet", "origin"}
@@ -58,18 +62,20 @@ func cloneOrFetch(ctx context.Context, url, dst string, fullClone bool, emit fun
 		if out, err := git(ctx, "", fetchArgs...); err != nil {
 			return fmt.Errorf("%s: %w", out, err)
 		}
-		if out, err := git(ctx, "", "-C", dst, "reset", "--quiet", "--hard", "origin/HEAD"); err != nil {
+		if out, err := git(ctx, "", "-C", dst, "reset", "--quiet", "--hard", resetTarget); err != nil {
 			return fmt.Errorf("%s: %w", out, err)
 		}
 		return nil
 	}
-	// -- stops git option parsing so a URL can't be interpreted as a flag.
-	// GIT_PROTOCOL_FROM_USER=0 blocks ext:: and other user-facing protocol handlers.
 	args := []string{"clone", "--quiet"}
 	msg := "$ git clone " + url
+	if ref != "" {
+		args = append(args, "--branch", ref)
+		msg += " --branch " + ref
+	}
 	if !fullClone {
-		args = []string{"clone", "--depth", "1", "--quiet"}
-		msg = "$ git clone --depth 1 " + url
+		args = append(args, "--depth", "1")
+		msg += " (shallow)"
 	}
 	args = append(args, "--", url, dst)
 	emit(Event{Kind: KindText, Text: msg})

--- a/internal/worker/docker.go
+++ b/internal/worker/docker.go
@@ -44,7 +44,7 @@ func (d DockerRunner) image() string {
 // Egress is routed through scrutineer's allowlisting proxy on the host;
 // see EgressProxy. tmpfs/cap-drop rules mirror the local runner's intent.
 func (d DockerRunner) RunSkill(ctx context.Context, sj SkillJob, emit func(Event)) (SkillResult, error) {
-	src, err := ensureClone(ctx, sj.Repo, sj.WorkRoot, d.FullClone, emit)
+	src, err := ensureClone(ctx, sj.Repo, sj.WorkRoot, d.FullClone, sj.Ref, emit)
 	if err != nil {
 		return SkillResult{}, err
 	}

--- a/internal/worker/skill.go
+++ b/internal/worker/skill.go
@@ -33,6 +33,9 @@ type skillContextScrutineer struct {
 	RepoID    uint   `json:"repository_id"`        // convenience for URL building
 	SkillID   uint   `json:"skill_id,omitempty"`   // the running skill
 	FindingID uint   `json:"finding_id,omitempty"` // set for finding-scoped scans
+	// ScanRef is the git ref (branch/tag) the clone was checked out to.
+	// Empty means the repository's default branch.
+	ScanRef string `json:"scan_ref,omitempty"`
 	// ScanSubPath scopes code analysis to a sub-folder of ./src (monorepo
 	// support). Empty means the repo root. Skills that walk files honour
 	// this; skills that query external APIs ignore it.
@@ -100,6 +103,7 @@ func (w *Worker) doSkill(ctx context.Context, scan *db.Scan, emit func(Event)) (
 		Name:       skill.Name,
 		SkillDir:   skillDir,
 		OutputFile: skill.OutputFile,
+		Ref:        scan.Ref,
 	}
 	res, err := w.Runner.RunSkill(ctx, sj, emit)
 	scan.Commit = res.Commit
@@ -373,6 +377,9 @@ func stageContext(workRoot, apiBase string, scan *db.Scan, repo *db.Repository) 
 	}
 	if scan.FindingID != nil {
 		ctx.Scrutineer.FindingID = *scan.FindingID
+	}
+	if scan.Ref != "" {
+		ctx.Scrutineer.ScanRef = scan.Ref
 	}
 	if scan.SubPath != "" {
 		ctx.Scrutineer.ScanSubPath = scan.SubPath

--- a/internal/worker/skill_test.go
+++ b/internal/worker/skill_test.go
@@ -203,3 +203,39 @@ func TestStageSkill_writesMarkdownAndSchema(t *testing.T) {
 		t.Errorf("schema: %q", string(sch))
 	}
 }
+
+func TestStageContext_includesRef(t *testing.T) {
+	dir := t.TempDir()
+	repo := &db.Repository{URL: "https://example.com/x", Name: "x"}
+	scan := &db.Scan{ID: 1, RepositoryID: 1, APIToken: "t", Ref: "2.4.x"}
+	if err := stageContext(dir, "http://127.0.0.1:8080/api", scan, repo); err != nil {
+		t.Fatal(err)
+	}
+	b, err := os.ReadFile(filepath.Join(dir, "context.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got skillContext
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Scrutineer.ScanRef != "2.4.x" {
+		t.Errorf("scan_ref = %q, want %q", got.Scrutineer.ScanRef, "2.4.x")
+	}
+}
+
+func TestStageContext_omitsRefWhenEmpty(t *testing.T) {
+	dir := t.TempDir()
+	repo := &db.Repository{URL: "https://example.com/x", Name: "x"}
+	scan := &db.Scan{ID: 1, RepositoryID: 1, APIToken: "t"}
+	if err := stageContext(dir, "http://127.0.0.1:8080/api", scan, repo); err != nil {
+		t.Fatal(err)
+	}
+	b, err := os.ReadFile(filepath.Join(dir, "context.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(b), "scan_ref") {
+		t.Errorf("scan_ref should be omitted when empty, got: %s", b)
+	}
+}

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -118,6 +118,7 @@ func (w *Worker) wrap(h handler) func(context.Context, []byte) error {
 
 		now := time.Now()
 		scan.Status = db.ScanRunning
+		scan.StatusPriority = db.StatusPriorityFor(db.ScanRunning)
 		scan.StartedAt = &now
 		scan.Log = ""
 		scan.Error = ""
@@ -161,6 +162,7 @@ func (w *Worker) wrap(h handler) func(context.Context, []byte) error {
 			scan.Status = db.ScanDone
 			scan.Report = report
 		}
+		scan.StatusPriority = db.StatusPriorityFor(scan.Status)
 		if saveErr := w.DB.Save(&scan).Error; saveErr != nil {
 			return saveErr
 		}

--- a/skills/triage/SKILL.md
+++ b/skills/triage/SKILL.md
@@ -36,7 +36,9 @@ A docs repo (markdown only) has neither. An infrastructure repo (terraform, helm
 
 Before enqueueing anything, check what already ran so a re-trigger is idempotent: `GET {api_base}/repositories/{repository_id}/scans` returns every scan on this repository with `skill_name` and `status`. Build a set of skill names with `status="done"` or `status="running"` and skip those.
 
-For every remaining skill in the list below, enqueue it: `POST {api_base}/repositories/{id}/skills/{name}/run` with an `Authorization: Bearer {token}` header. Empty JSON body. Order does not matter; the scrutineer worker runs them as they come in.
+For every remaining skill in the list below, enqueue it: `POST {api_base}/repositories/{id}/skills/{name}/run` with an `Authorization: Bearer {token}` header. Order does not matter; the scrutineer worker runs them as they come in.
+
+If `scrutineer.scan_ref` is set in `context.json`, include it in the POST body as `{"ref": "<value>"}` so child scans clone the same branch. If it is empty, send an empty JSON body or omit the body.
 
 Always:
 


### PR DESCRIPTION
Two query performance fixes for large databases (#134, #135).

`/scans` default sort used a `CASE` expression on `status` that prevented index use and scanned all 15K rows (~1.8s). Replaced with a `StatusPriority` column set on every status transition, with a composite index on `(status_priority, id DESC)`. Existing rows are backfilled at startup.

`/repositories/{id}` ran `SELECT * FROM packages` (10K+ rows) inside `buildKnownPURLs`. Now selects only `p_url, repository_id`.