### PR TITLE
web: consolidate shared helpers

### DIFF
--- a/internal/db/finding_helpers.go
+++ b/internal/db/finding_helpers.go
@@ -71,11 +71,13 @@ func syncCVSSScore(gdb *gorm.DB, f *Finding, vector string, source FindingSource
 	}).Error
 }
 
-// confidenceLevels and severityLevels are ordered low to high; the
+// confidenceLevels and SeverityLevels are ordered low to high; the
 // index is the rank used for threshold comparisons. An empty or
-// unknown value ranks below everything.
+// unknown value ranks below everything. SeverityLevels is exported so
+// the web layer can derive its ORDER BY CASE clause from the same
+// list rather than hard-coding the four labels twice.
 var confidenceLevels = []string{"low", "medium", "high"}
-var severityLevels = []string{"Low", "Medium", "High", "Critical"}
+var SeverityLevels = []string{"Low", "Medium", "High", "Critical"}
 
 func rank(levels []string, v string) int {
 	for i, l := range levels {
@@ -104,7 +106,7 @@ func SeverityAtLeast(got, threshold string) bool {
 	if threshold == "" {
 		return false
 	}
-	return rank(severityLevels, got) >= rank(severityLevels, threshold)
+	return rank(SeverityLevels, got) >= rank(SeverityLevels, threshold)
 }
 
 // findingFieldAccessor maps the API-facing field name to the current

--- a/internal/web/finding_exposure.go
+++ b/internal/web/finding_exposure.go
@@ -20,9 +20,8 @@ const exposureTopN = 10
 // URL are recorded as under_investigation immediately so the per-
 // dependent table is complete; the rest queue at PrioFinding.
 func (s *Server) findingExposureRun(w http.ResponseWriter, r *http.Request) {
-	var f db.Finding
-	if err := s.DB.First(&f, r.PathValue("id")).Error; err != nil {
-		http.NotFound(w, r)
+	f, ok := loadByID[db.Finding](s, w, r)
+	if !ok {
 		return
 	}
 	var scan db.Scan

--- a/internal/web/finding_forms.go
+++ b/internal/web/finding_forms.go
@@ -23,9 +23,8 @@ var analystFields = []string{
 }
 
 func (s *Server) findingFields(w http.ResponseWriter, r *http.Request) {
-	var f db.Finding
-	if err := s.DB.First(&f, r.PathValue("id")).Error; err != nil {
-		http.NotFound(w, r)
+	f, ok := loadByID[db.Finding](s, w, r)
+	if !ok {
 		return
 	}
 	if err := r.ParseForm(); err != nil {
@@ -46,9 +45,8 @@ func (s *Server) findingFields(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) findingCommunications(w http.ResponseWriter, r *http.Request) {
-	var f db.Finding
-	if err := s.DB.First(&f, r.PathValue("id")).Error; err != nil {
-		http.NotFound(w, r)
+	f, ok := loadByID[db.Finding](s, w, r)
+	if !ok {
 		return
 	}
 	if err := r.ParseForm(); err != nil {
@@ -71,9 +69,8 @@ func (s *Server) findingCommunications(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) findingReferences(w http.ResponseWriter, r *http.Request) {
-	var f db.Finding
-	if err := s.DB.First(&f, r.PathValue("id")).Error; err != nil {
-		http.NotFound(w, r)
+	f, ok := loadByID[db.Finding](s, w, r)
+	if !ok {
 		return
 	}
 	if err := r.ParseForm(); err != nil {
@@ -89,9 +86,8 @@ func (s *Server) findingReferences(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) findingLabels(w http.ResponseWriter, r *http.Request) {
-	var f db.Finding
-	if err := s.DB.First(&f, r.PathValue("id")).Error; err != nil {
-		http.NotFound(w, r)
+	f, ok := loadByID[db.Finding](s, w, r)
+	if !ok {
 		return
 	}
 	if err := r.ParseForm(); err != nil {

--- a/internal/web/finding_patch.go
+++ b/internal/web/finding_patch.go
@@ -50,9 +50,8 @@ func (s *Server) latestPatchScan(findingID uint) (*db.Scan, *patchReport, error)
 // gate passes, so a download is always a diff that parsed, targeted real
 // files, overlapped Location, and survived git apply --check.
 func (s *Server) findingPatchDownload(w http.ResponseWriter, r *http.Request) {
-	var f db.Finding
-	if err := s.DB.First(&f, r.PathValue("id")).Error; err != nil {
-		http.NotFound(w, r)
+	f, ok := loadByID[db.Finding](s, w, r)
+	if !ok {
 		return
 	}
 	if strings.TrimSpace(f.SuggestedFix) == "" {

--- a/internal/web/repo_report.go
+++ b/internal/web/repo_report.go
@@ -18,9 +18,8 @@ import (
 // dependents, dependencies, and maintainers. Served as text/markdown with
 // a filename hint so clicking the download button saves a file.
 func (s *Server) repoReport(w http.ResponseWriter, r *http.Request) {
-	var repo db.Repository
-	if err := s.DB.First(&repo, r.PathValue("id")).Error; err != nil {
-		http.NotFound(w, r)
+	repo, ok := loadByID[db.Repository](s, w, r)
+	if !ok {
 		return
 	}
 
@@ -466,15 +465,6 @@ func formatScanDate(s *db.Scan) string {
 		return s.FinishedAt.UTC().Format("2006-01-02")
 	}
 	return s.CreatedAt.UTC().Format("2006-01-02")
-}
-
-func firstNonEmpty(vals ...string) string {
-	for _, v := range vals {
-		if v != "" {
-			return v
-		}
-	}
-	return ""
 }
 
 func sanitiseFilename(s string) string {

--- a/internal/web/sboms.go
+++ b/internal/web/sboms.go
@@ -183,9 +183,8 @@ func (s *Server) sbomShow(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) sbomResolve(w http.ResponseWriter, r *http.Request) {
-	var up db.SBOMUpload
-	if err := s.DB.First(&up, r.PathValue("id")).Error; err != nil {
-		http.NotFound(w, r)
+	up, ok := loadByID[db.SBOMUpload](s, w, r)
+	if !ok {
 		return
 	}
 	s.goResolve(up.ID)

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -662,12 +662,12 @@ func (s *Server) orgShow(w http.ResponseWriter, r *http.Request) {
 	var findings []db.Finding
 	findingsQ.Order(severityOrder).Order("id desc").
 		Limit(orgTabLimit).Find(&findings)
-	reposByID := loadRepoMap(s.DB, findings)
+	reposByID := loadRepoMap(s.DB, findings, findingRepoID)
 
 	var advisories []db.Advisory
 	s.DB.Where("repository_id IN ?", repoIDs).Order("cvss_score desc").
 		Limit(orgTabLimit).Find(&advisories)
-	advisoryRepos := loadAdvisoryRepoMap(s.DB, advisories)
+	advisoryRepos := loadRepoMap(s.DB, advisories, advisoryRepoID)
 
 	var maintainers []db.Maintainer
 	s.DB.Joins("JOIN repository_maintainers rm ON rm.maintainer_id = maintainers.id").
@@ -803,39 +803,78 @@ func (s *Server) maintainerShow(w http.ResponseWriter, r *http.Request) {
 			Where("scan_id IN (?)", deepDiveScanIDs(s.DB)).
 			Order("id desc").Find(&findings)
 	}
-	reposByID := loadRepoMap(s.DB, findings)
+	reposByID := loadRepoMap(s.DB, findings, findingRepoID)
 	s.render(w, r, "maintainer_show.html", map[string]any{
 		"M": m, "Findings": findings, "Repos": reposByID,
 	})
 }
 
 // loadRepoMap batch-loads the repositories referenced by a slice of
-// findings and returns a map keyed by repository ID. Templates render
-// per-finding repo info by looking up the map.
-func loadRepoMap(gdb *gorm.DB, findings []db.Finding) map[uint]db.Repository {
+// rows and returns a map keyed by repository ID. The repoID accessor
+// abstracts over Finding.RepositoryID, Advisory.RepositoryID and any
+// other row shape that links back to a repository. Templates render
+// per-row repo info by looking up the map.
+func loadRepoMap[T any](gdb *gorm.DB, rows []T, repoID func(T) uint) map[uint]db.Repository {
 	seen := make(map[uint]bool)
 	ids := make([]uint, 0)
-	for _, f := range findings {
-		if !seen[f.RepositoryID] {
-			seen[f.RepositoryID] = true
-			ids = append(ids, f.RepositoryID)
+	for _, row := range rows {
+		id := repoID(row)
+		if !seen[id] {
+			seen[id] = true
+			ids = append(ids, id)
 		}
 	}
 	result := make(map[uint]db.Repository, len(ids))
 	if len(ids) == 0 {
 		return result
 	}
-	var rows []db.Repository
-	gdb.Where("id IN ?", ids).Find(&rows)
-	for _, r := range rows {
+	var repos []db.Repository
+	gdb.Where("id IN ?", ids).Find(&repos)
+	for _, r := range repos {
 		result[r.ID] = r
 	}
 	return result
 }
 
-var severityOrder = `CASE severity
-	WHEN 'Critical' THEN 0 WHEN 'High' THEN 1
-	WHEN 'Medium' THEN 2 WHEN 'Low' THEN 3 ELSE 4 END`
+func findingRepoID(f db.Finding) uint   { return f.RepositoryID }
+func advisoryRepoID(a db.Advisory) uint { return a.RepositoryID }
+
+// severityOrder is a SQL CASE expression that ranks db.SeverityLevels
+// highest-first with unknown values last, derived from the same slice
+// SeverityAtLeast uses so the two never disagree.
+var severityOrder = func() string {
+	var b strings.Builder
+	b.WriteString("CASE severity")
+	for i, s := range db.SeverityLevels {
+		fmt.Fprintf(&b, " WHEN '%s' THEN %d", s, len(db.SeverityLevels)-1-i)
+	}
+	fmt.Fprintf(&b, " ELSE %d END", len(db.SeverityLevels))
+	return b.String()
+}()
+
+// loadByID loads the row whose primary key matches the request's {id}
+// path parameter, writing a 404 and returning ok=false when it does
+// not exist. It collapses the four-line First-then-NotFound prelude
+// that opened most show/edit handlers.
+//
+//nolint:ireturn // T is a concrete struct at every call site, not an interface
+func loadByID[T any](s *Server, w http.ResponseWriter, r *http.Request) (T, bool) {
+	var v T
+	if err := s.DB.First(&v, r.PathValue("id")).Error; err != nil {
+		http.NotFound(w, r)
+		return v, false
+	}
+	return v, true
+}
+
+func firstNonEmpty(vals ...string) string {
+	for _, v := range vals {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}
 
 // loadRepoFindings returns the open findings for a repo split into two
 // slices: deep-dive output and tool-scanner output (zizmor, semgrep, …).
@@ -930,7 +969,7 @@ func (s *Server) findings(w http.ResponseWriter, r *http.Request) {
 	var rows []db.Finding
 	q.Limit(perPage).Offset((page.N - 1) * perPage).Find(&rows)
 
-	reposByID := loadRepoMap(s.DB, rows)
+	reposByID := loadRepoMap(s.DB, rows, findingRepoID)
 	anySubPath := false
 	for _, r := range rows {
 		if r.SubPath != "" {
@@ -956,9 +995,8 @@ func (s *Server) findings(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) depScan(w http.ResponseWriter, r *http.Request) {
-	var dep db.Dependency
-	if err := s.DB.First(&dep, r.PathValue("id")).Error; err != nil {
-		http.NotFound(w, r)
+	dep, ok := loadByID[db.Dependency](s, w, r)
+	if !ok {
 		return
 	}
 
@@ -994,9 +1032,8 @@ func resolvePURLRepo(ctx context.Context, purl string) string {
 }
 
 func (s *Server) dependentScan(w http.ResponseWriter, r *http.Request) {
-	var dep db.Dependent
-	if err := s.DB.First(&dep, r.PathValue("id")).Error; err != nil {
-		http.NotFound(w, r)
+	dep, ok := loadByID[db.Dependent](s, w, r)
+	if !ok {
 		return
 	}
 	if dep.RepositoryURL == "" {
@@ -1053,9 +1090,8 @@ func (s *Server) addRepoAndScan(w http.ResponseWriter, r *http.Request, repoURL 
 }
 
 func (s *Server) findingStatus(w http.ResponseWriter, r *http.Request) {
-	var f db.Finding
-	if err := s.DB.First(&f, r.PathValue("id")).Error; err != nil {
-		http.NotFound(w, r)
+	f, ok := loadByID[db.Finding](s, w, r)
+	if !ok {
 		return
 	}
 	status := db.FindingLifecycle(r.FormValue("status"))
@@ -1096,9 +1132,8 @@ func (s *Server) findingPatchRun(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) runFindingSkill(w http.ResponseWriter, r *http.Request, name string) {
-	var f db.Finding
-	if err := s.DB.First(&f, r.PathValue("id")).Error; err != nil {
-		http.NotFound(w, r)
+	f, ok := loadByID[db.Finding](s, w, r)
+	if !ok {
 		return
 	}
 	var scan db.Scan
@@ -1120,9 +1155,8 @@ func (s *Server) runFindingSkill(w http.ResponseWriter, r *http.Request, name st
 }
 
 func (s *Server) findingNotes(w http.ResponseWriter, r *http.Request) {
-	var f db.Finding
-	if err := s.DB.First(&f, r.PathValue("id")).Error; err != nil {
-		http.NotFound(w, r)
+	f, ok := loadByID[db.Finding](s, w, r)
+	if !ok {
 		return
 	}
 	if _, err := db.AddFindingNote(s.DB, f.ID, r.FormValue("body"), ""); err != nil {
@@ -1221,7 +1255,7 @@ func (s *Server) advisoriesList(w http.ResponseWriter, r *http.Request) {
 	var rows []db.Advisory
 	q.Limit(perPage).Offset((page.N - 1) * perPage).Find(&rows)
 
-	reposByID := loadAdvisoryRepoMap(s.DB, rows)
+	reposByID := loadRepoMap(s.DB, rows, advisoryRepoID)
 	var severities []string
 	s.DB.Model(&db.Advisory{}).Where("severity != ''").Distinct("severity").
 		Order("severity").Pluck("severity", &severities)
@@ -1230,31 +1264,6 @@ func (s *Server) advisoriesList(w http.ResponseWriter, r *http.Request) {
 		"Advisories": rows, "Page": page, "Severity": sev, "Sort": sort,
 		"Severities": severities, "Repos": reposByID, "Q": search,
 	})
-}
-
-// loadAdvisoryRepoMap batch-loads the repositories referenced by a slice
-// of advisories (Advisory.RepositoryID). Same pattern as loadRepoMap for
-// findings, duplicated rather than generified because the source field
-// is a different type.
-func loadAdvisoryRepoMap(gdb *gorm.DB, rows []db.Advisory) map[uint]db.Repository {
-	seen := make(map[uint]bool)
-	ids := make([]uint, 0)
-	for _, a := range rows {
-		if !seen[a.RepositoryID] {
-			seen[a.RepositoryID] = true
-			ids = append(ids, a.RepositoryID)
-		}
-	}
-	result := make(map[uint]db.Repository, len(ids))
-	if len(ids) == 0 {
-		return result
-	}
-	var repos []db.Repository
-	gdb.Where("id IN ?", ids).Find(&repos)
-	for _, r := range repos {
-		result[r.ID] = r
-	}
-	return result
 }
 
 func (s *Server) findingShow(w http.ResponseWriter, r *http.Request) {
@@ -1531,9 +1540,8 @@ func bulkToastDescription(invalid []string) string {
 }
 
 func (s *Server) repoShow(w http.ResponseWriter, r *http.Request) {
-	var repo db.Repository
-	if err := s.DB.First(&repo, r.PathValue("id")).Error; err != nil {
-		http.NotFound(w, r)
+	repo, ok := loadByID[db.Repository](s, w, r)
+	if !ok {
 		return
 	}
 	var scans []db.Scan
@@ -1668,9 +1676,8 @@ func (s *Server) repoShow(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) repoScan(w http.ResponseWriter, r *http.Request) {
-	var repo db.Repository
-	if err := s.DB.First(&repo, r.PathValue("id")).Error; err != nil {
-		http.NotFound(w, r)
+	repo, ok := loadByID[db.Repository](s, w, r)
+	if !ok {
 		return
 	}
 	// The "New scan" button enqueues the deep-dive skill; everything else is
@@ -1719,9 +1726,8 @@ func (s *Server) scanShow(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) scanRetry(w http.ResponseWriter, r *http.Request) {
-	var scan db.Scan
-	if err := s.DB.First(&scan, r.PathValue("id")).Error; err != nil {
-		http.NotFound(w, r)
+	scan, ok := loadByID[db.Scan](s, w, r)
+	if !ok {
 		return
 	}
 	if scan.Kind != worker.JobSkill || scan.SkillID == nil {
@@ -1827,9 +1833,8 @@ func retryFailedToast(retried, skipped, errored int) Flash {
 }
 
 func (s *Server) scanCancel(w http.ResponseWriter, r *http.Request) {
-	var scan db.Scan
-	if err := s.DB.First(&scan, r.PathValue("id")).Error; err != nil {
-		http.NotFound(w, r)
+	scan, ok := loadByID[db.Scan](s, w, r)
+	if !ok {
 		return
 	}
 	if scan.Status.Terminal() {
@@ -1850,9 +1855,8 @@ func (s *Server) scanCancel(w http.ResponseWriter, r *http.Request) {
 // scanLog returns just the <pre> log block. The scan page polls this with
 // hx-trigger while the scan is running so the operator can watch claude work.
 func (s *Server) scanLog(w http.ResponseWriter, r *http.Request) {
-	var scan db.Scan
-	if err := s.DB.First(&scan, r.PathValue("id")).Error; err != nil {
-		http.NotFound(w, r)
+	scan, ok := loadByID[db.Scan](s, w, r)
+	if !ok {
 		return
 	}
 	if scan.Status != db.ScanQueued && scan.Status != db.ScanRunning {

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -47,6 +47,55 @@ func localReq(method, path string) *http.Request {
 	return r
 }
 
+func TestSeverityOrder(t *testing.T) {
+	want := "CASE severity WHEN 'Low' THEN 3 WHEN 'Medium' THEN 2 WHEN 'High' THEN 1 WHEN 'Critical' THEN 0 ELSE 4 END"
+	if severityOrder != want {
+		t.Errorf("severityOrder = %q, want %q", severityOrder, want)
+	}
+}
+
+func TestLoadRepoMap(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	r1 := db.Repository{URL: "https://example.com/a", Name: "a"}
+	r2 := db.Repository{URL: "https://example.com/b", Name: "b"}
+	s.DB.Create(&r1)
+	s.DB.Create(&r2)
+
+	findings := []db.Finding{{RepositoryID: r1.ID}, {RepositoryID: r2.ID}, {RepositoryID: r1.ID}}
+	m := loadRepoMap(s.DB, findings, findingRepoID)
+	if len(m) != 2 || m[r1.ID].Name != "a" || m[r2.ID].Name != "b" {
+		t.Errorf("findings map = %+v", m)
+	}
+
+	advisories := []db.Advisory{{RepositoryID: r2.ID}}
+	m = loadRepoMap(s.DB, advisories, advisoryRepoID)
+	if len(m) != 1 || m[r2.ID].Name != "b" {
+		t.Errorf("advisories map = %+v", m)
+	}
+}
+
+func TestLoadByID(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	repo := db.Repository{URL: "https://example.com/x", Name: "x"}
+	s.DB.Create(&repo)
+
+	r := localReq("GET", "/")
+	r.SetPathValue("id", fmt.Sprint(repo.ID))
+	w := httptest.NewRecorder()
+	got, ok := loadByID[db.Repository](s, w, r)
+	if !ok || got.ID != repo.ID || got.Name != "x" {
+		t.Fatalf("got %+v ok=%v", got, ok)
+	}
+
+	r.SetPathValue("id", "999999")
+	w = httptest.NewRecorder()
+	if _, ok := loadByID[db.Repository](s, w, r); ok || w.Code != http.StatusNotFound {
+		t.Errorf("missing id: ok=%v code=%d, want false/404", ok, w.Code)
+	}
+}
+
 func TestRepoList_batchedFindingsCountAcrossRepos(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()


### PR DESCRIPTION
Housekeeping pass over `internal/web` with no behaviour change.

`loadRepoMap` is now generic with a `repoID func(T) uint` accessor, so `loadAdvisoryRepoMap` (which carried a comment apologising for being a copy) is gone. Both `db.Finding` and `db.Advisory` callers go through the one function.

`loadByID[T]` collapses the `var x T; if err := s.DB.First(&x, r.PathValue("id")).Error; err != nil { http.NotFound(w, r); return }` prelude that opened 18 handlers. The five Preload variants stay as-is.

`severityOrder` (the SQL `CASE severity WHEN ... END` used for sorting) is now derived from `db.SeverityLevels` at init rather than hardcoding the four labels a second time, so the Go-side `SeverityAtLeast` ranking and the SQL ranking can't drift. `severityLevels` is exported to make that possible.

`firstNonEmpty` moves from `repo_report.go` to `server.go` next to the other cross-file helpers; it was already called from `sboms.go`.

New tests cover the generated `severityOrder` string, `loadRepoMap` over both finding and advisory slices, and `loadByID` hit and miss.