### PR TITLE
worker: validate report.json against the skill's schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ When the docker runner is active, scrutineer starts an authenticated egress prox
 | `-clone` | `shallow` | Clone depth: `shallow` (`--depth 1`) or `full` |
 | `-scan-timeout` | `1h` | Wall-clock limit per scan; exceeded scans fail |
 | `-max-turns` | `0` | Passed as `--max-turns` to claude-code (0 = unlimited) |
+| `-schema-strict` | `false` | Fail a scan when its `report.json` does not validate against the skill's `schema.json` (default: warn in the scan log and parse anyway) |
 | `-anthropic-base-url` | - | Custom Anthropic API base URL (env: `ANTHROPIC_BASE_URL`) |
 
 ## Config file

--- a/cmd/scrutineer/main.go
+++ b/cmd/scrutineer/main.go
@@ -63,6 +63,7 @@ type flags struct {
 	maxTurns         int
 	anthropicBaseURL string
 	forkOrg          string
+	schemaStrict     bool
 	skillLocal       skillDirs
 
 	// set records which flags were passed on the command line so merge
@@ -85,6 +86,7 @@ func parseFlags() *flags {
 	flag.IntVar(&f.maxTurns, "max-turns", 0, "claude --max-turns limit (0 = unlimited)")
 	flag.StringVar(&f.anthropicBaseURL, "anthropic-base-url", "", "custom Anthropic API base URL (env: ANTHROPIC_BASE_URL)")
 	flag.StringVar(&f.forkOrg, "fork-org", "", "GitHub org the fork skill forks into and files draft advisories against")
+	flag.BoolVar(&f.schemaStrict, "schema-strict", false, "fail scans whose report.json does not validate against the skill's schema (default: warn and continue)")
 	flag.Var(&f.skillLocal, "skills", "directory to load SKILL.md files from (repeatable)")
 	flag.Parse()
 
@@ -137,6 +139,9 @@ func (f *flags) merge(cfg *config.Config) {
 	}
 	if cfg.ForkOrg != "" && !f.set["fork-org"] {
 		f.forkOrg = cfg.ForkOrg
+	}
+	if cfg.SchemaStrict != nil && !f.set["schema-strict"] {
+		f.schemaStrict = *cfg.SchemaStrict
 	}
 
 	if len(cfg.Models) > 0 {
@@ -271,13 +276,14 @@ func run(log *slog.Logger) error {
 	}
 
 	w := &worker.Worker{
-		DB:          gdb,
-		Log:         log,
-		DataDir:     filepath.Join(f.dataDir, "work"),
-		APIBase:     apiBase,
-		ForkOrg:     f.forkOrg,
-		Runner:      runner,
-		ScanTimeout: f.scanTimeout,
+		DB:           gdb,
+		Log:          log,
+		DataDir:      filepath.Join(f.dataDir, "work"),
+		APIBase:      apiBase,
+		ForkOrg:      f.forkOrg,
+		Runner:       runner,
+		ScanTimeout:  f.scanTimeout,
+		SchemaStrict: f.schemaStrict,
 		OnEvent: func(scanID, repoID uint, name, data string) {
 			broker.Publish(web.Event{Name: name, Data: data, ScanID: scanID, RepoID: repoID})
 		},

--- a/docs/development.md
+++ b/docs/development.md
@@ -84,11 +84,11 @@ Scans are claude-code skills on disk. Adding one is a directory drop, no Go chan
 
 2. Write the body: instructions for claude. Reference the skill-facing API when the skill needs context scrutineer already holds (prior scans, maintainers, packages, etc.). See `openapi.yaml` at the repo root.
 
-3. Optional: `scripts/` for bundled helpers, `schema.json` for output validation.
+3. Optional: `scripts/` for bundled helpers, `schema.json` for output validation. The schema is staged into the workspace so the model can read it, and after the run scrutineer validates `report.json` against it. By default a mismatch is logged to the scan transcript and the kind-specific parser still runs; start scrutineer with `-schema-strict` (or `schema_strict: true` in `scrutineer.yaml`) while iterating on a skill to turn that into a scan failure with the validator output in `Scan.Error`.
 
 4. Restart scrutineer; the skill loader picks it up on startup. No code change.
 
-When a scan runs, the worker stages the skill into `work/{scanID}/.claude/skills/{name}/`, writes a `context.json` with the repo identity plus `scrutineer.api_base` and `scrutineer.token`, and invokes `claude -p "Use the {name} skill..."`. The skill's output goes to `./report.json` (or whatever `output_file` names) and scrutineer's parser for the declared `output_kind` handles it.
+When a scan runs, the worker stages the skill into `work/{scanID}/.claude/skills/{name}/`, writes a `context.json` with the repo identity plus `scrutineer.api_base` and `scrutineer.token`, and invokes `claude -p "Use the {name} skill..."`. The skill's output goes to `./report.json` (or whatever `output_file` names), is validated against `schema.json` if one is present, and scrutineer's parser for the declared `output_kind` handles it.
 
 ### When you do need Go changes
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -58,6 +58,11 @@ type Config struct {
 	// repositories into and files draft advisories against. Empty disables
 	// the fork skill (it will refuse to run without a target org).
 	ForkOrg string `yaml:"fork_org"`
+	// SchemaStrict makes a skill report that fails JSON-schema validation
+	// fail the scan. When false (the default) the validator output is
+	// emitted to the scan log and the kind-specific parser still runs.
+	// Intended as a development aid while iterating on a skill.
+	SchemaStrict *bool `yaml:"schema_strict"`
 }
 
 // ParseScanTimeout validates and parses a scan_timeout string. Empty

--- a/internal/worker/schema_bundled_test.go
+++ b/internal/worker/schema_bundled_test.go
@@ -1,0 +1,96 @@
+package worker
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestBundledSchemas_compileAndAcceptSamples checks that the three schemas
+// added for #182 compile and accept a representative report. repo-overview
+// and sbom samples are external-tool output so the schemas are intentionally
+// loose; the point is catching a typo in the schema, not proving CycloneDX
+// conformance.
+func TestBundledSchemas_compileAndAcceptSamples(t *testing.T) {
+	cases := []struct {
+		schema string
+		report string
+	}{
+		{
+			"../../skills/triage/schema.json",
+			`{"has_code":true,"has_packages":true,
+			  "brief":{"languages":["Go"],"package_managers":["Go Modules"]},
+			  "triggered":["packages","advisories","security-deep-dive"],
+			  "skipped":["semgrep"],"gated":[],"already_done":["metadata"],
+			  "verify":[12,34],"errors":[]}`,
+		},
+		{
+			"../../skills/triage/schema.json",
+			`{"error":"context.json missing scrutineer block"}`,
+		},
+		{
+			"../../skills/repo-overview/schema.json",
+			`{"version":"dev","path":"/x",
+			  "languages":[{"name":"Go","category":"language"}],
+			  "package_managers":[{"name":"Go Modules"}],
+			  "git":{"branch":"main","default_branch":"main"},
+			  "resources":{"license_type":"MIT","readme":"README.md"},
+			  "tools":{},"lines":{"total_files":1},"dependencies":[],
+			  "stats":{"duration_ms":1.2},"unknown_future_key":42}`,
+		},
+		{
+			"../../skills/repo-overview/schema.json",
+			`{"error":"scan_subpath not found: pkg/x"}`,
+		},
+		{
+			"../../skills/sbom/schema.json",
+			`{"bomFormat":"CycloneDX","specVersion":"1.5","version":1,
+			  "metadata":{"timestamp":"2026-01-01T00:00:00Z"},
+			  "components":[{"type":"library","name":"left-pad","version":"1.0.0",
+			    "purl":"pkg:npm/left-pad@1.0.0","bom-ref":"a"}],
+			  "dependencies":[]}`,
+		},
+		{
+			"../../skills/sbom/schema.json",
+			`{"error":"git-pkgs: exit 1"}`,
+		},
+	}
+	for _, tc := range cases {
+		schema, err := os.ReadFile(tc.schema)
+		if err != nil {
+			t.Fatalf("read %s: %v", tc.schema, err)
+		}
+		if got := validateReportSchema(string(schema), tc.report); got != "" {
+			t.Errorf("%s rejected sample: %s\nreport: %s", tc.schema, got, tc.report)
+		}
+	}
+}
+
+func TestBundledSchemas_rejectBadShapes(t *testing.T) {
+	cases := []struct {
+		schema string
+		report string
+		want   string
+	}{
+		{"../../skills/triage/schema.json", `{"triggered":"not-a-list"}`, "/triggered"},
+		{"../../skills/triage/schema.json", `{"triggered":["Bad Name"]}`, "/triggered/0"},
+		{"../../skills/repo-overview/schema.json", `{"languages":"go"}`, "/languages"},
+		{"../../skills/sbom/schema.json", `{"bomFormat":"SPDX","specVersion":"1.5"}`, "/bomFormat"},
+		{"../../skills/sbom/schema.json", `{"specVersion":"1.5"}`, "bomFormat"},
+		{"../../skills/sbom/schema.json", `{}`, "oneOf"},
+	}
+	for _, tc := range cases {
+		schema, err := os.ReadFile(tc.schema)
+		if err != nil {
+			t.Fatalf("read %s: %v", tc.schema, err)
+		}
+		got := validateReportSchema(string(schema), tc.report)
+		if got == "" {
+			t.Errorf("%s accepted bad report %s", tc.schema, tc.report)
+			continue
+		}
+		if !strings.Contains(got, tc.want) {
+			t.Errorf("%s: error %q does not mention %q", tc.schema, got, tc.want)
+		}
+	}
+}

--- a/internal/worker/schema_validate.go
+++ b/internal/worker/schema_validate.go
@@ -1,0 +1,85 @@
+package worker
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/santhosh-tekuri/jsonschema/v6"
+)
+
+// SchemaValidationError carries the formatted validator output for a report
+// that did not match its skill's schema. wrap() treats it like
+// FailOnThresholdError: the scan is marked failed but Scan.Report is kept so
+// the operator can inspect what was produced.
+type SchemaValidationError struct {
+	Skill  string
+	Detail string
+}
+
+func (e *SchemaValidationError) Error() string {
+	return fmt.Sprintf("report.json failed schema validation for skill %q: %s", e.Skill, e.Detail)
+}
+
+const maxSchemaErrors = 8
+
+// validateReportSchema compiles schemaJSON and validates report against it.
+// Returns "" when valid, otherwise a one-line-per-failure summary capped at
+// maxSchemaErrors. A schema that does not compile, or a report that is not
+// JSON, returns a single line saying so; both are treated as validation
+// failures rather than scan errors so a malformed schema cannot fail every
+// scan in strict mode.
+func validateReportSchema(schemaJSON, report string) string {
+	c := jsonschema.NewCompiler()
+	doc, err := jsonschema.UnmarshalJSON(strings.NewReader(schemaJSON))
+	if err != nil {
+		return "schema.json is not valid JSON: " + err.Error()
+	}
+	if err := c.AddResource("schema.json", doc); err != nil {
+		return "schema.json could not be loaded: " + err.Error()
+	}
+	sch, err := c.Compile("schema.json")
+	if err != nil {
+		return "schema.json could not be compiled: " + err.Error()
+	}
+
+	inst, err := jsonschema.UnmarshalJSON(strings.NewReader(report))
+	if err != nil {
+		return "report.json is not valid JSON: " + err.Error()
+	}
+	verr := sch.Validate(inst)
+	if verr == nil {
+		return ""
+	}
+	ve, ok := verr.(*jsonschema.ValidationError)
+	if !ok {
+		return verr.Error()
+	}
+	return formatValidationError(ve)
+}
+
+// formatValidationError flattens a jsonschema validation error into one line
+// per leaf failure as "/json/pointer: message". The library's BasicOutput
+// already produces a flat list; we just trim it to something readable in a
+// scan log.
+func formatValidationError(ve *jsonschema.ValidationError) string {
+	out := ve.BasicOutput()
+	var lines []string
+	for _, u := range out.Errors {
+		if u.Error == nil {
+			continue
+		}
+		loc := u.InstanceLocation
+		if loc == "" {
+			loc = "/"
+		}
+		lines = append(lines, loc+": "+u.Error.String())
+		if len(lines) >= maxSchemaErrors {
+			lines = append(lines, fmt.Sprintf("... (%d more)", len(out.Errors)-maxSchemaErrors))
+			break
+		}
+	}
+	if len(lines) == 0 {
+		return ve.Error()
+	}
+	return strings.Join(lines, "\n")
+}

--- a/internal/worker/schema_validate_test.go
+++ b/internal/worker/schema_validate_test.go
@@ -1,0 +1,232 @@
+package worker
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"scrutineer/internal/db"
+	"scrutineer/internal/queue"
+)
+
+const testSchema = `{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["tier"],
+  "additionalProperties": false,
+  "properties": {
+    "tier":    {"type": "string", "enum": ["ready", "partial", "unprepared"]},
+    "summary": {"type": "string"}
+  }
+}`
+
+func TestValidateReportSchema_valid(t *testing.T) {
+	got := validateReportSchema(testSchema, `{"tier":"ready","summary":"ok"}`)
+	if got != "" {
+		t.Errorf("expected no validation error, got %q", got)
+	}
+}
+
+func TestValidateReportSchema_failures(t *testing.T) {
+	tests := []struct {
+		name   string
+		report string
+		want   string
+	}{
+		{"wrong type", `{"tier":{"x":1}}`, "/tier"},
+		{"missing required", `{"summary":"x"}`, "tier"},
+		{"bad enum", `{"tier":"great"}`, "/tier"},
+		{"extra prop", `{"tier":"ready","extra":1}`, "additional"},
+		{"not json", `not json`, "report.json is not valid JSON"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := validateReportSchema(testSchema, tc.report)
+			if got == "" {
+				t.Fatalf("expected validation failure, got none")
+			}
+			if !strings.Contains(got, tc.want) {
+				t.Errorf("output %q does not mention %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestValidateReportSchema_malformedSchema(t *testing.T) {
+	if got := validateReportSchema(`not json`, `{}`); !strings.Contains(got, "schema.json is not valid JSON") {
+		t.Errorf("got %q", got)
+	}
+	if got := validateReportSchema(`{"type":42}`, `{}`); !strings.Contains(got, "schema.json could not be compiled") {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestValidateReportSchema_capsErrorCount(t *testing.T) {
+	schema := `{"type":"object","properties":{
+		"a":{"type":"string"},"b":{"type":"string"},"c":{"type":"string"},
+		"d":{"type":"string"},"e":{"type":"string"},"f":{"type":"string"},
+		"g":{"type":"string"},"h":{"type":"string"},"i":{"type":"string"},
+		"j":{"type":"string"}}}`
+	report := `{"a":1,"b":1,"c":1,"d":1,"e":1,"f":1,"g":1,"h":1,"i":1,"j":1}`
+	got := validateReportSchema(schema, report)
+	lines := strings.Count(got, "\n") + 1
+	if lines > maxSchemaErrors+1 {
+		t.Errorf("output has %d lines, want at most %d (cap + ellipsis): %q", lines, maxSchemaErrors+1, got)
+	}
+	if !strings.Contains(got, "more)") {
+		t.Errorf("expected ellipsis line, got %q", got)
+	}
+}
+
+func newSchemaTestWorker(t *testing.T, strict bool) (*Worker, *db.Skill, *db.Scan) {
+	t.Helper()
+	gdb, err := db.Open(filepath.Join(t.TempDir(), "p.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo := db.Repository{URL: "https://example.com/x", Name: "x"}
+	gdb.Create(&repo)
+	skill := db.Skill{
+		Name: "posture-test", Description: "d", Body: "b",
+		OutputFile: "report.json", OutputKind: "posture",
+		SchemaJSON: testSchema, Version: 1, Active: true, Source: "ui",
+	}
+	gdb.Create(&skill)
+	scan := db.Scan{RepositoryID: repo.ID, Kind: JobSkill, Status: db.ScanRunning, SkillID: &skill.ID}
+	gdb.Create(&scan)
+	w := &Worker{
+		DB: gdb, Log: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		DataDir: t.TempDir(), SchemaStrict: strict,
+	}
+	return w, &skill, &scan
+}
+
+func TestParseSkillOutput_schemaWarnAndContinue(t *testing.T) {
+	w, skill, scan := newSchemaTestWorker(t, false)
+
+	// "extra" violates additionalProperties:false so schema fails, but the
+	// posture parser only decodes tier+summary and ignores unknown keys.
+	report := `{"tier":"ready","summary":"ok","extra":1}`
+	var events []Event
+	err := w.parseSkillOutput(skill, scan, report, func(e Event) { events = append(events, e) })
+	if err != nil {
+		t.Fatalf("warn mode should not return error: %v", err)
+	}
+
+	var sawSchemaErr, sawParserSuccess bool
+	for _, e := range events {
+		if e.Kind == KindError && strings.Contains(e.Text, "schema:") {
+			sawSchemaErr = true
+		}
+		if strings.Contains(e.Text, "posture: ready") {
+			sawParserSuccess = true
+		}
+	}
+	if !sawSchemaErr {
+		t.Error("expected schema error event in log")
+	}
+	if !sawParserSuccess {
+		t.Error("expected posture parser to run after schema warning")
+	}
+
+	var repo db.Repository
+	w.DB.First(&repo, scan.RepositoryID)
+	if repo.Posture != "ready" {
+		t.Errorf("repo.Posture = %q, want ready (parser should have run)", repo.Posture)
+	}
+}
+
+func TestParseSkillOutput_schemaStrictFails(t *testing.T) {
+	w, skill, scan := newSchemaTestWorker(t, true)
+
+	report := `{"tier":{"x":1}}`
+	var events []Event
+	err := w.parseSkillOutput(skill, scan, report, func(e Event) { events = append(events, e) })
+
+	var sve *SchemaValidationError
+	if !errors.As(err, &sve) {
+		t.Fatalf("expected *SchemaValidationError, got %T: %v", err, err)
+	}
+	if sve.Skill != "posture-test" {
+		t.Errorf("Skill = %q, want posture-test", sve.Skill)
+	}
+	if !strings.Contains(sve.Detail, "/tier") {
+		t.Errorf("Detail = %q, want mention of /tier", sve.Detail)
+	}
+
+	var repo db.Repository
+	w.DB.First(&repo, scan.RepositoryID)
+	if repo.Posture != "" {
+		t.Errorf("repo.Posture = %q, want empty (parser should not have run)", repo.Posture)
+	}
+}
+
+func TestParseSkillOutput_schemaStrictPassesThrough(t *testing.T) {
+	w, skill, scan := newSchemaTestWorker(t, true)
+
+	report := `{"tier":"partial","summary":"ok"}`
+	if err := w.parseSkillOutput(skill, scan, report, func(Event) {}); err != nil {
+		t.Fatalf("valid report should not error in strict mode: %v", err)
+	}
+	var repo db.Repository
+	w.DB.First(&repo, scan.RepositoryID)
+	if repo.Posture != "partial" {
+		t.Errorf("repo.Posture = %q, want partial", repo.Posture)
+	}
+}
+
+func TestWrap_schemaStrictKeepsReportOnFailure(t *testing.T) {
+	gdb, err := db.Open(filepath.Join(t.TempDir(), "p.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo := db.Repository{URL: "https://example.com/x", Name: "x"}
+	gdb.Create(&repo)
+	skill := db.Skill{
+		Name: "posture-test", Description: "d", Body: "b",
+		OutputFile: "report.json", OutputKind: "posture",
+		SchemaJSON: testSchema, Version: 1, Active: true, Source: "ui",
+	}
+	gdb.Create(&skill)
+	scan := db.Scan{RepositoryID: repo.ID, Kind: JobSkill, Status: db.ScanQueued,
+		SkillID: &skill.ID, Model: "fake"}
+	gdb.Create(&scan)
+
+	report := `{"tier":{"x":1}}`
+	w := &Worker{
+		DB: gdb, Log: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		DataDir:      t.TempDir(),
+		SchemaStrict: true,
+		Runner:       fakeRunner{skillRes: SkillResult{Commit: "abc", Report: report}},
+	}
+	body, _ := json.Marshal(queue.Payload{ScanID: scan.ID})
+	if err := w.wrap(w.doSkill)(context.Background(), body); err != nil {
+		t.Fatalf("wrap should save and return nil, got %v", err)
+	}
+
+	var got db.Scan
+	gdb.First(&got, scan.ID)
+	if got.Status != db.ScanFailed {
+		t.Errorf("Status = %s, want failed", got.Status)
+	}
+	if got.Report != report {
+		t.Errorf("Report = %q, want preserved %q", got.Report, report)
+	}
+	if !strings.Contains(got.Error, "schema validation") {
+		t.Errorf("Error = %q, want mention of schema validation", got.Error)
+	}
+}
+
+func TestParseSkillOutput_noSchemaSkipsValidation(t *testing.T) {
+	w, skill, scan := newSchemaTestWorker(t, true)
+	skill.SchemaJSON = ""
+
+	if err := w.parseSkillOutput(skill, scan, `{"tier":"ready"}`, func(Event) {}); err != nil {
+		t.Fatalf("no schema should skip validation: %v", err)
+	}
+}

--- a/internal/worker/skill.go
+++ b/internal/worker/skill.go
@@ -133,6 +133,14 @@ func (w *Worker) doSkill(ctx context.Context, scan *db.Scan, emit func(Event)) (
 }
 
 func (w *Worker) parseSkillOutput(skill *db.Skill, scan *db.Scan, report string, emit func(Event)) error {
+	if skill.SchemaJSON != "" {
+		if detail := validateReportSchema(skill.SchemaJSON, report); detail != "" {
+			emit(Event{Kind: KindError, Text: "schema: report.json does not validate against schema.json:\n" + detail})
+			if w.SchemaStrict {
+				return &SchemaValidationError{Skill: skill.Name, Detail: detail}
+			}
+		}
+	}
 	switch skill.OutputKind {
 	case "findings":
 		return w.parseFindingsOutput(skill, scan, report, emit)

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -43,6 +43,10 @@ type Worker struct {
 	Runner      SkillRunner
 	OnEvent     func(scanID, repoID uint, name, data string) // optional SSE bridge
 	ScanTimeout time.Duration
+	// SchemaStrict makes a report.json that fails validation against the
+	// skill's schema.json fail the scan. When false the validator output
+	// is emitted to the log and the kind-specific parser still runs.
+	SchemaStrict bool
 
 	mu      sync.Mutex
 	running map[uint]context.CancelFunc
@@ -166,6 +170,10 @@ func (w *Worker) wrap(h handler) func(context.Context, []byte) error {
 				scan.Report = report
 				scan.Error = err.Error()
 				emit(Event{Kind: KindError, Text: err.Error()})
+			} else if _, ok := errors.AsType[*SchemaValidationError](err); ok {
+				scan.Status = db.ScanFailed
+				scan.Report = report
+				scan.Error = err.Error()
 			} else {
 				scan.Status = db.ScanFailed
 				scan.Error = err.Error()

--- a/scrutineer.sample.yaml
+++ b/scrutineer.sample.yaml
@@ -54,6 +54,12 @@
 # When set, acts as a fallback for skills that don't declare their own cap.
 # max_turns: 0
 
+# Fail a scan when its report.json does not validate against the skill's
+# schema.json. Default (false) emits the validator output to the scan log
+# and the parser still runs. Turn on while iterating on a skill so shape
+# mistakes surface as a scan failure rather than a buried log line.
+# schema_strict: false
+
 # Custom Anthropic API base URL. When set, the hostname is automatically
 # added to the egress allowlist. Falls back to the ANTHROPIC_BASE_URL
 # environment variable when empty.

--- a/skills/repo-overview/schema.json
+++ b/skills/repo-overview/schema.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "repo-overview report",
+  "description": "Output of `brief --json` against ./src (or ./src/{scan_subpath}). Only the fields scrutineer's parser reads are typed strictly; everything else passes through so brief can grow without breaking validation. The error key is for the scan_subpath-not-found bail case.",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "languages": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "name":     { "type": "string" },
+          "category": { "type": "string" }
+        }
+      }
+    },
+    "package_managers": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "name": { "type": "string" }
+        }
+      }
+    },
+    "git": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "default_branch": { "type": "string" }
+      }
+    },
+    "resources": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "license_type": { "type": "string" }
+      }
+    },
+    "tools":        { "type": "object" },
+    "style":        { "type": "object" },
+    "layout":       { "type": "object" },
+    "lines":        { "type": "object" },
+    "dependencies": { "type": "array" },
+    "stats":        { "type": "object" },
+    "version":      { "type": "string" },
+    "path":         { "type": "string" },
+    "error":        { "type": "string" }
+  }
+}

--- a/skills/sbom/schema.json
+++ b/skills/sbom/schema.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "sbom report",
+  "description": "CycloneDX JSON SBOM as produced by `git-pkgs sbom --format json`, or {\"error\": \"...\"} when the script failed. This is a thin sanity check (bomFormat, specVersion, components shape), not the full CycloneDX schema; the document is stored verbatim and consumed by downstream CycloneDX-aware tooling, not by scrutineer's own parsers.",
+  "type": "object",
+  "oneOf": [
+    { "required": ["bomFormat", "specVersion"] },
+    { "required": ["error"] }
+  ],
+  "additionalProperties": true,
+  "properties": {
+    "bomFormat":   { "type": "string", "const": "CycloneDX" },
+    "specVersion": { "type": "string", "pattern": "^1\\.[0-9]+$" },
+    "serialNumber": { "type": "string" },
+    "version":     { "type": "integer", "minimum": 1 },
+    "metadata":    { "type": "object" },
+    "components": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": ["type", "name"],
+        "properties": {
+          "type":    { "type": "string" },
+          "name":    { "type": "string" },
+          "version": { "type": "string" },
+          "purl":    { "type": "string" },
+          "bom-ref": { "type": "string" }
+        }
+      }
+    },
+    "dependencies": { "type": "array" },
+    "error":        { "type": "string" }
+  }
+}

--- a/skills/triage/schema.json
+++ b/skills/triage/schema.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "triage report",
+  "description": "Record of which downstream skills triage enqueued, skipped, gated, or found already done. The error key is for the bail case (missing context.json scrutineer block); when set the other fields may be absent.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "has_code":     { "type": "boolean" },
+    "has_packages": { "type": "boolean" },
+    "brief": {
+      "type": "object",
+      "description": "Subset of brief --json the gates were derived from.",
+      "additionalProperties": true,
+      "properties": {
+        "languages":        { "type": "array", "items": { "type": "string" } },
+        "package_managers": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "triggered":    { "$ref": "#/$defs/skill_list" },
+    "skipped":      { "$ref": "#/$defs/skill_list" },
+    "gated":        { "$ref": "#/$defs/skill_list" },
+    "already_done": { "$ref": "#/$defs/skill_list" },
+    "verify": {
+      "type": "array",
+      "items": { "type": "integer", "minimum": 1 },
+      "description": "Finding ids that had a verify run enqueued."
+    },
+    "errors": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Per-skill enqueue failures that did not stop the run."
+    },
+    "error": {
+      "type": "string",
+      "description": "Set when triage refused to run (missing scrutineer block in context.json). Other fields may be absent."
+    }
+  },
+  "$defs": {
+    "skill_list": {
+      "type": "array",
+      "items": { "type": "string", "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$" }
+    }
+  }
+}


