### PR TITLE
Add a note about using Scrutineer when you have a sandboxed Claude Code config

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,15 +204,13 @@ The config file can also replace the model pick list and pin the default model:
       - name: Opus
         id:   claude-opus-4-7
 
-## Interaction with Claude Code Sandboxing
+## Sandboxed Claude Code configs
 
-If you use [sandboxing for Claude Code](https://code.claude.com/docs/en/sandboxing) and your `~/.claude/settings.json` file enforces it, Scrutineer scans will fail due to network restrictions and other limitations.
-
-You should not disable or remove your sandboxing config globally just to run Scrutineer, you can instead create a separate config file with relaxed restrictions and point Claude at it while using Scrutineer.
-
-Copy your Claude config to another directory, like `~/.claude-scrutineer/settings.json`, and remove the sandbox-related settings from the copied file. Then run Scrutineer with `CLAUDE_CONFIG_DIR` set to the given directory. Scrutineer will then use the relaxed configuration without affecting your normal Claude Code usage:
+In `--no-docker` mode the `claude` subprocess inherits your `~/.claude/settings.json`, so [sandbox settings](https://code.claude.com/docs/en/sandboxing) that restrict network or filesystem access there will fail skills that need them. Point `claude` at a separate config directory just for scrutineer runs:
 
     CLAUDE_CONFIG_DIR=~/.claude-scrutineer go run ./cmd/scrutineer -skills ./skills
+
+Copy your `settings.json` into that directory and drop the sandbox keys; your normal Claude Code config is untouched. Docker mode is not affected: `claude` runs inside the container with its own environment regardless of the host config.
 
 ## Security
 

--- a/README.md
+++ b/README.md
@@ -204,6 +204,16 @@ The config file can also replace the model pick list and pin the default model:
       - name: Opus
         id:   claude-opus-4-7
 
+## Interaction with Claude Code Sandboxing
+
+If you use [sandboxing for Claude Code](https://code.claude.com/docs/en/sandboxing) and your `~/.claude/settings.json` file enforces it, Scrutineer scans will fail due to network restrictions and other limitations.
+
+You should not disable or remove your sandboxing config globally just to run Scrutineer, you can instead create a separate config file with relaxed restrictions and point Claude at it while using Scrutineer.
+
+Copy your Claude config to another directory, like `~/.claude-scrutineer/settings.json`, and remove the sandbox-related settings from the copied file. Then run Scrutineer with `CLAUDE_CONFIG_DIR` set to the given directory. Scrutineer will then use the relaxed configuration without affecting your normal Claude Code usage:
+
+    CLAUDE_CONFIG_DIR=~/.claude-scrutineer go run ./cmd/scrutineer -skills ./skills
+
 ## Security
 
 See [SECURITY.md](SECURITY.md) for the reporting policy and [threatmodel.md](threatmodel.md) for the full threat model. The short version: scanning a repository is equivalent to running code from it. The containerised runner (when available) isolates each scan, but the default bare-metal mode runs everything as your user. Only scan repositories you'd be willing to clone and build locally.


### PR DESCRIPTION
I can put this in another section of the README if there's a specific place we want it, but nothing really stood out to me as fitting.

I should note that we may want to clarify a few things before merging:

- Does Claude Code run within the Docker container when run with Scrutineer, I'm fairly certain it does not?
- Rather than recommending that the user disable sandboxing to use Scrutineer, we would ideally provide a sandbox config that works and allows the necessary ports/commands/filesystem locations for Scrutineer to be run.
Fixes #197.