### PR TITLE
fix: Fix button styling for "Add multiple"

### DIFF
--- a/internal/web/templates/layout.html
+++ b/internal/web/templates/layout.html
@@ -96,7 +96,7 @@
         <input class="input" type="text" name="url"
                placeholder="https://github.com/maragudk/goqite.git" required>
         <footer class="flex justify-between items-center gap-2">
-          <a href="/repositories/new?bulk=1" data-dialog="bulk-add-repo" class="btn-ghost-sm">
+          <a href="/repositories/new?bulk=1" data-dialog="bulk-add-repo" class="btn-sm-ghost">
             <i data-lucide="list-plus"></i> Add multiple
           </a>
           <div class="flex gap-2">

--- a/internal/web/templates/repo_new.html
+++ b/internal/web/templates/repo_new.html
@@ -21,7 +21,7 @@
     <input class="input" type="text" name="url"
            placeholder="https://github.com/maragudk/goqite.git" required>
     <footer class="flex justify-between items-center gap-2">
-      <a href="/repositories/new?bulk=1" class="btn-ghost-sm">
+      <a href="/repositories/new?bulk=1" class="btn-sm-ghost">
         <i data-lucide="list-plus"></i> Add multiple
       </a>
       <div class="flex gap-2">


### PR DESCRIPTION
The class name was typo'd, this fixes it.

Before:

<img width="517" height="179" alt="Screenshot 2026-05-13 at 6 21 01 PM" src="https://github.com/user-attachments/assets/a6412dc5-1b54-48ab-9b71-92bac72eb400" />

After:

<img width="518" height="175" alt="Screenshot 2026-05-13 at 6 21 42 PM" src="https://github.com/user-attachments/assets/15d26ec7-86ec-49e3-bb86-62d13bc16add" />
