### PR TITLE
build: bump go to 1.26.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.2-alpine@sha256:f85330846cde1e57ca9ec309382da3b8e6ae3ab943d2739500e08c86393a21b1 AS build
+FROM golang:1.26.3-alpine@sha256:91eda9776261207ea25fd06b5b7fed8d397dd2c0a283e77f2ab6e91bfa71079d AS build
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download
@@ -11,7 +11,7 @@ RUN npm install -g @anthropic-ai/claude-code@2.1.119
 FROM python:3.13-alpine@sha256:420cd0bf0f3998275875e02ecd5808168cf0843cbb4d3c536432f729247b2acc AS python-tools
 RUN pip install --no-cache-dir semgrep==1.116.0 "setuptools<81"
 
-FROM golang:1.26.2-alpine@sha256:f85330846cde1e57ca9ec309382da3b8e6ae3ab943d2739500e08c86393a21b1 AS go-tools
+FROM golang:1.26.3-alpine@sha256:91eda9776261207ea25fd06b5b7fed8d397dd2c0a283e77f2ab6e91bfa71079d AS go-tools
 RUN apk add --no-cache git
 RUN GOBIN=/out go install github.com/git-pkgs/git-pkgs@v0.15.3 && \
     GOBIN=/out go install github.com/git-pkgs/brief/cmd/brief@v0.6.0

--- a/Dockerfile.runner
+++ b/Dockerfile.runner
@@ -19,7 +19,7 @@ RUN set -eux; \
     echo "${sha}  /tmp/claude.tgz" | sha256sum -c -; \
     mkdir -p /out && tar -xzf /tmp/claude.tgz -C /out && chmod +x /out/claude
 
-FROM golang:1.26.2-alpine@sha256:f85330846cde1e57ca9ec309382da3b8e6ae3ab943d2739500e08c86393a21b1 AS go-tools
+FROM golang:1.26.3-alpine@sha256:91eda9776261207ea25fd06b5b7fed8d397dd2c0a283e77f2ab6e91bfa71079d AS go-tools
 RUN apk add --no-cache git
 RUN GOBIN=/out go install github.com/git-pkgs/git-pkgs@v0.15.3 && \
     GOBIN=/out go install github.com/git-pkgs/brief/cmd/brief@v0.6.0

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module scrutineer
 
 go 1.26
 
-toolchain go1.26.2
+toolchain go1.26.3
 
 require (
 	github.com/git-pkgs/sbom v0.1.0


### PR DESCRIPTION
Bumps the toolchain in `go.mod` and the `golang:alpine` base images in `Dockerfile` and `Dockerfile.runner` to 1.26.3.

Clears four stdlib advisories `govulncheck` flags on 1.26.2: GO-2026-4982 and GO-2026-4980 (`html/template` XSS, reached via `internal/web/server.go`), GO-2026-4971 (`net` NUL-byte panic on Windows, reached via `internal/worker/egress.go`), and GO-2026-4918 (HTTP/2 transport loop, reached via `internal/worker/metadata.go`).

CI reads the version from `go.mod` via `go-version-file` so no workflow changes needed.