### PR TITLE
Split scanner findings (zizmor, semgrep) from the deep-dive audit

### DIFF
--- a/internal/web/org_report.go
+++ b/internal/web/org_report.go
@@ -51,8 +51,12 @@ func renderOrgReport(gdb *gorm.DB, owner string, repos []db.Repository) string {
 	for _, r := range repos {
 		repoIDs = append(repoIDs, r.ID)
 	}
+	// Org report mirrors what the UI shows: deep-dive findings only.
+	// Scanner output (zizmor, semgrep) lives in each repo's Scanners tab
+	// and would dominate the totals if rolled in here.
 	var findings []db.Finding
 	gdb.Where("repository_id IN ?", repoIDs).
+		Where("scan_id IN (?)", deepDiveScanIDs(gdb)).
 		Order("severity, id").Find(&findings)
 
 	bySeverity := map[string]int{}

--- a/internal/web/repo_report.go
+++ b/internal/web/repo_report.go
@@ -174,8 +174,13 @@ func writeReportThreatModel(b *strings.Builder, scan *db.Scan, tm map[string]any
 
 func writeReportFindings(b *strings.Builder, gdb *gorm.DB, repoID uint, latest *db.Scan) {
 	fmt.Fprintf(b, "## Findings\n\n")
+	// Mirrors the repo page Findings tab: deep-dive output only. Scanner
+	// findings (zizmor, semgrep) belong to the Scanners tab and stay out of
+	// the curated report so download recipients don't drown in lint noise.
 	var findings []db.Finding
-	gdb.Where("repository_id = ?", repoID).Order("severity, id").Find(&findings)
+	gdb.Where("repository_id = ?", repoID).
+		Where("scan_id IN (?)", deepDiveScanIDs(gdb)).
+		Order("severity, id").Find(&findings)
 	if len(findings) == 0 {
 		fmt.Fprintf(b, "No findings recorded for this repository.\n\n")
 		return

--- a/internal/web/sboms.go
+++ b/internal/web/sboms.go
@@ -133,8 +133,12 @@ func (s *Server) sbomShow(w http.ResponseWriter, r *http.Request) {
 	var findings []db.Finding
 	var advisories []db.Advisory
 	if len(repoIDs) > 0 {
+		// Deep-dive findings only — the SBOM "Findings" tab is a
+		// downstream-impact view, where lint output from per-repo scanners
+		// (zizmor, semgrep) would be misleading at this level.
 		q := s.DB.Where("repository_id IN ? AND status NOT IN ?", repoIDs,
-			[]db.FindingLifecycle{db.FindingRejected, db.FindingDuplicate})
+			[]db.FindingLifecycle{db.FindingRejected, db.FindingDuplicate}).
+			Where("scan_id IN (?)", deepDiveScanIDs(s.DB))
 		if sev := r.URL.Query().Get("severity"); sev != "" {
 			q = q.Where("severity = ?", sev)
 		}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -405,7 +405,9 @@ func (s *Server) repoList(w http.ResponseWriter, r *http.Request) {
 		// Correlated subquery keeps the existing Count/Find chain intact
 		// (a JOIN+GROUP BY would change what Count(&total) returns). Low-
 		// thousands of repos so the per-row subselect is fine on sqlite.
-		q = q.Order("(SELECT COUNT(*) FROM findings WHERE findings.repository_id = repositories.id) desc, updated_at desc")
+		// Scanner-skill findings (zizmor, semgrep, …) are excluded so the
+		// list reflects curated audit output, matching the repo Findings tab.
+		q = q.Order("(" + deepDiveFindingsCountSQL + ") desc, updated_at desc")
 	default:
 		sort = defaultSort
 		q = q.Order("updated_at desc")
@@ -432,9 +434,13 @@ func (s *Server) repoList(w http.ResponseWriter, r *http.Request) {
 			N            int
 		}
 		var counts []rowCount
+		// Scope to deep-dive findings only so the column matches the repo
+		// page's Findings tab; scanner output (zizmor/semgrep) is reachable
+		// via that repo's Scanners tab.
 		s.DB.Model(&db.Finding{}).
 			Select("repository_id, COUNT(*) AS n").
 			Where("repository_id IN ?", repoIDs).
+			Where("scan_id IN (?)", deepDiveScanIDs(s.DB)).
 			Group("repository_id").
 			Scan(&counts)
 		for _, c := range counts {
@@ -539,13 +545,18 @@ func (s *Server) orgsList(w http.ResponseWriter, r *http.Request) {
 			N     int
 		}
 		var counts []c
+		// LEFT JOIN scans so the COUNT only includes findings whose scan is
+		// the curated audit. Tool-scanner output (zizmor, semgrep) is shown
+		// per-repo in the Scanners tab, not in cross-org totals.
 		s.DB.Raw(`
 			SELECT r.owner, COUNT(f.id) AS n
 			FROM repositories r
 			LEFT JOIN findings f ON f.repository_id = r.id
+			LEFT JOIN scans s ON s.id = f.scan_id
 			WHERE r.owner != ''
+			  AND (s.skill_name IS NULL OR s.skill_name = '' OR s.skill_name = ?)
 			GROUP BY r.owner
-		`).Scan(&counts)
+		`, deepDiveSkillName).Scan(&counts)
 		for _, x := range counts {
 			findingCounts[x.Owner] = x.N
 		}
@@ -618,7 +629,9 @@ func (s *Server) orgShow(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Per-repo finding count for the repos table, plus the full finding
-	// list for the Findings tab.
+	// list for the Findings tab. Scanner skills (zizmor, semgrep) are kept
+	// out of both so the org summary matches the repo Findings tab; the
+	// per-repo Scanners tab is where that output lives.
 	findingCounts := map[uint]int{}
 	type rowCount struct {
 		RepositoryID uint
@@ -628,6 +641,7 @@ func (s *Server) orgShow(w http.ResponseWriter, r *http.Request) {
 	s.DB.Model(&db.Finding{}).
 		Select("repository_id, COUNT(*) AS n").
 		Where("repository_id IN ?", repoIDs).
+		Where("scan_id IN (?)", deepDiveScanIDs(s.DB)).
 		Group("repository_id").Scan(&counts)
 	for _, c := range counts {
 		findingCounts[c.RepositoryID] = c.N
@@ -639,6 +653,7 @@ func (s *Server) orgShow(w http.ResponseWriter, r *http.Request) {
 	// before Medium, which misreads for a stakeholder scanning the tab.
 	var findings []db.Finding
 	s.DB.Where("repository_id IN ?", repoIDs).
+		Where("scan_id IN (?)", deepDiveScanIDs(s.DB)).
 		Order(severityOrder).Order("id desc").
 		Limit(orgTabLimit).Find(&findings)
 	reposByID := loadRepoMap(s.DB, findings)
@@ -714,13 +729,18 @@ func (s *Server) maintainersList(w http.ResponseWriter, r *http.Request) {
 			N            int
 		}
 		var counts []row
+		// LEFT JOIN scans so the COUNT only includes deep-dive findings.
+		// Scanner output (zizmor, semgrep) is per-repo lint noise and
+		// shouldn't drive maintainer routing.
 		s.DB.Raw(`
 			SELECT rm.maintainer_id, COUNT(f.id) AS n
 			FROM repository_maintainers rm
 			LEFT JOIN findings f ON f.repository_id = rm.repository_id
+			LEFT JOIN scans s ON s.id = f.scan_id
 			WHERE rm.maintainer_id IN ?
+			  AND (s.skill_name IS NULL OR s.skill_name = '' OR s.skill_name = ?)
 			GROUP BY rm.maintainer_id
-		`, ids).Scan(&counts)
+		`, ids, deepDiveSkillName).Scan(&counts)
 		for _, c := range counts {
 			findingCounts[c.MaintainerID] = c.N
 		}
@@ -767,7 +787,12 @@ func (s *Server) maintainerShow(w http.ResponseWriter, r *http.Request) {
 	}
 	var findings []db.Finding
 	if len(repoIDs) > 0 {
-		s.DB.Where("repository_id IN ?", repoIDs).Order("id desc").Find(&findings)
+		// Same filter the Findings tab applies elsewhere: deep-dive only,
+		// keeping scanner noise off the maintainer view used for disclosure
+		// routing.
+		s.DB.Where("repository_id IN ?", repoIDs).
+			Where("scan_id IN (?)", deepDiveScanIDs(s.DB)).
+			Order("id desc").Find(&findings)
 	}
 	reposByID := loadRepoMap(s.DB, findings)
 	s.render(w, r, "maintainer_show.html", map[string]any{
@@ -805,6 +830,13 @@ var severityOrder = `CASE severity
 
 func (s *Server) findings(w http.ResponseWriter, r *http.Request) {
 	q := s.DB.Model(&db.Finding{})
+	// Default to deep-dive findings only; scanner skills (zizmor, semgrep)
+	// are noisy enough to drown out the audit list. ?scanners=1 includes
+	// them and is exposed as a toggle in the UI.
+	scanners := r.URL.Query().Get("scanners") == "1"
+	if !scanners {
+		q = q.Where("scan_id IN (?)", deepDiveScanIDs(s.DB))
+	}
 	sev := r.URL.Query().Get("severity")
 	if sev != "" {
 		q = q.Where("severity = ?", sev)
@@ -855,10 +887,16 @@ func (s *Server) findings(w http.ResponseWriter, r *http.Request) {
 	var missedTotal int64
 	s.DB.Model(&db.Finding{}).Where("missed_count > 0").Count(&missedTotal)
 
+	var scannerTotal int64
+	s.DB.Model(&db.Finding{}).
+		Where("scan_id NOT IN (?)", deepDiveScanIDs(s.DB)).
+		Count(&scannerTotal)
+
 	s.render(w, r, "findings.html", map[string]any{
 		"Findings": rows, "Page": page, "Severity": sev, "Sort": sort,
 		"Repos": reposByID, "Q": search, "AnySubPath": anySubPath,
 		"Owner": owner, "Missed": missed, "MissedTotal": missedTotal,
+		"Scanners": scanners, "ScannerTotal": scannerTotal,
 	})
 }
 
@@ -926,6 +964,24 @@ const (
 	// section of the deep-dive report so older scans keep rendering.
 	threatModelSkillName = "threat-model"
 )
+
+// deepDiveFindingsCountSQL is a correlated subselect that counts deep-dive
+// findings for the surrounding repositories row. Used in the repos list
+// "findings" sort. Tool-scanner skills are excluded so the ordering matches
+// the counts shown in the Findings column.
+const deepDiveFindingsCountSQL = `SELECT COUNT(*) FROM findings f
+    WHERE f.repository_id = repositories.id
+      AND f.scan_id IN (SELECT id FROM scans
+        WHERE skill_name = '` + deepDiveSkillName + `' OR skill_name = '' OR skill_name IS NULL)`
+
+// deepDiveScanIDs returns a GORM subquery selecting scan IDs that belong to
+// the curated audit (security-deep-dive) or to legacy/empty skill_name rows.
+// Use it as a `scan_id IN (?)` filter to keep listings consistent with the
+// repo Findings tab.
+func deepDiveScanIDs(gdb *gorm.DB) *gorm.DB {
+	return gdb.Model(&db.Scan{}).Select("id").
+		Where("skill_name = ? OR skill_name = '' OR skill_name IS NULL", deepDiveSkillName)
+}
 
 func (s *Server) addRepoAndScan(w http.ResponseWriter, r *http.Request, repoURL string) {
 	input, err := ParseRepoInput(repoURL)
@@ -1443,10 +1499,35 @@ func (s *Server) repoShow(w http.ResponseWriter, r *http.Request) {
 	// deep-dive run. rejected/duplicate are analyst-dispositioned noise and
 	// stay off the tab; everything else is shown so an empty or failed
 	// latest scan does not hide earlier results (#72).
-	var findings []db.Finding
+	var allFindings []db.Finding
 	s.DB.Where("repository_id = ? AND status NOT IN ?", repo.ID,
 		[]db.FindingLifecycle{db.FindingRejected, db.FindingDuplicate}).
-		Order(severityOrder).Order("id desc").Find(&findings)
+		Order(severityOrder).Order("id desc").Find(&allFindings)
+
+	// Findings from the structured audit (security-deep-dive) and findings
+	// from tool-style scanners (zizmor, semgrep, …) render in separate tabs
+	// so the curated audit list isn't drowned out by lint noise. Anything
+	// without a matching scan is treated as deep-dive to avoid losing it.
+	scanSkill := map[uint]string{}
+	if len(allFindings) > 0 {
+		var rows []struct {
+			ID        uint
+			SkillName string
+		}
+		s.DB.Raw(`SELECT id, COALESCE(skill_name, '') AS skill_name FROM scans WHERE repository_id = ?`, repo.ID).Scan(&rows)
+		for _, row := range rows {
+			scanSkill[row.ID] = row.SkillName
+		}
+	}
+	var findings, scannerFindings []db.Finding
+	for _, f := range allFindings {
+		name := scanSkill[f.ScanID]
+		if name == "" || name == deepDiveSkillName {
+			findings = append(findings, f)
+		} else {
+			scannerFindings = append(scannerFindings, f)
+		}
+	}
 
 	var maintainers []db.Maintainer
 	s.DB.Joins("JOIN repository_maintainers ON repository_maintainers.maintainer_id = maintainers.id").
@@ -1495,10 +1576,12 @@ func (s *Server) repoShow(w http.ResponseWriter, r *http.Request) {
 
 	data := map[string]any{
 		"Repo": repo, "Scans": scans, "Latest": latest,
-		"Findings":  findings,
-		"TotalCost": totalCost,
-		"TMCommit":  tmCommit,
-		"Deps":      deps, "Pkgs": pkgs, "Dependents": dependents, "Advisories": advisories, "Maintainers": maintainers, "ThreatModel": threatModel,
+		"Findings":        findings,
+		"ScannerFindings": scannerFindings,
+		"ScanSkill":       scanSkill,
+		"TotalCost":       totalCost,
+		"TMCommit":        tmCommit,
+		"Deps":            deps, "Pkgs": pkgs, "Dependents": dependents, "Advisories": advisories, "Maintainers": maintainers, "ThreatModel": threatModel,
 		"KnownURLs": knownURLs, "KnownPURLs": knownPURLs,
 		"Skills":       activeSkills,
 		"Subprojects":  subprojects,

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -828,6 +828,41 @@ var severityOrder = `CASE severity
 	WHEN 'Critical' THEN 0 WHEN 'High' THEN 1
 	WHEN 'Medium' THEN 2 WHEN 'Low' THEN 3 ELSE 4 END`
 
+// loadRepoFindings returns the open findings for a repo split into two
+// slices: deep-dive output and tool-scanner output (zizmor, semgrep, …).
+// Findings with no matching scan or an empty skill_name are treated as
+// deep-dive so legacy rows don't get lost. The returned scanSkill map is
+// keyed by scan ID and is what the template reads to label scanner cards.
+func loadRepoFindings(gdb *gorm.DB, repoID uint) ([]db.Finding, []db.Finding, map[uint]string) {
+	var all []db.Finding
+	gdb.Where("repository_id = ? AND status NOT IN ?", repoID,
+		[]db.FindingLifecycle{db.FindingRejected, db.FindingDuplicate}).
+		Order(severityOrder).Order("id desc").Find(&all)
+
+	scanSkill := map[uint]string{}
+	if len(all) == 0 {
+		return nil, nil, scanSkill
+	}
+	var rows []struct {
+		ID        uint
+		SkillName string
+	}
+	gdb.Raw(`SELECT id, COALESCE(skill_name, '') AS skill_name FROM scans WHERE repository_id = ?`, repoID).Scan(&rows)
+	for _, row := range rows {
+		scanSkill[row.ID] = row.SkillName
+	}
+	var deepDive, scanners []db.Finding
+	for _, f := range all {
+		name := scanSkill[f.ScanID]
+		if name == "" || name == deepDiveSkillName {
+			deepDive = append(deepDive, f)
+		} else {
+			scanners = append(scanners, f)
+		}
+	}
+	return deepDive, scanners, scanSkill
+}
+
 func (s *Server) findings(w http.ResponseWriter, r *http.Request) {
 	q := s.DB.Model(&db.Finding{})
 	// Default to deep-dive findings only; scanner skills (zizmor, semgrep)
@@ -1495,39 +1530,7 @@ func (s *Server) repoShow(w http.ResponseWriter, r *http.Request) {
 	s.DB.Model(&db.Scan{}).Where("repository_id = ?", repo.ID).
 		Select("COALESCE(SUM(cost_usd), 0)").Scan(&totalCost)
 
-	// All findings across every scan of this repo, not just the latest
-	// deep-dive run. rejected/duplicate are analyst-dispositioned noise and
-	// stay off the tab; everything else is shown so an empty or failed
-	// latest scan does not hide earlier results (#72).
-	var allFindings []db.Finding
-	s.DB.Where("repository_id = ? AND status NOT IN ?", repo.ID,
-		[]db.FindingLifecycle{db.FindingRejected, db.FindingDuplicate}).
-		Order(severityOrder).Order("id desc").Find(&allFindings)
-
-	// Findings from the structured audit (security-deep-dive) and findings
-	// from tool-style scanners (zizmor, semgrep, …) render in separate tabs
-	// so the curated audit list isn't drowned out by lint noise. Anything
-	// without a matching scan is treated as deep-dive to avoid losing it.
-	scanSkill := map[uint]string{}
-	if len(allFindings) > 0 {
-		var rows []struct {
-			ID        uint
-			SkillName string
-		}
-		s.DB.Raw(`SELECT id, COALESCE(skill_name, '') AS skill_name FROM scans WHERE repository_id = ?`, repo.ID).Scan(&rows)
-		for _, row := range rows {
-			scanSkill[row.ID] = row.SkillName
-		}
-	}
-	var findings, scannerFindings []db.Finding
-	for _, f := range allFindings {
-		name := scanSkill[f.ScanID]
-		if name == "" || name == deepDiveSkillName {
-			findings = append(findings, f)
-		} else {
-			scannerFindings = append(scannerFindings, f)
-		}
-	}
+	findings, scannerFindings, scanSkill := loadRepoFindings(s.DB, repo.ID)
 
 	var maintainers []db.Maintainer
 	s.DB.Joins("JOIN repository_maintainers ON repository_maintainers.maintainer_id = maintainers.id").

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -647,7 +647,7 @@ func TestOrgsList_sortOptions(t *testing.T) {
 		r := db.Repository{URL: "https://example.com/" + owner + "/" + name, Name: name, Owner: owner}
 		s.DB.Create(&r)
 		if findings > 0 {
-			scan := db.Scan{RepositoryID: r.ID, Kind: "skill", Status: db.ScanDone, SkillName: "x"}
+			scan := db.Scan{RepositoryID: r.ID, Kind: "skill", Status: db.ScanDone, SkillName: deepDiveSkillName}
 			s.DB.Create(&scan)
 			for i := 0; i < findings; i++ {
 				s.DB.Create(&db.Finding{ScanID: scan.ID, RepositoryID: r.ID,
@@ -749,7 +749,7 @@ func TestOrgShow_findingsTabSortsBySeverity(t *testing.T) {
 
 	r := db.Repository{URL: "https://example.com/acme/web", Name: "web", Owner: "acme"}
 	s.DB.Create(&r)
-	scan := db.Scan{RepositoryID: r.ID, Kind: "skill", Status: db.ScanDone, SkillName: "x"}
+	scan := db.Scan{RepositoryID: r.ID, Kind: "skill", Status: db.ScanDone, SkillName: deepDiveSkillName}
 	s.DB.Create(&scan)
 	// Create in the wrong order on purpose, so id-desc would place Low
 	// above Medium and Medium above High.
@@ -778,6 +778,37 @@ func TestOrgShow_findingsTabSortsBySeverity(t *testing.T) {
 	}
 }
 
+func TestOrgShow_excludesScannerFindings(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	repo := db.Repository{URL: "https://example.com/acme/svc", Name: "svc", Owner: "acme"}
+	s.DB.Create(&repo)
+	dd := db.Scan{RepositoryID: repo.ID, Kind: "skill", Status: db.ScanDone, SkillName: deepDiveSkillName}
+	s.DB.Create(&dd)
+	sg := db.Scan{RepositoryID: repo.ID, Kind: "skill", Status: db.ScanDone, SkillName: "semgrep"}
+	s.DB.Create(&sg)
+	s.DB.Create(&db.Finding{ScanID: dd.ID, RepositoryID: repo.ID, Title: "audit-only", Severity: "High"})
+	s.DB.Create(&db.Finding{ScanID: sg.ID, RepositoryID: repo.ID, Title: "semgrep-only", Severity: "High"})
+
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq("GET", "/orgs/acme"))
+	if w.Code != 200 {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, "audit-only") {
+		t.Error("org show should include deep-dive findings")
+	}
+	if strings.Contains(body, "semgrep-only") {
+		t.Error("org show should hide scanner findings; visit the repo Scanners tab instead")
+	}
+	// Per-repo Findings column should count 1 (audit-only), not 2.
+	if !strings.Contains(body, `<span class="badge-destructive">1</span>`) {
+		t.Errorf("per-repo finding count should be 1 (deep-dive only); body=%s", body)
+	}
+}
+
 func TestOrgShow_unknownIs404(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()
@@ -796,9 +827,9 @@ func TestFindings_ownerFilter(t *testing.T) {
 	s.DB.Create(&a)
 	g := db.Repository{URL: "https://example.com/globex/svc", Name: "svc", Owner: "globex"}
 	s.DB.Create(&g)
-	sa := db.Scan{RepositoryID: a.ID, Kind: "skill", Status: db.ScanDone, SkillName: "x"}
+	sa := db.Scan{RepositoryID: a.ID, Kind: "skill", Status: db.ScanDone, SkillName: deepDiveSkillName}
 	s.DB.Create(&sa)
-	sg := db.Scan{RepositoryID: g.ID, Kind: "skill", Status: db.ScanDone, SkillName: "x"}
+	sg := db.Scan{RepositoryID: g.ID, Kind: "skill", Status: db.ScanDone, SkillName: deepDiveSkillName}
 	s.DB.Create(&sg)
 	s.DB.Create(&db.Finding{ScanID: sa.ID, RepositoryID: a.ID, Title: "acme-only finding", Severity: "High"})
 	s.DB.Create(&db.Finding{ScanID: sg.ID, RepositoryID: g.ID, Title: "globex-only finding", Severity: "High"})
@@ -817,7 +848,7 @@ func TestFindings_missedFilterAndBadge(t *testing.T) {
 
 	repo := db.Repository{URL: "https://example.com/r", Name: "r"}
 	s.DB.Create(&repo)
-	scan := db.Scan{RepositoryID: repo.ID, Kind: "skill", Status: db.ScanDone, SkillName: "x"}
+	scan := db.Scan{RepositoryID: repo.ID, Kind: "skill", Status: db.ScanDone, SkillName: deepDiveSkillName}
 	s.DB.Create(&scan)
 	s.DB.Create(&db.Finding{ScanID: scan.ID, RepositoryID: repo.ID, Title: "still-present finding",
 		Severity: "High"})
@@ -851,6 +882,48 @@ func TestFindings_missedFilterAndBadge(t *testing.T) {
 	// Severity/sort links preserve the missed filter.
 	if !strings.Contains(body, "severity=High&sort=newest&missed=1") {
 		t.Error("severity dropdown links should carry missed=1")
+	}
+}
+
+func TestFindings_scannerToggle(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	repo := db.Repository{URL: "https://example.com/sc", Name: "sc"}
+	s.DB.Create(&repo)
+	dd := db.Scan{RepositoryID: repo.ID, Kind: "skill", Status: db.ScanDone, SkillName: deepDiveSkillName}
+	s.DB.Create(&dd)
+	sg := db.Scan{RepositoryID: repo.ID, Kind: "skill", Status: db.ScanDone, SkillName: "semgrep"}
+	s.DB.Create(&sg)
+	zz := db.Scan{RepositoryID: repo.ID, Kind: "skill", Status: db.ScanDone, SkillName: "zizmor"}
+	s.DB.Create(&zz)
+	s.DB.Create(&db.Finding{ScanID: dd.ID, RepositoryID: repo.ID, Title: "audit-finding", Severity: "High"})
+	s.DB.Create(&db.Finding{ScanID: sg.ID, RepositoryID: repo.ID, Title: "semgrep-finding", Severity: "High"})
+	s.DB.Create(&db.Finding{ScanID: zz.ID, RepositoryID: repo.ID, Title: "zizmor-finding", Severity: "High"})
+
+	// Default: scanner findings hidden, audit visible. Toggle advertises the
+	// total scanner count so the operator knows what they're suppressing.
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq("GET", "/findings"))
+	body := w.Body.String()
+	if !strings.Contains(body, "audit-finding") {
+		t.Error("default listing should include deep-dive findings")
+	}
+	if strings.Contains(body, "semgrep-finding") || strings.Contains(body, "zizmor-finding") {
+		t.Error("default listing should hide scanner findings")
+	}
+	if !strings.Contains(body, "Include scanners (2)") {
+		t.Error("toolbar should show scanner total when scanners are suppressed")
+	}
+
+	// ?scanners=1: scanner findings reappear.
+	w = httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq("GET", "/findings?scanners=1"))
+	body = w.Body.String()
+	for _, want := range []string{"audit-finding", "semgrep-finding", "zizmor-finding"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("?scanners=1 should include %q", want)
+		}
 	}
 }
 
@@ -895,7 +968,7 @@ func TestOrgReport_rendersFindingsAcrossRepos(t *testing.T) {
 	s.DB.Create(&r2)
 	_ = db.Repository{URL: "https://example.com/globex/svc", Name: "svc", Owner: "globex"}
 
-	scan1 := db.Scan{RepositoryID: r1.ID, Kind: "skill", Status: db.ScanDone, SkillName: "x"}
+	scan1 := db.Scan{RepositoryID: r1.ID, Kind: "skill", Status: db.ScanDone, SkillName: deepDiveSkillName}
 	s.DB.Create(&scan1)
 	s.DB.Create(&db.Finding{ScanID: scan1.ID, RepositoryID: r1.ID,
 		Title: "SSRF in image fetch", Severity: "High", Location: "fetch.go:42",
@@ -903,7 +976,7 @@ func TestOrgReport_rendersFindingsAcrossRepos(t *testing.T) {
 	s.DB.Create(&db.Finding{ScanID: scan1.ID, RepositoryID: r1.ID,
 		Title: "Path traversal", Severity: "Medium", Location: "io.go:10"})
 
-	scan2 := db.Scan{RepositoryID: r2.ID, Kind: "skill", Status: db.ScanDone, SkillName: "x"}
+	scan2 := db.Scan{RepositoryID: r2.ID, Kind: "skill", Status: db.ScanDone, SkillName: deepDiveSkillName}
 	s.DB.Create(&scan2)
 	s.DB.Create(&db.Finding{ScanID: scan2.ID, RepositoryID: r2.ID,
 		Title: "XSS in admin panel", Severity: "High", Location: "views/admin.go:77"})
@@ -959,14 +1032,14 @@ func TestOrgSummary_rendersSynopsisShape(t *testing.T) {
 	empty := db.Repository{URL: "https://github.com/acme/quiet.git", Name: "quiet", Owner: "acme", FullName: "acme/quiet"}
 	s.DB.Create(&empty)
 
-	scan1 := db.Scan{RepositoryID: r1.ID, Kind: "skill", Status: db.ScanDone, SkillName: "x"}
+	scan1 := db.Scan{RepositoryID: r1.ID, Kind: "skill", Status: db.ScanDone, SkillName: deepDiveSkillName}
 	s.DB.Create(&scan1)
 	s.DB.Create(&db.Finding{ScanID: scan1.ID, RepositoryID: r1.ID,
 		Title: "Open redirect in /api/sso", Severity: "High",
 		Location: "src/route.ts:46", Rating: "**High.** Auth-adjacent; token leakage.",
 		Trace: "should not appear in summary"})
 
-	scan2 := db.Scan{RepositoryID: r2.ID, Kind: "skill", Status: db.ScanDone, SkillName: "x"}
+	scan2 := db.Scan{RepositoryID: r2.ID, Kind: "skill", Status: db.ScanDone, SkillName: deepDiveSkillName}
 	s.DB.Create(&scan2)
 	s.DB.Create(&db.Finding{ScanID: scan2.ID, RepositoryID: r2.ID,
 		Title: "CSV injection", Severity: "Medium",
@@ -1551,10 +1624,34 @@ func TestRepoShow_findingsTabAggregatesAcrossScans(t *testing.T) {
 	if strings.Contains(body, "old-noise") {
 		t.Errorf("rejected finding should be hidden from the tab")
 	}
-	// Severity ordering: Critical card before High card.
-	if strings.Index(body, "leaked-key") > strings.Index(body, "old-high") {
-		t.Errorf("expected Critical finding to sort before High")
+	// Deep-dive output and tool-scanner output render in separate tabs so the
+	// curated audit list isn't drowned out by lint noise.
+	if !strings.Contains(body, `id="rp11"`) {
+		t.Errorf("expected Scanners tab when non-deep-dive findings exist")
 	}
+	deepPanel := tabPanelBody(body, `id="rp4"`)
+	scannerPanel := tabPanelBody(body, `id="rp11"`)
+	if !strings.Contains(deepPanel, "old-high") || strings.Contains(deepPanel, "leaked-key") {
+		t.Errorf("Findings tab should hold deep-dive results only")
+	}
+	if !strings.Contains(scannerPanel, "leaked-key") || strings.Contains(scannerPanel, "old-high") {
+		t.Errorf("Scanners tab should hold non-deep-dive results only")
+	}
+}
+
+// tabPanelBody returns the substring of body starting at marker through the
+// next closing </div> that matches the panel's opening div. Cheap-and-good-
+// enough for assertions about which tab a finding renders inside.
+func tabPanelBody(body, marker string) string {
+	i := strings.Index(body, marker)
+	if i < 0 {
+		return ""
+	}
+	end := strings.Index(body[i:], "</div>\n  </div>")
+	if end < 0 {
+		return body[i:]
+	}
+	return body[i : i+end]
 }
 
 func TestRepoShow_displaysFindingStatus(t *testing.T) {

--- a/internal/web/templates/findings.html
+++ b/internal/web/templates/findings.html
@@ -6,22 +6,37 @@
   </h2>
   <div class="flex items-center gap-2">
     {{$mp := ""}}{{if .Missed}}{{$mp = "1"}}{{end}}
+    {{$sc := ""}}{{if .Scanners}}{{$sc = "1"}}{{end}}
     <form method="get" action="/findings" class="inline-flex">
       <input class="input" type="search" name="q" value="{{.Q}}" placeholder="Search findings"
              autocomplete="off" spellcheck="false">
       <input type="hidden" name="severity" value="{{.Severity}}">
       <input type="hidden" name="sort" value="{{.Sort}}">
       {{if .Missed}}<input type="hidden" name="missed" value="1">{{end}}
+      {{if .Scanners}}<input type="hidden" name="scanners" value="1">{{end}}
     </form>
+    {{if gt .ScannerTotal 0}}
+      {{if .Scanners}}
+        <a class="btn-outline" aria-pressed="true"
+           href="/findings?q={{.Q}}&severity={{.Severity}}&sort={{.Sort}}&missed={{$mp}}">
+          <i data-lucide="scan-search"></i> Include scanners ({{.ScannerTotal}})
+        </a>
+      {{else}}
+        <a class="btn-outline"
+           href="/findings?q={{.Q}}&severity={{.Severity}}&sort={{.Sort}}&missed={{$mp}}&scanners=1">
+          <i data-lucide="scan-search"></i> Include scanners ({{.ScannerTotal}})
+        </a>
+      {{end}}
+    {{end}}
     {{if gt .MissedTotal 0}}
       {{if .Missed}}
         <a class="btn-outline" aria-pressed="true"
-           href="/findings?q={{.Q}}&severity={{.Severity}}&sort={{.Sort}}">
+           href="/findings?q={{.Q}}&severity={{.Severity}}&sort={{.Sort}}&scanners={{$sc}}">
           <i data-lucide="eye-off"></i> Not seen on rescan ({{.MissedTotal}})
         </a>
       {{else}}
         <a class="btn-outline"
-           href="/findings?q={{.Q}}&severity={{.Severity}}&sort={{.Sort}}&missed=1">
+           href="/findings?q={{.Q}}&severity={{.Severity}}&sort={{.Sort}}&missed=1&scanners={{$sc}}">
           <i data-lucide="eye-off"></i> Not seen on rescan ({{.MissedTotal}})
         </a>
       {{end}}
@@ -34,9 +49,9 @@
       </button>
       <div data-popover aria-hidden="true" data-align="end">
         <div role="menu">
-          <a role="menuitem" href="/findings?q={{.Q}}&sort={{.Sort}}&missed={{$mp}}">All severities</a>
+          <a role="menuitem" href="/findings?q={{.Q}}&sort={{.Sort}}&missed={{$mp}}&scanners={{$sc}}">All severities</a>
           {{range (list "Critical" "High" "Medium" "Low")}}
-            <a role="menuitem" href="/findings?q={{$.Q}}&severity={{.}}&sort={{$.Sort}}&missed={{$mp}}"
+            <a role="menuitem" href="/findings?q={{$.Q}}&severity={{.}}&sort={{$.Sort}}&missed={{$mp}}&scanners={{$sc}}"
                {{if eq . $.Severity}}aria-current="true"{{end}}>{{.}}</a>
           {{end}}
         </div>
@@ -51,7 +66,7 @@
       <div data-popover aria-hidden="true" data-align="end">
         <div role="menu">
           {{range (list "newest" "severity" "repository")}}
-            <a role="menuitem" href="/findings?q={{$.Q}}&severity={{$.Severity}}&sort={{.}}&missed={{$mp}}"
+            <a role="menuitem" href="/findings?q={{$.Q}}&severity={{$.Severity}}&sort={{.}}&missed={{$mp}}&scanners={{$sc}}"
                {{if eq . $.Sort}}aria-current="true"{{end}}>{{.}}</a>
           {{end}}
         </div>

--- a/internal/web/templates/repo_show.html
+++ b/internal/web/templates/repo_show.html
@@ -51,6 +51,11 @@
         Findings <span class="badge-destructive ml-1">{{len .Findings}}</span>
       </button>
     {{end}}
+    {{if .ScannerFindings}}
+      <button type="button" role="tab" id="rt11" aria-controls="rp11" aria-selected="false">
+        Scanners <span class="badge-outline ml-1">{{len .ScannerFindings}}</span>
+      </button>
+    {{end}}
     {{if .Pkgs}}
     <button type="button" role="tab" id="rt6" aria-controls="rp6" aria-selected="false">
       Packages
@@ -175,8 +180,9 @@
   {{if .Findings}}
   <div role="tabpanel" id="rp4" aria-labelledby="rt4" hidden>
     <p class="text-sm text-muted-foreground mb-4">
-      All open findings for this repository across {{len .Scans}} scan{{if ne (len .Scans) 1}}s{{end}}.
-      Rejected and duplicate findings are hidden.
+      Open findings from the security-deep-dive audit.
+      Rejected and duplicate findings are hidden.{{if .ScannerFindings}} See the
+      Scanners tab for zizmor/semgrep output.{{end}}
     </p>
     <div class="grid gap-4">
       {{range .Findings}}
@@ -187,6 +193,38 @@
               {{template "finding-status" (fstatus .Status)}}
               <h3><a href="/findings/{{.ID}}">{{.Title}}</a></h3>
               {{if .CWE}}<span class="badge-outline ml-auto" data-tooltip="{{cwename .CWE}}">{{.CWE}}</span>{{end}}
+            </div>
+            <p>
+              <code class="text-xs">{{.Location}}</code>
+              <span class="text-xs text-muted-foreground">&middot; scan <a class="hover:underline" href="/scans/{{.ScanID}}">#{{.ScanID}}</a></span>
+            </p>
+          </header>
+          <section class="text-sm">
+            <p class="line-clamp-3">{{.Summary}}</p>
+          </section>
+        </div>
+      {{end}}
+    </div>
+  </div>
+  {{end}}
+
+  {{if .ScannerFindings}}
+  <div role="tabpanel" id="rp11" aria-labelledby="rt11" hidden>
+    <p class="text-sm text-muted-foreground mb-4">
+      Findings from tool-style scanners (zizmor, semgrep). These run as their
+      own skills and are kept separate from the curated deep-dive output.
+    </p>
+    <div class="grid gap-4">
+      {{$skills := .ScanSkill}}
+      {{range .ScannerFindings}}
+        <div id="finding-card-{{.ID}}" class="card">
+          <header>
+            <div class="flex items-center gap-2">
+              {{template "severity-badge" .Severity}}
+              {{template "finding-status" (fstatus .Status)}}
+              <h3><a href="/findings/{{.ID}}">{{.Title}}</a></h3>
+              <span class="badge-outline ml-auto">{{index $skills .ScanID}}</span>
+              {{if .CWE}}<span class="badge-outline" data-tooltip="{{cwename .CWE}}">{{.CWE}}</span>{{end}}
             </div>
             <p>
               <code class="text-xs">{{.Location}}</code>


### PR DESCRIPTION
The Findings tab on the repository page was mixing curated `security-deep-dive` results with zizmor and semgrep output, drowning the audit list. Every list and count that read like "audit findings" had the same problem: repo lists, org show, org/repo reports, SBOM impact view, maintainer counts, and the global `/findings` index.

Each repo now has a separate `Scanners` tab; the existing `Findings` tab is deep-dive only. Counts on the repos list, orgs list, org show, maintainers list, maintainer show, SBOM `Findings` tab, and downloadable org/repo reports filter to deep-dive too.

The global `/findings` index defaults to deep-dive and exposes an `Include scanners (N)` toggle (querystring `scanners=1`) so the noisier set is still reachable when wanted. Scanner skills are recognised by anything whose scan's `skill_name` is non-empty and not `security-deep-dive`; legacy/empty rows count as deep-dive so historical data isn't hidden.

Shared SQL lives in `deepDiveScanIDs` / `deepDiveFindingsCountSQL` so future surfaces can drop in the same filter.