### PR TITLE
worker: tolerate non-string top-level fields in findings reports

### DIFF
--- a/internal/worker/findings.go
+++ b/internal/worker/findings.go
@@ -8,25 +8,13 @@ import (
 	"scrutineer/internal/db"
 )
 
-// scanReport mirrors the security-deep-dive skill's report schema. Report-
-// level fields like boundaries, inventory and ruled_out stay in the raw
-// JSON (Scan.Report); findings are extracted into db.Finding rows.
+// scanReport extracts only the findings array from a security-deep-dive
+// report. All other top-level fields (repository, artefact, boundaries,
+// inventory, ruled_out, ...) stay in the raw JSON on Scan.Report and are
+// never read here, so we do not declare them: a strict Go type on an unused
+// field turns model output variance into a fatal scan error (#172).
 type scanReport struct {
-	Repository    string          `json:"repository"`
-	Commit        string          `json:"commit"`
-	Artefact      string          `json:"artefact"`
-	SpecVersion   int             `json:"spec_version"`
-	Model         string          `json:"model"`
-	Date          string          `json:"date"`
-	FilesReviewed int             `json:"files_reviewed"`
-	Languages     []string        `json:"languages"`
-	Findings      []scanFinding   `json:"findings"`
-	RuledOut      json.RawMessage `json:"ruled_out"`
-	Inventory     json.RawMessage `json:"inventory"`
-	Boundaries    json.RawMessage `json:"boundaries"`
-
-	// Legacy fields from the old minimal schema (for backward compat)
-	Notes string `json:"notes"`
+	Findings []scanFinding `json:"findings"`
 }
 
 type scanFinding struct {

--- a/internal/worker/findings_test.go
+++ b/internal/worker/findings_test.go
@@ -26,3 +26,45 @@ func TestToFindings_carriesReachabilityAndQualityTier(t *testing.T) {
 		t.Errorf("QualityTier = %q, want high", got[0].QualityTier)
 	}
 }
+
+func TestParseReport_toleratesNonStringTopLevelFields(t *testing.T) {
+	// #172: models sometimes copy context.json's repository object (and invent
+	// an artefact object) into report.json. Only findings[] is consumed, so
+	// the parser must not fail on the shape of fields it never reads.
+	raw := []byte(`{
+		"repository": {"url": "https://github.com/x/y.git", "name": "y"},
+		"artefact": {"name": "y", "version": "1.2.3"},
+		"languages": "rust",
+		"spec_version": "10",
+		"findings": [
+			{"id": "F1", "title": "t", "severity": "Low", "cwe": "CWE-20",
+			 "location": "src/a.rs:10", "sinks": ["S1"],
+			 "trace": "x", "boundary": "x", "validation": "x", "rating": "x"}
+		]
+	}`)
+	r, err := parseReport(raw)
+	if err != nil {
+		t.Fatalf("parseReport: %v", err)
+	}
+	if len(r.Findings) != 1 {
+		t.Fatalf("len(Findings) = %d, want 1", len(r.Findings))
+	}
+	if r.Findings[0].ID != "F1" || r.Findings[0].Title != "t" {
+		t.Errorf("finding not extracted: %+v", r.Findings[0])
+	}
+}
+
+func TestParseReport_stringTopLevelFieldsStillWork(t *testing.T) {
+	raw := []byte(`{
+		"repository": "https://github.com/x/y.git",
+		"artefact": "pkg:cargo/y@1.2.3",
+		"findings": []
+	}`)
+	r, err := parseReport(raw)
+	if err != nil {
+		t.Fatalf("parseReport: %v", err)
+	}
+	if len(r.Findings) != 0 {
+		t.Errorf("len(Findings) = %d, want 0", len(r.Findings))
+	}
+}

--- a/skills/security-deep-dive/SKILL.md
+++ b/skills/security-deep-dive/SKILL.md
@@ -147,4 +147,4 @@ Record `quality_tier` per sink class. For memory safety: heap overflow, use-afte
 
 ## Output
 
-Write your report to `./report.json`. It must validate against `./schema.json`. Every inventory sink must appear either in `findings[].sinks` or in `ruled_out[].sinks`. Use `findings: []` for a clean report. Read `./context.json` for the repository url, default branch, and other host-provided facts if you need them for the `repository`, `commit`, and `artefact` fields. Set `spec_version` to `12`. Use today's date for the `date` field.
+Write your report to `./report.json`. It must validate against `./schema.json`. Every inventory sink must appear either in `findings[].sinks` or in `ruled_out[].sinks`. Use `findings: []` for a clean report. Set `repository` to the URL string from `context.json`'s `repository.url` (a string, not the object), `commit` to the HEAD sha of `./src`, and `artefact` to the package coordinate string (purl or `name@version`) you verified against in step 4. Set `spec_version` to `12`. Use today's date for the `date` field.


### PR DESCRIPTION
Fixes #172.

`scanReport` in `internal/worker/findings.go` declared every top-level field from the `security-deep-dive` schema with strict Go types, but `toFindings` only reads `Findings`. When the model wrote `repository` as an object (copied verbatim from `context.json`, where `repository` is `{url, name, ...}`) or invented an object for `artefact`, `json.Unmarshal` failed the whole scan over a field nothing consumes. The reporter saw this on roughly half of Opus 4.6 runs.

Trimmed the struct to `Findings` only. The full report already lives untouched on `Scan.Report`. Added a regression test that feeds object-shaped `repository`/`artefact` (and a few other wrong-typed top-level fields) through `parseReport` and asserts findings are still extracted.

Also tightened `skills/security-deep-dive/SKILL.md` so the output instructions say `repository` is the URL string from `context.json`'s `repository.url`, `commit` is the HEAD sha, and `artefact` is a purl or `name@version` string. That should reduce how often the model writes the object shape in the first place, though the parser change is what actually fixes the failure.

Server-side schema validation (which would have given a clearer error here) is tracked separately in #175.