### PR TITLE
Add reachability and quality_tier fields to findings

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -341,6 +341,17 @@ type Finding struct {
 	CWE       string
 	Location  string
 	Affected  string // version range
+	// Reachability records whether a public entry point in the shipped
+	// artefact reaches the sink with attacker-controlled input
+	// (reachable), only a test driver does (harness_only), or the audit
+	// could not decide (unclear). harness_only findings are real bugs
+	// but not disclosable as vulnerabilities.
+	Reachability string `gorm:"index"`
+	// QualityTier classifies the sink: high (heap overflow, UAF, type
+	// confusion, controllable write, shell/eval injection) versus low
+	// (stack exhaustion, assertion failure, fixed-offset null deref, log
+	// injection). Low-tier hits are signposts to keep looking nearby.
+	QualityTier string `gorm:"index"`
 
 	// Disclosure / triage fields. Any of these may be set by a tool, a
 	// model-backed skill, or the analyst; see FindingHistory for the trail.

--- a/internal/db/finding_helpers.go
+++ b/internal/db/finding_helpers.go
@@ -58,6 +58,10 @@ func findingFieldAccessor(f *Finding, field string) (current, column string, err
 		return f.Location, "location", nil
 	case "affected":
 		return f.Affected, "affected", nil
+	case "reachability":
+		return f.Reachability, "reachability", nil
+	case "quality_tier":
+		return f.QualityTier, "quality_tier", nil
 	case "cve_id":
 		return f.CVEID, "cve_id", nil
 	case "cvss_vector":

--- a/internal/web/api_export.go
+++ b/internal/web/api_export.go
@@ -127,6 +127,8 @@ func findingExport(f db.Finding) map[string]any {
 		"cwe":                 f.CWE,
 		"location":            f.Location,
 		"affected":            f.Affected,
+		"reachability":        f.Reachability,
+		"quality_tier":        f.QualityTier,
 		"cve_id":              f.CVEID,
 		"cvss_vector":         f.CVSSVector,
 		"cvss_score":          f.CVSSScore,

--- a/internal/web/api_export_test.go
+++ b/internal/web/api_export_test.go
@@ -304,6 +304,7 @@ func TestExportFindings_carriesDBFields(t *testing.T) {
 		"id", "scan_id", "repository_id", "commit", "sub_path",
 		"fingerprint", "last_seen_scan_id", "last_seen_commit", "seen_count",
 		"finding_id", "sinks", "title", "severity", "status", "cwe", "location", "affected",
+		"reachability", "quality_tier",
 		"cve_id", "cvss_vector", "cvss_score", "fix_version", "fix_commit",
 		"resolution", "disclosure_draft", "assignee",
 		"trace", "boundary", "validation", "prior_art", "reach", "rating",

--- a/internal/web/api_reads.go
+++ b/internal/web/api_reads.go
@@ -230,6 +230,8 @@ func findingSummary(f db.Finding) map[string]any {
 		"cwe":           f.CWE,
 		"location":      f.Location,
 		"affected":      f.Affected,
+		"reachability":  f.Reachability,
+		"quality_tier":  f.QualityTier,
 		"cve_id":        f.CVEID,
 		"cvss_vector":   f.CVSSVector,
 		"cvss_score":    f.CVSSScore,

--- a/internal/web/templates/finding_show.html
+++ b/internal/web/templates/finding_show.html
@@ -47,6 +47,14 @@
     <dd>{{if $f.Affected}}{{$f.Affected}}{{else}}-{{end}}</dd>
   </div>
   <div>
+    <dt class="text-muted-foreground">Reachability</dt>
+    <dd>{{if $f.Reachability}}{{$f.Reachability}}{{else}}-{{end}}</dd>
+  </div>
+  <div>
+    <dt class="text-muted-foreground">Quality tier</dt>
+    <dd>{{if $f.QualityTier}}{{$f.QualityTier}}{{else}}-{{end}}</dd>
+  </div>
+  <div>
     <dt class="text-muted-foreground">Sinks</dt>
     <dd>{{if $f.Sinks}}<a href="/repositories/{{$repo.ID}}#rt10"
         class="underline underline-offset-2"><code>{{$f.Sinks}}</code></a>{{else}}-{{end}}</dd>

--- a/internal/worker/findings.go
+++ b/internal/worker/findings.go
@@ -37,6 +37,8 @@ type scanFinding struct {
 	CWE          string   `json:"cwe"`
 	Location     string   `json:"location"`
 	Affected     string   `json:"affected"`
+	Reachability string   `json:"reachability"`
+	QualityTier  string   `json:"quality_tier"`
 	ReachChecked int      `json:"reach_checked"`
 	ReachExposed int      `json:"reach_exposed"`
 
@@ -77,6 +79,8 @@ func (r scanReport) toFindings(scanID, repoID uint, commit, subPath string) []db
 			CWE:          f.CWE,
 			Location:     f.Location,
 			Affected:     f.Affected,
+			Reachability: f.Reachability,
+			QualityTier:  f.QualityTier,
 			Trace:        f.Trace,
 			Boundary:     f.Boundary,
 			Validation:   f.Validation,

--- a/internal/worker/findings_test.go
+++ b/internal/worker/findings_test.go
@@ -1,0 +1,28 @@
+package worker
+
+import "testing"
+
+func TestToFindings_carriesReachabilityAndQualityTier(t *testing.T) {
+	raw := []byte(`{
+	  "findings": [{
+	    "id": "F1", "sinks": ["S1"], "title": "heap overflow in parse",
+	    "severity": "High", "cwe": "CWE-787", "location": "src/parse.c:42",
+	    "reachability": "harness_only", "quality_tier": "high",
+	    "trace": "t", "boundary": "b", "validation": "v", "rating": "r"
+	  }]
+	}`)
+	rep, err := parseReport(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := rep.toFindings(1, 1, "abc", "")
+	if len(got) != 1 {
+		t.Fatalf("got %d findings, want 1", len(got))
+	}
+	if got[0].Reachability != "harness_only" {
+		t.Errorf("Reachability = %q, want harness_only", got[0].Reachability)
+	}
+	if got[0].QualityTier != "high" {
+		t.Errorf("QualityTier = %q, want high", got[0].QualityTier)
+	}
+}

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -813,6 +813,8 @@ components:
         cwe:           { type: string }
         location:      { type: string }
         affected:      { type: string }
+        reachability:  { type: string, enum: [reachable, harness_only, unclear] }
+        quality_tier:  { type: string, enum: [high, low] }
         cve_id:        { type: string }
         cvss_vector:   { type: string }
         cvss_score:    { type: number }

--- a/skills/reachability/SKILL.md
+++ b/skills/reachability/SKILL.md
@@ -76,8 +76,8 @@ You do not need to re-prove the library bug — that is the upstream finding's j
 Write `./report.json` conforming to `./schema.json`.
 
 - `inventory[]` — one entry per candidate you assessed: `id` `S{n}`, `class` derived from the candidate's CWE (best fit from the schema's `sink_class` enum), `location` `"{package} {requirement} → {candidate.location}"`, `consumes` set to the call-site argument you traced.
-- `findings[]` — each reachable sink. `title` should name both the app entry point and the library sink, e.g. `"Spreadsheet upload at ImportsController#create reaches roo xlsx range expansion (upstream finding #{finding_id})"`. Put the call-site trace in `trace`, the app's boundary in `boundary`, and what you checked for mitigations in `validation`. Reference the upstream finding by `finding_id` and `library_repository_url` in `prior_art`.
+- `findings[]` — each reachable sink. `title` should name both the app entry point and the library sink, e.g. `"Spreadsheet upload at ImportsController#create reaches roo xlsx range expansion (upstream finding #{finding_id})"`. Put the call-site trace in `trace`, the app's boundary in `boundary`, and what you checked for mitigations in `validation`. Reference the upstream finding by `finding_id` and `library_repository_url` in `prior_art`. Set `reachability` to `reachable` (anything else belongs in `ruled_out`). Set `quality_tier` from the upstream sink: shell/eval injection, controllable write, heap overflow, use-after-free, type confusion are `high`; log injection, stack exhaustion, assertion failure, fixed-offset null deref are `low`.
 - `ruled_out[]` — every candidate you did not promote to a finding, with `step` 1/2/3 matching the section above where it fell out and a one-line `reason`.
 - `boundaries[]` — the application's actors (anonymous web user, authenticated user, admin, background job feeder) as you found them while tracing.
 
-Set `spec_version` to `10`. Use the repository URL and HEAD commit of `./src` for `repository` and `commit`.
+Set `spec_version` to `11`. Use the repository URL and HEAD commit of `./src` for `repository` and `commit`.

--- a/skills/reachability/schema.json
+++ b/skills/reachability/schema.json
@@ -79,6 +79,14 @@
     "step":       { "type": "integer", "minimum": 1, "maximum": 6 },
     "cwe":        { "type": "string", "pattern": "^CWE-[0-9]+$" },
     "trusted":    { "type": "string", "enum": ["yes", "no", "conditional"] },
+    "reachability": {
+      "type": "string",
+      "enum": ["reachable", "harness_only", "unclear"]
+    },
+    "quality_tier": {
+      "type": "string",
+      "enum": ["high", "low"]
+    },
 
     "boundary": {
       "type": "object",
@@ -121,6 +129,7 @@
       "type": "object",
       "required": [
         "id", "sinks", "title", "severity", "cwe", "location",
+        "reachability", "quality_tier",
         "trace", "boundary", "validation", "rating"
       ],
       "additionalProperties": false,
@@ -132,6 +141,8 @@
         "cwe":           { "$ref": "#/$defs/cwe" },
         "location":      { "type": "string" },
         "affected":      { "type": "string" },
+        "reachability":  { "$ref": "#/$defs/reachability" },
+        "quality_tier":  { "$ref": "#/$defs/quality_tier" },
         "reach_checked": { "type": "integer", "minimum": 0 },
         "reach_exposed": { "type": "integer", "minimum": 0 },
         "trace":      { "$ref": "#/$defs/markdown" },

--- a/skills/security-deep-dive/SKILL.md
+++ b/skills/security-deep-dive/SKILL.md
@@ -123,6 +123,8 @@ For targets that are not library-shaped — package managers, servers, build too
 
 Reach is data, not a verdict. "No exposed dependent in the top N I checked" is a fact for the report. It does not make the sink safe — the search was bounded, private code exists, future code will be written.
 
+Record the verdict as `reachability`: `reachable` if a public entry point in the shipped artefact reaches the sink with attacker-controlled input; `harness_only` if the only path you can demonstrate is a test driver, fuzz target, or example program calling an internal function directly; `unclear` if you could not establish either. A `harness_only` finding is a real bug worth reporting upstream but is not disclosable as a vulnerability on its own.
+
 ### Step 6: Rate
 
 Severity, given everything above.
@@ -137,6 +139,8 @@ Low: unrealistic preconditions, narrow impact, or the deployment environment mos
 
 Confidence, separately: what you are certain of (the sink does X, per reproduction) versus what depends on context (an attacker reaches it if Y). Name the conditions.
 
+Record `quality_tier` per sink class. For memory safety: heap overflow, use-after-free, type confusion, and controllable write are `high`; stack exhaustion, assertion failure, and null-deref at a fixed offset are `low`. For injection: shell or eval with an attacker string is `high`; log injection is `low`. A `low` tier hit is a signpost, not a stopping point — when you land on one, keep tracing the same data path for a higher-tier sink nearby before writing it up.
+
 ## Output
 
-Write your report to `./report.json`. It must validate against `./schema.json`. Every inventory sink must appear either in `findings[].sinks` or in `ruled_out[].sinks`. Use `findings: []` for a clean report. Read `./context.json` for the repository url, default branch, and other host-provided facts if you need them for the `repository`, `commit`, and `artefact` fields. Set `spec_version` to `10`. Use today's date for the `date` field.
+Write your report to `./report.json`. It must validate against `./schema.json`. Every inventory sink must appear either in `findings[].sinks` or in `ruled_out[].sinks`. Use `findings: []` for a clean report. Read `./context.json` for the repository url, default branch, and other host-provided facts if you need them for the `repository`, `commit`, and `artefact` fields. Set `spec_version` to `11`. Use today's date for the `date` field.

--- a/skills/security-deep-dive/schema.json
+++ b/skills/security-deep-dive/schema.json
@@ -79,6 +79,14 @@
     "step":       { "type": "integer", "minimum": 1, "maximum": 6 },
     "cwe":        { "type": "string", "pattern": "^CWE-[0-9]+$" },
     "trusted":    { "type": "string", "enum": ["yes", "no", "conditional"] },
+    "reachability": {
+      "type": "string",
+      "enum": ["reachable", "harness_only", "unclear"]
+    },
+    "quality_tier": {
+      "type": "string",
+      "enum": ["high", "low"]
+    },
 
     "boundary": {
       "type": "object",
@@ -121,6 +129,7 @@
       "type": "object",
       "required": [
         "id", "sinks", "title", "severity", "cwe", "location",
+        "reachability", "quality_tier",
         "trace", "boundary", "validation", "rating"
       ],
       "additionalProperties": false,
@@ -132,6 +141,8 @@
         "cwe":           { "$ref": "#/$defs/cwe" },
         "location":      { "type": "string" },
         "affected":      { "type": "string" },
+        "reachability":  { "$ref": "#/$defs/reachability" },
+        "quality_tier":  { "$ref": "#/$defs/quality_tier" },
         "reach_checked": { "type": "integer", "minimum": 0 },
         "reach_exposed": { "type": "integer", "minimum": 0 },
         "trace":      { "$ref": "#/$defs/markdown" },


### PR DESCRIPTION
Closes #113.

Two classification fields the deep-dive already gathers in prose but never lands in a column anything can filter on:

- `reachability`: `reachable` / `harness_only` / `unclear` — whether a public entry point in the shipped artefact reaches the sink with attacker-controlled input, or only a test driver does. `harness_only` findings are real bugs but not disclosable as vulnerabilities.
- `quality_tier`: `high` / `low` per sink class. Heap overflow, UAF, type confusion, controllable write, shell/eval injection are high; stack exhaustion, assertion failure, fixed-offset null deref, log injection are low.

Threaded through `schema.json` for both findings-emitting skills, `db.Finding` (indexed), the report parser, the API summary and export, the `PATCH /findings/{id}` allowlist, `openapi.yaml`, and the finding detail page. `spec_version` bumped to 11.

The deep-dive prompt now records the reachability verdict at the end of Step 5, and Step 6 records `quality_tier` with a note that a low-tier hit is a signpost to keep tracing the same data path for a higher-tier sink rather than a place to stop. The `reachability` skill sets `reachability: reachable` on every finding (anything else belongs in `ruled_out`) and derives `quality_tier` from the upstream sink.

Left the filter dropdown on `/findings` for a follow-up once scans have actually populated the columns; an empty dropdown isn't useful yet.