### PR TITLE
fix: include skill name in scan queue.

### DIFF
--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -1458,6 +1458,7 @@ func (s *Server) enqueueSkillWith(ctx context.Context, repoID, skillID uint, opt
 		StatusPriority: db.StatusPriorityFor(db.ScanQueued),
 		Model:          opts.Model,
 		SkillID:        &skillID,
+		SkillName:      sk.Name,
 		FindingID:      opts.FindingID,
 		DependentID:    opts.DependentID,
 		SubPath:        opts.SubPath,


### PR DESCRIPTION
Otherwise we end up with the skill name displayed as "skill" in the Scans page, like this:

<img width="1248" height="601" alt="Screenshot 2026-05-26 at 4 42 27 PM" src="https://github.com/user-attachments/assets/e8d913ed-1bcc-4f31-bcb1-286125f4e39c" />
