### PR TITLE
findings: group same-fingerprint matches and carry full location set

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ When the containerised runner is active (the default when Docker is available), 
 - **SBOM import** -- upload a CycloneDX or SPDX document, resolve each component to a source repository, and queue scans automatically
 - **CNA matching** -- identify the CVE Numbering Authority whose scope covers a repo so disclosures go to the right contact
 - **Reachability analysis** -- trace sinks found in dependencies through application code to see which are actually reachable
-- **Rescan dedup** -- findings carry a content fingerprint so re-running a scan updates existing rows instead of creating duplicates; findings that stop appearing are marked "not seen" with a miss count
+- **Rescan dedup** -- findings carry a content fingerprint so re-running a scan updates existing rows instead of creating duplicates; same-fingerprint hits within one scan collapse to a single finding with a `+N` expandable location list, and findings that stop appearing are marked "not seen" with a miss count
 - **CSAF export** -- download any finding as a schema-validated CSAF 2.0 advisory document
 - **JSONL export** -- stream all findings or scans as line-delimited JSON for ingestion elsewhere
 - **Markdown report export** -- download a single consolidated `report.md` per repository or organisation

--- a/docs/database.md
+++ b/docs/database.md
@@ -118,7 +118,8 @@ One row per vulnerability. Lifecycle columns are mutated through `db.WriteFindin
 | confidence | text | `high`, `medium`, `low`; how certain the audit is. |
 | status | text | Lifecycle state: `new`, `enriched`, `triaged`, `ready`, `reported`, `acknowledged`, `fixed`, `published`, `rejected`, `duplicate`. |
 | cwe | text | e.g. `CWE-352`. Tooltips come from the embedded MITRE catalogue. |
-| location | text | `file:line` or `file:start-end`. |
+| location | text | Primary `file:line` or `file:start-end`. |
+| locations | text | Newline-joined set of every `file:line` that hit the same fingerprint in this scan. `location` is the first; the rest render as a `+N` badge and an expandable list on the finding page. Empty on rows that predate the column until the next rescan. |
 | reachability | text | `reachable`, `harness_only`, `unclear`. `harness_only` is a real bug but not disclosable as a vulnerability on its own. |
 | quality_tier | text | `high` (heap overflow, UAF, type confusion, controllable write, shell/eval injection) or `low` (stack exhaustion, assertion failure, fixed-offset null deref, log injection). |
 | affected | text | Version range, e.g. `>=0.2.0, <=4.0.5`. |

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -341,7 +341,15 @@ type Finding struct {
 	Status     FindingLifecycle `gorm:"index;default:new"`
 	CWE        string
 	Location   string
-	Affected   string // version range
+	// Locations is the newline-joined set of file:line positions for
+	// findings that represent one rule firing many times (#191). The
+	// first entry is duplicated in Location for the fingerprint and the
+	// table-view link; this column carries the full set so the finding
+	// page can list every hit. groupByFingerprint always seeds it with
+	// the primary, so it is non-empty for any finding written through
+	// the parser; rows that predate the column have it empty.
+	Locations string `gorm:"type:text"`
+	Affected  string // version range
 	// Reachability records whether a public entry point in the shipped
 	// artefact reaches the sink with attacker-controlled input
 	// (reachable), only a test driver does (harness_only), or the audit
@@ -400,6 +408,31 @@ func (f Finding) Summary() string {
 		return f.Trace[:i]
 	}
 	return f.Trace
+}
+
+// LocationList splits the Locations column into its file:line entries.
+// Returns nil for single-location findings (Locations empty), so
+// templates can range without an explicit emptiness check.
+func (f Finding) LocationList() []string {
+	if f.Locations == "" {
+		return nil
+	}
+	out := strings.Split(f.Locations, "\n")
+	for i := range out {
+		out[i] = strings.TrimSpace(out[i])
+	}
+	return out
+}
+
+// ExtraLocationCount is the number of grouped match positions beyond the
+// primary one shown in Location. Used by table views to render a "+N"
+// badge without unpacking the full list.
+func (f Finding) ExtraLocationCount() int {
+	n := len(f.LocationList())
+	if n <= 1 {
+		return 0
+	}
+	return n - 1
 }
 
 // FindingLabel is a tag independent of the lifecycle status. A finding can

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -5,6 +5,30 @@ import (
 	"testing"
 )
 
+func TestFindingLocationList(t *testing.T) {
+	var empty Finding
+	if empty.LocationList() != nil || empty.ExtraLocationCount() != 0 {
+		t.Errorf("empty Locations: list=%v extra=%d", empty.LocationList(), empty.ExtraLocationCount())
+	}
+
+	one := Finding{Locations: "a.go:1"}
+	if got := one.LocationList(); len(got) != 1 || got[0] != "a.go:1" {
+		t.Errorf("single: %v", got)
+	}
+	if one.ExtraLocationCount() != 0 {
+		t.Errorf("single ExtraLocationCount = %d, want 0", one.ExtraLocationCount())
+	}
+
+	many := Finding{Locations: "a.go:1\n b.go:2 \nc.go:3"}
+	got := many.LocationList()
+	if len(got) != 3 || got[1] != "b.go:2" {
+		t.Errorf("many: %v (whitespace should be trimmed)", got)
+	}
+	if many.ExtraLocationCount() != 2 {
+		t.Errorf("many ExtraLocationCount = %d, want 2", many.ExtraLocationCount())
+	}
+}
+
 func TestScanTokenHelpers(t *testing.T) {
 	s := Scan{InputTokens: 100, CacheReadTokens: 800, CacheWriteTokens: 100, OutputTokens: 50}
 	if s.TotalInputTokens() != 1000 {

--- a/internal/web/templates/finding_show.html
+++ b/internal/web/templates/finding_show.html
@@ -40,6 +40,23 @@
       {{if $u}}<a href="{{$u}}" target="_blank" rel="noopener" class="underline underline-offset-2">
         <code>{{$f.Location}}</code></a>
       {{else}}<code>{{$f.Location}}</code>{{end}}
+      {{if $f.ExtraLocationCount}}
+      <details class="mt-2">
+        <summary class="cursor-pointer text-muted-foreground">
+          {{$f.ExtraLocationCount}} more location{{if ne $f.ExtraLocationCount 1}}s{{end}}
+        </summary>
+        <ul class="mt-1 space-y-0.5">
+          {{range $i, $loc := $f.LocationList}}{{if $i}}
+          <li>
+            {{$lu := locurl $repo.HTMLURL $scan.Commit $loc}}
+            {{if $lu}}<a href="{{$lu}}" target="_blank" rel="noopener"
+              class="underline underline-offset-2"><code class="text-xs">{{$loc}}</code></a>
+            {{else}}<code class="text-xs">{{$loc}}</code>{{end}}
+          </li>
+          {{end}}{{end}}
+        </ul>
+      </details>
+      {{end}}
     </dd>
   </div>
   <div>

--- a/internal/web/templates/findings.html
+++ b/internal/web/templates/findings.html
@@ -94,7 +94,7 @@
         <td class="text-muted-foreground">
           {{if .CWE}}<span data-tooltip="{{cwename .CWE}}">{{.CWE}}</span>{{end}}
         </td>
-        <td class="whitespace-normal">{{template "loc-link" (dict "HTMLURL" $repo.HTMLURL "Commit" .Commit "Location" .Location)}}</td>
+        <td class="whitespace-normal">{{template "loc-link" (dict "HTMLURL" $repo.HTMLURL "Commit" .Commit "Location" .Location "Extra" .ExtraLocationCount)}}</td>
         <td class="text-muted-foreground">#{{.ScanID}}</td>
       </tr>
     {{end}}

--- a/internal/web/templates/partials.html
+++ b/internal/web/templates/partials.html
@@ -37,6 +37,9 @@
   {{else}}
     <code class="text-xs break-all">{{.Location}}</code>
   {{end}}
+  {{with .Extra}}
+    <span class="ml-1 rounded bg-muted px-1 text-xs text-muted-foreground" title="grouped match positions">+{{.}}</span>
+  {{end}}
 {{end}}
 
 {{define "empty"}}

--- a/internal/web/templates/repo_show.html
+++ b/internal/web/templates/repo_show.html
@@ -161,7 +161,10 @@
               <td>{{template "severity-badge" .Severity}}</td>
               <td class="min-w-0 whitespace-normal"><a href="/findings/{{.ID}}">{{.Title}}</a></td>
               <td>{{template "finding-status" (fstatus .Status)}}</td>
-              <td class="whitespace-normal"><code class="text-xs break-all">{{.Location}}</code></td>
+              <td class="whitespace-normal">
+                <code class="text-xs break-all">{{.Location}}</code>
+                {{with .ExtraLocationCount}}<span class="ml-1 rounded bg-muted px-1 text-xs text-muted-foreground">+{{.}}</span>{{end}}
+              </td>
             </tr>
           {{end}}
           </tbody>
@@ -190,6 +193,7 @@
             </div>
             <p>
               <code class="text-xs">{{.Location}}</code>
+              {{with .ExtraLocationCount}}<span class="ml-1 rounded bg-muted px-1 text-xs text-muted-foreground">+{{.}}</span>{{end}}
               <span class="text-xs text-muted-foreground">&middot; scan <a class="hover:underline" href="/scans/{{.ScanID}}">#{{.ScanID}}</a></span>
             </p>
           </header>

--- a/internal/web/templates/scan_show.html
+++ b/internal/web/templates/scan_show.html
@@ -107,7 +107,7 @@
             <td class="text-muted-foreground">
               {{if .CWE}}<span data-tooltip="{{cwename .CWE}}">{{.CWE}}</span>{{end}}
             </td>
-            <td class="whitespace-normal">{{template "loc-link" (dict "HTMLURL" $.Scan.Repository.HTMLURL "Commit" $.Scan.Commit "Location" .Location)}}</td>
+            <td class="whitespace-normal">{{template "loc-link" (dict "HTMLURL" $.Scan.Repository.HTMLURL "Commit" $.Scan.Commit "Location" .Location "Extra" .ExtraLocationCount)}}</td>
           </tr>
         {{end}}
         </tbody>

--- a/internal/worker/findings.go
+++ b/internal/worker/findings.go
@@ -25,6 +25,7 @@ type scanFinding struct {
 	Confidence   string   `json:"confidence"`
 	CWE          string   `json:"cwe"`
 	Location     string   `json:"location"`
+	Locations    []string `json:"locations"`
 	Affected     string   `json:"affected"`
 	Reachability string   `json:"reachability"`
 	QualityTier  string   `json:"quality_tier"`
@@ -67,6 +68,7 @@ func (r scanReport) toFindings(scanID, repoID uint, commit, subPath string) []db
 			Confidence:   strings.ToLower(f.Confidence),
 			CWE:          f.CWE,
 			Location:     f.Location,
+			Locations:    strings.Join(f.Locations, "\n"),
 			Affected:     f.Affected,
 			Reachability: f.Reachability,
 			QualityTier:  f.QualityTier,

--- a/internal/worker/findings_dedup_test.go
+++ b/internal/worker/findings_dedup_test.go
@@ -231,7 +231,7 @@ func TestParseFindingsOutput_preservesAnalystStatusOnReobservation(t *testing.T)
 	}
 }
 
-func TestParseFindingsOutput_intraScanCollisionCreatesOneRow(t *testing.T) {
+func TestParseFindingsOutput_intraScanCollisionMergesLocations(t *testing.T) {
 	gdb, err := db.Open(filepath.Join(t.TempDir(), "p.db"))
 	if err != nil {
 		t.Fatal(err)
@@ -251,13 +251,99 @@ func TestParseFindingsOutput_intraScanCollisionCreatesOneRow(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	var n int64
-	gdb.Model(&db.Finding{}).Count(&n)
-	if n != 1 {
-		t.Errorf("intra-scan fingerprint collision should yield one row, got %d", n)
+	var rows []db.Finding
+	gdb.Find(&rows)
+	if len(rows) != 1 {
+		t.Fatalf("intra-scan fingerprint collision should yield one row, got %d", len(rows))
 	}
-	if s.FindingsCount != 2 {
-		t.Errorf("scan.FindingsCount should report what the scan found (2), got %d", s.FindingsCount)
+	if s.FindingsCount != 1 {
+		t.Errorf("scan.FindingsCount should report grouped findings (1), got %d", s.FindingsCount)
+	}
+	f := rows[0]
+	if f.Location != "q.go:10" {
+		t.Errorf("primary Location = %q, want first match q.go:10", f.Location)
+	}
+	if f.Locations != "q.go:10\nq.go:20" {
+		t.Errorf("Locations = %q, want both match positions joined", f.Locations)
+	}
+	if f.ExtraLocationCount() != 1 {
+		t.Errorf("ExtraLocationCount = %d, want 1", f.ExtraLocationCount())
+	}
+}
+
+func TestParseFindingsOutput_locationsArrayFromReport(t *testing.T) {
+	gdb, err := db.Open(filepath.Join(t.TempDir(), "p.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo := db.Repository{URL: "https://x/r", Name: "r"}
+	gdb.Create(&repo)
+	w := &Worker{DB: gdb, Log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+
+	report := `{"findings":[{
+		"id":"F1","title":"var-in-href","severity":"Medium","cwe":"CWE-79",
+		"location":"a.html:5",
+		"locations":["a.html:5","a.html:12","b.html:3"]
+	}]}`
+	s := &db.Scan{RepositoryID: repo.ID, Kind: JobSkill, SkillName: "semgrep", Status: db.ScanDone, Commit: "abc"}
+	gdb.Create(s)
+	if err := w.parseFindingsOutput(&db.Skill{}, s, report, func(Event) {}); err != nil {
+		t.Fatal(err)
+	}
+
+	var f db.Finding
+	gdb.First(&f)
+	if f.Locations != "a.html:5\na.html:12\nb.html:3" {
+		t.Errorf("Locations = %q, want array joined and primary deduped", f.Locations)
+	}
+	if got := f.LocationList(); len(got) != 3 || got[2] != "b.html:3" {
+		t.Errorf("LocationList = %v, want 3 entries", got)
+	}
+	if f.ExtraLocationCount() != 2 {
+		t.Errorf("ExtraLocationCount = %d, want 2", f.ExtraLocationCount())
+	}
+}
+
+func TestParseFindingsOutput_rescanRefreshesLocations(t *testing.T) {
+	gdb, err := db.Open(filepath.Join(t.TempDir(), "p.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo := db.Repository{URL: "https://x/r", Name: "r"}
+	gdb.Create(&repo)
+	w := &Worker{DB: gdb, Log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	emit := func(Event) {}
+
+	mkScan := func(commit string) *db.Scan {
+		s := &db.Scan{RepositoryID: repo.ID, Kind: JobSkill, SkillName: "semgrep",
+			Status: db.ScanDone, Commit: commit}
+		gdb.Create(s)
+		return s
+	}
+
+	report1 := `{"findings":[{"id":"F1","title":"x","severity":"Low","cwe":"CWE-79",
+		"location":"a.html:5","locations":["a.html:5","a.html:12","a.html:30"]}]}`
+	if err := w.parseFindingsOutput(&db.Skill{}, mkScan("abc"), report1, emit); err != nil {
+		t.Fatal(err)
+	}
+
+	// Upstream fixes one occurrence and shifts another; rescan reports two.
+	report2 := `{"findings":[{"id":"F1","title":"x","severity":"Low","cwe":"CWE-79",
+		"location":"a.html:7","locations":["a.html:7","a.html:30"]}]}`
+	if err := w.parseFindingsOutput(&db.Skill{}, mkScan("def"), report2, emit); err != nil {
+		t.Fatal(err)
+	}
+
+	var f db.Finding
+	gdb.First(&f)
+	if f.Location != "a.html:7" {
+		t.Errorf("rescan should refresh primary location: %q", f.Location)
+	}
+	if f.Locations != "a.html:7\na.html:30" {
+		t.Errorf("rescan should replace location set, not accumulate: %q", f.Locations)
+	}
+	if f.SeenCount != 2 {
+		t.Errorf("SeenCount = %d, want 2", f.SeenCount)
 	}
 }
 

--- a/internal/worker/findings_test.go
+++ b/internal/worker/findings_test.go
@@ -1,6 +1,10 @@
 package worker
 
-import "testing"
+import (
+	"testing"
+
+	"scrutineer/internal/db"
+)
 
 func TestToFindings_carriesReachabilityAndQualityTier(t *testing.T) {
 	raw := []byte(`{
@@ -51,6 +55,61 @@ func TestParseReport_toleratesNonStringTopLevelFields(t *testing.T) {
 	}
 	if r.Findings[0].ID != "F1" || r.Findings[0].Title != "t" {
 		t.Errorf("finding not extracted: %+v", r.Findings[0])
+	}
+}
+
+func TestMergeLocations(t *testing.T) {
+	cases := []struct {
+		base string
+		more []string
+		want string
+	}{
+		{"", []string{"a:1"}, "a:1"},
+		{"a:1", []string{"a:1"}, "a:1"},
+		{"a:1\nb:2", []string{"b:2", "c:3"}, "a:1\nb:2\nc:3"},
+		{"a:1", []string{"", "  ", "a:1\n\nb:2"}, "a:1\nb:2"},
+		{"", []string{"", ""}, ""},
+	}
+	for _, tc := range cases {
+		if got := mergeLocations(tc.base, tc.more...); got != tc.want {
+			t.Errorf("mergeLocations(%q, %v) = %q, want %q", tc.base, tc.more, got, tc.want)
+		}
+	}
+}
+
+func TestGroupByFingerprint(t *testing.T) {
+	in := []db.Finding{
+		{CWE: "CWE-79", Location: "a.html:5", Title: "x"},
+		{CWE: "CWE-79", Location: "a.html:12", Title: "x"},
+		{CWE: "CWE-79", Location: "b.html:3", Title: "x"},
+		{CWE: "CWE-79", Location: "b.html:3", Title: "x"},
+		{CWE: "CWE-89", Location: "a.html:5", Title: "y"},
+	}
+	out := groupByFingerprint(in, "semgrep")
+	if len(out) != 3 {
+		t.Fatalf("got %d groups, want 3 (a.html cwe-79, b.html cwe-79, a.html cwe-89)", len(out))
+	}
+	if out[0].Location != "a.html:5" || out[0].Locations != "a.html:5\na.html:12" {
+		t.Errorf("group 0: loc=%q locs=%q", out[0].Location, out[0].Locations)
+	}
+	if out[1].Location != "b.html:3" || out[1].Locations != "b.html:3" {
+		t.Errorf("group 1: exact duplicate should dedupe to one location, got %q", out[1].Locations)
+	}
+	if out[2].CWE != "CWE-89" {
+		t.Errorf("group 2: different CWE should not merge with group 0")
+	}
+	if out[0].Fingerprint == "" || out[0].Fingerprint == out[1].Fingerprint {
+		t.Error("fingerprints should be set and distinct per group")
+	}
+}
+
+func TestGroupByFingerprint_preservesPreGroupedLocations(t *testing.T) {
+	in := []db.Finding{
+		{CWE: "CWE-79", Location: "a.html:5", Locations: "a.html:5\na.html:12\nb.html:3", Title: "x"},
+	}
+	out := groupByFingerprint(in, "semgrep")
+	if len(out) != 1 || out[0].Locations != "a.html:5\na.html:12\nb.html:3" {
+		t.Errorf("pre-grouped locations should pass through: %q", out[0].Locations)
 	}
 }
 

