### PR TITLE
skills: fix contradictions and context.json field mismatches

### DIFF
--- a/skills/cna-match/SKILL.md
+++ b/skills/cna-match/SKILL.md
@@ -14,7 +14,7 @@ Decide whether a CVE Numbering Authority covers this repository. When one does, 
 ## Workspace
 
 - `./src` — the cloned repository. Useful mainly for `SECURITY.md`, which sometimes names the CNA directly.
-- `./context.json` — read `repository.url`, `repository.full_name`, `repository.owner`, plus the `scrutineer` block with `api_base`, `token`, `repository_id`.
+- `./context.json` — read `repository.url` and `repository.full_name`, plus the `scrutineer` block with `api_base`, `token`, `repository_id`. The owner is the part of `full_name` before the `/`.
 - `./report.json` — write your result here.
 - `./schema.json` — the JSON schema your report must validate against.
 
@@ -35,16 +35,32 @@ CNA scopes are free-text prose, not patterns. Match in this order and stop at th
 1. **SECURITY.md names a CNA or its contact directly.** If the file says report to a specific security@ address or names a CNA programme, find that entry in `/cnas` and use it.
 2. **Owner matches a CNA's organization or scope.** Repo owner `apache` → CNA `apache` ("All Apache Software Foundation projects"). Owner `kubernetes` or `kubernetes-sigs` → CNA `kubernetes`. Owner `nodejs` → CNA `nodejs`. Check `?q={owner}` first.
 3. **Package or project name matches a single-project CNA scope.** Package `curl` or `libcurl` → CNA `curl`. Package `openssl` → CNA `openssl`. These CNAs have narrow scopes naming the project explicitly.
-4. **Hosted on github.com with no other match.** GitHub (`GitHub_M`) is the CNA of last resort for public repos on github.com that have no other CNA. Only use this if steps 1-3 found nothing.
 
 A scope like "Vendor X products only" or "issues discovered by our researchers" does not cover an unrelated open-source repo even if a keyword overlaps. Read the scope sentence, not just the keyword.
 
-If nothing matches, that is a valid result: most projects have no CNA and disclosure goes to the maintainer.
+If steps 1-3 find nothing, that is a valid result: most projects have no dedicated CNA and disclosure goes to the maintainer. For a repo hosted on github.com you may still record GitHub (`GitHub_M`) as the fallback CNA in the `cna` block with `match_rule: "github_fallback"`, since GitHub can issue a CVE via the advisory form, but do not set `disclosure_channel` from it. The maintainer contact (set by the `maintainers` skill) is the right first stop; the analyst can escalate to GitHub for a CVE ID later.
 
 ## Output
 
 Write `./report.json` matching `./schema.json`. The `output_kind` is `maintainers` so scrutineer's existing parser updates `Repository.DisclosureChannel` from the `disclosure_channel` field; `maintainers` stays an empty array. The `cna` block records which CNA matched and why so an analyst can review the reasoning in the scan report.
 
-When a CNA matched, set `disclosure_channel` to its email if it has one, otherwise its `contact_url`. Append the organization name in parentheses so the repo page shows where the address came from, e.g. `security@apache.org (Apache Software Foundation CNA)`.
+When a CNA matched via steps 1-3, set `disclosure_channel` to its email if it has one, otherwise its `contact_url`. Append the organization name in parentheses so the repo page shows where the address came from, e.g. `security@apache.org (Apache Software Foundation CNA)`.
 
-When nothing matched, leave `disclosure_channel` empty so any value the `maintainers` skill set earlier is left alone, and set `cna` to `null`.
+When nothing matched, or only the github.com fallback applied, leave `disclosure_channel` as `""`. The parser ignores empty values so any contact the `maintainers` skill set is left alone regardless of which skill ran first.
+
+```json
+{
+  "maintainers": [],
+  "disclosure_channel": "security@apache.org (Apache Software Foundation CNA)",
+  "cna": {
+    "short_name": "apache",
+    "organization": "Apache Software Foundation",
+    "email": "security@apache.org",
+    "contact_url": "https://www.apache.org/security/",
+    "policy_url": "https://www.apache.org/security/",
+    "scope": "All Apache Software Foundation projects",
+    "match_rule": "owner",
+    "match_reason": "repo owner 'apache' matches ASF CNA scope"
+  }
+}
+```

--- a/skills/disclose/SKILL.md
+++ b/skills/disclose/SKILL.md
@@ -81,13 +81,13 @@ Draft disclosure content for an existing finding in a shape that maps one-to-one
 
    Normalise the ecosystem string to the exact GHSA enum — all lowercase, with these specific spellings: `rubygems` (not `RubyGems`), `npm`, `pip` (not `pypi` or `PyPI`), `maven`, `nuget`, `composer`, `go`, `rust`, `erlang`, `actions`, `pub`, `other`. If a scrutineer package has `ecosystem: "Packagist"`, emit `"composer"`; if `"Cargo"`, emit `"rust"`. Map anything unrecognised to `"other"`.
 
