### PR TITLE
runner: disable claude-code telemetry and error reporting

### DIFF
--- a/cmd/scrutineer/main.go
+++ b/cmd/scrutineer/main.go
@@ -175,11 +175,13 @@ func run(log *slog.Logger) error {
 	}
 
 	// Suppress claude-code's telemetry, error reporting, auto-updater and
-	// feedback command. The docker runner sets this on the container too;
-	// setting it here covers the local runner, which inherits host env. The
-	// egress proxy already blocks the DataDog log-intake host this would
-	// reach, so without this the operator just sees denied-CONNECT noise.
+	// feedback command, and semgrep's metrics POST. The docker runner sets
+	// these on the container too; setting them here covers the local
+	// runner, which inherits host env. The egress proxy already blocks the
+	// hosts these reach (DataDog log-intake, metrics.semgrep.dev) so
+	// without this the operator just sees denied-CONNECT noise.
 	_ = os.Setenv("CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC", "1")
+	_ = os.Setenv("SEMGREP_SEND_METRICS", "off")
 
 	if f.anthropicBaseURL == "" {
 		f.anthropicBaseURL = os.Getenv("ANTHROPIC_BASE_URL")

--- a/cmd/scrutineer/main.go
+++ b/cmd/scrutineer/main.go
@@ -174,6 +174,13 @@ func run(log *slog.Logger) error {
 		log.Warn("ANTHROPIC_API_KEY looks like an OAuth token from `claude setup-token`; set it as CLAUDE_CODE_OAUTH_TOKEN instead")
 	}
 
+	// Suppress claude-code's telemetry, error reporting, auto-updater and
+	// feedback command. The docker runner sets this on the container too;
+	// setting it here covers the local runner, which inherits host env. The
+	// egress proxy already blocks the DataDog log-intake host this would
+	// reach, so without this the operator just sees denied-CONNECT noise.
+	_ = os.Setenv("CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC", "1")
+
 	if f.anthropicBaseURL == "" {
 		f.anthropicBaseURL = os.Getenv("ANTHROPIC_BASE_URL")
 	}

--- a/internal/worker/docker.go
+++ b/internal/worker/docker.go
@@ -69,6 +69,7 @@ func (d DockerRunner) RunSkill(ctx context.Context, sj SkillJob, emit func(Event
 		"--user", fmt.Sprintf("%d:%d", os.Getuid(), os.Getgid()),
 		"-e", "HOME=/tmp",
 		"-e", "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1",
+		"-e", "SEMGREP_SEND_METRICS=off",
 		"--tmpfs", "/tmp:rw,noexec,nosuid,size=256m",
 		"-v", absWork + ":/work",
 		"-w", "/work",

--- a/internal/worker/docker.go
+++ b/internal/worker/docker.go
@@ -68,6 +68,7 @@ func (d DockerRunner) RunSkill(ctx context.Context, sj SkillJob, emit func(Event
 		"--cap-drop", "ALL",
 		"--user", fmt.Sprintf("%d:%d", os.Getuid(), os.Getgid()),
 		"-e", "HOME=/tmp",
+		"-e", "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1",
 		"--tmpfs", "/tmp:rw,noexec,nosuid,size=256m",
 		"-v", absWork + ":/work",
 		"-w", "/work",


### PR DESCRIPTION
A user running the docker runner reported repeated `level=WARN msg="egress denied" method=CONNECT host=http-intake.logs.us5.datadoghq.com` lines, and later the same for `metrics.semgrep.dev`. The egress proxy is correctly blocking both so nothing leaves the box, but the warnings are noise.

Set `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1` and `SEMGREP_SEND_METRICS=off` on the `docker run` invocation in `internal/worker/docker.go`, and via `os.Setenv` in `cmd/scrutineer/main.go` so the local runner (which inherits host env) gets them too. The claude-code variable is the umbrella for `DISABLE_ERROR_REPORTING`, `DISABLE_TELEMETRY`, `DISABLE_AUTOUPDATER`, and `DISABLE_FEEDBACK_COMMAND`; the DataDog traffic is the error-reporting one specifically. Semgrep's rule fetching from `semgrep.dev` is unaffected and stays on the allowlist.

The other runner tools (`zizmor`, `git-pkgs`, `brief`) have no telemetry; zizmor's only outbound is the GitHub API for remote-workflow audits, which is intentional and allowlisted.