### PR TITLE
feat: Add external links to the forge in code browser.

### DIFF
--- a/internal/web/code_browser_test.go
+++ b/internal/web/code_browser_test.go
@@ -230,7 +230,42 @@ func TestRepoBlob_rendersMissingNoticeWhenNoCache(t *testing.T) {
 	if rec.Code != 200 {
 		t.Fatalf("status %d: %s", rec.Code, rec.Body.String())
 	}
-	if !strings.Contains(rec.Body.String(), "No local clone") {
-		t.Errorf("body missing 'No local clone' notice:\n%s", rec.Body.String())
+	body := rec.Body.String()
+	if !strings.Contains(body, "No local clone") {
+		t.Errorf("body missing 'No local clone' notice:\n%s", body)
+	}
+	if strings.Contains(body, "View on forge") {
+		t.Errorf("body should not contain forge link for unknown host:\n%s", body)
 	}
 }
+
+func TestRepoBlob_rendersForgeLinkInMissingState(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	s.Worker = &worker.Worker{DataDir: t.TempDir()}
+	repo := db.Repository{
+		URL:     "https://github.com/owner/repo",
+		HTMLURL: "https://github.com/owner/repo",
+		Name:    "repo",
+	}
+	s.DB.Create(&repo)
+
+	id := strconv.FormatUint(uint64(repo.ID), 10)
+	req := localReq("GET", "/repositories/"+id+"/blob/abc123/a.go")
+	req.SetPathValue("id", id)
+	req.SetPathValue("commit", "abc123")
+	req.SetPathValue("path", "a.go")
+	rec := httptest.NewRecorder()
+	s.repoBlob(rec, req)
+	if rec.Code != 200 {
+		t.Fatalf("status %d: %s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "https://github.com/owner/repo/blob/abc123/a.go") {
+		t.Errorf("body missing forge blob link:\n%s", body)
+	}
+	if !strings.Contains(body, "https://github.com/owner/repo/commit/abc123") {
+		t.Errorf("body missing forge commit link:\n%s", body)
+	}
+}
+

--- a/internal/web/code_browser_test.go
+++ b/internal/web/code_browser_test.go
@@ -268,4 +268,3 @@ func TestRepoBlob_rendersForgeLinkInMissingState(t *testing.T) {
 		t.Errorf("body missing forge commit link:\n%s", body)
 	}
 }
-

--- a/internal/web/forge_link.go
+++ b/internal/web/forge_link.go
@@ -1,0 +1,109 @@
+package web
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// forgeKind identifies the URL shape a forge uses for blob, commit, and
+// line links. It is inferred from a Repository.HTMLURL host: scrutineer
+// only commits a URL shape for the four hosts DefaultHTMLURL recognises,
+// so anything else maps to forgeUnknown and the link builders below
+// return "".
+type forgeKind int
+
+const (
+	forgeUnknown forgeKind = iota
+	forgeGitHub            // github.com
+	forgeGitLab            // gitlab.*
+	forgeGitea             // codeberg.org / Gitea / Forgejo
+	forgeBitbucket         // bitbucket.org
+)
+
+func detectForge(htmlURL string) forgeKind {
+	if htmlURL == "" {
+		return forgeUnknown
+	}
+	u, err := url.Parse(htmlURL)
+	if err != nil {
+		return forgeUnknown
+	}
+	host := strings.ToLower(u.Host)
+	switch {
+	case host == "github.com":
+		return forgeGitHub
+	case host == "codeberg.org":
+		return forgeGitea
+	case host == "bitbucket.org":
+		return forgeBitbucket
+	case strings.HasPrefix(host, "gitlab."):
+		return forgeGitLab
+	}
+	return forgeUnknown
+}
+
+// forgeBlobURL builds a link to one file at a specific commit on the
+// forge web UI. Returns "" when the host is not one of the four
+// recognised forges, when htmlURL/commit/path is empty, or when path
+// fails the same traversal/NUL checks as the in-app browser. Paths are
+// segment-escaped because forge URLs may include unicode or spaces.
+func forgeBlobURL(htmlURL, commit, blobPath string, line int) string {
+	if htmlURL == "" || commit == "" || blobPath == "" {
+		return ""
+	}
+	clean, ok := sanitizeBlobPath(blobPath)
+	if !ok {
+		return ""
+	}
+	base := strings.TrimRight(htmlURL, "/")
+	escaped := escapeBlobPath(clean)
+	switch detectForge(htmlURL) {
+	case forgeGitHub:
+		u := fmt.Sprintf("%s/blob/%s/%s", base, commit, escaped)
+		if line > 0 {
+			u += fmt.Sprintf("#L%d", line)
+		}
+		return u
+	case forgeGitLab:
+		u := fmt.Sprintf("%s/-/blob/%s/%s", base, commit, escaped)
+		if line > 0 {
+			u += fmt.Sprintf("#L%d", line)
+		}
+		return u
+	case forgeGitea:
+		u := fmt.Sprintf("%s/src/commit/%s/%s", base, commit, escaped)
+		if line > 0 {
+			u += fmt.Sprintf("#L%d", line)
+		}
+		return u
+	case forgeBitbucket:
+		u := fmt.Sprintf("%s/src/%s/%s", base, commit, escaped)
+		if line > 0 {
+			u += fmt.Sprintf("#lines-%d", line)
+		}
+		return u
+	}
+	return ""
+}
+
+// forgeCommitURL builds a link to one commit on the forge web UI. The
+// path segment differs by host: Bitbucket uses /commits/<sha> (plural),
+// the others use /commit/<sha>; GitLab namespaces it under /-/. Returns
+// "" for unknown hosts so callers can fall back to plain text.
+func forgeCommitURL(htmlURL, commit string) string {
+	if htmlURL == "" || commit == "" {
+		return ""
+	}
+	base := strings.TrimRight(htmlURL, "/")
+	switch detectForge(htmlURL) {
+	case forgeGitHub, forgeGitea:
+		return fmt.Sprintf("%s/commit/%s", base, commit)
+	case forgeGitLab:
+		return fmt.Sprintf("%s/-/commit/%s", base, commit)
+	case forgeBitbucket:
+		return fmt.Sprintf("%s/commits/%s", base, commit)
+	}
+	return ""
+}
+

--- a/internal/web/forge_link.go
+++ b/internal/web/forge_link.go
@@ -14,11 +14,11 @@ import (
 type forgeKind int
 
 const (
-	forgeUnknown forgeKind = iota
-	forgeGitHub            // github.com
-	forgeGitLab            // gitlab.*
-	forgeGitea             // codeberg.org / Gitea / Forgejo
-	forgeBitbucket         // bitbucket.org
+	forgeUnknown   forgeKind = iota
+	forgeGitHub              // github.com
+	forgeGitLab              // gitlab.*
+	forgeGitea               // codeberg.org / Gitea / Forgejo
+	forgeBitbucket           // bitbucket.org
 )
 
 func detectForge(htmlURL string) forgeKind {
@@ -106,4 +106,3 @@ func forgeCommitURL(htmlURL, commit string) string {
 	}
 	return ""
 }
-

--- a/internal/web/forge_link_test.go
+++ b/internal/web/forge_link_test.go
@@ -4,10 +4,10 @@ import "testing"
 
 func TestForgeBlobURL(t *testing.T) {
 	cases := []struct {
-		name                string
-		htmlURL, commit, p  string
-		line                int
-		want                string
+		name               string
+		htmlURL, commit, p string
+		line               int
+		want               string
 	}{
 		{"github no line", "https://github.com/owner/repo", "abc123", "lib/x.rb", 0,
 			"https://github.com/owner/repo/blob/abc123/lib/x.rb"},
@@ -66,4 +66,3 @@ func TestForgeCommitURL(t *testing.T) {
 		})
 	}
 }
-

--- a/internal/web/forge_link_test.go
+++ b/internal/web/forge_link_test.go
@@ -1,0 +1,69 @@
+package web
+
+import "testing"
+
+func TestForgeBlobURL(t *testing.T) {
+	cases := []struct {
+		name                string
+		htmlURL, commit, p  string
+		line                int
+		want                string
+	}{
+		{"github no line", "https://github.com/owner/repo", "abc123", "lib/x.rb", 0,
+			"https://github.com/owner/repo/blob/abc123/lib/x.rb"},
+		{"github with line", "https://github.com/owner/repo", "abc123", "lib/x.rb", 42,
+			"https://github.com/owner/repo/blob/abc123/lib/x.rb#L42"},
+		{"github trailing slash", "https://github.com/owner/repo/", "abc123", "x.go", 0,
+			"https://github.com/owner/repo/blob/abc123/x.go"},
+		{"gitlab", "https://gitlab.com/g/p", "abc123", "src/a.rb", 7,
+			"https://gitlab.com/g/p/-/blob/abc123/src/a.rb#L7"},
+		{"gitlab self-hosted", "https://gitlab.example.com/g/p", "abc", "x", 0,
+			"https://gitlab.example.com/g/p/-/blob/abc/x"},
+		{"codeberg gitea-shape", "https://codeberg.org/owner/repo", "abc", "x.go", 3,
+			"https://codeberg.org/owner/repo/src/commit/abc/x.go#L3"},
+		{"bitbucket hashlines", "https://bitbucket.org/owner/repo", "abc", "x.go", 3,
+			"https://bitbucket.org/owner/repo/src/abc/x.go#lines-3"},
+		{"path escaped", "https://github.com/o/r", "abc", "a b/c.rb", 0,
+			"https://github.com/o/r/blob/abc/a%20b/c.rb"},
+		{"unknown host", "https://example.com/o/r", "abc", "x.go", 0, ""},
+		{"empty htmlURL", "", "abc", "x.go", 0, ""},
+		{"empty commit", "https://github.com/o/r", "", "x.go", 0, ""},
+		{"empty path", "https://github.com/o/r", "abc", "", 0, ""},
+		{"path traversal rejected", "https://github.com/o/r", "abc", "../etc/passwd", 0, ""},
+		{"absolute path rejected", "https://github.com/o/r", "abc", "/etc/passwd", 0, ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := forgeBlobURL(c.htmlURL, c.commit, c.p, c.line)
+			if got != c.want {
+				t.Errorf("forgeBlobURL(%q,%q,%q,%d) = %q, want %q",
+					c.htmlURL, c.commit, c.p, c.line, got, c.want)
+			}
+		})
+	}
+}
+
+func TestForgeCommitURL(t *testing.T) {
+	cases := []struct {
+		name, htmlURL, commit, want string
+	}{
+		{"github", "https://github.com/o/r", "abc", "https://github.com/o/r/commit/abc"},
+		{"gitlab", "https://gitlab.com/g/p", "abc", "https://gitlab.com/g/p/-/commit/abc"},
+		{"gitlab self-hosted", "https://gitlab.foo.io/g/p", "abc", "https://gitlab.foo.io/g/p/-/commit/abc"},
+		{"codeberg", "https://codeberg.org/o/r", "abc", "https://codeberg.org/o/r/commit/abc"},
+		{"bitbucket plural", "https://bitbucket.org/o/r", "abc", "https://bitbucket.org/o/r/commits/abc"},
+		{"unknown", "https://example.com/o/r", "abc", ""},
+		{"empty htmlURL", "", "abc", ""},
+		{"empty commit", "https://github.com/o/r", "", ""},
+		{"trailing slash trimmed", "https://github.com/o/r/", "abc", "https://github.com/o/r/commit/abc"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := forgeCommitURL(c.htmlURL, c.commit)
+			if got != c.want {
+				t.Errorf("forgeCommitURL(%q,%q) = %q, want %q", c.htmlURL, c.commit, got, c.want)
+			}
+		})
+	}
+}
+

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -130,6 +130,8 @@ func New(gdb *gorm.DB, q *queue.Queue, log *slog.Logger, broker *Broker, w *work
 			l, _ := loc.(string)
 			return locationURL(id, c, l)
 		},
