### PR TITLE
Surface "Retry failed" button on the repo Scans tab

### DIFF
--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -1577,11 +1577,22 @@ func (s *Server) repoShow(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Count failed scans in the latest-per-skill set: same scope as the
+	// retry-failed handler would act on for this repo. Drives the
+	// "Retry failed" button on the Scans tab.
+	var failedScans int
+	for _, sc := range scans {
+		if sc.Status == db.ScanFailed {
+			failedScans++
+		}
+	}
+
 	data := map[string]any{
 		"Repo": repo, "Scans": scans, "Latest": latest,
 		"Findings":        findings,
 		"ScannerFindings": scannerFindings,
 		"ScanSkill":       scanSkill,
+		"FailedScans":     failedScans,
 		"TotalCost":       totalCost,
 		"TMCommit":        tmCommit,
 		"Deps":            deps, "Pkgs": pkgs, "Dependents": dependents, "Advisories": advisories, "Maintainers": maintainers, "ThreatModel": threatModel,
@@ -1669,10 +1680,14 @@ func (s *Server) scanRetry(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) scansRetryFailed(w http.ResponseWriter, r *http.Request) {
 	skillName := r.URL.Query().Get("skill")
+	repoID, _ := strconv.Atoi(r.URL.Query().Get("repository"))
 	q := s.DB.Model(&db.Scan{}).
 		Where("status = ? AND kind = ? AND skill_id IS NOT NULL", db.ScanFailed, worker.JobSkill)
 	if skillName != "" {
 		q = q.Where("skill_name = ?", skillName)
+	}
+	if repoID > 0 {
+		q = q.Where("repository_id = ?", repoID)
 	}
 
 	var totalFailed int64
@@ -1715,8 +1730,13 @@ func (s *Server) scansRetryFailed(w http.ResponseWriter, r *http.Request) {
 	skipped := int(totalFailed) - retried - errored
 
 	setFlash(w, retryFailedToast(retried, skipped, errored))
+	// Repo-scoped retries return to that repo's Scans tab so the operator
+	// stays in context; otherwise we send them to the global jobs list
+	// filtered to failed.
 	target := "/scans?status=failed"
-	if skillName != "" {
+	if repoID > 0 {
+		target = fmt.Sprintf("/repositories/%d#rt3", repoID)
+	} else if skillName != "" {
 		target += "&skill=" + url.QueryEscape(skillName)
 	}
 	s.redirect(w, r, target)

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -2189,6 +2189,88 @@ func TestScansRetryFailed_buttonVisibleWhenFiltered(t *testing.T) {
 	}
 }
 
+func TestRepoShow_retryFailedButton(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	repo := db.Repository{URL: "https://example.com/rep", Name: "rep"}
+	s.DB.Create(&repo)
+	skill := db.Skill{Name: "deep-dive", Description: "x", Body: "b", Active: true, Source: "ui", Version: 1}
+	s.DB.Create(&skill)
+
+	// No failed scans yet: button should not render.
+	body := getRepoPage(t, s, repo.ID)
+	if strings.Contains(body, "Retry failed") {
+		t.Error("button should not appear when no failed scans")
+	}
+
+	// One failed scan: button renders with count and the repo-scoped form
+	// action so the handler comes back to this Scans tab on completion.
+	s.DB.Create(&db.Scan{
+		RepositoryID: repo.ID, Kind: "skill", Status: db.ScanFailed,
+		StatusPriority: db.StatusPriorityFor(db.ScanFailed),
+		SkillID:        &skill.ID, SkillName: "deep-dive",
+	})
+	body = getRepoPage(t, s, repo.ID)
+	if !strings.Contains(body, "Retry failed (1)") {
+		t.Errorf("expected 'Retry failed (1)' button; body=%s", body)
+	}
+	if !strings.Contains(body, fmt.Sprintf(`/scans/retry-failed?repository=%d`, repo.ID)) {
+		t.Error("button form action should scope retry to this repository")
+	}
+}
+
+func TestScansRetryFailed_repositoryScopeRedirects(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	rA := db.Repository{URL: "https://example.com/a", Name: "a"}
+	s.DB.Create(&rA)
+	rB := db.Repository{URL: "https://example.com/b", Name: "b"}
+	s.DB.Create(&rB)
+	skill := db.Skill{Name: "deep-dive", Description: "x", Body: "b", Active: true, Source: "ui", Version: 1}
+	s.DB.Create(&skill)
+	mk := func(repoID uint) {
+		s.DB.Create(&db.Scan{
+			RepositoryID: repoID, Kind: "skill", Status: db.ScanFailed,
+			StatusPriority: db.StatusPriorityFor(db.ScanFailed),
+			SkillID:        &skill.ID, SkillName: "deep-dive",
+		})
+	}
+	mk(rA.ID)
+	mk(rA.ID)
+	mk(rB.ID)
+
+	req := httptest.NewRequest("POST",
+		fmt.Sprintf("/scans/retry-failed?repository=%d", rA.ID), nil)
+	req.Host = testHost
+	req.Header.Set("Sec-Fetch-Site", "same-origin")
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("status %d", w.Code)
+	}
+	if got := w.Header().Get("Location"); got != fmt.Sprintf("/repositories/%d#rt3", rA.ID) {
+		t.Errorf("redirect = %q, want repo Scans tab", got)
+	}
+
+	// Other repo's failed scan must remain untouched: only rA's two failed
+	// scans should have been requeued.
+	var queued int64
+	s.DB.Model(&db.Scan{}).
+		Where("status = ? AND repository_id = ?", db.ScanQueued, rA.ID).
+		Count(&queued)
+	if queued != 2 {
+		t.Errorf("rA queued count = %d, want 2", queued)
+	}
+	s.DB.Model(&db.Scan{}).
+		Where("status = ? AND repository_id = ?", db.ScanQueued, rB.ID).
+		Count(&queued)
+	if queued != 0 {
+		t.Errorf("rB queued count = %d, want 0 (repo scope leaked)", queued)
+	}
+}
+
 func TestJobs_defaultSortFloatsActiveFirst(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()

--- a/internal/web/templates/repo_show.html
+++ b/internal/web/templates/repo_show.html
@@ -381,6 +381,17 @@
   </div>
 
   <div role="tabpanel" id="rp3" aria-labelledby="rt3" hidden>
+    {{if gt .FailedScans 0}}
+      <div class="flex justify-end mb-2">
+        <form method="post" action="/scans/retry-failed?repository={{.Repo.ID}}"
+              hx-post="/scans/retry-failed?repository={{.Repo.ID}}" hx-swap="none"
+              hx-confirm="Re-enqueue every failed scan on this repository?">
+          <button type="submit" class="btn-outline">
+            <i data-lucide="refresh-cw"></i> Retry failed ({{.FailedScans}})
+          </button>
+        </form>
+      </div>
+    {{end}}
     <table class="table">
       <thead>
         <tr><th>#</th><th>Skill</th><th>Status</th><th>Findings</th><th>Model</th><th>Cost</th><th>Commit</th><th>Started</th><th>Duration</th><th class="w-12"></th></tr>


### PR DESCRIPTION
The retry-all-failed button from #174 only lives on the global `/jobs` page. When working from a single repository's view, the failed scans were easy to miss and required leaving the page to retry them.

The Scans tab on the repo show page now renders `Retry failed (N)` whenever any of the latest-per-skill scans on this repo are in `failed` state. The form POSTs to `/scans/retry-failed?repository=<id>`; the existing handler accepts the new query parameter, scopes the retry to that repo, and redirects back to the Scans tab so the operator stays in context.

The count is derived from the same latest-per-skill set already passed to the template, so this adds no extra queries.