### PR TITLE
feat: add CWE category breadcrumb to finding views

### DIFF
--- a/internal/web/cwe.go
+++ b/internal/web/cwe.go
@@ -108,6 +108,11 @@ func CategoryLabel(name string) string {
 	return name
 }
 
+// CWECategoryID returns the View-1400 category CWE-ID for a given weakness
+// CWE-ID (e.g. "CWE-352" -> "CWE-1411"). Returns "" when the weakness is
+// unknown or not mapped to a View-1400 bucket.
+func CWECategoryID(cwe string) string { return categoryCWEID[cweIndex[cwe].Category] }
+
 // CWEsInCategory returns the CWE-IDs that belong to a View-1400 category,
 // or nil for an unknown category. The UncategorizedCWE bucket is handled
 // by applyCWECategoryFilter, not here.

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -96,6 +96,7 @@ func New(gdb *gorm.DB, q *queue.Queue, log *slog.Logger, broker *Broker, w *work
 			return ""
 		},
 		"catlabel":   CategoryLabel,
+		"cwecatid":   CWECategoryID,
 		"md":         renderMarkdown,
 		"jsontree":   jsonTree,
 		"prettyjson": prettyJSON,

--- a/internal/web/templates/findings.html
+++ b/internal/web/templates/findings.html
@@ -100,7 +100,7 @@
       <th class="w-24">Severity</th><th>Title</th><th class="w-24">Status</th>
       <th class="w-32">Repository</th>
       {{if .AnySubPath}}<th class="w-32">Sub-path</th>{{end}}
-      <th class="w-24">CWE</th>
+      <th class="w-44">CWE</th>
       <th class="w-56">Location</th><th class="w-16">Scan</th>
     </tr></thead>
     <tbody>
@@ -126,7 +126,7 @@
           <td class="text-muted-foreground text-xs">{{if .SubPath}}<code>{{.SubPath}}</code>{{else}}<span class="text-muted-foreground">root</span>{{end}}</td>
         {{end}}
         <td class="text-muted-foreground">
-          {{if .CWE}}<span data-tooltip="{{cwename .CWE}}">{{.CWE}}</span>{{end}}
+          {{if .CWE}}<span data-tooltip="{{cwename .CWE}}">{{with cwecatid .CWE}}<span class="text-muted-foreground">{{.}} ›</span> {{end}}{{.CWE}}</span>{{end}}
         </td>
         <td class="whitespace-normal">{{template "loc-link" (dict "HTMLURL" $repo.HTMLURL "Commit" .Commit "Location" .Location "Extra" .ExtraLocationCount)}}</td>
         <td class="text-muted-foreground">#{{.ScanID}}</td>

--- a/internal/web/templates/maintainer_show.html
+++ b/internal/web/templates/maintainer_show.html
@@ -68,7 +68,7 @@
     <table class="table table-fixed w-full">
       <thead><tr>
         <th class="w-24">Severity</th><th>Title</th><th class="w-32">Repository</th>
-        <th class="w-24">Status</th><th class="w-24">CWE</th>
+        <th class="w-24">Status</th><th class="w-44">CWE</th>
       </tr></thead>
       <tbody>
       {{$repos := .Repos}}
@@ -83,7 +83,7 @@
           <td class="truncate">{{$repo.Name}}</td>
           <td>{{template "finding-status" (fstatus .Status)}}</td>
           <td class="text-muted-foreground">
-            {{if .CWE}}<span data-tooltip="{{cwename .CWE}}">{{.CWE}}</span>{{end}}
+            {{if .CWE}}<span data-tooltip="{{cwename .CWE}}">{{with cwecatid .CWE}}<span class="text-muted-foreground">{{.}} ›</span> {{end}}{{.CWE}}</span>{{end}}
           </td>
         </tr>
       {{end}}

--- a/internal/web/templates/org_show.html
+++ b/internal/web/templates/org_show.html
@@ -95,7 +95,7 @@
     <table class="table table-fixed w-full">
       <thead><tr>
         <th class="w-24">Severity</th><th>Title</th><th class="w-32">Repository</th>
-        <th class="w-24">Status</th><th class="w-20">CWE</th>
+        <th class="w-24">Status</th><th class="w-44">CWE</th>
       </tr></thead>
       <tbody>
       {{$repos := .FindingRepos}}
@@ -106,7 +106,7 @@
           <td class="min-w-0 whitespace-normal"><a href="/findings/{{.ID}}" class="font-medium">{{.Title}}</a></td>
           <td class="truncate">{{$repo.Name}}</td>
           <td>{{template "finding-status" (fstatus .Status)}}</td>
