### PR TITLE
Security sweep hardening

### DIFF
--- a/internal/skills/git.go
+++ b/internal/skills/git.go
@@ -96,7 +96,7 @@ func cloneOrPull(ctx context.Context, url, ref, dst string, fullClone bool) (str
 	}
 	target := "origin/HEAD"
 	if ref != "" {
-		if out, err := git(ctx, dst, "fetch", "--quiet", "origin", ref); err != nil {
+		if out, err := git(ctx, dst, "fetch", "--quiet", "origin", "--end-of-options", ref); err != nil {
 			return "", fmt.Errorf("fetch ref %s: %s: %w", ref, out, err)
 		}
 		target = "FETCH_HEAD"

--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -52,9 +52,12 @@ func (s *Server) apiAuth(next http.Handler) http.Handler {
 			return
 		}
 		ctx := context.WithValue(r.Context(), apiCtxKey{}, &scan)
+		r.Body = http.MaxBytesReader(w, r.Body, apiMaxBody)
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }
+
+const apiMaxBody = 1 << 20
 
 func bearer(h string) string {
 	const prefix = "Bearer "

--- a/internal/web/api_test.go
+++ b/internal/web/api_test.go
@@ -2,6 +2,7 @@ package web
 
 import (
 	"encoding/json"
+	"net/http"
 	"net/http/httptest"
 	"strconv"
 	"strings"
@@ -426,4 +427,23 @@ func toString(v any) string {
 		return strconv.Itoa(x)
 	}
 	return ""
+}
+
+func TestAPIAuth_capsRequestBody(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	repo, scan := seedRunningScan(t, s)
+
+	body := `{"fork":"` + strings.Repeat("x", apiMaxBody) + `"}`
+	r := httptest.NewRequest("PATCH", "/api/repositories/"+strconv.FormatUint(uint64(repo.ID), 10), strings.NewReader(body))
+	r.Host = testHost
+	r.Header.Set("Authorization", "Bearer "+scan.APIToken)
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, r)
+	if w.Code == http.StatusNoContent {
+		t.Fatalf("oversized body accepted: status %d", w.Code)
+	}
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status %d, want 400 (decode fails on capped body)", w.Code)
+	}
 }

--- a/internal/web/import.go
+++ b/internal/web/import.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 
 	"gorm.io/gorm"
@@ -137,15 +138,11 @@ func (s *Server) importFindings(scan *db.Scan, res ingest.Result) (created []uin
 			Confidence:     firstNonEmpty(in.Confidence, "low"),
 			CWE:            in.CWE,
 			Location:       in.Location,
-			Trace:          in.Description,
-			SuggestedFix:   in.SuggestedFix,
+			Trace:          appendFixDescription(in.Description, in.SuggestedFix),
 			ImportedFrom:   res.Tool,
 			LastSeenScanID: scan.ID,
 			LastSeenCommit: scan.Commit,
 			SeenCount:      1,
-		}
-		if f.SuggestedFix != "" {
-			f.SuggestedFixCommit = scan.Commit
 		}
 		f.Fingerprint = db.FingerprintFinding(res.Tool, "", f.CWE, f.Location, f.Title)
 
@@ -186,4 +183,18 @@ func (s *Server) importFindings(scan *db.Scan, res ingest.Result) (created []uin
 		created = append(created, f.ID)
 	}
 	return created, observed
+}
+
+// appendFixDescription folds an ingested fix description into the Trace
+// markdown rather than writing Finding.SuggestedFix, which is reserved for
+// diffs that have passed gatePatch (see finding_patch.go).
+func appendFixDescription(desc, fix string) string {
+	fix = strings.TrimSpace(fix)
+	if fix == "" {
+		return desc
+	}
+	if desc == "" {
+		return "## Suggested fix\n\n" + fix
+	}
+	return desc + "\n\n## Suggested fix\n\n" + fix
 }

