### PR TITLE
fix: put the Settings tooltip at bottom of the settings icon

### DIFF
--- a/internal/web/templates/layout.html
+++ b/internal/web/templates/layout.html
@@ -50,7 +50,7 @@
             <span class="truncate text-xs text-muted-foreground">local</span>
           </span>
         </a>
-        <a href="/settings" class="btn-ghost p-2 size-10 flex items-center justify-center rounded-lg text-muted-foreground hover:text-foreground" data-tooltip="Settings">
+        <a href="/settings" class="btn-ghost p-2 size-10 flex items-center justify-center rounded-lg text-muted-foreground hover:text-foreground" data-tooltip="Settings" data-side="bottom">
           <i data-lucide="settings" class="size-4"></i>
         </a>
       </div>


### PR DESCRIPTION
Otherwise it is cut off by the screen