### PR TITLE
Render finding fields as markdown with syntax highlighting

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
+	github.com/yuin/goldmark v1.8.2 // indirect
 	golang.org/x/sys v0.43.0 // indirect
 	golang.org/x/text v0.31.0 // indirect
 	modernc.org/libc v1.72.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -32,6 +32,8 @@ github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOF
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
+github.com/yuin/goldmark v1.8.2 h1:kEGpgqJXdgbkhcOgBxkC0X0PmoPG1ZyoZ117rDVp4zE=
+github.com/yuin/goldmark v1.8.2/go.mod h1:ip/1k0VRfGynBgxOz0yCqHrbZXhcjxyuS66Brc7iBKg=
 golang.org/x/crypto v0.45.0 h1:jMBrvKuj23MTlT0bQEOBcAE0mjg8mK9RXFhRH6nyF3Q=
 golang.org/x/crypto v0.45.0/go.mod h1:XTGrrkGJve7CYK7J8PEww4aY7gM3qMCElcJQ8n8JdX4=
 golang.org/x/mod v0.33.0 h1:tHFzIWbBifEmbwtGz65eaWyGiGZatSrT9prnU8DbVL8=

--- a/internal/web/markdown.go
+++ b/internal/web/markdown.go
@@ -1,0 +1,21 @@
+package web
+
+import (
+	"bytes"
+	"html/template"
+
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/extension"
+)
+
+var md = goldmark.New(
+	goldmark.WithExtensions(extension.GFM),
+)
+
+func renderMarkdown(src string) template.HTML {
+	var buf bytes.Buffer
+	if err := md.Convert([]byte(src), &buf); err != nil {
+		return template.HTML("<pre>" + template.HTMLEscapeString(src) + "</pre>")
+	}
+	return template.HTML(buf.String()) //nolint:gosec
+}

--- a/internal/web/markdown_test.go
+++ b/internal/web/markdown_test.go
@@ -1,0 +1,40 @@
+package web
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRenderMarkdown_codeBlock(t *testing.T) {
+	src := "Some text\n\n```go\nfmt.Println(\"hello\")\n```\n"
+	got := string(renderMarkdown(src))
+	if !strings.Contains(got, "<code class=\"language-go\">") {
+		t.Errorf("expected language-go code block, got:\n%s", got)
+	}
+	if !strings.Contains(got, "fmt.Println") {
+		t.Errorf("expected code content preserved, got:\n%s", got)
+	}
+}
+
+func TestRenderMarkdown_inlineCode(t *testing.T) {
+	src := "Use `foo()` here."
+	got := string(renderMarkdown(src))
+	if !strings.Contains(got, "<code>foo()</code>") {
+		t.Errorf("expected inline code, got:\n%s", got)
+	}
+}
+
+func TestRenderMarkdown_escapsHTML(t *testing.T) {
+	src := "Test <script>alert(1)</script> end"
+	got := string(renderMarkdown(src))
+	if strings.Contains(got, "<script>") {
+		t.Errorf("raw HTML should be escaped, got:\n%s", got)
+	}
+}
+
+func TestRenderMarkdown_empty(t *testing.T) {
+	got := string(renderMarkdown(""))
+	if got != "" {
+		t.Errorf("empty input should produce empty output, got:\n%q", got)
+	}
+}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -83,6 +83,7 @@ func New(gdb *gorm.DB, q *queue.Queue, log *slog.Logger, broker *Broker, w *work
 			}
 			return ""
 		},
+		"md":         renderMarkdown,
 		"jsontree":   jsonTree,
 		"prettyjson": prettyJSON,
 		"bignum":     bignum,

--- a/internal/web/static/app.js
+++ b/internal/web/static/app.js
@@ -5,6 +5,14 @@
     if (window.lucide) lucide.createIcons();
   }
 
+  function highlight() {
+    if (window.hljs) {
+      document.querySelectorAll('pre code:not(.hljs)').forEach(function (el) {
+        hljs.highlightElement(el);
+      });
+    }
+  }
+
   function restoreTab() {
     var h = location.hash.slice(1);
     if (!h) return;
@@ -22,19 +30,20 @@
 
   function init() {
     icons();
+    highlight();
     restoreTab();
   }
 
   if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', icons);
+    document.addEventListener('DOMContentLoaded', init);
     window.addEventListener('load', restoreTab);
   } else {
     init();
   }
 
-  document.addEventListener('htmx:afterSwap', icons);
+  document.addEventListener('htmx:afterSwap', function () { icons(); highlight(); });
   document.addEventListener('htmx:historyRestore', init);
