### PR TITLE
refactor: use `new()` syntax where possible

### DIFF
--- a/cmd/scrutineer/main_test.go
+++ b/cmd/scrutineer/main_test.go
@@ -8,12 +8,11 @@ import (
 )
 
 func fullConfig() *config.Config {
-	yes := true
 	return &config.Config{
 		Addr:             "0.0.0.0:9090",
 		Data:             "/var/lib/scrutineer",
 		Effort:           "medium",
-		NoDocker:         &yes,
+		NoDocker:         new(true),
 		RunnerImage:      "custom:v1",
 		SkillsRepo:       "https://example.com/skills.git",
 		Skills:           []string{"/etc/skills"},

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -732,13 +732,12 @@ func BackfillFindings(gdb *gorm.DB) {
 // startup: a running row with no worker attached means the previous process
 // died mid-job and the UI would otherwise show a spinner forever.
 func SweepRunning(gdb *gorm.DB) error {
-	now := time.Now()
 	return gdb.Model(&Scan{}).
 		Where("status = ?", ScanRunning).
 		Updates(map[string]any{
 			"status":      ScanFailed,
 			"error":       "server restarted during run",
-			"finished_at": &now,
+			"finished_at": new(time.Now()),
 		}).Error
 }
 

--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -256,8 +256,7 @@ func (s *Server) apiRunFindingSkill(w http.ResponseWriter, r *http.Request) {
 		Model string `json:"model"`
 	}
 	_ = json.NewDecoder(r.Body).Decode(&body)
-	fid := uint(id)
-	scanID, err := s.enqueueSkillScoped(r.Context(), repoID, skill.ID, &fid, body.Model)
+	scanID, err := s.enqueueSkillScoped(r.Context(), repoID, skill.ID, new(uint(id)), body.Model)
 	if err != nil {
 		writeAPIError(w, http.StatusInternalServerError, err.Error())
 		return

--- a/internal/web/api_test.go
+++ b/internal/web/api_test.go
@@ -18,14 +18,13 @@ func seedRunningScan(t *testing.T, s *Server) (db.Repository, db.Scan) {
 	t.Helper()
 	repo := db.Repository{URL: "https://example.com/x", Name: "x"}
 	s.DB.Create(&repo)
-	now := time.Now()
 	scan := db.Scan{
 		RepositoryID: repo.ID,
 		Kind:         worker.JobSkill,
 		Status:       db.ScanRunning,
 		Model:        "fake",
 		APIToken:     "tok-" + strconv.FormatUint(uint64(repo.ID), 10),
-		StartedAt:    &now,
+		StartedAt:    new(time.Now()),
 	}
 	s.DB.Create(&scan)
 	return repo, scan

--- a/internal/web/sboms_test.go
+++ b/internal/web/sboms_test.go
@@ -233,8 +233,7 @@ func TestSBOMShow_listsAdvisories(t *testing.T) {
 	s.DB.Create(&repo)
 	s.DB.Create(&db.Advisory{RepositoryID: repo.ID, Title: "CVE-2026-9999 prototype pollution",
 		Severity: "High", CVSSScore: 7.5, URL: "https://osv.dev/CVE-2026-9999"})
-	withdrawn := time.Now()
-	s.DB.Create(&db.Advisory{RepositoryID: repo.ID, Title: "withdrawn-one", WithdrawnAt: &withdrawn})
+	s.DB.Create(&db.Advisory{RepositoryID: repo.ID, Title: "withdrawn-one", WithdrawnAt: new(time.Now())})
 
 	up := db.SBOMUpload{Name: "demo", PackageCount: 1, Packages: []db.SBOMPackage{
 		{Name: "adv-pkg", PURL: "pkg:npm/adv", RepositoryID: &repo.ID},

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -1000,8 +1000,7 @@ func (s *Server) runFindingSkill(w http.ResponseWriter, r *http.Request, name st
 		http.Error(w, name+" skill is not installed", http.StatusPreconditionFailed)
 		return
 	}
-	fid := f.ID
-	scanID, err := s.enqueueSkillScoped(r.Context(), scan.RepositoryID, skill.ID, &fid, r.FormValue("model"))
+	scanID, err := s.enqueueSkillScoped(r.Context(), scan.RepositoryID, skill.ID, new(f.ID), r.FormValue("model"))
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -1670,11 +1669,10 @@ func (s *Server) scanCancel(w http.ResponseWriter, r *http.Request) {
 	}
 	if !s.Worker.Cancel(scan.ID) {
 		// Not in flight: mark the row so the queue handler drops it on pickup.
-		now := time.Now()
 		s.DB.Model(&scan).Updates(map[string]any{
 			"status":      db.ScanCancelled,
 			"error":       "cancelled by user",
-			"finished_at": &now,
+			"finished_at": new(time.Now()),
 		})
 	}
 	s.redirect(w, r, fmt.Sprintf("/scans/%d", scan.ID))

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -1425,14 +1425,12 @@ func TestFindingPatchDownload(t *testing.T) {
 		Status: db.FindingTriaged, SuggestedFix: gatedDiff, SuggestedFixCommit: "abc123"}
 	s.DB.Create(&finding)
 
-	fid := finding.ID
-	finished := time.Now()
 	report := `{"patch":"diff --git a/foo.go b/foo.go\n@@ -1 +1 @@\n-old\n+new\n","rationale":"adds guard","files_changed":["foo.go"],"base_commit":"abc123","tests_added":false}`
 	patchScan := db.Scan{
 		RepositoryID: repo.ID, Kind: "skill", Status: db.ScanDone,
 		SkillName:  "patch",
-		FindingID:  &fid,
-		FinishedAt: &finished,
+		FindingID:  new(finding.ID),
+		FinishedAt: new(time.Now()),
 		Report:     report,
 	}
 	s.DB.Create(&patchScan)
@@ -1822,11 +1820,10 @@ func TestRetry_preservesSubPath(t *testing.T) {
 	s.DB.Create(&repo)
 	skill := db.Skill{Name: "security-deep-dive", Description: "x", Body: "b", Active: true, Source: "ui", Version: 1}
 	s.DB.Create(&skill)
-	finished := time.Now()
 	orig := db.Scan{
 		RepositoryID: repo.ID, Kind: "skill", Status: db.ScanFailed,
 		SkillID: &skill.ID, SkillName: "security-deep-dive",
-		SubPath: "airflow-core", FinishedAt: &finished,
+		SubPath: "airflow-core", FinishedAt: new(time.Now()),
 	}
 	s.DB.Create(&orig)
 
@@ -2165,8 +2162,7 @@ func TestScanCancel_terminalRejected(t *testing.T) {
 
 	repo := db.Repository{URL: "https://example.com/x.git", Name: "x"}
 	s.DB.Create(&repo)
-	fin := time.Now()
-	scan := db.Scan{RepositoryID: repo.ID, Kind: "skill", Status: db.ScanDone, FinishedAt: &fin}
+	scan := db.Scan{RepositoryID: repo.ID, Kind: "skill", Status: db.ScanDone, FinishedAt: new(time.Now())}
 	s.DB.Create(&scan)
 
 	req := httptest.NewRequest("POST", fmt.Sprintf("/scans/%d/cancel", scan.ID), nil)
@@ -2183,8 +2179,7 @@ func TestSubprojectsRenderedOnRepoPage(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()
 
-	now := time.Now()
-	repo := db.Repository{URL: "https://github.com/apache/airflow.git", Name: "airflow", FetchedAt: &now}
+	repo := db.Repository{URL: "https://github.com/apache/airflow.git", Name: "airflow", FetchedAt: new(time.Now())}
 	s.DB.Create(&repo)
 	s.DB.Create(&db.Subproject{RepositoryID: repo.ID, Path: "airflow-core", Name: "airflow-core", Kind: "python-package", Description: "Core runtime"})
 	s.DB.Create(&db.Subproject{RepositoryID: repo.ID, Path: "providers/amazon", Kind: "python-package", Description: "AWS provider"})

--- a/internal/web/usage_test.go
+++ b/internal/web/usage_test.go
@@ -118,8 +118,7 @@ func TestRepoShow_totalCostBadge(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()
 
-	now := time.Now()
-	repo := db.Repository{URL: "https://x/spend", Name: "spend", FetchedAt: &now}
+	repo := db.Repository{URL: "https://x/spend", Name: "spend", FetchedAt: new(time.Now())}
 	s.DB.Create(&repo)
 	s.DB.Create(&db.Scan{RepositoryID: repo.ID, Kind: "skill", SkillName: "a", Status: db.ScanDone, CostUSD: 1.50})
 	s.DB.Create(&db.Scan{RepositoryID: repo.ID, Kind: "skill", SkillName: "b", Status: db.ScanDone, CostUSD: 0.25})

--- a/internal/worker/skill_parsers_test.go
+++ b/internal/worker/skill_parsers_test.go
@@ -239,14 +239,13 @@ func runSkillWithFinding(t *testing.T, outputKind, report string, startStatus db
 	gdb.Create(&finding)
 	skill := db.Skill{Name: "verify", Description: "d", Body: "b", OutputFile: "report.json", OutputKind: outputKind, Version: 1, Active: true, Source: "ui"}
 	gdb.Create(&skill)
-	fid := finding.ID
 	scan := db.Scan{
 		RepositoryID: repo.ID,
 		Kind:         JobSkill,
 		Status:       db.ScanQueued,
 		Model:        "fake",
 		SkillID:      &skill.ID,
-		FindingID:    &fid,
+		FindingID:    new(finding.ID),
 	}
 	gdb.Create(&scan)
 

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -122,10 +122,9 @@ func (w *Worker) wrap(h handler) func(context.Context, []byte) error {
 			w.mu.Unlock()
 		}()
 
-		now := time.Now()
 		scan.Status = db.ScanRunning
 		scan.StatusPriority = db.StatusPriorityFor(db.ScanRunning)
-		scan.StartedAt = &now
+		scan.StartedAt = new(time.Now())
 		scan.Log = ""
 		scan.Error = ""
 		if err := w.DB.Save(&scan).Error; err != nil {
@@ -149,8 +148,7 @@ func (w *Worker) wrap(h handler) func(context.Context, []byte) error {
 
 		report, err := h(ctx, &scan, emit)
 
-		fin := time.Now()
-		scan.FinishedAt = &fin
+		scan.FinishedAt = new(time.Now())
 		switch {
 		case errors.Is(ctx.Err(), context.DeadlineExceeded):
 			scan.Status = db.ScanFailed


### PR DESCRIPTION
Use the new syntax introduced in Go 1.26.