### PR TITLE
fix: Improve the code browser UI to have shorter line height.

### DIFF
--- a/internal/web/static/theme.css
+++ b/internal/web/static/theme.css
@@ -401,8 +401,7 @@ pre.log { background: var(--muted); padding: 1rem; border-radius: var(--radius);
 
 /* ── code browser ── */
 #blob { display: block; padding: 0.5rem 0; tab-size: 4; }
-.hl-line { display: block; padding-left: 3.5rem; position: relative;
-           min-height: 1.25rem; }
+.hl-line { padding-left: 3.5rem; position: relative; }
 .hl-num { position: absolute; left: 0; width: 3rem; text-align: right;
           padding-right: 0.75rem; color: var(--muted-foreground);
           user-select: none; font-size: 0.7rem; }


### PR DESCRIPTION
Before:

<img width="863" height="648" alt="Screenshot 2026-05-26 at 8 47 18 PM" src="https://github.com/user-attachments/assets/7862da7d-ae7d-4e98-85dc-ec14c140d9e7" />

After:

<img width="697" height="319" alt="Screenshot 2026-05-26 at 8 47 07 PM" src="https://github.com/user-attachments/assets/435362ca-3d51-4471-8742-83fc093c32fa" />

The downside is that the highlight line isn't full-width now, but I think this is much better.