### PR TITLE
docs: add missing skills, tables, and web files

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,11 @@ The optional analysis tools (semgrep, zizmor, git-pkgs, brief) are bundled in th
 - **Skill HTTP API** -- running skills can call back into scrutineer to list prior scans and enqueue further skills; surface documented in `openapi.yaml`
 - **Organisation rollup** -- repos, findings, and maintainers grouped by owning org, with per-org markdown exports
 - **Usage tracking** -- per-scan token and cost figures plus a `/usage` page totalling spend per skill
+- **SBOM import** -- upload a CycloneDX or SPDX document, resolve each component to a source repository, and queue scans automatically
+- **CNA matching** -- identify the CVE Numbering Authority whose scope covers a repo so disclosures go to the right contact
+- **Reachability analysis** -- trace sinks found in dependencies through application code to see which are actually reachable
 - **Rescan dedup** -- findings carry a content fingerprint so re-running a scan updates existing rows instead of creating duplicates
-- **Markdown report export** -- download a single consolidated `report.md` per repository covering threat model, findings (with six-step prose), packages, advisories, dependents, maintainers
+- **Markdown report export** -- download a single consolidated `report.md` per repository or organisation
 
 ## The default pipeline
 
@@ -75,6 +78,8 @@ When a repo is added, the `triage` skill is enqueued. Its SKILL.md lists the ski
 | `verify` | Re-checks one finding against current HEAD; records reproduces / fixed / can't-reproduce |
 | `disclose` | Drafts a GHSA-shaped advisory (title, description, CVSS, CWEs, references) for one finding |
 | `patch` | Proposes a unified diff fixing one finding, written back as a note for analyst review |
+| `reachability` | Traces dependency sinks through application code to determine which are reachable from trust boundaries |
+| `cna-match` | Matches a repository to its CVE Numbering Authority so disclosures route to the right contact |
 
 Edit `skills/triage/SKILL.md` to change what gets run by default. Drop new skill directories in `skills/` to add scan types; no code changes needed.
 
@@ -103,6 +108,7 @@ Every index page has a search box plus filter and sort dropdowns; the specifics 
 - **Packages** -- registry entries discovered across all repos.
 - **Advisories** -- known CVEs and security advisories pulled for any scanned package.
 - **Maintainers** -- people identified as maintainers, with their linked repos and findings.
+- **SBOMs** -- uploaded CycloneDX/SPDX documents. Each component is resolved to a source repository and can be imported for scanning.
 - **Scans** -- every scan that has run. Running or queued scans can be cancelled; failed ones retried.
 - **Skills** -- installed skills from disk and from the UI; view, edit, or run any of them.
 - **Usage** -- token and cost totals across all scans, broken down by skill.

--- a/docs/database.md
+++ b/docs/database.md
@@ -292,6 +292,78 @@ Join table. No extra columns.
 | maintainer_id | integer FK | |
 | repository_id | integer FK | |
 
