### PR TITLE
Per-skill confidence and severity thresholds

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -333,14 +333,15 @@ type Finding struct {
 	MissedCount      int
 	LastMissedScanID uint
 
-	FindingID string // e.g. F1, F2 within the report
-	Sinks     string // comma-joined sink IDs
-	Title     string
-	Severity  string           `gorm:"index"`
-	Status    FindingLifecycle `gorm:"index;default:new"`
-	CWE       string
-	Location  string
-	Affected  string // version range
+	FindingID  string // e.g. F1, F2 within the report
+	Sinks      string // comma-joined sink IDs
+	Title      string
+	Severity   string           `gorm:"index"`
+	Confidence string           `gorm:"index"` // high/medium/low; how certain the audit is
+	Status     FindingLifecycle `gorm:"index;default:new"`
+	CWE        string
+	Location   string
+	Affected   string // version range
 	// Reachability records whether a public entry point in the shipped
 	// artefact reaches the sink with attacker-controlled input
 	// (reachable), only a test driver does (harness_only), or the audit
@@ -490,6 +491,13 @@ type Skill struct {
 	OutputKind string `gorm:"index"` // from metadata["scrutineer.output_kind"]
 	MaxTurns   int    // from metadata["scrutineer.max_turns"]
 	Model      string // from metadata["scrutineer.model"]; empty = use scan/server default
+	// Thresholds: MinConfidence drops findings below the given confidence
+	// before they are written; FailOn marks the scan failed if any
+	// finding's severity is at or above it; ReportOn is the default
+	// severity floor for the repo findings tab. All optional.
+	MinConfidence string
+	ReportOn      string
+	FailOn        string
 
 	Version int  `gorm:"not null;default:1"`
 	Active  bool `gorm:"not null;default:true"`

--- a/internal/db/finding_helpers.go
+++ b/internal/db/finding_helpers.go
@@ -41,6 +41,42 @@ func WriteFindingField(gdb *gorm.DB, findingID uint, field, newValue string, sou
 	}).Error
 }
 
+// confidenceLevels and severityLevels are ordered low to high; the
+// index is the rank used for threshold comparisons. An empty or
+// unknown value ranks below everything.
+var confidenceLevels = []string{"low", "medium", "high"}
+var severityLevels = []string{"Low", "Medium", "High", "Critical"}
+
+func rank(levels []string, v string) int {
+	for i, l := range levels {
+		if l == v {
+			return i + 1
+		}
+	}
+	return 0
+}
+
+// ConfidenceAtLeast reports whether got ranks at or above min on the
+// low/medium/high scale. A finding without a confidence value is
+// dropped when a min_confidence is set; an empty min disables the
+// check.
+func ConfidenceAtLeast(got, minimum string) bool {
+	if minimum == "" {
+		return true
+	}
+	return rank(confidenceLevels, got) >= rank(confidenceLevels, minimum)
+}
+
+// SeverityAtLeast reports whether got ranks at or above the threshold
+// on the Low/Medium/High/Critical scale. An empty threshold never
+// matches.
+func SeverityAtLeast(got, threshold string) bool {
+	if threshold == "" {
+		return false
+	}
+	return rank(severityLevels, got) >= rank(severityLevels, threshold)
+}
+
 // findingFieldAccessor maps the API-facing field name to the current
 // value and the DB column name. It is the single list of mutable fields;
 // adding a new editable field means adding it here.

--- a/internal/db/finding_helpers_test.go
+++ b/internal/db/finding_helpers_test.go
@@ -29,6 +29,44 @@ func seedFinding(t *testing.T, gdb *gorm.DB) Finding {
 	return f
 }
 
