### PR TITLE
fix: Set a CSP that blocks inline JS

### DIFF
--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -1583,10 +1583,26 @@ func formatUSD(v float64) string {
 	return fmt.Sprintf("$%.2f", v)
 }
 
+// cspPolicy blocks inline scripts (the XSS mitigation that motivated this
+// header) and locks down loading to same-origin resources. 'unsafe-inline' is
+// kept for styles because tailwindcss-browser injects style tags at runtime.
+const cspPolicy = "default-src 'self'; " +
+	"script-src 'self'; " +
+	"style-src 'self' 'unsafe-inline'; " +
+	"img-src 'self' data:; " +
+	"font-src 'self' data:; " +
+	"connect-src 'self'; " +
+	"base-uri 'self'; " +
+	"form-action 'self'; " +
+	"frame-ancestors 'none'; " +
+	"object-src 'none'"
+
 // securityHeaders enforces T3 mitigations: host header check to prevent DNS
-// rebinding, and Sec-Fetch-Site check on POST to prevent cross-origin CSRF.
+// rebinding, Sec-Fetch-Site check on POST to prevent cross-origin CSRF, and
+// a CSP that prevents stored XSS in any rendered content from executing JS.
 func securityHeaders(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Security-Policy", cspPolicy)
 		host := r.Host
 		// Strip port for comparison
 		if i := strings.LastIndex(host, ":"); i >= 0 {

--- a/internal/web/static/app.js
+++ b/internal/web/static/app.js
@@ -57,6 +57,12 @@
 
     if (e.target.nodeName === 'DIALOG') e.target.close();
 
+    var closer = e.target.closest('[data-close]');
+    if (closer) {
+      var dlgToClose = closer.closest('dialog');
+      if (dlgToClose) { e.preventDefault(); dlgToClose.close(); return; }
+    }
+
     var opener = e.target.closest('[data-dialog]');
     if (opener) {
       var dlg = document.getElementById(opener.getAttribute('data-dialog'));

--- a/internal/web/static/theme-init.js
+++ b/internal/web/static/theme-init.js
@@ -1,0 +1,14 @@
+(function () {
+  var scheme = (document.cookie.match(/(?:^|; )color_scheme=(\w+)/) || [])[1] || 'system';
+  var mq = matchMedia('(prefers-color-scheme: dark)');
+  var apply = function () {
+    var dark = scheme === 'dark' || (scheme === 'system' && mq.matches);
+    document.documentElement.classList.toggle('dark', dark);
+    var hl = document.getElementById('hljs-light');
+    var hd = document.getElementById('hljs-dark');
+    if (hl) hl.disabled = dark;
+    if (hd) hd.disabled = !dark;
+  };
+  apply();
+  mq.addEventListener('change', apply);
+})();

--- a/internal/web/templates/layout.html
+++ b/internal/web/templates/layout.html
@@ -2,21 +2,7 @@
 <!doctype html>
 <html lang="en" data-theme="{{.Theme}}">
 <head>
-  <script>
-    (function () {
-      var scheme = (document.cookie.match(/(?:^|; )color_scheme=(\w+)/) || [])[1] || 'system';
-      var mq = matchMedia('(prefers-color-scheme: dark)');
-      var apply = function () {
-        var dark = scheme === 'dark' || (scheme === 'system' && mq.matches);
-        document.documentElement.classList.toggle('dark', dark);
-        var hl = document.getElementById('hljs-light');
-        var hd = document.getElementById('hljs-dark');
-        if (hl) hl.disabled = dark;
-        if (hd) hd.disabled = !dark;
-      };
-      apply(); mq.addEventListener('change', apply);
-    })();
-  </script>
+  <script src="/static/theme-init.js"></script>
   <link rel="icon" type="image/svg+xml" href="/static/favicon.svg">
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
@@ -102,8 +88,7 @@
             <i data-lucide="list-plus"></i> Add multiple
           </a>
           <div class="flex gap-2">
-            <button type="button" class="btn-outline"
-                    onclick="this.closest('dialog').close()">Cancel</button>
+            <button type="button" class="btn-outline" data-close>Cancel</button>
             <button type="submit" class="btn">
               <i data-lucide="play"></i> Scan
             </button>
@@ -131,8 +116,7 @@
         <textarea class="input font-mono text-xs" name="urls" rows="10" required
                   placeholder="https://github.com/maragudk/goqite.git&#10;https://github.com/spf13/cobra.git&#10;https://github.com/stretchr/testify.git"></textarea>
         <footer class="flex justify-end gap-2">
-          <button type="button" class="btn-outline"
-                  onclick="this.closest('dialog').close()">Cancel</button>
+          <button type="button" class="btn-outline" data-close>Cancel</button>
           <button type="submit" class="btn">
             <i data-lucide="play"></i> Import
           </button>


### PR DESCRIPTION
Adds Content-Security-Policy with `script-src 'self'` on every response from the UI handlers so stored content (e.g. scan logs) can never execute JS even if a renderer ever forgets to escape it.

`style-src` keeps 'unsafe-inline' because tailwindcss-browser injects style tags at runtime.

To stay compatible with the new policy remove all inline scripts.