### PR TITLE
feat: Improve "Disclosure Channel" section formatting/styling

### DIFF
--- a/internal/web/templates/repo_show.html
+++ b/internal/web/templates/repo_show.html
@@ -103,22 +103,27 @@
       <p class="text-muted-foreground text-sm mb-6">Metadata not fetched yet.</p>
     {{end}}
 
-    <details class="mb-4 max-w-3xl">
-      <summary class="text-sm text-muted-foreground cursor-pointer hover:underline">
+    <div class="mb-4 max-w-3xl">
+      <h3 class="text-sm font-medium flex items-center gap-2">
         <i data-lucide="send"></i>
-        Disclosure channel{{if not .Repo.DisclosureChannel}}<span class="italic"> — not set</span>{{end}}
-      </summary>
+        Disclosure channel
+      </h3>
       {{if .Repo.DisclosureChannel}}
         <p class="text-sm mt-2 whitespace-pre-wrap">{{.Repo.DisclosureChannel}}</p>
+      {{else}}
+        <p class="text-sm mt-2 italic text-muted-foreground">not set</p>
       {{end}}
-      <form method="post" action="/repositories/{{.Repo.ID}}/disclosure-channel" class="form grid grid-cols-[1fr_auto] gap-2 mt-2">
-        <input class="input text-xs" type="text" name="disclosure_channel"
-               value="{{.Repo.DisclosureChannel}}"
-               placeholder="security@example.org, https://…/security/advisories, …">
-        <button class="btn-sm" type="submit">Save</button>
-      </form>
-      <p class="text-xs text-muted-foreground mt-1">Auto-filled by the maintainers skill from <code>SECURITY.md</code>, registry owner data, or CODEOWNERS. Edit freely.</p>
-    </details>
+      <details class="mt-2">
+        <summary class="text-xs text-muted-foreground cursor-pointer hover:underline">Edit</summary>
+        <form method="post" action="/repositories/{{.Repo.ID}}/disclosure-channel" class="form grid grid-cols-[1fr_auto] gap-2 mt-2">
+          <input class="input text-xs" type="text" name="disclosure_channel"
+                 value="{{.Repo.DisclosureChannel}}"
+                 placeholder="security@example.org, https://…/security/advisories, …">
+          <button class="btn-sm" type="submit">Save</button>
+        </form>
+        <p class="text-xs text-muted-foreground mt-1">Auto-filled by the maintainers skill from <code>SECURITY.md</code>, registry owner data, or CODEOWNERS. Edit freely.</p>
+      </details>
+    </div>
 
     {{if .Subprojects}}
       <h3 class="font-medium mb-2">Subprojects <span class="text-muted-foreground text-xs">({{len .Subprojects}})</span></h3>

--- a/internal/web/templates/repo_show.html
+++ b/internal/web/templates/repo_show.html
@@ -106,10 +106,13 @@
     <details class="mb-4 max-w-3xl">
       <summary class="text-sm text-muted-foreground cursor-pointer hover:underline">
         <i data-lucide="send"></i>
-        Disclosure channel{{if .Repo.DisclosureChannel}}: <code class="text-xs">{{.Repo.DisclosureChannel}}</code>{{else}}<span class="italic"> not set</span>{{end}}
+        Disclosure channel{{if not .Repo.DisclosureChannel}}<span class="italic"> — not set</span>{{end}}
       </summary>
+      {{if .Repo.DisclosureChannel}}
+        <p class="text-sm mt-2 whitespace-pre-wrap">{{.Repo.DisclosureChannel}}</p>
+      {{end}}
       <form method="post" action="/repositories/{{.Repo.ID}}/disclosure-channel" class="form grid grid-cols-[1fr_auto] gap-2 mt-2">
-        <input class="input font-mono text-xs" type="text" name="disclosure_channel"
+        <input class="input text-xs" type="text" name="disclosure_channel"
                value="{{.Repo.DisclosureChannel}}"
                placeholder="security@example.org, https://…/security/advisories, …">
         <button class="btn-sm" type="submit">Save</button>


### PR DESCRIPTION
Before:

<img width="818" height="181" alt="Screenshot 2026-05-13 at 6 29 56 PM" src="https://github.com/user-attachments/assets/fa0e89dd-878e-417d-b8c1-b3c452066f31" />

<img width="820" height="136" alt="Screenshot 2026-05-13 at 6 30 14 PM" src="https://github.com/user-attachments/assets/b5d63aeb-d512-44c8-93a1-c85ea1910384" />

After:

<img width="739" height="132" alt="Screenshot 2026-05-13 at 6 28 02 PM" src="https://github.com/user-attachments/assets/137b87ea-8743-4f62-bbc4-2775ca8c14c5" />

<img width="845" height="201" alt="Screenshot 2026-05-13 at 6 28 08 PM" src="https://github.com/user-attachments/assets/916d001e-6eab-44f3-ada3-2f10a0805648" />

AI Disclosure: Generated with Claude Code, reviewed and tested by me.