### PR TITLE
feat: Ecosystem runner specific agent instructions

### DIFF
--- a/docker/profiles/php-ext/Dockerfile
+++ b/docker/profiles/php-ext/Dockerfile
@@ -1,0 +1,71 @@
+# PHP-extension profile.
+#
+# Ships PHP, built from source with --enable-debug + ASan + UBSan.
+
+ARG RUNNER_IMAGE=ghcr.io/alpha-omega-security/scrutineer-runner:latest
+ARG PHP_GIT_URL=https://github.com/php/php-src.git
+ARG PHP_GIT_REF=php-8.5.6
+
+FROM composer:2.9.8 AS composer
+
+FROM ${RUNNER_IMAGE}
+ARG PHP_GIT_URL
+ARG PHP_GIT_REF
+
+USER root
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    PATH=/usr/local/php/bin:/usr/local/php/sbin:$PATH \
+    COMPOSER_ALLOW_SUPERUSER=1 \
+    USE_ZEND_ALLOC=0 \
+    ASAN_OPTIONS="symbolize=1:strict_string_checks=1:detect_stack_use_after_return=1:detect_leaks=0:print_summary=1" \
+    UBSAN_OPTIONS="print_stacktrace=1:print_summary=1"
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential autoconf bison re2c pkg-config make \
+        clang lld llvm \
+        gdb strace \
+        unzip \
+        libxml2-dev libssl-dev libonig-dev libsqlite3-dev zlib1g-dev \
+ && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /opt
+RUN git clone --depth 1 --branch "${PHP_GIT_REF}" "${PHP_GIT_URL}" php-src
+WORKDIR /opt/php-src
+RUN ./buildconf --force \
+ && ./configure \
+        --prefix=/usr/local/php \
+        --with-config-file-path=/usr/local/php/etc \
+        --with-config-file-scan-dir=/usr/local/php/etc/conf.d \
+        --enable-debug \
+        --enable-address-sanitizer \
+        --enable-undefined-sanitizer \
+        --enable-cli \
+        --enable-mbstring \
+        --enable-pcntl \
+        --with-openssl \
+        --with-zlib \
+ && make -j"$(nproc)" \
+ && make install \
+ && mkdir -p /usr/local/php/etc/conf.d \
+ && cp php.ini-development /usr/local/php/etc/php.ini
+
+COPY <<'INI' /usr/local/php/etc/conf.d/99-scrutineer.ini
+zend.assertions=1
+phar.readonly=0
+memory_limit=-1
+date.timezone=UTC
+INI
+
+ENV CFLAGS="-fsanitize=address -DZEND_TRACK_ARENA_ALLOC -fsanitize=undefined -fno-sanitize-recover=undefined -fno-sanitize=object-size -fno-omit-frame-pointer -g -O1" \
+    CXXFLAGS="-fsanitize=address -DZEND_TRACK_ARENA_ALLOC -fsanitize=undefined -fno-sanitize-recover=undefined -fno-sanitize=object-size -fno-omit-frame-pointer -g -O1" \
+    LDFLAGS="-fsanitize=address -fsanitize=undefined"
+
+COPY --from=composer /usr/bin/composer /usr/local/bin/composer
+
+RUN php -v 2>&1 | grep -qE "DEBUG\)" && \
+    php-config --configure-options | grep -q "address-sanitizer" && \
+    php-config --configure-options | grep -q "undefined-sanitizer" && \
+    composer --version && gdb --version
+
+USER runner

