### PR TITLE
feat: Add error handling to the "Add Repository" modal.

### DIFF
--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -1034,15 +1034,33 @@ func (s *Server) findingShow(w http.ResponseWriter, r *http.Request) {
 func (s *Server) repoCreate(w http.ResponseWriter, r *http.Request) {
 	input, err := ParseRepoInput(r.FormValue("url"))
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusUnprocessableEntity)
+		s.repoCreateError(w, r, "Invalid repository URL", err, http.StatusUnprocessableEntity)
 		return
 	}
 	repo, _, err := s.createOrTriageRepo(r.Context(), input, r.FormValue("model"))
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		s.repoCreateError(w, r, "Couldn't add repository", err, http.StatusInternalServerError)
 		return
 	}
 	s.redirect(w, r, fmt.Sprintf("/repositories/%d", repo.ID))
+}
+
+// repoCreateError renders feedback for a failed Add Repository submission.
+// htmx clients get an OOB toast so the dialog stays open and the user can
+// fix their input; plain form posts fall back to a basic error page.
+func (s *Server) repoCreateError(w http.ResponseWriter, r *http.Request, title string, err error, status int) {
+	if !isHX(r) {
+		http.Error(w, err.Error(), status)
+		return
+	}
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	if execErr := s.tmpl.ExecuteTemplate(w, "toast-oob", Flash{
+		Category:    "error",
+		Title:       title,
+		Description: err.Error(),
+	}); execErr != nil {
+		s.Log.Error("render toast-oob", "err", execErr)
+	}
 }
 
 // repoNew is the no-javascript fallback for the Add Repository dialog.

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -240,6 +240,51 @@ func TestRepoNew_fallbackPages(t *testing.T) {
 	}
 }
 
+func TestRepoCreate_htmxInvalidURL_rendersToastOOB(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	form := url.Values{"url": {"not-a-url"}}
+	r := httptest.NewRequest("POST", "/repositories", strings.NewReader(form.Encode()))
+	r.Host = testHost
+	r.Header.Set("Sec-Fetch-Site", "same-origin")
+	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	r.Header.Set("HX-Request", "true")
+
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status %d, want 200 (htmx error path renders inline, no redirect)", w.Code)
+	}
+	if loc := w.Header().Get("Location"); loc != "" {
+		t.Errorf("unexpected Location %q (htmx error path must not redirect)", loc)
+	}
+	if hx := w.Header().Get("HX-Redirect"); hx != "" {
+		t.Errorf("unexpected HX-Redirect %q (htmx error path must not redirect)", hx)
+	}
+	if ct := w.Header().Get("Content-Type"); !strings.HasPrefix(ct, "text/html") {
+		t.Errorf("Content-Type %q, want text/html", ct)
+	}
+
+	body := w.Body.String()
+	if !strings.Contains(body, `hx-swap-oob="afterbegin:#toaster"`) {
+		t.Errorf("body missing toast-oob wrapper:\n%s", body)
+	}
+	if !strings.Contains(body, `data-category="error"`) {
+		t.Errorf("body missing error toast category:\n%s", body)
+	}
+	if !strings.Contains(body, "Invalid repository URL") {
+		t.Errorf("body missing error title:\n%s", body)
+	}
+
+	var n int64
+	s.DB.Model(&db.Repository{}).Count(&n)
+	if n != 0 {
+		t.Errorf("repository count = %d, want 0 (invalid input must not persist)", n)
+	}
+}
+
 func TestFlash_roundtrip(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()

--- a/internal/web/templates/layout.html
+++ b/internal/web/templates/layout.html
@@ -92,16 +92,19 @@
   <div>
     <header><h2>Add repository</h2></header>
     <section>
-      <form method="post" action="/repositories" class="form grid gap-3">
-        <input class="input" type="text" name="url"
+      <form method="post" action="/repositories"
+            hx-post="/repositories" hx-swap="none"
+            class="form grid gap-3">
+        <input class="input" type="url" name="url"
                placeholder="https://github.com/maragudk/goqite.git" required>
         <footer class="flex justify-between items-center gap-2">
           <a href="/repositories/new?bulk=1" data-dialog="bulk-add-repo" class="btn-ghost-sm">
             <i data-lucide="list-plus"></i> Add multiple
           </a>
           <div class="flex gap-2">
-            <button type="submit" class="btn-outline" formmethod="dialog" formnovalidate>Cancel</button>
-            <button type="submit" class="btn" hx-post="/repositories" hx-swap="none">
+            <button type="button" class="btn-outline"
+                    onclick="this.closest('dialog').close()">Cancel</button>
+            <button type="submit" class="btn">
               <i data-lucide="play"></i> Scan
             </button>
           </div>
@@ -122,12 +125,15 @@
       </p>
     </header>
     <section>
-      <form method="post" action="/repositories/bulk" class="form grid gap-3">
+      <form method="post" action="/repositories/bulk"
+            hx-post="/repositories/bulk" hx-swap="none"
+            class="form grid gap-3">
         <textarea class="input font-mono text-xs" name="urls" rows="10" required
                   placeholder="https://github.com/maragudk/goqite.git&#10;https://github.com/spf13/cobra.git&#10;https://github.com/stretchr/testify.git"></textarea>
         <footer class="flex justify-end gap-2">
-          <button type="submit" class="btn-outline" formmethod="dialog" formnovalidate>Cancel</button>
-          <button type="submit" class="btn" hx-post="/repositories/bulk" hx-swap="none">
+          <button type="button" class="btn-outline"
+                  onclick="this.closest('dialog').close()">Cancel</button>
+          <button type="submit" class="btn">
             <i data-lucide="play"></i> Import
           </button>
         </footer>
@@ -196,6 +202,8 @@
   </div>
 </div>
 {{end}}
+
+{{define "toast-oob"}}<div hx-swap-oob="afterbegin:#toaster">{{template "toast" .}}</div>{{end}}
 
 {{define "status-badge"}}
   {{if eq . "done"}}<span class="badge-secondary"><i data-lucide="check"></i> complete</span>


### PR DESCRIPTION
And also make hitting "Enter" submit the form instead of closing it. It was very confusing previously.

This may have conflicts with #223, I can fix them if so.

The toasts do end up behind the, which is jank, but I think it's still a better UX than silent failure:

<img width="1191" height="613" alt="Screenshot 2026-05-13 at 7 16 52 PM" src="https://github.com/user-attachments/assets/35cafba5-c434-4391-b07c-21e2a865c144" />

<img width="582" height="247" alt="Screenshot 2026-05-13 at 7 17 02 PM" src="https://github.com/user-attachments/assets/852b851a-ed6e-4072-b2d2-a101d0838a29" />


AI Disclosure: Generated with Claude Code, reviewed and tested by me.