### PR TITLE
Speed up /scans page with skill_name index and cache

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -89,7 +89,7 @@ type Scan struct {
 	// workspace; it is cleared when the scan reaches a terminal state.
 	SkillID      *uint `gorm:"index"`
 	SkillVersion int
-	SkillName    string
+	SkillName    string `gorm:"index"`
 	// FindingID is set when a scan is finding-scoped (verify, patch,
 	// disclose). Skills read it from context.json to know which finding
 	// they are acting on.

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -14,6 +14,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"gorm.io/gorm"
@@ -42,6 +43,10 @@ type Server struct {
 	// stub the network lookup.
 	resolvePURL func(ctx context.Context, purl string) string
 	resolveSync bool
+
+	skillNamesMu    sync.Mutex
+	skillNamesCache []string
+	skillNamesTTL   time.Time
 }
 
 func New(gdb *gorm.DB, q *queue.Queue, log *slog.Logger, broker *Broker, w *worker.Worker) (*Server, error) {
@@ -1219,9 +1224,7 @@ func (s *Server) jobs(w http.ResponseWriter, r *http.Request) {
 	q.Preload("Repository").
 		Limit(perPage).Offset((page.N - 1) * perPage).Find(&scans)
 
-	var skillNames []string
-	s.DB.Model(&db.Scan{}).Where("skill_name != ''").Distinct("skill_name").
-		Order("skill_name").Pluck("skill_name", &skillNames)
+	skillNames := s.scanSkillNames()
 
 	anySubPath := false
 	for _, sc := range scans {
@@ -1235,6 +1238,22 @@ func (s *Server) jobs(w http.ResponseWriter, r *http.Request) {
 		"Skill": skillName, "Status": status, "Sort": sort, "Skills": skillNames,
 		"AnySubPath": anySubPath,
 	})
+}
+
+const skillNamesCacheTTL = 30 * time.Second
+
+func (s *Server) scanSkillNames() []string {
+	s.skillNamesMu.Lock()
+	defer s.skillNamesMu.Unlock()
+	if time.Now().Before(s.skillNamesTTL) {
+		return s.skillNamesCache
+	}
+	var names []string
+	s.DB.Model(&db.Scan{}).Where("skill_name != ''").Distinct("skill_name").
+		Order("skill_name").Pluck("skill_name", &names)
+	s.skillNamesCache = names
+	s.skillNamesTTL = time.Now().Add(skillNamesCacheTTL)
+	return names
 }
 
 func (s *Server) repoCreate(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
The /scans page runs `SELECT DISTINCT skill_name FROM scans` on every load to populate the filter dropdown. With 18k rows and no index on `skill_name`, this was a full table scan taking 200-600ms per request (visible as GORM SLOW SQL warnings in the server log).

Two changes:

- Add `gorm:"index"` to `Scan.SkillName` so AutoMigrate creates `idx_scans_skill_name`
- Cache the distinct skill names list for 30 seconds on the Server struct, so repeat loads skip the query entirely