--- a/internal/web/import_test.go
+++ b/internal/web/import_test.go
@@ -1,9 +1,11 @@
 package web
 
 import (
+	"strings"
 	"testing"
 
 	"scrutineer/internal/db"
+	"scrutineer/internal/ingest"
 )
 
 func TestKnownPURLsMatchWithAndWithoutQualifiers(t *testing.T) {
@@ -85,5 +87,55 @@ func TestKnownURLsMatchDependents(t *testing.T) {
 	}
 	if rid := knownURLs["https://github.com/foo/bar"]; rid != 0 {
 		t.Errorf("unknown URL: got repo %d, want 0", rid)
+	}
+}
+
+func TestAppendFixDescription(t *testing.T) {
+	if got := appendFixDescription("desc", ""); got != "desc" {
+		t.Errorf("empty fix: got %q", got)
+	}
+	if got := appendFixDescription("", "do x"); got != "## Suggested fix\n\ndo x" {
+		t.Errorf("empty desc: got %q", got)
+	}
+	if got := appendFixDescription("desc", "  do x  "); got != "desc\n\n## Suggested fix\n\ndo x" {
+		t.Errorf("both: got %q", got)
+	}
+}
+
+func TestImportFindings_keepsSuggestedFixGated(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	repo := db.Repository{URL: "https://example.com/r", Name: "r"}
+	s.DB.Create(&repo)
+	scan := db.Scan{RepositoryID: repo.ID, Status: db.ScanDone, Commit: "abc"}
+	s.DB.Create(&scan)
+
+	res := ingest.Result{
+		Tool: "sarif-tool",
+		Findings: []ingest.Finding{{
+			Title:        "thing",
+			Severity:     "High",
+			Location:     "a.go:1",
+			Description:  "explanation",
+			SuggestedFix: "validate input before use",
+		}},
+	}
+	created, _ := s.importFindings(&scan, res)
+	if len(created) != 1 {
+		t.Fatalf("created %d findings, want 1", len(created))
+	}
+	var f db.Finding
+	s.DB.First(&f, created[0])
+	if f.SuggestedFix != "" {
+		t.Errorf("SuggestedFix = %q, want empty (gated column)", f.SuggestedFix)
+	}
+	if f.SuggestedFixCommit != "" {
+		t.Errorf("SuggestedFixCommit = %q, want empty", f.SuggestedFixCommit)
+	}
+	if !strings.Contains(f.Trace, "validate input before use") {
+		t.Errorf("Trace = %q, want fix text folded in", f.Trace)
+	}
+	if !strings.Contains(f.Trace, "explanation") {
+		t.Errorf("Trace = %q, want original description retained", f.Trace)
 	}
 }

--- a/internal/web/security_test.go
+++ b/internal/web/security_test.go
@@ -29,7 +29,10 @@ func TestSecurityHeadersAllowsLocalhost(t *testing.T) {
 	})
 	h := securityHeaders(inner)
 
