### PR TITLE
Fix blank repo show page caused by repo list poll

### DIFF
--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -1680,7 +1680,7 @@ func TestJobs_defaultSortFloatsActiveFirst(t *testing.T) {
 		t.Fatalf("status %d: %s", w.Code, w.Body)
 	}
 	body := w.Body.String()
-	pos := func(id uint) int { return strings.Index(body, fmt.Sprintf(`hx-get="/scans/%d"`, id)) }
+	pos := func(id uint) int { return strings.Index(body, fmt.Sprintf(`/scans/%d"`, id)) }
 	r, q, d := pos(runID), pos(queueID), pos(doneID)
 	if r < 0 || q < 0 || d < 0 {
 		t.Fatalf("scan rows not rendered: running=%d queued=%d done=%d", r, q, d)

--- a/internal/web/static/app.js
+++ b/internal/web/static/app.js
@@ -46,6 +46,12 @@
   document.addEventListener('htmx:oobAfterSwap', function () { icons(); highlight(); });
 
   document.addEventListener('click', function (e) {
+    var tr = e.target.closest('.table tbody tr');
+    if (tr && !e.target.closest('a, button, form, input')) {
+      var a = tr.querySelector('a[href]');
+      if (a) { a.click(); return; }
+    }
+
     var tab = e.target.closest('[role="tab"]');
     if (tab && tab.id) history.replaceState(null, '', '#' + tab.id);
 

--- a/internal/web/static/theme.css
+++ b/internal/web/static/theme.css
@@ -372,6 +372,7 @@ body { background: var(--background); color: var(--foreground);
 pre.log { background: var(--muted); padding: 1rem; border-radius: var(--radius);
           max-height: 60vh; overflow: auto; font-size: 0.8rem; white-space: pre-wrap; }
 .lucide:not([class*="size-"]) { width: 1em; height: 1em; vertical-align: -0.15em; }
+.table tbody tr:has(a) { cursor: pointer; }
 
 /* ── prose (rendered markdown in finding fields) ── */
 .prose { font-size: 0.875rem; line-height: 1.625; max-width: 80ch; }

--- a/internal/web/templates/findings.html
+++ b/internal/web/templates/findings.html
@@ -59,10 +59,10 @@
     {{$showSub := .AnySubPath}}
     {{range .Findings}}
       {{$repo := index $repos .RepositoryID}}
-      <tr id="finding-{{.ID}}" class="cursor-pointer" hx-get="/findings/{{.ID}}" hx-push-url="true">
+      <tr id="finding-{{.ID}}">
         <td>{{template "severity-badge" .Severity}}</td>
         <td class="min-w-0 whitespace-normal">
-          <a href="/findings/{{.ID}}" class="font-medium" hx-on:click="event.stopPropagation()">{{.Title}}</a>
+          <a href="/findings/{{.ID}}" class="font-medium">{{.Title}}</a>
           <div class="text-xs text-muted-foreground line-clamp-2">{{.Summary}}</div>
         </td>
         <td>{{template "finding-status" (fstatus .Status)}}</td>

--- a/internal/web/templates/jobs.html
+++ b/internal/web/templates/jobs.html
@@ -67,8 +67,8 @@
     <tbody>
     {{$showSub := .AnySubPath}}
     {{range .Scans}}
-      <tr id="scan-{{.ID}}" class="cursor-pointer" hx-get="/scans/{{.ID}}" hx-push-url="true">
-        <td><a href="/scans/{{.ID}}" hx-on:click="event.stopPropagation()">{{.ID}}</a></td>
+      <tr id="scan-{{.ID}}">
+        <td><a href="/scans/{{.ID}}">{{.ID}}</a></td>
         <td>{{.Repository.Name}}</td>
         {{if $showSub}}
           <td class="text-xs text-muted-foreground">{{if .SubPath}}<code>{{.SubPath}}</code>{{else}}<span>root</span>{{end}}</td>

--- a/internal/web/templates/layout.html
+++ b/internal/web/templates/layout.html
@@ -79,9 +79,7 @@
   </nav>
 </aside>
 
-<main id="content" class="min-h-screen"
-      hx-history-elt
-      hx-target="#content" hx-select="#content" hx-select-oob="#nav" hx-swap="outerHTML">
+<main id="content" class="min-h-screen">
   <div class="p-4 md:p-6 xl:p-12">
 {{end}}
 
@@ -174,12 +172,12 @@
 {{define "scan-actions"}}
   {{if or (eq (status .Status) "queued") (eq (status .Status) "running")}}
     <form method="post" action="/scans/{{.ID}}/cancel" hx-post="/scans/{{.ID}}/cancel"
-          hx-swap="none" hx-on:click="event.stopPropagation()">
+          hx-swap="none">
       <button type="submit" class="btn-sm-ghost" data-tooltip="Cancel"><i data-lucide="x"></i></button>
     </form>
   {{else if and (or (eq (status .Status) "failed") (eq (status .Status) "cancelled")) .SkillID}}
     <form method="post" action="/scans/{{.ID}}/retry" hx-post="/scans/{{.ID}}/retry"
-          hx-swap="none" hx-on:click="event.stopPropagation()">
+          hx-swap="none">
       <button type="submit" class="btn-sm-ghost" data-tooltip="Retry"><i data-lucide="refresh-cw"></i></button>
     </form>
   {{end}}

--- a/internal/web/templates/maintainer_show.html
+++ b/internal/web/templates/maintainer_show.html
@@ -50,8 +50,8 @@
         <thead><tr><th>Repository</th><th>Language</th><th>Stars</th></tr></thead>
         <tbody>
         {{range $m.Repositories}}
-          <tr id="repo-{{.ID}}" class="cursor-pointer" hx-get="/repositories/{{.ID}}" hx-push-url="true">
-            <td><a href="/repositories/{{.ID}}" class="font-medium" hx-on:click="event.stopPropagation()">{{trimscheme .URL}}</a></td>
+          <tr id="repo-{{.ID}}">
+            <td><a href="/repositories/{{.ID}}" class="font-medium">{{trimscheme .URL}}</a></td>
             <td class="text-muted-foreground">{{.Languages}}</td>
             <td class="text-muted-foreground">{{if .Stars}}{{bignum .Stars}}{{end}}</td>
           </tr>
@@ -74,10 +74,10 @@
       {{$repos := .Repos}}
       {{range .Findings}}
         {{$repo := index $repos .RepositoryID}}
-        <tr id="finding-{{.ID}}" class="cursor-pointer" hx-get="/findings/{{.ID}}" hx-push-url="true">
+        <tr id="finding-{{.ID}}">
           <td>{{template "severity-badge" .Severity}}</td>
           <td class="min-w-0 whitespace-normal">
-            <a href="/findings/{{.ID}}" class="font-medium" hx-on:click="event.stopPropagation()">{{.Title}}</a>
+            <a href="/findings/{{.ID}}" class="font-medium">{{.Title}}</a>
             <div class="text-xs text-muted-foreground line-clamp-1">{{.Summary}}</div>
           </td>
           <td class="truncate">{{$repo.Name}}</td>

--- a/internal/web/templates/maintainers.html
+++ b/internal/web/templates/maintainers.html
@@ -53,9 +53,9 @@
     <tbody>
     {{$counts := .FindingCounts}}
     {{range .Maintainers}}
-      <tr id="maintainer-{{.ID}}" class="cursor-pointer" hx-get="/maintainers/{{.ID}}" hx-push-url="true">
+      <tr id="maintainer-{{.ID}}">
         <td>
-          <a href="/maintainers/{{.ID}}" class="font-medium" hx-on:click="event.stopPropagation()">{{.Name}}</a>
+          <a href="/maintainers/{{.ID}}" class="font-medium">{{.Name}}</a>
           {{if .DoNotContact}}<span class="badge-destructive ml-1" data-tooltip="Do not contact">DNC</span>{{end}}
         </td>
         <td class="text-muted-foreground">{{.Login}}</td>

--- a/internal/web/templates/org_show.html
+++ b/internal/web/templates/org_show.html
@@ -51,8 +51,8 @@
       <tbody>
       {{$counts := .FindingCounts}}
       {{range .Repos}}
-        <tr id="repo-{{.ID}}" class="cursor-pointer" hx-get="/repositories/{{.ID}}" hx-push-url="true">
-          <td><a href="/repositories/{{.ID}}" class="font-medium" hx-on:click="event.stopPropagation()">{{.Name}}</a></td>
+        <tr id="repo-{{.ID}}">
+          <td><a href="/repositories/{{.ID}}" class="font-medium">{{.Name}}</a></td>
           <td class="text-muted-foreground">{{.Languages}}</td>
           <td class="text-right text-muted-foreground">{{if .Stars}}{{bignum .Stars}}{{end}}</td>
           <td class="text-right">{{template "findings-badge" (index $counts .ID)}}</td>
@@ -78,9 +78,9 @@
       {{$repos := .FindingRepos}}
       {{range .Findings}}
         {{$repo := index $repos .RepositoryID}}
-        <tr id="finding-{{.ID}}" class="cursor-pointer" hx-get="/findings/{{.ID}}" hx-push-url="true">
+        <tr id="finding-{{.ID}}">
           <td>{{template "severity-badge" .Severity}}</td>
-          <td class="min-w-0 whitespace-normal"><a href="/findings/{{.ID}}" class="font-medium" hx-on:click="event.stopPropagation()">{{.Title}}</a></td>
+          <td class="min-w-0 whitespace-normal"><a href="/findings/{{.ID}}" class="font-medium">{{.Title}}</a></td>
           <td class="truncate">{{$repo.Name}}</td>
           <td>{{template "finding-status" (fstatus .Status)}}</td>
           <td class="text-muted-foreground">{{.CWE}}</td>
@@ -128,8 +128,8 @@
       </tr></thead>
       <tbody>
       {{range .Maintainers}}
-        <tr id="maintainer-{{.ID}}" class="cursor-pointer" hx-get="/maintainers/{{.ID}}" hx-push-url="true">
-          <td><a href="/maintainers/{{.ID}}" class="font-medium" hx-on:click="event.stopPropagation()">{{.Name}}</a></td>
+        <tr id="maintainer-{{.ID}}">
+          <td><a href="/maintainers/{{.ID}}" class="font-medium">{{.Name}}</a></td>
           <td class="text-muted-foreground">{{.Login}}</td>
           <td class="text-muted-foreground">{{.Email}}</td>
           <td>{{template "status-badge" (printf "%s" .Status)}}</td>

--- a/internal/web/templates/orgs.html
+++ b/internal/web/templates/orgs.html
@@ -38,8 +38,8 @@
     </tr></thead>
     <tbody>
     {{range .Orgs}}
-      <tr id="org-{{.Owner}}" class="cursor-pointer" hx-get="/orgs/{{.Owner}}" hx-push-url="true">
-        <td><a href="/orgs/{{.Owner}}" class="font-medium" hx-on:click="event.stopPropagation()">{{.Owner}}</a></td>
+      <tr id="org-{{.Owner}}">
+        <td><a href="/orgs/{{.Owner}}" class="font-medium">{{.Owner}}</a></td>
         <td class="text-right text-muted-foreground">{{.Repos}}</td>
         <td class="text-right">{{template "findings-badge" .FindingsTotal}}</td>
         <td class="text-muted-foreground">{{if .LastActivity}}{{since .LastActivity}}{{end}}</td>

--- a/internal/web/templates/packages.html
+++ b/internal/web/templates/packages.html
@@ -54,8 +54,8 @@
     </tr></thead>
     <tbody>
     {{range .Pkgs}}
-      <tr id="package-{{.ID}}" class="cursor-pointer" hx-get="/packages/{{.ID}}" hx-push-url="true">
-        <td class="whitespace-normal"><a href="/packages/{{.ID}}" class="font-medium" hx-on:click="event.stopPropagation()">{{.Name}}</a></td>
+      <tr id="package-{{.ID}}">
+        <td class="whitespace-normal"><a href="/packages/{{.ID}}" class="font-medium">{{.Name}}</a></td>
         <td><span class="badge-outline">{{.Ecosystem}}</span></td>
         <td class="text-muted-foreground">{{if .RegistryURL}}{{domain .RegistryURL}}{{end}}</td>
         <td class="text-muted-foreground">{{.LatestVersion}}</td>

--- a/internal/web/templates/partials.html
+++ b/internal/web/templates/partials.html
@@ -32,7 +32,7 @@
 {{define "loc-link"}}
   {{$u := locurl .HTMLURL .Commit .Location}}
   {{if $u}}
-    <a href="{{$u}}" target="_blank" rel="noopener" hx-on:click="event.stopPropagation()"
+    <a href="{{$u}}" target="_blank" rel="noopener"
        class="hover:underline"><code class="text-xs break-all">{{.Location}}</code></a>
   {{else}}
     <code class="text-xs break-all">{{.Location}}</code>

--- a/internal/web/templates/repo_list.html
+++ b/internal/web/templates/repo_list.html
@@ -1,4 +1,4 @@
-<div id="repos" hx-get="/repositories?q={{.Q}}&page={{.Page.N}}&language={{.Language}}&sort={{.Sort}}" hx-trigger="every 5s[document.visibilityState==='visible']" hx-target="this" hx-select="#repos" hx-swap="outerHTML">
+<div id="repos">
 <div class="flex items-center justify-end gap-2 mb-4">
   <form method="get" action="/" class="inline-flex">
     <input class="input" type="search" name="q" value="{{.Q}}" placeholder="Search repositories"
@@ -45,9 +45,9 @@
     </thead>
     <tbody>
     {{range .Rows}}
-      <tr id="repo-{{.ID}}" class="cursor-pointer" hx-get="/repositories/{{.ID}}" hx-push-url="true">
+      <tr id="repo-{{.ID}}">
         <td>
-          <a href="/repositories/{{.ID}}" hx-on:click="event.stopPropagation()">{{trimscheme .URL}}</a>
+          <a href="/repositories/{{.ID}}">{{trimscheme .URL}}</a>
           {{if .CloneError}}<span class="badge-destructive ml-1" data-tooltip="{{.CloneError}}"><i data-lucide="wifi-off"></i></span>{{end}}
         </td>
         <td class="text-muted-foreground">{{if .Languages}}{{.Languages}}{{else}}-{{end}}</td>
@@ -56,8 +56,7 @@
         <td>{{template "findings-badge" .FindingsTotal}}</td>
         <td>
           <form method="post" action="/repositories/{{.ID}}/scan"
-                hx-post="/repositories/{{.ID}}/scan" hx-swap="none"
-                hx-on:click="event.stopPropagation()">
+                hx-post="/repositories/{{.ID}}/scan" hx-swap="none">
             <button type="submit" class="btn-sm-outline"><i data-lucide="refresh-cw"></i> Rescan</button>
           </form>
         </td>

--- a/internal/web/templates/repo_show.html
+++ b/internal/web/templates/repo_show.html
@@ -157,9 +157,9 @@
           </tr></thead>
           <tbody>
           {{range .Latest.Findings}}
-            <tr id="finding-{{.ID}}" class="cursor-pointer" hx-get="/findings/{{.ID}}" hx-push-url="true">
+            <tr id="finding-{{.ID}}">
               <td>{{template "severity-badge" .Severity}}</td>
-              <td class="min-w-0 whitespace-normal"><a href="/findings/{{.ID}}" hx-on:click="event.stopPropagation()">{{.Title}}</a></td>
+              <td class="min-w-0 whitespace-normal"><a href="/findings/{{.ID}}">{{.Title}}</a></td>
               <td>{{template "finding-status" (fstatus .Status)}}</td>
               <td class="whitespace-normal"><code class="text-xs break-all">{{.Location}}</code></td>
             </tr>
@@ -180,12 +180,12 @@
     </p>
     <div class="grid gap-4">
       {{range .Findings}}
-        <div id="finding-card-{{.ID}}" class="card cursor-pointer" hx-get="/findings/{{.ID}}" hx-push-url="true">
+        <div id="finding-card-{{.ID}}" class="card">
           <header>
             <div class="flex items-center gap-2">
               {{template "severity-badge" .Severity}}
               {{template "finding-status" (fstatus .Status)}}
-              <h3><a href="/findings/{{.ID}}" hx-on:click="event.stopPropagation()">{{.Title}}</a></h3>
+              <h3><a href="/findings/{{.ID}}">{{.Title}}</a></h3>
               {{if .CWE}}<span class="badge-outline ml-auto" data-tooltip="{{cwename .CWE}}">{{.CWE}}</span>{{end}}
             </div>
             <p>
@@ -212,8 +212,8 @@
       </tr></thead>
       <tbody>
       {{range .Pkgs}}
-        <tr id="package-{{.ID}}" class="cursor-pointer" hx-get="/packages/{{.ID}}" hx-push-url="true">
-          <td class="whitespace-normal"><a href="/packages/{{.ID}}" class="font-medium" hx-on:click="event.stopPropagation()">{{.Name}}</a></td>
+        <tr id="package-{{.ID}}">
+          <td class="whitespace-normal"><a href="/packages/{{.ID}}" class="font-medium">{{.Name}}</a></td>
           <td><span class="badge-outline">{{.Ecosystem}}</span></td>
           <td class="text-muted-foreground">{{if .RegistryURL}}{{domain .RegistryURL}}{{end}}</td>
           <td class="text-muted-foreground">{{.LatestVersion}}</td>
@@ -312,8 +312,8 @@
       <thead><tr><th>Login</th><th>Name</th><th>Email</th><th>Status</th></tr></thead>
       <tbody>
       {{range .Maintainers}}
-        <tr id="maintainer-{{.ID}}" class="cursor-pointer" hx-get="/maintainers/{{.ID}}" hx-push-url="true">
-          <td><a href="/maintainers/{{.ID}}" class="font-medium" hx-on:click="event.stopPropagation()">{{.Login}}</a></td>
+        <tr id="maintainer-{{.ID}}">
+          <td><a href="/maintainers/{{.ID}}" class="font-medium">{{.Login}}</a></td>
           <td>{{.Name}}</td>
           <td class="text-muted-foreground">{{.Email}}</td>
           <td>{{template "status-badge" (printf "%s" .Status)}}</td>
@@ -348,7 +348,7 @@
   </div>
 
   <div hx-ext="sse" sse-connect="/events?repo={{.Repo.ID}}"
-       sse-swap="scan-status" hx-swap="none" hidden></div>
+       sse-swap="scan-status" hx-swap="none" hx-disinherit="*" hidden></div>
 </div>
 
 {{template "foot" .}}
@@ -360,8 +360,8 @@
 {{end}}
 
 {{define "scan-row"}}{{with .S}}
-  <tr id="scan-{{.ID}}" class="cursor-pointer" hx-get="/scans/{{.ID}}" hx-push-url="true"{{if $.OOB}} hx-swap-oob="true"{{end}}>
-    <td><a href="/scans/{{.ID}}" hx-on:click="event.stopPropagation()">{{.ID}}</a></td>
+  <tr id="scan-{{.ID}}"{{if $.OOB}} hx-swap-oob="true"{{end}}>
+    <td><a href="/scans/{{.ID}}">{{.ID}}</a></td>
     <td>{{if .SkillName}}{{.SkillName}}{{else}}{{.Kind}}{{end}}</td>
     <td>{{template "status-badge" (status .Status)}}</td>
     <td>{{if gt .FindingsCount 0}}{{template "findings-badge" .FindingsCount}}{{end}}</td>

--- a/internal/web/templates/sbom_show.html
+++ b/internal/web/templates/sbom_show.html
@@ -153,9 +153,9 @@
       {{$repos := .Repos}}
       {{range .Findings}}
         {{$repo := index $repos .RepositoryID}}
-        <tr id="finding-{{.ID}}" class="cursor-pointer" hx-get="/findings/{{.ID}}" hx-push-url="true">
+        <tr id="finding-{{.ID}}">
           <td>{{template "severity-badge" .Severity}}</td>
-          <td class="min-w-0 whitespace-normal"><a href="/findings/{{.ID}}" class="font-medium" hx-on:click="event.stopPropagation()">{{.Title}}</a></td>
+          <td class="min-w-0 whitespace-normal"><a href="/findings/{{.ID}}" class="font-medium">{{.Title}}</a></td>
           <td class="truncate">{{$repo.Name}}</td>
           <td>{{template "finding-status" (fstatus .Status)}}</td>
           <td class="text-muted-foreground">{{.CWE}}</td>

--- a/internal/web/templates/sboms.html
+++ b/internal/web/templates/sboms.html
@@ -34,8 +34,8 @@
     </tr></thead>
     <tbody>
     {{range .SBOMs}}
-      <tr id="sbom-{{.ID}}" class="cursor-pointer" hx-get="/sboms/{{.ID}}" hx-push-url="true">
-        <td><a href="/sboms/{{.ID}}" class="font-medium" hx-on:click="event.stopPropagation()">{{.Name}}</a><div class="text-xs text-muted-foreground">{{.Filename}}</div></td>
+      <tr id="sbom-{{.ID}}">
+        <td><a href="/sboms/{{.ID}}" class="font-medium">{{.Name}}</a><div class="text-xs text-muted-foreground">{{.Filename}}</div></td>
         <td><span class="badge-outline">{{.Format}} {{.SpecVersion}}</span></td>
         <td class="text-right text-muted-foreground">{{.PackageCount}}</td>
         <td class="text-muted-foreground">{{since .CreatedAt}}</td>

--- a/internal/web/templates/scan_show.html
+++ b/internal/web/templates/scan_show.html
@@ -91,10 +91,10 @@
         </tr></thead>
         <tbody>
         {{range .Findings}}
-          <tr id="finding-{{.ID}}" class="cursor-pointer" hx-get="/findings/{{.ID}}" hx-push-url="true">
+          <tr id="finding-{{.ID}}">
             <td>{{template "severity-badge" .Severity}}</td>
             <td class="min-w-0 whitespace-normal">
-              <a href="/findings/{{.ID}}" class="font-medium" hx-on:click="event.stopPropagation()">{{.Title}}</a>
+              <a href="/findings/{{.ID}}" class="font-medium">{{.Title}}</a>
               <div class="text-xs text-muted-foreground line-clamp-2">{{.Summary}}</div>
             </td>
             <td>{{template "finding-status" (fstatus .Status)}}</td>
@@ -120,7 +120,7 @@
   <div role="tabpanel" id="p2" aria-labelledby="t2" {{if ne $default 2}}hidden{{end}}>
     {{if $live}}
       <div hx-ext="sse" sse-connect="/events?scan={{.ID}}"
-           sse-swap="scan-status" hx-swap="none"
+           sse-swap="scan-status" hx-swap="none" hx-disinherit="*"
            hx-on::sse-message="if(event.detail.type==='scan-status') location.reload()">
         <pre class="log" sse-swap="scan-log" hx-swap="beforeend scroll:bottom">{{template "scan_log.html" .}}</pre>
       </div>

--- a/internal/web/templates/skills.html
+++ b/internal/web/templates/skills.html
@@ -14,8 +14,8 @@
     </tr></thead>
     <tbody>
     {{range .Skills}}
-      <tr id="skill-{{.ID}}" class="cursor-pointer" hx-get="/skills/{{.ID}}" hx-push-url="true">
-        <td><a href="/skills/{{.ID}}" class="font-medium" hx-on:click="event.stopPropagation()">{{.Name}}</a></td>
+      <tr id="skill-{{.ID}}">
+        <td><a href="/skills/{{.ID}}" class="font-medium">{{.Name}}</a></td>
         <td class="text-muted-foreground whitespace-normal">{{.Description}}</td>
         <td>{{if .OutputKind}}<span class="badge-outline">{{.OutputKind}}</span>{{end}}</td>
         <td class="text-muted-foreground">{{.Source}}</td>


### PR DESCRIPTION
Replaces htmx-driven row navigation with progressive enhancement. Rows are now plain `<tr>` elements with `<a>` links inside. A small JS click handler in `app.js` delegates row clicks to the link, and a CSS `:has(a)` rule handles the pointer cursor.

- Strips `hx-target`, `hx-select`, `hx-select-oob` from `<main>`
- Adds `hx-disinherit="*"` on SSE divs to isolate them
- Removes `hx-get`/`hx-push-url`/`stopPropagation` from all rows, cards, links, and action forms
- SSE live updates and `hx-post` form submissions unchanged