### PR TITLE
runner: Switch base image from Alpine/musl to Debian/glibc

### DIFF
--- a/Dockerfile.runner
+++ b/Dockerfile.runner
@@ -31,10 +31,16 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
  && rm -rf /var/lib/apt/lists/*
 
 # semgrep in a venv so PEP 668 doesn't require --break-system-packages.
+# Smoke-test required CLIs at build time so missing packages or broken venv
+# symlinks fail the image build instead of later scan jobs.
 RUN python3 -m venv /opt/semgrep && \
     /opt/semgrep/bin/pip install --no-cache-dir "semgrep==${SEMGREP_VERSION}" "setuptools<81" && \
     ln -s /opt/semgrep/bin/semgrep /usr/local/bin/semgrep && \
-    ln -s /opt/semgrep/bin/pysemgrep /usr/local/bin/pysemgrep
+    ln -s /opt/semgrep/bin/pysemgrep /usr/local/bin/pysemgrep && \
+    python3 --version && \
+    gh --version && \
+    semgrep --version && \
+    pysemgrep --version
 
 # Glibc tarball; shas computed locally — upstream SHASUMS256.txt is musl-only.
 ARG TARGETARCH

--- a/Dockerfile.runner
+++ b/Dockerfile.runner
@@ -2,42 +2,56 @@
 # tools, not the web server or database. Built separately:
 #   docker build -t scrutineer-runner -f Dockerfile.runner .
 
-ARG SEMGREP_IMAGE=semgrep/semgrep:1.116.0@sha256:1844697a3d8b80166e2eaadb93f189a9372e6c8dc025cb14d9400f06e7475261
-
-FROM ${SEMGREP_IMAGE} AS claude
-ARG TARGETARCH
 ARG CLAUDE_VERSION=2.1.123
-# Checksums from https://github.com/anthropics/claude-code/releases/download/v${CLAUDE_VERSION}/SHASUMS256.txt
-RUN set -eux; \
-    case "${TARGETARCH}" in \
-      amd64) arch=x64;   sha=95256aab4b2677433a799498604c8f77eae434e8c2c6f05f5040ae1d10586a3e ;; \
-      arm64) arch=arm64; sha=e8ac56565de3eb482c6eaff90ea0ac248270b33e7705e0614be0c47c2387e615 ;; \
-      *) echo "unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;; \
-    esac; \
-    curl -fsSL -o /tmp/claude.tgz \
-      "https://github.com/anthropics/claude-code/releases/download/v${CLAUDE_VERSION}/claude-linux-${arch}-musl.tar.gz"; \
-    echo "${sha}  /tmp/claude.tgz" | sha256sum -c -; \
-    mkdir -p /out && tar -xzf /tmp/claude.tgz -C /out && chmod +x /out/claude
+ARG SEMGREP_VERSION=1.116.0
 
-FROM golang:1.26.3-alpine@sha256:91eda9776261207ea25fd06b5b7fed8d397dd2c0a283e77f2ab6e91bfa71079d AS go-tools
-RUN apk add --no-cache git
+FROM golang:1.26-bookworm@sha256:386d475a660466863d9f8c766fec64d7fdad3edac2c6a05020c09534d71edb4b AS go-tools
 RUN GOBIN=/out go install github.com/git-pkgs/git-pkgs@v0.15.3 && \
     GOBIN=/out go install github.com/git-pkgs/brief/cmd/brief@v0.6.0
 
-FROM rust:1.88-alpine@sha256:9dfaae478ecd298b6b5a039e1f2cc4fc040fc818a2de9aa78fa714dea036574d AS zizmor-build
-RUN apk add --no-cache build-base linux-headers
+FROM rust:1.88-bookworm@sha256:af306cfa71d987911a781c37b59d7d67d934f49684058f96cf72079c3626bfe0 AS zizmor-build
 RUN cargo install --locked --root /out zizmor@1.24.1
 
-# semgrep's image is alpine + apk python3 + git/bash/curl/ca-certificates,
-# so it doubles as the final base and we inherit semgrep without a pip step.
-FROM ${SEMGREP_IMAGE}
-RUN apk add --no-cache coreutils
+FROM debian:bookworm-slim@sha256:0104b334637a5f19aa9c983a91b54c89887c0984081f2068983107a6f6c21eeb
+ARG CLAUDE_VERSION
+ARG SEMGREP_VERSION
 
-COPY --from=claude /out/claude /usr/local/bin/claude
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates curl git bash coreutils \
+        python3 python3-venv \
+ && install -d -m 0755 /etc/apt/keyrings \
+ && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+        -o /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+ && chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+ && echo "deb [signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+        > /etc/apt/sources.list.d/github-cli.list \
+ && apt-get update && apt-get install -y --no-install-recommends gh \
+ && rm -rf /var/lib/apt/lists/*
+
+# semgrep in a venv so PEP 668 doesn't require --break-system-packages.
+RUN python3 -m venv /opt/semgrep && \
+    /opt/semgrep/bin/pip install --no-cache-dir "semgrep==${SEMGREP_VERSION}" "setuptools<81" && \
+    ln -s /opt/semgrep/bin/semgrep /usr/local/bin/semgrep && \
+    ln -s /opt/semgrep/bin/pysemgrep /usr/local/bin/pysemgrep
+
+# Glibc tarball; shas computed locally — upstream SHASUMS256.txt is musl-only.
+ARG TARGETARCH
+RUN set -eux; \
+    case "${TARGETARCH}" in \
+      amd64) arch=x64;   sha=d1135f2b066b4b09a77fefaeafc537731061af7af315f291f8090e57fc7489d0 ;; \
+      arm64) arch=arm64; sha=743c5c8a31ef58a6b76916ce8279a65f7a1295d279656bd60ed4038bb6f5f476 ;; \
+      *) echo "unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;; \
+    esac; \
+    curl -fsSL -o /tmp/claude.tgz \
+      "https://github.com/anthropics/claude-code/releases/download/v${CLAUDE_VERSION}/claude-linux-${arch}.tar.gz"; \
+    echo "${sha}  /tmp/claude.tgz" | sha256sum -c -; \
+    tar -xzf /tmp/claude.tgz -C /usr/local/bin claude && rm /tmp/claude.tgz
+
 COPY --from=go-tools /out/* /usr/local/bin/
 COPY --from=zizmor-build /out/bin/zizmor /usr/local/bin/zizmor
 
-# Non-root
-RUN adduser -D -h /home/runner runner
+RUN useradd -ms /bin/bash runner
 USER runner
 WORKDIR /out

--- a/docker/profiles/php/Dockerfile
+++ b/docker/profiles/php/Dockerfile
@@ -10,20 +10,26 @@
 ARG RUNNER_IMAGE=ghcr.io/alpha-omega-security/scrutineer-runner:latest
 FROM ${RUNNER_IMAGE}
 
+ARG PHP_VERSION=8.4.21-3+0~20260514.49+debian12~1.gbp45ccaf
+
 USER root
-RUN apk add --no-cache \
-        php84=8.4.21-r0 \
-        php84-phar=8.4.21-r0 \
-        php84-openssl=8.4.21-r0 \
-        php84-mbstring=8.4.21-r0 \
-        php84-tokenizer=8.4.21-r0 \
-        php84-curl=8.4.21-r0 \
-        php84-dom=8.4.21-r0 \
-        php84-simplexml=8.4.21-r0 \
-        php84-xml=8.4.21-r0 \
-        php84-xmlwriter=8.4.21-r0 \
-        php84-fileinfo=8.4.21-r0 \
-        php84-iconv=8.4.21-r0 \
-    && ln -sf /usr/bin/php84 /usr/local/bin/php
+# sury packages PHP 8.4 for bookworm; signed-by keyring, no apt-key.
+# Extension parity with the prior Alpine pin (phar, openssl, tokenizer,
+# fileinfo, iconv, dom, simplexml, xml, xmlwriter): php8.4-cli covers
+# phar/openssl/tokenizer/fileinfo/iconv as builtins; php8.4-xml covers
+# dom/simplexml/xml/xmlwriter; mbstring and curl are their own packages.
+RUN install -d -m 0755 /etc/apt/keyrings \
+ && curl -fsSL https://packages.sury.org/php/apt.gpg \
+        -o /etc/apt/keyrings/sury-php.gpg \
+ && chmod go+r /etc/apt/keyrings/sury-php.gpg \
+ && echo "deb [signed-by=/etc/apt/keyrings/sury-php.gpg] https://packages.sury.org/php/ bookworm main" \
+        > /etc/apt/sources.list.d/sury-php.list \
+ && apt-get update \
+ && apt-get install -y --no-install-recommends \
+        php8.4-cli=${PHP_VERSION} \
+        php8.4-mbstring=${PHP_VERSION} \
+        php8.4-curl=${PHP_VERSION} \
+        php8.4-xml=${PHP_VERSION} \
+ && rm -rf /var/lib/apt/lists/*
 
 USER runner

--- a/threatmodel.md
+++ b/threatmodel.md
@@ -118,9 +118,15 @@ No rate limiting on `POST /repositories`, no cap on clone size, no timeout on th
 
 ### T11: Image supply chain (partially mitigated)
 
-Tool versions are pinned: `claude-code@2.1.119`, `semgrep==1.116.0`, `git-pkgs@v0.15.3`, `brief@v0.6.0`, `zizmor@1.24.1`. Base images are pinned by sha256 digest. The container runs as non-root user `scrutineer`. `curl`, `npm`, and `pip` are stripped from the final stage. The runner image is built in CI, smoke-tested, and published to GHCR; users pull a known-good artifact rather than rebuilding against live registries.
+Tool versions are pinned: `claude-code@2.1.123`, `semgrep==1.116.0`, `git-pkgs@v0.15.3`, `brief@v0.6.0`, `zizmor@1.24.1`. The final stage is `debian:bookworm-slim`; the `golang:1.26-bookworm` and `rust:1.88-bookworm` builder stages are pinned by sha256 digest. The container runs as non-root user `runner`. The runner image is built in CI, smoke-tested, and published to GHCR; users pull a known-good artifact rather than rebuilding against live registries.
 
-Residual: tool installs are pinned by version tag, not by content hash. A compromised release republished at the same version (e.g. a yanked-and-republished npm package) would still land. Hash-pinned lockfiles for pip/npm are tracked in #56.
+Supply-chain surface in the final stage:
+- `apt` pulls from Debian's official mirrors plus the GitHub CLI repo at `cli.github.com/packages` (signed-by keyring under `/etc/apt/keyrings/`). `gh` is used at scan time by the `fork` and `report-upstream` skills.
+- `claude` is the glibc tarball from `github.com/anthropics/claude-code` releases, SHA256-pinned per architecture. The hashes are computed locally and reviewed on version bumps because the un-suffixed assets are not in upstream `SHASUMS256.txt`.
+- `semgrep` is installed via `pip` into a venv at `/opt/semgrep` (PEP 668 dodge without `--break-system-packages`). `pip` is therefore present, scoped to that venv.
+- `curl` remains on PATH; used at build time to fetch the claude tarball and apt keyrings, and at scan time inside the egress-proxied container. `npm` is not installed.
+
+Residual: `apt` and `pip` installs are pinned by version, not by content hash. A compromised release republished at the same version on Debian, sury, or PyPI would still land. Hash-pinned lockfiles for `pip` are tracked in #56.
 
 ### T12: Docker socket exposure in per-job runner (design risk, critical if adopted)
 
@@ -169,8 +175,8 @@ GORM usage is consistently parameterised; no `Raw`, no string-built `Where`, and
 - [x] `0700` on the data directory at startup (T8).
 - [x] `toolchain go1.26.2` in go.mod so host builds match the image (T10).
 - [x] Pin tool versions in Dockerfile: claude-code, semgrep, git-pkgs, brief, zizmor (T11).
-- [x] Non-root `USER scrutineer` in Dockerfile (T11).
-- [x] Strip `curl`, `npm`, `pip` from final Docker stage (T11).
+- [x] Non-root `USER runner` in Dockerfile (T11).
+- [x] Trim final Docker stage: `npm` absent, `pip` scoped to the `/opt/semgrep` venv, `curl` retained for build- and scan-time fetches (T11).
 - [ ] Per-job ephemeral runner (T1). See T12 before reaching for the Docker socket.
 - [ ] URL allowlist at enqueue time; block RFC1918 redirects in HTTP client (T4).
 - [ ] Finding provenance tagging: source job on each finding row (T5).


### PR DESCRIPTION
When trying to add/refine/test profiles for PHP and PHP-Ext, I ran into some issues with teh C-Toolchain that can be patched and worked around on musl but work stably on glibc. 

So this is one proposal to make it easier for all images to all use the same base image on a full, known, and reliable distro for profile-images to extend from.

If you have reasons to not want to do this, that's also fine with me, of course. But I wanted to raise this before continuing on the PHP refinements.

--

The per-job ephemeral runner now uses debian:bookworm-slim instead of chaining on top of semgrep's Alpine image (which contains more unknowns than a stable distro image).

Claude is downloaded from the glibc tarball (sha256-pinned); semgrep is installed into a venv; gh is added via apt for use during scans (skills/fork/SKILL.md & report-upstream).

## Why:

Scans need to build, load, debug, and reproduce native code - PHP extensions, Python/Ruby C bindings, anything with libc-linked binaries or apt-installable dev libs.

Using common tooling, like integrating ASan/UBSan checks, should be easier and better mirror how projects are built.

Image is still minimal, with the main driver of image size being the Claude install. The go-tools and Zizmor Builder stages now use bookworm variants.