### PR TITLE
feat: Add a cancel button to the Scan view for queued and running scans.

### DIFF
--- a/internal/web/templates/scan_show.html
+++ b/internal/web/templates/scan_show.html
@@ -17,10 +17,17 @@
         <i data-lucide="download"></i> Export as markdown
       </a>
       {{end}}
+      {{if or (eq (status .Status) "queued") (eq (status .Status) "running")}}
+      <form method="post" action="/scans/{{.ID}}/cancel"
+            hx-post="/scans/{{.ID}}/cancel" hx-swap="none">
+        <button type="submit" class="btn-outline"><i data-lucide="x"></i> Cancel</button>
+      </form>
+      {{else}}
       <form method="post" action="/scans/{{.ID}}/retry"
             hx-post="/scans/{{.ID}}/retry" hx-swap="none">
         <button type="submit" class="btn-outline"><i data-lucide="refresh-cw"></i> Retry</button>
       </form>
+      {{end}}
     </div>
   {{else if .HasExportableReport}}
     <a href="/scans/{{.ID}}/report.md" class="btn-outline" download>


### PR DESCRIPTION
This hides the Retry button if the scan is is in progress or queued, I think that's probably more correct than the previous behavior?

<img width="1226" height="434" alt="Screenshot 2026-05-13 at 7 14 07 PM" src="https://github.com/user-attachments/assets/96e8c2c4-dc56-4ddc-b193-69f39305dcb4" />

Generated with Claude Code, reviewed and tested by me.
