### PR TITLE
fix: normalize ecosystem names for packages and dependencies

### DIFF
--- a/internal/worker/ecosystem.go
+++ b/internal/worker/ecosystem.go
@@ -1,0 +1,117 @@
+package worker
+
+import "strings"
+
+// normalizeEcosystem canonicalises the ecosystem string for a package row.
+// Upstream sources (packages.ecosyste.ms, git-pkgs manifest scans) are
+// inconsistent: the same logical ecosystem can arrive as "rubygems" or "gem",
+// "go" or "golang", and frequently as an empty string when the upstream
+// record is incomplete. The Packages tab displays this value directly and
+// builds its filter dropdown from the distinct set, so any variance becomes
+// visible as either empty badges or duplicate filter entries.
+//
+// Resolution order: the explicit field, then the PURL type segment, then a
+// registry-host fallback. Synonyms collapse onto the canonical name that the
+// rest of the system already uses ("rubygems", "go", "npm", …).
+func normalizeEcosystem(ecosystem, purl, registryURL string) string {
+	if e := canonicalEcosystem(ecosystem); e != "" {
+		return e
+	}
+	if e := canonicalEcosystem(purlEcosystem(purl)); e != "" {
+		return e
+	}
+	return canonicalEcosystem(registryEcosystem(registryURL))
+}
+
+// purlEcosystem returns the type segment of a Package URL: "pkg:gem/foo"
+// becomes "gem". Empty string for non-PURL inputs.
+func purlEcosystem(purl string) string {
+	const prefix = "pkg:"
+	if !strings.HasPrefix(purl, prefix) {
+		return ""
+	}
+	rest := purl[len(prefix):]
+	if i := strings.IndexByte(rest, '/'); i > 0 {
+		return rest[:i]
+	}
+	return rest
+}
+
+// registryEcosystem maps the host of a registry URL to a canonical ecosystem
+// name. Returns "" for hosts we don't recognise.
+func registryEcosystem(registryURL string) string {
+	if registryURL == "" {
+		return ""
+	}
+	host := registryURL
+	if i := strings.Index(host, "://"); i >= 0 {
+		host = host[i+3:]
+	}
+	if i := strings.IndexAny(host, "/?#"); i >= 0 {
+		host = host[:i]
+	}
+	host = strings.ToLower(strings.TrimPrefix(host, "www."))
+	switch host {
+	case "rubygems.org", "gem.coop":
+		return "rubygems"
+	case "npmjs.com", "registry.npmjs.org":
+		return "npm"
+	case "pypi.org":
+		return "pypi"
+	case "pkg.go.dev", "proxy.golang.org":
+		return "go"
+	case "crates.io":
+		return "cargo"
+	case "packagist.org":
+		return "packagist"
+	case "hex.pm":
+		return "hex"
+	case "nuget.org", "www.nuget.org":
+		return "nuget"
+	case "search.maven.org", "central.sonatype.com", "repo.maven.apache.org":
+		return "maven"
+	case "launchpad.net":
+		return "ubuntu"
+	}
+	return ""
+}
+
+// ecosystemAliases maps known synonyms onto the canonical name used by the
+// existing data set. The canonical names match what packages.ecosyste.ms
+// emits when it does populate the field.
+var ecosystemAliases = map[string]string{
+	"gem":       "rubygems",
+	"gems":      "rubygems",
+	"rubygems":  "rubygems",
+	"go":        "go",
+	"golang":    "go",
+	"npm":       "npm",
+	"node":      "npm",
+	"pypi":      "pypi",
+	"python":    "pypi",
+	"pip":       "pypi",
+	"cargo":     "cargo",
+	"crates":    "cargo",
+	"crate":     "cargo",
+	"packagist": "packagist",
+	"composer":  "packagist",
+	"hex":       "hex",
+	"nuget":     "nuget",
+	"maven":     "maven",
+	"deb":       "deb",
+	"ubuntu":    "ubuntu",
+	"debian":    "debian",
+	"apk":       "apk",
+	"alpine":    "apk",
+}
+
+func canonicalEcosystem(s string) string {
+	s = strings.ToLower(strings.TrimSpace(s))
+	if s == "" {
+		return ""
+	}
+	if c, ok := ecosystemAliases[s]; ok {
+		return c
+	}
+	return s
+}

