### PR TITLE
fix: Improve the styling of the active/inactive badge, fix some class names

### DIFF
--- a/internal/web/templates/finding_show.html
+++ b/internal/web/templates/finding_show.html
@@ -275,7 +275,7 @@
         <a class="btn-sm" href="/findings/{{$f.ID}}/patch.diff">
           <i data-lucide="download"></i> Download .patch
         </a>
-        <a class="btn-outline-sm" href="/scans/{{$ps.ID}}">
+        <a class="btn-sm-outline" href="/scans/{{$ps.ID}}">
           <i data-lucide="arrow-up-right"></i> View scan
         </a>
         {{if $p.BaseCommit}}

--- a/internal/web/templates/layout.html
+++ b/internal/web/templates/layout.html
@@ -202,5 +202,7 @@
   {{else if eq . "failed"}}<span class="badge-destructive"><i data-lucide="x"></i> failed</span>
   {{else if eq . "cancelled"}}<span class="badge-outline"><i data-lucide="circle-slash"></i> cancelled</span>
   {{else if eq . "running"}}<span class="badge-primary"><i data-lucide="loader-circle" class="animate-spin"></i> running</span>
+  {{else if eq . "active"}}<span class="badge-secondary"><i data-lucide="circle-check"></i> active</span>
+  {{else if eq . "inactive"}}<span class="badge-outline"><i data-lucide="moon"></i> inactive</span>
   {{else}}<span class="badge-outline"><i data-lucide="clock"></i> {{.}}</span>{{end}}
 {{end}}

--- a/internal/web/templates/maintainer_show.html
+++ b/internal/web/templates/maintainer_show.html
@@ -20,11 +20,11 @@
           class="contents">
     {{if $m.DoNotContact}}
       <span class="badge-destructive" data-tooltip="Maintainer has asked not to be contacted, or routing is known to leak">Do not contact</span>
-      <button type="submit" name="value" value="false" class="btn-outline-sm">
+      <button type="submit" name="value" value="false" class="btn-sm-outline">
         Clear flag
       </button>
     {{else}}
-      <button type="submit" name="value" value="true" class="btn-outline-sm"
+      <button type="submit" name="value" value="true" class="btn-sm-outline"
               data-tooltip="Suppress from disclosure routing">
         <i data-lucide="ban"></i> Do not contact
       </button>

--- a/internal/web/templates/repo_show.html
+++ b/internal/web/templates/repo_show.html
@@ -140,7 +140,7 @@
             <td>
               <form method="post" action="/repositories/{{$repoID}}/scan" hx-post="/repositories/{{$repoID}}/scan" hx-swap="none">
                 <input type="hidden" name="sub_path" value="{{.Path}}">
-                <button type="submit" class="btn-outline-sm"><i data-lucide="play"></i> Scan</button>
+                <button type="submit" class="btn-sm-outline"><i data-lucide="play"></i> Scan</button>
               </form>
             </td>
           </tr>


### PR DESCRIPTION
Update the active/inactive badges so they're visually distinct in the Maintainers tab and elsewhere.

Before:

<img width="135" height="379" alt="Screenshot 2026-05-13 at 6 40 15 PM" src="https://github.com/user-attachments/assets/412c6762-7e4c-4809-b060-1c329994c662" />

After:

<img width="135" height="389" alt="Screenshot 2026-05-13 at 6 39 37 PM" src="https://github.com/user-attachments/assets/326db1ca-5d06-40d9-98d0-307687ed8a65" />

Fixes the class names for a few buttons so they actually get styled as buttons.

Before:

<img width="244" height="113" alt="Screenshot 2026-05-13 at 6 38 25 PM" src="https://github.com/user-attachments/assets/f078d4bb-bf80-46e2-b39c-2b88b1877a2b" />

After:

<img width="269" height="81" alt="Screenshot 2026-05-13 at 6 38 42 PM" src="https://github.com/user-attachments/assets/ecb37546-633f-4c01-a8e5-b5a9c07fbf48" />

Generated with Claude Code, tested and reviewed by me.