+		"forgeBlobURL":   forgeBlobURL,
+		"forgeCommitURL": forgeCommitURL,
 		"domain": func(u string) string {
 			u = strings.TrimPrefix(u, "https://")
 			u = strings.TrimPrefix(u, "http://")

--- a/internal/web/templates/code_browser.html
+++ b/internal/web/templates/code_browser.html
@@ -4,9 +4,20 @@
   .Repo.Name (printf "/repositories/%d" .Repo.ID)
   .Path "")}}
 
+{{$forgeFile := forgeBlobURL .Repo.HTMLURL .Commit .Path 0}}
+{{$forgeCommit := forgeCommitURL .Repo.HTMLURL .Commit}}
 <header class="mb-4 flex flex-wrap items-baseline gap-2">
   <h2 class="text-xl font-semibold font-mono break-all">{{.Path}}</h2>
-  <span class="text-muted-foreground text-xs font-mono">@ {{short .Commit}}</span>
+  <span class="text-muted-foreground text-xs font-mono">@
+    {{if $forgeCommit}}<a href="{{$forgeCommit}}" class="hover:underline" rel="noopener noreferrer" target="_blank">{{short .Commit}}</a>
+    {{else}}{{short .Commit}}{{end}}
+  </span>
+  {{if $forgeFile}}
+    <a href="{{$forgeFile}}" rel="noopener noreferrer" target="_blank"
+       class="text-xs text-muted-foreground hover:text-foreground hover:underline ml-auto inline-flex items-center gap-1">
+      <i data-lucide="external-link" class="size-3.5"></i> View on forge
+    </a>
+  {{end}}
 </header>
 
 {{if .Missing}}


### PR DESCRIPTION
Link to the file externally. Also link the commit SHA to the commit in the forge.

<img width="439" height="93" alt="Screenshot 2026-05-26 at 8 55 53 PM" src="https://github.com/user-attachments/assets/535f4f83-7a1b-43b0-b096-59877c0934cf" />

<img width="1195" height="199" alt="Screenshot 2026-05-26 at 8 56 00 PM" src="https://github.com/user-attachments/assets/8f1c27e4-81b6-4dc7-a6cd-3008511e9ec2" />

Can update the text to "View on GitHub"/"View on GitLab"/whatever if preferred.

Changeset generated with Claude Code, reviewed and tested by me.