-	for _, host := range []string{"127.0.0.1:8080", "localhost:8080", "[::1]:8080"} {
+	for _, host := range []string{
+		"127.0.0.1:8080", "localhost:8080", "[::1]:8080",
+		"127.0.0.1", "localhost", "[::1]",
+	} {
 		r := httptest.NewRequest("GET", "/", nil)
 		r.Host = host
 		w := httptest.NewRecorder()

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -10,6 +10,7 @@ import (
 	"html/template"
 	"log/slog"
 	"maps"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -1654,11 +1655,11 @@ func securityHeaders(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Security-Policy", cspPolicy)
 		host := r.Host
-		// Strip port for comparison
-		if i := strings.LastIndex(host, ":"); i >= 0 {
-			host = host[:i]
+		if h, _, err := net.SplitHostPort(host); err == nil {
+			host = h
 		}
-		if host != "127.0.0.1" && host != "localhost" && host != "[::1]" {
+		host = strings.Trim(host, "[]")
+		if host != "127.0.0.1" && host != "localhost" && host != "::1" {
 			http.Error(w, "forbidden: invalid host", http.StatusForbidden)
 			return
 		}

--- a/internal/worker/docker.go
+++ b/internal/worker/docker.go
@@ -100,7 +100,7 @@ func (d DockerRunner) RunSkill(ctx context.Context, sj SkillJob, emit func(Event
 	if d.AnthropicBaseURL != "" {
 		dockerArgs = append(dockerArgs, "-e", "ANTHROPIC_BASE_URL="+d.AnthropicBaseURL)
 	}
-	dockerArgs = append(dockerArgs, d.image())
+	dockerArgs = append(dockerArgs, "--", d.image())
 	dockerArgs = append(dockerArgs, claudeArgs...)
 
 	cmd := exec.CommandContext(ctx, "docker", dockerArgs...)
@@ -163,7 +163,7 @@ func ResolveHostGatewayIPv4(image string) string {
 	out, err := exec.Command("docker", "run", "--rm",
 		"--add-host", "hgw:host-gateway",
 		"--entrypoint", "grep",
-		image, "hgw", "/etc/hosts").Output()
+		"--", image, "hgw", "/etc/hosts").Output()
 	if err != nil {
 		return ""
 	}

--- a/internal/worker/patch_gate.go
+++ b/internal/worker/patch_gate.go
@@ -169,6 +169,9 @@ func parseUnifiedDiff(diff string) ([]diffFile, error) {
 			if to == "/dev/null" {
 				path = ""
 			}
+			if path != "" && !filepath.IsLocal(path) {
+				return nil, fmt.Errorf("diff target escapes workspace: %q", path)
+			}
 			files = append(files, diffFile{Path: path, NewFile: newFile})
 			cur = &files[len(files)-1]
 			newFile = false

--- a/internal/worker/patch_gate_test.go
+++ b/internal/worker/patch_gate_test.go
@@ -85,6 +85,15 @@ func TestParseUnifiedDiff_errors(t *testing.T) {
 	if _, err := parseUnifiedDiff("--- a/x\n+++ b/x\n@@ garbage @@\n"); err == nil {
 		t.Error("expected error for bad hunk header")
 	}
+	if _, err := parseUnifiedDiff("--- a/x\n+++ b/../../etc/passwd\n@@ -1 +1 @@\n"); err == nil {
+		t.Error("expected error for .. escape in target path")
+	}
+	if _, err := parseUnifiedDiff("--- a/x\n+++ b//etc/passwd\n@@ -1 +1 @@\n"); err == nil {
+		t.Error("expected error for absolute target path")
+	}
+	if _, err := parseUnifiedDiff("--- /dev/null\n+++ b/sub/new.go\n@@ -0,0 +1 @@\n"); err != nil {
+		t.Errorf("local relative path should be accepted: %v", err)
+	}
 }
 
 func TestParseLocation(t *testing.T) {


### PR DESCRIPTION
Closes #257.

Six low-severity items from the post-#240/#241 sweep:

- `internal/skills/git.go`: `--end-of-options` before the ref in `git fetch origin <ref>` so a `-skills-repo` ref beginning with `-` cannot be parsed as an option.
- `internal/worker/docker.go`: `--` before the image name in both `docker run` calls so an operator-configured image beginning with `-` is treated as a reference, not a flag.
- `internal/worker/patch_gate.go`: `parseUnifiedDiff` rejects `+++` target paths that escape the workspace (`filepath.IsLocal`), closing the `os.Stat` existence probe.
- `internal/web/import.go`: ingested fix descriptions are folded into `Trace` under a `## Suggested fix` heading instead of `Finding.SuggestedFix`, restoring the invariant in `finding_patch.go` that only `gatePatch` writes that column. SARIF `fixes[].description.text` is prose, not a diff, so serving it as `text/x-diff` was wrong anyway.
- `internal/web/api.go`: `apiAuth` caps request bodies at 1 MiB via `http.MaxBytesReader` so a compromised scan workspace cannot OOM the server through the bearer-auth skill API.
- `internal/web/server.go`: `securityHeaders` strips the Host port with `net.SplitHostPort` and trims brackets, so a bare `[::1]` Host is accepted.

Tests added for the diff-path rejection, the import behaviour, the body cap, and the IPv6 host variants.