--- a/docker/profiles/php-ext/PROFILE.md
+++ b/docker/profiles/php-ext/PROFILE.md
@@ -1,0 +1,118 @@
+# PHP-extension scanning container
+
+The repository under `./src` is a PHP-C extension. The job is to find **security vulnerabilities** in it.
+
+## Why this container
+
+PHP here is built **debug + AddressSanitizer + UndefinedBehaviorSanitizer**. ASan/UBSan are detection tooling: they
+turn silent memory corruption into loud, pinpointable hits so you can actually find bugs in C code instead of guessing
+from static reading. They are not the deliverable.
+
+The deliverable is a security finding: what the bug is, what an attacker controls from the PHP side, what the impact
+is (info disclosure, memory corruption → RCE, DoS, type confusion bypassing a security check), and a reproducer that
+shows it. A sanitizer hit is a starting point, not a report.
+
+If a specific case genuinely needs uninstrumented PHP (you suspect a sanitizer false positive — e.g., interceptor
+mismatch), say so in the finding and `apt-get install -y php-cli` for one. Don't make it the default workflow.
+
+## Layout
+
+- `./src` — extension source (start here).
+- `/usr/local/php` — debug+ASan+UBSan PHP. `php`, `phpize`, `php-config` on PATH. `php -v` reports `(DEBUG)`.
+- `/opt/php-src` — PHP source tree. Cross-reference Zend internals (`Zend/zend_*.h`) when triaging.
+- `composer`, `gh`, `claude`, `gdb`, `strace` — on PATH.
+
+## gcc vs clang
+
+PHP is gcc-built, so its ASan runtime is gcc's `libasan.so`.
+
+- **PHP extensions** (anything you `extension=` into PHP): build with **gcc** (the default `cc`). The pre-exported
+  `CFLAGS`/`LDFLAGS` work as-is. A clang-built `.so` dlopen'd into the gcc-asan PHP aborts with runtime-mismatch.
+- **Standalone fuzz harnesses, libFuzzer targets, test programs**: build with **clang** (`CC=clang CXX=clang++`).
+  Same sanitizer flags; clang additionally gives `-fsanitize=fuzzer`, `-fsanitize=memory`, `-fsanitize=thread`.
+- **Rebuilding PHP itself with clang**: supported but invasive — re-run `/opt/php-src` configure with
+  `CC=clang CXX=clang++`. Clang-built extensions will then load. Don't mix afterward.
+
+## Sanitizer config (pre-exported)
+
+```
+USE_ZEND_ALLOC=0
+  Disables Zend's arena allocator. Without this, ASan sees only the big chunks Zend asks libc for, not the
+  per-emalloc sub-allocations inside them — most extension bugs would slip past. Keep on for analysis.
+
+ASAN_OPTIONS=
+  symbolize=1                       readable stack traces
+  strict_string_checks=1            catch strlen/strcpy on non-NUL-terminated bufs
+  detect_stack_use_after_return=1   catch returning pointer-to-stack
+  detect_leaks=0                    PHP has known startup leaks; flip to 1 only when chasing a focused suspect
+  print_summary=1                   one-line summary at the end
+
+UBSAN_OPTIONS=
+  print_stacktrace=1
+  print_summary=1
+```
+
+Re-running a confusing hit with `USE_ZEND_ALLOC=1` sometimes produces a cleaner trace — useful while investigating;
+the underlying bug exists either way.
+
+## Building the extension
+
+```bash
+cd src
+phpize
+./configure --enable-<name>   # macro from PHP_ARG_ENABLE in config.m4
+make -j"$(nproc)"
+
+# Smoke load
+php -d extension="$(pwd)/modules/<name>.so" --ri <name>
+```
+
+Only run the full `make test` suite when investigating something specific — it's slow and noisy.
+
+## Investigating a sanitizer hit
+
+A hit means there's a memory-safety bug in C code. The investigation is figuring out whether it's security-relevant
+and how. Work the bug, don't just file the trace.
+
+1. **What is the primitive?** Read the ASan/UBSan output — heap-buffer-overflow (read or write?), UAF, double-free,
+   stack-buffer-overflow, integer overflow into allocation, type confusion. Each has a different ceiling for
+   exploitability.
+2. **What does an attacker control?** Walk back from the crashing call to the PHP-level entry point — the
+   `ZEND_FUNCTION(...)`, the `zend_parse_parameters`. Which argument's length / contents / type reaches the bad code?
+   Could a script (or a `.phpt`, an HTTP route, a Phar) realistically pass that?
+3. **What is the impact?**
+   - OOB read → potential info disclosure (heap contents readable back from PHP / leaked over the wire).
+   - OOB write / UAF / double-free → memory corruption; in native code that's frequently RCE-able.
+   - Integer overflow into alloc → undersized buffer + subsequent write → heap overflow.
+   - Type confusion (missing `Z_TYPE_P` check, wrong `convert_to_*`) → pivots to one of the above, or bypasses a
+     security check in pure PHP land.
+   - UBSan-only hits (e.g., signed overflow) → may be benign, may underpin a real bug. Chase the consequence, not
+     the UBSan label.
+4. **Reduce to the smallest reproducer that still triggers it.** Strip dependencies, strip noise — minimal PHP, only
+   what's needed. The minimal form is the evidence.
+5. Cross-reference `/opt/php-src` for Zend macro semantics (`ZVAL_*`, `Z_ADDREF_P`, `OBJ_RELEASE`, arena vs emalloc)
+   when the surrounding C uses contracts whose details aren't local.
+
+## Creating reproducers
+
+A reproducer demonstrates the security bug, not just that something crashed. It must be something you actually ran
+in this container. If you couldn't run it here, say so explicitly — never invent one.
+
+- Small case: a script run with `php -d extension="$(pwd)/modules/<name>.so" /tmp/poc.php`.
+- Regression-style: a `.phpt` under the project's `tests/`, run via `make test TESTS=tests/<file>.phpt`.
+- The reproducer should show the **attacker-controlled input** reaching the bug — what PHP-level call, what argument,
+  what value. A bug that only triggers under values nobody could realistically supply is a weak finding; either find
+  the real attack surface or downgrade the report.
+- Quote the sanitizer output as **evidence** that the bug fires (the `SUMMARY:` line plus the relevant top of the
+  stack), then describe what the bug is in one line — e.g., "1-byte heap-buffer-overflow write at
+  `foo_parse_header+0x42`, byte sourced from attacker-supplied `$header[i]`".
+- Where you can, push further: an OOB read PoC that prints leaked heap bytes back through PHP, a type-confusion PoC
+  that bypasses a `Z_TYPE_P` check and reaches an unintended path. "Potential RCE" with no demonstrated primitive is
+  a hypothesis — say so honestly rather than overclaiming.
+
+## Rules
+
+- Back every claim with a command you ran in the container. Prefer running things over static reasoning.
+- Build the extension before analyzing. If `config.m4` exists but no `Makefile`, run
+  `phpize && ./configure --enable-<name> && make`.
+- Install missing build deps via `apt-get` without asking.

--- a/docker/profiles/php/Dockerfile
+++ b/docker/profiles/php/Dockerfile
@@ -6,6 +6,10 @@ FROM composer:2.9.8 AS composer
 
 FROM ${RUNNER_IMAGE}
 
+ARG PHP_VERSION=8.4.21-3+0~20260514.49+debian12~1.gbp45ccaf
+# php8.4-redis is the only PECL pkg whose sury build differs across arches.
+ARG TARGETARCH
+
 USER root
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -17,16 +21,47 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
  && echo "deb [signed-by=/etc/apt/keyrings/sury-php.gpg] https://packages.sury.org/php/ $(lsb_release -sc) main" \
         > /etc/apt/sources.list.d/sury-php.list \
  && apt-get update \
