### PR TITLE
fix(db): safely strip line numbers to prevent Windows path truncation

### DIFF
--- a/internal/db/fingerprint.go
+++ b/internal/db/fingerprint.go
@@ -38,8 +38,23 @@ func FingerprintFinding(skillName, subPath, cwe, location, title string) string 
 func normaliseLocation(loc string) string {
 	loc = strings.TrimSpace(loc)
 	loc = strings.TrimPrefix(loc, "./")
-	if i := strings.IndexByte(loc, ':'); i >= 0 {
-		loc = loc[:i]
+	for {
+		i := strings.LastIndexByte(loc, ':')
+		if i <= 0 {
+			break
+		}
+		isNum := true
+		for _, c := range loc[i+1:] {
+			if c < '0' || c > '9' {
+				isNum = false
+				break
+			}
+		}
+		if isNum && len(loc[i+1:]) > 0 {
+			loc = loc[:i]
+		} else {
+			break
+		}
 	}
 	return strings.ToLower(loc)
 }

--- a/internal/db/fingerprint_test.go
+++ b/internal/db/fingerprint_test.go
@@ -4,12 +4,15 @@ import "testing"
 
 func TestNormaliseLocation(t *testing.T) {
 	cases := map[string]string{
-		"src/users.rb:42":     "src/users.rb",
-		"src/users.rb:42:7":   "src/users.rb",
-		"src/users.rb":        "src/users.rb",
-		"./src/users.rb:1":    "src/users.rb",
-		"  Src/Users.rb:10  ": "src/users.rb",
-		"":                    "",
+		"src/users.rb:42":                "src/users.rb",
+		"src/users.rb:42:7":              "src/users.rb",
+		"src/users.rb":                   "src/users.rb",
+		"./src/users.rb:1":               "src/users.rb",
+		"  Src/Users.rb:10  ":            "src/users.rb",
+		"C:\\project\\src\\main.go:42":   "c:\\project\\src\\main.go",
+		"C:\\project\\src\\main.go:42:7": "c:\\project\\src\\main.go",
+		"C:\\project\\src\\main.go":      "c:\\project\\src\\main.go",
+		"":                               "",
 	}
 	for in, want := range cases {
 		if got := normaliseLocation(in); got != want {


### PR DESCRIPTION
### Summary
The `normaliseLocation` function in `internal/db/fingerprint.go` naively split the location string on the first `:` to strip line and column numbers. However, when processing findings with Windows absolute paths (e.g., `C:\project\src\main.go:42`), this logic incorrectly truncates the entire path, leaving only the drive letter (`"c"`).

This causes massive false-positive deduplication collisions for findings generated on Windows, as they all map to the exact same file location.

### Changes
- Updated `normaliseLocation` to iterate backwards and only strip the trailing segment if it is purely numeric.
- This safely removes `:line:col` or `:line` suffixes without truncating drive letters.
- Added test cases in `fingerprint_test.go` to explicitly cover Windows absolute paths.
