### PR TITLE
feat: add profile support for skill scans

### DIFF
--- a/cmd/scrutineer/main.go
+++ b/cmd/scrutineer/main.go
@@ -56,6 +56,7 @@ type flags struct {
 	effort           string
 	noDocker         bool
 	runnerImage      string
+	profilesDir      string
 	skillsRepo       string
 	concurrency      int
 	cloneMode        string
@@ -79,6 +80,7 @@ func parseFlags() *flags {
 	flag.StringVar(&f.effort, "effort", "high", "claude effort")
 	flag.BoolVar(&f.noDocker, "no-docker", false, "disable containerised runner even if docker is available")
 	flag.StringVar(&f.runnerImage, "runner-image", worker.DefaultRunnerImage, "docker image for per-job containers")
+	flag.StringVar(&f.profilesDir, "profiles-dir", "docker/profiles", "directory containing per-ecosystem runner profiles (Dockerfile per profile); empty disables profiles")
 	flag.StringVar(&f.skillsRepo, "skills-repo", "", "clone skills on startup; owner/repo[@ref] or https://host/path[@ref]")
 	flag.IntVar(&f.concurrency, "concurrency", queue.DefaultWorkerConcurrency, "number of scans to run in parallel")
 	flag.StringVar(&f.cloneMode, "clone", "shallow", "clone depth: shallow (--depth 1) or full")
@@ -115,6 +117,9 @@ func (f *flags) merge(cfg *config.Config) {
 	}
 	if cfg.RunnerImage != "" && !f.set["runner-image"] {
 		f.runnerImage = cfg.RunnerImage
+	}
+	if cfg.ProfilesDir != "" && !f.set["profiles-dir"] {
+		f.profilesDir = cfg.ProfilesDir
 	}
 	if cfg.SkillsRepo != "" && !f.set["skills-repo"] {
 		f.skillsRepo = cfg.SkillsRepo
@@ -279,6 +284,7 @@ func run(log *slog.Logger) error {
 			MaxTurns:         f.maxTurns,
 			AnthropicBaseURL: f.anthropicBaseURL,
 			HostGatewayIP:    gwIP,
+			ProfilesDir:      f.profilesDir,
 		}
 		// Skills inside the container reach the host via host.docker.internal,
 		// which the egress proxy rewrites to 127.0.0.1 when dialing.

--- a/docker/profiles/php/Dockerfile
+++ b/docker/profiles/php/Dockerfile
@@ -1,0 +1,29 @@
+# PHP profile. Extends the scrutineer runner with a PHP interpreter so
+# scans of Composer projects can audit or reproduce in-place.
+#
+# Built on demand by the worker; the image tag is content-addressed on
+# this Dockerfile's sha so an edit invalidates the cache automatically.
+#
+#   docker build --build-arg RUNNER_IMAGE=<digest-pinned-runner> \
+#     -t scrutineer-profile-php:<sha> docker/profiles/php
+
+ARG RUNNER_IMAGE=ghcr.io/alpha-omega-security/scrutineer-runner:latest
+FROM ${RUNNER_IMAGE}
+
+USER root
+RUN apk add --no-cache \
+        php84=8.4.21-r0 \
+        php84-phar=8.4.21-r0 \
+        php84-openssl=8.4.21-r0 \
+        php84-mbstring=8.4.21-r0 \
+        php84-tokenizer=8.4.21-r0 \
+        php84-curl=8.4.21-r0 \
+        php84-dom=8.4.21-r0 \
+        php84-simplexml=8.4.21-r0 \
+        php84-xml=8.4.21-r0 \
+        php84-xmlwriter=8.4.21-r0 \
+        php84-fileinfo=8.4.21-r0 \
+        php84-iconv=8.4.21-r0 \
+    && ln -sf /usr/bin/php84 /usr/local/bin/php
+
+USER runner

--- a/docs/database.md
+++ b/docs/database.md
@@ -54,6 +54,7 @@ One row per skill execution or external import. `skill_name` / `skill_version` p
 | ref | text | Git ref to checkout after cloning. Empty means the default branch. |
 | skills_repo_sha | text | Commit of `-skills-repo` resolved at startup and stamped on every skill scan. Empty when `-skills-repo` is unset or for `import` scans. |
 | sub_path | text | Scopes code analysis to a sub-folder of the clone (monorepo packages). Empty means repo root. |
+| profile | text | Runner profile that ran the scan (e.g. `php`). Empty = the default runner image. Set explicitly via `?profile=` or auto-detected from the clone by `brief` before launch; persisted so retries reuse the choice. |
 | commit | text | Git HEAD at scan time. |
 | started_at | datetime | |
 | finished_at | datetime | |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -31,6 +31,7 @@ type Config struct {
 	SkillsRepo   string   `yaml:"skills_repo"`
 	NoDocker     *bool    `yaml:"no_docker"`
 	RunnerImage  string   `yaml:"runner_image"`
+	ProfilesDir  string   `yaml:"profiles_dir"`
 	// EgressAllow extends the docker runner's egress proxy allowlist with
 	// extra hostnames. Entries are appended to worker.DefaultEgressAllow,
 	// not replacing it. "*.example.com" matches subdomains.

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -151,6 +151,12 @@ type Scan struct {
 	// external APIs (packages/advisories/dependents) ignore it.
 	SubPath string `gorm:"index"`
 
+	// Profile is the runner profile that ran (or was overridden to run)
+	// this scan. Empty means the default runner image; non-empty names
+	// a docker/profiles/<name>/ entry. Persisted so retries reuse the
+	// operator's override and the UI can show the chosen ecosystem.
+	Profile string `gorm:"index"`
+
 	Commit     string
 	StartedAt  *time.Time
 	FinishedAt *time.Time

--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -18,6 +18,7 @@ import (
 	"gorm.io/gorm"
 
 	"scrutineer/internal/db"
+	"scrutineer/internal/worker"
 )
 
 const apiPrefix = "/api"
@@ -220,13 +221,19 @@ func (s *Server) apiRunSkill(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	var body struct {
-		Model string `json:"model"`
-		Ref   string `json:"ref"`
+		Model   string `json:"model"`
+		Ref     string `json:"ref"`
+		Profile string `json:"profile"`
 	}
 	_ = json.NewDecoder(r.Body).Decode(&body)
+	if body.Profile != "" && !worker.KnownProfile(body.Profile) {
+		writeAPIError(w, http.StatusBadRequest, "unknown profile")
+		return
+	}
 	scanID, err := s.enqueueSkillWith(r.Context(), uint(id), skill.ID, ScanOpts{
-		Model: body.Model,
-		Ref:   body.Ref,
+		Model:   body.Model,
+		Ref:     body.Ref,
+		Profile: body.Profile,
 	})
 	if err != nil {
 		if errors.Is(err, ErrSkillRequiresRemote) {

--- a/internal/web/api_test.go
+++ b/internal/web/api_test.go
@@ -356,6 +356,56 @@ func TestAPIListDependencyFindings(t *testing.T) {
 	}
 }
 
+func TestAPIRunSkill_profileOverridePersists(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	repo, scan := seedRunningScan(t, s)
+
+	skill := db.Skill{Name: "metadata", Description: "m", Body: "b", OutputFile: "report.json", Version: 1, Active: true, Source: "ui"}
+	s.DB.Create(&skill)
+
+	path := "/api/repositories/" + strconv.FormatUint(uint64(repo.ID), 10) + "/skills/metadata/run"
+	r := httptest.NewRequest("POST", path, strings.NewReader(`{"profile":"php"}`))
+	r.Host = testHost
+	r.Header.Set("Authorization", "Bearer "+scan.APIToken)
+	r.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, r)
+	if w.Code != 201 {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+	var row db.Scan
+	s.DB.Where("skill_id = ?", skill.ID).First(&row)
+	if row.Profile != "php" {
+		t.Errorf("scan.Profile = %q, want %q", row.Profile, "php")
+	}
+}
+
+func TestAPIRunSkill_unknownProfileRejected(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	repo, scan := seedRunningScan(t, s)
+
+	skill := db.Skill{Name: "metadata", Description: "m", Body: "b", OutputFile: "report.json", Version: 1, Active: true, Source: "ui"}
+	s.DB.Create(&skill)
+
+	path := "/api/repositories/" + strconv.FormatUint(uint64(repo.ID), 10) + "/skills/metadata/run"
+	r := httptest.NewRequest("POST", path, strings.NewReader(`{"profile":"bogus"}`))
+	r.Host = testHost
+	r.Header.Set("Authorization", "Bearer "+scan.APIToken)
+	r.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, r)
+	if w.Code != 400 {
+		t.Fatalf("status %d, want 400. body=%s", w.Code, w.Body)
+	}
+	var count int64
+	s.DB.Model(&db.Scan{}).Where("skill_id = ?", skill.ID).Count(&count)
+	if count != 0 {
+		t.Errorf("rejected enqueue still created %d scans", count)
+	}
+}
+
 func TestAPIRunFindingSkill_scopesFindingID(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()

--- a/internal/web/scans.go
+++ b/internal/web/scans.go
@@ -99,6 +99,7 @@ func (s *Server) scanRetry(w http.ResponseWriter, r *http.Request) {
 		FindingID: scan.FindingID,
 		SubPath:   scan.SubPath,
 		Ref:       scan.Ref,
+		Profile:   scan.Profile,
 	})
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -126,7 +127,7 @@ func (s *Server) scansRetryFailed(w http.ResponseWriter, r *http.Request) {
 	// (repository, skill, sub_path, ref, finding_id) tuple already in
 	// queued/running/done.
 	var scans []db.Scan
-	err := q.Select("id, repository_id, skill_id, model, finding_id, sub_path, ref").
+	err := q.Select("id, repository_id, skill_id, model, finding_id, sub_path, ref, profile").
 		Where(`NOT EXISTS (
 			SELECT 1 FROM scans n
 			WHERE n.id > scans.id
@@ -150,6 +151,7 @@ func (s *Server) scansRetryFailed(w http.ResponseWriter, r *http.Request) {
 			FindingID: sc.FindingID,
 			SubPath:   sc.SubPath,
 			Ref:       sc.Ref,
+			Profile:   sc.Profile,
 		}); err != nil {
 			errored++
 			continue

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -1414,6 +1414,7 @@ type ScanOpts struct {
 	DependentID *uint
 	SubPath     string
 	Ref         string
+	Profile     string
 }
 
 func (s *Server) enqueueSkill(ctx context.Context, repoID, skillID uint, model string) (uint, error) {
@@ -1462,6 +1463,7 @@ func (s *Server) enqueueSkillWith(ctx context.Context, repoID, skillID uint, opt
 		DependentID:    opts.DependentID,
 		SubPath:        opts.SubPath,
 		Ref:            opts.Ref,
+		Profile:        opts.Profile,
 		SkillsRepoSHA:  s.SkillsRepoSHA,
 		APIToken:       NewAPIToken(),
 	}

--- a/internal/worker/claude.go
+++ b/internal/worker/claude.go
@@ -54,11 +54,20 @@ type SkillJob struct {
 	// cache). When true the runner skips its own clone and reads HEAD
 	// from the existing tree.
 	SrcReady bool
+	// Profile names a runner profile (docker/profiles/<name>/). Empty
+	// means "auto-detect from the clone"; "default" forces the default
+	// runner image. Only the docker runner honours this; the local
+	// runner ignores it (no per-profile image to swap to).
+	Profile string
 }
 
 type SkillResult struct {
 	Commit string
 	Report string // contents of OutputFile, or "" if none declared/written
+	// Profile is the runner profile actually used. Empty when the
+	// default runner image ran. The worker persists this on the scan
+	// so retries and the UI can show what was picked.
+	Profile string
 }
 
 type LocalClaude struct {

--- a/internal/worker/docker.go
+++ b/internal/worker/docker.go
@@ -28,6 +28,10 @@ type DockerRunner struct {
 	MaxTurns         int
 	AnthropicBaseURL string // passed as ANTHROPIC_BASE_URL env var to the container
 	HostGatewayIP    string // IPv4 address for --add-host; falls back to "host-gateway"
+	// ProfilesDir is the host directory containing docker/profiles/<name>/
+	// Dockerfile entries. When empty, profile resolution is skipped and
+	// every scan runs in the default Image.
+	ProfilesDir string
 }
 
 func (d DockerRunner) image() string {
@@ -56,6 +60,8 @@ func (d DockerRunner) RunSkill(ctx context.Context, sj SkillJob, emit func(Event
 	commit := gitHead(src)
 	work := sj.WorkRoot
 	absWork, _ := filepath.Abs(work)
+
+	profile, image := d.resolveProfile(ctx, sj.Profile, src, emit)
 
 	var outPath string
 	if sj.OutputFile != "" {
@@ -100,7 +106,7 @@ func (d DockerRunner) RunSkill(ctx context.Context, sj SkillJob, emit func(Event
 	if d.AnthropicBaseURL != "" {
 		dockerArgs = append(dockerArgs, "-e", "ANTHROPIC_BASE_URL="+d.AnthropicBaseURL)
 	}
-	dockerArgs = append(dockerArgs, "--", d.image())
+	dockerArgs = append(dockerArgs, "--", image)
 	dockerArgs = append(dockerArgs, claudeArgs...)
 
 	cmd := exec.CommandContext(ctx, "docker", dockerArgs...)
@@ -113,7 +119,7 @@ func (d DockerRunner) RunSkill(ctx context.Context, sj SkillJob, emit func(Event
 	}
 	cmd.Stderr = cmd.Stdout
 
-	logLine := "$ docker run --rm " + d.image() + " <skill:" + sj.Name + ">"
+	logLine := "$ docker run --rm " + image + " <skill:" + sj.Name + ">"
 	if d.AnthropicBaseURL != "" {
 		logLine += " [ANTHROPIC_BASE_URL=" + d.AnthropicBaseURL + "]"
 	}
@@ -135,7 +141,7 @@ func (d DockerRunner) RunSkill(ctx context.Context, sj SkillJob, emit func(Event
 		_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGTERM)
 	}
 
-	res := SkillResult{Commit: commit}
+	res := SkillResult{Commit: commit, Profile: profile}
 	if outPath != "" {
 		res.Report = readCappedReport(outPath, emit)
 	}
@@ -146,6 +152,41 @@ func (d DockerRunner) RunSkill(ctx context.Context, sj SkillJob, emit func(Event
 		return res, fmt.Errorf("docker exited: %w", waitErr)
 	}
 	return res, nil
+}
+
+// resolveProfile picks the runner image for this scan. When requested
+// is non-empty, the operator's choice wins (and "default" forces the
+// default image); when empty, scrutineer probes the clone with `brief`
+// to auto-select. Any failure along the way falls back to the default
+// image with a log line so a missing profile never blocks a scan.
+func (d DockerRunner) resolveProfile(ctx context.Context, requested, src string, emit func(Event)) (string, string) {
+	defaultImg := d.image()
+	if d.ProfilesDir == "" {
+		return "", defaultImg
+	}
+	var p Profile
+	if requested != "" {
+		if requested == "default" {
+			return "", defaultImg
+		}
+		p = ProfileByName(requested)
+		if p.IsDefault() {
+			emit(Event{Kind: KindText, Text: "profile: unknown " + requested + ", using default"})
+			return "", defaultImg
+		}
+	} else {
+		p = DetectProfile(ctx, defaultImg, src)
+		if p.IsDefault() {
+			return "", defaultImg
+		}
+	}
+	img, err := p.EnsureImage(ctx, d.ProfilesDir, defaultImg)
+	if err != nil {
+		emit(Event{Kind: KindText, Text: "profile: " + p.Name + " build failed, using default: " + err.Error()})
+		return "", defaultImg
+	}
+	emit(Event{Kind: KindText, Text: "profile: " + p.Name + " (" + img + ")"})
+	return p.Name, img
 }
 
 // DockerAvailable checks if docker is in PATH and the daemon is reachable.

--- a/internal/worker/exposure.go
+++ b/internal/worker/exposure.go
@@ -182,10 +182,15 @@ func (w *Worker) doExposure(ctx context.Context, scan *db.Scan, emit func(Event)
 		MaxTurns:     skill.MaxTurns,
 		AllowedTools: skill.AllowedTools,
 		SrcReady:     true,
+		Profile:      scan.Profile,
 	}
 	res, err := w.Runner.RunSkill(ctx, sj, emit)
 	if res.Commit != "" {
 		scan.Commit = res.Commit
+	}
+	if res.Profile != "" && res.Profile != scan.Profile {
+		scan.Profile = res.Profile
+		w.DB.Model(scan).Update("profile", res.Profile)
 	}
 	if err != nil {
 		if _, ok := errors.AsType[*MaxTurnsReachedError](err); ok && res.Report != "" {

--- a/internal/worker/profile.go
+++ b/internal/worker/profile.go
@@ -1,0 +1,198 @@
+package worker
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+// Profile selects a per-ecosystem runner image. The default profile
+// (empty name) uses the runner image configured globally; named profiles
+// build a Dockerfile under docker/profiles/<name>/ on demand and tag the
+// resulting image with the sha of the Dockerfile contents.
+type Profile struct {
+	// Name matches the directory under docker/profiles/. Empty means
+	// "use the default runner image, no per-profile build".
+	Name string
+	// Ecosystem is the `brief` package_managers[0].name that auto-selects
+	// this profile. Matched case-insensitively.
+	Ecosystem string
+}
+
+// IsDefault reports whether p falls back to the configured runner image
+// instead of a profile-specific built one.
+func (p Profile) IsDefault() bool { return p.Name == "" }
+
+// builtinProfiles is the v1 registry. Add a new entry plus a Dockerfile
+// under docker/profiles/<name>/ to expose a profile. Kept in code (not
+// YAML) until a second/third profile lands and the duplication justifies
+// the indirection.
+var builtinProfiles = []Profile{
+	{Name: "php", Ecosystem: "Composer"},
+}
+
+// ProfileByName returns the registered profile, or the default profile
+// when name is empty / "default" / unknown. Unknown names fall back
+// rather than erroring so an operator's typo does not block a scan; the
+// override path that accepts user input validates separately.
+func ProfileByName(name string) Profile {
+	if name == "" || name == "default" {
+		return Profile{}
+	}
+	for _, p := range builtinProfiles {
+		if p.Name == name {
+			return p
+		}
+	}
+	return Profile{}
+}
+
+// KnownProfile reports whether name is a registered non-default profile.
+// Use this to validate operator-supplied `?profile=` values before
+// silently falling back to the default.
+func KnownProfile(name string) bool {
+	if name == "" || name == "default" {
+		return true
+	}
+	for _, p := range builtinProfiles {
+		if p.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// matchProfile picks the registered profile whose Ecosystem matches the
+// first package manager `brief` detected. Returns the zero profile when
+// nothing matches.
+func matchProfile(briefOut []byte) Profile {
+	var brief struct {
+		PackageManagers []struct {
+			Name string `json:"name"`
+		} `json:"package_managers"`
+	}
+	if err := json.Unmarshal(briefOut, &brief); err != nil {
+		return Profile{}
+	}
+	for _, pm := range brief.PackageManagers {
+		for _, p := range builtinProfiles {
+			if strings.EqualFold(pm.Name, p.Ecosystem) {
+				return p
+			}
+		}
+	}
+	return Profile{}
+}
+
+// DetectProfile runs `brief` against the cloned source inside the
+// default runner image (which already ships brief) and returns the
+// matching profile. Falls back to the zero profile on any error so a
+// detection blip never blocks a scan.
+func DetectProfile(ctx context.Context, runnerImage, srcDir string) Profile {
+	absSrc, err := filepath.Abs(srcDir)
+	if err != nil {
+		return Profile{}
+	}
+	cmd := exec.CommandContext(ctx, "docker", "run", "--rm",
+		"--network", "none",
+		"--user", fmt.Sprintf("%d:%d", os.Getuid(), os.Getgid()),
+		"-v", absSrc+":/src:ro",
+		"--entrypoint", "brief",
+		runnerImage, "/src",
+	)
+	out, err := cmd.Output()
+	if err != nil {
+		return Profile{}
+	}
+	return matchProfile(out)
+}
+
+// ErrNoProfilesDir is returned by EnsureImage when the worker has no
+// configured docker/profiles/ directory (e.g. tests, or a misconfigured
+// deployment). The caller falls back to the default runner image.
+var ErrNoProfilesDir = errors.New("profiles dir not configured")
+
+// profileBuildLocks serialises `docker build` per image tag. Two scans
+// that both detect the same profile must not race on the local image
+// cache. One mutex per tag avoids serialising builds of distinct
+// profiles.
+var profileBuildLocks = struct {
+	sync.Mutex
+	m map[string]*sync.Mutex
+}{m: map[string]*sync.Mutex{}}
+
+func lockForTag(tag string) *sync.Mutex {
+	profileBuildLocks.Lock()
+	defer profileBuildLocks.Unlock()
+	mu, ok := profileBuildLocks.m[tag]
+	if !ok {
+		mu = &sync.Mutex{}
+		profileBuildLocks.m[tag] = mu
+	}
+	return mu
+}
+
+// imageTag returns the content-addressed tag for a profile's Dockerfile.
+// The runner image ref is folded into the hash so a `--runner-image`
+// bump invalidates profile images whose FROM resolved to the old base.
+// Editing the Dockerfile produces a new tag, so the local cache is
+// invalidated transparently. Old tags stay cached until the operator
+// prunes them.
+func imageTag(profileName string, dockerfile []byte, runnerImage string) string {
+	h := sha256.New()
+	h.Write(dockerfile)
+	h.Write([]byte{0})
+	h.Write([]byte(runnerImage))
+	sum := h.Sum(nil)
+	return fmt.Sprintf("scrutineer-profile-%s:%s", profileName, hex.EncodeToString(sum[:6]))
+}
+
+// EnsureImage builds the profile's Docker image if it is not in the
+// local cache and returns the tag to pass to `docker run`. The
+// `--build-arg RUNNER_IMAGE=...` is wired so the profile's FROM picks
+// up whichever runner image the operator configured. Concurrency-safe:
+// a per-tag mutex serialises duplicate builds.
+func (p Profile) EnsureImage(ctx context.Context, profilesDir, runnerImage string) (string, error) {
+	if p.IsDefault() {
+		return runnerImage, nil
+	}
+	if profilesDir == "" {
+		return "", ErrNoProfilesDir
+	}
+	dockerfile := filepath.Join(profilesDir, p.Name, "Dockerfile")
+	contents, err := os.ReadFile(dockerfile)
+	if err != nil {
+		return "", fmt.Errorf("read profile dockerfile: %w", err)
+	}
+	tag := imageTag(p.Name, contents, runnerImage)
+
+	mu := lockForTag(tag)
+	mu.Lock()
+	defer mu.Unlock()
+
+	if imageExistsLocally(ctx, tag) {
+		return tag, nil
+	}
+	buildArgs := []string{"build", "-t", tag, "-f", dockerfile}
+	if runnerImage != "" {
+		buildArgs = append(buildArgs, "--build-arg", "RUNNER_IMAGE="+runnerImage)
+	}
+	buildArgs = append(buildArgs, filepath.Join(profilesDir, p.Name))
+	cmd := exec.CommandContext(ctx, "docker", buildArgs...)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("docker build %s: %w\n%s", tag, err, out)
+	}
+	return tag, nil
+}
+
+func imageExistsLocally(ctx context.Context, tag string) bool {
+	return exec.CommandContext(ctx, "docker", "image", "inspect", tag).Run() == nil
+}

--- a/internal/worker/profile_test.go
+++ b/internal/worker/profile_test.go
@@ -1,0 +1,125 @@
+package worker
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestProfileByName(t *testing.T) {
+	tests := []struct {
+		name    string
+		want    string
+		isKnown bool
+	}{
+		{"", "", true},
+		{"default", "", true},
+		{"php", "php", true},
+		{"unknown", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ProfileByName(tt.name)
+			if got.Name != tt.want {
+				t.Errorf("ProfileByName(%q).Name = %q, want %q", tt.name, got.Name, tt.want)
+			}
+			if KnownProfile(tt.name) != tt.isKnown {
+				t.Errorf("KnownProfile(%q) = %v, want %v", tt.name, !tt.isKnown, tt.isKnown)
+			}
+		})
+	}
+}
+
+func TestMatchProfile(t *testing.T) {
+	tests := []struct {
+		name string
+		json string
+		want string
+	}{
+		{"composer matches php", `{"package_managers":[{"name":"Composer"}]}`, "php"},
+		{"composer case-insensitive", `{"package_managers":[{"name":"composer"}]}`, "php"},
+		{"first match wins over later", `{"package_managers":[{"name":"Composer"},{"name":"npm"}]}`, "php"},
+		{"unknown manager falls back", `{"package_managers":[{"name":"npm"}]}`, ""},
+		{"empty list falls back", `{"package_managers":[]}`, ""},
+		{"missing field falls back", `{}`, ""},
+		{"invalid json falls back", `not json`, ""},
+		{"no first match but later is known", `{"package_managers":[{"name":"npm"},{"name":"Composer"}]}`, "php"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := matchProfile([]byte(tt.json))
+			if got.Name != tt.want {
+				t.Errorf("matchProfile = %q, want %q", got.Name, tt.want)
+			}
+		})
+	}
+}
+
+func TestImageTag_contentAddressed(t *testing.T) {
+	a := imageTag("php", []byte("FROM x\nRUN echo a\n"), "runner:1")
+	b := imageTag("php", []byte("FROM x\nRUN echo a\n"), "runner:1")
+	c := imageTag("php", []byte("FROM x\nRUN echo b\n"), "runner:1")
+	d := imageTag("php", []byte("FROM x\nRUN echo a\n"), "runner:2")
+
+	if a != b {
+		t.Errorf("same contents and runner should yield same tag: %q vs %q", a, b)
+	}
+	if a == c {
+		t.Errorf("different contents should yield different tag, both %q", a)
+	}
+	if a == d {
+		t.Errorf("different runner image should yield different tag, both %q", a)
+	}
+	if !strings.HasPrefix(a, "scrutineer-profile-php:") {
+		t.Errorf("tag %q does not have expected prefix", a)
+	}
+}
+
+func TestLockForTag_sameTagSameMutex(t *testing.T) {
+	a := lockForTag("scrutineer-profile-test:abc")
+	b := lockForTag("scrutineer-profile-test:abc")
+	c := lockForTag("scrutineer-profile-test:xyz")
+
+	if a != b {
+		t.Errorf("same tag must yield same mutex")
+	}
+	if a == c {
+		t.Errorf("different tag must yield distinct mutex")
+	}
+}
+
+func TestEnsureImage_defaultReturnsRunnerImage(t *testing.T) {
+	img, err := Profile{}.EnsureImage(context.Background(), "", "default-runner:latest")
+	if err != nil {
+		t.Fatalf("default profile: %v", err)
+	}
+	if img != "default-runner:latest" {
+		t.Errorf("got %q, want default runner image", img)
+	}
+}
+
+func TestEnsureImage_noProfilesDir(t *testing.T) {
+	_, err := Profile{Name: "php"}.EnsureImage(context.Background(), "", "default:latest")
+	if err == nil {
+		t.Fatal("expected ErrNoProfilesDir, got nil")
+	}
+}
+
+func TestEnsureImage_missingDockerfile(t *testing.T) {
+	dir := t.TempDir()
+	_, err := Profile{Name: "php"}.EnsureImage(context.Background(), dir, "default:latest")
+	if err == nil {
+		t.Fatal("expected error for missing dockerfile, got nil")
+	}
+}
+
+func TestRepoShipsPHPDockerfile(t *testing.T) {
+	wd, _ := os.Getwd()
+	repoRoot := filepath.Join(wd, "..", "..")
+	path := filepath.Join(repoRoot, "docker", "profiles", "php", "Dockerfile")
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("expected php profile Dockerfile to exist: %v", err)
+	}
+}

--- a/internal/worker/skill.go
+++ b/internal/worker/skill.go
@@ -139,10 +139,15 @@ func (w *Worker) doSkill(ctx context.Context, scan *db.Scan, emit func(Event)) (
 		MaxTurns:     skill.MaxTurns,
 		AllowedTools: skill.AllowedTools,
 		SrcReady:     true,
+		Profile:      scan.Profile,
 	}
 	res, err := w.Runner.RunSkill(ctx, sj, emit)
 	if res.Commit != "" {
 		scan.Commit = res.Commit
+	}
+	if res.Profile != "" && res.Profile != scan.Profile {
+		scan.Profile = res.Profile
+		w.DB.Model(scan).Update("profile", res.Profile)
 	}
 	if err != nil {
 		if _, ok := errors.AsType[*MaxTurnsReachedError](err); ok && res.Report != "" {

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -221,12 +221,25 @@ paths:
                 model:
                   type: string
                   description: Override model; defaults to the system default.
+                ref:
+                  type: string
+                  description: Git ref to checkout; empty means the repository's default branch.
+                profile:
+                  type: string
+                  description: |
+                    Runner profile name (e.g. `php`). Empty auto-detects from the clone via `brief`;
+                    `default` forces the default runner image. Unknown names return 400.
       responses:
         '201':
           description: Scan enqueued
           content:
             application/json:
               schema: { $ref: '#/components/schemas/Scan' }
+        '400':
+          description: Bad request (e.g. unknown profile)
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
         '403': { $ref: '#/components/responses/Forbidden' }
         '404':
           description: Skill or repository not found

--- a/scrutineer.sample.yaml
+++ b/scrutineer.sample.yaml
@@ -37,6 +37,14 @@
 # Docker image used for per-scan containers.
 # runner_image: ghcr.io/alpha-omega-security/scrutineer-runner:latest
 
+# Directory containing per-ecosystem runner profiles. Each profile is a
+# Dockerfile under <dir>/<name>/Dockerfile; the worker auto-detects the
+# right profile from the cloned source via `brief` and builds the image
+# locally on demand (cache-keyed on the Dockerfile sha). Operators can
+# force a profile by passing `profile: <name>` to the API. Empty value
+# disables the mechanism entirely.
+# profiles_dir: docker/profiles
+
 # Extra hosts the docker runner's egress proxy will tunnel to, on top of
 # the built-in allowlist (Anthropic API, *.ecosyste.ms, major forges,
 # package registries, advisory sources, host.docker.internal). Use


### PR DESCRIPTION
Fix #254

@edorian don't hesitate to comment if the new Dockerfile is not exactly what you would need!

For now, it uses Brief to autodetect the profile. A followup could add an input select in the UI for example to force the profile to use.