### PR TITLE
feat: Add mass-verify button for findings

### DIFF
--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -236,6 +236,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("GET /findings/{id}/csaf.json", s.findingCSAF)
 	mux.HandleFunc("POST /findings/{id}/status", s.findingStatus)
 	mux.HandleFunc("POST /findings/{id}/verify", s.findingVerify)
+	mux.HandleFunc("POST /repositories/{id}/verify-all", s.repoVerifyAll)
 	mux.HandleFunc("POST /findings/{id}/disclose", s.findingDisclose)
 	mux.HandleFunc("POST /findings/{id}/patch", s.findingPatchRun)
 	mux.HandleFunc("POST /findings/{id}/exposure", s.findingExposureRun)
@@ -895,6 +896,77 @@ func (s *Server) runFindingSkill(w http.ResponseWriter, r *http.Request, name st
 	s.redirect(w, r, fmt.Sprintf("/scans/%d", scanID))
 }
 
+// repoVerifyAll is the bulk equivalent of the per-finding Verify button: it
+// enqueues the verify skill for every deep-dive finding on the repo that is
+// still awaiting verification (status "new"). The ?category= filter is
+// honoured so the action scope matches the visible (and badge-counted)
+// findings on the tab. Findings that already have a queued or running verify
+// scan are skipped, so re-clicking the button doesn't pile up duplicate jobs.
+func (s *Server) repoVerifyAll(w http.ResponseWriter, r *http.Request) {
+	repo, ok := loadByID[db.Repository](s, w, r)
+	if !ok {
+		return
+	}
+	var skill db.Skill
+	if err := s.DB.Where("name = ? AND active = ?", verifySkillName, true).First(&skill).Error; err != nil {
+		setFlash(w, Flash{Category: "error", Title: verifySkillName + " skill is not installed"})
+		s.redirect(w, r, fmt.Sprintf("/repositories/%d#rt4", repo.ID))
+		return
+	}
+
+	q := s.DB.Model(&db.Finding{}).
+		Where("repository_id = ? AND status = ? AND scan_id IN (?)",
+			repo.ID, db.FindingNew, deepDiveScanIDs(s.DB))
+	if category := r.URL.Query().Get("category"); category != "" {
+		q = applyCWECategoryFilter(q, category)
+	}
+	var findings []db.Finding
+	q.Select("id").Find(&findings)
+
+	model := r.FormValue("model")
+	var queued, skipped, errored int
+	for _, f := range findings {
+		var inflight int64
+		s.DB.Model(&db.Scan{}).
+			Where("finding_id = ? AND skill_id = ? AND status IN ?",
+				f.ID, skill.ID, []db.ScanStatus{db.ScanQueued, db.ScanRunning}).
+			Count(&inflight)
+		if inflight > 0 {
+			skipped++
+			continue
+		}
+		if _, err := s.enqueueSkillScoped(r.Context(), repo.ID, skill.ID, new(f.ID), model); err != nil {
+			errored++
+			continue
+		}
+		queued++
+	}
+	setFlash(w, verifyAllToast(queued, skipped, errored))
+	// Land on the Scans tab so the operator can watch the verify jobs run.
+	s.redirect(w, r, fmt.Sprintf("/repositories/%d#rt3", repo.ID))
+}
+
+func verifyAllToast(queued, skipped, errored int) Flash {
+	if queued == 0 && skipped == 0 && errored == 0 {
+		return Flash{Category: "success", Title: "No findings awaiting verification"}
+	}
+	parts := []string{fmt.Sprintf("%d queued", queued)}
+	if skipped > 0 {
+		parts = append(parts, fmt.Sprintf("%d already running", skipped))
+	}
+	if errored > 0 {
+		parts = append(parts, fmt.Sprintf("%d errored", errored))
+	}
+	cat := "success"
+	switch {
+	case errored > 0:
+		cat = "error"
+	case queued == 0:
+		cat = "warning"
+	}
+	return Flash{Category: cat, Title: "Verify all: " + strings.Join(parts, ", ")}
+}
+
 func (s *Server) findingNotes(w http.ResponseWriter, r *http.Request) {
 	f, ok := loadByID[db.Finding](s, w, r)
 	if !ok {
@@ -1315,6 +1387,18 @@ func (s *Server) repoShow(w http.ResponseWriter, r *http.Request) {
 	category := r.URL.Query().Get("category")
 	findings, scannerFindings, scanSkill, scanCommit := loadRepoFindings(s.DB, repo.ID, category)
 
+	// Count deep-dive findings still awaiting verification, scoped to the
+	// same category filter as the visible list. Drives the "Verify all new"
+	// button on the Findings tab; the bulk handler acts on this exact set.
+	newFindingsQuery := s.DB.Model(&db.Finding{}).
+		Where("repository_id = ? AND status = ? AND scan_id IN (?)",
+			repo.ID, db.FindingNew, deepDiveScanIDs(s.DB))
+	if category != "" {
+		newFindingsQuery = applyCWECategoryFilter(newFindingsQuery, category)
+	}
+	var newFindings int64
+	newFindingsQuery.Count(&newFindings)
+
 	var maintainers []db.Maintainer
 	s.DB.Joins("JOIN repository_maintainers ON repository_maintainers.maintainer_id = maintainers.id").
 		Where("repository_maintainers.repository_id = ?", repo.ID).Find(&maintainers)
@@ -1376,6 +1460,7 @@ func (s *Server) repoShow(w http.ResponseWriter, r *http.Request) {
 		"ScannerFindings": scannerFindings,
 		"ScanSkill":       scanSkill,
 		"ScanCommit":      scanCommit,
+		"NewFindingCount": int(newFindings),
 		"FailedScans":     failedScans,
 		"TotalCost":       totalCost,
 		"TMCommit":        tmCommit,

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -1787,6 +1787,120 @@ func TestEnqueueSkillWith_findingScopedJumpsQueue(t *testing.T) {
 	}
 }
 
+func TestRepoVerifyAll(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	repo := db.Repository{URL: "https://github.com/foo/bar", Name: "bar"}
+	s.DB.Create(&repo)
+	scan := db.Scan{RepositoryID: repo.ID, Kind: "skill", Status: db.ScanDone, SkillName: "security-deep-dive"}
+	s.DB.Create(&scan)
+	verify := db.Skill{Name: "verify", Body: "b", OutputFile: "r.json", OutputKind: "freeform", Version: 1, Active: true, Source: "ui"}
+	s.DB.Create(&verify)
+
+	// Three findings awaiting verification.
+	for i := range 3 {
+		s.DB.Create(&db.Finding{ScanID: scan.ID, RepositoryID: repo.ID,
+			FindingID: fmt.Sprintf("N%d", i), Title: "x", Severity: "High", Status: db.FindingNew})
+	}
+	// A triaged finding that must be ignored.
+	s.DB.Create(&db.Finding{ScanID: scan.ID, RepositoryID: repo.ID,
+		FindingID: "T1", Title: "x", Severity: "High", Status: db.FindingTriaged})
+	// A new finding that already has a running verify scan: must be skipped.
+	skipF := db.Finding{ScanID: scan.ID, RepositoryID: repo.ID,
+		FindingID: "S1", Title: "x", Severity: "High", Status: db.FindingNew}
+	s.DB.Create(&skipF)
+	s.DB.Create(&db.Scan{RepositoryID: repo.ID, Kind: "skill", Status: db.ScanRunning,
+		SkillName: "verify", SkillID: new(verify.ID), FindingID: new(skipF.ID)})
+
+	req := httptest.NewRequest("POST", fmt.Sprintf("/repositories/%d/verify-all", repo.ID), nil)
+	req.Host = testHost
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+
+	// One queued verify scan per "new" finding without an in-flight verify.
+	var queued []db.Scan
+	s.DB.Where("skill_name = ? AND status = ?", "verify", db.ScanQueued).Find(&queued)
+	if len(queued) != 3 {
+		t.Fatalf("queued verify scans = %d, want 3", len(queued))
+	}
+	for _, sc := range queued {
+		if sc.FindingID == nil {
+			t.Errorf("queued verify scan %d missing finding id", sc.ID)
+		}
+	}
+	if f := flashFrom(t, w); !strings.Contains(f.Title, "3 queued") || !strings.Contains(f.Title, "1 already running") {
+		t.Errorf("flash = %q, want 3 queued / 1 already running", f.Title)
+	}
+}
+
+func TestRepoVerifyAll_respectsCategoryFilter(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	repo := db.Repository{URL: "https://github.com/foo/bar", Name: "bar"}
+	s.DB.Create(&repo)
+	scan := db.Scan{RepositoryID: repo.ID, Kind: "skill", Status: db.ScanDone, SkillName: "security-deep-dive"}
+	s.DB.Create(&scan)
+	verify := db.Skill{Name: "verify", Body: "b", OutputFile: "r.json", OutputKind: "freeform", Version: 1, Active: true, Source: "ui"}
+	s.DB.Create(&verify)
+
+	// One new finding in each of two categories.
+	s.DB.Create(&db.Finding{ScanID: scan.ID, RepositoryID: repo.ID,
+		FindingID: "INJ", Title: "x", Severity: "High", Status: db.FindingNew, CWE: "CWE-78"})
+	s.DB.Create(&db.Finding{ScanID: scan.ID, RepositoryID: repo.ID,
+		FindingID: "MEM", Title: "x", Severity: "High", Status: db.FindingNew, CWE: "CWE-416"})
+
+	// The badge counts only the filtered category.
+	body := getRepoPage(t, s, repo.ID)
+	if !strings.Contains(body, "Verify all new (2)") {
+		t.Errorf("unfiltered badge should be 2; body=%s", body)
+	}
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq("GET", fmt.Sprintf("/repositories/%d?category=Injection", repo.ID)))
+	if !strings.Contains(w.Body.String(), "Verify all new (1)") {
+		t.Errorf("Injection-filtered badge should be 1; body=%s", w.Body)
+	}
+
+	// The action enqueues only the filtered category's finding.
+	req := httptest.NewRequest("POST", fmt.Sprintf("/repositories/%d/verify-all?category=Injection", repo.ID), nil)
+	req.Host = testHost
+	w = httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+
+	var queued []db.Scan
+	s.DB.Where("skill_name = ? AND status = ?", "verify", db.ScanQueued).Find(&queued)
+	if len(queued) != 1 {
+		t.Fatalf("queued verify scans = %d, want 1 (category-scoped)", len(queued))
+	}
+}
+
+func TestRepoVerifyAll_skillNotInstalled(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	repo := db.Repository{URL: "https://github.com/foo/bar", Name: "bar"}
+	s.DB.Create(&repo)
+	scan := db.Scan{RepositoryID: repo.ID, Kind: "skill", Status: db.ScanDone, SkillName: "security-deep-dive"}
+	s.DB.Create(&scan)
+	s.DB.Create(&db.Finding{ScanID: scan.ID, RepositoryID: repo.ID,
+		FindingID: "N1", Title: "x", Severity: "High", Status: db.FindingNew})
+
+	req := httptest.NewRequest("POST", fmt.Sprintf("/repositories/%d/verify-all", repo.ID), nil)
+	req.Host = testHost
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+
+	var n int64
+	s.DB.Model(&db.Scan{}).Where("skill_name = ?", "verify").Count(&n)
+	if n != 0 {
+		t.Errorf("verify scans created = %d, want 0 when skill missing", n)
+	}
+	if f := flashFrom(t, w); f.Category != "error" {
+		t.Errorf("flash category = %q, want error", f.Category)
+	}
+}
+
 func TestFindingPatchDownload(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()
@@ -2557,6 +2671,36 @@ func TestRepoShow_retryFailedButton(t *testing.T) {
 	}
 	if !strings.Contains(body, fmt.Sprintf(`/scans/retry-failed?repository=%d`, repo.ID)) {
 		t.Error("button form action should scope retry to this repository")
+	}
+}
+
+func TestRepoShow_verifyAllButton(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	repo := db.Repository{URL: "https://example.com/rep", Name: "rep"}
+	s.DB.Create(&repo)
+	scan := db.Scan{RepositoryID: repo.ID, Kind: "skill", Status: db.ScanDone, SkillName: deepDiveSkillName}
+	s.DB.Create(&scan)
+
+	// A triaged finding does not count as awaiting verification, so no button.
+	s.DB.Create(&db.Finding{ScanID: scan.ID, RepositoryID: repo.ID,
+		FindingID: "T1", Title: "x", Severity: "High", Status: db.FindingTriaged})
+	if body := getRepoPage(t, s, repo.ID); strings.Contains(body, "Verify all new") {
+		t.Error("button should not appear when no findings await verification")
+	}
+
+	// Two new findings: button renders with the count and repo-scoped action.
+	s.DB.Create(&db.Finding{ScanID: scan.ID, RepositoryID: repo.ID,
+		FindingID: "N1", Title: "x", Severity: "High", Status: db.FindingNew})
+	s.DB.Create(&db.Finding{ScanID: scan.ID, RepositoryID: repo.ID,
+		FindingID: "N2", Title: "x", Severity: "High", Status: db.FindingNew})
+	body := getRepoPage(t, s, repo.ID)
+	if !strings.Contains(body, "Verify all new (2)") {
+		t.Errorf("expected 'Verify all new (2)' button; body=%s", body)
+	}
+	if !strings.Contains(body, fmt.Sprintf(`/repositories/%d/verify-all`, repo.ID)) {
+		t.Error("button form action should scope verify-all to this repository")
 	}
 }
 

--- a/internal/web/templates/repo_show.html
+++ b/internal/web/templates/repo_show.html
@@ -201,6 +201,18 @@
         Rejected and duplicate findings are hidden.{{if .ScannerFindings}} See the
         Scanners tab for zizmor/semgrep output.{{end}}
       </p>
+      <div class="flex items-center gap-2 shrink-0">
+      {{if gt .NewFindingCount 0}}
+        <form method="post"
+              action="/repositories/{{.Repo.ID}}/verify-all{{if .Category}}?category={{.Category}}{{end}}"
+              hx-post="/repositories/{{.Repo.ID}}/verify-all{{if .Category}}?category={{.Category}}{{end}}"
+              hx-swap="none"
+              hx-confirm="Enqueue a verification job for {{.NewFindingCount}} finding(s) awaiting verification?">
+          <button type="submit" class="btn-outline">
+            <i data-lucide="shield-check"></i> Verify all new ({{.NewFindingCount}})
+          </button>
+        </form>
+      {{end}}
       <div class="dropdown-menu">
         <button type="button" class="btn-outline" aria-haspopup="menu" aria-expanded="false">
           <i data-lucide="tags"></i>
@@ -218,6 +230,7 @@
                {{if eq .Uncategorized .Category}}aria-current="true"{{end}}>{{.Uncategorized}}</a>
           </div>
         </div>
+      </div>
       </div>
     </div>
     {{if not .Findings}}


### PR DESCRIPTION
Resolve #230.

Add a "Verify all new" button to a repository's Findings tab that enqueues a verification job for every finding still in "new", instead of clicking through each finding one at a time.

<img width="1200" height="62" alt="Screenshot 2026-05-28 at 10 56 28 PM" src="https://github.com/user-attachments/assets/499627f5-fbc0-476d-9109-0ddfbc6add7d" />

The confirmation dialog is maybe excessive:

<img width="408" height="175" alt="Screenshot 2026-05-28 at 10 56 36 PM" src="https://github.com/user-attachments/assets/bbb6fc4d-44d2-446f-bcc7-014b7e54652f" />


Generated with Claude Code.