### PR TITLE
findings: store gated suggested-fix diff on the row

### DIFF
--- a/docs/database.md
+++ b/docs/database.md
@@ -108,6 +108,8 @@ One row per vulnerability. Lifecycle columns are mutated through `db.WriteFindin
 | resolution | text | `fix`, `migrate`, `workaround`, `adopt`, `wontfix`. |
 | disclosure_draft | text | Draft advisory text. |
 | assignee | text | Free-text. |
+| suggested_fix | text | Unified diff from the `patch` skill that passed the applicability gate. Empty when no patch run or the gate rejected it. |
+| suggested_fix_commit | text | Sha the suggested_fix applies cleanly against. |
 | trace | text | Step 1 prose. Markdown. |
 | boundary | text | Step 2. |
 | validation | text | Step 3: reproduction. |

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -364,6 +364,12 @@ type Finding struct {
 	Resolution      FindingResolution `gorm:"index"`
 	DisclosureDraft string            `gorm:"type:text"`
 	Assignee        string            `gorm:"index"`
+	// SuggestedFix is a unified diff from the patch skill that has passed
+	// the applicability gate (parses, targets real files, overlaps
+	// Location, git apply --check clean). Empty when no patch has run or
+	// the gate rejected it. SuggestedFixCommit is the sha it applies to.
+	SuggestedFix       string `gorm:"type:text"`
+	SuggestedFixCommit string
 
 	// Per-step prose from the six-step audit checklist.
 	Trace      string `gorm:"type:text"`

--- a/internal/db/finding_helpers.go
+++ b/internal/db/finding_helpers.go
@@ -112,6 +112,10 @@ func findingFieldAccessor(f *Finding, field string) (current, column string, err
 		return f.DisclosureDraft, "disclosure_draft", nil
 	case "assignee":
 		return f.Assignee, "assignee", nil
+	case "suggested_fix":
+		return f.SuggestedFix, "suggested_fix", nil
+	case "suggested_fix_commit":
+		return f.SuggestedFixCommit, "suggested_fix_commit", nil
 	default:
 		return "", "", fmt.Errorf("field %q is not editable", field)
 	}

--- a/internal/skills/parse.go
+++ b/internal/skills/parse.go
@@ -83,6 +83,7 @@ var OutputKinds = map[string]bool{
 	"subprojects":   true,
 	"repo_overview": true,
 	"posture":       true,
+	"patch":         true,
 }
 
 var nameRE = regexp.MustCompile(`^[a-z0-9]+(-[a-z0-9]+)*$`)

--- a/internal/web/api_reads.go
+++ b/internal/web/api_reads.go
@@ -214,6 +214,8 @@ func (s *Server) apiGetFinding(w http.ResponseWriter, r *http.Request) {
 	summary["reach"] = f.Reach
 	summary["rating"] = f.Rating
 	summary["disclosure_draft"] = f.DisclosureDraft
+	summary["suggested_fix"] = f.SuggestedFix
+	summary["suggested_fix_commit"] = f.SuggestedFixCommit
 	writeJSON(w, http.StatusOK, summary)
 }
 

--- a/internal/web/finding_patch.go
+++ b/internal/web/finding_patch.go
@@ -45,27 +45,22 @@ func (s *Server) latestPatchScan(findingID uint) (*db.Scan, *patchReport, error)
 	return &scan, &rep, nil
 }
 
-// findingPatchDownload serves the latest patch scan's diff as a .patch file.
-// No .patch scan done -> 404; done but empty diff (the skill refused) -> 404
-// with a small message so the download link never yields a confusing empty
-// file.
+// findingPatchDownload serves Finding.SuggestedFix as a .patch file. The
+// column is only ever populated by parsePatchOutput after the applicability
+// gate passes, so a download is always a diff that parsed, targeted real
+// files, overlapped Location, and survived git apply --check.
 func (s *Server) findingPatchDownload(w http.ResponseWriter, r *http.Request) {
 	var f db.Finding
 	if err := s.DB.First(&f, r.PathValue("id")).Error; err != nil {
 		http.NotFound(w, r)
 		return
 	}
-	_, rep, err := s.latestPatchScan(f.ID)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-	if rep == nil || strings.TrimSpace(rep.Patch) == "" {
-		http.Error(w, "no patch available for this finding", http.StatusNotFound)
+	if strings.TrimSpace(f.SuggestedFix) == "" {
+		http.Error(w, "no gated patch stored for this finding", http.StatusNotFound)
 		return
 	}
 	w.Header().Set("Content-Type", "text/x-diff; charset=utf-8")
 	w.Header().Set("Content-Disposition",
 		fmt.Sprintf(`attachment; filename="finding-%d.patch"`, f.ID))
-	_, _ = w.Write([]byte(rep.Patch))
+	_, _ = w.Write([]byte(f.SuggestedFix))
 }

--- a/internal/web/finding_patch_test.go
+++ b/internal/web/finding_patch_test.go
@@ -1,0 +1,58 @@
+package web
+
+import (
+	"fmt"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"scrutineer/internal/db"
+	"scrutineer/internal/worker"
+)
+
+func TestFindingPatchDownload_servesGatedColumn(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	repo := db.Repository{URL: "https://example.com/x", Name: "x"}
+	s.DB.Create(&repo)
+	scan := db.Scan{RepositoryID: repo.ID, Kind: worker.JobSkill, Status: db.ScanDone}
+	s.DB.Create(&scan)
+	diff := "--- a/x.go\n+++ b/x.go\n@@ -1 +1 @@\n-a\n+b\n"
+	f := db.Finding{ScanID: scan.ID, RepositoryID: repo.ID, Title: "t",
+		Severity: "Low", Location: "x.go:1", SuggestedFix: diff, SuggestedFixCommit: "abc"}
+	s.DB.Create(&f)
+
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq("GET", fmt.Sprintf("/findings/%d/patch.diff", f.ID)))
+	if w.Code != 200 {
+		t.Fatalf("status = %d: %s", w.Code, w.Body)
+	}
+	if w.Body.String() != diff {
+		t.Errorf("body = %q, want the stored diff", w.Body.String())
+	}
+	if ct := w.Header().Get("Content-Type"); !strings.Contains(ct, "text/x-diff") {
+		t.Errorf("content-type = %q", ct)
+	}
+}
+
+func TestFindingPatchDownload_404WhenNoGatedFix(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	repo := db.Repository{URL: "https://example.com/x", Name: "x"}
+	s.DB.Create(&repo)
+	scan := db.Scan{RepositoryID: repo.ID, Kind: worker.JobSkill, Status: db.ScanDone}
+	s.DB.Create(&scan)
+	f := db.Finding{ScanID: scan.ID, RepositoryID: repo.ID, Title: "t", Severity: "Low"}
+	s.DB.Create(&f)
+
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq("GET", fmt.Sprintf("/findings/%d/patch.diff", f.ID)))
+	if w.Code != 404 {
+		t.Fatalf("status = %d, want 404", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "no gated patch") {
+		t.Errorf("body = %q", w.Body.String())
+	}
+}

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -1420,7 +1420,9 @@ func TestFindingPatchDownload(t *testing.T) {
 	s.DB.Create(&repo)
 	scan := db.Scan{RepositoryID: repo.ID, Kind: "skill", Status: db.ScanDone, SkillName: "security-deep-dive"}
 	s.DB.Create(&scan)
-	finding := db.Finding{ScanID: scan.ID, RepositoryID: repo.ID, FindingID: "F1", Title: "x", Severity: "High", Status: db.FindingTriaged}
+	gatedDiff := "diff --git a/foo.go b/foo.go\n@@ -1 +1 @@\n-old\n+new\n"
+	finding := db.Finding{ScanID: scan.ID, RepositoryID: repo.ID, FindingID: "F1", Title: "x", Severity: "High",
+		Status: db.FindingTriaged, SuggestedFix: gatedDiff, SuggestedFixCommit: "abc123"}
 	s.DB.Create(&finding)
 
 	fid := finding.ID

--- a/internal/worker/patch_gate.go
+++ b/internal/worker/patch_gate.go
@@ -1,0 +1,235 @@
+package worker
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"scrutineer/internal/db"
+)
+
+// patchReport mirrors the patch skill's report.json shape. Only the fields
+// the gate needs; rationale, files_changed, tests_added, notes stay in the
+// raw Scan.Report and are surfaced by the web layer.
+type patchReport struct {
+	Patch      string `json:"patch"`
+	BaseCommit string `json:"base_commit"`
+	Error      string `json:"error"`
+}
+
+// parsePatchOutput runs the applicability gate over a patch skill's diff and,
+// on pass, writes Finding.SuggestedFix and Finding.SuggestedFixCommit via
+// WriteFindingField so the change is recorded in FindingHistory. A gate
+// failure is not a scan error: the scan completed and the diff is in
+// Scan.Report; we just decline to promote it onto the finding.
+func (w *Worker) parsePatchOutput(scan *db.Scan, report string, emit func(Event)) error {
+	var rep patchReport
+	if err := json.Unmarshal([]byte(report), &rep); err != nil {
+		return fmt.Errorf("parse patch: %w", err)
+	}
+	if rep.Error != "" {
+		emit(Event{Kind: KindText, Text: "patch: skill refused: " + rep.Error})
+		return nil
+	}
+	if strings.TrimSpace(rep.Patch) == "" {
+		emit(Event{Kind: KindText, Text: "patch: empty diff, nothing to gate"})
+		return nil
+	}
+	if scan.FindingID == nil {
+		emit(Event{Kind: KindText, Text: "patch: scan is not finding-scoped, leaving suggested_fix unset"})
+		return nil
+	}
+
+	var f db.Finding
+	if err := w.DB.First(&f, *scan.FindingID).Error; err != nil {
+		return fmt.Errorf("load finding %d: %w", *scan.FindingID, err)
+	}
+
+	srcDir := filepath.Join(w.workRoot(scan.ID), "src")
+	if reason := gatePatch(srcDir, f.Location, rep.Patch); reason != "" {
+		emit(Event{Kind: KindText, Text: "patch: gate rejected: " + reason})
+		return nil
+	}
+
+	if err := db.WriteFindingField(w.DB, f.ID, "suggested_fix", rep.Patch, db.SourceModel, "patch"); err != nil {
+		return fmt.Errorf("write suggested_fix: %w", err)
+	}
+	if err := db.WriteFindingField(w.DB, f.ID, "suggested_fix_commit", rep.BaseCommit, db.SourceModel, "patch"); err != nil {
+		return fmt.Errorf("write suggested_fix_commit: %w", err)
+	}
+	emit(Event{Kind: KindText, Text: fmt.Sprintf("patch: gate passed, wrote suggested_fix on finding %d", f.ID)})
+	return nil
+}
+
+// gatePatch returns "" when the diff is acceptable, otherwise a one-line
+// reason. Checks: diff parses; every target file exists under srcDir; at
+// least one hunk overlaps the line in location; git apply --check accepts it.
+func gatePatch(srcDir, location, diff string) string {
+	files, err := parseUnifiedDiff(diff)
+	if err != nil {
+		return "diff does not parse: " + err.Error()
+	}
+	if len(files) == 0 {
+		return "diff has no file headers"
+	}
+
+	for _, df := range files {
+		if df.NewFile {
+			continue
+		}
+		if _, err := os.Stat(filepath.Join(srcDir, df.Path)); err != nil {
+			return "diff targets missing file: " + df.Path
+		}
+	}
+
+	if reason := checkLocationOverlap(files, location); reason != "" {
+		return reason
+	}
+
+	if out, err := gitApplyCheck(srcDir, diff); err != nil {
+		return "git apply --check: " + firstLine(out)
+	}
+
+	return ""
+}
+
+func checkLocationOverlap(files []diffFile, location string) string {
+	locPath, start, end, ok := parseLocation(location)
+	if !ok {
+		return ""
+	}
+	for _, df := range files {
+		if df.Path != locPath {
+			continue
+		}
+		if start == 0 {
+			return ""
+		}
+		for _, h := range df.Hunks {
+			if h.OldStart <= end && h.OldStart+h.OldCount-1 >= start {
+				return ""
+			}
+		}
+	}
+	if start == 0 {
+		return "no hunk touches " + locPath
+	}
+	return fmt.Sprintf("no hunk overlaps %s:%d", locPath, start)
+}
+
+type diffFile struct {
+	Path    string
+	NewFile bool
+	Hunks   []diffHunk
+}
+
+type diffHunk struct {
+	OldStart int
+	OldCount int
+}
+
+var hunkRE = regexp.MustCompile(`^@@ -(\d+)(?:,(\d+))? \+\d+(?:,\d+)? @@`)
+
+const maxDiffLineBytes = 4 << 20
+
+// parseUnifiedDiff extracts target file paths and old-side hunk ranges from
+// a unified diff. It is deliberately minimal: enough to drive the gate, not
+// a general diff library.
+func parseUnifiedDiff(diff string) ([]diffFile, error) {
+	var files []diffFile
+	var cur *diffFile
+	sawFrom := false
+	newFile := false
+
+	sc := bufio.NewScanner(strings.NewReader(diff))
+	sc.Buffer(nil, maxDiffLineBytes)
+	for sc.Scan() {
+		line := sc.Text()
+		switch {
+		case strings.HasPrefix(line, "--- "):
+			sawFrom = true
+			newFile = strings.TrimPrefix(line, "--- ") == "/dev/null"
+		case strings.HasPrefix(line, "+++ "):
+			if !sawFrom {
+				return nil, fmt.Errorf("+++ without preceding ---")
+			}
+			sawFrom = false
+			to := strings.TrimPrefix(line, "+++ ")
+			if i := strings.IndexByte(to, '\t'); i >= 0 {
+				to = to[:i]
+			}
+			path := strings.TrimPrefix(to, "b/")
+			if to == "/dev/null" {
+				path = ""
+			}
+			files = append(files, diffFile{Path: path, NewFile: newFile})
+			cur = &files[len(files)-1]
+			newFile = false
+		case strings.HasPrefix(line, "@@ "):
+			if cur == nil {
+				return nil, fmt.Errorf("hunk header before any file header")
+			}
+			m := hunkRE.FindStringSubmatch(line)
+			if m == nil {
+				return nil, fmt.Errorf("bad hunk header: %q", line)
+			}
+			start, _ := strconv.Atoi(m[1])
+			count := 1
+			if m[2] != "" {
+				count, _ = strconv.Atoi(m[2])
+			}
+			cur.Hunks = append(cur.Hunks, diffHunk{OldStart: start, OldCount: count})
+		}
+	}
+	if err := sc.Err(); err != nil {
+		return nil, err
+	}
+	return files, nil
+}
+
+// parseLocation accepts "path/to/file.ext:N", "path/to/file.ext:N-M", or a
+// bare path. Returns ok=false for anything else (empty, multiple colons that
+// don't end in a line spec); callers treat that as "no overlap check".
+func parseLocation(loc string) (path string, start, end int, ok bool) {
+	loc = strings.TrimSpace(loc)
+	if loc == "" {
+		return "", 0, 0, false
+	}
+	i := strings.LastIndexByte(loc, ':')
+	if i < 0 {
+		return loc, 0, 0, true
+	}
+	spec := loc[i+1:]
+	if lo, hi, found := strings.Cut(spec, "-"); found {
+		a, errA := strconv.Atoi(lo)
+		b, errB := strconv.Atoi(hi)
+		if errA == nil && errB == nil && a > 0 && b >= a {
+			return loc[:i], a, b, true
+		}
+	} else if n, err := strconv.Atoi(spec); err == nil && n > 0 {
+		return loc[:i], n, n, true
+	}
+	return loc, 0, 0, true
+}
+
+func gitApplyCheck(srcDir, diff string) (string, error) {
+	cmd := exec.Command("git", "-C", srcDir, "apply", "--check", "-")
+	cmd.Stdin = strings.NewReader(diff)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+func firstLine(s string) string {
+	line, _, _ := strings.Cut(strings.TrimSpace(s), "\n")
+	return line
+}

--- a/internal/worker/patch_gate_test.go
+++ b/internal/worker/patch_gate_test.go
@@ -1,0 +1,333 @@
+package worker
+
+import (
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"scrutineer/internal/db"
+)
+
+func TestParseUnifiedDiff(t *testing.T) {
+	tests := []struct {
+		name string
+		diff string
+		want []diffFile
+	}{
+		{
+			"single file single hunk",
+			"--- a/pkg/foo.go\n+++ b/pkg/foo.go\n@@ -10,3 +10,4 @@ func x() {\n a\n-b\n+c\n+d\n",
+			[]diffFile{{Path: "pkg/foo.go", Hunks: []diffHunk{{OldStart: 10, OldCount: 3}}}},
+		},
+		{
+			"multi file",
+			"diff --git a/a.go b/a.go\n--- a/a.go\n+++ b/a.go\n@@ -1 +1 @@\n-x\n+y\n" +
+				"diff --git a/b.go b/b.go\n--- a/b.go\n+++ b/b.go\n@@ -5,2 +5,3 @@\n a\n-b\n+c\n+d\n",
+			[]diffFile{
+				{Path: "a.go", Hunks: []diffHunk{{OldStart: 1, OldCount: 1}}},
+				{Path: "b.go", Hunks: []diffHunk{{OldStart: 5, OldCount: 2}}},
+			},
+		},
+		{
+			"new file",
+			"--- /dev/null\n+++ b/new.go\n@@ -0,0 +1,3 @@\n+a\n+b\n+c\n",
+			[]diffFile{{Path: "new.go", NewFile: true, Hunks: []diffHunk{{OldStart: 0, OldCount: 0}}}},
+		},
+		{
+			"deleted file",
+			"--- a/gone.go\n+++ /dev/null\n@@ -1,2 +0,0 @@\n-a\n-b\n",
+			[]diffFile{{Path: "", Hunks: []diffHunk{{OldStart: 1, OldCount: 2}}}},
+		},
+		{
+			"timestamp after path",
+			"--- a/x.go\t2026-01-01\n+++ b/x.go\t2026-01-02\n@@ -3 +3 @@\n-a\n+b\n",
+			[]diffFile{{Path: "x.go", Hunks: []diffHunk{{OldStart: 3, OldCount: 1}}}},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseUnifiedDiff(tc.diff)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(got) != len(tc.want) {
+				t.Fatalf("files = %d, want %d: %+v", len(got), len(tc.want), got)
+			}
+			for i := range got {
+				if got[i].Path != tc.want[i].Path || got[i].NewFile != tc.want[i].NewFile {
+					t.Errorf("file[%d] = %+v, want %+v", i, got[i], tc.want[i])
+				}
+				if len(got[i].Hunks) != len(tc.want[i].Hunks) {
+					t.Fatalf("file[%d] hunks = %d, want %d", i, len(got[i].Hunks), len(tc.want[i].Hunks))
+				}
+				for j := range got[i].Hunks {
+					if got[i].Hunks[j] != tc.want[i].Hunks[j] {
+						t.Errorf("file[%d] hunk[%d] = %+v, want %+v", i, j, got[i].Hunks[j], tc.want[i].Hunks[j])
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestParseUnifiedDiff_errors(t *testing.T) {
+	if _, err := parseUnifiedDiff("+++ b/x.go\n"); err == nil {
+		t.Error("expected error for +++ without ---")
+	}
+	if _, err := parseUnifiedDiff("@@ -1 +1 @@\n"); err == nil {
+		t.Error("expected error for hunk before file header")
+	}
+	if _, err := parseUnifiedDiff("--- a/x\n+++ b/x\n@@ garbage @@\n"); err == nil {
+		t.Error("expected error for bad hunk header")
+	}
+}
+
+func TestParseLocation(t *testing.T) {
+	tests := []struct {
+		in         string
+		path       string
+		start, end int
+		ok         bool
+	}{
+		{"pkg/foo.go:42", "pkg/foo.go", 42, 42, true},
+		{"pkg/foo.go:10-20", "pkg/foo.go", 10, 20, true},
+		{"pkg/foo.go", "pkg/foo.go", 0, 0, true},
+		{"", "", 0, 0, false},
+		{"a/b/c.rs:abc", "a/b/c.rs:abc", 0, 0, true},
+		{"a/b/c.rs:5-2", "a/b/c.rs:5-2", 0, 0, true},
+		{"  pkg/foo.go:7  ", "pkg/foo.go", 7, 7, true},
+	}
+	for _, tc := range tests {
+		path, start, end, ok := parseLocation(tc.in)
+		if path != tc.path || start != tc.start || end != tc.end || ok != tc.ok {
+			t.Errorf("parseLocation(%q) = (%q,%d,%d,%v), want (%q,%d,%d,%v)",
+				tc.in, path, start, end, ok, tc.path, tc.start, tc.end, tc.ok)
+		}
+	}
+}
+
+func TestCheckLocationOverlap(t *testing.T) {
+	files := []diffFile{
+		{Path: "pkg/foo.go", Hunks: []diffHunk{{OldStart: 10, OldCount: 5}}},
+		{Path: "pkg/bar.go", Hunks: []diffHunk{{OldStart: 100, OldCount: 1}}},
+	}
+	tests := []struct {
+		loc  string
+		want string
+	}{
+		{"pkg/foo.go:12", ""},
+		{"pkg/foo.go:10", ""},
+		{"pkg/foo.go:14", ""},
+		{"pkg/foo.go:8-11", ""},
+		{"pkg/foo.go:50", "no hunk overlaps pkg/foo.go:50"},
+		{"pkg/foo.go", ""},
+		{"pkg/other.go:5", "no hunk overlaps pkg/other.go:5"},
+		{"pkg/other.go", "no hunk touches pkg/other.go"},
+		{"", ""},
+	}
+	for _, tc := range tests {
+		got := checkLocationOverlap(files, tc.loc)
+		if got != tc.want {
+			t.Errorf("checkLocationOverlap(%q) = %q, want %q", tc.loc, got, tc.want)
+		}
+	}
+}
+
+// gateRepo creates a git repo under dir with one file pkg/foo.go containing
+// numbered lines 1..20, edits targetLine, captures a real `git diff`, then
+// resets the working tree. The returned diff is what the patch skill would
+// produce, so git apply --check accepts it without --unidiff-zero.
+func gateRepo(t *testing.T, dir string, targetLine int) (relPath, diff string) {
+	t.Helper()
+	relPath = "pkg/foo.go"
+	full := filepath.Join(dir, relPath)
+	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	var lines []string
+	for i := 1; i <= 20; i++ {
+		lines = append(lines, fmt.Sprintf("line %d", i))
+	}
+	write := func(ls []string) {
+		if err := os.WriteFile(full, []byte(strings.Join(ls, "\n")+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write(lines)
+	run := func(args ...string) string {
+		cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+		return string(out)
+	}
+	run("init", "-q")
+	run("config", "user.email", "t@t")
+	run("config", "user.name", "t")
+	run("add", ".")
+	run("commit", "-q", "-m", "init")
+
+	patched := append([]string(nil), lines...)
+	patched[targetLine-1] = fmt.Sprintf("patched %d", targetLine)
+	write(patched)
+	diff = run("diff")
+	run("checkout", "--", ".")
+	return relPath, diff
+}
+
+func TestGatePatch(t *testing.T) {
+	src := t.TempDir()
+	rel, diff := gateRepo(t, src, 12)
+
+	if r := gatePatch(src, rel+":12", diff); r != "" {
+		t.Errorf("pass case rejected: %q", r)
+	}
+	if r := gatePatch(src, rel+":3", diff); !strings.Contains(r, "no hunk overlaps") {
+		t.Errorf("expected overlap rejection, got %q", r)
+	}
+	if r := gatePatch(src, "pkg/missing.go:12",
+		"--- a/pkg/missing.go\n+++ b/pkg/missing.go\n@@ -1 +1 @@\n-x\n+y\n"); !strings.Contains(r, "missing file") {
+		t.Errorf("expected missing-file rejection, got %q", r)
+	}
+	if r := gatePatch(src, rel+":12", "not a diff"); !strings.Contains(r, "no file headers") {
+		t.Errorf("expected no-file-headers rejection, got %q", r)
+	}
+	bad := strings.Replace(diff, "-line 12", "-WRONG", 1)
+	if r := gatePatch(src, rel+":12", bad); !strings.Contains(r, "git apply --check") {
+		t.Errorf("expected git apply rejection, got %q", r)
+	}
+	newFileDiff := "--- /dev/null\n+++ b/pkg/foo_test.go\n@@ -0,0 +1 @@\n+test\n" + diff
+	if r := gatePatch(src, rel+":12", newFileDiff); r != "" {
+		t.Errorf("new-file alongside fix rejected: %q", r)
+	}
+}
+
+func newPatchOutputFixture(t *testing.T) (*Worker, db.Finding) {
+	t.Helper()
+	gdb, err := db.Open(filepath.Join(t.TempDir(), "p.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo := db.Repository{URL: "https://example.com/x", Name: "x"}
+	if err := gdb.Create(&repo).Error; err != nil {
+		t.Fatal(err)
+	}
+	base := db.Scan{RepositoryID: repo.ID, Kind: JobSkill, Status: db.ScanDone}
+	if err := gdb.Create(&base).Error; err != nil {
+		t.Fatal(err)
+	}
+	finding := db.Finding{ScanID: base.ID, RepositoryID: repo.ID, Title: "t",
+		Severity: "Low", Location: "pkg/foo.go:12"}
+	if err := gdb.Create(&finding).Error; err != nil {
+		t.Fatal(err)
+	}
+	w := &Worker{DB: gdb, Log: slog.New(slog.NewTextHandler(io.Discard, nil)), DataDir: t.TempDir()}
+	return w, finding
+}
+
+func TestParsePatchOutput_passWritesColumnsAndHistory(t *testing.T) {
+	w, finding := newPatchOutputFixture(t)
+	sc := db.Scan{RepositoryID: finding.RepositoryID, Kind: JobSkill, Status: db.ScanRunning, FindingID: &finding.ID}
+	if err := w.DB.Create(&sc).Error; err != nil {
+		t.Fatal(err)
+	}
+	src := filepath.Join(w.workRoot(sc.ID), "src")
+	_, diff := gateRepo(t, src, 12)
+	report := fmt.Sprintf(`{"patch":%q,"base_commit":"abc123"}`, diff)
+
+	var events []string
+	if err := w.parsePatchOutput(&sc, report, func(e Event) { events = append(events, e.Text) }); err != nil {
+		t.Fatal(err)
+	}
+	var f db.Finding
+	w.DB.First(&f, finding.ID)
+	if f.SuggestedFix != diff {
+		t.Errorf("SuggestedFix not written; got %q", f.SuggestedFix)
+	}
+	if f.SuggestedFixCommit != "abc123" {
+		t.Errorf("SuggestedFixCommit = %q, want abc123", f.SuggestedFixCommit)
+	}
+	var hist []db.FindingHistory
+	w.DB.Where("finding_id = ? AND field = ?", finding.ID, "suggested_fix").Find(&hist)
+	if len(hist) != 1 || hist[0].By != "patch" || hist[0].Source != db.SourceModel {
+		t.Errorf("history = %+v, want one row by=patch source=model_suggested", hist)
+	}
+	if !containsSubstr(events, "gate passed") {
+		t.Errorf("events = %v, want gate-passed message", events)
+	}
+}
+
+func TestParsePatchOutput_gateRejectLeavesColumnsEmpty(t *testing.T) {
+	w, finding := newPatchOutputFixture(t)
+	sc := db.Scan{RepositoryID: finding.RepositoryID, Kind: JobSkill, Status: db.ScanRunning, FindingID: &finding.ID}
+	if err := w.DB.Create(&sc).Error; err != nil {
+		t.Fatal(err)
+	}
+	src := filepath.Join(w.workRoot(sc.ID), "src")
+	gateRepo(t, src, 12)
+	report := `{"patch":"--- a/pkg/missing.go\n+++ b/pkg/missing.go\n@@ -1 +1 @@\n-x\n+y\n","base_commit":"abc"}`
+
+	var events []string
+	if err := w.parsePatchOutput(&sc, report, func(e Event) { events = append(events, e.Text) }); err != nil {
+		t.Fatal(err)
+	}
+	var f db.Finding
+	w.DB.First(&f, finding.ID)
+	if f.SuggestedFix != "" || f.SuggestedFixCommit != "" {
+		t.Errorf("columns should be empty after gate reject: fix=%q commit=%q", f.SuggestedFix, f.SuggestedFixCommit)
+	}
+	if !containsSubstr(events, "gate rejected") {
+		t.Errorf("events = %v, want gate-rejected message", events)
+	}
+}
+
+func TestParsePatchOutput_skillRefused(t *testing.T) {
+	w, finding := newPatchOutputFixture(t)
+	sc := db.Scan{RepositoryID: finding.RepositoryID, Kind: JobSkill, Status: db.ScanRunning, FindingID: &finding.ID}
+	if err := w.DB.Create(&sc).Error; err != nil {
+		t.Fatal(err)
+	}
+	var events []string
+	if err := w.parsePatchOutput(&sc, `{"error":"thin prose"}`, func(e Event) { events = append(events, e.Text) }); err != nil {
+		t.Fatal(err)
+	}
+	var f db.Finding
+	w.DB.First(&f, finding.ID)
+	if f.SuggestedFix != "" {
+		t.Error("SuggestedFix should be empty when skill refused")
+	}
+	if !containsSubstr(events, "skill refused") {
+		t.Errorf("events = %v", events)
+	}
+}
+
+func TestParsePatchOutput_notFindingScoped(t *testing.T) {
+	w, finding := newPatchOutputFixture(t)
+	sc := db.Scan{RepositoryID: finding.RepositoryID, Kind: JobSkill, Status: db.ScanRunning}
+	if err := w.DB.Create(&sc).Error; err != nil {
+		t.Fatal(err)
+	}
+	var events []string
+	if err := w.parsePatchOutput(&sc, `{"patch":"--- a/x\n+++ b/x\n@@ -1 +1 @@\n-a\n+b\n"}`,
+		func(e Event) { events = append(events, e.Text) }); err != nil {
+		t.Fatal(err)
+	}
+	if !containsSubstr(events, "not finding-scoped") {
+		t.Errorf("events = %v, want not-finding-scoped message", events)
+	}
+}
+
+func containsSubstr(events []string, sub string) bool {
+	for _, e := range events {
+		if strings.Contains(e, sub) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/worker/skill.go
+++ b/internal/worker/skill.go
@@ -156,6 +156,8 @@ func (w *Worker) parseSkillOutput(skill *db.Skill, scan *db.Scan, report string,
 		return w.parseRepoOverviewOutput(scan, report, emit)
 	case "posture":
 		return w.parsePostureOutput(scan, report, emit)
+	case "patch":
+		return w.parsePatchOutput(scan, report, emit)
 	}
 	return nil
 }

--- a/skills/patch/SKILL.md
+++ b/skills/patch/SKILL.md
@@ -6,7 +6,7 @@ compatibility: Needs network access to the scrutineer API (http://host:port/api)
 metadata:
   scrutineer.version: 1
   scrutineer.output_file: report.json
-  scrutineer.output_kind: freeform
+  scrutineer.output_kind: patch
 ---
 
 # patch


### PR DESCRIPTION
Refs #64. Covers the column, the parser, the gate, the API field, and the download switch; the markdown export inclusion is left as a follow-up.

`db.Finding` gets `SuggestedFix` (unified diff text) and `SuggestedFixCommit` (the sha it applies against). Both are wired into `findingFieldAccessor` so writes go through `WriteFindingField` and land in `FindingHistory` with `by: "patch"`, `source: model_suggested`.

`skills/patch/SKILL.md` switches `scrutineer.output_kind` from `freeform` to `patch`, and `parseSkillOutput` dispatches that to a new `parsePatchOutput` in `internal/worker/patch_gate.go`. The parser decodes `report.json`, bails (emit + return nil) when the skill set `error`, the diff is empty, or the scan is not finding-scoped, then runs `gatePatch` against the workspace clone at `{workRoot}/src` (still on disk; cleanup runs after `doSkill` returns).

The gate checks four things and returns the first failure as a one-line reason:

- the diff parses (a minimal hand-rolled `parseUnifiedDiff` that extracts `+++ b/<path>` targets and `@@ -start,count` old-side ranges; no new dependency)
- every target path that is not `/dev/null` exists under `./src`
- at least one hunk overlaps `Finding.Location`, parsed as `path:N`, `path:N-M`, or a bare path; an unparseable location skips this check rather than failing
- `git -C ./src apply --check -` exits clean

On pass the two columns are written. On reject the scan log gets `patch: gate rejected: <reason>` and the columns stay empty; the raw diff is still on `Scan.Report` and the finding page still renders rationale and files-changed via `latestPatchScan`.

`GET /findings/{id}` now includes `suggested_fix` and `suggested_fix_commit` so the upstream-PVR skill in #177 can read the diff directly instead of digging through scan reports. `GET /findings/{id}/patch.diff` serves `Finding.SuggestedFix` so a download is always a gated diff.

Dropped from the original #64 list, with the issue body updated to match: per-finding diffs from `security-deep-dive` (keep `patch` as the dedicated fix-proposer) and the "Apply patch" button (download plus the gate result is enough for now).