--- a/internal/worker/ecosystem_test.go
+++ b/internal/worker/ecosystem_test.go
@@ -1,0 +1,46 @@
+package worker
+
+import "testing"
+
+func TestNormalizeEcosystem(t *testing.T) {
+	cases := []struct {
+		name      string
+		ecosystem string
+		purl      string
+		registry  string
+		want      string
+	}{
+		{"explicit canonical", "rubygems", "", "", "rubygems"},
+		{"explicit synonym gem", "gem", "", "", "rubygems"},
+		{"explicit synonym golang", "golang", "", "", "go"},
+		{"explicit case insensitive", "  NPM  ", "", "", "npm"},
+
+		{"purl fallback gem", "", "pkg:gem/foo@1.0", "", "rubygems"},
+		{"purl fallback golang", "", "pkg:golang/example.com/foo", "", "go"},
+		{"purl fallback npm scoped", "", "pkg:npm/@scope/pkg@1", "", "npm"},
+
+		{"registry fallback rubygems.org", "", "", "https://rubygems.org/gems/faker", "rubygems"},
+		{"registry fallback npmjs.com", "", "", "https://www.npmjs.com/package/foo", "npm"},
+		{"registry fallback pkg.go.dev", "", "", "https://pkg.go.dev/github.com/x/y", "go"},
+		{"registry fallback launchpad", "", "", "https://launchpad.net/ubuntu/+source/ruby-faker", "ubuntu"},
+		{"registry fallback gem.coop", "", "", "https://gem.coop/gems/foo", "rubygems"},
+		{"registry fallback pypi", "", "", "https://pypi.org/project/x/", "pypi"},
+
+		{"explicit wins over purl", "npm", "pkg:gem/foo", "", "npm"},
+		{"purl wins over registry", "", "pkg:npm/foo", "https://rubygems.org/gems/foo", "npm"},
+
+		{"unknown passes through", "exoticpkg", "", "", "exoticpkg"},
+		{"all empty stays empty", "", "", "", ""},
+		{"unknown registry stays empty", "", "", "https://example.com/x", ""},
+		{"malformed purl ignored", "", "not-a-purl", "https://rubygems.org/gems/x", "rubygems"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := normalizeEcosystem(tc.ecosystem, tc.purl, tc.registry)
+			if got != tc.want {
+				t.Errorf("normalizeEcosystem(%q, %q, %q) = %q, want %q",
+					tc.ecosystem, tc.purl, tc.registry, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/worker/skill_parsers.go
+++ b/internal/worker/skill_parsers.go
@@ -108,7 +108,7 @@ func (w *Worker) parsePackagesOutput(scan *db.Scan, report string, emit func(Eve
 		row := db.Package{
 			RepositoryID:         scan.RepositoryID,
 			Name:                 p.Name,
-			Ecosystem:            p.Ecosystem,
+			Ecosystem:            normalizeEcosystem(p.Ecosystem, p.PURL, p.RegistryURL),
 			PURL:                 p.PURL,
 			Licenses:             p.Licenses,
 			LatestVersion:        p.LatestVersion,
@@ -215,7 +215,7 @@ func (w *Worker) parseDependentsOutput(scan *db.Scan, report string, emit func(E
 		rows = append(rows, db.Dependent{
 			RepositoryID:   scan.RepositoryID,
 			Name:           d.Name,
-			Ecosystem:      d.Ecosystem,
+			Ecosystem:      normalizeEcosystem(d.Ecosystem, d.PURL, d.RegistryURL),
 			PURL:           d.PURL,
 			RepositoryURL:  d.RepositoryURL,
 			Downloads:      d.Downloads,
@@ -264,7 +264,7 @@ func (w *Worker) parseDependenciesOutput(scan *db.Scan, report string, emit func
 		rows = append(rows, db.Dependency{
 			RepositoryID:   scan.RepositoryID,
 			Name:           d.Name,
-			Ecosystem:      d.Ecosystem,
+			Ecosystem:      normalizeEcosystem(d.Ecosystem, d.PURL, ""),
 			PURL:           d.PURL,
 			Requirement:    d.Requirement,
 			DependencyType: depType,


### PR DESCRIPTION
Previously I was getting a lot of empty strings for the ecosystem value in the packages table, this should improve the situation, especially for the most common ecosystems.

Previously I'd get things like this in the Packages view:

<img width="1207" height="186" alt="Screenshot 2026-05-20 at 3 21 19 PM" src="https://github.com/user-attachments/assets/5d1fdbfd-473f-4769-bf69-d64cbc62be5c" />

Now it'll do a better job normalizing the ecosystem name it finds.

This change was generated using Claude Code, reviewed and tested by me. I looked in the SQLite database and confirmed that the `ecosystem` value for rubygems gems was saved as `gem` for whatever reason originally, in the dependencies table, and just an empty string in the `packages` table.

This is maybe something that should be handled/normalized elsewhere (in git-pkgs maybe?), but I'm not totally sure. This PR can be closed if this solution doesn't fit in correctly.