### PR TITLE
feat: Add "Status" filter to Findings index page

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -234,6 +234,13 @@ const (
 	FindingDuplicate    FindingLifecycle = "duplicate"
 )
 
+// FindingLifecycles lists every finding status in workflow order. Used to
+// render the Status filter on the findings index.
+var FindingLifecycles = []FindingLifecycle{
+	FindingNew, FindingEnriched, FindingTriaged, FindingReady, FindingReported,
+	FindingAcknowledged, FindingFixed, FindingPublished, FindingRejected, FindingDuplicate,
+}
+
 // Advisory is a known security advisory from advisories.ecosyste.ms.
 type Advisory struct {
 	ID           uint `gorm:"primarykey"`

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -621,6 +621,10 @@ func (s *Server) findings(w http.ResponseWriter, r *http.Request) {
 	if sev != "" {
 		q = q.Where("severity = ?", sev)
 	}
+	status := r.URL.Query().Get("status")
+	if status != "" {
+		q = q.Where("status = ?", status)
+	}
 	category := r.URL.Query().Get("category")
 	if category != "" {
 		q = applyCWECategoryFilter(q, category)
@@ -682,6 +686,7 @@ func (s *Server) findings(w http.ResponseWriter, r *http.Request) {
 		"Repos": reposByID, "Q": search, "AnySubPath": anySubPath,
 		"Owner": owner, "Missed": missed, "MissedTotal": missedTotal,
 		"Scanners": scanners, "ScannerTotal": scannerTotal,
+		"Status": status, "Statuses": db.FindingLifecycles,
 	})
 }
 

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -710,6 +710,60 @@ func TestFindings_categoryFilter(t *testing.T) {
 	}
 }
 
