### PR TITLE
Show Propose patch button on every finding page

### DIFF
--- a/internal/web/templates/finding_show.html
+++ b/internal/web/templates/finding_show.html
@@ -9,10 +9,19 @@
   (printf "scan #%d" $f.ScanID) (printf "/scans/%d" $f.ScanID)
   (printf "finding #%d" $f.ID) "")}}
 
-<h2 class="text-2xl font-semibold mt-1 mb-4 flex items-center gap-3">
-  {{$f.Title}}
-  {{template "finding-status" (fstatus $f.Status)}}
-</h2>
+<div class="flex items-start justify-between gap-4 mb-4">
+  <h2 class="text-2xl font-semibold mt-1 flex items-center gap-3">
+    {{$f.Title}}
+    {{template "finding-status" (fstatus $f.Status)}}
+  </h2>
+  <form method="post" action="/findings/{{$f.ID}}/patch"
+        hx-post="/findings/{{$f.ID}}/patch" hx-swap="none"
+        class="shrink-0">
+    <button type="submit" class="btn-outline">
+      <i data-lucide="wrench"></i> Propose patch
+    </button>
+  </form>
+</div>
 
 {{if $f.Labels}}
 <div class="flex flex-wrap gap-1 mb-4">


### PR DESCRIPTION
The patch button was only reachable from the workflow card when a finding was in `triaged` status. Now it sits next to the title so you can generate a patch from any finding regardless of lifecycle state.

Refs #64