+ && case "${TARGETARCH}" in \
+      amd64) PHP_REDIS=6.3.0-2+0~20251204.66+debian12~1.gbpd148c3 ;; \
+      arm64) PHP_REDIS=6.3.0-1+0~20251120.64+debian12~1.gbpd464c1 ;; \
+      *) echo "unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;; \
+    esac \
  && apt-get install -y --no-install-recommends \
-        php8.4-cli php8.4-common php8.4-dev \
-        php8.4-amqp php8.4-apcu php8.4-bcmath php8.4-bz2 php8.4-curl \
-        php8.4-dba php8.4-gd php8.4-gmp php8.4-grpc php8.4-igbinary \
-        php8.4-imagick php8.4-imap php8.4-intl php8.4-ldap \
-        php8.4-mbstring php8.4-memcached php8.4-mongodb php8.4-msgpack \
-        php8.4-mysql php8.4-opcache php8.4-pgsql php8.4-protobuf \
-        php8.4-rdkafka php8.4-redis php8.4-snmp php8.4-soap \
-        php8.4-sqlite3 php8.4-tidy php8.4-xml php8.4-xsl \
-        php8.4-yaml php8.4-zip \
+        php8.4-cli=${PHP_VERSION} \
+        php8.4-common=${PHP_VERSION} \
+        php8.4-dev=${PHP_VERSION} \
+        php8.4-bcmath=${PHP_VERSION} \
+        php8.4-bz2=${PHP_VERSION} \
+        php8.4-curl=${PHP_VERSION} \
+        php8.4-dba=${PHP_VERSION} \
+        php8.4-gd=${PHP_VERSION} \
+        php8.4-gmp=${PHP_VERSION} \
+        php8.4-intl=${PHP_VERSION} \
+        php8.4-ldap=${PHP_VERSION} \
+        php8.4-mbstring=${PHP_VERSION} \
+        php8.4-mysql=${PHP_VERSION} \
+        php8.4-opcache=${PHP_VERSION} \
+        php8.4-pgsql=${PHP_VERSION} \
+        php8.4-snmp=${PHP_VERSION} \
+        php8.4-soap=${PHP_VERSION} \
+        php8.4-sqlite3=${PHP_VERSION} \
+        php8.4-tidy=${PHP_VERSION} \
+        php8.4-xml=${PHP_VERSION} \
+        php8.4-xsl=${PHP_VERSION} \
+        php8.4-zip=${PHP_VERSION} \
+        php8.4-amqp=2.1.2-7+0~20260519.35+debian12~1.gbpff72ce \
+        php8.4-apcu=5.1.28-1+0~20260518.58+debian12~1.gbp5969fc \
+        php8.4-grpc=1.80.0-1+0~20260331.43+debian12~1.gbpa12d0b \
+        php8.4-igbinary=3.2.16-6+0~20260330.57+debian12~1.gbp1eff65 \
+        php8.4-imagick=3.8.1-1+0~20251220.54+debian12~1.gbpde1d95 \
+        php8.4-imap=3:1.0.3-2+0~20251203.6+debian12~1.gbp0bf79d \
+        php8.4-memcached=3.4.0-1+0~20260331.75+debian12~1.gbp3fb0c0 \
+        php8.4-mongodb=2.1.4-4+0~20251203.65+debian12~1.gbp6dbd50 \
+        php8.4-msgpack=1:3.0.0-2+0~20251124.50+debian12~1.gbp330ae0 \
+        php8.4-protobuf=4.33.2-1+0~20251220.29+debian12~1.gbp93d410 \
+        php8.4-rdkafka=6.0.5-2+0~20251124.9+debian12~1.gbpdc15a9 \
+        php8.4-redis=${PHP_REDIS} \
+        php8.4-yaml=2.3.0-2+0~20251124.42+debian12~1.gbp29d390 \
         build-essential autoconf libtool pkg-config re2c \
  && rm -rf /var/lib/apt/lists/*
 

--- a/docker/profiles/php/Dockerfile
+++ b/docker/profiles/php/Dockerfile
@@ -1,35 +1,72 @@
-# PHP profile. Extends the scrutineer runner with a PHP interpreter so
-# scans of Composer projects can audit or reproduce in-place.
-#
-# Built on demand by the worker; the image tag is content-addressed on
-# this Dockerfile's sha so an edit invalidates the cache automatically.
-#
-#   docker build --build-arg RUNNER_IMAGE=<digest-pinned-runner> \
-#     -t scrutineer-profile-php:<sha> docker/profiles/php
+# PHP profile.
 
 ARG RUNNER_IMAGE=ghcr.io/alpha-omega-security/scrutineer-runner:latest
+
+FROM composer:2.9.8 AS composer
+
 FROM ${RUNNER_IMAGE}
 
-ARG PHP_VERSION=8.4.21-3+0~20260514.49+debian12~1.gbp45ccaf
-
 USER root
-# sury packages PHP 8.4 for bookworm; signed-by keyring, no apt-key.
-# Extension parity with the prior Alpine pin (phar, openssl, tokenizer,
-# fileinfo, iconv, dom, simplexml, xml, xmlwriter): php8.4-cli covers
-# phar/openssl/tokenizer/fileinfo/iconv as builtins; php8.4-xml covers
-# dom/simplexml/xml/xmlwriter; mbstring and curl are their own packages.
-RUN install -d -m 0755 /etc/apt/keyrings \
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        gnupg lsb-release \
+ && install -d -m 0755 /etc/apt/keyrings \
  && curl -fsSL https://packages.sury.org/php/apt.gpg \
         -o /etc/apt/keyrings/sury-php.gpg \
  && chmod go+r /etc/apt/keyrings/sury-php.gpg \
