### PR TITLE
Add posture skill for disclosure-readiness assessment

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -46,6 +46,13 @@ type Repository struct {
 	// it from the repo page.
 	DisclosureChannel string
 
+	// Posture is the disclosure-readiness tier assigned by the posture
+	// skill: "ready", "partial", or "unprepared". PostureSummary is the
+	// one-line explanation that goes with it. Both are advisory only and
+	// are overwritten on each posture run.
+	Posture        string `gorm:"index"`
+	PostureSummary string
+
 	// CloneError is set when the last clone/fetch attempt failed (repo
 	// deleted, made private, wrong URL). Non-empty means the repo is
 	// currently unreachable. Cleared on next successful clone.

--- a/internal/worker/skill.go
+++ b/internal/worker/skill.go
@@ -116,52 +116,40 @@ func (w *Worker) doSkill(ctx context.Context, scan *db.Scan, emit func(Event)) (
 	}
 	w.clearCloneError(scan)
 
-	if res.Report == "" {
-		return res.Report, nil
-	}
-	switch skill.OutputKind {
-	case "findings":
-		if err := w.parseFindingsOutput(scan, res.Report, emit); err != nil {
-			return res.Report, err
-		}
-	case "maintainers":
-		if err := w.parseMaintainersOutput(scan, res.Report, emit); err != nil {
-			return res.Report, err
-		}
-	case "repo_metadata":
-		if err := w.parseRepoMetadataOutput(scan, res.Report, emit); err != nil {
-			return res.Report, err
-		}
-	case "packages":
-		if err := w.parsePackagesOutput(scan, res.Report, emit); err != nil {
-			return res.Report, err
-		}
-	case "advisories":
-		if err := w.parseAdvisoriesOutput(scan, res.Report, emit); err != nil {
-			return res.Report, err
-		}
-	case "dependents":
-		if err := w.parseDependentsOutput(scan, res.Report, emit); err != nil {
-			return res.Report, err
-		}
-	case "dependencies":
-		if err := w.parseDependenciesOutput(scan, res.Report, emit); err != nil {
-			return res.Report, err
-		}
-	case "verify":
-		if err := w.parseVerifyOutput(scan, res.Report, emit); err != nil {
-			return res.Report, err
-		}
-	case "subprojects":
-		if err := w.parseSubprojectsOutput(scan, res.Report, emit); err != nil {
-			return res.Report, err
-		}
-	case "repo_overview":
-		if err := w.parseRepoOverviewOutput(scan, res.Report, emit); err != nil {
+	if res.Report != "" {
+		if err := w.parseSkillOutput(&skill, scan, res.Report, emit); err != nil {
 			return res.Report, err
 		}
 	}
 	return res.Report, nil
+}
+
+func (w *Worker) parseSkillOutput(skill *db.Skill, scan *db.Scan, report string, emit func(Event)) error {
+	switch skill.OutputKind {
+	case "findings":
+		return w.parseFindingsOutput(scan, report, emit)
+	case "maintainers":
+		return w.parseMaintainersOutput(scan, report, emit)
+	case "repo_metadata":
+		return w.parseRepoMetadataOutput(scan, report, emit)
+	case "packages":
+		return w.parsePackagesOutput(scan, report, emit)
+	case "advisories":
+		return w.parseAdvisoriesOutput(scan, report, emit)
+	case "dependents":
+		return w.parseDependentsOutput(scan, report, emit)
+	case "dependencies":
+		return w.parseDependenciesOutput(scan, report, emit)
+	case "verify":
+		return w.parseVerifyOutput(scan, report, emit)
+	case "subprojects":
+		return w.parseSubprojectsOutput(scan, report, emit)
+	case "repo_overview":
+		return w.parseRepoOverviewOutput(scan, report, emit)
+	case "posture":
+		return w.parsePostureOutput(scan, report, emit)
+	}
+	return nil
 }
 
 func (w *Worker) handleCloneError(scan *db.Scan, err error, emit func(Event)) (string, bool) {

--- a/internal/worker/skill_parsers.go
+++ b/internal/worker/skill_parsers.go
@@ -379,6 +379,38 @@ func (w *Worker) parseRepoOverviewOutput(scan *db.Scan, report string, emit func
 	return nil
 }
 
+// parsePostureOutput writes the disclosure-readiness tier and summary onto
+// the Repository row. The full check list stays in scan.Report; only the
+// tier and one-line summary are promoted to columns so the repo list can
+// sort and filter on them.
+func (w *Worker) parsePostureOutput(scan *db.Scan, report string, emit func(Event)) error {
+	var result struct {
+		Tier    string `json:"tier"`
+		Summary string `json:"summary"`
+	}
+	if err := json.Unmarshal([]byte(report), &result); err != nil {
+		return fmt.Errorf("parse posture: %w", err)
+	}
+	tier := strings.TrimSpace(result.Tier)
+	switch tier {
+	case "ready", "partial", "unprepared":
+	case "":
+		emit(Event{Kind: KindText, Text: "posture: no tier in report, leaving repository unchanged"})
+		return nil
+	default:
+		return fmt.Errorf("posture tier %q is not one of ready|partial|unprepared", tier)
+	}
+	updates := map[string]any{
+		"posture":         tier,
+		"posture_summary": strings.TrimSpace(result.Summary),
+	}
+	if err := w.DB.Model(&db.Repository{}).Where("id = ?", scan.RepositoryID).Updates(updates).Error; err != nil {
+		return fmt.Errorf("update posture: %w", err)
+	}
+	emit(Event{Kind: KindText, Text: "posture: " + tier})
+	return nil
+}
+
 // parseVerifyOutput records the outcome of a finding-scoped verification
 // run. Evidence and notes become a FindingNote; the status transition is
 // written via WriteFindingField with source=model_suggested so the audit

--- a/internal/worker/skill_parsers_test.go
+++ b/internal/worker/skill_parsers_test.go
@@ -168,6 +168,51 @@ func TestParseMaintainers_emptyChannelLeavesRepoAlone(t *testing.T) {
 	}
 }
 
+func TestParsePosture_writesTierAndSummary(t *testing.T) {
+	report := `{
+		"tier": "partial",
+		"summary": "SECURITY.md present but PVR disabled",
+		"checks": [{"id":"security_policy","present":true}]
+	}`
+	repo, gdb := runSkillWithReport(t, "posture", report)
+	var got db.Repository
+	gdb.First(&got, repo.ID)
+	if got.Posture != "partial" {
+		t.Errorf("Posture = %q, want partial", got.Posture)
+	}
+	if got.PostureSummary != "SECURITY.md present but PVR disabled" {
+		t.Errorf("PostureSummary = %q", got.PostureSummary)
+	}
+}
+
+func TestParsePosture_rejectsUnknownTier(t *testing.T) {
+	gdb, _ := db.Open(filepath.Join(t.TempDir(), "p.db"))
+	repo := db.Repository{URL: "https://example.com/x", Name: "x"}
+	gdb.Create(&repo)
+	scan := db.Scan{RepositoryID: repo.ID}
+	w := &Worker{DB: gdb, Log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	err := w.parsePostureOutput(&scan, `{"tier":"medium"}`, func(Event) {})
+	if err == nil || !strings.Contains(err.Error(), "medium") {
+		t.Fatalf("expected tier validation error, got %v", err)
+	}
+}
+
+func TestParsePosture_emptyTierLeavesRepoAlone(t *testing.T) {
+	repo, gdb := runSkillWithReport(t, "posture", `{"summary":"x"}`)
+	gdb.Model(&db.Repository{}).Where("id = ?", repo.ID).Update("posture", "ready")
+
+	scan := db.Scan{RepositoryID: repo.ID}
+	w := &Worker{DB: gdb, Log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	if err := w.parsePostureOutput(&scan, `{"checks":[]}`, func(Event) {}); err != nil {
+		t.Fatal(err)
+	}
+	var got db.Repository
+	gdb.First(&got, repo.ID)
+	if got.Posture != "ready" {
+		t.Errorf("prior tier clobbered: %q", got.Posture)
+	}
+}
+
 func TestParseDependents_replacesDependentRows(t *testing.T) {
 	report := `{"dependents":[
 		{"name":"rails-x","ecosystem":"rubygems","purl":"pkg:gem/rails-x","downloads":5000,"dependent_repos":200,"latest_version":"7.0.0"}

--- a/skills/posture/SKILL.md
+++ b/skills/posture/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: posture
+description: Assess a repository's security posture and its readiness to receive a vulnerability report. Checks for a security policy, private vulnerability reporting, security.txt, prior advisories, scanning workflows, and other hygiene signals, then rates the project ready / partial / unprepared. Use before disclosure to decide how much hand-holding the maintainer will need, or as a standalone health check.
+license: MIT
+compatibility: Needs network access to api.github.com and api.securityscorecards.dev. Works best on GitHub-hosted repositories; degrades to file-only checks elsewhere.
+metadata:
+  scrutineer.output_file: report.json
+  scrutineer.output_kind: posture
+---
+
+# posture
+
+You are scoring how prepared a project is to receive and act on a security report. This is not a code audit. You are looking at policy files, repository settings, and process signals, then producing a checklist and a one-word tier.
+
+## Workspace
+
+- `./src` — the cloned repository
+- `./context.json` — has `repository.url` and `repository.host` (e.g. `github.com`)
+- `./report.json` — write the result here
+- `./schema.json` — shape of `report.json`
+
+## Checks
+
+Run every check below. For each one, record `present` (true/false/unknown), a one-line `evidence` string saying what you found, and a `url` pointing at the file or API result when there is one. Do not skip checks; an explicit `false` is more useful downstream than a missing key.
+
+### Disclosure intake
+
+**security_policy** — Look for `SECURITY.md`, `.github/SECURITY.md`, `docs/SECURITY.md`, `SECURITY.rst`, or a `## Security` section in `README.md`. If found, read it and fill the `security_policy_detail` object: does it name a `contact` (email, form, or "use GitHub advisories"), list `supported_versions`, and give a `response_sla`? A file that just says "open an issue" counts as present but with empty detail.
+
+**private_vulnerability_reporting** — Only when the host is `github.com`. Fetch `https://api.github.com/repos/{owner}/{repo}/private-vulnerability-reporting` (no auth needed for public repos). It returns `{"enabled": true|false}`. On 404 or a non-GitHub host, record `unknown`.
+
+**security_txt** — Look for `.well-known/security.txt` or `security.txt` in `./src`. Some projects vendor it for the website they ship.
+
+**manifest_security_contact** — Read the top-level package manifest if one exists (`package.json` `bugs`/`security`, `pyproject.toml` `[project.urls] Security`, `*.gemspec` `metadata["security_uri"]`, `Cargo.toml` `[package.metadata.security]`, etc). Present if any names a security URL or email.
+
+**bounty_or_lifter** — Grep `README*` and `SECURITY*` for Tidelift, HackerOne, Bugcrowd, Open Collective security, or an explicit bounty programme. Record which one in `evidence`.
+
+**prior_advisories** — Fetch `https://api.github.com/repos/{owner}/{repo}/security-advisories?state=published`. Present if the array is non-empty; put the count in `evidence`. A project that has published before knows the drill.
+
+### Hygiene
+
+**scorecard** — Fetch `https://api.securityscorecards.dev/projects/github.com/{owner}/{repo}`. If it returns a result, put the overall score in `evidence` and `present: true`. 404 means not scanned; record `unknown`.
+
+**dependency_updates** — Look for `.github/dependabot.yml`, `.github/dependabot.yaml`, `renovate.json`, `.renovaterc*`, or `.github/renovate.json`.
+
+**code_scanning** — Look in `.github/workflows/*.y*ml` for `github/codeql-action`, `securego/gosec`, `aquasecurity/trivy-action`, `snyk/actions`, or similar. Present if any scanning workflow exists.
+
+**signed_releases** — Look in `.github/workflows/` for `sigstore/cosign`, `slsa-framework/slsa-github-generator`, `goreleaser` with `signs:`, or GPG signing steps. Also check `git tag -l | head` in `./src` and `git tag -v` one recent tag for a signature.
+
+**codeowners** — Look for `CODEOWNERS`, `.github/CODEOWNERS`, or `docs/CODEOWNERS`.
+
+**funding** — Look for `.github/FUNDING.yml`. A funded project is more likely to have time to respond.
+
+**security_issue_template** — Look in `.github/ISSUE_TEMPLATE/` for a template that redirects security reports away from public issues (mentions `SECURITY.md`, "do not report vulnerabilities here", or similar). Also check `.github/ISSUE_TEMPLATE/config.yml` for a `contact_links` entry pointing at a security channel.
+
+**archived** — From `context.json` `repository.archived` if set, otherwise the GitHub API repo response. An archived repo is an automatic `unprepared` regardless of other checks.
+
+## Tier
+
+Assign exactly one of:
+
+- `ready` — has a security policy with a contact AND (PVR enabled OR a working security email/form), and is not archived.
+- `partial` — has at least one intake signal (policy, PVR, security.txt, manifest contact) but it is incomplete or untested, and is not archived.
+- `unprepared` — no intake signal at all, or the repository is archived.
+
+Hygiene checks inform the `summary` prose but do not on their own move the tier; a project with CodeQL and Dependabot but no way to receive a report is still `unprepared`.
+
+## Output
+
+Write `./report.json` matching `./schema.json`:
+
+```json
+{
+  "tier": "partial",
+  "summary": "SECURITY.md names security@example.org but PVR is off and no advisories have been published. Dependabot and CodeQL are configured.",
+  "checks": [
+    { "id": "security_policy", "present": true, "evidence": "SECURITY.md at repo root, names email contact", "url": "https://github.com/o/r/blob/main/SECURITY.md" },
+    { "id": "private_vulnerability_reporting", "present": false, "evidence": "API returned enabled:false" }
+  ],
+  "security_policy_detail": {
+    "contact": "security@example.org",
+    "supported_versions": ">= 2.x",
+    "response_sla": "5 business days"
+  },
+  "notes": "anything that did not fit a check: pending maintainer handover, org-level policy inherited, etc."
+}
+```
+
+Keep `summary` to one or two sentences a human can read in the repo list. Do not write to the scrutineer API; this skill is read-only and its output is the report file.

--- a/skills/posture/schema.json
+++ b/skills/posture/schema.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "posture report",
+  "type": "object",
+  "required": ["tier", "summary", "checks"],
+  "additionalProperties": false,
+  "properties": {
+    "tier": {
+      "type": "string",
+      "enum": ["ready", "partial", "unprepared"]
+    },
+    "summary": {
+      "type": "string",
+      "description": "One or two sentences for the repo list."
+    },
+    "checks": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id", "present"],
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "type": "string",
+            "enum": [
+              "security_policy",
+              "private_vulnerability_reporting",
+              "security_txt",
+              "manifest_security_contact",
+              "bounty_or_lifter",
+              "prior_advisories",
+              "scorecard",
+              "dependency_updates",
+              "code_scanning",
+              "signed_releases",
+              "codeowners",
+              "funding",
+              "security_issue_template",
+              "archived"
+            ]
+          },
+          "present":  { "type": ["boolean", "string"], "enum": [true, false, "unknown"] },
+          "evidence": { "type": "string" },
+          "url":      { "type": "string", "format": "uri" }
+        }
+      }
+    },
+    "security_policy_detail": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "contact":            { "type": "string" },
+        "supported_versions": { "type": "string" },
+        "response_sla":       { "type": "string" }
+      }
+    },
+    "notes": { "type": "string" }
+  }
+}


### PR DESCRIPTION
Adds a `posture` skill that scores how prepared a project is to receive a security report. It checks for `SECURITY.md`, GitHub private vulnerability reporting, `security.txt`, manifest security contacts, prior published advisories, and hygiene signals (Scorecard, Dependabot/Renovate, CodeQL, signed releases, CODEOWNERS, FUNDING, issue-template redirects), then assigns a tier of `ready`, `partial`, or `unprepared`.

The tier and one-line summary are written to new `Repository.Posture` and `Repository.PostureSummary` columns via a `posture` output-kind parser so the repo list can later filter on them. The full check list stays in the scan report.

Also extracts the output-kind dispatch in `doSkill` into `parseSkillOutput` since the extra case pushed it over the gocognit limit.

Not yet surfaced in any template; that can follow once the tiers look right on real repos.