### PR TITLE
Seed Repository.Owner from the URL at import time

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -773,18 +773,3 @@ func SweepRunning(gdb *gorm.DB) error {
 			"finished_at": new(time.Now()),
 		}).Error
 }
-
-// NameFromURL derives a short display name from a git URL. It is the last
-// non-empty path segment with a trailing .git stripped.
-func NameFromURL(u string) string {
-	u = strings.TrimSpace(u)
-	u = strings.TrimSuffix(u, "/")
-	u = strings.TrimSuffix(u, ".git")
-	if i := strings.LastIndexAny(u, "/:"); i >= 0 {
-		u = u[i+1:]
-	}
-	if u == "" {
-		return "repo"
-	}
-	return u
-}

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -72,23 +72,6 @@ func TestBackfillFindingRepositoryFillsCommit(t *testing.T) {
 	}
 }
 
-func TestNameFromURL(t *testing.T) {
-	cases := map[string]string{
-		"https://github.com/foo/bar":     "bar",
-		"https://github.com/foo/bar.git": "bar",
-		"https://github.com/foo/bar/":    "bar",
-		"git@github.com:foo/bar.git":     "bar",
-		"ssh://git@host.xz/path/to/repo": "repo",
-		"https://gitlab.com/g/sub/proj":  "proj",
-		"":                               "repo",
-	}
-	for in, want := range cases {
-		if got := NameFromURL(in); got != want {
-			t.Errorf("NameFromURL(%q) = %q, want %q", in, got, want)
-		}
-	}
-}
-
 func TestOpenAndMigrate(t *testing.T) {
 	gdb, err := Open(":memory:")
 	if err != nil {

--- a/internal/web/parse_repo_url.go
+++ b/internal/web/parse_repo_url.go
@@ -12,8 +12,16 @@ import (
 // the repo root). Branch is extracted from /tree/<branch>/<path> URLs so
 // the operator knows it was present, but is not honoured for clone (see
 // #19 discussion) — scrutineer still clones the default branch.
+//
+// Owner and Name are derived from the URL path (last two segments) and
+// seed the Repository row at import time so listings and the orgs view
+// work before the metadata job has run; the metadata job overwrites them
+// with the canonical forge values when it lands. Owner is empty when the
+// URL has fewer than two path segments (cgit-style host/<repo>).
 type RepoInput struct {
 	CloneURL string
+	Owner    string
+	Name     string
 	SubPath  string
 	Branch   string
 }
@@ -53,10 +61,7 @@ func ParseRepoInput(raw string) (RepoInput, error) {
 	if u.Fragment != "" {
 		sub := strings.Trim(u.Fragment, "/")
 		u.Fragment = ""
-		return RepoInput{
-			CloneURL: cloneURL(u, u.Path),
-			SubPath:  sub,
-		}, nil
+		return newRepoInput(cloneURL(u, u.Path), sub, ""), nil
 	}
 
 	// /tree/<branch>/<path> shape (GitHub, Gitea, Forgejo).
@@ -76,15 +81,30 @@ func ParseRepoInput(raw string) (RepoInput, error) {
 		if treeIdx+2 < len(parts) {
 			subPath = strings.Join(parts[treeIdx+2:], "/")
 		}
-		return RepoInput{
-			CloneURL: cloneURL(u, repoPath),
-			SubPath:  subPath,
-			Branch:   branch,
-		}, nil
+		return newRepoInput(cloneURL(u, repoPath), subPath, branch), nil
 	}
 
 	// Plain clone URL.
-	return RepoInput{CloneURL: cloneURL(u, u.Path)}, nil
+	return newRepoInput(cloneURL(u, u.Path), "", ""), nil
+}
+
+// newRepoInput builds a RepoInput and derives Owner/Name from the
+// already-normalised clone URL so every parse path agrees on what those
+// values are.
+func newRepoInput(clone, sub, branch string) RepoInput {
+	r := RepoInput{CloneURL: clone, SubPath: sub, Branch: branch, Name: "repo"}
+	u, err := url.Parse(clone)
+	if err != nil {
+		return r
+	}
+	parts := strings.Split(strings.Trim(u.Path, "/"), "/")
+	if last := len(parts) - 1; last >= 0 && parts[last] != "" {
+		r.Name = parts[last]
+		if last >= 1 {
+			r.Owner = parts[last-1]
+		}
+	}
+	return r
 }
 
 // caseInsensitiveForges treat owner/repo path segments as

--- a/internal/web/parse_repo_url_test.go
+++ b/internal/web/parse_repo_url_test.go
@@ -12,18 +12,20 @@ func TestParseRepoInput(t *testing.T) {
 		{
 			name:  "plain github url without .git",
 			input: "https://github.com/rails/rails",
-			want:  RepoInput{CloneURL: "https://github.com/rails/rails"},
+			want:  RepoInput{CloneURL: "https://github.com/rails/rails", Owner: "rails", Name: "rails"},
 		},
 		{
 			name:  "plain github url with .git",
 			input: "https://github.com/rails/rails.git",
-			want:  RepoInput{CloneURL: "https://github.com/rails/rails"},
+			want:  RepoInput{CloneURL: "https://github.com/rails/rails", Owner: "rails", Name: "rails"},
 		},
 		{
 			name:  "github tree url with sub-path",
 			input: "https://github.com/apache/airflow/tree/main/airflow-core",
 			want: RepoInput{
 				CloneURL: "https://github.com/apache/airflow",
+				Owner:    "apache",
+				Name:     "airflow",
 				SubPath:  "airflow-core",
 				Branch:   "main",
 			},
@@ -33,6 +35,8 @@ func TestParseRepoInput(t *testing.T) {
 			input: "https://github.com/kubernetes/kubernetes/tree/master/staging/src/k8s.io/api",
 			want: RepoInput{
 				CloneURL: "https://github.com/kubernetes/kubernetes",
+				Owner:    "kubernetes",
+				Name:     "kubernetes",
 				SubPath:  "staging/src/k8s.io/api",
 				Branch:   "master",
 			},
@@ -42,6 +46,8 @@ func TestParseRepoInput(t *testing.T) {
 			input: "https://github.com/apache/airflow/tree/v2.9.0/airflow-core",
 			want: RepoInput{
 				CloneURL: "https://github.com/apache/airflow",
+				Owner:    "apache",
+				Name:     "airflow",
 				SubPath:  "airflow-core",
 				Branch:   "v2.9.0",
 			},
@@ -51,6 +57,8 @@ func TestParseRepoInput(t *testing.T) {
 			input: "https://github.com/apache/airflow/tree/main",
 			want: RepoInput{
 				CloneURL: "https://github.com/apache/airflow",
+				Owner:    "apache",
+				Name:     "airflow",
 				SubPath:  "",
 				Branch:   "main",
 			},
@@ -60,6 +68,8 @@ func TestParseRepoInput(t *testing.T) {
 			input: "https://gitlab.com/group/project#services/api",
 			want: RepoInput{
 				CloneURL: "https://gitlab.com/group/project",
+				Owner:    "group",
+				Name:     "project",
 				SubPath:  "services/api",
 			},
 		},
@@ -68,39 +78,43 @@ func TestParseRepoInput(t *testing.T) {
 			input: "https://github.com/rails/rails#/railties",
 			want: RepoInput{
 				CloneURL: "https://github.com/rails/rails",
+				Owner:    "rails",
+				Name:     "rails",
 				SubPath:  "railties",
 			},
 		},
 		{
 			name:  "trailing slash stripped",
 			input: "https://github.com/rails/rails/",
-			want:  RepoInput{CloneURL: "https://github.com/rails/rails"},
+			want:  RepoInput{CloneURL: "https://github.com/rails/rails", Owner: "rails", Name: "rails"},
 		},
 		{
 			name:  ".git/ trailing slash stripped",
 			input: "https://github.com/rails/rails.git/",
-			want:  RepoInput{CloneURL: "https://github.com/rails/rails"},
+			want:  RepoInput{CloneURL: "https://github.com/rails/rails", Owner: "rails", Name: "rails"},
 		},
 		{
 			name:  "query string dropped",
 			input: "https://github.com/rails/rails?tab=readme-ov-file",
-			want:  RepoInput{CloneURL: "https://github.com/rails/rails"},
+			want:  RepoInput{CloneURL: "https://github.com/rails/rails", Owner: "rails", Name: "rails"},
 		},
 		{
 			name:  "host lowercased",
 			input: "https://GitHub.com/rails/rails",
-			want:  RepoInput{CloneURL: "https://github.com/rails/rails"},
+			want:  RepoInput{CloneURL: "https://github.com/rails/rails", Owner: "rails", Name: "rails"},
 		},
 		{
 			name:  "owner/repo lowercased on known forge",
 			input: "https://github.com/Rails/Rails",
-			want:  RepoInput{CloneURL: "https://github.com/rails/rails"},
+			want:  RepoInput{CloneURL: "https://github.com/rails/rails", Owner: "rails", Name: "rails"},
 		},
 		{
 			name:  "tree url owner/repo lowercased but branch and sub-path keep case",
 			input: "https://github.com/Apache/Airflow/tree/Main/Airflow-Core",
 			want: RepoInput{
 				CloneURL: "https://github.com/apache/airflow",
+				Owner:    "apache",
+				Name:     "airflow",
 				SubPath:  "Airflow-Core",
 				Branch:   "Main",
 			},
@@ -110,18 +124,30 @@ func TestParseRepoInput(t *testing.T) {
 			input: "https://github.com/Rails/Rails#ActionPack",
 			want: RepoInput{
 				CloneURL: "https://github.com/rails/rails",
+				Owner:    "rails",
+				Name:     "rails",
 				SubPath:  "ActionPack",
 			},
 		},
 		{
 			name:  "unknown host keeps path case",
 			input: "https://git.internal/Team/Project",
-			want:  RepoInput{CloneURL: "https://git.internal/Team/Project"},
+			want:  RepoInput{CloneURL: "https://git.internal/Team/Project", Owner: "Team", Name: "Project"},
+		},
+		{
+			name:  "gitlab subgroup: name is last segment, owner is the segment before",
+			input: "https://gitlab.com/group/sub/project",
+			want:  RepoInput{CloneURL: "https://gitlab.com/group/sub/project", Owner: "sub", Name: "project"},
+		},
+		{
+			name:  "single-segment path: no owner",
+			input: "https://git.kernel.org/torvalds",
+			want:  RepoInput{CloneURL: "https://git.kernel.org/torvalds", Owner: "", Name: "torvalds"},
 		},
 		{
 			name:  "all of the above at once",
 			input: "https://GitHub.com/Rails/Rails.git/?tab=readme",
-			want:  RepoInput{CloneURL: "https://github.com/rails/rails"},
+			want:  RepoInput{CloneURL: "https://github.com/rails/rails", Owner: "rails", Name: "rails"},
 		},
 		{
 			name:    "non-https rejected",

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -1416,7 +1416,13 @@ func (s *Server) repoBulkCreate(w http.ResponseWriter, r *http.Request) {
 func (s *Server) createOrTriageRepo(ctx context.Context, input RepoInput, model string) (db.Repository, bool, error) {
 	existing := int64(0)
 	s.DB.Model(&db.Repository{}).Where("url = ?", input.CloneURL).Count(&existing)
-	repo := db.Repository{URL: input.CloneURL, Name: db.NameFromURL(input.CloneURL)}
+	// Owner and FullName seed from ParseRepoInput so the orgs view groups
+	// newly added repos before the metadata job has run; the metadata job
+	// later overwrites them with the canonical forge values.
+	repo := db.Repository{URL: input.CloneURL, Name: input.Name, Owner: input.Owner}
+	if input.Owner != "" {
+		repo.FullName = input.Owner + "/" + input.Name
+	}
 	if err := s.DB.Where(db.Repository{URL: input.CloneURL}).FirstOrCreate(&repo).Error; err != nil {
 		return repo, false, err
 	}

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -2565,6 +2565,38 @@ func TestMaintainerShow_displaysFindingStatus(t *testing.T) {
 	}
 }
 
+func TestRepoCreate_seedsOwnerAndFullNameFromURL(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	s.DB.Create(&db.Skill{Name: "triage", Active: true, Source: "test", Body: "test", OutputFile: "report.json", OutputKind: "freeform", Version: 1})
+
+	form := url.Values{"url": {"https://github.com/simonw/datasette"}}
+	req := httptest.NewRequest("POST", "/repositories", strings.NewReader(form.Encode()))
+	req.Host = testHost
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Sec-Fetch-Site", "same-origin")
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+
+	var repo db.Repository
+	if err := s.DB.Where("url = ?", "https://github.com/simonw/datasette").First(&repo).Error; err != nil {
+		t.Fatalf("repo not created: %v", err)
+	}
+	if repo.Owner != "simonw" {
+		t.Errorf("Owner = %q, want simonw (so orgs view groups before metadata fetch)", repo.Owner)
+	}
+	if repo.Name != "datasette" {
+		t.Errorf("Name = %q, want datasette", repo.Name)
+	}
+	if repo.FullName != "simonw/datasette" {
+		t.Errorf("FullName = %q, want simonw/datasette", repo.FullName)
+	}
+}
+
 func TestRepoCreate_branchURLTriggersTriageWithRef(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()


### PR DESCRIPTION
The orgs view groups by `owner`, which is only populated once the metadata skill has fetched the repos.ecosyste.ms record. When the first clone fails (network blip, repo gone private, rate limit) the metadata fetch never runs, so the row sits with `owner = ""` and the entire org disappears from `/orgs` even though all its repos are present.

`ParseRepoInput` already normalises the clone URL and splits the path, so it now also returns `Owner` and `Name`. `createOrTriageRepo` reads those to seed the new `Repository` row (plus `FullName` as `owner/name`), and the metadata job still overwrites them with the canonical forge values once it lands.

`db.NameFromURL` is folded into `ParseRepoInput` since its only caller was `createOrTriageRepo` and its ssh/git handling was unreachable behind the https-only gate. URL parsing now lives in one place.