+## subprojects
+
+Monorepo sub-paths discovered by the `subprojects` skill.
+
+| Column | Type | Notes |
+|--------|------|-------|
+| id | integer PK | |
+| repository_id | integer FK | |
+| path | text, not null | Sub-folder relative to repo root. The root itself is represented by absence of a row, not an empty path. |
+| name | text | Short human label; falls back to the last path segment. |
+| kind | text | Detected flavour: `go-module`, `npm-workspace`, `python-package`, `rust-crate`, `composer-package`, `monorepo-root`, etc. Free-form. |
+| description | text | |
+| created_at | datetime | |
+| updated_at | datetime | |
+
+## sbom_uploads
+
+User-uploaded CycloneDX or SPDX documents. Packages are replaced wholesale on re-upload (cascade delete) but resolved repository rows survive so prior scan results stay attached.
+
+| Column | Type | Notes |
+|--------|------|-------|
+| id | integer PK | |
+| name | text | Display name for the upload. |
+| filename | text | Original filename. |
+| format | text | `CycloneDX` or `SPDX`. |
+| spec_version | text | e.g. `1.5`. |
+| raw | blob | The original document bytes. |
+| package_count | integer | Denormalised count of components. |
+| created_at | datetime | |
+| updated_at | datetime | |
+
+## sbom_packages
+
+One component from an uploaded SBOM. `repository_id` is set asynchronously once the PURL resolves to a source repo.
+
+| Column | Type | Notes |
+|--------|------|-------|
+| id | integer PK | |
+| sbom_upload_id | integer FK | Cascade delete. |
+| name | text | |
+| version | text | |
+| p_url | text | Package URL. Indexed. |
+| ecosystem | text | |
+| license | text | |
+| scope | text | `direct`, `transitive`, or empty when the document had no dependency graph. |
+| repository_id | integer FK, nullable | Set once resolved. References `repositories.id`. |
+| resolve_error | text | Error message if PURL resolution failed. |
+| created_at | datetime | |
+
+## cnas
+
+CVE Numbering Authorities from the public cve.org partner list. Used by the `cna-match` skill to route disclosures.
+
+| Column | Type | Notes |
+|--------|------|-------|
+| id | integer PK | |
+| short_name | text, unique | e.g. `GitHub_M`. |
+| cna_id | text | cve.org CNA identifier. |
+| organization | text | Full org name. |
+| scope | text | Free-text coverage description as published. |
+| email | text | Security contact email. |
+| contact_url | text | |
+| policy_url | text | |
+| advisory_url | text | |
+| root | text | Root CNA if this is a sub-CNA. |
+| types | text | |
+| country | text | |
+| metadata | text | Full upstream JSON. |
+| fetched_at | datetime | When the CNA list was last refreshed. |
+| created_at | datetime | |
+| updated_at | datetime | |
+
 ## goqite
 
 Job queue managed by the goqite library. Not accessed directly by application code except through the queue package.

--- a/docs/development.md
+++ b/docs/development.md
@@ -8,7 +8,8 @@
       db.go                  Repository, Scan, Skill, Finding + sibling tables
                              (FindingLabel, FindingNote, FindingCommunication,
                               FindingReference, FindingHistory), Dependency,
-                              Package, Dependent, Advisory, Maintainer
+                              Package, Dependent, Advisory, Maintainer,
+                              Subproject, SBOMUpload, SBOMPackage, CNA
       finding_helpers.go     WriteFindingField, AddFindingNote,
                              AddFindingCommunication, AddFindingReference,
                              SetFindingLabels, SeedDefaultLabels
@@ -35,15 +36,23 @@
       api_finding_writes.go  PATCH/POST/PUT for finding notes, communications,
                              references, labels, field updates, history
       finding_forms.go       browser-form analogues of the api finding writes
+      finding_patch.go       patch scan lookup and diff download
       skills_handlers.go     /skills UI routes
       repo_report.go         markdown report export per repository
+      org_report.go          markdown report export per organisation
+      org_summary.go         organisation summary page
+      sboms.go               SBOM upload, list, and component resolution
+      usage.go               per-skill token and cost totals
+      theme.go               colour scheme cookie + dark mode toggle
+      parse_repo_url.go      git URL to forge web URL conversion
+      api_export.go          bulk JSON export endpoints
       sse.go                 SSE broker, splits data lines per spec
       cwe.go + cwe.json      embedded MITRE CWE catalogue (944 entries)
       models.go              model pick list, swappable from config
       location.go            forge URL builder for source links
       jsontree.go            JSON-to-HTML renderer for the Data tab
       templates/             html/template files
-      static/                theme CSS, favicon
+      static/                theme CSS, app.js, favicon
 
 ## Running tests
 


### PR DESCRIPTION
README was missing `reachability`, `cna-match` from the skills table, `SBOMs` from the UI navigation section, and three features (SBOM import, CNA matching, reachability analysis). Also updated the markdown report export bullet to mention org-level exports.

`docs/database.md` was missing four tables that have been in AutoMigrate for a while: `subprojects`, `sbom_uploads`, `sbom_packages`, `cnas`.

`docs/development.md` project layout was missing `finding_patch.go`, `org_report.go`, `org_summary.go`, `sboms.go`, `usage.go`, `theme.go`, `parse_repo_url.go`, `api_export.go` from the web package listing, and `Subproject`, `SBOMUpload`, `SBOMPackage`, `CNA` from the db model list. Also added `app.js` to the `static/` description.