### PR TITLE
Validate scrutineer.* metadata in SKILL.md and add version field

### DIFF
--- a/internal/skills/load.go
+++ b/internal/skills/load.go
@@ -44,8 +44,7 @@ func LoadDirectory(gdb *gorm.DB, log *slog.Logger, root, source string) (int, er
 		}
 		p, perr := ParseFile(path)
 		if perr != nil {
-			log.Warn("skill parse failed", "path", path, "err", perr)
-			return nil
+			return perr
 		}
 		for _, w := range p.Warnings {
 			log.Warn("skill warning", "name", p.Name, "path", path, "warn", w)

--- a/internal/skills/parse.go
+++ b/internal/skills/parse.go
@@ -3,9 +3,11 @@
 // with YAML frontmatter plus optional supporting files; see the spec at
 // https://agentskills.io/specification.
 //
-// Lenient parsing: we warn on spec violations but load the skill anyway, in
-// line with the client-implementation guide. Only an unparseable SKILL.md or
-// a missing description causes a skip.
+// agentskills.io spec violations (name format, field lengths) are lenient:
+// they log a warning and the skill loads anyway, per the client guide. The
+// scrutineer.* metadata keys are scrutineer's own and are checked strictly:
+// an unknown key, a bad output_kind, or an unsupported scrutineer.version is
+// a hard parse error and stops server startup.
 package skills
 
 import (
@@ -33,7 +35,46 @@ const (
 	metaOutputKind = "scrutineer.output_kind"
 	metaMaxTurns   = "scrutineer.max_turns"
 	metaModel      = "scrutineer.model"
+	metaVersion    = "scrutineer.version"
+
+	// SchemaVersion is the only scrutineer.version this build accepts.
+	// Skills omitting the key are treated as version 1. Bump when the
+	// scrutineer.* metadata keys change shape so old skill repos fail
+	// loudly instead of silently misbehaving.
+	SchemaVersion = 1
 )
+
+// scrutineerKeys is the closed set of scrutineer.* metadata keys this
+// build understands. Anything else under that prefix is rejected at
+// parse time so a typo like scrutineer.outputkind surfaces immediately
+// rather than after a worker falls through to freeform.
+var scrutineerKeys = map[string]bool{
+	metaOutputFile: true,
+	metaOutputKind: true,
+	metaMaxTurns:   true,
+	metaModel:      true,
+	metaVersion:    true,
+}
+
+// OutputKinds is the set of values scrutineer.output_kind may take.
+// "freeform" and the empty string both mean "store the report verbatim
+// without parsing"; everything else maps to a parser in
+// internal/worker/skill.go.
+var OutputKinds = map[string]bool{
+	"":              true,
+	"freeform":      true,
+	"findings":      true,
+	"maintainers":   true,
+	"repo_metadata": true,
+	"packages":      true,
+	"advisories":    true,
+	"dependents":    true,
+	"dependencies":  true,
+	"verify":        true,
+	"subprojects":   true,
+	"repo_overview": true,
+	"posture":       true,
+}
 
 var nameRE = regexp.MustCompile(`^[a-z0-9]+(-[a-z0-9]+)*$`)
 
@@ -105,6 +146,9 @@ func ParseFile(path string) (*Parsed, error) {
 		SourcePath:    filepath.Dir(path),
 	}
 	p.validate()
+	if err := p.validateMetadata(); err != nil {
+		return nil, fmt.Errorf("%s: %w", path, err)
+	}
 	p.extractMetadataKeys()
 	p.loadSchema()
 	p.hash(raw)
@@ -142,6 +186,41 @@ func (p *Parsed) validate() {
 	if len(p.Compatibility) > maxCompatLen {
 		p.Warnings = append(p.Warnings, fmt.Sprintf("compatibility exceeds %d characters", maxCompatLen))
 	}
+}
+
+// validateMetadata checks the scrutineer.* keys strictly. agentskills.io
+// spec violations stay as warnings (see validate); scrutineer-specific
+// keys are a closed set under our control so typos are hard errors.
+func (p *Parsed) validateMetadata() error {
+	for k := range p.Metadata {
+		if strings.HasPrefix(k, "scrutineer.") && !scrutineerKeys[k] {
+			return fmt.Errorf("unknown metadata key %q", k)
+		}
+	}
+	if v, ok := p.Metadata[metaVersion]; ok {
+		got, ok := v.(int)
+		if !ok {
+			return fmt.Errorf("%s must be an integer, got %T", metaVersion, v)
+		}
+		if got != SchemaVersion {
+			return fmt.Errorf("%s %d not supported (this build accepts %d)", metaVersion, got, SchemaVersion)
+		}
+	}
+	if v, ok := p.Metadata[metaOutputKind]; ok {
+		s, ok := v.(string)
+		if !ok {
+			return fmt.Errorf("%s must be a string, got %T", metaOutputKind, v)
+		}
+		if !OutputKinds[strings.TrimSpace(s)] {
+			return fmt.Errorf("%s %q is not a recognised parser", metaOutputKind, s)
+		}
+	}
+	if v, ok := p.Metadata[metaMaxTurns]; ok {
+		if _, ok := v.(int); !ok {
+			return fmt.Errorf("%s must be an integer, got %T", metaMaxTurns, v)
+		}
+	}
+	return nil
 }
 
 func (p *Parsed) extractMetadataKeys() {

--- a/internal/skills/parse_test.go
+++ b/internal/skills/parse_test.go
@@ -255,6 +255,136 @@ body`)
 	}
 }
 
+func TestParseFile_rejectsUnknownScrutineerKey(t *testing.T) {
+	dir := t.TempDir()
+	path := writeSkill(t, dir, "typo", `---
+name: typo
+description: d
+metadata:
+  scrutineer.outputkind: findings
+---
+body`)
+	_, err := ParseFile(path)
+	if err == nil || !strings.Contains(err.Error(), "scrutineer.outputkind") {
+		t.Errorf("expected unknown-key error, got %v", err)
+	}
+}
+
+func TestParseFile_rejectsUnknownOutputKind(t *testing.T) {
+	dir := t.TempDir()
+	path := writeSkill(t, dir, "badkind", `---
+name: badkind
+description: d
+metadata:
+  scrutineer.output_kind: finddings
+---
+body`)
+	_, err := ParseFile(path)
+	if err == nil || !strings.Contains(err.Error(), "not a recognised parser") {
+		t.Errorf("expected output_kind error, got %v", err)
+	}
+}
+
+func TestParseFile_rejectsUnsupportedVersion(t *testing.T) {
+	dir := t.TempDir()
+	path := writeSkill(t, dir, "future", `---
+name: future
+description: d
+metadata:
+  scrutineer.version: 2
+---
+body`)
+	_, err := ParseFile(path)
+	if err == nil || !strings.Contains(err.Error(), "not supported") {
+		t.Errorf("expected version error, got %v", err)
+	}
+}
+
+func TestParseFile_acceptsVersion1(t *testing.T) {
+	dir := t.TempDir()
+	path := writeSkill(t, dir, "v1", `---
+name: v1
+description: d
+metadata:
+  scrutineer.version: 1
+  scrutineer.output_kind: findings
+---
+body`)
+	if _, err := ParseFile(path); err != nil {
+		t.Errorf("version 1 should parse: %v", err)
+	}
+}
+
+func TestParseFile_allowsNonScrutineerMetadata(t *testing.T) {
+	dir := t.TempDir()
+	path := writeSkill(t, dir, "extra", `---
+name: extra
+description: d
+metadata:
+  author: someone
+  unrelated.key: value
+---
+body`)
+	if _, err := ParseFile(path); err != nil {
+		t.Errorf("non-scrutineer keys should pass through: %v", err)
+	}
+}
+
+func TestParseFile_rejectsNonIntegerMaxTurns(t *testing.T) {
+	dir := t.TempDir()
+	path := writeSkill(t, dir, "badturns", `---
+name: badturns
+description: d
+metadata:
+  scrutineer.max_turns: fifty
+---
+body`)
+	_, err := ParseFile(path)
+	if err == nil || !strings.Contains(err.Error(), "must be an integer") {
+		t.Errorf("expected max_turns type error, got %v", err)
+	}
+}
+
+func TestLoadDirectory_bundledSkillsAreValid(t *testing.T) {
+	gdb, err := db.Open(filepath.Join(t.TempDir(), "t.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	n, err := LoadDirectory(gdb, log, "../../skills", "local")
+	if err != nil {
+		t.Fatalf("bundled skills failed validation: %v", err)
+	}
+	if n == 0 {
+		t.Fatal("no skills loaded from ../../skills")
+	}
+}
+
+func TestLoadDirectory_failsOnInvalidSkill(t *testing.T) {
+	gdb, err := db.Open(filepath.Join(t.TempDir(), "t.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	root := t.TempDir()
+	writeSkill(t, root, "good", `---
+name: good
+description: d
+---
+body`)
+	writeSkill(t, root, "bad", `---
+name: bad
+description: d
+metadata:
+  scrutineer.output_kind: nope
+---
+body`)
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	_, err = LoadDirectory(gdb, log, root, "local")
+	if err == nil {
+		t.Error("expected LoadDirectory to fail on invalid skill")
+	}
+}
+
 func TestParseFile_namedoesntmatch(t *testing.T) {
 	dir := t.TempDir()
 	path := writeSkill(t, dir, "dirname", `---

--- a/internal/web/skills_handlers.go
+++ b/internal/web/skills_handlers.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"scrutineer/internal/db"
+	"scrutineer/internal/skills"
 )
 
 var skillNameRE = regexp.MustCompile(`^[a-z0-9]+(-[a-z0-9]+)*$`)
@@ -93,6 +94,10 @@ func (s *Server) skillCreate(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "output_file must be a plain filename with no path separators", http.StatusBadRequest)
 		return
 	}
+	if !skills.OutputKinds[skill.OutputKind] {
+		http.Error(w, "output_kind is not a recognised parser", http.StatusBadRequest)
+		return
+	}
 	if err := s.DB.Create(&skill).Error; err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
@@ -126,6 +131,10 @@ func (s *Server) skillUpdate(w http.ResponseWriter, r *http.Request) {
 	}
 	if !validateOutputFile(skill.OutputFile) {
 		http.Error(w, "output_file must be a plain filename with no path separators", http.StatusBadRequest)
+		return
+	}
+	if !skills.OutputKinds[skill.OutputKind] {
+		http.Error(w, "output_kind is not a recognised parser", http.StatusBadRequest)
 		return
 	}
 	skill.Version++

--- a/skills/advisories/SKILL.md
+++ b/skills/advisories/SKILL.md
@@ -5,6 +5,7 @@ license: MIT
 compatibility: Needs network access to advisories.ecosyste.ms.
 allowed-tools: Read,Write,WebFetch,Grep,Glob,LS
 metadata:
+  scrutineer.version: 1
   scrutineer.output_file: report.json
   scrutineer.output_kind: advisories
 ---

--- a/skills/cna-match/SKILL.md
+++ b/skills/cna-match/SKILL.md
@@ -3,6 +3,7 @@ name: cna-match
 description: Determine which CVE Numbering Authority (if any) covers this repository, so disclosures can be routed to the CNA's security contact rather than only the maintainer. Reads scrutineer's cached CNA list and matches the repo's owner, project name, and published packages against each CNA's published scope.
 license: MIT
 metadata:
+  scrutineer.version: 1
   scrutineer.output_file: report.json
   scrutineer.output_kind: maintainers
 ---

--- a/skills/dependencies/SKILL.md
+++ b/skills/dependencies/SKILL.md
@@ -4,6 +4,7 @@ description: Index every dependency declared in the repository's manifest and lo
 license: MIT
 compatibility: Requires the `git-pkgs` CLI (https://github.com/ecosyste-ms/git-pkgs) on PATH.
 metadata:
+  scrutineer.version: 1
   scrutineer.output_file: report.json
   scrutineer.output_kind: dependencies
 ---

--- a/skills/dependents/SKILL.md
+++ b/skills/dependents/SKILL.md
@@ -5,6 +5,7 @@ license: MIT
 compatibility: Needs network access to packages.ecosyste.ms.
 allowed-tools: Read,Write,WebFetch,Grep,Glob,LS
 metadata:
+  scrutineer.version: 1
   scrutineer.output_file: report.json
   scrutineer.output_kind: dependents
 ---

--- a/skills/disclose/SKILL.md
+++ b/skills/disclose/SKILL.md
@@ -4,6 +4,7 @@ description: Draft the disclosure content for a finding in GitHub Security Advis
 license: MIT
 compatibility: Needs network access to the scrutineer API (http://host:port/api). Finding-scoped; runs on one finding at a time.
 metadata:
+  scrutineer.version: 1
   scrutineer.output_file: report.json
   scrutineer.output_kind: freeform
 ---

--- a/skills/fork/SKILL.md
+++ b/skills/fork/SKILL.md
@@ -4,6 +4,7 @@ description: Fork the scanned repository into the configured GitHub organisation
 license: MIT
 compatibility: Needs the gh CLI authenticated with a token that can create forks in the fork_org and manage repository settings and security advisories there. Needs network access to api.github.com and the scrutineer API. github.com upstreams only for now.
 metadata:
+  scrutineer.version: 1
   scrutineer.output_file: report.json
   scrutineer.output_kind: freeform
 ---

--- a/skills/maintainers/SKILL.md
+++ b/skills/maintainers/SKILL.md
@@ -5,6 +5,7 @@ license: MIT
 compatibility: Needs network access to commits.ecosyste.ms, issues.ecosyste.ms, and packages.ecosyste.ms.
 allowed-tools: Read,Write,WebFetch,Grep,Glob,LS
 metadata:
+  scrutineer.version: 1
   scrutineer.output_file: report.json
   scrutineer.output_kind: maintainers
 ---

--- a/skills/metadata/SKILL.md
+++ b/skills/metadata/SKILL.md
@@ -5,6 +5,7 @@ license: MIT
 compatibility: Needs network access to repos.ecosyste.ms.
 allowed-tools: Read,Write,WebFetch,Grep,Glob,LS
 metadata:
+  scrutineer.version: 1
   scrutineer.output_file: report.json
   scrutineer.output_kind: repo_metadata
 ---

--- a/skills/packages/SKILL.md
+++ b/skills/packages/SKILL.md
@@ -5,6 +5,7 @@ license: MIT
 compatibility: Needs network access to packages.ecosyste.ms.
 allowed-tools: Read,Write,WebFetch,Grep,Glob,LS
 metadata:
+  scrutineer.version: 1
   scrutineer.output_file: report.json
   scrutineer.output_kind: packages
 ---

--- a/skills/patch/SKILL.md
+++ b/skills/patch/SKILL.md
@@ -4,6 +4,7 @@ description: Propose a code patch for a finding. Produces a unified diff against
 license: MIT
 compatibility: Needs network access to the scrutineer API (http://host:port/api). Finding-scoped; runs against ./src at HEAD.
 metadata:
+  scrutineer.version: 1
   scrutineer.output_file: report.json
   scrutineer.output_kind: freeform
 ---

--- a/skills/posture/SKILL.md
+++ b/skills/posture/SKILL.md
@@ -4,6 +4,7 @@ description: Assess a repository's security posture and its readiness to receive
 license: MIT
 compatibility: Needs network access to api.github.com and api.securityscorecards.dev. Works best on GitHub-hosted repositories; degrades to file-only checks elsewhere.
 metadata:
+  scrutineer.version: 1
   scrutineer.output_file: report.json
   scrutineer.output_kind: posture
 ---

--- a/skills/reachability/SKILL.md
+++ b/skills/reachability/SKILL.md
@@ -3,6 +3,7 @@ name: reachability
 description: Check whether known sinks in this application's dependencies are reachable from its own trust boundaries. Scrutineer already holds findings against the libraries this app uses; this skill traces each one from the app's entry points to the library call and reports the ones an attacker can reach. Use on applications (Gemfile.lock / package-lock.json present), not on libraries.
 license: MIT
 metadata:
+  scrutineer.version: 1
   scrutineer.output_file: report.json
   scrutineer.output_kind: findings
 ---

--- a/skills/repo-overview/SKILL.md
+++ b/skills/repo-overview/SKILL.md
@@ -4,6 +4,7 @@ description: Produce a structured plain-language overview of what a repository d
 license: MIT
 compatibility: Requires the `brief` CLI (https://github.com/ecosyste-ms/brief) on PATH.
 metadata:
+  scrutineer.version: 1
   scrutineer.output_file: report.json
   scrutineer.output_kind: repo_overview
 ---

--- a/skills/sbom/SKILL.md
+++ b/skills/sbom/SKILL.md
@@ -4,6 +4,7 @@ description: Generate a CycloneDX Software Bill of Materials for the repository.
 license: MIT
 compatibility: Requires the `git-pkgs` CLI on PATH.
 metadata:
+  scrutineer.version: 1
   scrutineer.output_file: report.json
   scrutineer.output_kind: freeform
 ---

--- a/skills/security-deep-dive/SKILL.md
+++ b/skills/security-deep-dive/SKILL.md
@@ -3,6 +3,7 @@ name: security-deep-dive
 description: Audit first-party source for security vulnerabilities using an inventory-first, six-step per-sink methodology. Use when you want a thorough scan that distinguishes real findings from pattern matches and records both in a machine-readable report. The target is this codebase's own code, not its dependencies.
 license: MIT
 metadata:
+  scrutineer.version: 1
   scrutineer.output_file: report.json
   scrutineer.output_kind: findings
 ---

--- a/skills/semgrep/SKILL.md
+++ b/skills/semgrep/SKILL.md
@@ -4,6 +4,7 @@ description: Run semgrep static analysis with the security-audit and secrets rul
 license: MIT
 compatibility: Requires `semgrep` (https://semgrep.dev) and `python3` on PATH.
 metadata:
+  scrutineer.version: 1
   scrutineer.output_file: report.json
   scrutineer.output_kind: freeform
 ---

--- a/skills/subprojects/SKILL.md
+++ b/skills/subprojects/SKILL.md
@@ -4,6 +4,7 @@ description: Enumerate scannable sub-folders inside a repository. Identifies mon
 license: MIT
 compatibility: Needs network access to the scrutineer API only for logging; the enumeration itself is filesystem-only against ./src.
 metadata:
+  scrutineer.version: 1
   scrutineer.output_file: report.json
   scrutineer.output_kind: subprojects
 ---

--- a/skills/triage/SKILL.md
+++ b/skills/triage/SKILL.md
@@ -4,6 +4,7 @@ description: Default pipeline scrutineer runs when a repository is added. Trigge
 license: MIT
 compatibility: Needs network access to the scrutineer API (http://host:port/api). Uses `brief` (github.com/git-pkgs/brief) to classify the repository before deciding which scans to enqueue; falls back to enqueueing everything if brief is unavailable.
 metadata:
+  scrutineer.version: 1
   scrutineer.output_file: report.json
   scrutineer.output_kind: freeform
 ---

--- a/skills/verify/SKILL.md
+++ b/skills/verify/SKILL.md
@@ -4,6 +4,7 @@ description: Independently verify a specific finding by re-running its reproduct
 license: MIT
 compatibility: Needs network access to the scrutineer API (http://host:port/api). Expects the finding's reproduction instructions to be runnable against ./src with commonly available tooling.
 metadata:
+  scrutineer.version: 1
   scrutineer.output_file: report.json
   scrutineer.output_kind: verify
 ---

--- a/skills/zizmor/SKILL.md
+++ b/skills/zizmor/SKILL.md
@@ -4,6 +4,7 @@ description: Audit the repository's GitHub Actions workflows for common security
 license: MIT
 compatibility: Requires `zizmor` (https://github.com/woodruffw/zizmor) and `python3` on PATH.
 metadata:
+  scrutineer.version: 1
   scrutineer.output_file: report.json
   scrutineer.output_kind: freeform
 ---


### PR DESCRIPTION
Closes #162.

A typo like `scrutineer.outputkind: findings` was silently ignored at load time and only surfaced when a worker tried to parse the report and fell through to freeform. With third-party skill repos via `-skills-repo` and the UI editor both feeding into this path, that's a footgun.

agentskills.io spec violations (name format, field lengths) stay lenient as warnings per the client guide. The `scrutineer.*` metadata keys are scrutineer's own and are now a closed set checked at parse time:

- any `scrutineer.*` key not in `{output_file, output_kind, max_turns, version}` is a hard error
- `scrutineer.output_kind` must name a recognised parser (or `freeform`/empty)
- `scrutineer.max_turns` must be an integer
- `scrutineer.version` must equal `1` if present (omitted = implicitly 1)

`ParseFile` errors now propagate out of `LoadDirectory` so a broken skill stops server startup with a path-qualified message instead of a quiet `warn` line. The UI form's create/update handlers validate `output_kind` against the same `skills.OutputKinds` set.

Added `scrutineer.version: 1` to all twenty bundled skills and a test that loads `skills/` through the real parser so a bad frontmatter fails CI before it reaches a worker.

Went with the hand-rolled validator (~30 lines on the existing struct) over a JSON Schema file: the shape is small, fixed, and `santhosh-tekuri/jsonschema` is already in `go.sum` for CSAF but using it here wouldn't give better errors than `fmt.Errorf` does.

Will trivially conflict with #167 in the bundled skill frontmatter (both add a line under `metadata:` / above it); whichever lands second is a clean re-merge.