### PR TITLE
feat: implement exposure skill for assessing dependent reachability

### DIFF
--- a/docs/database.md
+++ b/docs/database.md
@@ -48,7 +48,8 @@ One row per skill execution. Every scan is a skill; `kind` is always `skill`. `s
 | skill_id | integer FK | References `skills.id`. Null for legacy non-skill rows. |
 | skill_version | integer | Version of the skill at run time; the skill row's `version` bumps on every edit so older scans stay readable. |
 | skill_name | text | Denormalised skill name for UI display. |
-| finding_id | integer FK | Set when the scan is finding-scoped (verify/patch/disclose). References `findings.id`. |
+| finding_id | integer FK | Set when the scan is finding-scoped (verify/patch/disclose/exposure). References `findings.id`. |
+| dependent_id | integer FK | Set on `exposure` scans only. References `dependents.id`; identifies which downstream consumer the skill is auditing for reachability of the upstream finding. |
 | api_token | text | Per-scan bearer token that the skill presents when calling `/api`. Only valid while the scan is running. |
 | ref | text | Git ref to checkout after cloning. Empty means the default branch. |
 | sub_path | text | Scopes code analysis to a sub-folder of the clone (monorepo packages). Empty means repo root. |
@@ -85,7 +86,7 @@ One row per installed skill. Loaded from `skills/` directories on disk or the UI
 | body | text | Markdown body after the frontmatter. The prompt. |
 | schema_json | text | Optional schema.json contents. |
 | output_file | text | Relative path the skill writes to. Promoted from metadata. |
-| output_kind | text | Parser key: `findings`, `maintainers`, `packages`, `advisories`, `dependents`, `dependencies`, `repo_metadata`, `repo_overview`, `subprojects`, `posture`, `verify`, `patch`, `threat_model`, `freeform`. Promoted from metadata. |
+| output_kind | text | Parser key: `findings`, `maintainers`, `packages`, `advisories`, `dependents`, `dependencies`, `repo_metadata`, `repo_overview`, `subprojects`, `posture`, `verify`, `patch`, `threat_model`, `exposure`, `freeform`. Promoted from metadata. |
 | version | integer | Bumps on every save. |
 | active | boolean | |
 | source | text | `local`, `remote`, or `ui`. |
@@ -269,6 +270,23 @@ Top runtime dependents of this repository's packages. Populated by the `dependen
 | registry_url | text | |
 | latest_version | text | |
 | created_at | datetime | |
+
+## finding_dependents
+
+One row per (finding, dependent) pair the `exposure` skill has audited. Status mirrors the CSAF 2.0 product_status buckets so the VEX export streams the value through unchanged. Upserted on each rerun; the unique index on `(finding_id, dependent_id)` prevents duplicates.
+
+| Column | Type | Notes |
+|--------|------|-------|
+| id | integer PK | |
+| finding_id | integer FK | References `findings.id`. Part of the unique index. |
+| dependent_id | integer FK | References `dependents.id`. Part of the unique index. |
+| status | text | `known_affected`, `known_not_affected`, `under_investigation`, or `fixed`. |
+| justification | text | CSAF VEX flag label. Only valid when status is `known_not_affected`; cleared by the parser otherwise. |
+| rationale | text | One-paragraph explanation written by the skill, rendered in the finding page's per-dependent table. |
+| scan_id | integer FK | Exposure scan that wrote this row. |
+| scan_commit | text | HEAD of the dependent's clone when the verdict was made; lets the operator tell whether a later rescan would still apply. |
+| created_at | datetime | |
+| updated_at | datetime | |
 
 ## advisories
 

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -27,6 +27,7 @@ These ship in `skills/` and are loaded with `-skills ./skills`. The `triage` ski
 | `threat-model` | Derives the project's security contract from source and docs: components, entry-point trust table, claimed and disclaimed properties, and disposition labels. Loaded by `security-deep-dive` so it does not re-derive boundaries per run. |
 | `security-deep-dive` | The model-driven audit. Inventories trust boundaries and sinks, then runs a six-step trace/boundary/validate/prior-art/reach/rate analysis on each. |
 | `reachability` | Traces sinks already found in this app's dependencies through the app's own code to see which are reachable from its trust boundaries. |
+| `exposure` | For one (finding, dependent) pair, decides whether the dependent's published code actually reaches the upstream library finding. Emits one CSAF 2.0 product_status verdict so scrutineer can record affected vs not_affected and stamp the right VEX justification. |
 | `verify` | Re-checks one finding against current HEAD and records reproduces / fixed / cannot-reproduce. |
 | `disclose` | Drafts a GHSA-shaped advisory (title, description, CVSS, CWEs, references) for one finding. |
 | `patch` | Proposes a unified diff fixing one finding, written back as a note for analyst review. |
@@ -105,6 +106,7 @@ metadata:
 | `verify` | Verification result and miss-count update on one Finding. |
 | `patch` | Suggested-fix diff and base commit on one Finding. |
 | `threat_model` | Raw on the scan row; rendered on the repository's Threat Model tab. |