+func TestFindings_statusFilter(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	repo := db.Repository{URL: "https://example.com/x", Name: "x"}
+	s.DB.Create(&repo)
+	scan := db.Scan{RepositoryID: repo.ID, Kind: "skill", Status: db.ScanDone, SkillName: "security-deep-dive"}
+	s.DB.Create(&scan)
+	s.DB.Create(&db.Finding{ScanID: scan.ID, RepositoryID: repo.ID, Title: "fresh finding",
+		Severity: "High", Status: db.FindingNew})
+	s.DB.Create(&db.Finding{ScanID: scan.ID, RepositoryID: repo.ID, Title: "triaged finding",
+		Severity: "High", Status: db.FindingTriaged})
+	s.DB.Create(&db.Finding{ScanID: scan.ID, RepositoryID: repo.ID, Title: "fixed finding",
+		Severity: "High", Status: db.FindingFixed})
+
+	cases := []struct {
+		status  string
+		want    []string
+		missing []string
+	}{
+		{"new", []string{"fresh finding"}, []string{"triaged finding", "fixed finding"}},
+		{"triaged", []string{"triaged finding"}, []string{"fresh finding", "fixed finding"}},
+		{"fixed", []string{"fixed finding"}, []string{"fresh finding", "triaged finding"}},
+		{"rejected", nil, []string{"fresh finding", "triaged finding", "fixed finding"}},
+	}
+	for _, tc := range cases {
+		w := httptest.NewRecorder()
+		s.Handler().ServeHTTP(w, localReq("GET", "/findings?status="+url.QueryEscape(tc.status)))
+		if w.Code != 200 {
+			t.Errorf("status=%q status code %d", tc.status, w.Code)
+			continue
+		}
+		body := w.Body.String()
+		for _, title := range tc.want {
+			if !strings.Contains(body, ">"+title+"</a>") {
+				t.Errorf("status=%q missing %q", tc.status, title)
+			}
+		}
+		for _, title := range tc.missing {
+			if strings.Contains(body, ">"+title+"</a>") {
+				t.Errorf("status=%q should not include %q", tc.status, title)
+			}
+		}
+	}
+
+	// The status filter is preserved across the other filter links.
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq("GET", "/findings?status=new"))
+	body := w.Body.String()
+	if !strings.Contains(body, "severity=High&status=new&category=") {
+		t.Error("severity dropdown links should carry status=new")
+	}
+}
+
 func TestPackagesSearchFilters(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()
@@ -1020,7 +1074,7 @@ func TestFindings_missedFilterAndBadge(t *testing.T) {
 		t.Error("?missed=1 should show findings with missed_count > 0")
 	}
 	// Severity/sort links preserve the missed filter.
-	if !strings.Contains(body, "severity=High&category=&sort=newest&missed=1") {
+	if !strings.Contains(body, "severity=High&status=&category=&sort=newest&missed=1") {
 		t.Error("severity dropdown links should carry missed=1")
 	}
 }

--- a/internal/web/templates/findings.html
+++ b/internal/web/templates/findings.html
@@ -7,10 +7,12 @@
   <div class="flex items-center gap-2">
     {{$mp := ""}}{{if .Missed}}{{$mp = "1"}}{{end}}
     {{$sc := ""}}{{if .Scanners}}{{$sc = "1"}}{{end}}
+    {{$st := .Status}}
     <form method="get" action="/findings" class="inline-flex">
       <input class="input" type="search" name="q" value="{{.Q}}" placeholder="Search findings"
              autocomplete="off" spellcheck="false">
       <input type="hidden" name="severity" value="{{.Severity}}">
+      <input type="hidden" name="status" value="{{.Status}}">
       <input type="hidden" name="category" value="{{.Category}}">
       <input type="hidden" name="sort" value="{{.Sort}}">
       {{if .Missed}}<input type="hidden" name="missed" value="1">{{end}}
@@ -19,12 +21,12 @@
     {{if gt .ScannerTotal 0}}
       {{if .Scanners}}
         <a class="btn-outline" aria-pressed="true"
-           href="/findings?q={{.Q}}&severity={{.Severity}}&category={{.Category}}&sort={{.Sort}}&missed={{$mp}}">
+           href="/findings?q={{.Q}}&severity={{.Severity}}&status={{$st}}&category={{.Category}}&sort={{.Sort}}&missed={{$mp}}">
           <i data-lucide="scan-search"></i> Include scanners ({{.ScannerTotal}})
         </a>
       {{else}}
         <a class="btn-outline"
-           href="/findings?q={{.Q}}&severity={{.Severity}}&category={{.Category}}&sort={{.Sort}}&missed={{$mp}}&scanners=1">
+           href="/findings?q={{.Q}}&severity={{.Severity}}&status={{$st}}&category={{.Category}}&sort={{.Sort}}&missed={{$mp}}&scanners=1">
           <i data-lucide="scan-search"></i> Include scanners ({{.ScannerTotal}})
         </a>
       {{end}}
@@ -32,12 +34,12 @@
     {{if gt .MissedTotal 0}}
       {{if .Missed}}
         <a class="btn-outline" aria-pressed="true"
-           href="/findings?q={{.Q}}&severity={{.Severity}}&category={{.Category}}&sort={{.Sort}}&scanners={{$sc}}">
+           href="/findings?q={{.Q}}&severity={{.Severity}}&status={{$st}}&category={{.Category}}&sort={{.Sort}}&scanners={{$sc}}">
           <i data-lucide="eye-off"></i> Not seen on rescan ({{.MissedTotal}})
         </a>
       {{else}}
         <a class="btn-outline"
-           href="/findings?q={{.Q}}&severity={{.Severity}}&category={{.Category}}&sort={{.Sort}}&missed=1&scanners={{$sc}}">
+           href="/findings?q={{.Q}}&severity={{.Severity}}&status={{$st}}&category={{.Category}}&sort={{.Sort}}&missed=1&scanners={{$sc}}">
           <i data-lucide="eye-off"></i> Not seen on rescan ({{.MissedTotal}})
         </a>
       {{end}}
@@ -50,10 +52,26 @@
       </button>
       <div data-popover aria-hidden="true" data-align="end">
         <div role="menu">
-          <a role="menuitem" href="/findings?q={{.Q}}&category={{.Category}}&sort={{.Sort}}&missed={{$mp}}&scanners={{$sc}}">All severities</a>
+          <a role="menuitem" href="/findings?q={{.Q}}&status={{$st}}&category={{.Category}}&sort={{.Sort}}&missed={{$mp}}&scanners={{$sc}}">All severities</a>
           {{range (list "Critical" "High" "Medium" "Low")}}
-            <a role="menuitem" href="/findings?q={{$.Q}}&severity={{.}}&category={{$.Category}}&sort={{$.Sort}}&missed={{$mp}}&scanners={{$sc}}"
+            <a role="menuitem" href="/findings?q={{$.Q}}&severity={{.}}&status={{$st}}&category={{$.Category}}&sort={{$.Sort}}&missed={{$mp}}&scanners={{$sc}}"
                {{if eq . $.Severity}}aria-current="true"{{end}}>{{.}}</a>
+          {{end}}
+        </div>
+      </div>
+    </div>
+    <div class="dropdown-menu">
+      <button type="button" class="btn-outline" aria-haspopup="menu" aria-expanded="false">
+        <i data-lucide="circle-dot"></i>
+        {{if .Status}}{{.Status}}{{else}}Status{{end}}
+        <i data-lucide="chevron-down"></i>
+      </button>
+      <div data-popover aria-hidden="true" data-align="end">
+        <div role="menu">
+          <a role="menuitem" href="/findings?q={{.Q}}&severity={{.Severity}}&category={{.Category}}&sort={{.Sort}}&missed={{$mp}}&scanners={{$sc}}">All statuses</a>
+          {{range .Statuses}}
+            <a role="menuitem" href="/findings?q={{$.Q}}&severity={{$.Severity}}&status={{.}}&category={{$.Category}}&sort={{$.Sort}}&missed={{$mp}}&scanners={{$sc}}"
+               {{if eq (printf "%s" .) $.Status}}aria-current="true"{{end}}>{{.}}</a>
           {{end}}
         </div>
       </div>
@@ -66,12 +84,12 @@
       </button>
       <div data-popover aria-hidden="true" data-align="end">
         <div role="menu">
-          <a role="menuitem" href="/findings?q={{.Q}}&severity={{.Severity}}&sort={{.Sort}}&missed={{$mp}}&scanners={{$sc}}">All categories</a>
+          <a role="menuitem" href="/findings?q={{.Q}}&severity={{.Severity}}&status={{$st}}&sort={{.Sort}}&missed={{$mp}}&scanners={{$sc}}">All categories</a>
           {{range .Categories}}
-            <a role="menuitem" href="/findings?q={{$.Q}}&severity={{$.Severity}}&category={{.}}&sort={{$.Sort}}&missed={{$mp}}&scanners={{$sc}}"
+            <a role="menuitem" href="/findings?q={{$.Q}}&severity={{$.Severity}}&status={{$st}}&category={{.}}&sort={{$.Sort}}&missed={{$mp}}&scanners={{$sc}}"
                {{if eq . $.Category}}aria-current="true"{{end}}>{{catlabel .}}</a>
           {{end}}
-          <a role="menuitem" href="/findings?q={{.Q}}&severity={{.Severity}}&category={{.Uncategorized}}&sort={{.Sort}}&missed={{$mp}}&scanners={{$sc}}"
+          <a role="menuitem" href="/findings?q={{.Q}}&severity={{.Severity}}&status={{$st}}&category={{.Uncategorized}}&sort={{.Sort}}&missed={{$mp}}&scanners={{$sc}}"
              {{if eq .Uncategorized .Category}}aria-current="true"{{end}}>{{.Uncategorized}}</a>
         </div>
       </div>
@@ -85,7 +103,7 @@
       <div data-popover aria-hidden="true" data-align="end">
         <div role="menu">
           {{range (list "newest" "severity" "repository")}}
-            <a role="menuitem" href="/findings?q={{$.Q}}&severity={{$.Severity}}&category={{$.Category}}&sort={{.}}&missed={{$mp}}&scanners={{$sc}}"
+            <a role="menuitem" href="/findings?q={{$.Q}}&severity={{$.Severity}}&status={{$st}}&category={{$.Category}}&sort={{.}}&missed={{$mp}}&scanners={{$sc}}"
                {{if eq . $.Sort}}aria-current="true"{{end}}>{{.}}</a>
           {{end}}
         </div>


### PR DESCRIPTION
Resolves #246. This allows filtering Findings by their status, so you can filter to only "new" findings, for example.

<img width="126" height="424" alt="Screenshot 2026-05-22 at 3 48 56 PM" src="https://github.com/user-attachments/assets/878f3c68-4a0e-4087-a31b-2d06c0e58730" />

<img width="1214" height="126" alt="Screenshot 2026-05-22 at 3 49 01 PM" src="https://github.com/user-attachments/assets/e33fbead-3c12-44d4-ae0d-8daee749a522" />

AI Disclosure: Generated with Claude Code, reviewed and tested by me.