### PR TITLE
Fix disk exhaustion via orphaned scan workspaces

### DIFF
--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -193,7 +193,7 @@ func (w *Worker) wrap(h handler) func(context.Context, []byte) error {
 		if saveErr := w.DB.Save(&scan).Error; saveErr != nil {
 			return saveErr
 		}
-		if scan.Status == db.ScanDone {
+		if scan.Status.Terminal() {
 			if rmErr := os.RemoveAll(w.workRoot(scan.ID)); rmErr != nil {
 				w.Log.Warn("workspace cleanup failed", "scan", scan.ID, "err", rmErr)
 			}

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -172,12 +172,12 @@ func TestWorker_workspaceCleanup(t *testing.T) {
 		t.Errorf("workspace %s not removed after successful scan", okRoot)
 	}
 
-	// Failed scan: workspace kept for inspection.
+	// Failed scan: workspace also removed (prevents disk exhaustion).
 	fail, failRoot := run(fakeRunner{skillErr: errors.New("boom")})
 	if fail.Status != db.ScanFailed {
 		t.Fatalf("status = %s, want failed", fail.Status)
 	}
-	if _, err := os.Stat(failRoot); err != nil {
-		t.Errorf("workspace %s should be kept after failed scan: %v", failRoot, err)
+	if _, err := os.Stat(failRoot); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("workspace %s not removed after failed scan", failRoot)
 	}
 }


### PR DESCRIPTION
Fix disk exhaustion caused by orphaned scan workspaces

Currently, the workspace directory is only removed if `scan.Status == db.ScanDone`. If a scan fails or is cancelled, the directory (and the cloned repo) is left on disk indefinitely, which can quickly lead to disk exhaustion.

This changes the cleanup check to `scan.Status.Terminal()` to ensure the workspace is properly removed across all terminal states (done, failed, cancelled).
