### PR TITLE
Handle unreachable repos gracefully instead of failing scans

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -46,6 +46,11 @@ type Repository struct {
 	// it from the repo page.
 	DisclosureChannel string
 
+	// CloneError is set when the last clone/fetch attempt failed (repo
+	// deleted, made private, wrong URL). Non-empty means the repo is
+	// currently unreachable. Cleared on next successful clone.
+	CloneError string
+
 	CreatedAt time.Time
 	UpdatedAt time.Time
 

--- a/internal/web/templates/repo_list.html
+++ b/internal/web/templates/repo_list.html
@@ -46,7 +46,10 @@
     <tbody>
     {{range .Rows}}
       <tr id="repo-{{.ID}}" class="cursor-pointer" hx-get="/repositories/{{.ID}}" hx-push-url="true">
-        <td><a href="/repositories/{{.ID}}" hx-on:click="event.stopPropagation()">{{trimscheme .URL}}</a></td>
+        <td>
+          <a href="/repositories/{{.ID}}" hx-on:click="event.stopPropagation()">{{trimscheme .URL}}</a>
+          {{if .CloneError}}<span class="badge-destructive ml-1" data-tooltip="{{.CloneError}}"><i data-lucide="wifi-off"></i></span>{{end}}
+        </td>
         <td class="text-muted-foreground">{{if .Languages}}{{.Languages}}{{else}}-{{end}}</td>
         <td>{{if .LastScan}}{{.LastScan.CreatedAt.Format "15:04:05"}}{{else}}never{{end}}</td>
         <td>{{if .LastScan}}{{template "status-badge" (status .LastScan.Status)}}{{end}}</td>

--- a/internal/web/templates/repo_show.html
+++ b/internal/web/templates/repo_show.html
@@ -92,6 +92,7 @@
         {{if .Repo.PushedAt}}<span class="badge-outline"><i data-lucide="clock"></i>pushed {{since .Repo.PushedAt}}</span>{{end}}
         {{if gt .TotalCost 0.0}}<span class="badge-outline" data-tooltip="Total scan spend on this repository"><i data-lucide="coins"></i>{{usd .TotalCost}}</span>{{end}}
         {{if .Repo.Archived}}<span class="badge-destructive"><i data-lucide="archive"></i>archived</span>{{end}}
+        {{if .Repo.CloneError}}<span class="badge-destructive" data-tooltip="{{.Repo.CloneError}}"><i data-lucide="wifi-off"></i>unreachable</span>{{end}}
       </div>
     {{else}}
       <p class="text-muted-foreground text-sm mb-6">Metadata not fetched yet.</p>

--- a/internal/worker/clone.go
+++ b/internal/worker/clone.go
@@ -13,6 +13,19 @@ import (
 
 const dirPerm = 0o755
 
+// RepoUnreachableError is returned when git clone/fetch fails because the
+// remote is unreachable (deleted, private, wrong URL, network error).
+type RepoUnreachableError struct {
+	URL string
+	Err error
+}
+
+func (e *RepoUnreachableError) Error() string {
+	return fmt.Sprintf("repository unreachable %s: %s", e.URL, e.Err)
+}
+
+func (e *RepoUnreachableError) Unwrap() error { return e.Err }
+
 // ensureClone returns the path to an up-to-date clone of repo.URL under
 // the given work root. fullClone selects between --depth 1 (false, the
 // default) and full history (true). Clones on first call; fetches +
@@ -26,7 +39,7 @@ func ensureClone(ctx context.Context, repo db.Repository, work string, fullClone
 		return "", err
 	}
 	if err := cloneOrFetch(ctx, repo.URL, src, fullClone, ref, emit); err != nil {
-		return "", fmt.Errorf("clone: %w", err)
+		return "", &RepoUnreachableError{URL: repo.URL, Err: err}
 	}
 	return src, nil
 }

--- a/internal/worker/skill.go
+++ b/internal/worker/skill.go
@@ -3,6 +3,7 @@ package worker
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -108,8 +109,12 @@ func (w *Worker) doSkill(ctx context.Context, scan *db.Scan, emit func(Event)) (
 	res, err := w.Runner.RunSkill(ctx, sj, emit)
 	scan.Commit = res.Commit
 	if err != nil {
+		if report, ok := w.handleCloneError(scan, err, emit); ok {
+			return report, nil
+		}
 		return res.Report, err
 	}
+	w.clearCloneError(scan)
 
 	if res.Report == "" {
 		return res.Report, nil
@@ -157,6 +162,25 @@ func (w *Worker) doSkill(ctx context.Context, scan *db.Scan, emit func(Event)) (
 		}
 	}
 	return res.Report, nil
+}
+
+func (w *Worker) handleCloneError(scan *db.Scan, err error, emit func(Event)) (string, bool) {
+	var ure *RepoUnreachableError
+	if !errors.As(err, &ure) {
+		return "", false
+	}
+	w.DB.Model(&db.Repository{}).Where("id = ?", scan.RepositoryID).
+		Update("clone_error", ure.Error())
+	emit(Event{Kind: KindText, Text: "repository unreachable, flagging"})
+	report := fmt.Sprintf(`{"error":"repository unreachable","detail":%q}`, ure.Error())
+	return report, true
+}
+
+func (w *Worker) clearCloneError(scan *db.Scan) {
+	if scan.Repository.CloneError != "" {
+		w.DB.Model(&db.Repository{}).Where("id = ?", scan.RepositoryID).
+			Update("clone_error", "")
+	}
 }
 
 // parseFindingsOutput feeds the existing spec-deep parser so skill-driven

--- a/internal/worker/skill_test.go
+++ b/internal/worker/skill_test.go
@@ -3,6 +3,7 @@ package worker
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"log/slog"
 	"os"
@@ -140,6 +141,98 @@ func TestDoSkill_maintainersKind(t *testing.T) {
 	gdb.Preload("Maintainers").First(&fresh, repo.ID)
 	if len(fresh.Maintainers) != 2 {
 		t.Errorf("repo linked to %d maintainers, want 2", len(fresh.Maintainers))
+	}
+}
+
+func TestDoSkill_cloneErrorFlagsRepo(t *testing.T) {
+	gdb, err := db.Open(filepath.Join(t.TempDir(), "ce.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo := db.Repository{URL: "https://example.com/gone", Name: "gone"}
+	gdb.Create(&repo)
+	skill := db.Skill{
+		Name: "metadata", Description: "d", Body: "b",
+		OutputFile: "report.json", OutputKind: "freeform",
+		Version: 1, Active: true, Source: "ui",
+	}
+	gdb.Create(&skill)
+	scan := db.Scan{
+		RepositoryID: repo.ID, Kind: JobSkill,
+		Status: db.ScanQueued, Model: "fake", SkillID: &skill.ID,
+	}
+	gdb.Create(&scan)
+
+	cloneErr := &RepoUnreachableError{
+		URL: repo.URL,
+		Err: fmt.Errorf("fatal: repository 'https://example.com/gone' not found"),
+	}
+	w := &Worker{
+		DB:      gdb,
+		Log:     slog.New(slog.NewTextHandler(io.Discard, nil)),
+		DataDir: t.TempDir(),
+		Runner:  fakeRunner{skillErr: cloneErr},
+	}
+
+	body, _ := json.Marshal(queue.Payload{ScanID: scan.ID})
+	if err := w.wrap(w.doSkill)(context.Background(), body); err != nil {
+		t.Fatal(err)
+	}
+
+	var got db.Scan
+	gdb.First(&got, scan.ID)
+	if got.Status != db.ScanDone {
+		t.Errorf("status = %s, want done (err=%q)", got.Status, got.Error)
+	}
+	if !strings.Contains(got.Report, "repository unreachable") {
+		t.Errorf("report should mention unreachable: %q", got.Report)
+	}
+
+	var fresh db.Repository
+	gdb.First(&fresh, repo.ID)
+	if fresh.CloneError == "" {
+		t.Error("repo CloneError should be set after clone failure")
+	}
+}
+
+func TestDoSkill_successClearsCloneError(t *testing.T) {
+	gdb, err := db.Open(filepath.Join(t.TempDir(), "cc.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo := db.Repository{
+		URL: "https://example.com/back", Name: "back",
+		CloneError: "previously unreachable",
+	}
+	gdb.Create(&repo)
+	skill := db.Skill{
+		Name: "metadata", Description: "d", Body: "b",
+		OutputFile: "report.json", OutputKind: "freeform",
+		Version: 1, Active: true, Source: "ui",
+	}
+	gdb.Create(&skill)
+	scan := db.Scan{
+		RepositoryID: repo.ID, Kind: JobSkill,
+		Status: db.ScanQueued, Model: "fake", SkillID: &skill.ID,
+	}
+	gdb.Create(&scan)
+
+	w := &Worker{
+		DB:      gdb,
+		Log:     slog.New(slog.NewTextHandler(io.Discard, nil)),
+		DataDir: t.TempDir(),
+		Runner:  fakeRunner{skillRes: SkillResult{Commit: "abc", Report: "{}"}},
+	}
+
+	body, _ := json.Marshal(queue.Payload{ScanID: scan.ID})
+	if err := w.wrap(w.doSkill)(context.Background(), body); err != nil {
+		t.Fatal(err)
+	}
+
+	var fresh db.Repository
+	gdb.First(&fresh, repo.ID)
+	if fresh.CloneError != "" {
+		t.Errorf("CloneError should be cleared after success, got %q", fresh.CloneError)
 	}
 }
 


### PR DESCRIPTION
When a clone or fetch fails (repo deleted, made private, wrong URL), the scan previously ended up as `failed` with a git error. Now:

- The scan finishes as `done` with a JSON report explaining the repo is unreachable
- The `Repository.CloneError` field is set so the UI shows an "unreachable" badge on the repo list and detail page (with the error in a tooltip)
- A subsequent successful clone clears the flag automatically

`RepoUnreachableError` is a typed error returned by `ensureClone` so `doSkill` can distinguish clone failures from other errors without string matching.

Closes #129