### PR DESCRIPTION
Fixes #175. Fixes #182.

When a skill declares a `schema.json`, scrutineer stages it into the workspace and the prompt tells the model the report must validate against it, but nothing on the server side ever checked. A shape mismatch surfaced as a Go decode error from the kind-specific parser, which is what made #172 hard to read.

`validateReportSchema` in `internal/worker/schema_validate.go` compiles the skill's schema with `jsonschema/v6` (already a dep via the CSAF exporter) and validates the report. The output is flattened from `BasicOutput()` into one `"/json/pointer: message"` line per leaf failure, capped at eight. A schema that does not compile, or a report that is not JSON, becomes a single-line message rather than a hard error so a malformed `schema.json` cannot fail every run.

`parseSkillOutput` runs the validator before the kind dispatch when `skill.SchemaJSON` is non-empty. By default a mismatch is emitted to the scan log as a `KindError` line and the parser still runs, so anything that passed before still passes. With `-schema-strict` (or `schema_strict: true` in `scrutineer.yaml`) it returns a `*SchemaValidationError`, and `wrap()` handles that the same way as `*FailOnThresholdError`: scan marked failed, `Scan.Error` carries the validator output, `Scan.Report` is kept so the operator can see what was produced. The strict knob is meant for iterating on a skill, not for production.

Also adds `schema.json` to the three bundled skills that did not have one (`triage`, `repo-overview`, `sbom`). `triage` is strict (`additionalProperties: false`) since the shape is ours; `repo-overview` and `sbom` wrap `brief` and `git-pkgs` output respectively so they are loose and only type the fields scrutineer's parser reads, so the upstream tools can grow without tripping validation. All three accept the `{"error": "..."}` bail case their SKILL.md describes. Checked against live `brief --json` output and stored CycloneDX reports.

Documented in the README flags table, `docs/development.md` skill-authoring section, `scrutineer.sample.yaml`, and the flag's help text.