+| `exposure` | One CSAF product_status verdict upserted into a `finding_dependents` row keyed by `(finding_id, dependent_id)`. |
 
 If you need an output shape that is not in this list, see "When you need Go changes" in [development.md](development.md). For most custom skills `freeform` (store the JSON as-is, render it on the scan's Data tab) or `findings` (surface as triaged vulnerabilities) is enough.
 
@@ -142,6 +144,7 @@ then runs `claude -p "Use the {name} skill in this workspace"` with the working 
     "repository_id": 7,
     "skill_id": 3,
     "finding_id": 19,
+    "dependent_id": 11,
     "scan_ref": "release/2.x",
     "scan_subpath": "packages/core",
     "fork_org": "your-security-forks"
@@ -149,7 +152,7 @@ then runs `claude -p "Use the {name} skill in this workspace"` with the working 
 }
 ```
 
-`finding_id` is only present for finding-scoped skills (`verify`, `disclose`, `patch`). `scan_ref` is empty when the scan is on the default branch. `scan_subpath` is set when the operator scoped the scan to a monorepo sub-folder; skills that walk source honour it, skills that query external APIs by repository URL ignore it. `fork_org` is absent unless `-fork-org` is configured. `packages` is a convenience copy of the package rows when the `packages` skill has already run; otherwise it is omitted.
+`finding_id` is only present for finding-scoped skills (`verify`, `disclose`, `patch`, `exposure`). `dependent_id` is only set on `exposure` runs and points to the dependent whose code is under audit; `./src` is then a copy of that dependent's clone, not of the finding's repository. `scan_ref` is empty when the scan is on the default branch. `scan_subpath` is set when the operator scoped the scan to a monorepo sub-folder; skills that walk source honour it, skills that query external APIs by repository URL ignore it. `fork_org` is absent unless `-fork-org` is configured. `packages` is a convenience copy of the package rows when the `packages` skill has already run; otherwise it is omitted.
 
 ## schema.json
 

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -105,8 +105,13 @@ type Scan struct {
 	// FindingID is set when a scan is finding-scoped (verify, patch,
 	// disclose). Skills read it from context.json to know which finding
 	// they are acting on.
-	FindingID *uint  `gorm:"index"`
-	APIToken  string `gorm:"index"`
+	FindingID *uint `gorm:"index"`
+	// DependentID is set on exposure scans: the Dependent the skill is
+	// auditing for reachability of the upstream finding. The scan's
+	// Repository remains the library; ./src is staged from the
+	// dependent's repo URL via the dependent-clone cache.
+	DependentID *uint  `gorm:"index"`
+	APIToken    string `gorm:"index"`
 
 	// StatusPriority is a denormalised sort key so the scans index can use
 	// an index instead of evaluating a CASE on every row. 0 = running,
@@ -456,6 +461,73 @@ type FindingReference struct {
 	CreatedAt time.Time
 }
 
+// CSAF 2.0 product_status buckets, reused as the FindingDependent.Status
+// enum so the VEX export can pass them through without translation.
+const (
+	ExposureKnownAffected      = "known_affected"
+	ExposureKnownNotAffected   = "known_not_affected"
+	ExposureUnderInvestigation = "under_investigation"
+	ExposureFixed              = "fixed"
+)
+
+// CSAF 2.0 VEX flag labels. Only valid when Status is known_not_affected.
+const (
+	JustifComponentNotPresent        = "component_not_present"
+	JustifVulnerableCodeNotPresent   = "vulnerable_code_not_present"
+	JustifVulnerableCodeNotInPath    = "vulnerable_code_not_in_execute_path"
+	JustifVulnerableCodeNotReachable = "vulnerable_code_cannot_be_controlled_by_adversary"
+	JustifInlineMitigationsExist     = "inline_mitigations_already_exist"
+)
+
+// ValidExposureStatus reports whether s is one of the CSAF product_status
+// buckets FindingDependent stores. Empty is treated as under_investigation
+// by the caller; this returns false on empty.
+func ValidExposureStatus(s string) bool {
+	switch s {
+	case ExposureKnownAffected, ExposureKnownNotAffected, ExposureUnderInvestigation, ExposureFixed:
+		return true
+	}
+	return false
+}
+
+// ValidExposureJustification reports whether j is one of the CSAF VEX
+// flag labels. Empty is valid (no flag attached).
+func ValidExposureJustification(j string) bool {
+	if j == "" {
+		return true
+	}
+	switch j {
+	case JustifComponentNotPresent, JustifVulnerableCodeNotPresent,
+		JustifVulnerableCodeNotInPath, JustifVulnerableCodeNotReachable,
+		JustifInlineMitigationsExist:
+		return true
+	}
+	return false
+}
+
+// FindingDependent records, per (finding, dependent), whether that
+// downstream consumer of the vulnerable library reaches the sink. Status
+// mirrors the CSAF 2.0 product_status bucket so the VEX export can stream
+// it through unchanged; Justification holds a CSAF VEX flag label and is
+// only set when Status is known_not_affected. ScanCommit is the dependent
+// repo HEAD when the call was made so a later rescan can tell whether
+// the answer is still valid.
+type FindingDependent struct {
+	ID          uint `gorm:"primarykey"`
+	FindingID   uint `gorm:"index;not null;uniqueIndex:idx_finding_dependent"`
+	DependentID uint `gorm:"index;not null;uniqueIndex:idx_finding_dependent"`
+
+	Status        string `gorm:"index"` // known_affected | known_not_affected | under_investigation | fixed
+	Justification string // CSAF VEX flag label, only for known_not_affected
+	Rationale     string `gorm:"type:text"`
+
+	ScanID     *uint
+	ScanCommit string
+
+	CreatedAt time.Time
+	UpdatedAt time.Time
+}
+
 // FindingHistory records every change to a mutable field on a Finding.
 // Together with the Finding row's current columns it gives you "what is
 // the current value, who set it, from what source, and when".
@@ -570,7 +642,7 @@ func Open(dsn string) (*gorm.DB, error) {
 		&Repository{}, &Scan{},
 		&Finding{}, &FindingLabel{}, &FindingNote{},
 		&FindingCommunication{}, &FindingReference{}, &FindingHistory{},
-		&Dependency{}, &Package{}, &Dependent{}, &Advisory{},
+		&Dependency{}, &Package{}, &Dependent{}, &FindingDependent{}, &Advisory{},
 		&Maintainer{}, &Skill{}, &Subproject{},
 		&SBOMUpload{}, &SBOMPackage{}, &CNA{},
 	); err != nil {

--- a/internal/skills/parse.go
+++ b/internal/skills/parse.go
@@ -85,6 +85,7 @@ var OutputKinds = map[string]bool{
 	"posture":       true,
 	"patch":         true,
 	"threat_model":  true,
+	"exposure":      true,
 }
 
 var nameRE = regexp.MustCompile(`^[a-z0-9]+(-[a-z0-9]+)*$`)

--- a/internal/web/finding_csaf.go
+++ b/internal/web/finding_csaf.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -460,8 +461,13 @@ func buildFlags(f db.Finding, productIDs []string, fdRows []db.FindingDependent,
 		}
 		byLabel[r.Justification] = append(byLabel[r.Justification], dependentProductID(dep))
 	}
-	for label, ids := range byLabel {
-		flags = append(flags, csafFlag{Label: label, ProductIDs: ids})
+	labels := make([]string, 0, len(byLabel))
+	for label := range byLabel {
+		labels = append(labels, label)
+	}
+	sort.Strings(labels)
+	for _, label := range labels {
+		flags = append(flags, csafFlag{Label: label, ProductIDs: byLabel[label]})
 	}
 	return flags
 }

--- a/internal/web/finding_csaf.go
+++ b/internal/web/finding_csaf.go
@@ -102,8 +102,11 @@ func (s *Server) findingCSAF(w http.ResponseWriter, r *http.Request) {
 	s.DB.Where("finding_id = ?", f.ID).Order("id desc").Find(&refs)
 	var pkgs []db.Package
 	s.DB.Where("repository_id = ?", f.RepositoryID).Find(&pkgs)
+	var fdRows []db.FindingDependent
+	s.DB.Where("finding_id = ?", f.ID).Find(&fdRows)
+	deps := loadFindingDependents(s, fdRows)
 
-	raw, err := json.MarshalIndent(buildCSAF(f, repo, refs, pkgs), "", "  ")
+	raw, err := json.MarshalIndent(buildCSAF(f, repo, refs, pkgs, fdRows, deps), "", "  ")
 	if err != nil {
 		s.Log.Error("csaf marshal", "finding", f.ID, "err", err)
 		http.Error(w, "failed to generate CSAF document", http.StatusInternalServerError)
@@ -272,7 +275,30 @@ type csafReference struct {
 	URL      string `json:"url"`
 }
 
-func buildCSAF(f db.Finding, repo db.Repository, refs []db.FindingReference, pkgs []db.Package) csafDocument {
+// loadFindingDependents fetches the Dependent rows referenced by the
+// given exposure rows, keyed by ID for cheap lookup in buildCSAF.
+func loadFindingDependents(s *Server, rows []db.FindingDependent) map[uint]db.Dependent {
+	if len(rows) == 0 {
+		return nil
+	}
+	ids := make([]uint, len(rows))
+	for i, r := range rows {
+		ids[i] = r.DependentID
+	}
+	var deps []db.Dependent
+	s.DB.Where("id IN ?", ids).Find(&deps)
+	out := make(map[uint]db.Dependent, len(deps))
+	for _, d := range deps {
+		out[d.ID] = d
+	}
+	return out
+}
+
+func dependentProductID(d db.Dependent) string {
+	return fmt.Sprintf("DEP-%d", d.ID)
+}
+
+func buildCSAF(f db.Finding, repo db.Repository, refs []db.FindingReference, pkgs []db.Package, fdRows []db.FindingDependent, deps map[uint]db.Dependent) csafDocument {
 	productID := fmt.Sprintf("PKG-%d-%s", f.RepositoryID, csafProductSuffix(f))
 
 	now := time.Now().UTC().Format(time.RFC3339)
@@ -321,7 +347,7 @@ func buildCSAF(f db.Finding, repo db.Repository, refs []db.FindingReference, pkg
 
 	productName := firstNonEmpty(repo.FullName, repo.Name, "package")
 	productVersion := firstNonEmpty(f.Affected, "unknown")
-	doc.ProductTree = buildProductTree(productName, productVersion, productID, pkgs)
+	doc.ProductTree = buildProductTree(productName, productVersion, productID, pkgs, fdRows, deps)
 
 	productIDs := []string{productID}
 	for _, pkg := range pkgs {
@@ -333,10 +359,10 @@ func buildCSAF(f db.Finding, repo db.Repository, refs []db.FindingReference, pkg
 	v := csafVulnerability{
 		CVE:           f.CVEID,
 		Title:         f.Title,
-		ProductStatus: buildProductStatusMulti(f, productIDs),
+		ProductStatus: buildProductStatusMulti(f, productIDs, fdRows, deps),
 		References:    buildReferences(refs),
 		Notes:         buildAuditNotes(f),
-		Flags:         buildFlags(f, productIDs),
+		Flags:         buildFlags(f, productIDs, fdRows, deps),
 	}
 	if cwe := buildCWE(f.CWE); cwe != nil {
 		v.CWE = cwe
@@ -356,7 +382,7 @@ func pkgProductID(pkg db.Package) string {
 	return fmt.Sprintf("PKG-%d-%s-%s", pkg.RepositoryID, pkg.Ecosystem, pkg.Name)
 }
 
-func buildProductTree(productName, productVersion, baseProductID string, pkgs []db.Package) *csafProductTree {
+func buildProductTree(productName, productVersion, baseProductID string, pkgs []db.Package, fdRows []db.FindingDependent, deps map[uint]db.Dependent) *csafProductTree {
 	baseProduct := csafBranch{
 		Category: "product_version",
 		Name:     productVersion,
@@ -382,26 +408,65 @@ func buildProductTree(productName, productVersion, baseProductID string, pkgs []
 			},
 		})
 	}
-	return &csafProductTree{
-		Branches: []csafBranch{{
-			Category: "product_name",
-			Name:     productName,
-			Branches: versionBranches,
-		}},
-	}
-}
-
-func buildFlags(f db.Finding, productIDs []string) []csafFlag {
-	if mapProductStatus(f) != csafStatusKnownNotAffected {
-		return nil
-	}
-	return []csafFlag{{
-		Label:      "vulnerable_code_not_present",
-		ProductIDs: productIDs,
+	branches := []csafBranch{{
+		Category: "product_name",
+		Name:     productName,
+		Branches: versionBranches,
 	}}
+	for _, r := range fdRows {
+		dep, ok := deps[r.DependentID]
+		if !ok {
+			continue
+		}
+		name := firstNonEmpty(dep.Name, fmt.Sprintf("dependent-%d", dep.ID))
+		ver := firstNonEmpty(dep.LatestVersion, "unknown")
+		var ident *csafProductIdentifier
+		if dep.PURL != "" {
+			ident = &csafProductIdentifier{PURL: dep.PURL}
+		}
+		branches = append(branches, csafBranch{
+			Category: "product_name",
+			Name:     name,
+			Branches: []csafBranch{{
+				Category: "product_version",
+				Name:     ver,
+				Product: &csafProduct{
+					Name:        fmt.Sprintf("%s %s", name, ver),
+					ProductID:   dependentProductID(dep),
+					IdentHelper: ident,
+				},
+			}},
+		})
+	}
+	return &csafProductTree{Branches: branches}
 }
 
-func buildProductStatusMulti(f db.Finding, productIDs []string) *csafProductStatus {
+func buildFlags(f db.Finding, productIDs []string, fdRows []db.FindingDependent, deps map[uint]db.Dependent) []csafFlag {
+	var flags []csafFlag
+	if mapProductStatus(f) == csafStatusKnownNotAffected {
+		flags = append(flags, csafFlag{
+			Label:      "vulnerable_code_not_present",
+			ProductIDs: productIDs,
+		})
+	}
+	byLabel := make(map[string][]string)
+	for _, r := range fdRows {
+		if r.Status != db.ExposureKnownNotAffected || r.Justification == "" {
+			continue
+		}
+		dep, ok := deps[r.DependentID]
+		if !ok {
+			continue
+		}
+		byLabel[r.Justification] = append(byLabel[r.Justification], dependentProductID(dep))
+	}
+	for label, ids := range byLabel {
+		flags = append(flags, csafFlag{Label: label, ProductIDs: ids})
+	}
+	return flags
+}
+
+func buildProductStatusMulti(f db.Finding, productIDs []string, fdRows []db.FindingDependent, deps map[uint]db.Dependent) *csafProductStatus {
 	ps := &csafProductStatus{}
 	switch mapProductStatus(f) {
 	case csafStatusFixed:
@@ -412,6 +477,23 @@ func buildProductStatusMulti(f db.Finding, productIDs []string) *csafProductStat
 		ps.KnownAffected = productIDs
 	default:
 		ps.UnderInvestigation = productIDs
+	}
+	for _, r := range fdRows {
+		dep, ok := deps[r.DependentID]
+		if !ok {
+			continue
+		}
+		pid := dependentProductID(dep)
+		switch r.Status {
+		case db.ExposureKnownAffected:
+			ps.KnownAffected = append(ps.KnownAffected, pid)
+		case db.ExposureKnownNotAffected:
+			ps.KnownNotAffected = append(ps.KnownNotAffected, pid)
+		case db.ExposureFixed:
+			ps.Fixed = append(ps.Fixed, pid)
+		default:
+			ps.UnderInvestigation = append(ps.UnderInvestigation, pid)
+		}
 	}
 	return ps
 }

--- a/internal/web/finding_csaf_test.go
+++ b/internal/web/finding_csaf_test.go
@@ -151,11 +151,11 @@ func TestFindingCSAF_perDependentVEX(t *testing.T) {
 	ps := v["product_status"].(map[string]any)
 
 	affected := toStringSlice(ps["known_affected"])
-	if !contains(affected, "DEP-"+strconv.FormatUint(uint64(depAffected.ID), 10)) {
+	if !slices.Contains(affected, "DEP-"+strconv.FormatUint(uint64(depAffected.ID), 10)) {
 		t.Errorf("known_affected missing DEP-%d: %+v", depAffected.ID, affected)
 	}
 	notAffected := toStringSlice(ps["known_not_affected"])
-	if !contains(notAffected, "DEP-"+strconv.FormatUint(uint64(depSafe.ID), 10)) {
+	if !slices.Contains(notAffected, "DEP-"+strconv.FormatUint(uint64(depSafe.ID), 10)) {
 		t.Errorf("known_not_affected missing DEP-%d: %+v", depSafe.ID, notAffected)
 	}
 
@@ -165,7 +165,7 @@ func TestFindingCSAF_perDependentVEX(t *testing.T) {
 		flag := raw.(map[string]any)
 		if flag["label"] == db.JustifVulnerableCodeNotInPath {
 			sawJustif = true
-			if !contains(toStringSlice(flag["product_ids"]), "DEP-"+strconv.FormatUint(uint64(depSafe.ID), 10)) {
+			if !slices.Contains(toStringSlice(flag["product_ids"]), "DEP-"+strconv.FormatUint(uint64(depSafe.ID), 10)) {
 				t.Errorf("justification flag missing dependent id: %+v", flag)
 			}
 		}
@@ -187,10 +187,6 @@ func toStringSlice(v any) []string {
 		}
 	}
 	return out
-}
-
-func contains(xs []string, want string) bool {
-	return slices.Contains(xs, want)
 }
 
 func TestFindingCSAF_rejectedMapsToNotAffected(t *testing.T) {

--- a/internal/web/finding_csaf_test.go
+++ b/internal/web/finding_csaf_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -126,6 +127,70 @@ func TestFindingCSAF_omitsCVEWhenAbsent(t *testing.T) {
 	if tracking["id"] != "scrutineer-finding-"+strconv.FormatUint(uint64(f.ID), 10) {
 		t.Errorf("tracking id = %v", tracking["id"])
 	}
+}
+
+func TestFindingCSAF_perDependentVEX(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	f := seedCSAFFinding(t, s, nil)
+	depAffected := db.Dependent{RepositoryID: f.RepositoryID, Name: "downstream-affected", PURL: "pkg:npm/downstream-affected@1.0.0", LatestVersion: "1.0.0"}
+	depSafe := db.Dependent{RepositoryID: f.RepositoryID, Name: "downstream-safe", PURL: "pkg:npm/downstream-safe@2.0.0", LatestVersion: "2.0.0"}
+	s.DB.Create(&depAffected)
+	s.DB.Create(&depSafe)
+	s.DB.Create(&db.FindingDependent{FindingID: f.ID, DependentID: depAffected.ID, Status: db.ExposureKnownAffected})
+	s.DB.Create(&db.FindingDependent{FindingID: f.ID, DependentID: depSafe.ID,
+		Status: db.ExposureKnownNotAffected, Justification: db.JustifVulnerableCodeNotInPath})
+
+	w := getCSAF(t, s, f.ID)
+	if w.Code != 200 {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+	doc := decodeCSAF(t, w.Body.Bytes())
+	v := doc["vulnerabilities"].([]any)[0].(map[string]any)
+	ps := v["product_status"].(map[string]any)
+
+	affected := toStringSlice(ps["known_affected"])
+	if !contains(affected, "DEP-"+strconv.FormatUint(uint64(depAffected.ID), 10)) {
+		t.Errorf("known_affected missing DEP-%d: %+v", depAffected.ID, affected)
+	}
+	notAffected := toStringSlice(ps["known_not_affected"])
+	if !contains(notAffected, "DEP-"+strconv.FormatUint(uint64(depSafe.ID), 10)) {
+		t.Errorf("known_not_affected missing DEP-%d: %+v", depSafe.ID, notAffected)
+	}
+
+	flags := v["flags"].([]any)
+	var sawJustif bool
+	for _, raw := range flags {
+		flag := raw.(map[string]any)
+		if flag["label"] == db.JustifVulnerableCodeNotInPath {
+			sawJustif = true
+			if !contains(toStringSlice(flag["product_ids"]), "DEP-"+strconv.FormatUint(uint64(depSafe.ID), 10)) {
+				t.Errorf("justification flag missing dependent id: %+v", flag)
+			}
+		}
+	}
+	if !sawJustif {
+		t.Errorf("expected a %s flag, got %+v", db.JustifVulnerableCodeNotInPath, flags)
+	}
+}
+
+func toStringSlice(v any) []string {
+	xs, ok := v.([]any)
+	if !ok {
+		return nil
+	}
+	out := make([]string, 0, len(xs))
+	for _, x := range xs {
+		if s, ok := x.(string); ok {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+func contains(xs []string, want string) bool {
+	return slices.Contains(xs, want)
 }
 
 func TestFindingCSAF_rejectedMapsToNotAffected(t *testing.T) {

--- a/internal/web/finding_exposure.go
+++ b/internal/web/finding_exposure.go
@@ -45,7 +45,6 @@ func (s *Server) findingExposureRun(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	model := r.FormValue("model")
-	queued := 0
 	for i := range deps {
 		dep := deps[i]
 		if dep.RepositoryURL == "" {
@@ -60,7 +59,6 @@ func (s *Server) findingExposureRun(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
-		queued++
 	}
 	s.redirect(w, r, fmt.Sprintf("/findings/%d", f.ID))
 }

--- a/internal/web/finding_exposure.go
+++ b/internal/web/finding_exposure.go
@@ -1,0 +1,83 @@
+package web
+
+import (
+	"fmt"
+	"net/http"
+
+	"scrutineer/internal/db"
+)
+
+// exposureSkillName is the skill the per-finding "Run exposure" action
+// invokes. One scan per top-N dependent of the finding's repository.
+const exposureSkillName = "exposure"
+
+// exposureTopN caps how many of the finding's library's dependents the
+// exposure runner audits per click.
+const exposureTopN = 10
+
+// findingExposureRun enqueues one exposure scan per top-N dependent of
+// the library this finding lives in. Dependents without a repository
+// URL are recorded as under_investigation immediately so the per-
+// dependent table is complete; the rest queue at PrioFinding.
+func (s *Server) findingExposureRun(w http.ResponseWriter, r *http.Request) {
+	var f db.Finding
+	if err := s.DB.First(&f, r.PathValue("id")).Error; err != nil {
+		http.NotFound(w, r)
+		return
+	}
+	var scan db.Scan
+	if err := s.DB.First(&scan, f.ScanID).Error; err != nil {
+		http.Error(w, "scan for finding not found", http.StatusInternalServerError)
+		return
+	}
+	var skill db.Skill
+	if err := s.DB.Where("name = ? AND active = ?", exposureSkillName, true).First(&skill).Error; err != nil {
+		http.Error(w, "exposure skill is not installed", http.StatusPreconditionFailed)
+		return
+	}
+	var deps []db.Dependent
+	s.DB.Where("repository_id = ?", scan.RepositoryID).
+		Order("dependent_repos desc, downloads desc").
+		Limit(exposureTopN).
+		Find(&deps)
+	if len(deps) == 0 {
+		http.Error(w, "no dependents recorded for this repository", http.StatusUnprocessableEntity)
+		return
+	}
+	model := r.FormValue("model")
+	queued := 0
+	for i := range deps {
+		dep := deps[i]
+		if dep.RepositoryURL == "" {
+			s.recordSkippedExposure(f.ID, dep.ID)
+			continue
+		}
+		if _, err := s.enqueueSkillWith(r.Context(), scan.RepositoryID, skill.ID, ScanOpts{
+			Model:       model,
+			FindingID:   &f.ID,
+			DependentID: &dep.ID,
+		}); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		queued++
+	}
+	s.redirect(w, r, fmt.Sprintf("/findings/%d", f.ID))
+}
+
+// recordSkippedExposure writes an under_investigation row for a
+// dependent we cannot audit (no upstream repo URL) so the per-dependent
+// table on the finding page stays complete.
+func (s *Server) recordSkippedExposure(findingID, dependentID uint) {
+	row := db.FindingDependent{
+		FindingID:   findingID,
+		DependentID: dependentID,
+		Status:      db.ExposureUnderInvestigation,
+		Rationale:   "skipped: dependent has no repository URL",
+	}
+	var existing db.FindingDependent
+	if err := s.DB.Where("finding_id = ? AND dependent_id = ?", findingID, dependentID).First(&existing).Error; err == nil {
+		return
+	}
+	s.DB.Create(&row)
+}

--- a/internal/web/finding_exposure_test.go
+++ b/internal/web/finding_exposure_test.go
@@ -1,6 +1,7 @@
 package web
 
 import (
+	"fmt"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -27,8 +28,7 @@ func TestFindingExposureRun_enqueuesScanPerDependent(t *testing.T) {
 	defer done()
 
 	f, skill := seedExposureFinding(t, s)
-	for i, name := range []string{"a", "b", "c"} {
-		_ = i
+	for _, name := range []string{"a", "b", "c"} {
 		s.DB.Create(&db.Dependent{RepositoryID: f.RepositoryID, Name: name, Ecosystem: "npm",
 			RepositoryURL: "https://github.com/example/" + name, DependentRepos: 100})
 	}
@@ -36,7 +36,7 @@ func TestFindingExposureRun_enqueuesScanPerDependent(t *testing.T) {
 	s.DB.Create(&skipped)
 
 	w := httptest.NewRecorder()
-	s.Handler().ServeHTTP(w, localReq("POST", "/findings/1/exposure"))
+	s.Handler().ServeHTTP(w, localReq("POST", fmt.Sprintf("/findings/%d/exposure", f.ID)))
 	if w.Code != 200 && w.Code != 303 {
 		t.Fatalf("status %d: %s", w.Code, w.Body)
 	}
@@ -62,10 +62,10 @@ func TestFindingExposureRun_enqueuesScanPerDependent(t *testing.T) {
 func TestFindingExposureRun_noDependents422(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()
-	seedExposureFinding(t, s)
+	f, _ := seedExposureFinding(t, s)
 
 	w := httptest.NewRecorder()
-	s.Handler().ServeHTTP(w, localReq("POST", "/findings/1/exposure"))
+	s.Handler().ServeHTTP(w, localReq("POST", fmt.Sprintf("/findings/%d/exposure", f.ID)))
 	if w.Code != 422 {
 		t.Fatalf("status %d: %s", w.Code, w.Body)
 	}
@@ -85,7 +85,7 @@ func TestFindingExposureRun_skillMissing412(t *testing.T) {
 		RepositoryURL: "https://github.com/example/a", DependentRepos: 1})
 
 	w := httptest.NewRecorder()
-	s.Handler().ServeHTTP(w, localReq("POST", "/findings/1/exposure"))
+	s.Handler().ServeHTTP(w, localReq("POST", fmt.Sprintf("/findings/%d/exposure", f.ID)))
 	if w.Code != 412 {
 		t.Fatalf("status %d: %s", w.Code, w.Body)
 	}

--- a/internal/web/finding_exposure_test.go
+++ b/internal/web/finding_exposure_test.go
@@ -1,0 +1,95 @@
+package web
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"scrutineer/internal/db"
+	"scrutineer/internal/worker"
+)
+
+func seedExposureFinding(t *testing.T, s *Server) (db.Finding, db.Skill) {
+	t.Helper()
+	repo := db.Repository{URL: "https://github.com/example/lib.git", Name: "lib", FullName: "example/lib"}
+	s.DB.Create(&repo)
+	scan := db.Scan{RepositoryID: repo.ID, Kind: worker.JobSkill, Status: db.ScanDone, SkillName: "security-deep-dive"}
+	s.DB.Create(&scan)
+	f := db.Finding{ScanID: scan.ID, RepositoryID: repo.ID, Title: "ReDoS", Severity: "High", Status: db.FindingTriaged}
+	s.DB.Create(&f)
+	skill := db.Skill{Name: "exposure", Body: "x", Active: true, OutputFile: "report.json", OutputKind: "exposure"}
+	s.DB.Create(&skill)
+	return f, skill
+}
+
+func TestFindingExposureRun_enqueuesScanPerDependent(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	f, skill := seedExposureFinding(t, s)
+	for i, name := range []string{"a", "b", "c"} {
+		_ = i
+		s.DB.Create(&db.Dependent{RepositoryID: f.RepositoryID, Name: name, Ecosystem: "npm",
+			RepositoryURL: "https://github.com/example/" + name, DependentRepos: 100})
+	}
+	skipped := db.Dependent{RepositoryID: f.RepositoryID, Name: "no-url", Ecosystem: "npm", DependentRepos: 50}
+	s.DB.Create(&skipped)
+
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq("POST", "/findings/1/exposure"))
+	if w.Code != 200 && w.Code != 303 {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+
+	var scans []db.Scan
+	s.DB.Where("kind = ? AND skill_id = ?", worker.JobExposure, skill.ID).Find(&scans)
+	if len(scans) != 3 {
+		t.Fatalf("expected 3 exposure scans, got %d", len(scans))
+	}
+	for _, sc := range scans {
+		if sc.FindingID == nil || sc.DependentID == nil {
+			t.Errorf("scan %d missing finding_id or dependent_id", sc.ID)
+		}
+	}
+
+	var rows []db.FindingDependent
+	s.DB.Where("finding_id = ?", f.ID).Find(&rows)
+	if len(rows) != 1 || rows[0].DependentID != skipped.ID || rows[0].Status != db.ExposureUnderInvestigation {
+		t.Fatalf("expected one under_investigation row for the URL-less dependent, got %+v", rows)
+	}
+}
+
+func TestFindingExposureRun_noDependents422(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	seedExposureFinding(t, s)
+
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq("POST", "/findings/1/exposure"))
+	if w.Code != 422 {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+}
+
+func TestFindingExposureRun_skillMissing412(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	repo := db.Repository{URL: "https://github.com/x/y", Name: "y"}
+	s.DB.Create(&repo)
+	scan := db.Scan{RepositoryID: repo.ID, Kind: worker.JobSkill, Status: db.ScanDone}
+	s.DB.Create(&scan)
+	f := db.Finding{ScanID: scan.ID, RepositoryID: repo.ID, Title: "x"}
+	s.DB.Create(&f)
+	s.DB.Create(&db.Dependent{RepositoryID: repo.ID, Name: "a",
+		RepositoryURL: "https://github.com/example/a", DependentRepos: 1})
+
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq("POST", "/findings/1/exposure"))
+	if w.Code != 412 {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+	if !strings.Contains(w.Body.String(), "exposure skill is not installed") {
+		t.Errorf("body = %q", w.Body.String())
+	}
+}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -184,6 +184,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("POST /findings/{id}/verify", s.findingVerify)
 	mux.HandleFunc("POST /findings/{id}/disclose", s.findingDisclose)
 	mux.HandleFunc("POST /findings/{id}/patch", s.findingPatchRun)
+	mux.HandleFunc("POST /findings/{id}/exposure", s.findingExposureRun)
 	mux.HandleFunc("GET /findings/{id}/patch.diff", s.findingPatchDownload)
 	mux.HandleFunc("POST /findings/{id}/notes", s.findingNotes)
 	mux.HandleFunc("POST /findings/{id}/fields", s.findingFields)
@@ -1172,6 +1173,38 @@ func (s *Server) findingShow(w http.ResponseWriter, r *http.Request) {
 		selected[l.Name] = true
 	}
 
+	type exposureRow struct {
+		Dep    db.Dependent
+		Status string
+		Justif string
+		Why    string
+		At     time.Time
+	}
+	var fdRows []db.FindingDependent
+	s.DB.Where("finding_id = ?", f.ID).Find(&fdRows)
+	exposures := make([]exposureRow, 0, len(fdRows))
+	if len(fdRows) > 0 {
+		depIDs := make([]uint, len(fdRows))
+		for i, r := range fdRows {
+			depIDs[i] = r.DependentID
+		}
+		var depRows []db.Dependent
+		s.DB.Where("id IN ?", depIDs).Find(&depRows)
+		byID := make(map[uint]db.Dependent, len(depRows))
+		for _, d := range depRows {
+			byID[d.ID] = d
+		}
+		for _, r := range fdRows {
+			exposures = append(exposures, exposureRow{
+				Dep:    byID[r.DependentID],
+				Status: r.Status,
+				Justif: r.Justification,
+				Why:    r.Rationale,
+				At:     r.UpdatedAt,
+			})
+		}
+	}
+
 	data := map[string]any{
 		"F":              f,
 		"Scan":           scan,
@@ -1182,6 +1215,7 @@ func (s *Server) findingShow(w http.ResponseWriter, r *http.Request) {
 		"History":        history,
 		"AllLabels":      labels,
 		"Selected":       selected,
+		"Exposures":      exposures,
 	}
 	if id, c, ok := LookupCWE(f.CWE); ok {
 		data["CWE"] = map[string]any{"ID": id, "Name": c.Name, "Description": c.Description}
@@ -1702,10 +1736,11 @@ func (s *Server) scanLog(w http.ResponseWriter, r *http.Request) {
 // enqueue signature from drifting into an unreadable positional list as
 // new options (SubPath, FindingID, Model) accumulate.
 type ScanOpts struct {
-	Model     string
-	FindingID *uint
-	SubPath   string
-	Ref       string
+	Model       string
+	FindingID   *uint
+	DependentID *uint
+	SubPath     string
+	Ref         string
 }
 
 func (s *Server) enqueueSkill(ctx context.Context, repoID, skillID uint, model string) (uint, error) {
@@ -1731,14 +1766,19 @@ func (s *Server) enqueueSkillWith(ctx context.Context, repoID, skillID uint, opt
 			opts.Model = DefaultModel()
 		}
 	}
+	kind := worker.JobSkill
+	if opts.DependentID != nil {
+		kind = worker.JobExposure
+	}
 	scan := db.Scan{
 		RepositoryID:   repoID,
-		Kind:           worker.JobSkill,
+		Kind:           kind,
 		Status:         db.ScanQueued,
 		StatusPriority: db.StatusPriorityFor(db.ScanQueued),
 		Model:          opts.Model,
 		SkillID:        &skillID,
 		FindingID:      opts.FindingID,
+		DependentID:    opts.DependentID,
 		SubPath:        opts.SubPath,
 		Ref:            opts.Ref,
 		APIToken:       NewAPIToken(),
@@ -1750,7 +1790,7 @@ func (s *Server) enqueueSkillWith(ctx context.Context, repoID, skillID uint, opt
 	if opts.FindingID != nil {
 		prio = worker.PrioFinding
 	}
-	if err := s.Queue.Enqueue(ctx, worker.JobSkill, scan.ID, prio); err != nil {
+	if err := s.Queue.Enqueue(ctx, kind, scan.ID, prio); err != nil {
 		return 0, err
 	}
 	s.DB.Model(&db.Repository{}).Where("id = ?", repoID).Update("updated_at", time.Now())

--- a/internal/web/templates/finding_show.html
+++ b/internal/web/templates/finding_show.html
@@ -198,6 +198,43 @@
   </details>
   {{end}}
 
+  <details open class="group border-b">
+    <summary class="w-full outline-none rounded-md focus-visible:ring-ring/50 focus-visible:ring-[3px]">
+      <h3 class="flex flex-1 items-center justify-between gap-4 py-4 text-sm font-medium hover:underline">
+        Dependent exposure
+        <span class="text-muted-foreground ml-auto mr-2 text-xs">{{len .Exposures}}</span>
+        <i data-lucide="chevron-down" class="text-muted-foreground size-4 shrink-0 transition-transform duration-200 group-open:rotate-180"></i>
+      </h3>
+    </summary>
+    <section class="pb-4 grid gap-3">
+      <div class="flex items-center gap-2">
+        <form method="post" action="/findings/{{$f.ID}}/exposure" hx-post="/findings/{{$f.ID}}/exposure" hx-swap="none">
+          <button type="submit" class="btn-sm">Run exposure on top-10 dependents</button>
+        </form>
+        <span class="text-xs text-muted-foreground">Clones each dependent and audits whether this finding is reachable in its code.</span>
+      </div>
+      {{if .Exposures}}
+      <table class="w-full text-sm">
+        <thead class="text-xs text-muted-foreground">
+          <tr><th class="text-left py-2">Dependent</th><th class="text-left">Status</th><th class="text-left">Justification</th><th class="text-left">Notes</th></tr>
+        </thead>
+        <tbody>
+          {{range .Exposures}}
+          <tr class="border-t align-top">
+            <td class="py-2"><code>{{.Dep.Name}}</code> <span class="text-xs text-muted-foreground">{{.Dep.Ecosystem}}</span></td>
+            <td>{{.Status}}</td>
+            <td>{{if .Justif}}<code class="text-xs">{{.Justif}}</code>{{else}}-{{end}}</td>
+            <td class="text-xs text-muted-foreground">{{.Why}}</td>
+          </tr>
+          {{end}}
+        </tbody>
+      </table>
+      {{else}}
+      <p class="text-xs text-muted-foreground">No exposure runs yet.</p>
+      {{end}}
+    </section>
+  </details>
+
   {{if .Patch}}{{$p := .Patch}}{{$ps := .PatchScan}}
   <details open class="group border-b">
     <summary class="w-full outline-none rounded-md focus-visible:ring-ring/50 focus-visible:ring-[3px]">

--- a/internal/worker/claude.go
+++ b/internal/worker/claude.go
@@ -49,6 +49,11 @@ type SkillJob struct {
 	Ref          string // git ref to checkout; empty = default branch
 	MaxTurns     int    // per-skill cap; 0 = use runner default
 	AllowedTools string // comma-separated; "" = full tool set under bypassPermissions
+	// SrcReady declares that WorkRoot/src is already populated by the
+	// caller (e.g. by the exposure handler copying from a dependent
+	// cache). When true the runner skips its own clone and reads HEAD
+	// from the existing tree.
+	SrcReady bool
 }
 
 type SkillResult struct {
@@ -69,9 +74,15 @@ type LocalClaude struct {
 //	{DataDir}/scan-{id}/.claude/skills/NAME staged skill (read by claude-code)
 //	{DataDir}/scan-{id}/OutputFile          where the skill writes, if any
 func (l LocalClaude) RunSkill(ctx context.Context, sj SkillJob, emit func(Event)) (SkillResult, error) {
-	src, err := ensureClone(ctx, sj.Repo, sj.WorkRoot, l.FullClone, sj.Ref, emit)
-	if err != nil {
-		return SkillResult{}, err
+	var src string
+	if sj.SrcReady {
+		src = filepath.Join(sj.WorkRoot, "src")
+	} else {
+		var err error
+		src, err = ensureClone(ctx, sj.Repo, sj.WorkRoot, l.FullClone, sj.Ref, emit)
+		if err != nil {
+			return SkillResult{}, err
+		}
 	}
 	commit := gitHead(src)
 	work := sj.WorkRoot

--- a/internal/worker/docker.go
+++ b/internal/worker/docker.go
@@ -43,9 +43,15 @@ func (d DockerRunner) image() string {
 // Egress is routed through scrutineer's allowlisting proxy on the host;
 // see EgressProxy. tmpfs/cap-drop rules mirror the local runner's intent.
 func (d DockerRunner) RunSkill(ctx context.Context, sj SkillJob, emit func(Event)) (SkillResult, error) {
-	src, err := ensureClone(ctx, sj.Repo, sj.WorkRoot, d.FullClone, sj.Ref, emit)
-	if err != nil {
-		return SkillResult{}, err
+	var src string
+	if sj.SrcReady {
+		src = filepath.Join(sj.WorkRoot, "src")
+	} else {
+		var err error
+		src, err = ensureClone(ctx, sj.Repo, sj.WorkRoot, d.FullClone, sj.Ref, emit)
+		if err != nil {
+			return SkillResult{}, err
+		}
 	}
 	commit := gitHead(src)
 	work := sj.WorkRoot

--- a/internal/worker/exposure.go
+++ b/internal/worker/exposure.go
@@ -7,8 +7,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
+	"sync"
 
 	"scrutineer/internal/db"
 )
@@ -23,12 +25,94 @@ func dependentCacheRoot(dataDir, url string) string {
 	return filepath.Join(dataDir, "dependent-cache", hex.EncodeToString(sum[:]))
 }
 
+// cacheMutex returns the per-URL mutex used to serialise fetch+copy on
+// the dependent cache. Lazily created on first use.
+func (w *Worker) cacheMutex(url string) *sync.Mutex {
+	v, _ := w.cacheMu.LoadOrStore(url, &sync.Mutex{})
+	return v.(*sync.Mutex)
+}
+
+// prepareDependentSrc updates the shared dependent cache for url under a
+// per-URL lock, then copies it into workRoot/src so the skill operates
+// on its own tree. The cache survives across scans; the per-scan copy
+// is whatever the skill leaves behind. Returns the HEAD commit of the
+// freshly-synced cache.
+func (w *Worker) prepareDependentSrc(ctx context.Context, url, ref, workRoot string, emit func(Event)) (string, error) {
+	mu := w.cacheMutex(url)
+	mu.Lock()
+	defer mu.Unlock()
+
+	cacheRoot := dependentCacheRoot(w.DataDir, url)
+	if err := os.MkdirAll(cacheRoot, dirPerm); err != nil {
+		return "", err
+	}
+	cacheSrc, err := ensureClone(ctx, db.Repository{URL: url}, cacheRoot, false, ref, emit)
+	if err != nil {
+		return "", err
+	}
+	commit := gitHead(cacheSrc)
+	dst := filepath.Join(workRoot, "src")
+	if err := os.RemoveAll(dst); err != nil {
+		return "", err
+	}
+	if err := copyTree(cacheSrc, dst); err != nil {
+		return "", fmt.Errorf("copy dependent cache: %w", err)
+	}
+	return commit, nil
+}
+
+// copyTree recursively copies src to dst, preserving permissions but not
+// ownership or timestamps. Symlinks are recreated; everything else is
+// copied byte-for-byte. Fast enough for git trees up to a few hundred MB.
+func copyTree(src, dst string) error {
+	return filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(dst, rel)
+		switch {
+		case info.IsDir():
+			return os.MkdirAll(target, info.Mode().Perm())
+		case info.Mode()&os.ModeSymlink != 0:
+			link, err := os.Readlink(path)
+			if err != nil {
+				return err
+			}
+			return os.Symlink(link, target)
+		default:
+			return copyFile(path, target, info.Mode().Perm())
+		}
+	})
+}
+
+func copyFile(src, dst string, perm os.FileMode) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = in.Close() }()
+	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, perm)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		_ = out.Close()
+		return err
+	}
+	return out.Close()
+}
+
 // doExposure runs the exposure skill for one (finding, dependent) pair.
 // The scan's Repository stays the library being audited; ./src in the
-// workspace is symlinked to the shared dependent cache so concurrent
-// scans on different findings against the same dependent share the
-// clone. The skill returns one product_status verdict that is upserted
-// into finding_dependents.
+// workspace is a fresh copy of the shared dependent cache, so the
+// skill cannot pollute the cache and concurrent scans against the same
+// dependent serialise on a per-URL lock around the fetch. The skill
+// returns one product_status verdict that is upserted into
+// finding_dependents.
 func (w *Worker) doExposure(ctx context.Context, scan *db.Scan, emit func(Event)) (string, error) {
 	if scan.FindingID == nil || scan.DependentID == nil {
 		return "", fmt.Errorf("exposure scan %d missing finding_id or dependent_id", scan.ID)
@@ -63,15 +147,16 @@ func (w *Worker) doExposure(ctx context.Context, scan *db.Scan, emit func(Event)
 	if err := os.MkdirAll(workRoot, dirPerm); err != nil {
 		return "", err
 	}
-	cache := dependentCacheRoot(w.DataDir, dep.RepositoryURL)
-	if err := os.MkdirAll(cache, dirPerm); err != nil {
+	cacheCommit, err := w.prepareDependentSrc(ctx, dep.RepositoryURL, scan.Ref, workRoot, emit)
+	if err != nil {
+		if _, ok := errors.AsType[*RepoUnreachableError](err); ok {
+			w.upsertExposure(scan, dep.ID, db.ExposureUnderInvestigation, "", "dependent repository unreachable", "")
+			emit(Event{Kind: KindError, Text: err.Error()})
+			return "", nil
+		}
 		return "", err
 	}
-	srcLink := filepath.Join(workRoot, "src")
-	_ = os.Remove(srcLink)
-	if err := os.Symlink(cache, srcLink); err != nil {
-		return "", fmt.Errorf("symlink dependent cache: %w", err)
-	}
+	scan.Commit = cacheCommit
 
 	skillDir := filepath.Join(workRoot, ".claude", "skills", skill.Name)
 	if err := stageSkill(&skill, skillDir); err != nil {
@@ -96,9 +181,12 @@ func (w *Worker) doExposure(ctx context.Context, scan *db.Scan, emit func(Event)
 		Ref:          scan.Ref,
 		MaxTurns:     skill.MaxTurns,
 		AllowedTools: skill.AllowedTools,
+		SrcReady:     true,
 	}
 	res, err := w.Runner.RunSkill(ctx, sj, emit)
-	scan.Commit = res.Commit
+	if res.Commit != "" {
+		scan.Commit = res.Commit
+	}
 	if err != nil {
 		if _, ok := errors.AsType[*MaxTurnsReachedError](err); ok && res.Report != "" {
 			_ = w.parseExposureOutput(&skill, scan, dep.ID, res.Report, emit)

--- a/internal/worker/exposure.go
+++ b/internal/worker/exposure.go
@@ -1,0 +1,172 @@
+package worker
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"scrutineer/internal/db"
+)
+
+// dependentCacheRoot returns the shared on-disk path scrutineer reuses
+// across exposure scans of the same dependent URL. Keyed by sha256 of the
+// URL so different URLs cannot collide and the path is filesystem-safe.
+// The directory survives wrap()'s per-scan workspace cleanup, so the
+// second exposure scan on the same dependent only fetches the delta.
+func dependentCacheRoot(dataDir, url string) string {
+	sum := sha256.Sum256([]byte(url))
+	return filepath.Join(dataDir, "dependent-cache", hex.EncodeToString(sum[:]))
+}
+
+// doExposure runs the exposure skill for one (finding, dependent) pair.
+// The scan's Repository stays the library being audited; ./src in the
+// workspace is symlinked to the shared dependent cache so concurrent
+// scans on different findings against the same dependent share the
+// clone. The skill returns one product_status verdict that is upserted
+// into finding_dependents.
+func (w *Worker) doExposure(ctx context.Context, scan *db.Scan, emit func(Event)) (string, error) {
+	if scan.FindingID == nil || scan.DependentID == nil {
+		return "", fmt.Errorf("exposure scan %d missing finding_id or dependent_id", scan.ID)
+	}
+	if scan.SkillID == nil {
+		return "", fmt.Errorf("exposure scan %d has no skill id", scan.ID)
+	}
+	var dep db.Dependent
+	if err := w.DB.First(&dep, *scan.DependentID).Error; err != nil {
+		return "", fmt.Errorf("load dependent %d: %w", *scan.DependentID, err)
+	}
+	if dep.RepositoryURL == "" {
+		w.upsertExposure(scan, dep.ID, db.ExposureUnderInvestigation, "", "dependent has no repository URL", "")
+		emit(Event{Kind: KindText, Text: "dependent has no repository URL; marked under_investigation"})
+		return "", nil
+	}
+	var skill db.Skill
+	if err := w.DB.First(&skill, *scan.SkillID).Error; err != nil {
+		return "", fmt.Errorf("load skill %d: %w", *scan.SkillID, err)
+	}
+	scan.SkillName = skill.Name
+	scan.SkillVersion = skill.Version
+	w.DB.Model(scan).Updates(map[string]any{
+		"skill_name":    skill.Name,
+		"skill_version": skill.Version,
+	})
+
+	workRoot := w.workRoot(scan.ID)
+	if err := validateSkillPaths(skill.Name, skill.OutputFile); err != nil {
+		return "", err
+	}
+	if err := os.MkdirAll(workRoot, dirPerm); err != nil {
+		return "", err
+	}
+	cache := dependentCacheRoot(w.DataDir, dep.RepositoryURL)
+	if err := os.MkdirAll(cache, dirPerm); err != nil {
+		return "", err
+	}
+	srcLink := filepath.Join(workRoot, "src")
+	_ = os.Remove(srcLink)
+	if err := os.Symlink(cache, srcLink); err != nil {
+		return "", fmt.Errorf("symlink dependent cache: %w", err)
+	}
+
+	skillDir := filepath.Join(workRoot, ".claude", "skills", skill.Name)
+	if err := stageSkill(&skill, skillDir); err != nil {
+		return "", fmt.Errorf("stage skill: %w", err)
+	}
+	if err := stageContext(workRoot, w.APIBase, w.ForkOrg, scan, &scan.Repository); err != nil {
+		return "", fmt.Errorf("stage context: %w", err)
+	}
+
+	depRepo := db.Repository{URL: dep.RepositoryURL, Name: dep.Name}
+	prompt := buildSkillPrompt(skill.Name, skill.OutputFile)
+	scan.Prompt = prompt
+	w.DB.Model(scan).Update("prompt", prompt)
+
+	sj := SkillJob{
+		Repo:         depRepo,
+		WorkRoot:     workRoot,
+		Model:        scan.Model,
+		Name:         skill.Name,
+		SkillDir:     skillDir,
+		OutputFile:   skill.OutputFile,
+		Ref:          scan.Ref,
+		MaxTurns:     skill.MaxTurns,
+		AllowedTools: skill.AllowedTools,
+	}
+	res, err := w.Runner.RunSkill(ctx, sj, emit)
+	scan.Commit = res.Commit
+	if err != nil {
+		if _, ok := errors.AsType[*MaxTurnsReachedError](err); ok && res.Report != "" {
+			_ = w.parseExposureOutput(&skill, scan, dep.ID, res.Report, emit)
+		}
+		return res.Report, err
+	}
+	if res.Report != "" {
+		if perr := w.parseExposureOutput(&skill, scan, dep.ID, res.Report, emit); perr != nil {
+			return res.Report, perr
+		}
+	} else {
+		w.upsertExposure(scan, dep.ID, db.ExposureUnderInvestigation, "", "skill produced no report", res.Commit)
+	}
+	return res.Report, nil
+}
+
+// parseExposureOutput reads the one-shot verdict produced by the exposure
+// skill and upserts a finding_dependents row. Unknown status values fall
+// back to under_investigation; invalid justification labels are dropped.
+func (w *Worker) parseExposureOutput(skill *db.Skill, scan *db.Scan, depID uint, report string, emit func(Event)) error {
+	if skill.SchemaJSON != "" {
+		if detail := validateReportSchema(skill.SchemaJSON, report); detail != "" {
+			emit(Event{Kind: KindError, Text: "schema: report.json does not validate against schema.json:\n" + detail})
+			if w.SchemaStrict {
+				return &SchemaValidationError{Skill: skill.Name, Detail: detail}
+			}
+		}
+	}
+	var r struct {
+		Status        string `json:"status"`
+		Justification string `json:"justification"`
+		Rationale     string `json:"rationale"`
+	}
+	if err := json.Unmarshal([]byte(report), &r); err != nil {
+		return fmt.Errorf("parse exposure report: %w", err)
+	}
+	if !db.ValidExposureStatus(r.Status) {
+		r.Status = db.ExposureUnderInvestigation
+	}
+	if r.Status != db.ExposureKnownNotAffected || !db.ValidExposureJustification(r.Justification) {
+		r.Justification = ""
+	}
+	w.upsertExposure(scan, depID, r.Status, r.Justification, r.Rationale, scan.Commit)
+	emit(Event{Kind: KindText, Text: fmt.Sprintf("recorded exposure: %s", r.Status)})
+	return nil
+}
+
+func (w *Worker) upsertExposure(scan *db.Scan, depID uint, status, justification, rationale, commit string) {
+	row := db.FindingDependent{
+		FindingID:     *scan.FindingID,
+		DependentID:   depID,
+		Status:        status,
+		Justification: justification,
+		Rationale:     rationale,
+		ScanID:        &scan.ID,
+		ScanCommit:    commit,
+	}
+	var existing db.FindingDependent
+	err := w.DB.Where("finding_id = ? AND dependent_id = ?", row.FindingID, row.DependentID).First(&existing).Error
+	if err != nil {
+		_ = w.DB.Create(&row).Error
+		return
+	}
+	w.DB.Model(&existing).Updates(map[string]any{
+		"status":        row.Status,
+		"justification": row.Justification,
+		"rationale":     row.Rationale,
+		"scan_id":       row.ScanID,
+		"scan_commit":   row.ScanCommit,
+	})
+}

--- a/internal/worker/exposure_test.go
+++ b/internal/worker/exposure_test.go
@@ -10,7 +10,7 @@ import (
 
 func newExposureWorker(t *testing.T) *Worker {
 	t.Helper()
-	gdb, err := db.Open("file::memory:?cache=shared")
+	gdb, err := db.Open("file::memory:")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -19,8 +19,7 @@ func newExposureWorker(t *testing.T) *Worker {
 
 func seedExposureFixtures(t *testing.T, w *Worker) (db.Scan, db.Skill, db.Dependent) {
 	t.Helper()
-	tag := t.Name()
-	repo := db.Repository{URL: "https://github.com/example/lib-" + tag, Name: "lib"}
+	repo := db.Repository{URL: "https://github.com/example/lib", Name: "lib"}
 	if err := w.DB.Create(&repo).Error; err != nil {
 		t.Fatalf("seed repo: %v", err)
 	}
@@ -43,8 +42,8 @@ func seedExposureFixtures(t *testing.T, w *Worker) (db.Scan, db.Skill, db.Depend
 	if err := w.DB.Create(&scan).Error; err != nil {
 		t.Fatalf("seed scan: %v", err)
 	}
-	var skill db.Skill
-	if err := w.DB.Where(db.Skill{Name: "exposure"}).Attrs(db.Skill{Body: "x"}).FirstOrCreate(&skill).Error; err != nil {
+	skill := db.Skill{Name: "exposure", Body: "x"}
+	if err := w.DB.Create(&skill).Error; err != nil {
 		t.Fatalf("seed skill: %v", err)
 	}
 	return scan, skill, dep

--- a/internal/worker/exposure_test.go
+++ b/internal/worker/exposure_test.go
@@ -1,0 +1,143 @@
+package worker
+
+import (
+	"log/slog"
+	"os"
+	"testing"
+
+	"scrutineer/internal/db"
+)
+
+func newExposureWorker(t *testing.T) *Worker {
+	t.Helper()
+	gdb, err := db.Open("file::memory:?cache=shared")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &Worker{DB: gdb, Log: slog.New(slog.NewTextHandler(os.Stderr, nil))}
+}
+
+func seedExposureFixtures(t *testing.T, w *Worker) (db.Scan, db.Skill, db.Dependent) {
+	t.Helper()
+	tag := t.Name()
+	repo := db.Repository{URL: "https://github.com/example/lib-" + tag, Name: "lib"}
+	if err := w.DB.Create(&repo).Error; err != nil {
+		t.Fatalf("seed repo: %v", err)
+	}
+	dep := db.Dependent{RepositoryID: repo.ID, Name: "downstream",
+		RepositoryURL: "https://github.com/example/downstream"}
+	if err := w.DB.Create(&dep).Error; err != nil {
+		t.Fatalf("seed dependent: %v", err)
+	}
+	parentScan := db.Scan{RepositoryID: repo.ID, Kind: JobSkill, Status: db.ScanDone}
+	if err := w.DB.Create(&parentScan).Error; err != nil {
+		t.Fatalf("seed parent scan: %v", err)
+	}
+	f := db.Finding{ScanID: parentScan.ID, RepositoryID: repo.ID, Title: "x"}
+	if err := w.DB.Create(&f).Error; err != nil {
+		t.Fatalf("seed finding: %v", err)
+	}
+	scan := db.Scan{RepositoryID: repo.ID, Kind: JobExposure, Status: db.ScanRunning}
+	scan.FindingID = &f.ID
+	scan.DependentID = &dep.ID
+	if err := w.DB.Create(&scan).Error; err != nil {
+		t.Fatalf("seed scan: %v", err)
+	}
+	var skill db.Skill
+	if err := w.DB.Where(db.Skill{Name: "exposure"}).Attrs(db.Skill{Body: "x"}).FirstOrCreate(&skill).Error; err != nil {
+		t.Fatalf("seed skill: %v", err)
+	}
+	return scan, skill, dep
+}
+
+func TestParseExposureOutput_knownNotAffected(t *testing.T) {
+	w := newExposureWorker(t)
+	scan, skill, dep := seedExposureFixtures(t, w)
+
+	report := `{"status":"known_not_affected","justification":"vulnerable_code_not_in_execute_path","rationale":"only test code reaches it","spec_version":1}`
+	if err := w.parseExposureOutput(&skill, &scan, dep.ID, report, func(Event) {}); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	var row db.FindingDependent
+	if err := w.DB.Where("finding_id = ? AND dependent_id = ?", *scan.FindingID, dep.ID).First(&row).Error; err != nil {
+		t.Fatalf("row: %v", err)
+	}
+	if row.Status != db.ExposureKnownNotAffected {
+		t.Errorf("status = %q", row.Status)
+	}
+	if row.Justification != db.JustifVulnerableCodeNotInPath {
+		t.Errorf("justification = %q", row.Justification)
+	}
+}
+
+func TestParseExposureOutput_dropsJustificationWhenAffected(t *testing.T) {
+	w := newExposureWorker(t)
+	scan, skill, dep := seedExposureFixtures(t, w)
+
+	report := `{"status":"known_affected","justification":"vulnerable_code_not_present","spec_version":1}`
+	if err := w.parseExposureOutput(&skill, &scan, dep.ID, report, func(Event) {}); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	var row db.FindingDependent
+	w.DB.Where("finding_id = ? AND dependent_id = ?", *scan.FindingID, dep.ID).First(&row)
+	if row.Justification != "" {
+		t.Errorf("justification should be dropped on known_affected, got %q", row.Justification)
+	}
+}
+
+func TestParseExposureOutput_unknownStatusFallsBack(t *testing.T) {
+	w := newExposureWorker(t)
+	scan, skill, dep := seedExposureFixtures(t, w)
+
+	report := `{"status":"maybe","spec_version":1}`
+	if err := w.parseExposureOutput(&skill, &scan, dep.ID, report, func(Event) {}); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	var row db.FindingDependent
+	w.DB.Where("finding_id = ? AND dependent_id = ?", *scan.FindingID, dep.ID).First(&row)
+	if row.Status != db.ExposureUnderInvestigation {
+		t.Errorf("status = %q, want under_investigation fallback", row.Status)
+	}
+}
+
+func TestParseExposureOutput_invalidJSON(t *testing.T) {
+	w := newExposureWorker(t)
+	scan, skill, dep := seedExposureFixtures(t, w)
+	if err := w.parseExposureOutput(&skill, &scan, dep.ID, "not-json", func(Event) {}); err == nil {
+		t.Fatal("expected error on invalid JSON")
+	}
+}
+
+func TestParseExposureOutput_upsertsExistingRow(t *testing.T) {
+	w := newExposureWorker(t)
+	scan, skill, dep := seedExposureFixtures(t, w)
+
+	first := `{"status":"under_investigation","spec_version":1}`
+	if err := w.parseExposureOutput(&skill, &scan, dep.ID, first, func(Event) {}); err != nil {
+		t.Fatal(err)
+	}
+	second := `{"status":"known_affected","spec_version":1}`
+	if err := w.parseExposureOutput(&skill, &scan, dep.ID, second, func(Event) {}); err != nil {
+		t.Fatal(err)
+	}
+	var rows []db.FindingDependent
+	w.DB.Where("finding_id = ? AND dependent_id = ?", *scan.FindingID, dep.ID).Find(&rows)
+	if len(rows) != 1 {
+		t.Fatalf("expected upsert, got %d rows", len(rows))
+	}
+	if rows[0].Status != db.ExposureKnownAffected {
+		t.Errorf("status = %q", rows[0].Status)
+	}
+}
+
+func TestDependentCacheRoot_keyedByURL(t *testing.T) {
+	a := dependentCacheRoot("/data", "https://github.com/a/b")
+	b := dependentCacheRoot("/data", "https://github.com/a/b")
+	c := dependentCacheRoot("/data", "https://github.com/c/d")
+	if a != b {
+		t.Errorf("same URL must yield same path: %s vs %s", a, b)
+	}
+	if a == c {
+		t.Errorf("different URLs must yield different paths")
+	}
+}

--- a/internal/worker/skill.go
+++ b/internal/worker/skill.go
@@ -28,12 +28,13 @@ type skillContext struct {
 }
 
 type skillContextScrutineer struct {
-	APIBase   string `json:"api_base"`             // e.g. http://127.0.0.1:8080/api
-	ScanID    uint   `json:"scan_id"`              // the scan that owns this run
-	Token     string `json:"token"`                // bearer for api_base
-	RepoID    uint   `json:"repository_id"`        // convenience for URL building
-	SkillID   uint   `json:"skill_id,omitempty"`   // the running skill
-	FindingID uint   `json:"finding_id,omitempty"` // set for finding-scoped scans
+	APIBase     string `json:"api_base"`               // e.g. http://127.0.0.1:8080/api
+	ScanID      uint   `json:"scan_id"`                // the scan that owns this run
+	Token       string `json:"token"`                  // bearer for api_base
+	RepoID      uint   `json:"repository_id"`          // convenience for URL building
+	SkillID     uint   `json:"skill_id,omitempty"`     // the running skill
+	FindingID   uint   `json:"finding_id,omitempty"`   // set for finding-scoped scans
+	DependentID uint   `json:"dependent_id,omitempty"` // set on exposure scans
 	// ScanRef is the git ref (branch/tag) the clone was checked out to.
 	// Empty means the repository's default branch.
 	ScanRef string `json:"scan_ref,omitempty"`
@@ -489,6 +490,9 @@ func stageContext(workRoot, apiBase, forkOrg string, scan *db.Scan, repo *db.Rep
 	}
 	if scan.FindingID != nil {
 		ctx.Scrutineer.FindingID = *scan.FindingID
+	}
+	if scan.DependentID != nil {
+		ctx.Scrutineer.DependentID = *scan.DependentID
 	}
 	if scan.Ref != "" {
 		ctx.Scrutineer.ScanRef = scan.Ref

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -51,6 +51,12 @@ type Worker struct {
 
 	mu      sync.Mutex
 	running map[uint]context.CancelFunc
+
+	// cacheMu serialises clone/fetch on the dependent-clone cache per
+	// URL. A Mutex per URL keeps two exposure scans from racing inside
+	// the same physical dir while leaving scans of different
+	// dependents free to run in parallel.
+	cacheMu sync.Map
 }
 
 // Cancel aborts an in-flight scan. Returns true if a running job was found and

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -20,7 +20,8 @@ import (
 )
 
 const (
-	JobSkill = "skill"
+	JobSkill    = "skill"
+	JobExposure = "exposure"
 
 	PrioScan     = 0
 	PrioFinding  = 2
@@ -78,6 +79,7 @@ func (w *Worker) workRoot(scanID uint) string {
 
 func (w *Worker) Register(q *queue.Queue) {
 	q.Register(JobSkill, w.wrap(w.doSkill))
+	q.Register(JobExposure, w.wrap(w.doExposure))
 }
 
 // handler does the actual work for one job kind. It receives the loaded scan

--- a/skills/exposure/SKILL.md
+++ b/skills/exposure/SKILL.md
@@ -2,6 +2,7 @@
 name: exposure
 description: For one (finding, dependent) pair, decide whether the dependent's published code actually reaches the upstream library finding. Emit one CSAF 2.0 product_status verdict so scrutineer can record affected vs not_affected and stamp the right VEX justification.
 license: MIT
+allowed-tools: Read,Write,Glob,Grep,WebFetch,LS
 metadata:
   scrutineer.version: 1
   scrutineer.output_file: report.json
@@ -16,7 +17,7 @@ Your verdict feeds CSAF VEX export, so use the CSAF product_status vocabulary. T
 
 ## Workspace
 
-- `./src` — the dependent's cloned source (a symlink into scrutineer's dependent-cache; treat as read-only)
+- `./src` — a per-scan copy of the dependent's cloned source
 - `./context.json` — has `scrutineer.api_base`, `scrutineer.token`, `scrutineer.finding_id`, `scrutineer.dependent_id`
 - `./report.json` — write your verdict here
 - `./schema.json` — output shape
@@ -36,7 +37,7 @@ Read `title`, `location`, `sinks`, `trace`, `boundary` and `affected`. These tel
 
 1. **Find how this dependent uses the library.** Grep `./src` for imports/requires of the library package (the finding's `repository_url` / `affected` field name it). If the lockfile lists the lib but no source file uses the dangerous symbol, status is `known_not_affected` with justification `vulnerable_code_not_in_execute_path`.
 
-2. **Check the pinned version against `affected`.** If the dependent pins a version outside the affected range, status is `known_not_affected` with justification `component_not_present` (the vulnerable build is not present in this consumer).
+2. **Check the pinned version against `affected`.** If the dependent pins a version outside the affected range, status is `known_not_affected` with justification `vulnerable_code_not_present` (the consumer ships the library, but the build it ships does not contain the vulnerable code). `component_not_present` is reserved for the case where the library itself is not in the dependent at all.
 
 3. **Trace from a public entry point to the call.** Use the same heuristics `reachability` uses: request handlers, CLI entry points, library exports. If the only callers are test fixtures or admin-only tooling, status is `known_not_affected` with justification `vulnerable_code_not_in_execute_path`.
 

--- a/skills/exposure/SKILL.md
+++ b/skills/exposure/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: exposure
+description: For one (finding, dependent) pair, decide whether the dependent's published code actually reaches the upstream library finding. Emit one CSAF 2.0 product_status verdict so scrutineer can record affected vs not_affected and stamp the right VEX justification.
+license: MIT
+metadata:
+  scrutineer.version: 1
+  scrutineer.output_file: report.json
+  scrutineer.output_kind: exposure
+---
+
+# exposure
+
+Scrutineer just finished a `security-deep-dive` on a library and is now walking that library's top dependents. For each dependent, this skill answers the same question `reachability` asks application-side, but scoped to a single upstream finding: does this dependent's code path the bug requires actually exist?
+
+Your verdict feeds CSAF VEX export, so use the CSAF product_status vocabulary. The four legal status values are `known_affected`, `known_not_affected`, `under_investigation`, `fixed`. `justification` is a CSAF VEX flag label and only applies when status is `known_not_affected`.
+
+## Workspace
+
+- `./src` — the dependent's cloned source (a symlink into scrutineer's dependent-cache; treat as read-only)
+- `./context.json` — has `scrutineer.api_base`, `scrutineer.token`, `scrutineer.finding_id`, `scrutineer.dependent_id`
+- `./report.json` — write your verdict here
+- `./schema.json` — output shape
+
+## Inputs
+
+Fetch the upstream finding so you know what to look for:
+
+```
+GET {api_base}/findings/{finding_id}
+Authorization: Bearer {token}
+```
+
+Read `title`, `location`, `sinks`, `trace`, `boundary` and `affected`. These tell you which call inside the library is dangerous, the input shape it needs, and which versions are vulnerable.
+
+## Procedure
+
+1. **Find how this dependent uses the library.** Grep `./src` for imports/requires of the library package (the finding's `repository_url` / `affected` field name it). If the lockfile lists the lib but no source file uses the dangerous symbol, status is `known_not_affected` with justification `vulnerable_code_not_in_execute_path`.
+
+2. **Check the pinned version against `affected`.** If the dependent pins a version outside the affected range, status is `known_not_affected` with justification `component_not_present` (the vulnerable build is not present in this consumer).
+
+3. **Trace from a public entry point to the call.** Use the same heuristics `reachability` uses: request handlers, CLI entry points, library exports. If the only callers are test fixtures or admin-only tooling, status is `known_not_affected` with justification `vulnerable_code_not_in_execute_path`.
+
+4. **Check the dependent's own validation around the call.** A size cap, schema check, or safe-mode flag the dependent applies before forwarding to the library may neutralise the bug. If you can show that, status is `known_not_affected` with justification `inline_mitigations_already_exist`.
+
+5. **If a real call path exists and reaches the sink with attacker-controlled input**, status is `known_affected`. Leave `justification` empty.
+
+6. **If the upstream finding has a `fix_version` set and the dependent pins at or above it**, status is `fixed`. Leave `justification` empty.
+
+7. **If the dependent's code base is too large to be confident in two-pass triage**, status is `under_investigation`. Say so in `rationale`.
+
+## Output
+
+Write `./report.json`:
+
+```json
+{
+  "status": "known_not_affected",
+  "justification": "vulnerable_code_not_in_execute_path",
+  "rationale": "Dependent foo imports bar but only calls bar.SafeParse(). The vulnerable bar.UnsafeParse() is never referenced.",
+  "spec_version": 1
+}
+```
+
+Keep `rationale` to one paragraph, citing the file paths you checked. The scrutineer UI displays it under the per-dependent table on the finding page.

--- a/skills/exposure/schema.json
+++ b/skills/exposure/schema.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "exposure report",
+  "description": "One CSAF 2.0 product_status verdict for a (finding, dependent) pair.",
+  "type": "object",
+  "required": ["status", "spec_version"],
+  "additionalProperties": false,
+  "properties": {
+    "spec_version": { "type": "integer", "minimum": 1 },
+    "status": {
+      "type": "string",
+      "enum": ["known_affected", "known_not_affected", "under_investigation", "fixed"]
+    },
+    "justification": {
+      "type": "string",
+      "enum": [
+        "",
+        "component_not_present",
+        "vulnerable_code_not_present",
+        "vulnerable_code_not_in_execute_path",
+        "vulnerable_code_cannot_be_controlled_by_adversary",
+        "inline_mitigations_already_exist"
+      ]
+    },
+    "rationale": { "type": "string" }
+  },
+  "allOf": [
+    {
+      "if": { "properties": { "status": { "const": "known_not_affected" } }, "required": ["status"] },
+      "then": { "required": ["justification"], "properties": { "justification": { "minLength": 1 } } }
+    },
+    {
+      "if": { "properties": { "status": { "not": { "const": "known_not_affected" } } }, "required": ["status"] },
+      "then": { "properties": { "justification": { "const": "" } } }
+    }
+  ]
+}


### PR DESCRIPTION
Fix #9

A few design choices I made, open to debate 🙂 

- The status column mirrors the CSAF `product_status` buckets verbatim, so the VEX export is a passthrough rather than a translation that can drift.
- Each (finding, dependent) pair is its own scan. Prompts stay short, failures are isolated, and the shared clone cache amortises the extra git work.
- Top 10 dependents per click, should we change it maybe or add a way to customize it?
- The new skill is pretty minimal, happy to improve it one way or another 