+func TestConfidenceAtLeast(t *testing.T) {
+	cases := []struct {
+		got, min string
+		want     bool
+	}{
+		{"high", "medium", true},
+		{"medium", "medium", true},
+		{"low", "medium", false},
+		{"", "low", false},
+		{"high", "", true},
+		{"garbage", "low", false},
+	}
+	for _, tc := range cases {
+		if r := ConfidenceAtLeast(tc.got, tc.min); r != tc.want {
+			t.Errorf("ConfidenceAtLeast(%q, %q) = %v, want %v", tc.got, tc.min, r, tc.want)
+		}
+	}
+}
+
+func TestSeverityAtLeast(t *testing.T) {
+	cases := []struct {
+		got, threshold string
+		want           bool
+	}{
+		{"Critical", "High", true},
+		{"High", "High", true},
+		{"Medium", "High", false},
+		{"Low", "Critical", false},
+		{"High", "", false},
+		{"", "Low", false},
+	}
+	for _, tc := range cases {
+		if r := SeverityAtLeast(tc.got, tc.threshold); r != tc.want {
+			t.Errorf("SeverityAtLeast(%q, %q) = %v, want %v", tc.got, tc.threshold, r, tc.want)
+		}
+	}
+}
+
 func TestWriteFindingField_logsHistory(t *testing.T) {
 	gdb := newTestDB(t)
 	f := seedFinding(t, gdb)

--- a/internal/skills/parse.go
+++ b/internal/skills/parse.go
@@ -26,16 +26,19 @@ import (
 )
 
 const (
-	skillFile      = "SKILL.md"
-	schemaFile     = "schema.json"
-	maxNameLen     = 64
-	maxDescLen     = 1024
-	maxCompatLen   = 500
-	metaOutputFile = "scrutineer.output_file"
-	metaOutputKind = "scrutineer.output_kind"
-	metaMaxTurns   = "scrutineer.max_turns"
-	metaModel      = "scrutineer.model"
-	metaVersion    = "scrutineer.version"
+	skillFile         = "SKILL.md"
+	schemaFile        = "schema.json"
+	maxNameLen        = 64
+	maxDescLen        = 1024
+	maxCompatLen      = 500
+	metaOutputFile    = "scrutineer.output_file"
+	metaOutputKind    = "scrutineer.output_kind"
+	metaMaxTurns      = "scrutineer.max_turns"
+	metaModel         = "scrutineer.model"
+	metaVersion       = "scrutineer.version"
+	metaMinConfidence = "scrutineer.min_confidence"
+	metaReportOn      = "scrutineer.report_on"
+	metaFailOn        = "scrutineer.fail_on"
 
 	// SchemaVersion is the only scrutineer.version this build accepts.
 	// Skills omitting the key are treated as version 1. Bump when the
@@ -49,12 +52,18 @@ const (
 // parse time so a typo like scrutineer.outputkind surfaces immediately
 // rather than after a worker falls through to freeform.
 var scrutineerKeys = map[string]bool{
-	metaOutputFile: true,
-	metaOutputKind: true,
-	metaMaxTurns:   true,
-	metaModel:      true,
-	metaVersion:    true,
+	metaOutputFile:    true,
+	metaOutputKind:    true,
+	metaMaxTurns:      true,
+	metaModel:         true,
+	metaVersion:       true,
+	metaMinConfidence: true,
+	metaReportOn:      true,
+	metaFailOn:        true,
 }
+
+var confidenceLevels = map[string]bool{"low": true, "medium": true, "high": true}
+var severityLevels = map[string]bool{"Low": true, "Medium": true, "High": true, "Critical": true}
 
 // OutputKinds is the set of values scrutineer.output_kind may take.
 // "freeform" and the empty string both mean "store the report verbatim
@@ -94,12 +103,15 @@ type Parsed struct {
 	AllowedTools  string
 	Metadata      map[string]any
 
-	Body       string
-	SchemaJSON string
-	OutputFile string
-	OutputKind string
-	MaxTurns   int
-	Model      string
+	Body          string
+	SchemaJSON    string
+	OutputFile    string
+	OutputKind    string
+	MaxTurns      int
+	Model         string
+	MinConfidence string
+	ReportOn      string
+	FailOn        string
 
 	SourcePath string // absolute path to the skill directory
 	SourceHash string // sha256 of SKILL.md + schema.json contents
@@ -220,6 +232,30 @@ func (p *Parsed) validateMetadata() error {
 			return fmt.Errorf("%s must be an integer, got %T", metaMaxTurns, v)
 		}
 	}
+	if err := checkEnum(p.Metadata, metaMinConfidence, confidenceLevels); err != nil {
+		return err
+	}
+	if err := checkEnum(p.Metadata, metaReportOn, severityLevels); err != nil {
+		return err
+	}
+	if err := checkEnum(p.Metadata, metaFailOn, severityLevels); err != nil {
+		return err
+	}
+	return nil
+}
+
+func checkEnum(m map[string]any, key string, allowed map[string]bool) error {
+	v, ok := m[key]
+	if !ok {
+		return nil
+	}
+	s, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("%s must be a string, got %T", key, v)
+	}
+	if !allowed[strings.TrimSpace(s)] {
+		return fmt.Errorf("%s %q is not a valid level", key, s)
+	}
 	return nil
 }
 
@@ -242,6 +278,15 @@ func (p *Parsed) extractMetadataKeys() {
 				p.Warnings = append(p.Warnings, fmt.Sprintf("model %q is not in the configured model list, ignoring", m))
 			}
 		}
