### PR TITLE
fix: Escape event response output

### DIFF
--- a/internal/web/sse.go
+++ b/internal/web/sse.go
@@ -2,6 +2,7 @@ package web
 
 import (
 	"fmt"
+	"html"
 	"io"
 	"net/http"
 	"strconv"
@@ -102,9 +103,12 @@ func (s *Server) events(w http.ResponseWriter, r *http.Request) {
 		case <-ctx.Done():
 			return
 		case e := <-c.ch:
-			data := e.Data
-			if e.Name == "scan-status" {
+			var data string
+			switch e.Name {
+			case "scan-status":
 				data = s.renderScanStatus(e.ScanID)
+			default:
+				data = html.EscapeString(e.Data)
 			}
 			writeSSEEvent(w, e.Name, data)
 			flusher.Flush()


### PR DESCRIPTION
Related: #240 

Manually tested with xss payloads in 20+ data fields and all renders correctly.

Might not be the best place for this, but it's a universal escape for data.