### PR TITLE
Pass skill allowed-tools through to claude

### DIFF
--- a/internal/worker/claude.go
+++ b/internal/worker/claude.go
@@ -40,14 +40,15 @@ type SkillRunner interface {
 // parallel skills on the same repository do not share src or
 // report.json, so neither clobbers the other's output.
 type SkillJob struct {
-	Repo       db.Repository
-	WorkRoot   string
-	Model      string
-	Name       string
-	SkillDir   string // host absolute path to the staged skill directory
-	OutputFile string // relative to the scan workspace, e.g. "report.json"
-	Ref        string // git ref to checkout; empty = default branch
-	MaxTurns   int    // per-skill cap; 0 = use runner default
+	Repo         db.Repository
+	WorkRoot     string
+	Model        string
+	Name         string
+	SkillDir     string // host absolute path to the staged skill directory
+	OutputFile   string // relative to the scan workspace, e.g. "report.json"
+	Ref          string // git ref to checkout; empty = default branch
+	MaxTurns     int    // per-skill cap; 0 = use runner default
+	AllowedTools string // comma-separated; "" = full tool set under bypassPermissions
 }
 
 type SkillResult struct {
@@ -81,20 +82,7 @@ func (l LocalClaude) RunSkill(ctx context.Context, sj SkillJob, emit func(Event)
 		_ = os.Remove(outPath)
 	}
 
-	prompt := buildSkillPrompt(sj.Name, sj.OutputFile)
-	args := []string{
-		"-p",
-		"--output-format", "stream-json",
-		"--verbose",
-		"--permission-mode", "bypassPermissions",
-		"--model", sj.Model,
-	}
-	if l.Effort != "" {
-		args = append(args, "--effort", l.Effort)
-	}
-	args = append(args, "--max-turns", strconv.Itoa(effectiveMaxTurns(sj.MaxTurns, l.MaxTurns)))
-	args = append(args, prompt)
-
+	args := buildClaudeArgs(sj, l.Effort, l.MaxTurns)
 	cmd := exec.CommandContext(ctx, "claude", args...)
 	cmd.Dir = work
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
@@ -166,6 +154,34 @@ func readCappedReport(path string, emit func(Event)) string {
 		return ""
 	}
 	return string(b)
+}
+
+// buildClaudeArgs assembles the `claude -p` argv shared by the local and
+// docker runners. When the skill declares an allowed-tools list the agent
+// is held to it under acceptEdits (writes to report.json still go through
+// unprompted, arbitrary Bash does not); otherwise it falls back to the
+// historical bypassPermissions behaviour.
+func buildClaudeArgs(sj SkillJob, effort string, globalMaxTurns int) []string {
+	args := []string{
+		"-p",
+		"--output-format", "stream-json",
+		"--verbose",
+		"--model", sj.Model,
+	}
+	if sj.AllowedTools != "" {
+		args = append(args,
+			"--permission-mode", "acceptEdits",
+			"--allowedTools", sj.AllowedTools,
+		)
+	} else {
+		args = append(args, "--permission-mode", "bypassPermissions")
+	}
+	if effort != "" {
+		args = append(args, "--effort", effort)
+	}
+	args = append(args, "--max-turns", strconv.Itoa(effectiveMaxTurns(sj.MaxTurns, globalMaxTurns)))
+	args = append(args, buildSkillPrompt(sj.Name, sj.OutputFile))
+	return args
 }
 
 // effectiveMaxTurns resolves the turn cap: per-skill wins, then global, then

--- a/internal/worker/claude_test.go
+++ b/internal/worker/claude_test.go
@@ -1,0 +1,60 @@
+package worker
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestBuildClaudeArgs_NoAllowedTools(t *testing.T) {
+	sj := SkillJob{Name: "metadata", Model: "claude-opus-4-7", OutputFile: "report.json"}
+	args := buildClaudeArgs(sj, "", 0)
+
+	if got := flagValue(args, "--permission-mode"); got != "bypassPermissions" {
+		t.Errorf("permission-mode = %q, want bypassPermissions", got)
+	}
+	if slices.Contains(args, "--allowedTools") {
+		t.Errorf("did not expect --allowedTools in %v", args)
+	}
+	if got := flagValue(args, "--max-turns"); got != "30" {
+		t.Errorf("max-turns = %q, want default 30", got)
+	}
+	if args[len(args)-1] != buildSkillPrompt("metadata", "report.json") {
+		t.Errorf("prompt is not the final arg: %v", args)
+	}
+}
+
+func TestBuildClaudeArgs_AllowedTools(t *testing.T) {
+	sj := SkillJob{
+		Name:         "metadata",
+		Model:        "claude-sonnet-4-6",
+		OutputFile:   "report.json",
+		AllowedTools: "Read,Write,WebFetch",
+		MaxTurns:     50,
+	}
+	args := buildClaudeArgs(sj, "high", 0)
+
+	if got := flagValue(args, "--permission-mode"); got != "acceptEdits" {
+		t.Errorf("permission-mode = %q, want acceptEdits", got)
+	}
+	if got := flagValue(args, "--allowedTools"); got != "Read,Write,WebFetch" {
+		t.Errorf("allowedTools = %q, want Read,Write,WebFetch", got)
+	}
+	if got := flagValue(args, "--model"); got != "claude-sonnet-4-6" {
+		t.Errorf("model = %q", got)
+	}
+	if got := flagValue(args, "--effort"); got != "high" {
+		t.Errorf("effort = %q, want high", got)
+	}
+	if got := flagValue(args, "--max-turns"); got != "50" {
+		t.Errorf("max-turns = %q, want per-skill 50", got)
+	}
+}
+
+func flagValue(args []string, flag string) string {
+	for i, a := range args {
+		if a == flag && i+1 < len(args) {
+			return args[i+1]
+		}
+	}
+	return ""
+}

--- a/internal/worker/docker.go
+++ b/internal/worker/docker.go
@@ -11,7 +11,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"syscall"
 )