+	}
+	if v, ok := p.Metadata[metaMinConfidence].(string); ok {
+		p.MinConfidence = strings.TrimSpace(v)
+	}
+	if v, ok := p.Metadata[metaReportOn].(string); ok {
+		p.ReportOn = strings.TrimSpace(v)
+	}
+	if v, ok := p.Metadata[metaFailOn].(string); ok {
+		p.FailOn = strings.TrimSpace(v)
 	}
 }
 
@@ -286,6 +331,9 @@ func (p *Parsed) ToModel(source string) (*db.Skill, error) {
 		OutputKind:    p.OutputKind,
 		MaxTurns:      p.MaxTurns,
 		Model:         p.Model,
+		MinConfidence: p.MinConfidence,
+		ReportOn:      p.ReportOn,
+		FailOn:        p.FailOn,
 		Active:        true,
 		Source:        source,
 		SourcePath:    p.SourcePath,

--- a/internal/skills/parse_test.go
+++ b/internal/skills/parse_test.go
@@ -345,6 +345,55 @@ body`)
 	}
 }
 
+func TestParseFile_thresholdKeys(t *testing.T) {
+	dir := t.TempDir()
+	path := writeSkill(t, dir, "thresh", `---
+name: thresh
+description: d
+metadata:
+  scrutineer.min_confidence: medium
+  scrutineer.report_on: Low
+  scrutineer.fail_on: High
+---
+body`)
+	p, err := ParseFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.MinConfidence != "medium" || p.ReportOn != "Low" || p.FailOn != "High" {
+		t.Errorf("thresholds not extracted: %+v", p)
+	}
+	m, _ := p.ToModel("local")
+	if m.MinConfidence != "medium" || m.FailOn != "High" {
+		t.Errorf("ToModel did not carry thresholds: %+v", m)
+	}
+}
+
+func TestParseFile_rejectsBadThresholdValues(t *testing.T) {
+	dir := t.TempDir()
+	path := writeSkill(t, dir, "badconf", `---
+name: badconf
+description: d
+metadata:
+  scrutineer.min_confidence: maybe
+---
+body`)
+	if _, err := ParseFile(path); err == nil || !strings.Contains(err.Error(), "not a valid level") {
+		t.Errorf("expected min_confidence enum error, got %v", err)
+	}
+
+	path = writeSkill(t, dir, "badfail", `---
+name: badfail
+description: d
+metadata:
+  scrutineer.fail_on: extreme
+---
+body`)
+	if _, err := ParseFile(path); err == nil || !strings.Contains(err.Error(), "not a valid level") {
+		t.Errorf("expected fail_on enum error, got %v", err)
+	}
+}
+
 func TestLoadDirectory_bundledSkillsAreValid(t *testing.T) {
 	gdb, err := db.Open(filepath.Join(t.TempDir(), "t.db"))
 	if err != nil {

--- a/internal/worker/findings.go
+++ b/internal/worker/findings.go
@@ -34,6 +34,7 @@ type scanFinding struct {
 	Sinks        []string `json:"sinks"`
 	Title        string   `json:"title"`
 	Severity     string   `json:"severity"`
+	Confidence   string   `json:"confidence"`
 	CWE          string   `json:"cwe"`
 	Location     string   `json:"location"`
 	Affected     string   `json:"affected"`
@@ -51,9 +52,8 @@ type scanFinding struct {
 	Rating     string `json:"rating"`
 
 	// Legacy fields (old schema)
-	Confidence string `json:"confidence"`
-	Summary    string `json:"summary"`
-	Details    string `json:"details"`
+	Summary string `json:"summary"`
+	Details string `json:"details"`
 }
 
 func parseReport(raw []byte) (scanReport, error) {
@@ -76,6 +76,7 @@ func (r scanReport) toFindings(scanID, repoID uint, commit, subPath string) []db
 			Sinks:        strings.Join(f.Sinks, ", "),
 			Title:        f.Title,
 			Severity:     f.Severity,
+			Confidence:   strings.ToLower(f.Confidence),
 			CWE:          f.CWE,
 			Location:     f.Location,
 			Affected:     f.Affected,

--- a/internal/worker/findings_dedup_test.go
+++ b/internal/worker/findings_dedup_test.go
@@ -1,13 +1,97 @@
 package worker
 
 import (
+	"errors"
 	"io"
 	"log/slog"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"scrutineer/internal/db"
 )
+
+func TestParseFindingsOutput_minConfidenceDropsBelowThreshold(t *testing.T) {
+	gdb, err := db.Open(filepath.Join(t.TempDir(), "p.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo := db.Repository{URL: "https://x/r", Name: "r"}
+	gdb.Create(&repo)
+	scan := &db.Scan{RepositoryID: repo.ID, Kind: JobSkill, SkillName: "x", Status: db.ScanDone}
+	gdb.Create(scan)
+	w := &Worker{DB: gdb, Log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+
+	report := `{"findings":[
+		{"id":"F1","title":"a","severity":"High","cwe":"CWE-1","location":"a.rb:1","confidence":"high"},
+		{"id":"F2","title":"b","severity":"High","cwe":"CWE-2","location":"b.rb:1","confidence":"low"},
+		{"id":"F3","title":"c","severity":"High","cwe":"CWE-3","location":"c.rb:1"}
+	]}`
+	skill := &db.Skill{MinConfidence: "medium"}
+	var lines []string
+	emit := func(e Event) { lines = append(lines, e.Text) }
+
+	if err := w.parseFindingsOutput(skill, scan, report, emit); err != nil {
+		t.Fatal(err)
+	}
+	var n int64
+	gdb.Model(&db.Finding{}).Count(&n)
+	if n != 1 {
+		t.Errorf("stored %d findings, want 1 (only high-confidence)", n)
+	}
+	joined := strings.Join(lines, "\n")
+	if !strings.Contains(joined, "dropped 2 finding(s) below min_confidence=medium") {
+		t.Errorf("expected drop log line, got: %s", joined)
+	}
+}
+
+func TestParseFindingsOutput_failOnTriggers(t *testing.T) {
+	gdb, err := db.Open(filepath.Join(t.TempDir(), "p.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo := db.Repository{URL: "https://x/r", Name: "r"}
+	gdb.Create(&repo)
+	scan := &db.Scan{RepositoryID: repo.ID, Kind: JobSkill, SkillName: "x", Status: db.ScanDone}
+	gdb.Create(scan)
+	w := &Worker{DB: gdb, Log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+
+	report := `{"findings":[
+		{"id":"F1","title":"a","severity":"Medium","cwe":"CWE-1","location":"a.rb:1"},
+		{"id":"F2","title":"b","severity":"Critical","cwe":"CWE-2","location":"b.rb:1"}
+	]}`
+	skill := &db.Skill{FailOn: "High"}
+	err = w.parseFindingsOutput(skill, scan, report, func(Event) {})
+	var fe *FailOnThresholdError
+	if !errors.As(err, &fe) {
+		t.Fatalf("expected FailOnThresholdError, got %v", err)
+	}
+	if fe.Worst != "Critical" || fe.Threshold != "High" {
+		t.Errorf("error fields: %+v", fe)
+	}
+	var n int64
+	gdb.Model(&db.Finding{}).Count(&n)
+	if n != 2 {
+		t.Errorf("findings should still be stored on fail_on, got %d", n)
+	}
+}
+
+func TestParseFindingsOutput_failOnNoTriggerBelowThreshold(t *testing.T) {
+	gdb, err := db.Open(filepath.Join(t.TempDir(), "p.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo := db.Repository{URL: "https://x/r", Name: "r"}
+	gdb.Create(&repo)
+	scan := &db.Scan{RepositoryID: repo.ID, Kind: JobSkill, SkillName: "x", Status: db.ScanDone}
+	gdb.Create(scan)
+	w := &Worker{DB: gdb, Log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+
+	report := `{"findings":[{"id":"F1","title":"a","severity":"Low","cwe":"CWE-1","location":"a.rb:1"}]}`
+	if err := w.parseFindingsOutput(&db.Skill{FailOn: "High"}, scan, report, func(Event) {}); err != nil {
+		t.Errorf("Low finding should not trigger fail_on=High: %v", err)
+	}
+}
 
 func TestParseFindingsOutput_dedupesAcrossScans(t *testing.T) {
 	gdb, err := db.Open(filepath.Join(t.TempDir(), "p.db"))
@@ -33,7 +117,7 @@ func TestParseFindingsOutput_dedupesAcrossScans(t *testing.T) {
 		{"id":"F2","title":"XSS in view","severity":"Medium","cwe":"CWE-79","location":"src/view.erb:10"}
 	]}`
 	s1 := mkScan("abc")
-	if err := w.parseFindingsOutput(s1, report1, emit); err != nil {
+	if err := w.parseFindingsOutput(&db.Skill{}, s1, report1, emit); err != nil {
 		t.Fatal(err)
 	}
 
@@ -52,7 +136,7 @@ func TestParseFindingsOutput_dedupesAcrossScans(t *testing.T) {
 		{"id":"F3","title":"Path traversal","severity":"High","cwe":"CWE-22","location":"src/files.rb:5"}
 	]}`
 	s2 := mkScan("def")
-	if err := w.parseFindingsOutput(s2, report2, emit); err != nil {
+	if err := w.parseFindingsOutput(&db.Skill{}, s2, report2, emit); err != nil {
 		t.Fatal(err)
 	}
 
@@ -121,7 +205,7 @@ func TestParseFindingsOutput_preservesAnalystStatusOnReobservation(t *testing.T)
 	report := `{"findings":[{"id":"F1","title":"noise","severity":"Low","cwe":"CWE-200","location":"x.go:1"}]}`
 	s1 := &db.Scan{RepositoryID: repo.ID, Kind: JobSkill, SkillName: "semgrep", Status: db.ScanDone, Commit: "abc"}
 	gdb.Create(s1)
-	if err := w.parseFindingsOutput(s1, report, emit); err != nil {
+	if err := w.parseFindingsOutput(&db.Skill{}, s1, report, emit); err != nil {
 		t.Fatal(err)
 	}
 
@@ -130,7 +214,7 @@ func TestParseFindingsOutput_preservesAnalystStatusOnReobservation(t *testing.T)
 
 	s2 := &db.Scan{RepositoryID: repo.ID, Kind: JobSkill, SkillName: "semgrep", Status: db.ScanDone, Commit: "def"}
 	gdb.Create(s2)
-	if err := w.parseFindingsOutput(s2, report, emit); err != nil {
+	if err := w.parseFindingsOutput(&db.Skill{}, s2, report, emit); err != nil {
 		t.Fatal(err)
 	}
 
@@ -163,7 +247,7 @@ func TestParseFindingsOutput_intraScanCollisionCreatesOneRow(t *testing.T) {
 	]}`
 	s := &db.Scan{RepositoryID: repo.ID, Kind: JobSkill, SkillName: "k", Status: db.ScanDone, Commit: "abc"}
 	gdb.Create(s)
-	if err := w.parseFindingsOutput(s, report, func(Event) {}); err != nil {
+	if err := w.parseFindingsOutput(&db.Skill{}, s, report, func(Event) {}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -193,7 +277,7 @@ func TestParseFindingsOutput_notObservedScopedToSkillAndSubpath(t *testing.T) {
 	s1 := &db.Scan{RepositoryID: repo.ID, Kind: JobSkill, SkillName: "security-deep-dive",
 		SubPath: "", Status: db.ScanDone, Commit: "abc"}
 	gdb.Create(s1)
-	if err := w.parseFindingsOutput(s1, report, emit); err != nil {
+	if err := w.parseFindingsOutput(&db.Skill{}, s1, report, emit); err != nil {
 		t.Fatal(err)
 	}
 
@@ -201,7 +285,7 @@ func TestParseFindingsOutput_notObservedScopedToSkillAndSubpath(t *testing.T) {
 	s2 := &db.Scan{RepositoryID: repo.ID, Kind: JobSkill, SkillName: "semgrep",
 		SubPath: "", Status: db.ScanDone, Commit: "abc"}
 	gdb.Create(s2)
-	if err := w.parseFindingsOutput(s2, `{"findings":[]}`, emit); err != nil {
+	if err := w.parseFindingsOutput(&db.Skill{}, s2, `{"findings":[]}`, emit); err != nil {
 		t.Fatal(err)
 	}
 
@@ -210,7 +294,7 @@ func TestParseFindingsOutput_notObservedScopedToSkillAndSubpath(t *testing.T) {
 	s3 := &db.Scan{RepositoryID: repo.ID, Kind: JobSkill, SkillName: "security-deep-dive",
 		SubPath: "pkg/foo", Status: db.ScanDone, Commit: "abc"}
 	gdb.Create(s3)
-	if err := w.parseFindingsOutput(s3, `{"findings":[]}`, emit); err != nil {
+	if err := w.parseFindingsOutput(&db.Skill{}, s3, `{"findings":[]}`, emit); err != nil {
 		t.Fatal(err)
 	}
 
@@ -224,7 +308,7 @@ func TestParseFindingsOutput_notObservedScopedToSkillAndSubpath(t *testing.T) {
 	s4 := &db.Scan{RepositoryID: repo.ID, Kind: JobSkill, SkillName: "security-deep-dive",
 		SubPath: "", Status: db.ScanDone, Commit: "def"}
 	gdb.Create(s4)
-	if err := w.parseFindingsOutput(s4, `{"findings":[]}`, emit); err != nil {
+	if err := w.parseFindingsOutput(&db.Skill{}, s4, `{"findings":[]}`, emit); err != nil {
 		t.Fatal(err)
 	}
 
@@ -253,13 +337,13 @@ func TestParseFindingsOutput_reobservationResetsMissedCount(t *testing.T) {
 		return s
 	}
 
-	if err := w.parseFindingsOutput(mkScan("aaa"), report, emit); err != nil {
+	if err := w.parseFindingsOutput(&db.Skill{}, mkScan("aaa"), report, emit); err != nil {
 		t.Fatal(err)
 	}
-	if err := w.parseFindingsOutput(mkScan("bbb"), `{"findings":[]}`, emit); err != nil {
+	if err := w.parseFindingsOutput(&db.Skill{}, mkScan("bbb"), `{"findings":[]}`, emit); err != nil {
 		t.Fatal(err)
 	}
-	if err := w.parseFindingsOutput(mkScan("ccc"), `{"findings":[]}`, emit); err != nil {
+	if err := w.parseFindingsOutput(&db.Skill{}, mkScan("ccc"), `{"findings":[]}`, emit); err != nil {
 		t.Fatal(err)
 	}
 
@@ -270,7 +354,7 @@ func TestParseFindingsOutput_reobservationResetsMissedCount(t *testing.T) {
 	}
 
 	// Reappears: missed count resets, seen count is now 2.
-	if err := w.parseFindingsOutput(mkScan("ddd"), report, emit); err != nil {
+	if err := w.parseFindingsOutput(&db.Skill{}, mkScan("ddd"), report, emit); err != nil {
 		t.Fatal(err)
 	}
 	gdb.First(&f)
@@ -296,14 +380,14 @@ func TestParseFindingsOutput_notObservedSkipsClosedFindings(t *testing.T) {
 	report := `{"findings":[{"id":"F1","title":"x","severity":"High","cwe":"CWE-89","location":"a.rb:1"}]}`
 	s1 := &db.Scan{RepositoryID: repo.ID, Kind: JobSkill, SkillName: "k", Status: db.ScanDone, Commit: "abc"}
 	gdb.Create(s1)
-	if err := w.parseFindingsOutput(s1, report, emit); err != nil {
+	if err := w.parseFindingsOutput(&db.Skill{}, s1, report, emit); err != nil {
 		t.Fatal(err)
 	}
 	gdb.Model(&db.Finding{}).Where("repository_id = ?", repo.ID).Update("status", db.FindingFixed)
 
 	s2 := &db.Scan{RepositoryID: repo.ID, Kind: JobSkill, SkillName: "k", Status: db.ScanDone, Commit: "def"}
 	gdb.Create(s2)
-	if err := w.parseFindingsOutput(s2, `{"findings":[]}`, emit); err != nil {
+	if err := w.parseFindingsOutput(&db.Skill{}, s2, `{"findings":[]}`, emit); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/worker/skill.go
+++ b/internal/worker/skill.go
@@ -135,7 +135,7 @@ func (w *Worker) doSkill(ctx context.Context, scan *db.Scan, emit func(Event)) (
 func (w *Worker) parseSkillOutput(skill *db.Skill, scan *db.Scan, report string, emit func(Event)) error {
 	switch skill.OutputKind {
 	case "findings":
-		return w.parseFindingsOutput(scan, report, emit)
+		return w.parseFindingsOutput(skill, scan, report, emit)
 	case "maintainers":
 		return w.parseMaintainersOutput(scan, report, emit)
 	case "repo_metadata":
@@ -184,18 +184,35 @@ func (w *Worker) clearCloneError(scan *db.Scan) {
 // Findings are deduped against prior scans of the same repository by
 // fingerprint: a match bumps last-seen on the existing row instead of
 // creating a duplicate, so analyst triage state survives a rescan (#75).
-func (w *Worker) parseFindingsOutput(scan *db.Scan, report string, emit func(Event)) error {
+func (w *Worker) parseFindingsOutput(skill *db.Skill, scan *db.Scan, report string, emit func(Event)) error {
 	rep, err := parseReport([]byte(report))
 	if err != nil {
 		return err
 	}
 	findings := rep.toFindings(scan.ID, scan.RepositoryID, scan.Commit, scan.SubPath)
+
+	if skill.MinConfidence != "" {
+		kept := findings[:0]
+		for _, f := range findings {
+			if db.ConfidenceAtLeast(f.Confidence, skill.MinConfidence) {
+				kept = append(kept, f)
+			}
+		}
+		if dropped := len(findings) - len(kept); dropped > 0 {
+			emit(Event{Kind: KindText, Text: fmt.Sprintf("dropped %d finding(s) below min_confidence=%s", dropped, skill.MinConfidence)})
+		}
+		findings = kept
+	}
 	scan.FindingsCount = len(findings)
 
+	worst := ""
 	created, observed := 0, 0
 	seenThisScan := map[string]bool{}
 	for i := range findings {
 		f := &findings[i]
+		if db.SeverityAtLeast(f.Severity, worst) || worst == "" {
+			worst = f.Severity
+		}
 		f.Fingerprint = db.FingerprintFinding(scan.SkillName, f.SubPath, f.CWE, f.Location, f.Title)
 		f.LastSeenScanID = scan.ID
 		f.LastSeenCommit = scan.Commit
@@ -239,7 +256,24 @@ func (w *Worker) parseFindingsOutput(scan *db.Scan, report string, emit func(Eve
 
 	emit(Event{Kind: KindText, Text: fmt.Sprintf("parsed %d finding(s): %d new, %d re-observed, %d not-observed",
 		len(findings), created, observed, missed)})
+
+	if db.SeverityAtLeast(worst, skill.FailOn) {
+		return &FailOnThresholdError{Worst: worst, Threshold: skill.FailOn}
+	}
 	return nil
+}
+
+// FailOnThresholdError is returned when a scan's findings include at
+// least one at or above the skill's fail_on severity. wrap() treats it
+// as a completed run (the report is saved) that is marked failed so
+// the repo list shows red.
+type FailOnThresholdError struct {
+	Worst     string
+	Threshold string
+}
+
+func (e *FailOnThresholdError) Error() string {
+	return fmt.Sprintf("%s-severity finding meets fail_on=%s", e.Worst, e.Threshold)
 }
 
 // markNotObserved bumps MissedCount on open findings that this scan was

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -161,6 +161,11 @@ func (w *Worker) wrap(h handler) func(context.Context, []byte) error {
 				scan.Status = db.ScanDone
 				scan.Report = report
 				emit(Event{Kind: KindText, Text: "scan completed (hit max turns cap)"})
+			} else if _, ok := errors.AsType[*FailOnThresholdError](err); ok {
+				scan.Status = db.ScanFailed
+				scan.Report = report
+				scan.Error = err.Error()
+				emit(Event{Kind: KindError, Text: err.Error()})
 			} else {
 				scan.Status = db.ScanFailed
 				scan.Error = err.Error()

--- a/skills/reachability/schema.json
+++ b/skills/reachability/schema.json
@@ -53,6 +53,10 @@
       "type": "string",
       "enum": ["Critical", "High", "Medium", "Low"]
     },
+    "confidence": {
+      "type": "string",
+      "enum": ["high", "medium", "low"]
+    },
     "sink_class": {
       "type": "string",
       "enum": [
@@ -139,6 +143,7 @@
         "sinks":         { "type": "array", "items": { "$ref": "#/$defs/sink_id" }, "minItems": 1 },
         "title":         { "type": "string" },
         "severity":      { "$ref": "#/$defs/severity" },
+        "confidence":    { "$ref": "#/$defs/confidence" },
         "cwe":           { "$ref": "#/$defs/cwe" },
         "location":      { "type": "string" },
         "affected":      { "type": "string" },

--- a/skills/security-deep-dive/schema.json
+++ b/skills/security-deep-dive/schema.json
@@ -53,6 +53,10 @@
       "type": "string",
       "enum": ["Critical", "High", "Medium", "Low"]
     },
+    "confidence": {
+      "type": "string",
+      "enum": ["high", "medium", "low"]
+    },
     "sink_class": {
       "type": "string",
       "enum": [
@@ -139,6 +143,7 @@
         "sinks":         { "type": "array", "items": { "$ref": "#/$defs/sink_id" }, "minItems": 1 },
         "title":         { "type": "string" },
         "severity":      { "$ref": "#/$defs/severity" },
+        "confidence":    { "$ref": "#/$defs/confidence" },
         "cwe":           { "$ref": "#/$defs/cwe" },
         "location":      { "type": "string" },
         "affected":      { "type": "string" },


### PR DESCRIPTION
Closes #67. Stacked on #169.

Three optional `scrutineer.*` metadata keys:

```yaml
metadata:
  scrutineer.min_confidence: medium   # drop findings below this before insert
  scrutineer.report_on:      Low      # default severity floor for findings views
  scrutineer.fail_on:        High     # mark the scan failed if any finding at/above
```

The issue assumed `Finding.Confidence` was already stored, but it was only on the legacy parser struct and never reached `db.Finding`. This promotes it to a first-class indexed column, adds it to `schema.json` as an optional `high`/`medium`/`low` enum on the finding object, and maps it through `toFindings`.

`db.ConfidenceAtLeast` and `db.SeverityAtLeast` are the shared rank comparison so worker and web don't each grow their own (web already has a private `severityRank` in `org_summary.go` that can fold into this later).

`parseFindingsOutput` now takes the skill row. It filters by `min_confidence` before insert (logging "dropped N finding(s) below min_confidence=X" to the scan output), tracks worst severity across the batch, and returns `FailOnThresholdError` when `fail_on` is met. `wrap()` handles that error by saving the report and marking the scan failed, so the repo list shows red without losing the findings.

`report_on` is parsed, validated, and stored on `db.Skill` but the UI default-filter wiring is left for a follow-up since it threads through every link in `findings.html` and the per-repo/org/SBOM tabs.

Will conflict with #168 in `db.go`, `findings.go`, and the two `schema.json` files (both add fields in the same blocks); whichever lands second is a mechanical re-merge.