-          <td class="text-muted-foreground">{{.CWE}}</td>
+          <td class="text-muted-foreground">{{if .CWE}}{{with cwecatid .CWE}}{{.}} › {{end}}{{.CWE}}{{end}}</td>
         </tr>
       {{end}}
       </tbody>

--- a/internal/web/templates/repo_show.html
+++ b/internal/web/templates/repo_show.html
@@ -218,7 +218,7 @@
               {{template "severity-badge" .Severity}}
               {{template "finding-status" (fstatus .Status)}}
               <h3><a href="/findings/{{.ID}}">{{.Title}}</a></h3>
-              {{if .CWE}}<span class="badge-outline ml-auto" data-tooltip="{{cwename .CWE}}">{{.CWE}}</span>{{end}}
+              {{if .CWE}}<span class="badge-outline ml-auto" data-tooltip="{{cwename .CWE}}">{{with cwecatid .CWE}}<span class="text-muted-foreground">{{.}} ›</span> {{end}}{{.CWE}}</span>{{end}}
             </div>
             <p>
               <code class="text-xs">{{.Location}}</code>
@@ -251,7 +251,7 @@
               {{template "finding-status" (fstatus .Status)}}
               <h3><a href="/findings/{{.ID}}">{{.Title}}</a></h3>
               <span class="badge-outline ml-auto">{{index $skills .ScanID}}</span>
-              {{if .CWE}}<span class="badge-outline" data-tooltip="{{cwename .CWE}}">{{.CWE}}</span>{{end}}
+              {{if .CWE}}<span class="badge-outline" data-tooltip="{{cwename .CWE}}">{{with cwecatid .CWE}}<span class="text-muted-foreground">{{.}} ›</span> {{end}}{{.CWE}}</span>{{end}}
             </div>
             <p>
               <code class="text-xs">{{.Location}}</code>

--- a/internal/web/templates/sbom_show.html
+++ b/internal/web/templates/sbom_show.html
@@ -165,7 +165,7 @@
     <table class="table table-fixed w-full">
       <thead><tr>
         <th class="w-24">Severity</th><th>Title</th><th class="w-32">Repository</th>
-        <th class="w-24">Status</th><th class="w-20">CWE</th>
+        <th class="w-24">Status</th><th class="w-44">CWE</th>
       </tr></thead>
       <tbody>
       {{$repos := .Repos}}
@@ -176,7 +176,7 @@
           <td class="min-w-0 whitespace-normal"><a href="/findings/{{.ID}}" class="font-medium">{{.Title}}</a></td>
           <td class="truncate">{{$repo.Name}}</td>
           <td>{{template "finding-status" (fstatus .Status)}}</td>
-          <td class="text-muted-foreground">{{.CWE}}</td>
+          <td class="text-muted-foreground">{{if .CWE}}{{with cwecatid .CWE}}{{.}} › {{end}}{{.CWE}}{{end}}</td>
         </tr>
       {{end}}
       </tbody>

--- a/internal/web/templates/scan_show.html
+++ b/internal/web/templates/scan_show.html
@@ -99,7 +99,7 @@
       <table class="table table-fixed w-full mb-4">
         <thead><tr>
           <th class="w-24">Severity</th><th>Title</th><th class="w-24">Status</th>
-          <th class="w-28">CWE</th><th class="w-64">Location</th>
+          <th class="w-44">CWE</th><th class="w-64">Location</th>
         </tr></thead>
         <tbody>
         {{range .Findings}}
@@ -111,7 +111,7 @@
             </td>
             <td>{{template "finding-status" (fstatus .Status)}}</td>
             <td class="text-muted-foreground">
-              {{if .CWE}}<span data-tooltip="{{cwename .CWE}}">{{.CWE}}</span>{{end}}
+              {{if .CWE}}<span data-tooltip="{{cwename .CWE}}">{{with cwecatid .CWE}}<span class="text-muted-foreground">{{.}} ›</span> {{end}}{{.CWE}}</span>{{end}}
             </td>
             <td class="whitespace-normal">{{template "loc-link" (dict "HTMLURL" $.Scan.Repository.HTMLURL "Commit" $.Scan.Commit "Location" .Location "Extra" .ExtraLocationCount)}}</td>
           </tr>


### PR DESCRIPTION
Display the View-1400 category CWE-ID alongside each finding's CWE so users immediately see why a CWE shows up under a given category filter.

<img width="343" height="224" alt="Capture d’écran 2026-05-13 à 15 42 19" src="https://github.com/user-attachments/assets/f15b8adb-4ea9-4167-a3a8-1acf7203c397" />
<img width="1004" height="224" alt="Capture d’écran 2026-05-13 à 15 42 31" src="https://github.com/user-attachments/assets/df50fc0e-d4d9-45a2-b59e-768dc04e7b9f" />
