### PR TITLE
Query only page-visible PURLs and URLs on repo show

### DIFF
--- a/internal/web/import_test.go
+++ b/internal/web/import_test.go
@@ -41,8 +41,12 @@ func TestKnownPURLsMatchWithAndWithoutQualifiers(t *testing.T) {
 		PURL:         "pkg:gem/bigdecimal",
 	})
 
-	// Simulate what repoShow does to build KnownPURLs
-	knownPURLs := buildKnownPURLs(gdb)
+	srv := &Server{DB: gdb}
+	deps := []DepGroup{
+		{Dependency: db.Dependency{PURL: "pkg:gem/bigdecimal"}},
+		{Dependency: db.Dependency{PURL: "pkg:gem/bigdecimal?repository_url=https://gem.coop"}},
+	}
+	knownPURLs := srv.lookupKnownPURLs(deps)
 
 	// bare PURL should resolve to repo2
 	if rid := knownPURLs["pkg:gem/bigdecimal"]; rid != repo2.ID {
@@ -69,7 +73,13 @@ func TestKnownURLsMatchDependents(t *testing.T) {
 	repo := db.Repository{URL: "https://github.com/ruby/bigdecimal", Name: "bigdecimal"}
 	gdb.Create(&repo)
 
-	knownURLs := buildKnownURLs(gdb)
+	srv := &Server{DB: gdb}
+	dependents := []db.Dependent{
+		{RepositoryURL: "https://github.com/ruby/bigdecimal"},
+		{RepositoryURL: "https://github.com/foo/bar"},
+	}
+	knownURLs := srv.lookupKnownURLs(dependents)
+
 	if rid := knownURLs["https://github.com/ruby/bigdecimal"]; rid != repo.ID {
 		t.Errorf("got repo %d, want %d", rid, repo.ID)
 	}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -1435,8 +1435,8 @@ func (s *Server) repoShow(w http.ResponseWriter, r *http.Request) {
 	var advisories []db.Advisory
 	s.DB.Where("repository_id = ?", repo.ID).Order("cvss_score desc").Find(&advisories)
 
-	knownURLs := buildKnownURLs(s.DB)
-	knownPURLs := buildKnownPURLs(s.DB)
+	knownPURLs := s.lookupKnownPURLs(deps)
+	knownURLs := s.lookupKnownURLs(dependents)
 
 	// Pass repo html_url and commit for location links in threat model
 	tmCommit := ""
@@ -1701,28 +1701,56 @@ func groupDeps(deps []db.Dependency) []DepGroup {
 	return out
 }
 
-func buildKnownURLs(gdb *gorm.DB) map[string]uint {
+func (s *Server) lookupKnownPURLs(deps []DepGroup) map[string]uint {
 	m := map[string]uint{}
-	var rows []db.Repository
-	gdb.Select("id", "url").Find(&rows)
-	for _, r := range rows {
-		m[r.URL] = r.ID
+	if len(deps) == 0 {
+		return m
 	}
-	return m
-}
-
-func buildKnownPURLs(gdb *gorm.DB) map[string]uint {
-	m := map[string]uint{}
+	purls := make([]string, 0, len(deps))
+	for _, d := range deps {
+		if d.PURL != "" {
+			purls = append(purls, d.PURL)
+			if base, _, ok := strings.Cut(d.PURL, "?"); ok {
+				purls = append(purls, base)
+			}
+		}
+	}
+	if len(purls) == 0 {
+		return m
+	}
 	var rows []struct {
 		PURL         string
 		RepositoryID uint
 	}
-	gdb.Model(&db.Package{}).Select("p_url, repository_id").Find(&rows)
-	for _, p := range rows {
-		m[p.PURL] = p.RepositoryID
-		if base, _, ok := strings.Cut(p.PURL, "?"); ok {
-			m[base] = p.RepositoryID
+	s.DB.Model(&db.Package{}).Select("p_url, repository_id").
+		Where("p_url IN ?", purls).Find(&rows)
+	for _, r := range rows {
+		m[r.PURL] = r.RepositoryID
+		if base, _, ok := strings.Cut(r.PURL, "?"); ok {
+			m[base] = r.RepositoryID
 		}
+	}
+	return m
+}
+
+func (s *Server) lookupKnownURLs(dependents []db.Dependent) map[string]uint {
+	m := map[string]uint{}
+	if len(dependents) == 0 {
+		return m
+	}
+	urls := make([]string, 0, len(dependents))
+	for _, d := range dependents {
+		if d.RepositoryURL != "" {
+			urls = append(urls, d.RepositoryURL)
+		}
+	}
+	if len(urls) == 0 {
+		return m
+	}
+	var repos []db.Repository
+	s.DB.Select("id", "url").Where("url IN ?", urls).Find(&repos)
+	for _, r := range repos {
+		m[r.URL] = r.ID
 	}
 	return m
 }


### PR DESCRIPTION
The repo show page was loading all package PURLs (11k rows) and all repository URLs (1.2k rows) into maps on every load to render "already imported" indicators on the dependencies/dependents tabs. This was a 200-600ms pair of full table scans that would only get worse as data grows.

Instead of caching the full maps, collect the specific PURLs from the dependency list and URLs from the dependents list already loaded for the page, then do targeted \`WHERE IN\` queries. Cost scales with the number of deps on the page (typically tens), not the total row count.