-   If the repository has no packages, omit the `vulnerabilities` array entirely and note in the `notes` field of `report.json` that this advisory is source-only (a maintainer filing it would still need to add an affected-product block manually).
+   If the repository has no packages, emit a single placeholder entry `[{"package": {"ecosystem": "other", "name": "{owner}/{repo}"}}]` and note in the `notes` field of `report.json` that this advisory is source-only. GitHub's REST endpoint rejects a body with no `vulnerabilities` entry, and the `ghsa` block in `report.json` is meant to be POSTable as-is.
 
    `vulnerable_functions` is optional; fill it only when the Trace field names specific exported symbols (e.g. `pkg.Foo`, `Class#method`). Leave empty otherwise.
 
    **`severity` / `cvss_vector_string`.** GHSA accepts exactly one of the two; prefer the CVSS vector when you can derive one confidently, fall back to the severity label otherwise.
 
-   Use CVSS 3.1. Derive each metric from the finding prose: `AV` from the attack surface described in Boundary, `AC` from how contrived the trigger is in Validation, `PR`/`UI` from whether the trigger needs authentication or human interaction, `S` from whether the impact crosses a trust boundary, and `C`/`I`/`A` from the dangerous behaviour in Rating. Write the full vector string (e.g. `CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H`).
+   Use CVSS 3.1. Derive each metric from the finding prose: `AV` from the attack surface described in Boundary, `AC` from how contrived the trigger is in Validation, `PR`/`UI` from whether the trigger needs authentication or human interaction, `S` from whether the impact crosses a trust boundary, and `C`/`I`/`A` from the dangerous behaviour in Rating. Write the full vector string (e.g. `CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H`). If any single metric cannot be derived from the prose, do not guess a value for it; omit `cvss_vector_string` entirely and emit the `severity` label instead.
 
    For the severity label fallback, map scrutineer's `severity` field (`Critical`/`High`/`Medium`/`Low`) to GHSA's lowercase `critical`/`high`/`medium`/`low`. If the finding has a pre-existing `cvss_vector`, leave it alone and reuse it here — do not overwrite analyst edits.
 

