### PR TITLE
queue: finding-scoped skills jump bulk scans

### DIFF
--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -1637,7 +1637,11 @@ func (s *Server) enqueueSkillWith(ctx context.Context, repoID, skillID uint, opt
 	if err := s.DB.Create(&scan).Error; err != nil {
 		return 0, err
 	}
-	if err := s.Queue.Enqueue(ctx, worker.JobSkill, scan.ID, worker.PrioScan); err != nil {
+	prio := worker.PrioScan
+	if opts.FindingID != nil {
+		prio = worker.PrioFinding
+	}
+	if err := s.Queue.Enqueue(ctx, worker.JobSkill, scan.ID, prio); err != nil {
 		return 0, err
 	}
 	s.DB.Model(&db.Repository{}).Where("id = ?", repoID).Update("updated_at", time.Now())

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -1258,6 +1258,47 @@ func TestFindingPatchRunEnqueuesPatchSkill(t *testing.T) {
 	}
 }
 
+func TestEnqueueSkillWith_findingScopedJumpsQueue(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	repo := db.Repository{URL: "https://github.com/foo/bar", Name: "bar"}
+	s.DB.Create(&repo)
+	prior := db.Scan{RepositoryID: repo.ID, Kind: "skill", Status: db.ScanDone}
+	s.DB.Create(&prior)
+	skill := db.Skill{Name: "verify", Body: "b", OutputFile: "r.json", OutputKind: "freeform", Version: 1, Active: true, Source: "ui"}
+	s.DB.Create(&skill)
+	finding := db.Finding{ScanID: prior.ID, RepositoryID: repo.ID, FindingID: "F1", Title: "x", Severity: "High"}
+	s.DB.Create(&finding)
+
+	if _, err := s.enqueueSkillWith(context.Background(), repo.ID, skill.ID, ScanOpts{}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.enqueueSkillWith(context.Background(), repo.ID, skill.ID, ScanOpts{FindingID: &finding.ID}); err != nil {
+		t.Fatal(err)
+	}
+
+	sqldb, _ := s.DB.DB()
+	rows, err := sqldb.Query("SELECT priority FROM goqite")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = rows.Close() }()
+	var got []int
+	for rows.Next() {
+		var p int
+		if err := rows.Scan(&p); err != nil {
+			t.Fatal(err)
+		}
+		got = append(got, p)
+	}
+	sort.Ints(got)
+	want := []int{worker.PrioScan, worker.PrioFinding}
+	if len(got) != 2 || got[0] != want[0] || got[1] != want[1] {
+		t.Errorf("queue priorities = %v, want %v", got, want)
+	}
+}
+
 func TestFindingPatchDownload(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -23,6 +23,7 @@ const (
 	JobSkill = "skill"
 
 	PrioScan     = 0
+	PrioFinding  = 2
 	PrioTool     = 5
 	PrioFastTool = 8
 	PrioMetadata = 10


### PR DESCRIPTION
Verify/patch/disclose are interactive follow-ups on a single finding; queueing them behind hundreds of bulk repo scans means the operator clicks a button and nothing happens for hours.

Adds `worker.PrioFinding = 2` and routes any enqueue with a `FindingID` through it. goqite already dequeues by `priority DESC, created`, so these jump ahead of `PrioScan` (0) work but stay below tool/metadata jobs.