- && echo "deb [signed-by=/etc/apt/keyrings/sury-php.gpg] https://packages.sury.org/php/ bookworm main" \
+ && echo "deb [signed-by=/etc/apt/keyrings/sury-php.gpg] https://packages.sury.org/php/ $(lsb_release -sc) main" \
         > /etc/apt/sources.list.d/sury-php.list \
  && apt-get update \
  && apt-get install -y --no-install-recommends \
-        php8.4-cli=${PHP_VERSION} \
-        php8.4-mbstring=${PHP_VERSION} \
-        php8.4-curl=${PHP_VERSION} \
-        php8.4-xml=${PHP_VERSION} \
+        php8.4-cli php8.4-common php8.4-dev \
+        php8.4-amqp php8.4-apcu php8.4-bcmath php8.4-bz2 php8.4-curl \
+        php8.4-dba php8.4-gd php8.4-gmp php8.4-grpc php8.4-igbinary \
+        php8.4-imagick php8.4-imap php8.4-intl php8.4-ldap \
+        php8.4-mbstring php8.4-memcached php8.4-mongodb php8.4-msgpack \
+        php8.4-mysql php8.4-opcache php8.4-pgsql php8.4-protobuf \
+        php8.4-rdkafka php8.4-redis php8.4-snmp php8.4-soap \
+        php8.4-sqlite3 php8.4-tidy php8.4-xml php8.4-xsl \
+        php8.4-yaml php8.4-zip \
+        build-essential autoconf libtool pkg-config re2c \
  && rm -rf /var/lib/apt/lists/*
+
+COPY --from=composer /usr/bin/composer /usr/local/bin/composer
+
+ARG PIE_VERSION=1.4.5
+ARG PIE_SHA256=6cdc03b8861b290d4e2a61147082a9f21dac5af572c66f0d121f266361499662
+RUN install -d /usr/local/lib/pie && \
+    curl -fsSL -o /usr/local/lib/pie/pie.phar \
+        "https://github.com/php/pie/releases/download/${PIE_VERSION}/pie.phar" && \
+    echo "${PIE_SHA256}  /usr/local/lib/pie/pie.phar" | sha256sum -c - && \
+    chmod +x /usr/local/lib/pie/pie.phar
+
+# pie unpacks tarballs under $HOME/.pie and runs configure/make there. The
+# worker sets HOME=/tmp, but /tmp is mounted noexec so unpacked shell helpers
+# (shtool, libtool) won't execute. Wrapper redirects HOME to a real
+# (exec-capable) image dir; 1777 so any host uid can write.
+RUN install -d -m 1777 /opt/pie-home
+COPY <<'WRAP' /usr/local/bin/pie
+#!/bin/sh
+exec env HOME=/opt/pie-home /usr/local/lib/pie/pie.phar "$@"
+WRAP
+RUN chmod +x /usr/local/bin/pie
+
+# memory_limit: Avoid OOMs from default limits
+# date.timezone: otherwise every CLI run prints an implicit-tz warning that leaks into findings.
+# phar.readonly: lets a PoC build a hostile phar to confirm a deserialization sink, not just read one.
+COPY <<'INI' /etc/php/8.4/cli/conf.d/99-scrutineer.ini
+zend.assertions=0
+phar.readonly=0
+memory_limit=-1
+date.timezone=UTC
+INI
+
+# pie writes the built .so into the extension dir and an enable-ini into conf.d.
+# The runtime user is the host's uid (docker --user $(id -u):$(id -g)), not the
+# image's runner, so make both paths writable by any uid. Container is ephemeral
+# and --rm'd after the scan, so the blast radius of a malicious write is zero.
+RUN chmod 1777 /usr/lib/php/20240924 /etc/php/8.4/cli/conf.d
+
+RUN php -v && composer --version && pie --version
 
 USER runner

--- a/docker/profiles/php/PROFILE.md
+++ b/docker/profiles/php/PROFILE.md
@@ -11,7 +11,7 @@ The repository under `./src` is a PHP project.
 
 ## Operating procedure
 
-### Code scanning preperations
+### Code scanning preparations
 
 Before deeper analysis, `./src/composer.lock` exists, install dependencies first:
 

--- a/docker/profiles/php/PROFILE.md
+++ b/docker/profiles/php/PROFILE.md
@@ -1,0 +1,44 @@
+# PHP scanning container
+
+The repository under `./src` is a PHP project.
+
+## Runtime
+
+- **PHP 8.4** — `php`
+- **`composer`** 2.x on PATH. Use `--no-interaction --no-progress`.
+- **`phpize`, `php-config`** on PATH (from `php8.4-dev`) for projects that build their own native extensions.
+- **`pie`** on PATH. Installs PIE-compatible PHP extensions at scan time, e.g. `pie install xdebug/xdebug`.
+
+## Operating procedure
+
+### Code scanning preperations
+
+Before deeper analysis, `./src/composer.lock` exists, install dependencies first:
+
+```bash
+cd src && composer install --no-interaction --no-progress
+```
+
+If only `composer.json` exists (no lock), call out the missing lock in the report but try anyway. If composer fails
+with `Could not resolve host` the scan is offline — proceed without vendored deps and note which checks you had to
+skip.
+
+### Creating reproducers
+
+Every finding ships with a reproducer — a small piece of code that, when run in this container, actually triggers the
+issue. Paste the exact command you ran and the verbatim output (error message, return value, observable side effect)
+into the finding. Reasoning-only or "this would" reproducers do not count; if you couldn't run it here, say so
+explicitly instead of inventing one.
+
+- One-liner: `php -r '<code>'`
+- Multi-line: write to `/tmp/poc.php`, run `php /tmp/poc.php`
+- If the reproducer depends on the project's autoloader or classes, run from `./src` after `composer install` so
+  `vendor/autoload.php` resolves
+- For framework- or HTTP-routed bugs, isolate the vulnerable call and invoke it directly with the malicious input
+  rather than spinning up a server — keeps the reproducer minimal and the evidence trivial to verify
+- If you need an extension not in `php -m`, `pie install <vendor>/<package>` first and note that in the finding
+
+## Out of scope
+
+- `./src/vendor/` after `composer install` — third-party code, not the target of this scan unless a finding
+   specifically pivots there.

--- a/internal/worker/docker.go
+++ b/internal/worker/docker.go
@@ -95,6 +95,17 @@ func (d DockerRunner) RunSkill(ctx context.Context, sj SkillJob, emit func(Event
 		}
 		return SkillResult{Commit: commit, Profile: profile}, fmt.Errorf("skill %q requires profile %q, resolved %q", sj.Name, sj.RequiresProfile, got)
 	}
+	profileGuide := d.profileGuidePath(profile)
+	if profileGuide != "" {
+		target := filepath.Join(absWork, "CLAUDE.md")
+		if data, err := os.ReadFile(profileGuide); err != nil {
+			emit(Event{Kind: KindText, Text: "profile guide: read " + profileGuide + ": " + err.Error()})
+		} else if err := os.WriteFile(target, data, 0o644); err != nil {
+			emit(Event{Kind: KindText, Text: "profile guide: write " + target + ": " + err.Error()})
+		} else {
+			emit(Event{Kind: KindText, Text: "profile guide: " + profileGuide + " -> /work/CLAUDE.md"})
+		}
+	}
 
 	var outPath string
 	if sj.OutputFile != "" {
@@ -240,6 +251,26 @@ func (d DockerRunner) resolveProfile(ctx context.Context, requested, src string,
 	}
 	emit(Event{Kind: KindText, Text: "profile: " + p.Name + " (" + img + ")"})
 	return p.Name, img
+}
+
+// profileGuidePath returns the profile's on-disk PROFILE.md if present.
+// The caller mounts it at the agent's project-memory path (CLAUDE.md
+// for claude-code) so it's auto-loaded before the skill prompt runs.
+// The on-disk name stays agent-neutral to support a future codex runner
+// reading the same file as AGENTS.md.
+func (d DockerRunner) profileGuidePath(profile string) string {
+	if profile == "" || d.ProfilesDir == "" {
+		return ""
+	}
+	guide := filepath.Join(d.ProfilesDir, profile, "PROFILE.md")
+	abs, err := filepath.Abs(guide)
+	if err != nil {
+		return ""
+	}
+	if _, err := os.Stat(abs); err != nil {
+		return ""
+	}
+	return abs
 }
 
 // DockerAvailable checks if docker is in PATH and the daemon is reachable.

--- a/internal/worker/docker.go
+++ b/internal/worker/docker.go
@@ -74,14 +74,8 @@ func (d DockerRunner) RunSkill(ctx context.Context, sj SkillJob, emit func(Event
 			return SkillResult{}, err
 		}
 	}
-	if d.Hardened {
-		size, err := dirSize(sj.WorkRoot)
-		if err != nil {
-			return SkillResult{}, fmt.Errorf("hardened workspace size check: %w", err)
-		}
-		if size > HardenedWorkspaceCapBytes {
-			return SkillResult{}, fmt.Errorf("hardened workspace exceeds %d bytes after clone (got %d)", HardenedWorkspaceCapBytes, size)
-		}
+	if err := d.checkHardenedWorkspace(sj.WorkRoot); err != nil {
+		return SkillResult{}, err
 	}
 	commit := gitHead(src)
 	work := sj.WorkRoot
@@ -95,17 +89,7 @@ func (d DockerRunner) RunSkill(ctx context.Context, sj SkillJob, emit func(Event
 		}
 		return SkillResult{Commit: commit, Profile: profile}, fmt.Errorf("skill %q requires profile %q, resolved %q", sj.Name, sj.RequiresProfile, got)
 	}
-	profileGuide := d.profileGuidePath(profile)
-	if profileGuide != "" {
-		target := filepath.Join(absWork, "CLAUDE.md")
-		if data, err := os.ReadFile(profileGuide); err != nil {
-			emit(Event{Kind: KindText, Text: "profile guide: read " + profileGuide + ": " + err.Error()})
-		} else if err := os.WriteFile(target, data, 0o644); err != nil {
-			emit(Event{Kind: KindText, Text: "profile guide: write " + target + ": " + err.Error()})
-		} else {
-			emit(Event{Kind: KindText, Text: "profile guide: " + profileGuide + " -> /work/CLAUDE.md"})
-		}
-	}
+	d.injectProfileGuide(profile, absWork, emit)
 
 	var outPath string
 	if sj.OutputFile != "" {
@@ -251,6 +235,53 @@ func (d DockerRunner) resolveProfile(ctx context.Context, requested, src string,
 	}
 	emit(Event{Kind: KindText, Text: "profile: " + p.Name + " (" + img + ")"})
 	return p.Name, img
+}
+
+// profileGuideFileMode is the mode used when copying a profile's
+// PROFILE.md into the workspace as CLAUDE.md. The workspace already
+// belongs to the host user (the docker runner mounts it as that uid),
+// so a plain 0644 keeps it readable by the agent without surprises.
+const profileGuideFileMode os.FileMode = 0o644
+
+// checkHardenedWorkspace returns an error when hardened mode is on
+// and the cloned workspace exceeds HardenedWorkspaceCapBytes. A no-op
+// outside hardened mode so the cap doesn't apply to default scans.
+func (d DockerRunner) checkHardenedWorkspace(workRoot string) error {
+	if !d.Hardened {
+		return nil
+	}
+	size, err := dirSize(workRoot)
+	if err != nil {
+		return fmt.Errorf("hardened workspace size check: %w", err)
+	}
+	if size > HardenedWorkspaceCapBytes {
+		return fmt.Errorf("hardened workspace exceeds %d bytes after clone (got %d)", HardenedWorkspaceCapBytes, size)
+	}
+	return nil
+}
+
+// injectProfileGuide copies the resolved profile's PROFILE.md into the
+// workspace as CLAUDE.md so claude-code auto-loads it as project memory
+// ahead of the skill prompt. A workspace copy (rather than a bind mount)
+// avoids Docker Desktop's refusal to materialise a sub-path mountpoint
+// inside another bind mount. No-ops when the profile has no guide;
+// failures are reported via emit but never block the scan.
+func (d DockerRunner) injectProfileGuide(profile, absWork string, emit func(Event)) {
+	guide := d.profileGuidePath(profile)
+	if guide == "" {
+		return
+	}
+	target := filepath.Join(absWork, "CLAUDE.md")
+	data, err := os.ReadFile(guide)
+	if err != nil {
+		emit(Event{Kind: KindText, Text: "profile guide: read " + guide + ": " + err.Error()})
+		return
+	}
+	if err := os.WriteFile(target, data, profileGuideFileMode); err != nil {
+		emit(Event{Kind: KindText, Text: "profile guide: write " + target + ": " + err.Error()})
+		return
+	}
+	emit(Event{Kind: KindText, Text: "profile guide: " + guide + " -> /work/CLAUDE.md"})
 }
 
 // profileGuidePath returns the profile's on-disk PROFILE.md if present.

--- a/internal/worker/profile.go
+++ b/internal/worker/profile.go
@@ -1,18 +1,29 @@
 package worker
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync"
 )
+
+// ProfileMarker refines profile selection beyond what brief reports.
+// Path is relative to the cloned source root; Contains, when set, must
+// also appear inside the file — used e.g. to distinguish a phpize
+// config.m4 from any unrelated autoconf file.
+type ProfileMarker struct {
+	Path     string
+	Contains string
+}
 
 // Profile selects a per-ecosystem runner image. The default profile
 // (empty name) uses the runner image configured globally; named profiles
@@ -22,20 +33,29 @@ type Profile struct {
 	// Name matches the directory under docker/profiles/. Empty means
 	// "use the default runner image, no per-profile build".
 	Name string
-	// Ecosystem is the `brief` package_managers[0].name that auto-selects
-	// this profile. Matched case-insensitively.
+	// Ecosystem is a `brief` package_managers[].name, matched
+	// case-insensitively. Empty falls back to Markers — useful for
+	// ecosystems brief cannot see (e.g. a PECL C extension repo without
+	// composer.json).
 	Ecosystem string
+	Markers   []ProfileMarker
 }
 
 // IsDefault reports whether p falls back to the configured runner image
 // instead of a profile-specific built one.
 func (p Profile) IsDefault() bool { return p.Name == "" }
 
-// builtinProfiles is the v1 registry. Add a new entry plus a Dockerfile
-// under docker/profiles/<name>/ to expose a profile. Kept in code (not
-// YAML) until a second/third profile lands and the duplication justifies
-// the indirection.
+// builtinProfiles is the v1 registry. Order matters: first match wins,
+// so more specific profiles (php-ext) come before their general
+// counterparts (php). Add a new entry plus a Dockerfile under
+// docker/profiles/<name>/ to expose a profile.
 var builtinProfiles = []Profile{
+	{
+		Name: "php-ext",
+		Markers: []ProfileMarker{
+			{Path: "config.m4", Contains: "PHP_ARG_"},
+		},
+	},
 	{Name: "php", Ecosystem: "Composer"},
 }
 
@@ -77,26 +97,78 @@ func IsNamedProfile(name string) bool {
 	return false
 }
 
-// matchProfile picks the registered profile whose Ecosystem matches the
-// first package manager `brief` detected. Returns the zero profile when
-// nothing matches.
-func matchProfile(briefOut []byte) Profile {
+func matchProfile(briefOut []byte, srcDir string) Profile {
 	var brief struct {
 		PackageManagers []struct {
 			Name string `json:"name"`
 		} `json:"package_managers"`
 	}
-	if err := json.Unmarshal(briefOut, &brief); err != nil {
-		return Profile{}
-	}
+	_ = json.Unmarshal(briefOut, &brief)
+	pms := make([]string, 0, len(brief.PackageManagers))
 	for _, pm := range brief.PackageManagers {
-		for _, p := range builtinProfiles {
-			if strings.EqualFold(pm.Name, p.Ecosystem) {
-				return p
-			}
+		pms = append(pms, pm.Name)
+	}
+	for _, p := range builtinProfiles {
+		if !ecosystemMatch(p.Ecosystem, pms) {
+			continue
 		}
+		if !markersMatch(p.Markers, srcDir) {
+			continue
+		}
+		return p
 	}
 	return Profile{}
+}
+
+func ecosystemMatch(ecosystem string, pms []string) bool {
+	if ecosystem == "" {
+		return true
+	}
+	for _, pm := range pms {
+		if strings.EqualFold(pm, ecosystem) {
+			return true
+		}
+	}
+	return false
+}
+
+func markersMatch(markers []ProfileMarker, srcDir string) bool {
+	if len(markers) == 0 {
+		return true
+	}
+	if srcDir == "" {
+		return false
+	}
+	for _, m := range markers {
+		full := filepath.Join(srcDir, m.Path)
+		if m.Contains == "" {
+			if _, err := os.Stat(full); err != nil {
+				return false
+			}
+			continue
+		}
+		if !fileContains(full, m.Contains) {
+			return false
+		}
+	}
+	return true
+}
+
+// markerReadCap bounds Contains-substring scans so a hostile or
+// runaway file can't stall detection.
+const markerReadCap = 1 << 20
+
+func fileContains(path, needle string) bool {
+	f, err := os.Open(path)
+	if err != nil {
+		return false
+	}
+	defer func() { _ = f.Close() }()
+	b, err := io.ReadAll(io.LimitReader(f, markerReadCap))
+	if err != nil {
+		return false
+	}
+	return bytes.Contains(b, []byte(needle))
 }
 
 // DetectProfile runs `brief` against the cloned source inside the
@@ -117,9 +189,10 @@ func DetectProfile(ctx context.Context, runnerImage, srcDir string) Profile {
 	)
 	out, err := cmd.Output()
 	if err != nil {
-		return Profile{}
+		// Marker-only profiles can still match when brief is unavailable.
+		out = nil
 	}
-	return matchProfile(out)
+	return matchProfile(out, absSrc)
 }
 
 // ErrNoProfilesDir is returned by EnsureImage when the worker has no

--- a/internal/worker/profile_test.go
+++ b/internal/worker/profile_test.go
@@ -48,10 +48,12 @@ const configM4WithoutPHPArg = `dnl just a stray autoconf file
 AC_INIT([thing], [1.0])
 `
 
-func writeMarker(t *testing.T, dir, name, contents string) {
+func writeConfigM4(t *testing.T, dir, contents string) {
 	t.Helper()
-	if err := os.WriteFile(filepath.Join(dir, name), []byte(contents), 0o644); err != nil {
-		t.Fatalf("write %s: %v", name, err)
+	const configM4FileMode = 0o644
+	path := filepath.Join(dir, "config.m4")
+	if err := os.WriteFile(path, []byte(contents), configM4FileMode); err != nil {
+		t.Fatalf("write %s: %v", path, err)
 	}
 }
 
@@ -107,7 +109,7 @@ func TestMatchProfile(t *testing.T) {
 			name: "config.m4 with PHP_ARG selects php-ext",
 			json: `{"package_managers":[]}`,
 			setup: func(t *testing.T, dir string) {
-				writeMarker(t, dir, "config.m4", configM4Body)
+				writeConfigM4(t, dir, configM4Body)
 			},
 			want: "php-ext",
 		},
@@ -115,7 +117,7 @@ func TestMatchProfile(t *testing.T) {
 			name: "php-ext wins over php when both signals present",
 			json: `{"package_managers":[{"name":"Composer"}]}`,
 			setup: func(t *testing.T, dir string) {
-				writeMarker(t, dir, "config.m4", configM4Body)
+				writeConfigM4(t, dir, configM4Body)
 			},
 			want: "php-ext",
 		},
@@ -123,7 +125,7 @@ func TestMatchProfile(t *testing.T) {
 			name: "config.m4 without PHP_ARG does not match php-ext",
 			json: `{"package_managers":[{"name":"Composer"}]}`,
 			setup: func(t *testing.T, dir string) {
-				writeMarker(t, dir, "config.m4", configM4WithoutPHPArg)
+				writeConfigM4(t, dir, configM4WithoutPHPArg)
 			},
 			want: "php", // composer marker still picks php
 		},
@@ -131,7 +133,7 @@ func TestMatchProfile(t *testing.T) {
 			name: "config.m4 without PHP_ARG and no composer falls back",
 			json: `{"package_managers":[]}`,
 			setup: func(t *testing.T, dir string) {
-				writeMarker(t, dir, "config.m4", configM4WithoutPHPArg)
+				writeConfigM4(t, dir, configM4WithoutPHPArg)
 			},
 			want: "",
 		},

--- a/internal/worker/profile_test.go
+++ b/internal/worker/profile_test.go
@@ -18,6 +18,7 @@ func TestProfileByName(t *testing.T) {
 		{"", "", true, false},
 		{"default", "", true, false},
 		{"php", "php", true, true},
+		{"php-ext", "php-ext", true, true},
 		{"unknown", "", false, false},
 	}
 	for _, tt := range tests {
@@ -36,24 +37,121 @@ func TestProfileByName(t *testing.T) {
 	}
 }
 
+const configM4Body = `dnl Minimal extension config
+PHP_ARG_ENABLE([example], [whether to enable example], [--enable-example])
+if test "$PHP_EXAMPLE" != "no"; then
+  PHP_NEW_EXTENSION(example, example.c, $ext_shared)
+fi
+`
+
+const configM4WithoutPHPArg = `dnl just a stray autoconf file
+AC_INIT([thing], [1.0])
+`
+
+func writeMarker(t *testing.T, dir, name, contents string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(contents), 0o644); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+}
+
 func TestMatchProfile(t *testing.T) {
 	tests := []struct {
-		name string
-		json string
-		want string
+		name    string
+		json    string
+		setup   func(t *testing.T, dir string)
+		want    string
+		noSrcOK bool // if true, srcDir is "" for this case
 	}{
-		{"composer matches php", `{"package_managers":[{"name":"Composer"}]}`, "php"},
-		{"composer case-insensitive", `{"package_managers":[{"name":"composer"}]}`, "php"},
-		{"first match wins over later", `{"package_managers":[{"name":"Composer"},{"name":"npm"}]}`, "php"},
-		{"unknown manager falls back", `{"package_managers":[{"name":"npm"}]}`, ""},
-		{"empty list falls back", `{"package_managers":[]}`, ""},
-		{"missing field falls back", `{}`, ""},
-		{"invalid json falls back", `not json`, ""},
-		{"no first match but later is known", `{"package_managers":[{"name":"npm"},{"name":"Composer"}]}`, "php"},
+		{
+			name: "composer matches php",
+			json: `{"package_managers":[{"name":"Composer"}]}`,
+			want: "php",
+		},
+		{
+			name: "composer case-insensitive",
+			json: `{"package_managers":[{"name":"composer"}]}`,
+			want: "php",
+		},
+		{
+			name: "first composer match wins",
+			json: `{"package_managers":[{"name":"Composer"},{"name":"npm"}]}`,
+			want: "php",
+		},
+		{
+			name: "composer present even if not first",
+			json: `{"package_managers":[{"name":"npm"},{"name":"Composer"}]}`,
+			want: "php",
+		},
+		{
+			name: "unknown manager falls back",
+			json: `{"package_managers":[{"name":"npm"}]}`,
+			want: "",
+		},
+		{
+			name: "empty manager list falls back",
+			json: `{"package_managers":[]}`,
+			want: "",
+		},
+		{
+			name: "missing field falls back",
+			json: `{}`,
+			want: "",
+		},
+		{
+			name: "invalid json falls back",
+			json: `not json`,
+			want: "",
+		},
+		{
+			name: "config.m4 with PHP_ARG selects php-ext",
+			json: `{"package_managers":[]}`,
+			setup: func(t *testing.T, dir string) {
+				writeMarker(t, dir, "config.m4", configM4Body)
+			},
+			want: "php-ext",
+		},
+		{
+			name: "php-ext wins over php when both signals present",
+			json: `{"package_managers":[{"name":"Composer"}]}`,
+			setup: func(t *testing.T, dir string) {
+				writeMarker(t, dir, "config.m4", configM4Body)
+			},
+			want: "php-ext",
+		},
+		{
+			name: "config.m4 without PHP_ARG does not match php-ext",
+			json: `{"package_managers":[{"name":"Composer"}]}`,
+			setup: func(t *testing.T, dir string) {
+				writeMarker(t, dir, "config.m4", configM4WithoutPHPArg)
+			},
+			want: "php", // composer marker still picks php
+		},
+		{
+			name: "config.m4 without PHP_ARG and no composer falls back",
+			json: `{"package_managers":[]}`,
+			setup: func(t *testing.T, dir string) {
+				writeMarker(t, dir, "config.m4", configM4WithoutPHPArg)
+			},
+			want: "",
+		},
+		{
+			name:    "marker profile cannot match without srcDir",
+			json:    `{"package_managers":[]}`,
+			noSrcOK: true,
+			want:    "",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := matchProfile([]byte(tt.json))
+			dir := ""
+			if !tt.noSrcOK {
+				dir = t.TempDir()
+			}
+			if tt.setup != nil {
+				tt.setup(t, dir)
+			}
+			got := matchProfile([]byte(tt.json), dir)
 			if got.Name != tt.want {
 				t.Errorf("matchProfile = %q, want %q", got.Name, tt.want)
 			}
@@ -122,8 +220,14 @@ func TestEnsureImage_missingDockerfile(t *testing.T) {
 func TestRepoShipsPHPDockerfile(t *testing.T) {
 	wd, _ := os.Getwd()
 	repoRoot := filepath.Join(wd, "..", "..")
-	path := filepath.Join(repoRoot, "docker", "profiles", "php", "Dockerfile")
-	if _, err := os.Stat(path); err != nil {
-		t.Errorf("expected php profile Dockerfile to exist: %v", err)
+	for _, profile := range []string{"php", "php-ext"} {
+		path := filepath.Join(repoRoot, "docker", "profiles", profile, "Dockerfile")
+		if _, err := os.Stat(path); err != nil {
+			t.Errorf("expected %s profile Dockerfile to exist: %v", profile, err)
+		}
+		guide := filepath.Join(repoRoot, "docker", "profiles", profile, "PROFILE.md")
+		if _, err := os.Stat(guide); err != nil {
+			t.Errorf("expected %s profile PROFILE.md to exist: %v", profile, err)
+		}
 	}
 }


### PR DESCRIPTION
This is a two-part change.

The main focus point is runner-specific agent instructions; the PHP runners are a good example and demonstrate the need and approach.

As we have #254 / #259 now with ecosystem-specific containers, this is something we can build on in two ways:

## Runner-specific agent instructions

PROFILE.md auto-injection. When a profile resolves, its docker/profiles/<name>/PROFILE.md is copied to the workspace as  CLAUDE.md before the container starts. claude-code reads that as  project memory. Each profile can give the agent a short orientation without touching the skills.

## Runner-containers more specific than just the ecosystem

**Why?**

PHP has extensions written in C, which need a different container than PHP userland code. But also should have different instructions than other C code.

My proposal is to have simple matching on top of brief for these cases. For PHP extensions it's easy: `config.m4` with `PHP_ARG_` in there should match well enough:

ProfileMarker. Match a profile on a file in the cloned source (path + optional substring), not just on what `brief` reports.  A PHP C-extension repo with a config.m4 containing PHP_ARG_ is now  detectable, even though it has no composer.json. The profile list  is ordered: marker-specific profiles (php-ext) win over general  ecosystems (php / composer).

---

The file is named PROFILE.md to not trigger any auto-injection when the repo is worked on and so it can be copied into an AGENTS.md for a codex or other runners in the future.

---

The main changes are in: f333cea0235c4608d6db1521d8d96cea1121051f

Cleanup diff is a big bigger than needed to avoid `//nolint:gocognit` 