-  document.addEventListener('htmx:oobAfterSwap', icons);
+  document.addEventListener('htmx:oobAfterSwap', function () { icons(); highlight(); });
 
   document.addEventListener('click', function (e) {
     var tab = e.target.closest('[role="tab"]');

--- a/internal/web/static/theme.css
+++ b/internal/web/static/theme.css
@@ -372,3 +372,28 @@ body { background: var(--background); color: var(--foreground);
 pre.log { background: var(--muted); padding: 1rem; border-radius: var(--radius);
           max-height: 60vh; overflow: auto; font-size: 0.8rem; white-space: pre-wrap; }
 .lucide:not([class*="size-"]) { width: 1em; height: 1em; vertical-align: -0.15em; }
+
+/* ── prose (rendered markdown in finding fields) ── */
+.prose { font-size: 0.875rem; line-height: 1.625; max-width: 80ch; }
+.prose p { margin: 0.75em 0; }
+.prose p:first-child { margin-top: 0; }
+.prose ul, .prose ol { margin: 0.75em 0; padding-left: 1.5em; }
+.prose ul { list-style: disc; }
+.prose ol { list-style: decimal; }
+.prose li { margin: 0.25em 0; }
+.prose h1, .prose h2, .prose h3, .prose h4 { font-weight: 600; margin: 1em 0 0.5em; }
+.prose h1 { font-size: 1.25rem; }
+.prose h2 { font-size: 1.125rem; }
+.prose h3 { font-size: 1rem; }
+.prose code { font-size: 0.8125rem; background: var(--muted); padding: 0.15em 0.35em;
+              border-radius: 0.25rem; }
+.prose pre { background: var(--muted); padding: 1rem; border-radius: var(--radius);
+             max-height: 60vh; overflow: auto; margin: 0.75em 0; }
+.prose pre code { background: none; padding: 0; font-size: 0.8rem; }
+.prose blockquote { border-left: 3px solid var(--border); padding-left: 1em;
+                    color: var(--muted-foreground); margin: 0.75em 0; }
+.prose a { color: var(--primary); text-decoration: underline; text-underline-offset: 2px; }
+.prose table { border-collapse: collapse; margin: 0.75em 0; font-size: 0.8125rem; }
+.prose th, .prose td { border: 1px solid var(--border); padding: 0.35em 0.75em; }
+.prose th { background: var(--muted); font-weight: 600; }
+.prose hr { border: none; border-top: 1px solid var(--border); margin: 1.5em 0; }

--- a/internal/web/templates/finding_show.html
+++ b/internal/web/templates/finding_show.html
@@ -117,7 +117,7 @@
         <i data-lucide="chevron-down" class="text-muted-foreground size-4 shrink-0 transition-transform duration-200 group-open:rotate-180"></i>
       </h3>
     </summary>
-    <section class="pb-4"><pre class="log">{{$f.Trace}}</pre></section>
+    <section class="pb-4 prose">{{md $f.Trace}}</section>
   </details>
   {{end}}
 
@@ -129,7 +129,7 @@
         <i data-lucide="chevron-down" class="text-muted-foreground size-4 shrink-0 transition-transform duration-200 group-open:rotate-180"></i>
       </h3>
     </summary>
-    <section class="pb-4"><pre class="log">{{$f.Boundary}}</pre></section>
+    <section class="pb-4 prose">{{md $f.Boundary}}</section>
   </details>
   {{end}}
 
@@ -141,7 +141,7 @@
         <i data-lucide="chevron-down" class="text-muted-foreground size-4 shrink-0 transition-transform duration-200 group-open:rotate-180"></i>
       </h3>
     </summary>
-    <section class="pb-4"><pre class="log">{{$f.Validation}}</pre></section>
+    <section class="pb-4 prose">{{md $f.Validation}}</section>
   </details>
   {{end}}
 
@@ -153,7 +153,7 @@
         <i data-lucide="chevron-down" class="text-muted-foreground size-4 shrink-0 transition-transform duration-200 group-open:rotate-180"></i>
       </h3>
     </summary>
-    <section class="pb-4"><pre class="log">{{$f.PriorArt}}</pre></section>
+    <section class="pb-4 prose">{{md $f.PriorArt}}</section>
   </details>
   {{end}}
 
@@ -165,7 +165,7 @@
         <i data-lucide="chevron-down" class="text-muted-foreground size-4 shrink-0 transition-transform duration-200 group-open:rotate-180"></i>
       </h3>
     </summary>
-    <section class="pb-4"><pre class="log">{{$f.Reach}}</pre></section>
+    <section class="pb-4 prose">{{md $f.Reach}}</section>
   </details>
   {{end}}
 
@@ -177,7 +177,7 @@
         <i data-lucide="chevron-down" class="text-muted-foreground size-4 shrink-0 transition-transform duration-200 group-open:rotate-180"></i>
       </h3>
     </summary>
-    <section class="pb-4"><pre class="log">{{$f.Rating}}</pre></section>
+    <section class="pb-4 prose">{{md $f.Rating}}</section>
   </details>
   {{end}}
 

--- a/internal/web/templates/layout.html
+++ b/internal/web/templates/layout.html
@@ -9,6 +9,10 @@
       var apply = function () {
         var dark = scheme === 'dark' || (scheme === 'system' && mq.matches);
         document.documentElement.classList.toggle('dark', dark);
+        var hl = document.getElementById('hljs-light');
+        var hd = document.getElementById('hljs-dark');
+        if (hl) hl.disabled = dark;
+        if (hd) hd.disabled = !dark;
       };
       apply(); mq.addEventListener('change', apply);
     })();
@@ -25,6 +29,9 @@
   <script src="https://cdn.jsdelivr.net/npm/htmx.org@2.0.6/dist/htmx.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/htmx-ext-sse@2.2.4/sse.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/lucide@0.545.0/dist/umd/lucide.min.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.11.1/build/styles/github.min.css" id="hljs-light">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.11.1/build/styles/github-dark.min.css" id="hljs-dark" disabled>
+  <script src="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.11.1/build/highlight.min.js"></script>
   <script src="/static/app.js" defer></script>
 </head>
 <body>


### PR DESCRIPTION
Finding prose fields (trace, boundary, validation, prior art, reach, rating) were rendered as raw text inside `<pre>` tags. Now they go through goldmark for proper markdown rendering and highlight.js for syntax-highlighted code blocks.

- goldmark with GFM extensions renders markdown to HTML server-side (HTML in source is escaped, not passed through)
- highlight.js (github/github-dark themes from CDN) highlights `<pre><code class="language-x">` blocks client-side
- `.prose` CSS styles the rendered output (paragraphs, lists, tables, blockquotes, inline code)
- hljs theme toggles with the dark mode class, not just `prefers-color-scheme`
- highlighting runs on page load and after htmx swaps

See #142 for vendoring the CDN assets.