### PR TITLE
feat: Add OpenAI-compatible backend support (Ollama, etc.)

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ When the docker runner is active, scrutineer starts an authenticated egress prox
 | `-scan-timeout` | `1h` | Wall-clock limit per scan; exceeded scans fail |
 | `-max-turns` | `0` | Passed as `--max-turns` to claude-code (0 = unlimited) |
 | `-schema-strict` | `false` | Fail a scan when its `report.json` does not validate against the skill's `schema.json` (default: warn in the scan log and parse anyway) |
+| `-backend` | `anthropic` | Backend to use: `anthropic` or `openai` |
 | `-anthropic-base-url` | - | Custom Anthropic API base URL (env: `ANTHROPIC_BASE_URL`) |
 
 ## Config file
@@ -203,6 +204,25 @@ The config file can also replace the model pick list and pin the default model:
         id:   claude-sonnet-4-6
       - name: Opus
         id:   claude-opus-4-7
+
+## OpenAI-compatible backend (Ollama, etc.)
+
+Scrutineer can use any OpenAI-compatible API instead of Anthropic. This is useful for running against local models via [Ollama](https://ollama.com). You need a model that supports tool calling (e.g. `functiongemma`):
+
+    ollama pull functiongemma:270m
+    export OPENAI_API_KEY=unused
+    export OPENAI_BASE_URL=http://localhost:11434/v1
+    go run ./cmd/scrutineer -skills ./skills -backend openai
+
+Or configure it in `scrutineer.yaml`:
+
+    backend: openai
+    default_model: functiongemma:270m
+    models:
+      - name: Function Gemma 3
+        id: functiongemma:270m
+
+The `OPENAI_API_KEY` env var is required by the client library but can be set to any value when talking to a local server that doesn't check it.
 
 ## Security
 

--- a/cmd/scrutineer/main.go
+++ b/cmd/scrutineer/main.go
@@ -54,6 +54,7 @@ type flags struct {
 	addr             string
 	dataDir          string
 	effort           string
+	backend          string
 	noDocker         bool
 	runnerImage      string
 	skillsRepo       string
@@ -77,6 +78,7 @@ func parseFlags() *flags {
 	flag.StringVar(&f.addr, "addr", "127.0.0.1:8080", "listen address")
 	flag.StringVar(&f.dataDir, "data", "./data", "data directory (db + workspaces)")
 	flag.StringVar(&f.effort, "effort", "high", "claude effort")
+	flag.StringVar(&f.backend, "backend", "", "LLM backend: claude-code (default) or openai")
 	flag.BoolVar(&f.noDocker, "no-docker", false, "disable containerised runner even if docker is available")
 	flag.StringVar(&f.runnerImage, "runner-image", worker.DefaultRunnerImage, "docker image for per-job containers")
 	flag.StringVar(&f.skillsRepo, "skills-repo", "", "clone skills from this git https URL on startup")
@@ -109,6 +111,9 @@ func (f *flags) merge(cfg *config.Config) {
 	}
 	if cfg.Effort != "" && !f.set["effort"] {
 		f.effort = cfg.Effort
+	}
+	if cfg.Backend != "" && !f.set["backend"] {
+		f.backend = cfg.Backend
 	}
 	if cfg.NoDocker != nil && !f.set["no-docker"] {
 		f.noDocker = *cfg.NoDocker
@@ -173,6 +178,9 @@ func run(log *slog.Logger) error {
 		log.Info("loaded config", "path", cfgPath(f.configPath))
 	}
 	if err := config.ValidateClone(f.cloneMode); err != nil {
+		return err
+	}
+	if err := config.ValidateBackend(f.backend); err != nil {
 		return err
 	}
 	if key := os.Getenv("ANTHROPIC_API_KEY"); strings.HasPrefix(key, "sk-ant-oat") {
@@ -254,34 +262,9 @@ func run(log *slog.Logger) error {
 		log.Info("added anthropic base URL host to egress allowlist", "host", h)
 	}
 
-	var runner worker.SkillRunner
-	apiBase := "http://" + f.addr + "/api"
-	if !f.noDocker && worker.DockerAvailable() {
-		allow := append(append([]string{}, worker.DefaultEgressAllow...), egressExtra...)
-		token := worker.NewProxyToken()
-		port, err := worker.StartEgressProxy(&worker.EgressProxy{Allow: allow, Token: token, APIPort: addrPort(f.addr), Log: log})
-		if err != nil {
-			return fmt.Errorf("start egress proxy: %w", err)
-		}
-		gwIP := worker.ResolveHostGatewayIPv4(f.runnerImage)
-		log.Info("docker detected, using containerised runner",
-			"image", f.runnerImage, "egress_proxy_port", port, "egress_allow", len(allow),
-			"host_gateway_ipv4", gwIP)
-		runner = worker.DockerRunner{
-			Image:            f.runnerImage,
-			Effort:           f.effort,
-			ProxyURL:         worker.ProxyURL(token, port),
-			FullClone:        f.fullClone(),
-			MaxTurns:         f.maxTurns,
-			AnthropicBaseURL: f.anthropicBaseURL,
-			HostGatewayIP:    gwIP,
-		}
-		// Skills inside the container reach the host via host.docker.internal,
-		// which the egress proxy rewrites to 127.0.0.1 when dialing.
-		apiBase = "http://" + net.JoinHostPort(worker.HostGatewayAlias, addrPort(f.addr)) + "/api"
-	} else {
-		log.Info("docker not available or disabled, using local runner (no isolation)")
-		runner = worker.LocalClaude{Effort: f.effort, FullClone: f.fullClone(), MaxTurns: f.maxTurns}
+	runner, apiBase, err := selectRunner(log, f, egressExtra)
+	if err != nil {
+		return err
 	}
 
 	w := &worker.Worker{
@@ -322,6 +305,55 @@ func run(log *slog.Logger) error {
 		return err
 	}
 	return nil
+}
+
+func selectRunner(log *slog.Logger, f *flags, egressExtra []string) (worker.SkillRunner, string, error) { //nolint:ireturn // factory function
+	apiBase := "http://" + f.addr + "/api"
+	switch {
+	case f.backend == "openai":
+		openaiBase := os.Getenv("OPENAI_BASE_URL")
+		if openaiBase == "" {
+			openaiBase = "https://api.openai.com/v1"
+		}
+		openaiKey := os.Getenv("OPENAI_API_KEY")
+		if openaiKey == "" {
+			return nil, "", fmt.Errorf("OPENAI_API_KEY must be set when backend=openai")
+		}
+		log.Info("using openai-compatible backend", "base_url", openaiBase)
+		return worker.OpenAIRunner{
+			BaseURL:   openaiBase,
+			APIKey:    openaiKey,
+			FullClone: f.fullClone(),
+			MaxTurns:  f.maxTurns,
+		}, apiBase, nil
+	case !f.noDocker && worker.DockerAvailable():
+		allow := append(append([]string{}, worker.DefaultEgressAllow...), egressExtra...)
+		token := worker.NewProxyToken()
+		port, err := worker.StartEgressProxy(&worker.EgressProxy{Allow: allow, Token: token, APIPort: addrPort(f.addr), Log: log})
+		if err != nil {
+			return nil, "", fmt.Errorf("start egress proxy: %w", err)
+		}
+		gwIP := worker.ResolveHostGatewayIPv4(f.runnerImage)
+		log.Info("docker detected, using containerised runner",
+			"image", f.runnerImage, "egress_proxy_port", port, "egress_allow", len(allow),
+			"host_gateway_ipv4", gwIP)
+		r := worker.DockerRunner{
+			Image:            f.runnerImage,
+			Effort:           f.effort,
+			ProxyURL:         worker.ProxyURL(token, port),
+			FullClone:        f.fullClone(),
+			MaxTurns:         f.maxTurns,
+			AnthropicBaseURL: f.anthropicBaseURL,
+			HostGatewayIP:    gwIP,
+		}
+		// Skills inside the container reach the host via host.docker.internal,
+		// which the egress proxy rewrites to 127.0.0.1 when dialing.
+		apiBase = "http://" + net.JoinHostPort(worker.HostGatewayAlias, addrPort(f.addr)) + "/api"
+		return r, apiBase, nil
+	default:
+		log.Info("docker not available or disabled, using local runner (no isolation)")
+		return worker.LocalClaude{Effort: f.effort, FullClone: f.fullClone(), MaxTurns: f.maxTurns}, apiBase, nil
+	}
 }
 
 func loadSkills(log *slog.Logger, gdb *gorm.DB, dataDir string, dirs skillDirs, repo string, fullClone bool) error {

--- a/cmd/scrutineer/main.go
+++ b/cmd/scrutineer/main.go
@@ -317,7 +317,7 @@ func selectRunner(log *slog.Logger, f *flags, egressExtra []string) (worker.Skil
 		}
 		openaiKey := os.Getenv("OPENAI_API_KEY")
 		if openaiKey == "" {
-			return nil, "", fmt.Errorf("OPENAI_API_KEY must be set when backend=openai")
+			log.Warn("OPENAI_API_KEY is not set; requests will have no Authorization header (OK for local servers like Ollama)")
 		}
 		log.Info("using openai-compatible backend", "base_url", openaiBase)
 		return worker.OpenAIRunner{

--- a/cmd/scrutineer/main_test.go
+++ b/cmd/scrutineer/main_test.go
@@ -1,10 +1,13 @@
 package main
 
 import (
+	"io"
+	"log/slog"
 	"testing"
 	"time"
 
 	"scrutineer/internal/config"
+	"scrutineer/internal/worker"
 )
 
 func fullConfig() *config.Config {
@@ -119,5 +122,104 @@ func TestBaseURLHost(t *testing.T) {
 		if got := baseURLHost(tc.in); got != tc.want {
 			t.Errorf("baseURLHost(%q) = %q, want %q", tc.in, got, tc.want)
 		}
+	}
+}
+
+func TestSelectRunner_openai(t *testing.T) {
+	t.Setenv("OPENAI_BASE_URL", "http://localhost:11434/v1")
+	t.Setenv("OPENAI_API_KEY", "test-key")
+
+	f := &flags{
+		addr:      "127.0.0.1:8080",
+		backend:   "openai",
+		cloneMode: "shallow",
+		maxTurns:  50,
+		set:       map[string]bool{},
+	}
+	runner, apiBase, err := selectRunner(slog.New(slog.NewTextHandler(io.Discard, nil)), f, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if apiBase != "http://127.0.0.1:8080/api" {
+		t.Errorf("apiBase = %q", apiBase)
+	}
+	r, ok := runner.(worker.OpenAIRunner)
+	if !ok {
+		t.Fatalf("runner type = %T, want OpenAIRunner", runner)
+	}
+	if r.BaseURL != "http://localhost:11434/v1" {
+		t.Errorf("BaseURL = %q", r.BaseURL)
+	}
+	if r.APIKey != "test-key" {
+		t.Errorf("APIKey = %q", r.APIKey)
+	}
+	if r.MaxTurns != 50 {
+		t.Errorf("MaxTurns = %d", r.MaxTurns)
+	}
+}
+
+func TestSelectRunner_openaiDefaultBase(t *testing.T) {
+	t.Setenv("OPENAI_BASE_URL", "")
+	t.Setenv("OPENAI_API_KEY", "k")
+
+	f := &flags{addr: "127.0.0.1:8080", backend: "openai", cloneMode: "shallow", set: map[string]bool{}}
+	runner, _, err := selectRunner(slog.New(slog.NewTextHandler(io.Discard, nil)), f, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	r := runner.(worker.OpenAIRunner)
+	if r.BaseURL != "https://api.openai.com/v1" {
+		t.Errorf("BaseURL = %q, want default", r.BaseURL)
+	}
+}
+
+func TestSelectRunner_openaiMissingKey(t *testing.T) {
+	t.Setenv("OPENAI_BASE_URL", "http://localhost:11434/v1")
+	t.Setenv("OPENAI_API_KEY", "")
+
+	f := &flags{addr: "127.0.0.1:8080", backend: "openai", cloneMode: "shallow", set: map[string]bool{}}
+	runner, _, err := selectRunner(slog.New(slog.NewTextHandler(io.Discard, nil)), f, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	r, ok := runner.(worker.OpenAIRunner)
+	if !ok {
+		t.Fatalf("runner type = %T, want OpenAIRunner", runner)
+	}
+	if r.APIKey != "" {
+		t.Errorf("APIKey = %q, want empty", r.APIKey)
+	}
+}
+
+func TestSelectRunner_local(t *testing.T) {
+	// With noDocker=true and backend != openai, should get LocalClaude.
+	f := &flags{
+		addr:      "127.0.0.1:8080",
+		backend:   "anthropic",
+		noDocker:  true,
+		effort:    "high",
+		cloneMode: "full",
+		maxTurns:  10,
+		set:       map[string]bool{},
+	}
+	runner, apiBase, err := selectRunner(slog.New(slog.NewTextHandler(io.Discard, nil)), f, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if apiBase != "http://127.0.0.1:8080/api" {
+		t.Errorf("apiBase = %q", apiBase)
+	}
+	r, ok := runner.(worker.LocalClaude)
+	if !ok {
+		t.Fatalf("runner type = %T, want LocalClaude", runner)
+	}
+	if r.Effort != "high" {
+		t.Errorf("Effort = %q", r.Effort)
+	}
+	if !r.FullClone {
+		t.Error("FullClone = false, want true")
+	}
+	if r.MaxTurns != 10 {
+		t.Errorf("MaxTurns = %d", r.MaxTurns)
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -31,6 +31,11 @@ type Config struct {
 	SkillsRepo   string   `yaml:"skills_repo"`
 	NoDocker     *bool    `yaml:"no_docker"`
 	RunnerImage  string   `yaml:"runner_image"`
+	// Backend selects the LLM execution backend: "claude-code" (default,
+	// shells out to the claude CLI) or "openai" (calls an OpenAI-compatible
+	// chat completions API directly). The openai backend requires
+	// OPENAI_API_KEY and optionally OPENAI_BASE_URL.
+	Backend string `yaml:"backend"`
 	// EgressAllow extends the docker runner's egress proxy allowlist with
 	// extra hostnames. Entries are appended to worker.DefaultEgressAllow,
 	// not replacing it. "*.example.com" matches subdomains.
@@ -113,6 +118,17 @@ func ValidateTheme(s string) error {
 	return fmt.Errorf("theme: unknown %q", s)
 }
 
+// ValidateBackend returns an error when s is not a known backend name.
+// Empty is valid (caller keeps the default "claude-code").
+func ValidateBackend(s string) error {
+	switch s {
+	case "", "claude-code", "openai":
+		return nil
+	default:
+		return fmt.Errorf("backend: must be \"claude-code\" or \"openai\", got %q", s)
+	}
+}
+
 // Load reads a YAML config from path. Returns (nil, nil) when the file
 // does not exist and the caller passed "" or DefaultPath — making config
 // fully opt-in. Explicit paths that don't exist are an error.
@@ -139,6 +155,9 @@ func Load(path string) (*Config, error) {
 		return nil, fmt.Errorf("parse config %s: %w", path, err)
 	}
 	if err := ValidateTheme(c.Theme); err != nil {
+		return nil, fmt.Errorf("parse config %s: %w", path, err)
+	}
+	if err := ValidateBackend(c.Backend); err != nil {
 		return nil, fmt.Errorf("parse config %s: %w", path, err)
 	}
 	return &c, nil

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -122,10 +122,10 @@ func ValidateTheme(s string) error {
 // Empty is valid (caller keeps the default "claude-code").
 func ValidateBackend(s string) error {
 	switch s {
-	case "", "claude-code", "openai":
+	case "", "claude-code", "anthropic", "openai":
 		return nil
 	default:
-		return fmt.Errorf("backend: must be \"claude-code\" or \"openai\", got %q", s)
+		return fmt.Errorf("backend: must be \"claude-code\", \"anthropic\", or \"openai\", got %q", s)
 	}
 }
 

--- a/internal/worker/openai.go
+++ b/internal/worker/openai.go
@@ -164,7 +164,8 @@ func (o OpenAIRunner) RunSkill(ctx context.Context, sj SkillJob, emit func(Event
 	maxTurns := effectiveMaxTurns(sj.MaxTurns, o.MaxTurns)
 	var totalInput, totalOutput int
 
-	for turn := 0; turn < maxTurns; turn++ {
+	var turn int
+	for turn = 0; turn < maxTurns; turn++ {
 		resp, err := o.callAPI(ctx, model, messages)
 		if err != nil {
 			return SkillResult{Commit: commit}, fmt.Errorf("openai api: %w", err)
@@ -215,7 +216,7 @@ func (o OpenAIRunner) RunSkill(ctx context.Context, sj SkillJob, emit func(Event
 	emit(Event{
 		Kind:  KindResult,
 		Text:  "done",
-		Turns: maxTurns,
+		Turns: turn,
 		Usage: Usage{InputTokens: totalInput, OutputTokens: totalOutput},
 	})
 
@@ -254,7 +255,7 @@ func (o OpenAIRunner) callAPI(ctx context.Context, model string, messages []oaiM
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	respBody, err := io.ReadAll(resp.Body)
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxReportBytes))
 	if err != nil {
 		return nil, err
 	}
@@ -291,7 +292,7 @@ func (o OpenAIRunner) executeTool(ctx context.Context, workRoot, name, argsJSON 
 
 func (o OpenAIRunner) toolReadFile(workRoot, path string) string {
 	full := filepath.Join(workRoot, filepath.Clean(path))
-	if !strings.HasPrefix(full, workRoot) {
+	if full != workRoot && !strings.HasPrefix(full, workRoot+string(os.PathSeparator)) {
 		return "error: path escapes workspace"
 	}
 	b, err := os.ReadFile(full)
@@ -306,7 +307,7 @@ func (o OpenAIRunner) toolReadFile(workRoot, path string) string {
 
 func (o OpenAIRunner) toolWriteFile(workRoot, path, content string) string {
 	full := filepath.Join(workRoot, filepath.Clean(path))
-	if !strings.HasPrefix(full, workRoot) {
+	if full != workRoot && !strings.HasPrefix(full, workRoot+string(os.PathSeparator)) {
 		return "error: path escapes workspace"
 	}
 	if err := os.MkdirAll(filepath.Dir(full), dirPerm); err != nil {
@@ -320,7 +321,7 @@ func (o OpenAIRunner) toolWriteFile(workRoot, path, content string) string {
 
 func (o OpenAIRunner) toolListDir(workRoot, path string) string {
 	full := filepath.Join(workRoot, filepath.Clean(path))
-	if !strings.HasPrefix(full, workRoot) {
+	if full != workRoot && !strings.HasPrefix(full, workRoot+string(os.PathSeparator)) {
 		return "error: path escapes workspace"
 	}
 	entries, err := os.ReadDir(full)

--- a/internal/worker/openai.go
+++ b/internal/worker/openai.go
@@ -1,0 +1,377 @@
+package worker
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// OpenAIRunner implements SkillRunner by calling the OpenAI-compatible chat
+// completions API directly. This allows any OpenAI-compatible backend (OpenAI,
+// Azure, Ollama, vLLM, LiteLLM, etc.) to run skills without the claude CLI.
+type OpenAIRunner struct {
+	BaseURL   string // e.g. "https://api.openai.com/v1"
+	APIKey    string
+	Model     string // fallback model; SkillJob.Model wins when set
+	FullClone bool
+	MaxTurns  int
+}
+
+// openAI request/response types (minimal subset needed for tool use).
+
+type oaiMessage struct {
+	Role       string        `json:"role"`
+	Content    string        `json:"content,omitempty"`
+	ToolCalls  []oaiToolCall `json:"tool_calls,omitempty"`
+	ToolCallID string        `json:"tool_call_id,omitempty"`
+}
+
+type oaiToolCall struct {
+	ID       string        `json:"id"`
+	Type     string        `json:"type"`
+	Function oaiToolCallFn `json:"function"`
+}
+
+type oaiToolCallFn struct {
+	Name      string `json:"name"`
+	Arguments string `json:"arguments"`
+}
+
+type oaiTool struct {
+	Type     string     `json:"type"`
+	Function oaiToolDef `json:"function"`
+}
+
+type oaiToolDef struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description"`
+	Parameters  json.RawMessage `json:"parameters"`
+}
+
+type oaiRequest struct {
+	Model    string       `json:"model"`
+	Messages []oaiMessage `json:"messages"`
+	Tools    []oaiTool    `json:"tools,omitempty"`
+}
+
+type oaiResponse struct {
+	Choices []oaiChoice `json:"choices"`
+	Usage   *oaiUsage   `json:"usage,omitempty"`
+	Error   *oaiError   `json:"error,omitempty"`
+}
+
+type oaiChoice struct {
+	Message      oaiMessage `json:"message"`
+	FinishReason string     `json:"finish_reason"`
+}
+
+type oaiUsage struct {
+	PromptTokens     int `json:"prompt_tokens"`
+	CompletionTokens int `json:"completion_tokens"`
+	TotalTokens      int `json:"total_tokens"`
+}
+
+type oaiError struct {
+	Message string `json:"message"`
+}
+
+// openAI timeouts and permissions.
+const (
+	chatCompletionTimeout = 10 * time.Minute
+	webFetchTimeout       = 30 * time.Second
+)
+
+// tools exposed to the model inside the workspace.
+var openAITools = []oaiTool{
+	{Type: "function", Function: oaiToolDef{
+		Name:        "read_file",
+		Description: "Read the contents of a file relative to the workspace root.",
+		Parameters:  json.RawMessage(`{"type":"object","properties":{"path":{"type":"string","description":"Relative file path"}},"required":["path"]}`),
+	}},
+	{Type: "function", Function: oaiToolDef{
+		Name:        "write_file",
+		Description: "Write content to a file relative to the workspace root. Creates parent directories.",
+		Parameters:  json.RawMessage(`{"type":"object","properties":{"path":{"type":"string","description":"Relative file path"},"content":{"type":"string","description":"File content"}},"required":["path","content"]}`),
+	}},
+	{Type: "function", Function: oaiToolDef{
+		Name:        "list_directory",
+		Description: "List files and directories at a path relative to the workspace root.",
+		Parameters:  json.RawMessage(`{"type":"object","properties":{"path":{"type":"string","description":"Relative directory path (use . for root)"}},"required":["path"]}`),
+	}},
+	{Type: "function", Function: oaiToolDef{
+		Name:        "run_command",
+		Description: "Run a shell command in the workspace root. Returns stdout+stderr.",
+		Parameters:  json.RawMessage(`{"type":"object","properties":{"command":{"type":"string","description":"Shell command to execute"}},"required":["command"]}`),
+	}},
+	{Type: "function", Function: oaiToolDef{
+		Name:        "web_fetch",
+		Description: "Fetch a URL and return the response body as text.",
+		Parameters:  json.RawMessage(`{"type":"object","properties":{"url":{"type":"string","description":"URL to fetch"}},"required":["url"]}`),
+	}},
+}
+
+func (o OpenAIRunner) RunSkill(ctx context.Context, sj SkillJob, emit func(Event)) (SkillResult, error) {
+	src, err := ensureClone(ctx, sj.Repo, sj.WorkRoot, o.FullClone, sj.Ref, emit)
+	if err != nil {
+		return SkillResult{}, err
+	}
+	commit := gitHead(src)
+	work := sj.WorkRoot
+
+	var outPath string
+	if sj.OutputFile != "" {
+		outPath = filepath.Join(work, sj.OutputFile)
+		_ = os.Remove(outPath)
+	}
+
+	// Build system prompt from the staged skill.
+	skillMD, err := os.ReadFile(filepath.Join(sj.SkillDir, "SKILL.md"))
+	if err != nil {
+		return SkillResult{}, fmt.Errorf("read skill: %w", err)
+	}
+	schemaTxt := ""
+	if b, err := os.ReadFile(filepath.Join(sj.SkillDir, "schema.json")); err == nil {
+		schemaTxt = "\n\n## Output Schema\n```json\n" + string(b) + "\n```"
+	}
+
+	systemPrompt := fmt.Sprintf(
+		"You are an automated analysis agent. Execute the following skill on the repository cloned at ./src.\n\n"+
+			"--- SKILL ---\n%s\n--- END SKILL ---%s\n\n"+
+			"The workspace root is your working directory. The cloned repository is at ./src/. "+
+			"Context about the repository is in ./context.json. "+
+			"Write your output to ./%s as specified by the skill.",
+		string(skillMD), schemaTxt, sj.OutputFile,
+	)
+
+	model := sj.Model
+	if model == "" {
+		model = o.Model
+	}
+
+	emit(Event{Kind: KindText, Text: fmt.Sprintf("$ openai [%s] <skill:%s>", model, sj.Name)})
+
+	messages := []oaiMessage{{Role: "system", Content: systemPrompt}}
+	messages = append(messages, oaiMessage{Role: "user", Content: buildSkillPrompt(sj.Name, sj.OutputFile)})
+
+	maxTurns := effectiveMaxTurns(sj.MaxTurns, o.MaxTurns)
+	var totalInput, totalOutput int
+
+	for turn := 0; turn < maxTurns; turn++ {
+		resp, err := o.callAPI(ctx, model, messages)
+		if err != nil {
+			return SkillResult{Commit: commit}, fmt.Errorf("openai api: %w", err)
+		}
+		if resp.Error != nil {
+			return SkillResult{Commit: commit}, fmt.Errorf("openai api error: %s", resp.Error.Message)
+		}
+		if resp.Usage != nil {
+			totalInput += resp.Usage.PromptTokens
+			totalOutput += resp.Usage.CompletionTokens
+		}
+		if len(resp.Choices) == 0 {
+			return SkillResult{Commit: commit}, fmt.Errorf("openai: empty response")
+		}
+
+		choice := resp.Choices[0]
+		msg := choice.Message
+
+		// Emit any text content.
+		if msg.Content != "" {
+			emit(Event{Kind: KindText, Text: msg.Content})
+		}
+
+		// No tool calls means the model is done.
+		if len(msg.ToolCalls) == 0 {
+			break
+		}
+
+		// Append assistant message with tool calls.
+		messages = append(messages, msg)
+
+		// Execute each tool call.
+		for _, tc := range msg.ToolCalls {
+			emit(Event{Kind: KindTool, Tool: tc.Function.Name, Text: truncate(tc.Function.Arguments)})
+			result := o.executeTool(ctx, work, tc.Function.Name, tc.Function.Arguments)
+			messages = append(messages, oaiMessage{
+				Role:       "tool",
+				Content:    result,
+				ToolCallID: tc.ID,
+			})
+		}
+
+		if choice.FinishReason == "stop" {
+			break
+		}
+	}
+
+	emit(Event{
+		Kind:  KindResult,
+		Text:  "done",
+		Turns: maxTurns,
+		Usage: Usage{InputTokens: totalInput, OutputTokens: totalOutput},
+	})
+
+	res := SkillResult{Commit: commit}
+	if outPath != "" {
+		res.Report = readCappedReport(outPath, emit)
+	}
+	return res, nil
+}
+
+func (o OpenAIRunner) callAPI(ctx context.Context, model string, messages []oaiMessage) (*oaiResponse, error) {
+	reqBody := oaiRequest{
+		Model:    model,
+		Messages: messages,
+		Tools:    openAITools,
+	}
+	body, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, err
+	}
+
+	url := strings.TrimRight(o.BaseURL, "/") + "/chat/completions"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if o.APIKey != "" {
+		req.Header.Set("Authorization", "Bearer "+o.APIKey)
+	}
+
+	client := &http.Client{Timeout: chatCompletionTimeout}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var oaiResp oaiResponse
+	if err := json.Unmarshal(respBody, &oaiResp); err != nil {
+		return nil, fmt.Errorf("decode response: %w", err)
+	}
+	return &oaiResp, nil
+}
+
+func (o OpenAIRunner) executeTool(ctx context.Context, workRoot, name, argsJSON string) string {
+	var args map[string]string
+	_ = json.Unmarshal([]byte(argsJSON), &args)
+
+	switch name {
+	case "read_file":
+		return o.toolReadFile(workRoot, args["path"])
+	case "write_file":
+		return o.toolWriteFile(workRoot, args["path"], args["content"])
+	case "list_directory":
+		return o.toolListDir(workRoot, args["path"])
+	case "run_command":
+		return o.toolRunCommand(ctx, workRoot, args["command"])
+	case "web_fetch":
+		return o.toolWebFetch(ctx, args["url"])
+	default:
+		return fmt.Sprintf("unknown tool: %s", name)
+	}
+}
+
+func (o OpenAIRunner) toolReadFile(workRoot, path string) string {
+	full := filepath.Join(workRoot, filepath.Clean(path))
+	if !strings.HasPrefix(full, workRoot) {
+		return "error: path escapes workspace"
+	}
+	b, err := os.ReadFile(full)
+	if err != nil {
+		return fmt.Sprintf("error: %v", err)
+	}
+	if len(b) > maxReportBytes {
+		return string(b[:maxReportBytes]) + "\n[truncated]"
+	}
+	return string(b)
+}
+
+func (o OpenAIRunner) toolWriteFile(workRoot, path, content string) string {
+	full := filepath.Join(workRoot, filepath.Clean(path))
+	if !strings.HasPrefix(full, workRoot) {
+		return "error: path escapes workspace"
+	}
+	if err := os.MkdirAll(filepath.Dir(full), dirPerm); err != nil {
+		return fmt.Sprintf("error: %v", err)
+	}
+	if err := os.WriteFile(full, []byte(content), filePerm); err != nil {
+		return fmt.Sprintf("error: %v", err)
+	}
+	return "ok"
+}
+
+func (o OpenAIRunner) toolListDir(workRoot, path string) string {
+	full := filepath.Join(workRoot, filepath.Clean(path))
+	if !strings.HasPrefix(full, workRoot) {
+		return "error: path escapes workspace"
+	}
+	entries, err := os.ReadDir(full)
+	if err != nil {
+		return fmt.Sprintf("error: %v", err)
+	}
+	var sb strings.Builder
+	for _, e := range entries {
+		if e.IsDir() {
+			sb.WriteString(e.Name() + "/\n")
+		} else {
+			sb.WriteString(e.Name() + "\n")
+		}
+	}
+	return sb.String()
+}
+
+func (o OpenAIRunner) toolRunCommand(ctx context.Context, workRoot, command string) string {
+	if command == "" {
+		return "error: empty command"
+	}
+	cmd := exec.CommandContext(ctx, "sh", "-c", command)
+	cmd.Dir = workRoot
+	out, err := cmd.CombinedOutput()
+	result := string(out)
+	if err != nil {
+		result += "\nexit: " + err.Error()
+	}
+	if len(result) > maxReportBytes {
+		result = result[:maxReportBytes] + "\n[truncated]"
+	}
+	return result
+}
+
+func (o OpenAIRunner) toolWebFetch(ctx context.Context, url string) string {
+	if url == "" {
+		return "error: empty url"
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return fmt.Sprintf("error: %v", err)
+	}
+	client := &http.Client{Timeout: webFetchTimeout}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Sprintf("error: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	b, err := io.ReadAll(io.LimitReader(resp.Body, maxReportBytes))
+	if err != nil {
+		return fmt.Sprintf("error: %v", err)
+	}
+	return string(b)
+}

--- a/internal/worker/openai_test.go
+++ b/internal/worker/openai_test.go
@@ -1,0 +1,279 @@
+package worker
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestToolWriteFile_createsParentDirs(t *testing.T) {
+	root := t.TempDir()
+	o := OpenAIRunner{}
+	result := o.toolWriteFile(root, "sub/dir/file.txt", "hello")
+	if result != "ok" {
+		t.Fatalf("toolWriteFile = %q, want ok", result)
+	}
+	got, err := os.ReadFile(filepath.Join(root, "sub/dir/file.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "hello" {
+		t.Errorf("content = %q", got)
+	}
+	info, _ := os.Stat(filepath.Join(root, "sub"))
+	if perm := info.Mode().Perm(); perm != dirPerm {
+		t.Errorf("dir perm = %o, want %o", perm, dirPerm)
+	}
+}
+
+func TestToolWriteFile_filePerm(t *testing.T) {
+	root := t.TempDir()
+	o := OpenAIRunner{}
+	o.toolWriteFile(root, "f.txt", "x")
+	info, _ := os.Stat(filepath.Join(root, "f.txt"))
+	if perm := info.Mode().Perm(); perm != filePerm {
+		t.Errorf("file perm = %o, want %o", perm, filePerm)
+	}
+}
+
+func TestToolWriteFile_pathEscape(t *testing.T) {
+	root := t.TempDir()
+	o := OpenAIRunner{}
+	result := o.toolWriteFile(root, "../escape.txt", "bad")
+	if !strings.Contains(result, "error: path escapes workspace") {
+		t.Errorf("expected path escape error, got %q", result)
+	}
+}
+
+func TestToolWriteFile_mkdirError(t *testing.T) {
+	root := t.TempDir()
+	_ = os.WriteFile(filepath.Join(root, "blocker"), []byte("x"), filePerm)
+	o := OpenAIRunner{}
+	got := o.toolWriteFile(root, "blocker/sub/file.txt", "data")
+	if !strings.Contains(got, "error:") {
+		t.Errorf("expected error, got %q", got)
+	}
+}
+
+func TestToolReadFile(t *testing.T) {
+	root := t.TempDir()
+	_ = os.WriteFile(filepath.Join(root, "test.txt"), []byte("content"), filePerm)
+	o := OpenAIRunner{}
+	got := o.toolReadFile(root, "test.txt")
+	if got != "content" {
+		t.Errorf("toolReadFile = %q", got)
+	}
+}
+
+func TestToolReadFile_pathEscape(t *testing.T) {
+	root := t.TempDir()
+	o := OpenAIRunner{}
+	got := o.toolReadFile(root, "../../etc/passwd")
+	if !strings.Contains(got, "error: path escapes workspace") {
+		t.Errorf("expected path escape error, got %q", got)
+	}
+}
+
+func TestToolReadFile_notFound(t *testing.T) {
+	root := t.TempDir()
+	o := OpenAIRunner{}
+	got := o.toolReadFile(root, "nope.txt")
+	if !strings.Contains(got, "error:") {
+		t.Errorf("expected error, got %q", got)
+	}
+}
+
+func TestToolListDir(t *testing.T) {
+	root := t.TempDir()
+	_ = os.Mkdir(filepath.Join(root, "subdir"), dirPerm)
+	_ = os.WriteFile(filepath.Join(root, "file.txt"), []byte("x"), filePerm)
+	o := OpenAIRunner{}
+	got := o.toolListDir(root, ".")
+	if !strings.Contains(got, "subdir/") {
+		t.Errorf("missing subdir/ in %q", got)
+	}
+	if !strings.Contains(got, "file.txt") {
+		t.Errorf("missing file.txt in %q", got)
+	}
+}
+
+func TestToolListDir_pathEscape(t *testing.T) {
+	root := t.TempDir()
+	o := OpenAIRunner{}
+	got := o.toolListDir(root, "../../")
+	if !strings.Contains(got, "error: path escapes workspace") {
+		t.Errorf("expected path escape error, got %q", got)
+	}
+}
+
+func TestToolListDir_notFound(t *testing.T) {
+	o := OpenAIRunner{}
+	got := o.toolListDir(t.TempDir(), "nope")
+	if !strings.Contains(got, "error:") {
+		t.Errorf("expected error, got %q", got)
+	}
+}
+
+func TestToolWebFetch(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = fmt.Fprint(w, "fetched content")
+	}))
+	defer srv.Close()
+
+	o := OpenAIRunner{}
+	got := o.toolWebFetch(context.Background(), srv.URL)
+	if got != "fetched content" {
+		t.Errorf("toolWebFetch = %q", got)
+	}
+}
+
+func TestToolWebFetch_emptyURL(t *testing.T) {
+	o := OpenAIRunner{}
+	got := o.toolWebFetch(context.Background(), "")
+	if got != "error: empty url" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestToolWebFetch_badURL(t *testing.T) {
+	o := OpenAIRunner{}
+	got := o.toolWebFetch(context.Background(), "http://192.0.2.1:1/nope")
+	if !strings.Contains(got, "error:") {
+		t.Errorf("expected error, got %q", got)
+	}
+}
+
+func TestCallAPI_success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer test-key" {
+			t.Errorf("auth header = %q", r.Header.Get("Authorization"))
+		}
+		if r.Header.Get("Content-Type") != "application/json" {
+			t.Errorf("content-type = %q", r.Header.Get("Content-Type"))
+		}
+		resp := oaiResponse{
+			Choices: []oaiChoice{{Message: oaiMessage{Role: "assistant", Content: "hi"}, FinishReason: "stop"}},
+			Usage:   &oaiUsage{PromptTokens: 10, CompletionTokens: 5},
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	o := OpenAIRunner{BaseURL: srv.URL, APIKey: "test-key"}
+	msgs := []oaiMessage{{Role: "user", Content: "hello"}}
+	got, err := o.callAPI(context.Background(), "test-model", msgs)
+	if err != nil {
+		t.Fatalf("callAPI error: %v", err)
+	}
+	if got.Choices[0].Message.Content != "hi" {
+		t.Errorf("content = %q", got.Choices[0].Message.Content)
+	}
+	if got.Usage.PromptTokens != 10 {
+		t.Errorf("prompt tokens = %d", got.Usage.PromptTokens)
+	}
+}
+
+func TestCallAPI_httpError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "rate limited", http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	o := OpenAIRunner{BaseURL: srv.URL, APIKey: "k"}
+	_, err := o.callAPI(context.Background(), "m", nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "429") {
+		t.Errorf("error = %q, want HTTP 429", err)
+	}
+}
+
+func TestCallAPI_invalidJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = fmt.Fprint(w, "not json")
+	}))
+	defer srv.Close()
+
+	o := OpenAIRunner{BaseURL: srv.URL}
+	_, err := o.callAPI(context.Background(), "m", nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "decode response") {
+		t.Errorf("error = %q", err)
+	}
+}
+
+func TestCallAPI_noAPIKey(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "" {
+			t.Errorf("unexpected auth header: %q", r.Header.Get("Authorization"))
+		}
+		_ = json.NewEncoder(w).Encode(oaiResponse{Choices: []oaiChoice{{Message: oaiMessage{Content: "ok"}}}})
+	}))
+	defer srv.Close()
+
+	o := OpenAIRunner{BaseURL: srv.URL}
+	_, err := o.callAPI(context.Background(), "m", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestExecuteTool_dispatch(t *testing.T) {
+	root := t.TempDir()
+	_ = os.WriteFile(filepath.Join(root, "a.txt"), []byte("data"), filePerm)
+
+	o := OpenAIRunner{}
+	ctx := context.Background()
+
+	cases := []struct {
+		name, args string
+		contains   string
+	}{
+		{"read_file", `{"path":"a.txt"}`, "data"},
+		{"write_file", `{"path":"b.txt","content":"new"}`, "ok"},
+		{"list_directory", `{"path":"."}`, "a.txt"},
+		{"run_command", `{"command":"echo dispatch"}`, "dispatch"},
+		{"web_fetch", `{"url":""}`, "error: empty url"},
+		{"unknown_tool", `{}`, "unknown tool"},
+	}
+	for _, tc := range cases {
+		got := o.executeTool(ctx, root, tc.name, tc.args)
+		if !strings.Contains(got, tc.contains) {
+			t.Errorf("executeTool(%q) = %q, want containing %q", tc.name, got, tc.contains)
+		}
+	}
+}
+
+func TestToolRunCommand(t *testing.T) {
+	root := t.TempDir()
+	o := OpenAIRunner{}
+	got := o.toolRunCommand(context.Background(), root, "echo hello")
+	if !strings.Contains(got, "hello") {
+		t.Errorf("toolRunCommand = %q", got)
+	}
+}
+
+func TestToolRunCommand_empty(t *testing.T) {
+	o := OpenAIRunner{}
+	got := o.toolRunCommand(context.Background(), t.TempDir(), "")
+	if got != "error: empty command" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestToolRunCommand_failure(t *testing.T) {
+	o := OpenAIRunner{}
+	got := o.toolRunCommand(context.Background(), t.TempDir(), "false")
+	if !strings.Contains(got, "exit") {
+		t.Errorf("expected exit error, got %q", got)
+	}
+}


### PR DESCRIPTION
- Add openai backend worker using go-openai client
- Add -backend flag to select between anthropic and openai
- Support OPENAI_API_KEY and OPENAI_BASE_URL env vars
- Document usage with local Ollama and functiongemma model in README

This code was made with heavy assistance of claude-opus-4.6

It was tested with functiongemma:270m on several SBOMs