### PR TITLE
chore: Disable telemetry/error-reporting in runner container

### DIFF
--- a/internal/worker/docker.go
+++ b/internal/worker/docker.go
@@ -81,6 +81,15 @@ func (d DockerRunner) RunSkill(ctx context.Context, sj SkillJob, emit func(Event
 		"--user", fmt.Sprintf("%d:%d", os.Getuid(), os.Getgid()),
 		"-e", "HOME=/tmp",
 		"-e", "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1",
+		// Suppress telemetry traffic
+		// Denied by the egress proxy anyway, but noisy in the log.
+		"-e", "OTEL_SDK_DISABLED=true",
+		"-e", "DISABLE_TELEMETRY=1",
+		"-e", "DISABLE_ERROR_REPORTING=1",
+		"-e", "DISABLE_BUG_COMMAND=1",
+		"-e", "DISABLE_AUTOUPDATER=1",
+		// Disable auxiliary calls not useful in headless mode
+		"-e", "DISABLE_NON_ESSENTIAL_MODEL_CALLS=1",
 		"-e", "SEMGREP_SEND_METRICS=off",
 		"--tmpfs", "/tmp:rw,noexec,nosuid,size=256m",
 		"-v", absWork + ":/work",


### PR DESCRIPTION
Without these the CLI tries to ship logs/metrics/errors to various endpoints.
The egress proxy already denies the connects, but they spam the log and burn startup time.

Disabling at the source removes the connect attempts entirely reducing log size and speeding things up slightly.

I've still seen calls despite CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC, maybe because the pinned claude code version was older than the flag or because the there is some overlap. With the current setting I'm not seeing any traffic any more.