### PR TITLE
skills/zizmor: handle full exit code range and 0-indexed rows

### DIFF
--- a/skills/zizmor/scripts/scan.py
+++ b/skills/zizmor/scripts/scan.py
@@ -29,13 +29,12 @@ def main():
         return
 
     proc = subprocess.run(
-        ["zizmor", "--format", "json", ".github/workflows"],
+        ["zizmor", "--no-exit-codes", "--format", "json", ".github/workflows"],
         cwd="./src",
         capture_output=True,
         text=True,
     )
-    # zizmor exits non-zero when it has findings; that's not a failure.
-    if proc.returncode not in (0, 14):
+    if proc.returncode != 0:
         print(json.dumps({"findings": [], "error": proc.stderr.strip()[:2000]}))
         return
 
@@ -57,8 +56,8 @@ def main():
             sym = locations[0].get("symbolic") or {}
             key = sym.get("key") or {}
             path = key.get("local", {}).get("given_path") or key.get("Local", {}).get("given_path") or "workflow"
-            line = locations[0].get("concrete", {}).get("location", {}).get("start_point", {}).get("row")
-            loc = f"{path}:{line}" if line else path
+            row = locations[0].get("concrete", {}).get("location", {}).get("start_point", {}).get("row")
+            loc = f"{path}:{row + 1}" if row is not None else path
         findings.append({
             "id": f"F{i}",
             "title": r.get("ident") or r.get("desc") or "zizmor finding",


### PR DESCRIPTION
zizmor encodes the highest finding severity in its exit code (10 through 14), but `scan.py` only accepted 0 or 14. Any repo whose worst finding was below High, for example uriparser which tops out at Medium and exits 13, was treated as a tool error and reported zero findings.

Switched to `--no-exit-codes` so zizmor returns 0 whenever it runs cleanly and non-zero only on real failures, which lets the returncode check become a plain `!= 0`.

Also fixed location line numbers. zizmor's `start_point.row` is 0-indexed, so reported locations were one line early. Changed the truthiness check to `is not None` at the same time so a finding on row 0 still gets a line number.