### PR TITLE
fix: stay on the "Findings" tab when applying a CWE category filter

### DIFF
--- a/internal/web/templates/org_show.html
+++ b/internal/web/templates/org_show.html
@@ -78,12 +78,12 @@
         </button>
         <div data-popover aria-hidden="true" data-align="end">
           <div role="menu">
-            <a role="menuitem" href="/orgs/{{$owner}}">All categories</a>
+            <a role="menuitem" href="/orgs/{{$owner}}#ot2">All categories</a>
             {{range .Categories}}
-              <a role="menuitem" href="/orgs/{{$owner}}?category={{.}}"
+              <a role="menuitem" href="/orgs/{{$owner}}?category={{.}}#ot2"
                  {{if eq . $.Category}}aria-current="true"{{end}}>{{catlabel .}}</a>
             {{end}}
-            <a role="menuitem" href="/orgs/{{$owner}}?category={{.Uncategorized}}"
+            <a role="menuitem" href="/orgs/{{$owner}}?category={{.Uncategorized}}#ot2"
                {{if eq .Uncategorized .Category}}aria-current="true"{{end}}>{{.Uncategorized}}</a>
           </div>
         </div>

--- a/internal/web/templates/repo_show.html
+++ b/internal/web/templates/repo_show.html
@@ -196,12 +196,12 @@
         </button>
         <div data-popover aria-hidden="true" data-align="end">
           <div role="menu">
-            <a role="menuitem" href="/repositories/{{.Repo.ID}}">All categories</a>
+            <a role="menuitem" href="/repositories/{{.Repo.ID}}#rt4">All categories</a>
             {{range .Categories}}
-              <a role="menuitem" href="/repositories/{{$.Repo.ID}}?category={{.}}"
+              <a role="menuitem" href="/repositories/{{$.Repo.ID}}?category={{.}}#rt4"
                  {{if eq . $.Category}}aria-current="true"{{end}}>{{catlabel .}}</a>
             {{end}}
-            <a role="menuitem" href="/repositories/{{.Repo.ID}}?category={{.Uncategorized}}"
+            <a role="menuitem" href="/repositories/{{.Repo.ID}}?category={{.Uncategorized}}#rt4"
                {{if eq .Uncategorized .Category}}aria-current="true"{{end}}>{{.Uncategorized}}</a>
           </div>
         </div>

--- a/internal/web/templates/sbom_show.html
+++ b/internal/web/templates/sbom_show.html
@@ -135,12 +135,12 @@
           </button>
           <div data-popover aria-hidden="true" data-align="end">
             <div role="menu">
-              <a role="menuitem" href="/sboms/{{.SBOM.ID}}?scope={{.Scope}}&severity={{.Severity}}&sort={{.Sort}}">All categories</a>
+              <a role="menuitem" href="/sboms/{{.SBOM.ID}}?scope={{.Scope}}&severity={{.Severity}}&sort={{.Sort}}#st2">All categories</a>
               {{range .Categories}}
-                <a role="menuitem" href="/sboms/{{$.SBOM.ID}}?scope={{$.Scope}}&severity={{$.Severity}}&sort={{$.Sort}}&category={{.}}"
+                <a role="menuitem" href="/sboms/{{$.SBOM.ID}}?scope={{$.Scope}}&severity={{$.Severity}}&sort={{$.Sort}}&category={{.}}#st2"
                    {{if eq . $.Category}}aria-current="true"{{end}}>{{catlabel .}}</a>
               {{end}}
-              <a role="menuitem" href="/sboms/{{.SBOM.ID}}?scope={{.Scope}}&severity={{.Severity}}&sort={{.Sort}}&category={{.Uncategorized}}"
+              <a role="menuitem" href="/sboms/{{.SBOM.ID}}?scope={{.Scope}}&severity={{.Severity}}&sort={{.Sort}}&category={{.Uncategorized}}#st2"
                  {{if eq .Uncategorized .Category}}aria-current="true"{{end}}>{{.Uncategorized}}</a>
             </div>
           </div>


### PR DESCRIPTION
Without this change, applying a CWE filter gets the user back to the summary tab, even though the list is indeed filtered when getting back on the right tab.