### PR TITLE
feat: Add links to the code location in the git host for each scanner finding.

### DIFF
--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -565,28 +565,33 @@ func firstNonEmpty(vals ...string) string {
 // loadRepoFindings returns the open findings for a repo split into two
 // slices: deep-dive output and tool-scanner output (zizmor, semgrep, …).
 // Findings with no matching scan or an empty skill_name are treated as
-// deep-dive so legacy rows don't get lost. The returned scanSkill map is
-// keyed by scan ID and is what the template reads to label scanner cards.
+// deep-dive so legacy rows don't get lost. The returned scanSkill and
+// scanCommit maps are keyed by scan ID; the template reads scanSkill to
+// label scanner cards and scanCommit to build forge links for each
+// finding's location (each scan can be on a different commit).
 // When category is non-empty, only the deep-dive slice is narrowed to the
 // View-1400 bucket; scanner findings are returned unfiltered so the Scanners
 // tab stays reachable.
-func loadRepoFindings(gdb *gorm.DB, repoID uint, category string) ([]db.Finding, []db.Finding, map[uint]string) {
+func loadRepoFindings(gdb *gorm.DB, repoID uint, category string) ([]db.Finding, []db.Finding, map[uint]string, map[uint]string) {
 	var all []db.Finding
 	gdb.Where("repository_id = ? AND status NOT IN ?", repoID,
 		[]db.FindingLifecycle{db.FindingRejected, db.FindingDuplicate}).
 		Order(severityOrder).Order("id desc").Find(&all)
 
 	scanSkill := map[uint]string{}
+	scanCommit := map[uint]string{}
 	if len(all) == 0 {
-		return nil, nil, scanSkill
+		return nil, nil, scanSkill, scanCommit
 	}
 	var rows []struct {
 		ID        uint
 		SkillName string
+		Commit    string
 	}
-	gdb.Raw(`SELECT id, COALESCE(skill_name, '') AS skill_name FROM scans WHERE repository_id = ?`, repoID).Scan(&rows)
+	gdb.Raw("SELECT id, COALESCE(skill_name, '') AS skill_name, COALESCE(`commit`, '') AS `commit` FROM scans WHERE repository_id = ?", repoID).Scan(&rows)
 	for _, row := range rows {
 		scanSkill[row.ID] = row.SkillName
+		scanCommit[row.ID] = row.Commit
 	}
 	var deepDive, scanners []db.Finding
 	for _, f := range all {
@@ -600,7 +605,7 @@ func loadRepoFindings(gdb *gorm.DB, repoID uint, category string) ([]db.Finding,
 			scanners = append(scanners, f)
 		}
 	}
-	return deepDive, scanners, scanSkill
+	return deepDive, scanners, scanSkill, scanCommit
 }
 
 func (s *Server) findings(w http.ResponseWriter, r *http.Request) {
@@ -1220,7 +1225,7 @@ func (s *Server) repoShow(w http.ResponseWriter, r *http.Request) {
 		Select("COALESCE(SUM(cost_usd), 0)").Scan(&totalCost)
 
 	category := r.URL.Query().Get("category")
-	findings, scannerFindings, scanSkill := loadRepoFindings(s.DB, repo.ID, category)
+	findings, scannerFindings, scanSkill, scanCommit := loadRepoFindings(s.DB, repo.ID, category)
 
 	var maintainers []db.Maintainer
 	s.DB.Joins("JOIN repository_maintainers ON repository_maintainers.maintainer_id = maintainers.id").
@@ -1282,6 +1287,7 @@ func (s *Server) repoShow(w http.ResponseWriter, r *http.Request) {
 		"Findings":        findings,
 		"ScannerFindings": scannerFindings,
 		"ScanSkill":       scanSkill,
+		"ScanCommit":      scanCommit,
 		"FailedScans":     failedScans,
 		"TotalCost":       totalCost,
 		"TMCommit":        tmCommit,

--- a/internal/web/templates/repo_show.html
+++ b/internal/web/templates/repo_show.html
@@ -167,8 +167,7 @@
               <td class="min-w-0 whitespace-normal"><a href="/findings/{{.ID}}">{{.Title}}</a></td>
               <td>{{template "finding-status" (fstatus .Status)}}</td>
               <td class="whitespace-normal">
-                <code class="text-xs break-all">{{.Location}}</code>
-                {{with .ExtraLocationCount}}<span class="ml-1 rounded bg-muted px-1 text-xs text-muted-foreground">+{{.}}</span>{{end}}
+                {{template "loc-link" (dict "HTMLURL" $.Repo.HTMLURL "Commit" $.Latest.Commit "Location" .Location "Extra" .ExtraLocationCount)}}
               </td>
             </tr>
           {{end}}
@@ -211,6 +210,7 @@
       <p class="text-sm text-muted-foreground">No findings in this category.</p>
     {{end}}
     <div class="grid gap-4">
+      {{$commits := .ScanCommit}}
       {{range .Findings}}
         <div id="finding-card-{{.ID}}" class="card">
           <header>
@@ -221,8 +221,7 @@
               {{if .CWE}}<span class="badge-outline ml-auto" data-tooltip="{{cwename .CWE}}">{{with cwecatid .CWE}}<span class="text-muted-foreground">{{.}} ›</span> {{end}}{{.CWE}}</span>{{end}}
             </div>
             <p>
-              <code class="text-xs">{{.Location}}</code>
-              {{with .ExtraLocationCount}}<span class="ml-1 rounded bg-muted px-1 text-xs text-muted-foreground">+{{.}}</span>{{end}}
+              {{template "loc-link" (dict "HTMLURL" $.Repo.HTMLURL "Commit" (index $commits .ScanID) "Location" .Location "Extra" .ExtraLocationCount)}}
               <span class="text-xs text-muted-foreground">&middot; scan <a class="hover:underline" href="/scans/{{.ScanID}}">#{{.ScanID}}</a></span>
             </p>
           </header>
@@ -243,6 +242,7 @@
     </p>
     <div class="grid gap-4">
       {{$skills := .ScanSkill}}
+      {{$commits := .ScanCommit}}
       {{range .ScannerFindings}}
         <div id="finding-card-{{.ID}}" class="card">
           <header>
@@ -254,7 +254,7 @@
               {{if .CWE}}<span class="badge-outline" data-tooltip="{{cwename .CWE}}">{{with cwecatid .CWE}}<span class="text-muted-foreground">{{.}} ›</span> {{end}}{{.CWE}}</span>{{end}}
             </div>
             <p>
-              <code class="text-xs">{{.Location}}</code>
+              {{template "loc-link" (dict "HTMLURL" $.Repo.HTMLURL "Commit" (index $commits .ScanID) "Location" .Location "Extra" .ExtraLocationCount)}}
               <span class="text-xs text-muted-foreground">&middot; scan <a class="hover:underline" href="/scans/{{.ScanID}}">#{{.ScanID}}</a></span>
             </p>
           </header>


### PR DESCRIPTION
I felt it'd be useful to have the permalinks available so it's easier to triage/manually validate findings.

<img width="1188" height="177" alt="Screenshot 2026-05-13 at 6 15 35 PM" src="https://github.com/user-attachments/assets/1d4db900-f002-4674-abd7-d2472062aa30" />

<img width="1209" height="269" alt="Screenshot 2026-05-13 at 6 15 46 PM" src="https://github.com/user-attachments/assets/970923c6-10b7-42ee-aa08-ad314db87498" />

For now this only applies to the scanner-based findings (zizmor and such), but it should be easy to extend it to the other finding types as well.

AI Disclosure: Generated with Claude Code because Go scares me, reviewed (to the extent I can with go code) by me and tested by me.