### PR TITLE
web: strip .git from repo URLs and normalise dep-scan path

### DIFF
--- a/internal/web/parse_repo_url.go
+++ b/internal/web/parse_repo_url.go
@@ -30,9 +30,9 @@ type RepoInput struct {
 //
 // CloneURL is normalised so the same repository pasted in different forms
 // dedupes to one row: the host is lowercased, the query string is dropped,
-// trailing slashes are stripped, `.git` is appended once, and for forges
-// known to treat owner/repo case-insensitively the path is lowercased.
-// Branch names and sub-paths keep their case.
+// trailing slashes and a `.git` suffix are stripped, and for forges known
+// to treat owner/repo case-insensitively the path is lowercased. Branch
+// names and sub-paths keep their case.
 func ParseRepoInput(raw string) (RepoInput, error) {
 	raw = strings.TrimSpace(raw)
 	if raw == "" {
@@ -103,14 +103,13 @@ func cloneURL(u *url.URL, path string) string {
 	if caseInsensitiveForges[c.Host] {
 		c.Path = strings.ToLower(c.Path)
 	}
-	return ensureGitSuffix(c.String())
+	return stripGitSuffix(c.String())
 }
 
-// ensureGitSuffix returns u with a single trailing ".git". Idempotent.
-func ensureGitSuffix(u string) string {
+// stripGitSuffix returns u with any trailing slash and ".git" removed.
+// All major forges clone fine without it and ecosyste.ms / web UIs emit
+// the bare form, so stripping is the canonical shape. Idempotent.
+func stripGitSuffix(u string) string {
 	u = strings.TrimRight(u, "/")
-	if strings.HasSuffix(u, ".git") {
-		return u
-	}
-	return u + ".git"
+	return strings.TrimSuffix(u, ".git")
 }

--- a/internal/web/parse_repo_url_test.go
+++ b/internal/web/parse_repo_url_test.go
@@ -12,18 +12,18 @@ func TestParseRepoInput(t *testing.T) {
 		{
 			name:  "plain github url without .git",
 			input: "https://github.com/rails/rails",
-			want:  RepoInput{CloneURL: "https://github.com/rails/rails.git"},
+			want:  RepoInput{CloneURL: "https://github.com/rails/rails"},
 		},
 		{
 			name:  "plain github url with .git",
 			input: "https://github.com/rails/rails.git",
-			want:  RepoInput{CloneURL: "https://github.com/rails/rails.git"},
+			want:  RepoInput{CloneURL: "https://github.com/rails/rails"},
 		},
 		{
 			name:  "github tree url with sub-path",
 			input: "https://github.com/apache/airflow/tree/main/airflow-core",
 			want: RepoInput{
-				CloneURL: "https://github.com/apache/airflow.git",
+				CloneURL: "https://github.com/apache/airflow",
 				SubPath:  "airflow-core",
 				Branch:   "main",
 			},
@@ -32,7 +32,7 @@ func TestParseRepoInput(t *testing.T) {
 			name:  "github tree url with nested sub-path",
 			input: "https://github.com/kubernetes/kubernetes/tree/master/staging/src/k8s.io/api",
 			want: RepoInput{
-				CloneURL: "https://github.com/kubernetes/kubernetes.git",
+				CloneURL: "https://github.com/kubernetes/kubernetes",
 				SubPath:  "staging/src/k8s.io/api",
 				Branch:   "master",
 			},
@@ -41,7 +41,7 @@ func TestParseRepoInput(t *testing.T) {
 			name:  "github tree url with release branch",
 			input: "https://github.com/apache/airflow/tree/v2.9.0/airflow-core",
 			want: RepoInput{
-				CloneURL: "https://github.com/apache/airflow.git",
+				CloneURL: "https://github.com/apache/airflow",
 				SubPath:  "airflow-core",
 				Branch:   "v2.9.0",
 			},
@@ -50,7 +50,7 @@ func TestParseRepoInput(t *testing.T) {
 			name:  "github tree url pointing at root of branch",
 			input: "https://github.com/apache/airflow/tree/main",
 			want: RepoInput{
-				CloneURL: "https://github.com/apache/airflow.git",
+				CloneURL: "https://github.com/apache/airflow",
 				SubPath:  "",
 				Branch:   "main",
 			},
@@ -59,7 +59,7 @@ func TestParseRepoInput(t *testing.T) {
 			name:  "fragment form explicit sub-path",
 			input: "https://gitlab.com/group/project#services/api",
 			want: RepoInput{
-				CloneURL: "https://gitlab.com/group/project.git",
+				CloneURL: "https://gitlab.com/group/project",
 				SubPath:  "services/api",
 			},
 		},
@@ -67,35 +67,40 @@ func TestParseRepoInput(t *testing.T) {
 			name:  "fragment form with leading slash",
 			input: "https://github.com/rails/rails#/railties",
 			want: RepoInput{
-				CloneURL: "https://github.com/rails/rails.git",
+				CloneURL: "https://github.com/rails/rails",
 				SubPath:  "railties",
 			},
 		},
 		{
 			name:  "trailing slash stripped",
 			input: "https://github.com/rails/rails/",
-			want:  RepoInput{CloneURL: "https://github.com/rails/rails.git"},
+			want:  RepoInput{CloneURL: "https://github.com/rails/rails"},
+		},
+		{
+			name:  ".git/ trailing slash stripped",
+			input: "https://github.com/rails/rails.git/",
+			want:  RepoInput{CloneURL: "https://github.com/rails/rails"},
 		},
 		{
 			name:  "query string dropped",
 			input: "https://github.com/rails/rails?tab=readme-ov-file",
-			want:  RepoInput{CloneURL: "https://github.com/rails/rails.git"},
+			want:  RepoInput{CloneURL: "https://github.com/rails/rails"},
 		},
 		{
 			name:  "host lowercased",
 			input: "https://GitHub.com/rails/rails",
-			want:  RepoInput{CloneURL: "https://github.com/rails/rails.git"},
+			want:  RepoInput{CloneURL: "https://github.com/rails/rails"},
 		},
 		{
 			name:  "owner/repo lowercased on known forge",
 			input: "https://github.com/Rails/Rails",
-			want:  RepoInput{CloneURL: "https://github.com/rails/rails.git"},
+			want:  RepoInput{CloneURL: "https://github.com/rails/rails"},
 		},
 		{
 			name:  "tree url owner/repo lowercased but branch and sub-path keep case",
 			input: "https://github.com/Apache/Airflow/tree/Main/Airflow-Core",
 			want: RepoInput{
-				CloneURL: "https://github.com/apache/airflow.git",
+				CloneURL: "https://github.com/apache/airflow",
 				SubPath:  "Airflow-Core",
 				Branch:   "Main",
 			},
@@ -104,19 +109,19 @@ func TestParseRepoInput(t *testing.T) {
 			name:  "fragment sub-path keeps case",
 			input: "https://github.com/Rails/Rails#ActionPack",
 			want: RepoInput{
-				CloneURL: "https://github.com/rails/rails.git",
+				CloneURL: "https://github.com/rails/rails",
 				SubPath:  "ActionPack",
 			},
 		},
 		{
 			name:  "unknown host keeps path case",
 			input: "https://git.internal/Team/Project",
-			want:  RepoInput{CloneURL: "https://git.internal/Team/Project.git"},
+			want:  RepoInput{CloneURL: "https://git.internal/Team/Project"},
 		},
 		{
 			name:  "all of the above at once",
-			input: "https://GitHub.com/Rails/Rails/?tab=readme",
-			want:  RepoInput{CloneURL: "https://github.com/rails/rails.git"},
+			input: "https://GitHub.com/Rails/Rails.git/?tab=readme",
+			want:  RepoInput{CloneURL: "https://github.com/rails/rails"},
 		},
 		{
 			name:    "non-https rejected",

--- a/internal/web/sboms_test.go
+++ b/internal/web/sboms_test.go
@@ -130,7 +130,7 @@ func TestSBOMResolve_linksRepoAndEnqueuesTriage(t *testing.T) {
 	}
 	var repo db.Repository
 	s.DB.First(&repo, *pkgs[0].RepositoryID)
-	if repo.URL != "https://github.com/lodash/lodash.git" {
+	if repo.URL != "https://github.com/lodash/lodash" {
 		t.Errorf("repo url = %q", repo.URL)
 	}
 	var scans int64

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -857,20 +857,11 @@ func (s *Server) depScan(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Try to find existing repo by PURL lookup
 	repoURL := resolveDepRepoURL(r.Context(), dep)
 	if repoURL == "" {
 		http.Error(w, "could not resolve repository URL for "+dep.Name, http.StatusUnprocessableEntity)
 		return
 	}
-
-	// Find or create
-	repo := db.Repository{URL: repoURL, Name: db.NameFromURL(repoURL)}
-	if err := s.DB.Where(db.Repository{URL: repoURL}).FirstOrCreate(&repo).Error; err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-
 	s.addRepoAndScan(w, r, repoURL)
 }
 
@@ -921,21 +912,15 @@ const (
 )
 
 func (s *Server) addRepoAndScan(w http.ResponseWriter, r *http.Request, repoURL string) {
-	repo := db.Repository{URL: repoURL, Name: db.NameFromURL(repoURL)}
-	if err := s.DB.Where(db.Repository{URL: repoURL}).FirstOrCreate(&repo).Error; err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+	input, err := ParseRepoInput(repoURL)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusUnprocessableEntity)
 		return
 	}
-	var scanCount int64
-	s.DB.Model(&db.Scan{}).Where("repository_id = ?", repo.ID).Count(&scanCount)
-	if scanCount == 0 {
-		var skill db.Skill
-		if err := s.DB.Where("name = ? AND active = ?", defaultSkillName, true).
-			First(&skill).Error; err == nil {
-			_, _ = s.enqueueSkill(r.Context(), repo.ID, skill.ID, "")
-		} else {
-			s.Log.Warn("default skill not found, repo added with no scans", "skill", defaultSkillName)
-		}
+	repo, _, err := s.createOrTriageRepo(r.Context(), input, "")
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
 	}
 	s.redirect(w, r, fmt.Sprintf("/repositories/%d", repo.ID))
 }

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -1429,16 +1429,49 @@ func TestRepoShow_displaysFindingStatus(t *testing.T) {
 	}
 }
 
+func TestDependentScan_dedupesAgainstNormalisedRepo(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	s.DB.Create(&db.Skill{Name: "triage", Description: "o", Body: "b", Active: true, Source: "ui", Version: 1})
+
+	// Repo added through the form (normalised, no .git).
+	existing := db.Repository{URL: "https://github.com/rack/rack", Name: "rack"}
+	s.DB.Create(&existing)
+
+	// Dependent whose RepositoryURL came from ecosyste.ms with .git.
+	dep := db.Dependent{RepositoryID: existing.ID, Name: "rack",
+		RepositoryURL: "https://github.com/rack/rack.git"}
+	s.DB.Create(&dep)
+
+	req := httptest.NewRequest("POST", fmt.Sprintf("/dependents/%d/scan", dep.ID), nil)
+	req.Host = testHost
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+
+	var repos []db.Repository
+	s.DB.Find(&repos)
+	if len(repos) != 1 {
+		t.Fatalf("want 1 repo row, got %d: %+v", len(repos), repos)
+	}
+	if got, want := w.Header().Get("Location"), fmt.Sprintf("/repositories/%d", existing.ID); got != want {
+		t.Errorf("redirect = %q, want %q", got, want)
+	}
+}
+
 func TestBulkImport_dedupesNormalisedURLs(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()
 	s.DB.Create(&db.Skill{Name: "triage", Description: "o", Body: "b", Active: true, Source: "ui", Version: 1})
 
-	// Same repo four ways: canonical, mixed case, trailing slash, query string.
+	// Same repo five ways: canonical, mixed case, trailing slash, .git, query string.
 	urls := strings.Join([]string{
 		"https://github.com/rails/rails",
 		"https://github.com/Rails/Rails",
 		"https://github.com/rails/rails/",
+		"https://github.com/rails/rails.git",
 		"https://GitHub.com/rails/rails?tab=readme",
 	}, "\n")
 	form := url.Values{"urls": {urls}}
@@ -1451,13 +1484,13 @@ func TestBulkImport_dedupesNormalisedURLs(t *testing.T) {
 		t.Fatalf("status %d: %s", w.Code, w.Body)
 	}
 	f := flashFrom(t, w)
-	if !strings.Contains(f.Title, "1 added") || !strings.Contains(f.Title, "3 already present") {
-		t.Errorf("flash title = %q, want 1 added / 3 already present", f.Title)
+	if !strings.Contains(f.Title, "1 added") || !strings.Contains(f.Title, "4 already present") {
+		t.Errorf("flash title = %q, want 1 added / 4 already present", f.Title)
 	}
 
 	var repos []db.Repository
 	s.DB.Find(&repos)
-	if len(repos) != 1 || repos[0].URL != "https://github.com/rails/rails.git" {
+	if len(repos) != 1 || repos[0].URL != "https://github.com/rails/rails" {
 		t.Fatalf("want one normalised row, got %+v", repos)
 	}
 }
@@ -1505,7 +1538,7 @@ func TestBulkImport_skipsDuplicates(t *testing.T) {
 
 	triage := db.Skill{Name: "triage", Description: "o", Body: "b", Active: true, Source: "ui", Version: 1}
 	s.DB.Create(&triage)
-	s.DB.Create(&db.Repository{URL: "https://github.com/foo/one.git", Name: "one"})
+	s.DB.Create(&db.Repository{URL: "https://github.com/foo/one", Name: "one"})
 
 	form := url.Values{"urls": {"https://github.com/foo/one.git\nhttps://github.com/foo/two.git"}}
 	req := httptest.NewRequest("POST", "/repositories/bulk", strings.NewReader(form.Encode()))
@@ -1615,7 +1648,7 @@ func TestCreateRepo_parsesGitHubTreeURL(t *testing.T) {
 	if err := s.DB.First(&repo).Error; err != nil {
 		t.Fatal(err)
 	}
-	if repo.URL != "https://github.com/apache/airflow.git" {
+	if repo.URL != "https://github.com/apache/airflow" {
 		t.Errorf("repo.URL = %q, want clone URL without /tree/", repo.URL)
 	}
 	var scan db.Scan
@@ -1927,7 +1960,7 @@ func TestRepoCreate_existingRepoWithBranchEnqueuesScan(t *testing.T) {
 	defer done()
 
 	s.DB.Create(&db.Skill{Name: "triage", Active: true, Source: "test", Body: "test", OutputFile: "report.json", OutputKind: "freeform", Version: 1})
-	s.DB.Create(&db.Repository{URL: "https://github.com/apache/httpd.git", Name: "httpd"})
+	s.DB.Create(&db.Repository{URL: "https://github.com/apache/httpd", Name: "httpd"})
 
 	form := url.Values{"url": {"https://github.com/apache/httpd/tree/2.4.x"}}
 	req := httptest.NewRequest("POST", "/repositories", strings.NewReader(form.Encode()))
@@ -1954,7 +1987,7 @@ func TestRepoCreate_existingRepoWithoutBranchDoesNotEnqueue(t *testing.T) {
 	defer done()
 
 	s.DB.Create(&db.Skill{Name: "triage", Active: true, Source: "test", Body: "test", OutputFile: "report.json", OutputKind: "freeform", Version: 1})
-	s.DB.Create(&db.Repository{URL: "https://github.com/apache/httpd.git", Name: "httpd"})
+	s.DB.Create(&db.Repository{URL: "https://github.com/apache/httpd", Name: "httpd"})
 
 	form := url.Values{"url": {"https://github.com/apache/httpd"}}
 	req := httptest.NewRequest("POST", "/repositories", strings.NewReader(form.Encode()))


### PR DESCRIPTION
`addRepoAndScan` (the dep/dependent "scan" buttons) was creating `Repository` rows from raw ecosyste.ms URLs without going through `ParseRepoInput`, so the same repo could land as two rows depending on which entry point added it first. It now uses the shared `ParseRepoInput` -> `createOrTriageRepo` path like the add form, bulk import, and SBOM resolver. Drops a redundant `FirstOrCreate` in `depScan` while there.

`ParseRepoInput` now strips a trailing `.git` instead of appending one. The bare form is what ecosyste.ms returns, what forge web UIs show, and what users paste; `git clone` works without it on every forge we target. The append behaviour came in with #43 with no stated rationale.

Existing DBs need a one-off after pulling this and restarting:

```
sqlite3 data/scrutineer.db "UPDATE repositories SET url = substr(url, 1, length(url)-4) WHERE url LIKE '%.git';"
```

If a DB already has both forms of the same repo, that update will fail the unique index; find the pairs first with:

```
sqlite3 data/scrutineer.db "SELECT a.id, a.url, b.id, b.url FROM repositories a JOIN repositories b ON b.url = a.url || '.git';"
```

and delete whichever side you care about less before re-running the update.