--- a/internal/worker/skill.go
+++ b/internal/worker/skill.go
@@ -200,6 +200,7 @@ func (w *Worker) parseFindingsOutput(skill *db.Skill, scan *db.Scan, report stri
 		return err
 	}
 	findings := rep.toFindings(scan.ID, scan.RepositoryID, scan.Commit, scan.SubPath)
+	findings = groupByFingerprint(findings, scan.SkillName)
 
 	if skill.MinConfidence != "" {
 		kept := findings[:0]
@@ -223,14 +224,9 @@ func (w *Worker) parseFindingsOutput(skill *db.Skill, scan *db.Scan, report stri
 		if db.SeverityAtLeast(f.Severity, worst) || worst == "" {
 			worst = f.Severity
 		}
-		f.Fingerprint = db.FingerprintFinding(scan.SkillName, f.SubPath, f.CWE, f.Location, f.Title)
 		f.LastSeenScanID = scan.ID
 		f.LastSeenCommit = scan.Commit
 		f.SeenCount = 1
-
-		if seenThisScan[f.Fingerprint] {
-			continue
-		}
 		seenThisScan[f.Fingerprint] = true
 
 		var existing db.Finding
@@ -243,6 +239,8 @@ func (w *Worker) parseFindingsOutput(skill *db.Skill, scan *db.Scan, report stri
 				"seen_count":          existing.SeenCount + 1,
 				"missed_count":        0,
 				"last_missed_scan_id": 0,
+				"location":            f.Location,
+				"locations":           f.Locations,
 			}).Error; uerr != nil {
 				return fmt.Errorf("update finding %d: %w", existing.ID, uerr)
 			}
@@ -271,6 +269,51 @@ func (w *Worker) parseFindingsOutput(skill *db.Skill, scan *db.Scan, report stri
 		return &FailOnThresholdError{Worst: worst, Threshold: skill.FailOn}
 	}
 	return nil
+}
+
+// groupByFingerprint computes each finding's fingerprint and collapses
+// entries that share one into a single finding whose Locations column
+// carries every match position from the group (#191). Skills that
+// emit one finding per match (semgrep, zizmor) hit this path when the
+// same rule fires repeatedly in one file; pre-grouping skills emit
+// distinct fingerprints and pass through unchanged.
+func groupByFingerprint(in []db.Finding, skillName string) []db.Finding {
+	out := make([]db.Finding, 0, len(in))
+	idx := map[string]int{}
+	for _, f := range in {
+		f.Fingerprint = db.FingerprintFinding(skillName, f.SubPath, f.CWE, f.Location, f.Title)
+		if i, ok := idx[f.Fingerprint]; ok {
+			out[i].Locations = mergeLocations(out[i].Locations, f.Location, f.Locations)
+			continue
+		}
+		f.Locations = mergeLocations(f.Locations, f.Location, "")
+		idx[f.Fingerprint] = len(out)
+		out = append(out, f)
+	}
+	return out
+}
+
+// mergeLocations folds extra file:line entries into a newline-joined
+// set, dropping blanks and duplicates while preserving first-seen
+// order so the primary entry stays at the head.
+func mergeLocations(base string, more ...string) string {
+	seen := map[string]bool{}
+	var out []string
+	add := func(s string) {
+		for _, e := range strings.Split(s, "\n") {
+			e = strings.TrimSpace(e)
+			if e == "" || seen[e] {
+				continue
+			}
+			seen[e] = true
+			out = append(out, e)
+		}
+	}
+	add(base)
+	for _, m := range more {
+		add(m)
+	}
+	return strings.Join(out, "\n")
 }
 
 // FailOnThresholdError is returned when a scan's findings include at