@@ -58,18 +57,7 @@ func (d DockerRunner) RunSkill(ctx context.Context, sj SkillJob, emit func(Event
 		_ = os.Remove(outPath)
 	}
 
-	claudeArgs := []string{
-		"claude", "-p",
-		"--output-format", "stream-json",
-		"--verbose",
-		"--permission-mode", "bypassPermissions",
-		"--model", sj.Model,
-	}
-	if d.Effort != "" {
-		claudeArgs = append(claudeArgs, "--effort", d.Effort)
-	}
-	claudeArgs = append(claudeArgs, "--max-turns", strconv.Itoa(effectiveMaxTurns(sj.MaxTurns, d.MaxTurns)))
-	claudeArgs = append(claudeArgs, buildSkillPrompt(sj.Name, sj.OutputFile))
+	claudeArgs := append([]string{"claude"}, buildClaudeArgs(sj, d.Effort, d.MaxTurns)...)
 
 	gwTarget := "host-gateway"
 	if d.HostGatewayIP != "" {

--- a/internal/worker/skill.go
+++ b/internal/worker/skill.go
@@ -101,14 +101,15 @@ func (w *Worker) doSkill(ctx context.Context, scan *db.Scan, emit func(Event)) (
 	w.DB.Model(scan).Update("prompt", prompt)
 
 	sj := SkillJob{
-		Repo:       scan.Repository,
-		WorkRoot:   workRoot,
-		Model:      scan.Model,
-		Name:       skill.Name,
-		SkillDir:   skillDir,
-		OutputFile: skill.OutputFile,
-		Ref:        scan.Ref,
-		MaxTurns:   skill.MaxTurns,
+		Repo:         scan.Repository,
+		WorkRoot:     workRoot,
+		Model:        scan.Model,
+		Name:         skill.Name,
+		SkillDir:     skillDir,
+		OutputFile:   skill.OutputFile,
+		Ref:          scan.Ref,
+		MaxTurns:     skill.MaxTurns,
+		AllowedTools: skill.AllowedTools,
 	}
 	res, err := w.Runner.RunSkill(ctx, sj, emit)
 	scan.Commit = res.Commit

--- a/skills/advisories/SKILL.md
+++ b/skills/advisories/SKILL.md
@@ -3,6 +3,7 @@ name: advisories
 description: Fetch the published security advisories that affect any package produced by this repository. Use to populate the Advisories tab with existing GHSA and CVE records so analysts can see what is already public before triaging new findings.
 license: MIT
 compatibility: Needs network access to advisories.ecosyste.ms.
+allowed-tools: Read,Write,WebFetch,Grep,Glob,LS
 metadata:
   scrutineer.output_file: report.json
   scrutineer.output_kind: advisories

--- a/skills/dependents/SKILL.md
+++ b/skills/dependents/SKILL.md
@@ -3,6 +3,7 @@ name: dependents
 description: For each published package of this repository, fetch the top runtime dependents so later exposure-analysis skills have a ranked shortlist to work against. Use after the packages skill has populated which packages exist.
 license: MIT
 compatibility: Needs network access to packages.ecosyste.ms.
+allowed-tools: Read,Write,WebFetch,Grep,Glob,LS
 metadata:
   scrutineer.output_file: report.json
   scrutineer.output_kind: dependents

--- a/skills/maintainers/SKILL.md
+++ b/skills/maintainers/SKILL.md
@@ -3,6 +3,7 @@ name: maintainers
 description: Identify the real maintainers of a repository and the best way to contact them about a security issue. Distinguishes active leads from occasional contributors and bots, using commit history, issue activity, and registry ownership. Use when preparing a disclosure and needing to know who to reach.
 license: MIT
 compatibility: Needs network access to commits.ecosyste.ms, issues.ecosyste.ms, and packages.ecosyste.ms.
+allowed-tools: Read,Write,WebFetch,Grep,Glob,LS
 metadata:
   scrutineer.output_file: report.json
   scrutineer.output_kind: maintainers

--- a/skills/metadata/SKILL.md
+++ b/skills/metadata/SKILL.md
@@ -3,6 +3,7 @@ name: metadata
 description: Fetch high-level repository metadata (description, default branch, languages, license, stars, forks, archived status, icon) and save it against the scan's repository row. Use as the first scan on a new repository or to refresh after upstream changes.
 license: MIT
 compatibility: Needs network access to repos.ecosyste.ms.
+allowed-tools: Read,Write,WebFetch,Grep,Glob,LS
 metadata:
   scrutineer.output_file: report.json
   scrutineer.output_kind: repo_metadata

--- a/skills/packages/SKILL.md
+++ b/skills/packages/SKILL.md
@@ -3,6 +3,7 @@ name: packages
 description: Look up every published package that corresponds to a repository, across all registries, and record download counts, dependent counts, latest version, and registry URL. Use to populate the Packages tab.
 license: MIT
 compatibility: Needs network access to packages.ecosyste.ms.
+allowed-tools: Read,Write,WebFetch,Grep,Glob,LS
 metadata:
   scrutineer.output_file: report.json
   scrutineer.output_kind: packages


### PR DESCRIPTION
Closes #161.

The `allowed-tools` frontmatter field was already parsed into `db.Skill` and round-tripped through the UI editor, but neither runner passed it to `claude`, so every skill ran with the full tool set under `--permission-mode bypassPermissions`.

This extracts a shared `buildClaudeArgs` helper used by both `LocalClaude` and `DockerRunner` (the two had drifted into near-duplicates). When `AllowedTools` is set the runner passes `--allowedTools <list>` and switches to `--permission-mode acceptEdits`, so writes to `report.json` still go through unprompted but arbitrary Bash is off the table. Skills without `allowed-tools` keep the existing behaviour.

Set `allowed-tools: Read,Write,WebFetch,Grep,Glob,LS` on the five pure-API skills (`metadata`, `maintainers`, `packages`, `advisories`, `dependents`). The issue also listed `repo-overview` and `sbom` but those shell out to `brief` and `git-pkgs`, so they keep Bash for now.