--- a/skills/fork/SKILL.md
+++ b/skills/fork/SKILL.md
@@ -96,10 +96,10 @@ For each remaining finding fetch the full record (`GET {api_base}/findings/{id}`
 Before filing, list the advisories already on the fork so re-runs do not duplicate:
 
 ```
-gh api repos/{fork_org}/{fork_name}/security-advisories --paginate --jq '.[].summary'
+gh api repos/{fork_org}/{fork_name}/security-advisories --paginate --jq '.[].description'
 ```
 
-Skip a finding whose title already appears as an advisory summary; record it under `"skipped_advisories"`.
+Every advisory this skill files carries a `[scrutineer-finding:{finding_id}]` marker on its last line (see below). Skip a finding whose marker already appears in any existing description; record it under `"skipped_advisories"` with reason `"already filed"`. Do not dedup on summary/title — distinct findings can share a title.
 
 For each remaining finding, build the request body and create a draft repository security advisory on the fork. Use the admin create endpoint, not `/reports` — `/reports` is for external reporters and is rejected when the caller is a repo admin, which we are.
 
@@ -124,7 +124,14 @@ The body shape is the GHSA create schema:
 
 Build `vulnerabilities` from `GET {api_base}/repositories/{repository_id}/packages` using the same ecosystem mapping the disclose skill uses (rubygems, npm, pip, maven, nuget, composer, go, rust, erlang, actions, pub, other). If the repository has no packages, send `"vulnerabilities": [{"package": {"ecosystem": "other", "name": "{owner}/{repo}"}}]` — the endpoint requires at least one entry.
 
-`vulnerable_version_range` must be a bare constraint string. `finding.affected` is analyst prose and often carries annotations like `<= 0.9.1 (all published versions)` or `1.x through 2.3`; reduce it to comma-separated `OP VERSION` clauses where OP is one of `<`, `<=`, `>`, `>=`, `=` and VERSION is dotted-numeric (a leading `v` is fine). Drop anything in parentheses, drop the package name if it was repeated, and turn `all versions` / `every release` into `>= 0`. If you cannot confidently reduce it to that shape, omit `vulnerable_version_range` from the entry and keep the original prose in the description's Affected versions section instead.
+`vulnerable_version_range` must be a bare constraint string. `finding.affected` is analyst prose; normalise it before sending:
+
+- drop anything in parentheses and any repeated package name
+- `all versions` / `every release` → `>= 0`
+- result must be comma-separated `OP VERSION` clauses where OP is one of `< <= > >= =` and VERSION is dotted-numeric (leading `v` is fine)
+- if you cannot reduce it to that shape, omit `vulnerable_version_range` and keep the original prose in the description's Affected versions section
+
+Whatever description you send (the disclose draft, or the template below), append a final line `[scrutineer-finding:{finding_id}]` so re-runs can dedup on it.
 
 If `disclosure_draft` is empty the disclose skill has not run on this finding yet. Assemble the description yourself from the finding's six-step prose (the full `GET {api_base}/findings/{id}` response includes `trace`, `boundary`, `validation`, `prior_art`, `reach`, `rating` even for `new` findings). Use this template, dropping any section whose source field is empty:
 

--- a/skills/maintainers/SKILL.md
+++ b/skills/maintainers/SKILL.md
@@ -34,6 +34,8 @@ Fetch each of these using your fetch tool. Each returns JSON. Include the reposi
 
 URL-encode the repository URL before substituting it into the query string.
 
+If all three lookups return empty or 404, fall back to `git -C ./src shortlog -sne --since='1 year ago'` plus `git -C ./src log --no-merges -20 --format='%aN <%aE>'` and classify from that alone; say so in `notes`.
+
 Also read `SECURITY.md`, `.github/SECURITY.md`, `CODEOWNERS`, and `README.md` in `./src` if they exist. These often name a security contact directly.
 
 ## How to classify
@@ -57,10 +59,10 @@ Pick the best one, based on what you found:
 - `SECURITY.md` email or contact block if present
 - GitHub Security Advisories if the repo is on GitHub and has advisories enabled
 - Registry owner contact if packages data surfaced one
-- Direct email to the identified lead if none of the above
+- The lead's git-log author email if none of the above; if it is a `noreply.github.com` address, skip it
 
 Put the concrete channel name or URL in `disclosure_channel`. Leave empty if nothing reliable was found.
 
 ## Output
 
-Write `./report.json` conforming to `./schema.json`. Include every classification decision you made, not just the top few. Use `notes` for anything a reviewer would want to know that does not fit the schema — bus factor, recent turnover, maintainer handoff, corporate sponsorship.
+Write `./report.json` conforming to `./schema.json`. Include every human you classified, not just the top few; bots stay out of the list (per the filter above) but mention in `notes` how many were dropped. Use `notes` for anything a reviewer would want to know that does not fit the schema — bus factor, recent turnover, maintainer handoff, corporate sponsorship.

--- a/skills/patch/SKILL.md
+++ b/skills/patch/SKILL.md
@@ -15,7 +15,7 @@ Propose a minimal code patch that fixes a confirmed finding. You are not shippin
 ## Workspace
 
 - `./src` — the repository at its current HEAD, on the default branch, writable
-- `./context.json` — has `scrutineer.api_base`, `scrutineer.token`, `scrutineer.repository_id`, `scrutineer.finding_id` (required; this skill only makes sense finding-scoped)
+- `./context.json` — has `scrutineer.api_base`, `scrutineer.token`, `scrutineer.repository_id`, `scrutineer.scan_id`, `scrutineer.finding_id` (required; this skill only makes sense finding-scoped)
 - `./report.json` — write the patch + rationale here
 - `./schema.json` — shape of `report.json`
 
@@ -30,7 +30,7 @@ Propose a minimal code patch that fixes a confirmed finding. You are not shippin
    - **Minimal.** Change only what the fix requires. Do not refactor surrounding code, rename variables, reformat unrelated lines, or upgrade dependencies unless the fix inherently requires it.
    - **In place.** Fix the sink where it lives. If the finding's `location` is `pkg/foo/bar.go:42`, that is where the patch should land (or at the nearest layer where a guard is sensible — e.g. the input validator that feeds the sink).
    - **Consistent.** Match the existing code style and idioms. If the codebase uses a specific sanitiser, validator, or helper for similar cases, reuse it. Do not introduce a new helper module for a one-off fix.
-   - **Safe.** The patch must not break the reproduction's documented legitimate behaviour — only block the dangerous path. If you cannot tell where the dangerous path diverges from legitimate use, stop and write an inconclusive report (see below).
+   - **Safe.** The patch must not break the reproduction's documented legitimate behaviour — only block the dangerous path. If you cannot tell where the dangerous path diverges from legitimate use, stop and refuse to patch (see "Refusing to patch" below for the `{"error": ...}` shape).
    - **Include a test when practical.** If the repo has a test suite that covers the vulnerable code path, add a regression test that would fail without your patch. If the repo has no tests, or the sink is in a place that is hard to cover, skip this and say why in `rationale`.
 
 4. Once you have a working tree edit, generate a unified diff against HEAD:
@@ -38,10 +38,10 @@ Propose a minimal code patch that fixes a confirmed finding. You are not shippin
    ```sh
    cd src
    git add -N .
-   git diff HEAD -- . > /tmp/patch.diff
+   git diff HEAD -- . > ../patch.diff
    ```
 
-   Read `/tmp/patch.diff` and put its contents into `report.json` under the `patch` field. Do not commit; the diff is the artefact. If the diff is empty, something went wrong — do not write an empty patch. Write `{"error": "patch produced no diff"}` and exit 0.
+   Read `../patch.diff` (the workspace root, alongside `report.json`) and put its contents into `report.json` under the `patch` field. Do not commit; the diff is the artefact. If the diff is empty, something went wrong — do not write an empty patch. Write `{"error": "patch produced no diff"}` and exit 0.
 
 5. POST a finding note summarising the patch: `POST {api_base}/findings/{finding_id}/notes` with:
 
@@ -86,6 +86,6 @@ Write `{"error": "...", "rationale": "..."}` and exit 0 in any of these cases �
 ## Constraints
 
 - Do not push. Do not commit. Do not open a PR. The scrutineer workspace is ephemeral and isolated; your diff is the only thing that survives the scan.
-- Do not add dependencies unless the vulnerability genuinely requires one (e.g. a sanitiser library the codebase already uses elsewhere). New top-level deps in a patch almost always mean the fix is in the wrong place.
+- Do not add new dependencies. If sanitisation or escaping is needed, reuse a helper the codebase already imports. A patch that needs a new top-level dep almost always means the fix is in the wrong place.
 - Do not edit the lockfile, go.sum, Gemfile.lock, package-lock.json, Cargo.lock, etc. unless you also changed the manifest that owns it. Stray lockfile churn makes diffs hard to review.
 - Do not touch files outside what the fix requires. CI config, docs unrelated to the fix, README — leave alone.

--- a/skills/posture/SKILL.md
+++ b/skills/posture/SKILL.md
@@ -15,7 +15,7 @@ You are scoring how prepared a project is to receive and act on a security repor
 ## Workspace
 
 - `./src` — the cloned repository
-- `./context.json` — has `repository.url` and `repository.host` (e.g. `github.com`)
+- `./context.json` — has `repository.url` and `repository.full_name` (e.g. `owner/repo`). Derive the host from `repository.url`; the GitHub-only checks below run when that host is `github.com`. Use `full_name` as `{owner}/{repo}` in API URLs.
 - `./report.json` — write the result here
 - `./schema.json` — shape of `report.json`
 
@@ -45,7 +45,7 @@ Run every check below. For each one, record `present` (true/false/unknown), a on
 
 **code_scanning** — Look in `.github/workflows/*.y*ml` for `github/codeql-action`, `securego/gosec`, `aquasecurity/trivy-action`, `snyk/actions`, or similar. Present if any scanning workflow exists.
 
-**signed_releases** — Look in `.github/workflows/` for `sigstore/cosign`, `slsa-framework/slsa-github-generator`, `goreleaser` with `signs:`, or GPG signing steps. Also check `git tag -l | head` in `./src` and `git tag -v` one recent tag for a signature.
+**signed_releases** — Look in `.github/workflows/` for `sigstore/cosign`, `slsa-framework/slsa-github-generator`, `goreleaser` with `signs:`, or GPG signing steps. Also check `git tag -l | head` in `./src` and `git tag -v` one recent tag. Treat `gpg: Can't check signature: No public key` as `present: true` with that message in `evidence`; the signature exists even if you cannot verify it. Only `no signature found` is `present: false`.
 
 **codeowners** — Look for `CODEOWNERS`, `.github/CODEOWNERS`, or `docs/CODEOWNERS`.
 
@@ -53,14 +53,14 @@ Run every check below. For each one, record `present` (true/false/unknown), a on
 
 **security_issue_template** — Look in `.github/ISSUE_TEMPLATE/` for a template that redirects security reports away from public issues (mentions `SECURITY.md`, "do not report vulnerabilities here", or similar). Also check `.github/ISSUE_TEMPLATE/config.yml` for a `contact_links` entry pointing at a security channel.
 
-**archived** — From `context.json` `repository.archived` if set, otherwise the GitHub API repo response. An archived repo is an automatic `unprepared` regardless of other checks.
+**archived** — From the GitHub API repo response (`GET https://api.github.com/repos/{owner}/{repo}`, field `archived`). On a non-GitHub host or a non-200 response, record `unknown`. An archived repo is an automatic `unprepared` regardless of other checks.
 
 ## Tier
 
 Assign exactly one of:
 
-- `ready` — has a security policy with a contact AND (PVR enabled OR a working security email/form), and is not archived.
-- `partial` — has at least one intake signal (policy, PVR, security.txt, manifest contact) but it is incomplete or untested, and is not archived.
+- `ready` — has a security policy with a contact AND (PVR `true`, OR PVR `unknown` with a security email/form documented in the policy), and is not archived. You are checking that a contact is documented, not that it works.
+- `partial` — has at least one intake signal (policy, PVR, security.txt, manifest contact) but no documented contact in the policy, and is not archived.
 - `unprepared` — no intake signal at all, or the repository is archived.
 
 Hygiene checks inform the `summary` prose but do not on their own move the tier; a project with CodeQL and Dependabot but no way to receive a report is still `unprepared`.

--- a/skills/reachability/SKILL.md
+++ b/skills/reachability/SKILL.md
@@ -31,7 +31,7 @@ Authorization: Bearer {token}
 
 Each entry has `package`, `ecosystem`, `requirement`, `manifest_path`, `dependency_type`, `severity`, `cwe`, `title`, `location` (file:line inside the library), `sinks`, `trace`, `boundary`, `library_repository_url`, and `finding_id`. The list is ordered by severity. If it is empty, either the dependencies skill has not indexed this repo yet or none of its dependencies have findings; write `{"findings": [], "ruled_out": [], "inventory": [], ...}` per the schema and stop.
 
-Work the list top-down. Budget your time toward High and Medium; Low entries are mostly resource-exhaustion in parsers and only worth a quick grep.
+Work the list top-down. Budget your time toward High and Medium; Low entries are mostly resource-exhaustion in parsers and only worth a quick grep for the call site. A Low entry whose grep finds nothing goes in `ruled_out` with `step: 1` and `reason: "low severity, no call site on quick grep"`.
 
 ## Per-sink procedure
 
@@ -41,9 +41,9 @@ For each candidate, the question is fixed: does untrusted input from one of this
 
 Find where this app calls into `package`. Start from the `boundary` field on the candidate — it names the library entry point that leads to the sink (e.g. `Roo::Spreadsheet.open`, `Icalendar::Calendar.parse`, `PDF::Reader.new`). Grep `./src` for that symbol, the `require`/`import` of `package`, and obvious wrappers around it. If `scan_subpath` is set, scope to that folder.
 
-If the package is only in `Gemfile.lock` as a transitive dependency and nothing in `./src` calls it directly, check whether the app calls the intermediate package in a way that forwards input (e.g. crass via `sanitize`/loofah, sawyer via Octokit). If you cannot find a call path in two hops, rule it out: "transitive, no direct or one-hop call site".
+If the package is only in the lockfile as a transitive dependency and nothing in `./src` calls it directly, check whether the app calls the intermediate package in a way that forwards input (e.g. crass via `sanitize`/loofah, sawyer via Octokit; for npm, follow `package-lock.json` `packages` entries one level). If you cannot find a call path in two hops, rule it out: "transitive, no direct or one-hop call site".
 
-If `dependency_type` is `development` or the only call sites are under `test/`, `spec/`, or `script/`, rule it out: "development-only".
+If `dependency_type` is `development` (npm `devDependencies`, Bundler `:development`/`:test` groups, etc.) or the only call sites are under `test/`, `spec/`, `__tests__/`, or `script/`, rule it out: "development-only".
 
 ### 2. Trace to a boundary
 
@@ -56,7 +56,7 @@ From each call site, walk backwards to where the argument originates. You are lo
 
 Name the route, controller action, job class, or CLI entry point. Quote the line where external data enters and each hop to the library call.
 
-If every call site receives only operator-chosen constants, fixtures, or admin-only input, rule it out and say which. Admin-only still counts if the app has self-service signup that grants the relevant role.
+If every call site receives only operator-chosen constants, fixtures, or admin-only input, rule it out and say which. Exception: do not rule out admin-only input when the app has self-service signup that grants the relevant role; that is reachable.
 
 ### 3. Confirm the sink behaviour applies
 

--- a/skills/repo-overview/SKILL.md
+++ b/skills/repo-overview/SKILL.md
@@ -15,7 +15,7 @@ Produce an overview of the repository cloned at `./src` by invoking the `brief` 
 ## Workspace
 
 - `./src` — the cloned repository
-- `./context.json` — repository url and metadata (not needed for this skill)
+- `./context.json` — read `scrutineer.scan_subpath`; other fields are unused
 - `./report.json` — write the final report here
 
 ## What to run
@@ -26,7 +26,7 @@ If `./context.json` has `scrutineer.scan_subpath` set, run `brief` against that 
 brief --json ./src/$(jq -r '.scrutineer.scan_subpath // ""' ./context.json | sed 's:^/*::') > ./report.json
 ```
 
-For a root scan (no `scan_subpath`), that reduces to the original:
+If `scan_subpath` points at a directory that does not exist under `./src`, write `{"error": "scan_subpath not found: <path>"}` and stop. For a root scan (no `scan_subpath`), the command reduces to:
 
 ```bash
 brief --json ./src > ./report.json

--- a/skills/security-deep-dive/SKILL.md
+++ b/skills/security-deep-dive/SKILL.md
@@ -26,7 +26,7 @@ Scrutineer API (call with `Authorization: Bearer {token}`):
 - `GET {api_base}/repositories/{repository_id}/dependents` — top dependents with download counts (reach)
 - `GET {api_base}/repositories/{repository_id}/scans?skill=repo-overview&status=done` — then `GET /scans/{id}` for the brief summary
 
-If any of those return an empty list, the upstream scans were not run yet; fall back to your own reasoning over `./src`.
+If any of those return an empty list or a non-200 status, the upstream scans were not run yet or the API is unreachable; fall back to your own reasoning over `./src`.
 
 ## Phase 1: Inventory
 
@@ -57,7 +57,7 @@ Sink classes to enumerate. The classes are conceptual; the language you are audi
 - Reflection or metaprogramming primitives the library installs into the caller's environment: monkeypatches, prototype extensions, import hooks, global registrations, anything that changes behaviour outside the library's own namespace.
 - Round-trip integrity: any pair of operations where one is meant to be the inverse of the other. parse and serialize, encode and decode, marshal and unmarshal, escape and unescape. The sink is the pair, not either operation alone. The danger is asymmetry: if `decode(encode(x))` does not equal `x`, or `encode(decode(s))` does not produce the same `s` on re-decode, then a value can change meaning across a store-and-reload cycle. A validation that runs at parse time can be bypassed by what serialize emits. List every such pair the library exposes; the inventory entry is the pair.
 
-Read the entire source tree. Grep exhaustively — every code-exec primitive this language has, every shell-out, every file-open, every unsafe block. The grep finds them; you confirm each is a real sink and not a comment, test fixture, or vendored dependency.
+Read the entire source tree. Grep exhaustively — every code-exec primitive this language has, every shell-out, every file-open, every unsafe block. The grep finds them; you confirm each is a real sink and not a comment, test fixture, or third-party code vendored into this repo unmodified from upstream. Modified vendored code is first-party. (The note in the introduction about findings following vendored copies is the other direction: this repo's own code copied outward into forks or downstream vendors.)
 
 ## Phase 2: Per-sink checklist
 
@@ -93,7 +93,7 @@ Write a reproduction script and run it. The script demonstrates that the sink do
 
 Before concluding you cannot reproduce, enumerate the mechanisms that produce the kind of value the sink consumes. If the sink takes a path: argv, environment, glob expansion, archive extraction. If the sink takes an identifier: dynamic-definition primitives, struct-from-hash, deserialisation that turns keys into accessors, ORM attribute generation. If the sink takes a host: user input, redirect targets, DNS, service discovery. Write the list. Try each.
 
-Verify against the published artefact, not just git. Fetch the latest release from the registry, unpack it, confirm the sink is in the lines you said. HEAD diverges from releases.
+Verify against the published artefact, not just git. If `GET {api_base}/repositories/{repository_id}/packages` returns at least one package, fetch its latest release from the registry, unpack it, and confirm the sink is in the lines you said; HEAD diverges from releases. If it returns an empty list (CLI, service, monorepo, unpublished) the git checkout is the artefact and this check is a no-op.
 
 For round-trip pairs, the reproduction is the round-trip. Construct values containing characters that are structural in the serialized form — delimiters, separators, escape sequences, percent-encoded equivalents of any of those — and run them through `decode(encode(x))` and `encode(decode(s))`. If the output differs from the input, trace what changed. A character the decoder interprets but the encoder emits raw is the asymmetry. Then check what consumes the serialized form: if anything stores it and re-parses later, the validation that ran on the first parse does not cover the second.
 

--- a/skills/semgrep/SKILL.md
+++ b/skills/semgrep/SKILL.md
@@ -5,7 +5,7 @@ license: MIT
 compatibility: Requires `semgrep` (https://semgrep.dev) and `python3` on PATH.
 metadata:
   scrutineer.output_file: report.json
-  scrutineer.output_kind: freeform
+  scrutineer.output_kind: findings
 ---
 
 # semgrep

--- a/skills/subprojects/SKILL.md
+++ b/skills/subprojects/SKILL.md
@@ -23,7 +23,7 @@ List the discrete scannable units inside a repository so the analyst can scope s
 
 A subproject is a sub-folder that looks like an independently buildable, scannable unit. Heuristics, in descending order of signal strength:
 
-1. **Explicit monorepo declarations.** If the repo has any of these at the root, the file names the workspaces directly — use them verbatim:
+1. **Explicit monorepo declarations.** If the repo has any of these at the root, the file names the workspaces directly. Expand any globs against `./src` and emit one row per matched directory:
    - `pnpm-workspace.yaml` — `packages:` glob list
    - `lerna.json` — `packages:` array
    - `nx.json` / `workspace.json` — NX workspace layout
@@ -32,7 +32,7 @@ A subproject is a sub-folder that looks like an independently buildable, scannab
    - root `Cargo.toml` with `[workspace].members`
    - `pyproject.toml` with `[tool.uv.workspace].members` or Rye/hatch equivalents
 
-2. **Sub-folder package manifests.** When no workspace declaration exists, scan sub-folders (depth ≤ 3, skip `node_modules`, `vendor`, `.git`, `dist`, `build`, `target`) for any of:
+2. **Sub-folder package manifests.** Scan sub-folders (depth ≤ 3, skip `node_modules`, `vendor`, `.git`, `dist`, `build`, `target`) for any of the manifests below. Run this even when a workspace declaration exists, then union the two sets — `go.work` and friends are often incomplete.
    - `go.mod` → go-module
    - `package.json` with a `name` field → npm-package
    - `pyproject.toml` / `setup.py` / `setup.cfg` → python-package
@@ -85,12 +85,12 @@ Fields:
 
 - `path` — required, relative to repo root, no leading slash. This is what scrutineer stores on `Scan.sub_path` when the analyst scans it.
 - `name` — short human label. Use the package's own name when the manifest has one (`name` in package.json, `module` path in go.mod, `[package].name` in Cargo.toml); otherwise the last segment of `path`.
-- `kind` — the detection hit: `go-module`, `npm-package`, `python-package`, `rust-crate`, `composer-package`, `maven-module`, `gradle-module`, `ruby-gem`, `swift-package`, `service`, `monorepo-root`, etc. Free-form; the UI renders it as a badge.
+- `kind` — the detection hit: `go-module`, `npm-package`, `python-package`, `rust-crate`, `composer-package`, `maven-module`, `gradle-module`, `ruby-gem`, `swift-package`, `service`, etc. Free-form; the UI renders it as a badge.
 - `description` — one or two sentences. Read the README in the sub-folder if present, or infer from the package name and directory structure. Keep it specific ("AWS provider package", not "code for AWS").
 
 ## Constraints
 
 - Empty list is the correct output for a single-package repo. Do not invent subprojects to avoid an empty array.
 - Do not include the root directory as a row. Root is implicit.
-- Do not add more than ~50 rows. If a monorepo is bigger than that, pick the 50 most significant (largest manifests, deepest tree, or named in a workspace declaration) and note the truncation in a `notes` field (the schema allows it).
+- Do not add more than ~50 rows. If a monorepo is bigger than that, keep workspace-declared entries first, then fill the remainder by file count (largest first), and set the top-level `notes` field to `"truncated to 50 of N"`.
 - Scrutineer replaces the full set on each re-run, so missing rows from a previous run will disappear — do not try to merge with prior output.

--- a/skills/subprojects/schema.json
+++ b/skills/subprojects/schema.json
@@ -25,7 +25,7 @@
           },
           "kind": {
             "type": "string",
-            "description": "Detected flavour: go-module, npm-package, python-package, rust-crate, composer-package, maven-module, gradle-module, ruby-gem, swift-package, service, monorepo-root."
+            "description": "Detected flavour: go-module, npm-package, python-package, rust-crate, composer-package, maven-module, gradle-module, ruby-gem, swift-package, service."
           },
           "description": {
             "type": "string",

--- a/skills/triage/SKILL.md
+++ b/skills/triage/SKILL.md
@@ -35,11 +35,11 @@ A docs repo (markdown only) has neither. Anything with detected source gets the 
 
 Before enqueueing anything, check what already ran so a re-trigger does not double-enqueue work that is already current.
 
-Get the commit you are running at: `git -C ./src rev-parse HEAD`. Then fetch `GET {api_base}/repositories/{repository_id}/scans`, which returns every scan on this repository with `skill_name`, `status`, and `commit`. Build a set of skill names to skip: a skill goes in the skip set if it has a scan with `status="running"`, or a scan with `status="done"` whose `commit` equals the current HEAD. A `done` scan at any other commit does not count; the repository has moved since then and the skill should run again.
+Get the commit you are running at: `git -C ./src rev-parse HEAD`. Then fetch `GET {api_base}/repositories/{repository_id}/scans`, which returns every scan on this repository with `skill_name`, `status`, and `commit`. If that fetch fails, treat the skip set as empty and carry on. Otherwise build a set of skill names to skip: a skill goes in the skip set if it has a scan with `status` in {`queued`, `running`}, or a scan with `status="done"` whose `commit` equals the current HEAD. A `done` scan at any other commit does not count; the repository has moved since then and the skill should run again. `failed` scans are re-enqueued.
 
-For every remaining skill in the list below, enqueue it: `POST {api_base}/repositories/{id}/skills/{name}/run` with an `Authorization: Bearer {token}` header. Order does not matter; the scrutineer worker runs them as they come in.
+Classify each skill in the list below into exactly one bucket, checking in this order and stopping at the first match: `gated` (its `has_code`/`has_packages` flag is false), `already_done` (it is in the skip set), `triggered` (enqueue it). Enqueue with `POST {api_base}/repositories/{id}/skills/{name}/run` and an `Authorization: Bearer {token}` header. Order does not matter; the scrutineer worker runs them as they come in. A 404 response moves the skill from `triggered` to `skipped`.
 
-If `scrutineer.scan_ref` is set in `context.json`, include it in the POST body as `{"ref": "<value>"}` so child scans clone the same branch. If it is empty, send an empty JSON body or omit the body.
+If `scrutineer.scan_ref` is set in `context.json`, include it in the POST body as `{"ref": "<value>"}` so child scans clone the same branch. If it is empty, send an empty JSON body or omit the body. Verify runs (below) always send `{}`; they are finding-scoped and do not take a ref.
 
 Always:
 
@@ -81,7 +81,7 @@ Write `./report.json` as:
   "has_code": true,
   "has_packages": true,
   "brief": {"languages": ["Ruby"], "package_managers": ["Bundler"]},
-  "triggered": ["metadata", "packages", ...],
+  "triggered": ["packages", "advisories", ...],
   "skipped":   ["semgrep"],
   "gated":     [],
   "already_done": ["metadata"],

--- a/skills/verify/SKILL.md
+++ b/skills/verify/SKILL.md
@@ -23,14 +23,14 @@ Take an existing finding produced by a prior audit skill and check whether it st
 
 1. Read `./context.json`. If `scrutineer.finding_id` is missing, write `{"status": "inconclusive", "notes": "no finding_id in context.json; verify is finding-scoped"}` and exit.
 
-2. Fetch the finding: `GET {api_base}/findings/{finding_id}` with `Authorization: Bearer {token}`. You get back title, severity, location, cwe, affected, and the six-step prose (trace, boundary, validation, prior_art, reach, rating).
+2. Fetch the finding: `GET {api_base}/findings/{finding_id}` with `Authorization: Bearer {token}`. You get back title, severity, location, cwe, affected, and the six-step prose (trace, boundary, validation, prior_art, reach, rating). If the fetch returns non-200, write `{"status": "inconclusive", "evidence": "", "notes": "fetch failed: <status>"}` and exit.
 
 3. Read the `validation` field. This is the original reproduction instructions: how to run it, what it looked like when it worked, what dangerous behaviour was observed.
 
-4. Re-run the reproduction against `./src`. Be conservative:
+4. Re-run the reproduction against `./src` at HEAD. The point of this skill is to check whether the finding still holds against the current code, so always test HEAD. Be conservative:
    - Only run what the validation field describes. Do not improvise a new attack vector.
    - If the validation is prose-only (no concrete script), try to execute what it describes literally. If you cannot turn the prose into a runnable check, that is `inconclusive` — say why.
-   - Prefer running the reproduction against the published artefact (as the original did) over git HEAD, if the validation mentions one.
+   - If the validation installs the package from a registry (`gem install foo`, `pip install foo`), build and install from `./src` instead so you are testing HEAD, not the last release. If the package cannot be built locally, status is `inconclusive` with the build error in `notes`.
    - Capture stdout, stderr, exit code. Paste relevant excerpts into `evidence`.
 
 5. Decide the status:

--- a/skills/zizmor/SKILL.md
+++ b/skills/zizmor/SKILL.md
@@ -5,7 +5,7 @@ license: MIT
 compatibility: Requires `zizmor` (https://github.com/woodruffw/zizmor) and `python3` on PATH.
 metadata:
   scrutineer.output_file: report.json
-  scrutineer.output_kind: freeform
+  scrutineer.output_kind: findings
 ---
 
 # zizmor
@@ -21,7 +21,7 @@ Run zizmor against `./src/.github/workflows` and map each issue into scrutineer'
 
 ## Available scripts
 
-- `scripts/scan.py` — invokes `zizmor --format json .github/workflows` and converts the output. If the repo has no workflows directory, it writes an empty result so the scan succeeds cleanly. zizmor's severity values (`unknown`, `low`, `medium`, `high`, `critical`) are mapped to scrutineer's `Low`/`Medium`/`High`/`Critical`.
+- `scripts/scan.py` — invokes `zizmor --format json .github/workflows` and converts the output. If the repo has no workflows directory, it writes an empty result so the scan succeeds cleanly. zizmor's severity values are mapped to scrutineer's: `unknown`/`informational`/`low` → `Low`, `medium` → `Medium`, `high` → `High`, `critical` → `Critical`.
 
 ## What to do
 


### PR DESCRIPTION
Ran a contradiction / ambiguity / coverage pass over every `skills/*/SKILL.md` and fixed the things that would cause wrong agent behaviour. One commit per skill so individual changes are easy to review or revert.

Verified against `internal/worker/skill.go`:

- `patch` wrote its intermediate diff to `/tmp/patch.diff`, which is shared across scan workers. Now writes to the per-scan workspace. Fixes #178.
- `posture` read `repository.host` and `repository.archived` from context.json, and `cna-match` read `repository.owner`; none of those fields exist in `skillContextRepo`. Both now derive what they need from `repository.url` / `repository.full_name`.
- `semgrep` and `zizmor` declared `output_kind: freeform` while their scripts already emit `{"findings": [...]}` and their prose says the hits should surface alongside model-driven audits. `parseSkillOutput` has no freeform path, so the hits were never becoming Finding rows. Flipped both to `findings`. This is a behaviour change: their output will now be ingested.

Per-skill contradictions:

- `triage`: example output listed `metadata` in two mutually exclusive buckets; `queued`/`failed` scan statuses were undefined in the skip rule; bucket precedence was implicit.
- `repo-overview`: said context.json was "not needed" then read `scan_subpath` from it.
- `maintainers`: "filter bots out" vs "include every classification decision".
- `subprojects`: `monorepo-root` was a valid `kind` while root rows are forbidden; workspace globs were "use verbatim".
- `security-deep-dive`: vendored code was both in and out of scope depending on which paragraph you read; resolved as third-party-vendored-in is out, first-party-vendored-out carries the finding.
- `reachability`: "admin-only still counts" read either way after a rule-out instruction.
- `verify`: "check against current code" then "prefer the published artefact over HEAD".
- `fork`: deduped advisories on title, which is also what it set summary from, so distinct findings with the same title collided. Now dedups on a `[scrutineer-finding:{id}]` marker appended to every description.
- `disclose`: omitted `vulnerabilities[]` for source-only repos while also claiming the `ghsa` block is a drop-in POST body, which GitHub rejects without at least one entry.
- `cna-match`: GitHub_M as a step-4 last resort made the documented no-match path unreachable for any github.com repo. Now records GitHub_M in the `cna` block without overriding `disclosure_channel`.

Not touched: the medium-rated error-path gaps in `advisories`, `dependents`, `metadata`, `packages`, and the stderr-capture quirk in `sbom`/`dependencies`. Can follow up separately.