### PR TITLE
fork: skill to stage scanned repos and findings into a GitHub org

### DIFF
--- a/cmd/scrutineer/main.go
+++ b/cmd/scrutineer/main.go
@@ -62,6 +62,7 @@ type flags struct {
 	scanTimeout      time.Duration
 	maxTurns         int
 	anthropicBaseURL string
+	forkOrg          string
 	skillLocal       skillDirs
 
 	// set records which flags were passed on the command line so merge
@@ -83,6 +84,7 @@ func parseFlags() *flags {
 	flag.DurationVar(&f.scanTimeout, "scan-timeout", worker.DefaultScanTimeout, "wall-clock limit per scan")
 	flag.IntVar(&f.maxTurns, "max-turns", 0, "claude --max-turns limit (0 = unlimited)")
 	flag.StringVar(&f.anthropicBaseURL, "anthropic-base-url", "", "custom Anthropic API base URL (env: ANTHROPIC_BASE_URL)")
+	flag.StringVar(&f.forkOrg, "fork-org", "", "GitHub org the fork skill forks into and files draft advisories against")
 	flag.Var(&f.skillLocal, "skills", "directory to load SKILL.md files from (repeatable)")
 	flag.Parse()
 
@@ -94,6 +96,8 @@ func parseFlags() *flags {
 // merge layers cfg underneath f: a config value applies only when the
 // matching CLI flag was not set explicitly. Also pushes model overrides
 // into the web package.
+//
+//nolint:gocognit,gocyclo // flat: one guarded assignment per config key
 func (f *flags) merge(cfg *config.Config) {
 	if cfg.Addr != "" && !f.set["addr"] {
 		f.addr = cfg.Addr
@@ -130,6 +134,9 @@ func (f *flags) merge(cfg *config.Config) {
 	}
 	if cfg.AnthropicBaseURL != "" && !f.set["anthropic-base-url"] {
 		f.anthropicBaseURL = cfg.AnthropicBaseURL
+	}
+	if cfg.ForkOrg != "" && !f.set["fork-org"] {
+		f.forkOrg = cfg.ForkOrg
 	}
 
 	if len(cfg.Models) > 0 {
@@ -267,6 +274,7 @@ func run(log *slog.Logger) error {
 		Log:         log,
 		DataDir:     filepath.Join(f.dataDir, "work"),
 		APIBase:     apiBase,
+		ForkOrg:     f.forkOrg,
 		Runner:      runner,
 		ScanTimeout: f.scanTimeout,
 		OnEvent: func(scanID, repoID uint, name, data string) {

--- a/cmd/scrutineer/main_test.go
+++ b/cmd/scrutineer/main_test.go
@@ -22,6 +22,7 @@ func fullConfig() *config.Config {
 		ScanTimeout:      "30m",
 		MaxTurns:         200,
 		AnthropicBaseURL: "https://proxy.corp.com/v1",
+		ForkOrg:          "fork-central",
 	}
 }
 
@@ -55,6 +56,9 @@ func TestFlagsMerge_configFillsUnset(t *testing.T) {
 	}
 	if f.anthropicBaseURL != cfg.AnthropicBaseURL {
 		t.Errorf("anthropicBaseURL = %q, want %q", f.anthropicBaseURL, cfg.AnthropicBaseURL)
+	}
+	if f.forkOrg != cfg.ForkOrg {
+		t.Errorf("forkOrg = %q, want %q", f.forkOrg, cfg.ForkOrg)
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -54,6 +54,10 @@ type Config struct {
 	// Theme selects the colour scheme: "claude" (default), "ocean-breeze",
 	// "catppuccin", "sunset-horizon", "midnight-bloom", or "northern-lights".
 	Theme string `yaml:"theme"`
+	// ForkOrg is the GitHub organisation the fork skill forks scanned
+	// repositories into and files draft advisories against. Empty disables
+	// the fork skill (it will refuse to run without a target org).
+	ForkOrg string `yaml:"fork_org"`
 }
 
 // ParseScanTimeout validates and parses a scan_timeout string. Empty

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -65,6 +65,7 @@ concurrency: 8
 clone: full
 scan_timeout: 30m
 max_turns: 200
+fork_org: fork-central
 `)
 	c, err := Load(path)
 	if err != nil {
@@ -93,6 +94,9 @@ max_turns: 200
 	}
 	if c.ScanTimeout != "30m" || c.MaxTurns != 200 {
 		t.Errorf("scan_timeout=%q max_turns=%d", c.ScanTimeout, c.MaxTurns)
+	}
+	if c.ForkOrg != "fork-central" {
+		t.Errorf("fork_org=%q, want fork-central", c.ForkOrg)
 	}
 }
 

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -53,6 +53,11 @@ type Repository struct {
 	Posture        string `gorm:"index"`
 	PostureSummary string
 
+	// Fork is the full_name (owner/name) of this repository's fork inside
+	// the configured fork_org. Written by the fork skill so later runs and
+	// the UI can find the staging fork without re-resolving the name.
+	Fork string
+
 	// CloneError is set when the last clone/fetch attempt failed (repo
 	// deleted, made private, wrong URL). Non-empty means the repo is
 	// currently unreachable. Cleared on next successful clone.

--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -82,6 +82,7 @@ func (s *Server) scanOwnsRepo(r *http.Request, repoID uint) bool {
 func (s *Server) apiHandler() http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /repositories/{id}", s.apiGetRepository)
+	mux.HandleFunc("PATCH /repositories/{id}", s.apiPatchRepository)
 	mux.HandleFunc("GET /repositories/{id}/scans", s.apiListScans)
 	mux.HandleFunc("GET /repositories/{id}/maintainers", s.apiListMaintainers)
 	mux.HandleFunc("GET /repositories/{id}/packages", s.apiListPackages)
@@ -131,7 +132,35 @@ func (s *Server) apiGetRepository(w http.ResponseWriter, r *http.Request) {
 		"archived":       repo.Archived,
 		"languages":      repo.Languages,
 		"license":        repo.License,
+		"fork":           repo.Fork,
 	})
+}
+
+// apiPatchRepository lets a skill write back fields it derived for the
+// repository. Currently only `fork` (the staging fork's owner/name) is
+// accepted; everything else on Repository is owned by the metadata job.
+func (s *Server) apiPatchRepository(w http.ResponseWriter, r *http.Request) {
+	id, _ := strconv.Atoi(r.PathValue("id"))
+	if !s.scanOwnsRepo(r, uint(id)) {
+		writeAPIError(w, http.StatusForbidden, "scan may only edit its own repository")
+		return
+	}
+	var body struct {
+		Fork *string `json:"fork"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeAPIError(w, http.StatusBadRequest, "body must be JSON")
+		return
+	}
+	if body.Fork == nil {
+		writeAPIError(w, http.StatusUnprocessableEntity, "no writable fields in body")
+		return
+	}
+	if err := s.DB.Model(&db.Repository{}).Where("id = ?", id).Update("fork", *body.Fork).Error; err != nil {
+		writeAPIError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
 }
 
 func (s *Server) apiListScans(w http.ResponseWriter, r *http.Request) {

--- a/internal/web/api_test.go
+++ b/internal/web/api_test.go
@@ -143,6 +143,72 @@ func TestAPIListsTypedReads(t *testing.T) {
 	}
 }
 
+func TestAPIPatchRepositoryFork(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	repo, scan := seedRunningScan(t, s)
+
+	r := httptest.NewRequest("PATCH", "/api/repositories/"+strconv.FormatUint(uint64(repo.ID), 10),
+		strings.NewReader(`{"fork":"fork-central/x"}`))
+	r.Host = testHost
+	r.Header.Set("Authorization", "Bearer "+scan.APIToken)
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, r)
+	if w.Code != 204 {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+	var got db.Repository
+	s.DB.First(&got, repo.ID)
+	if got.Fork != "fork-central/x" {
+		t.Errorf("Fork = %q, want fork-central/x", got.Fork)
+	}
+
+	r = httptest.NewRequest("GET", "/api/repositories/"+strconv.FormatUint(uint64(repo.ID), 10), nil)
+	r.Host = testHost
+	r.Header.Set("Authorization", "Bearer "+scan.APIToken)
+	w = httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, r)
+	var body map[string]any
+	_ = json.NewDecoder(w.Body).Decode(&body)
+	if body["fork"] != "fork-central/x" {
+		t.Errorf("GET fork = %v", body["fork"])
+	}
+}
+
+func TestAPIPatchRepositoryRejectsOtherRepo(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	_, scan := seedRunningScan(t, s)
+	other := db.Repository{URL: "https://example.com/y", Name: "y"}
+	s.DB.Create(&other)
+
+	r := httptest.NewRequest("PATCH", "/api/repositories/"+strconv.FormatUint(uint64(other.ID), 10),
+		strings.NewReader(`{"fork":"fork-central/y"}`))
+	r.Host = testHost
+	r.Header.Set("Authorization", "Bearer "+scan.APIToken)
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, r)
+	if w.Code != 403 {
+		t.Fatalf("status %d, want 403", w.Code)
+	}
+}
+
+func TestAPIPatchRepositoryRejectsEmptyBody(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	repo, scan := seedRunningScan(t, s)
+
+	r := httptest.NewRequest("PATCH", "/api/repositories/"+strconv.FormatUint(uint64(repo.ID), 10),
+		strings.NewReader(`{}`))
+	r.Host = testHost
+	r.Header.Set("Authorization", "Bearer "+scan.APIToken)
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, r)
+	if w.Code != 422 {
+		t.Fatalf("status %d, want 422", w.Code)
+	}
+}
+
 func TestAPIFindingReadsAndFilters(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()

--- a/internal/worker/skill.go
+++ b/internal/worker/skill.go
@@ -41,6 +41,9 @@ type skillContextScrutineer struct {
 	// support). Empty means the repo root. Skills that walk files honour
 	// this; skills that query external APIs ignore it.
 	ScanSubPath string `json:"scan_subpath,omitempty"`
+	// ForkOrg is the GitHub organisation the fork skill forks into and
+	// files draft advisories against. Absent when fork_org is unconfigured.
+	ForkOrg string `json:"fork_org,omitempty"`
 }
 
 type skillContextRepo struct {
@@ -89,7 +92,7 @@ func (w *Worker) doSkill(ctx context.Context, scan *db.Scan, emit func(Event)) (
 	if err := stageSkill(&skill, skillDir); err != nil {
 		return "", fmt.Errorf("stage skill: %w", err)
 	}
-	if err := stageContext(workRoot, w.APIBase, scan, &scan.Repository); err != nil {
+	if err := stageContext(workRoot, w.APIBase, w.ForkOrg, scan, &scan.Repository); err != nil {
 		return "", fmt.Errorf("stage context: %w", err)
 	}
 
@@ -412,7 +415,7 @@ func oneLine(s string) string {
 // rely on. Kept small and boring on purpose: skills that need more detail
 // can read it from the clone. The scrutineer block gives skills enough to
 // call back into the host API (list scans, trigger more skills).
-func stageContext(workRoot, apiBase string, scan *db.Scan, repo *db.Repository) error {
+func stageContext(workRoot, apiBase, forkOrg string, scan *db.Scan, repo *db.Repository) error {
 	if err := os.MkdirAll(workRoot, dirPerm); err != nil {
 		return err
 	}
@@ -429,6 +432,7 @@ func stageContext(workRoot, apiBase string, scan *db.Scan, repo *db.Repository) 
 			ScanID:  scan.ID,
 			Token:   scan.APIToken,
 			RepoID:  scan.RepositoryID,
+			ForkOrg: forkOrg,
 		},
 	}
 	if scan.SkillID != nil {

--- a/internal/worker/skill_test.go
+++ b/internal/worker/skill_test.go
@@ -246,7 +246,7 @@ func TestStageContext_writesRepoFacts(t *testing.T) {
 		DefaultBranch: "main",
 	}
 	scan := &db.Scan{ID: 7, RepositoryID: 3, APIToken: "tok"}
-	if err := stageContext(dir, "http://127.0.0.1:8080/api", scan, repo); err != nil {
+	if err := stageContext(dir, "http://127.0.0.1:8080/api", "", scan, repo); err != nil {
 		t.Fatal(err)
 	}
 	b, err := os.ReadFile(filepath.Join(dir, "context.json"))
@@ -301,7 +301,7 @@ func TestStageContext_includesRef(t *testing.T) {
 	dir := t.TempDir()
 	repo := &db.Repository{URL: "https://example.com/x", Name: "x"}
 	scan := &db.Scan{ID: 1, RepositoryID: 1, APIToken: "t", Ref: "2.4.x"}
-	if err := stageContext(dir, "http://127.0.0.1:8080/api", scan, repo); err != nil {
+	if err := stageContext(dir, "http://127.0.0.1:8080/api", "", scan, repo); err != nil {
 		t.Fatal(err)
 	}
 	b, err := os.ReadFile(filepath.Join(dir, "context.json"))
@@ -321,7 +321,7 @@ func TestStageContext_omitsRefWhenEmpty(t *testing.T) {
 	dir := t.TempDir()
 	repo := &db.Repository{URL: "https://example.com/x", Name: "x"}
 	scan := &db.Scan{ID: 1, RepositoryID: 1, APIToken: "t"}
-	if err := stageContext(dir, "http://127.0.0.1:8080/api", scan, repo); err != nil {
+	if err := stageContext(dir, "http://127.0.0.1:8080/api", "", scan, repo); err != nil {
 		t.Fatal(err)
 	}
 	b, err := os.ReadFile(filepath.Join(dir, "context.json"))
@@ -330,5 +330,28 @@ func TestStageContext_omitsRefWhenEmpty(t *testing.T) {
 	}
 	if strings.Contains(string(b), "scan_ref") {
 		t.Errorf("scan_ref should be omitted when empty, got: %s", b)
+	}
+	if strings.Contains(string(b), "fork_org") {
+		t.Errorf("fork_org should be omitted when empty, got: %s", b)
+	}
+}
+
+func TestStageContext_includesForkOrg(t *testing.T) {
+	dir := t.TempDir()
+	repo := &db.Repository{URL: "https://github.com/o/r", Name: "r"}
+	scan := &db.Scan{ID: 1, RepositoryID: 1, APIToken: "t"}
+	if err := stageContext(dir, "http://127.0.0.1:8080/api", "fork-central", scan, repo); err != nil {
+		t.Fatal(err)
+	}
+	b, err := os.ReadFile(filepath.Join(dir, "context.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got skillContext
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Scrutineer.ForkOrg != "fork-central" {
+		t.Errorf("fork_org = %q, want fork-central", got.Scrutineer.ForkOrg)
 	}
 }

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -39,6 +39,7 @@ type Worker struct {
 	Log         *slog.Logger
 	DataDir     string // workspace root for clones
 	APIBase     string // base URL for the scrutineer skill API (http://host:port/api)
+	ForkOrg     string // github org the fork skill targets; empty disables it
 	Runner      SkillRunner
 	OnEvent     func(scanID, repoID uint, name, data string) // optional SSE bridge
 	ScanTimeout time.Duration

--- a/skills/fork/SKILL.md
+++ b/skills/fork/SKILL.md
@@ -183,7 +183,13 @@ List the org's teams once:
 gh api orgs/{fork_org}/teams --paginate --jq '.[].slug'
 ```
 
-Pick at most one team whose slug matches the repository. Run `brief ./src` and look at `languages[0].name` and `package_managers[0].name`; match those (lowercased, non-alphanumerics stripped) against the team slugs. For example a Go repo matches a `go` or `golang` team, an npm repo matches `npm` or `javascript` or `nodejs`, a Cargo repo matches `rust`. If nothing matches, leave `"team": null` and move on — do not invent a team.
+Pick at most one team whose slug matches the repository, trying these signals in order and stopping at the first hit:
+
+1. **Foundation / upstream org.** Lowercase the upstream `{owner}` and see if any team slug is a substring of it or vice versa. `eclipse-platform` or `eclipse-ee4j` matches an `eclipse` team, `apache` matches `apache`, a `kubernetes-sigs` repo matches `kubernetes` or `cncf`. Also check `GET {api_base}/repositories/{repository_id}/maintainers` — if a maintainer's affiliation or the repo's funding/SECURITY.md (already in `./src`) names a foundation that appears as a team slug, prefer that.
+2. **Ecosystem.** `package_managers[0].name` from `brief ./src`, mapped the same way as the GHSA ecosystem enum: Bundler→`ruby`/`rubygems`, npm/Yarn/pnpm→`npm`/`javascript`/`nodejs`, Cargo→`rust`, Go Modules→`go`/`golang`, pip/Poetry→`python`/`pypi`, Maven/Gradle→`java`/`maven`, Composer→`php`.
+3. **Primary language.** `languages[0].name` from `brief ./src`, lowercased.
+
+Match by normalising both the candidate and each team slug (lowercase, strip non-alphanumerics) and testing whether either contains the other. If nothing matches, leave `"team": null` and move on — do not invent a team.
 
 If a team matched and you filed at least one advisory, add the team as a collaborator on each new advisory:
 

--- a/skills/fork/SKILL.md
+++ b/skills/fork/SKILL.md
@@ -89,9 +89,9 @@ If the workspace clone is shallow `git push` may need `git -C ./src fetch --unsh
 
 ## 4. File draft advisories for findings
 
-Fetch the repository's findings: `GET {api_base}/repositories/{repository_id}/findings` with `Authorization: Bearer {token}`. Filter to findings whose `status` is `ready` — those have been through verify and disclose and have a `disclosure_draft`. If none are `ready`, record `"advisories": []` and skip to step 5.
+Fetch the repository's findings: `GET {api_base}/repositories/{repository_id}/findings` with `Authorization: Bearer {token}`. File an advisory for every finding whose `status` is one of `new`, `enriched`, `triaged`, or `ready` — that is, anything that has not already been reported upstream or closed out. Skip `reported`, `acknowledged`, `fixed`, `published`, `rejected`, and `duplicate`; record those under `"skipped_advisories"` with the status as the reason. If nothing is left, record `"advisories": []` and skip to step 5.
 
-For each ready finding fetch the full record (`GET {api_base}/findings/{id}`) so you have `disclosure_draft`, `cvss_vector`, `cwe`, `affected`, and `title`.
+For each remaining finding fetch the full record (`GET {api_base}/findings/{id}`) so you have `disclosure_draft`, `cvss_vector`, `cwe`, `affected`, and `title`.
 
 Before filing, list the advisories already on the fork so re-runs do not duplicate:
 
@@ -122,13 +122,56 @@ The body shape is the GHSA report schema:
 }
 ```
 
-Build `vulnerabilities` from `GET {api_base}/repositories/{repository_id}/packages` using the same ecosystem mapping the disclose skill uses (rubygems, npm, pip, maven, nuget, composer, go, rust, erlang, actions, pub, other). If the repository has no packages, send `"vulnerabilities": [{"package": {"ecosystem": "other", "name": "{owner}/{repo}"}}]` — the endpoint requires at least one entry. If `disclosure_draft` is empty, fall back to a short description assembled from the finding's `location`, `cwe`, and `severity`; note in `notes` that disclose has not run on that finding.
+Build `vulnerabilities` from `GET {api_base}/repositories/{repository_id}/packages` using the same ecosystem mapping the disclose skill uses (rubygems, npm, pip, maven, nuget, composer, go, rust, erlang, actions, pub, other). If the repository has no packages, send `"vulnerabilities": [{"package": {"ecosystem": "other", "name": "{owner}/{repo}"}}]` — the endpoint requires at least one entry.
+
+If `disclosure_draft` is empty the disclose skill has not run on this finding yet. Assemble the description yourself from the finding's six-step prose (the full `GET {api_base}/findings/{id}` response includes `trace`, `boundary`, `validation`, `prior_art`, `reach`, `rating` even for `new` findings). Use this template, dropping any section whose source field is empty:
+
+```
+> Draft staged by scrutineer from finding {finding_id} (scan {scan_id}). Not yet reviewed by an analyst.
+
+## Summary
+
+{title}. {first sentence of rating, or "Severity: {severity}" if rating is empty}.
+
+## Location
+
+`{location}` on `{owner}/{repo}`.
+
+## Details
+
+{trace}
+
+## Trigger
+
+{boundary}
+
+## Reproduction
+
+{validation}
+
+## Impact
+
+{rating}
+
+## Reach
+
+{reach}
+
+## References
+
+- {repository.html_url}/blob/{default_branch}/{location path without :line}
+- https://cwe.mitre.org/data/definitions/{n}.html  (one per CWE in finding.cwe)
+- {each URL that appears verbatim in prior_art}
+```
+
+Do not invent content for missing sections; the draft is allowed to be sparse. Note in `notes` that disclose has not run on that finding.
 
 Capture the `ghsa_id` and `html_url` from the response. Then write them back to scrutineer so the finding page links to the draft:
 
 - `POST {api_base}/findings/{id}/references` with `{"url": "<html_url>", "tags": "ghsa-draft", "summary": "Draft advisory on {fork_org} fork"}`
 - `POST {api_base}/findings/{id}/communications` with `{"channel": "ghsa", "direction": "outbound", "actor": "fork", "body": "Draft advisory <ghsa_id> opened on {fork_org}/{fork_name}"}`
-- `PATCH {api_base}/findings/{id}` with `{"fields": {"status": "reported"}, "by": "fork"}`
+
+Do not change the finding's `status`. `reported` means reported to the upstream maintainer; a draft on the staging fork is not that.
 
 ## 5. Invite a team
 

--- a/skills/fork/SKILL.md
+++ b/skills/fork/SKILL.md
@@ -66,13 +66,13 @@ Authorization: Bearer {token}
 
 ## 2. Enable private vulnerability reporting on the fork
 
+Use the dedicated endpoint; the `security_and_analysis` block on `PATCH /repos/...` accepts the field but does not actually flip it.
+
 ```
-gh api -X PATCH repos/{fork_org}/{fork_name} --input - <<'JSON'
-{"security_and_analysis": {"private_vulnerability_reporting": {"status": "enabled"}}}
-JSON
+gh api -X PUT repos/{fork_org}/{fork_name}/private-vulnerability-reporting
 ```
 
-A 200 means it is on. A 422 usually means the org has it forced on or off at the org level; record that in `notes` and carry on.
+A 204 means it is on. Confirm with `gh api repos/{fork_org}/{fork_name}/private-vulnerability-reporting` which returns `{"enabled": true|false}`. A 422 usually means the org has it forced on or off at the org level; record that in `notes` and carry on.
 
 ## 3. Record the scan on the fork
 
@@ -101,13 +101,13 @@ gh api repos/{fork_org}/{fork_name}/security-advisories --paginate --jq '.[].sum
 
 Skip a finding whose title already appears as an advisory summary; record it under `"skipped_advisories"`.
 
-For each remaining finding, build the request body and file it as a private vulnerability report on the fork:
+For each remaining finding, build the request body and create a draft repository security advisory on the fork. Use the admin create endpoint, not `/reports` — `/reports` is for external reporters and is rejected when the caller is a repo admin, which we are.
 
 ```
-gh api -X POST repos/{fork_org}/{fork_name}/security-advisories/reports --input ./advisory-{finding_id}.json
+gh api -X POST repos/{fork_org}/{fork_name}/security-advisories --input ./advisory-{finding_id}.json
 ```
 
-The body shape is the GHSA report schema:
+The body shape is the GHSA create schema:
 
 ```json
 {
@@ -123,6 +123,8 @@ The body shape is the GHSA report schema:
 ```
 
 Build `vulnerabilities` from `GET {api_base}/repositories/{repository_id}/packages` using the same ecosystem mapping the disclose skill uses (rubygems, npm, pip, maven, nuget, composer, go, rust, erlang, actions, pub, other). If the repository has no packages, send `"vulnerabilities": [{"package": {"ecosystem": "other", "name": "{owner}/{repo}"}}]` — the endpoint requires at least one entry.
+
+`vulnerable_version_range` must be a bare constraint string. `finding.affected` is analyst prose and often carries annotations like `<= 0.9.1 (all published versions)` or `1.x through 2.3`; reduce it to comma-separated `OP VERSION` clauses where OP is one of `<`, `<=`, `>`, `>=`, `=` and VERSION is dotted-numeric (a leading `v` is fine). Drop anything in parentheses, drop the package name if it was repeated, and turn `all versions` / `every release` into `>= 0`. If you cannot confidently reduce it to that shape, omit `vulnerable_version_range` from the entry and keep the original prose in the description's Affected versions section instead.
 
 If `disclosure_draft` is empty the disclose skill has not run on this finding yet. Assemble the description yourself from the finding's six-step prose (the full `GET {api_base}/findings/{id}` response includes `trace`, `boundary`, `validation`, `prior_art`, `reach`, `rating` even for `new` findings). Use this template, dropping any section whose source field is empty:
 

--- a/skills/fork/SKILL.md
+++ b/skills/fork/SKILL.md
@@ -1,0 +1,189 @@
+---
+name: fork
+description: Fork the scanned repository into the configured GitHub organisation, enable private vulnerability reporting on the fork, record the scan as a git note, and file each finding as a draft security advisory on the fork with a relevant org team invited as collaborator. Run after a scan has produced findings; the fork is the staging area for disclosure work.
+license: MIT
+compatibility: Needs the gh CLI authenticated with a token that can create forks in the fork_org and manage repository settings and security advisories there. Needs network access to api.github.com and the scrutineer API. github.com upstreams only for now.
+metadata:
+  scrutineer.output_file: report.json
+  scrutineer.output_kind: freeform
+---
+
+# fork
+
+Stage a scanned repository into the disclosure org. Forks the upstream into `fork_org`, turns on private vulnerability reporting on the fork, leaves a git note recording when scrutineer last scanned the upstream, and opens one draft advisory per finding on the fork so analysts and the relevant team can collaborate on the write-up before anything goes upstream.
+
+## Workspace
+
+- `./src` — the upstream clone at the commit that was scanned
+- `./context.json` — has `repository.url`, `repository.full_name`, `scrutineer.api_base`, `scrutineer.token`, `scrutineer.repository_id`, `scrutineer.scan_id`, and `scrutineer.fork_org`
+- `./report.json` — write what you did
+
+Use the `gh` CLI for every GitHub call. Do not use curl against api.github.com.
+
+## Preconditions
+
+Read `./context.json`. Refuse to continue (write `{"error": "..."}` to `report.json` and exit 0) if:
+
+- `scrutineer.fork_org` is missing or empty — the operator has not configured `fork_org` in scrutineer.yaml
+- `repository.url` does not have host `github.com` — only GitHub upstreams are supported for now; non-GitHub hosts will get a create-in-org path later
+- `gh auth status` fails — the runner has no GitHub credentials
+
+Derive `{owner}/{repo}` from `repository.full_name` (fall back to parsing the path of `repository.url`, stripping a trailing `.git`).
+
+## 1. Fork into the org
+
+First check whether scrutineer already knows the fork: `GET {api_base}/repositories/{repository_id}` returns a `fork` field. If it is non-empty and `gh repo view {fork}` succeeds with `.parent` pointing at `{owner}/{repo}`, use it as `{fork_org}/{fork_name}`, record `"forked": "exists"`, and skip to step 2.
+
+Otherwise the fork normally lives at `{fork_org}/{repo}`, but that slot may already be taken by an unrelated repository (e.g. forking `foo/redis` when `fork-central/redis` is already a fork of `bar/redis`). Resolve the fork name as follows.
+
+For each candidate name, in order `{repo}` then `{owner}-{repo}`:
+
+```
+gh repo view {fork_org}/{candidate} --json name,parent
+```
+
+- not found — the slot is free; remember this candidate as `{fork_name}` and stop
+- found and `.parent.owner.login == {owner}` and `.parent.name == {repo}` — this is already our fork; set `{fork_name}` to this candidate, record `"forked": "exists"`, and skip to step 2
+- found but the parent is something else (or null) — the name is taken by an unrelated repo; move to the next candidate
+
+If both candidates are taken by unrelated repositories, write `{"error": "no free fork name for {owner}/{repo} in {fork_org}"}` and exit 0.
+
+If you found a free slot, create the fork there:
+
+```
+gh repo fork {owner}/{repo} --org {fork_org} --fork-name {fork_name} --clone=false --default-branch-only
+```
+
+`gh repo fork` is asynchronous on GitHub's side. Poll `gh repo view {fork_org}/{fork_name}` until it returns 0 (a few seconds is normal; give up after a minute and report `{"error": "fork did not become available"}`). Record `"forked": "created"`.
+
+Whichever path you took, persist the resolved name back to scrutineer so the next run and the UI can find it without re-probing:
+
+```
+PATCH {api_base}/repositories/{repository_id}
+Authorization: Bearer {token}
+{"fork": "{fork_org}/{fork_name}"}
+```
+
+## 2. Enable private vulnerability reporting on the fork
+
+```
+gh api -X PATCH repos/{fork_org}/{fork_name} --input - <<'JSON'
+{"security_and_analysis": {"private_vulnerability_reporting": {"status": "enabled"}}}
+JSON
+```
+
+A 200 means it is on. A 422 usually means the org has it forced on or off at the org level; record that in `notes` and carry on.
+
+## 3. Record the scan on the fork
+
+Record when scrutineer last looked at this repository, regardless of whether there were findings, as a git note on the scanned commit and push it to the fork. The note lives under `refs/notes/scrutineer` so it does not collide with anything upstream uses.
+
+```
+HEAD=$(git -C ./src rev-parse HEAD)
+NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+git -C ./src notes --ref=scrutineer add -f -m "scrutineer: scanned $NOW at $HEAD (scan {scan_id})" "$HEAD"
+git -C ./src push -f "https://github.com/{fork_org}/{fork_name}.git" refs/notes/scrutineer
+```
+
+If the workspace clone is shallow `git push` may need `git -C ./src fetch --unshallow` first; only do that if the push is rejected for shallow reasons. If the push fails for any other reason (branch protection on notes refs, auth), record the error in `notes` and carry on — the note is a convenience, not a hard requirement.
+
+## 4. File draft advisories for findings
+
+Fetch the repository's findings: `GET {api_base}/repositories/{repository_id}/findings` with `Authorization: Bearer {token}`. Filter to findings whose `status` is `ready` — those have been through verify and disclose and have a `disclosure_draft`. If none are `ready`, record `"advisories": []` and skip to step 5.
+
+For each ready finding fetch the full record (`GET {api_base}/findings/{id}`) so you have `disclosure_draft`, `cvss_vector`, `cwe`, `affected`, and `title`.
+
+Before filing, list the advisories already on the fork so re-runs do not duplicate:
+
+```
+gh api repos/{fork_org}/{fork_name}/security-advisories --paginate --jq '.[].summary'
+```
+
+Skip a finding whose title already appears as an advisory summary; record it under `"skipped_advisories"`.
+
+For each remaining finding, build the request body and file it as a private vulnerability report on the fork:
+
+```
+gh api -X POST repos/{fork_org}/{fork_name}/security-advisories/reports --input ./advisory-{finding_id}.json
+```
+
+The body shape is the GHSA report schema:
+
+```json
+{
+  "summary": "<finding.title>",
+  "description": "<finding.disclosure_draft>",
+  "severity": "<critical|high|medium|low, lowercased from finding.severity>",
+  "cvss_vector_string": "<finding.cvss_vector, omit severity if this is set>",
+  "cwe_ids": ["CWE-79"],
+  "vulnerabilities": [
+    {"package": {"ecosystem": "<ghsa enum>", "name": "<pkg>"}, "vulnerable_version_range": "<finding.affected>"}
+  ]
+}
+```
+
+Build `vulnerabilities` from `GET {api_base}/repositories/{repository_id}/packages` using the same ecosystem mapping the disclose skill uses (rubygems, npm, pip, maven, nuget, composer, go, rust, erlang, actions, pub, other). If the repository has no packages, send `"vulnerabilities": [{"package": {"ecosystem": "other", "name": "{owner}/{repo}"}}]` — the endpoint requires at least one entry. If `disclosure_draft` is empty, fall back to a short description assembled from the finding's `location`, `cwe`, and `severity`; note in `notes` that disclose has not run on that finding.
+
+Capture the `ghsa_id` and `html_url` from the response. Then write them back to scrutineer so the finding page links to the draft:
+
+- `POST {api_base}/findings/{id}/references` with `{"url": "<html_url>", "tags": "ghsa-draft", "summary": "Draft advisory on {fork_org} fork"}`
+- `POST {api_base}/findings/{id}/communications` with `{"channel": "ghsa", "direction": "outbound", "actor": "fork", "body": "Draft advisory <ghsa_id> opened on {fork_org}/{fork_name}"}`
+- `PATCH {api_base}/findings/{id}` with `{"fields": {"status": "reported"}, "by": "fork"}`
+
+## 5. Invite a team
+
+List the org's teams once:
+
+```
+gh api orgs/{fork_org}/teams --paginate --jq '.[].slug'
+```
+
+Pick at most one team whose slug matches the repository. Run `brief ./src` and look at `languages[0].name` and `package_managers[0].name`; match those (lowercased, non-alphanumerics stripped) against the team slugs. For example a Go repo matches a `go` or `golang` team, an npm repo matches `npm` or `javascript` or `nodejs`, a Cargo repo matches `rust`. If nothing matches, leave `"team": null` and move on — do not invent a team.
+
+If a team matched and you filed at least one advisory, add the team as a collaborator on each new advisory:
+
+```
+gh api -X PATCH repos/{fork_org}/{fork_name}/security-advisories/{ghsa_id} --input - <<'JSON'
+{"collaborating_teams": ["<team-slug>"]}
+JSON
+```
+
+Also give the team push access to the fork itself so they can see it and work on a patch later:
+
+```
+gh api -X PUT orgs/{fork_org}/teams/{team-slug}/repos/{fork_org}/{fork_name} -f permission=push
+```
+
+## Output
+
+Write `./report.json`:
+
+```json
+{
+  "fork_org": "fork-central",
+  "upstream": "owner/repo",
+  "fork": "fork-central/repo",
+  "fork_name": "repo",
+  "forked": "created",
+  "private_reporting": "enabled",
+  "scanned_at": "2026-05-04T12:00:00Z",
+  "scanned_commit": "abc123...",
+  "note_pushed": true,
+  "advisories": [
+    {"finding_id": 17, "ghsa_id": "GHSA-xxxx-xxxx-xxxx", "url": "https://github.com/fork-central/repo/security/advisories/GHSA-..."}
+  ],
+  "skipped_advisories": [{"finding_id": 18, "reason": "already filed"}],
+  "team": "rust",
+  "notes": "anything that did not go cleanly",
+  "error": null
+}
+```
+
+`forked` is one of `created`, `exists`. `private_reporting` is `enabled`, `already-enabled`, or `org-managed`. `team` is the slug you invited or `null`.
+
+## Constraints
+
+- Do not touch the upstream repository's settings or file anything against it. Everything in this skill targets the fork.
+- Do not run if `fork_org` is unset; the operator must opt in.
+- Do not delete or overwrite an existing fork.
+- Do not invent CVE IDs, CWEs, or package names that are not on the finding.

--- a/skills/fork/schema.json
+++ b/skills/fork/schema.json
@@ -1,0 +1,86 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "fork report",
+  "description": "What the fork skill did: where the fork lives, whether private reporting is on, the scan note that was pushed, and which advisories were filed.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "fork_org": {
+      "type": "string",
+      "description": "The configured GitHub organisation."
+    },
+    "upstream": {
+      "type": "string",
+      "description": "owner/repo of the scanned upstream."
+    },
+    "fork": {
+      "type": "string",
+      "description": "owner/repo of the fork inside fork_org."
+    },
+    "fork_name": {
+      "type": "string",
+      "description": "Repository name used for the fork. Usually the upstream repo name; falls back to owner-repo on collision."
+    },
+    "forked": {
+      "type": "string",
+      "enum": ["created", "exists"],
+      "description": "Whether the fork was newly created or already present in the org."
+    },
+    "private_reporting": {
+      "type": "string",
+      "enum": ["enabled", "already-enabled", "org-managed", "failed"],
+      "description": "Outcome of turning on private vulnerability reporting on the fork."
+    },
+    "scanned_at": {
+      "type": "string",
+      "description": "RFC3339 UTC timestamp written into the git note."
+    },
+    "scanned_commit": {
+      "type": "string",
+      "description": "Upstream commit the scan ran at and the note is attached to."
+    },
+    "note_pushed": {
+      "type": "boolean",
+      "description": "True if refs/notes/scrutineer was pushed to the fork."
+    },
+    "advisories": {
+      "type": "array",
+      "description": "Draft advisories filed on the fork, one per ready finding.",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["finding_id", "ghsa_id", "url"],
+        "properties": {
+          "finding_id": { "type": "integer" },
+          "ghsa_id": { "type": "string" },
+          "url": { "type": "string" }
+        }
+      }
+    },
+    "skipped_advisories": {
+      "type": "array",
+      "description": "Findings that were not filed because an advisory with the same summary already exists on the fork, or the finding was not ready.",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["finding_id", "reason"],
+        "properties": {
+          "finding_id": { "type": "integer" },
+          "reason": { "type": "string" }
+        }
+      }
+    },
+    "team": {
+      "type": ["string", "null"],
+      "description": "Slug of the org team invited as collaborator on the fork and advisories. Null when no team matched."
+    },
+    "notes": {
+      "type": "string",
+      "description": "Anything that did not go cleanly: 422 from the settings PATCH, shallow-clone unshallow, missing disclosure_draft on a finding, etc."
+    },
+    "error": {
+      "type": ["string", "null"],
+      "description": "Set when the skill refused to run (no fork_org, non-github upstream, gh not authenticated, no free fork name)."
+    }
+  }
+}


### PR DESCRIPTION
Adds a `fork` skill that runs after a repository has been scanned and stages it into a configured GitHub org for disclosure work. All GitHub calls go through `gh`.

The skill forks the upstream into `fork_org` (handling name collisions by checking `.parent` and falling back to `{owner}-{repo}`), enables private vulnerability reporting on the fork via `PUT /repos/.../private-vulnerability-reporting`, and pushes a `refs/notes/scrutineer` note to the fork recording the scan timestamp and commit regardless of whether there were findings. For each open finding (`new`/`enriched`/`triaged`/`ready`) it creates a draft repository security advisory on the fork, building the body from the finding's six-step prose when `disclosure_draft` is empty and reducing `affected` to a clean `OP VERSION` range. It then picks one `fork_org` team to invite as collaborator, preferring a foundation/owner match (e.g. `eclipse-platform/*` → `eclipse`) over ecosystem or language.

To support that there is a new `fork_org` config key and `-fork-org` flag (no default; the skill refuses to run without it), surfaced to skills as `scrutineer.fork_org` in `context.json`. The resolved fork name is persisted on a new `Repository.Fork` column via a new `PATCH /api/repositories/{id}` endpoint so re-runs and the UI can find the staging fork without re-probing GitHub.

github.com upstreams only for now; non-GitHub hosts and private-fork patch work are follow-ups.