--- a/skills/semgrep/schema.json
+++ b/skills/semgrep/schema.json
@@ -18,6 +18,7 @@
           "severity": { "type": "string", "enum": ["Critical", "High", "Medium", "Low"] },
           "cwe":      { "type": "string" },
           "location": { "type": "string" },
+          "locations": { "type": "array", "items": { "type": "string" } },
           "trace":    { "type": "string" },
           "rating":   { "type": "string" },
           "boundary": { "type": "string" },

--- a/skills/semgrep/scripts/scan.py
+++ b/skills/semgrep/scripts/scan.py
@@ -3,11 +3,18 @@
 
 Requires semgrep on PATH. Writes structured JSON to stdout. Stderr carries
 progress and errors.
+
+Results are grouped by (check_id, message): the rule's message template
+interpolates whatever metavars the rule author considered significant, so
+identical messages are the rule author's signal that the matches are
+equivalent. Each group becomes one finding with the full set of file:line
+positions in `locations` (#191).
 """
 import json
 import shutil
 import subprocess
 import sys
+from collections import defaultdict
 
 SEVERITY_MAP = {
     "ERROR": "High",
@@ -48,9 +55,16 @@ def main():
         print(json.dumps({"findings": [], "error": f"semgrep json: {exc}"}))
         sys.exit(0)
 
-    findings = []
-    for i, r in enumerate(data.get("results", []), start=1):
+    groups = defaultdict(list)
+    for r in data.get("results", []):
         extra = r.get("extra") or {}
+        key = (r.get("check_id", "semgrep match"), extra.get("message", "").strip())
+        groups[key].append(r)
+
+    findings = []
+    for i, ((check_id, message), results) in enumerate(groups.items(), start=1):
+        first = results[0]
+        extra = first.get("extra") or {}
         meta = extra.get("metadata") or {}
         cwe = ""
         raw_cwe = meta.get("cwe") or meta.get("cwe_id")
@@ -59,20 +73,28 @@ def main():
         if isinstance(raw_cwe, str) and raw_cwe.startswith("CWE-"):
             cwe = raw_cwe.split()[0]
         severity = SEVERITY_MAP.get(str(extra.get("severity", "")).upper(), "Medium")
-        start = r.get("start") or {}
-        path = r.get("path", "")
-        location = f"{path}:{start.get('line', 0)}" if path else "unknown"
+
+        locations = sorted({result_location(r) for r in results})
+        n = len(locations)
+        suffix = f" ({n} locations)" if n > 1 else ""
         findings.append({
             "id": f"F{i}",
-            "title": r.get("check_id", "semgrep match"),
+            "title": check_id,
             "severity": severity,
             "cwe": cwe,
-            "location": location,
-            "trace": extra.get("message", "").strip(),
-            "rating": f"{severity} from semgrep rule {r.get('check_id', '')}",
+            "location": locations[0],
+            "locations": locations,
+            "trace": message,
+            "rating": f"{severity} from semgrep rule {check_id}{suffix}",
         })
 
     print(json.dumps({"findings": findings}))
+
+
+def result_location(r):
+    path = r.get("path", "")
+    start = r.get("start") or {}
+    return f"{path}:{start.get('line', 0)}" if path else "unknown"
 
 
 if __name__ == "__main__":

--- a/skills/zizmor/schema.json
+++ b/skills/zizmor/schema.json
@@ -17,6 +17,7 @@
           "severity": { "type": "string", "enum": ["Critical", "High", "Medium", "Low"] },
           "cwe":      { "type": "string" },
           "location": { "type": "string" },
+          "locations": { "type": "array", "items": { "type": "string" } },
           "trace":    { "type": "string" },
           "rating":   { "type": "string" }
         }

--- a/skills/zizmor/scripts/scan.py
+++ b/skills/zizmor/scripts/scan.py
@@ -1,12 +1,17 @@
 #!/usr/bin/env python3
 """Run zizmor against ./src/.github/workflows and emit findings in
 scrutineer's shape. Requires zizmor on PATH. Writes JSON to stdout.
+
+Results are grouped by (ident, desc) so the same audit firing on every
+job in a workflow becomes one finding with the full set of file:line
+positions in `locations` (#191).
 """
 import json
 import os
 import shutil
 import subprocess
 import sys
+from collections import defaultdict
 
 SEVERITY_MAP = {
     "unknown": "Low",
@@ -47,27 +52,42 @@ def main():
     if isinstance(data, dict):
         data = data.get("findings", [])
 
+    groups = defaultdict(list)
+    for r in data:
+        key = (r.get("ident") or "zizmor finding", (r.get("desc") or "").strip())
+        groups[key].append(r)
+
     findings = []
-    for i, r in enumerate(data, start=1):
-        severity = SEVERITY_MAP.get(str(r.get("determinations", {}).get("severity", "")).lower(), "Medium")
-        locations = r.get("locations") or []
-        loc = "unknown"
-        if locations:
-            sym = locations[0].get("symbolic") or {}
-            key = sym.get("key") or {}
-            path = key.get("local", {}).get("given_path") or key.get("Local", {}).get("given_path") or "workflow"
-            row = locations[0].get("concrete", {}).get("location", {}).get("start_point", {}).get("row")
-            loc = f"{path}:{row + 1}" if row is not None else path
+    for i, ((ident, desc), results) in enumerate(groups.items(), start=1):
+        first = results[0]
+        severity = SEVERITY_MAP.get(
+            str(first.get("determinations", {}).get("severity", "")).lower(), "Medium"
+        )
+        locations = sorted({result_location(r) for r in results})
+        n = len(locations)
+        suffix = f" ({n} locations)" if n > 1 else ""
         findings.append({
             "id": f"F{i}",
-            "title": r.get("ident") or r.get("desc") or "zizmor finding",
+            "title": ident,
             "severity": severity,
-            "location": loc,
-            "trace": r.get("desc", "").strip(),
-            "rating": f"{severity} from zizmor rule {r.get('ident', '')}",
+            "location": locations[0],
+            "locations": locations,
+            "trace": desc,
+            "rating": f"{severity} from zizmor rule {ident}{suffix}",
         })
 
     print(json.dumps({"findings": findings}))
+
+
+def result_location(r):
+    locations = r.get("locations") or []
+    if not locations:
+        return "unknown"
+    sym = locations[0].get("symbolic") or {}
+    key = sym.get("key") or {}
+    path = key.get("local", {}).get("given_path") or key.get("Local", {}).get("given_path") or "workflow"
+    row = locations[0].get("concrete", {}).get("location", {}).get("start_point", {}).get("row")
+    return f"{path}:{row + 1}" if row is not None else path
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #191.

Adds `db.Finding.Locations` (newline-joined `file:line` set) with `LocationList()` and `ExtraLocationCount()` helpers; GORM AutoMigrate adds the column on startup.

The findings parser now reads an optional `locations[]` array from `report.json`, and the within-scan dedupe is replaced by a `groupByFingerprint` pass that runs before the DB loop: entries that share a fingerprint accumulate their match positions into one row instead of silently dropping all but the first. On re-observation the existing row's `location` and `locations` are refreshed so the set tracks current HEAD.

`semgrep/scripts/scan.py` groups results by `(check_id, message)` and `zizmor/scripts/scan.py` by `(ident, desc)`, each emitting `location` (first sorted) plus the full `locations[]`. The rule's message template interpolates whatever metavars the rule author considered significant, so identical messages are the rule author's signal that the matches are equivalent; different messages stay as separate findings. Both schemas gain the array.

The finding page shows the primary location as before, then a collapsed "N more locations" block with each entry linked through the existing forge-URL helper. Findings, scan, and repo tables show a `+N` badge next to the primary location.

For the issue's example, 102 `var-in-href` hits with one message become one finding with a `+101` badge and an expandable list. The fingerprint function is unchanged so existing rows keep their identity across the upgrade; pre-existing rows have an empty `Locations` column until the next rescan populates it.

Not done here: the AST-normalisation grouping key the issue suggests for splitting same-message matches by metavar context. The `(check_id, message)` key is the practical signature semgrep already gives us; a per-language normaliser can layer on top of the `locations[]` plumbing later.