### PR TITLE
fix: Stage schema.json at the workspace root

### DIFF
--- a/internal/worker/exposure.go
+++ b/internal/worker/exposure.go
@@ -159,7 +159,7 @@ func (w *Worker) doExposure(ctx context.Context, scan *db.Scan, emit func(Event)
 	scan.Commit = cacheCommit
 
 	skillDir := filepath.Join(workRoot, ".claude", "skills", skill.Name)
-	if err := stageSkill(&skill, skillDir); err != nil {
+	if err := stageSkill(&skill, workRoot, skillDir); err != nil {
 		return "", fmt.Errorf("stage skill: %w", err)
 	}
 	if err := stageContext(workRoot, w.APIBase, w.ForkOrg, scan, &scan.Repository); err != nil {

--- a/internal/worker/skill.go
+++ b/internal/worker/skill.go
@@ -90,11 +90,11 @@ func (w *Worker) doSkill(ctx context.Context, scan *db.Scan, emit func(Event)) (
 		return "", err
 	}
 	skillDir := filepath.Join(workRoot, ".claude", "skills", skill.Name)
-	if err := stageSkill(&skill, skillDir); err != nil {
-		return "", fmt.Errorf("stage skill: %w", err)
-	}
 	if err := stageContext(workRoot, w.APIBase, w.ForkOrg, scan, &scan.Repository); err != nil {
 		return "", fmt.Errorf("stage context: %w", err)
+	}
+	if err := stageSkill(&skill, workRoot, skillDir); err != nil {
+		return "", fmt.Errorf("stage skill: %w", err)
 	}
 
 	prompt := buildSkillPrompt(skill.Name, skill.OutputFile)
@@ -446,7 +446,10 @@ func validateSkillPaths(name, outputFile string) error {
 // at ./.claude/skills/{name}. Only SKILL.md and schema.json are reconstructed
 // from the DB; supplementary files (scripts/, references/, assets/) are
 // copied from SourcePath when the skill was loaded from disk.
-func stageSkill(skill *db.Skill, dst string) error {
+//
+// schema.json is also written to workRoot so the `./schema.json` path every
+// SKILL.md references resolves without the model having to glob for it (#221).
+func stageSkill(skill *db.Skill, workRoot, dst string) error {
 	if err := os.RemoveAll(dst); err != nil {
 		return err
 	}
@@ -459,6 +462,9 @@ func stageSkill(skill *db.Skill, dst string) error {
 	}
 	if skill.SchemaJSON != "" {
 		if err := os.WriteFile(filepath.Join(dst, "schema.json"), []byte(skill.SchemaJSON), filePerm); err != nil {
+			return err
+		}
+		if err := os.WriteFile(filepath.Join(workRoot, "schema.json"), []byte(skill.SchemaJSON), filePerm); err != nil {
 			return err
 		}
 	}

--- a/internal/worker/skill_test.go
+++ b/internal/worker/skill_test.go
@@ -266,8 +266,8 @@ func TestStageContext_writesRepoFacts(t *testing.T) {
 }
 
 func TestStageSkill_writesMarkdownAndSchema(t *testing.T) {
-	dst := t.TempDir()
-	dir := filepath.Join(dst, "ns")
+	work := t.TempDir()
+	dir := filepath.Join(work, ".claude", "skills", "s")
 	skill := &db.Skill{
 		Name:        "s",
 		Description: "d",
@@ -275,7 +275,7 @@ func TestStageSkill_writesMarkdownAndSchema(t *testing.T) {
 		SchemaJSON:  `{"x":1}`,
 		Source:      "ui",
 	}
-	if err := stageSkill(skill, dir); err != nil {
+	if err := stageSkill(skill, work, dir); err != nil {
 		t.Fatal(err)
 	}
 	md, err := os.ReadFile(filepath.Join(dir, "SKILL.md"))
@@ -293,7 +293,14 @@ func TestStageSkill_writesMarkdownAndSchema(t *testing.T) {
 		t.Fatal(err)
 	}
 	if string(sch) != `{"x":1}` {
-		t.Errorf("schema: %q", string(sch))
+		t.Errorf("schema in skill dir: %q", string(sch))
+	}
+	rootSch, err := os.ReadFile(filepath.Join(work, "schema.json"))
+	if err != nil {
+		t.Fatalf("schema.json not staged at work root: %v", err)
+	}
+	if string(rootSch) != `{"x":1}` {
+		t.Errorf("schema at work root: %q", string(rootSch))
 	}
 }
 


### PR DESCRIPTION
Every SKILL.md tells the model to read `./schema.json`, but `stageSkill` only wrote it to `.claude/skills/{name}/schema.json`. The model would try `./schema.json`, get file-not-found, then glob around for it. In `--no-docker` runs that glob falls through to the scrutineer source tree so it always recovered, which is why this never showed up locally; in a docker workspace there is no fallback and the hunt sometimes gave up, at which point the model invented its own report shape (`github_username`, `is_rubygems_owner`, `evidence` as an array, top-level `analysis` etc) and `parseMaintainersOutput` choked on it.

Now `stageSkill` also writes `schema.json` to the work root alongside `context.json` and `report.json`, so the `./schema.json` path every skill references resolves on the first read. Reordered `stageContext` before `stageSkill` in `doSkill` since `stageContext` is what creates the work root.

Fixes #221.