### PR TITLE
feat(skills): add model and max_turns metadata to maintainers skill

### DIFF
--- a/skills/maintainers/SKILL.md
+++ b/skills/maintainers/SKILL.md
@@ -9,6 +9,8 @@ metadata:
   scrutineer.output_file: report.json
   scrutineer.output_kind: maintainers
   scrutineer.requires_remote: true
+  scrutineer.model: claude-sonnet-4-6
+  scrutineer.max_turns: 20
 ---
 
 # maintainers


### PR DESCRIPTION
Fix #243 

Here's a proposition to speed up the maintainer skill: stick to Sonnet with 20 max turns.