### PR TITLE
security-deep-dive: check existing mitigations before recommendations

### DIFF
--- a/skills/security-deep-dive/SKILL.md
+++ b/skills/security-deep-dive/SKILL.md
@@ -95,6 +95,8 @@ For agentic sinks, the boundary is crossed when user-controlled content reaches 
 
 If the boundary check rules the sink out — input is internal, or comes from a trusted documented source — write the reason and move to the next sink.
 
+Even where the input is attacker-controlled, check whether the project has already mitigated the danger. The mitigation may live in a centralised handler, a framework default that escapes or binds, a build flag, a sanitiser library, a type-system rule, or a project-wide lint. Grep for it — the directive, the helper, the import, the config line. If the control is in place, rule the sink out at this step and cite the file and line of the existing control in the reason. Do not recommend adding a control the project already has; if the existing one is stricter than what you would have suggested, an analyst applying the advice literally weakens the project. As an example: a template `var-in-href` warning resolves here in a project whose request lifecycle sets `Content-Security-Policy: script-src 'self'`, with the rule-out reason citing that handler.
+
 Even where the input is attacker-controlled, check the precondition does not subsume the conclusion. If reaching the sink requires the attacker to already hold a capability equal to or stronger than what the sink grants — write access to a directory documented as holding executable hooks, MITM position on a connection the finding claims to let them influence — the finding is circular. The attack path's first step already arrives at its last. Write "precondition subsumes conclusion" and move to the next sink.
 
 ### Step 3: Validate


### PR DESCRIPTION
Closes #190.

Step 2's trust-boundary check decides whether a sink is exploitable based on whether the input is attacker-controlled. It does not currently look at whether the project has already mitigated the danger somewhere else. Without that step the model writes recommendations against codebases that have already addressed the issue, ranging from noise to actively misleading advice (a stricter existing control taken at face value gets weakened).

The reporter case in #190: a deep-dive against a Quart application flagged 102 `var-in-href` template sinks and recommended adding a Content Security Policy. The repo already configured a stricter CSP in an `after_request` handler. The recommendation, applied literally, would have removed directives the project already had.

Add an explicit pass between Step 2's rule-out branch and the precondition-subsumes branch: grep the codebase for the relevant control, cite its file and line in the rule-out reason if found, and do not recommend adding what already exists. The wording covers controls across domains (centralised handlers, framework defaults, build flags, sanitiser libraries, type-system rules, project-wide lints), with CSP as one illustrative instantiation rather than the focus.