### PR TITLE
feat: emit scan-log progress during profile image build

### DIFF
--- a/internal/worker/docker.go
+++ b/internal/worker/docker.go
@@ -240,7 +240,7 @@ func (d DockerRunner) resolveProfile(ctx context.Context, requested, src string,
 			return "", defaultImg
 		}
 	}
-	img, err := p.EnsureImage(ctx, d.ProfilesDir, defaultImg)
+	img, err := p.EnsureImage(ctx, d.ProfilesDir, defaultImg, emit)
 	if err != nil {
 		emit(Event{Kind: KindText, Text: "profile: " + p.Name + " build failed, using default: " + err.Error()})
 		return "", defaultImg

--- a/internal/worker/profile.go
+++ b/internal/worker/profile.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 )
 
 // Profile selects a per-ecosystem runner image. The default profile
@@ -167,8 +168,10 @@ func imageTag(profileName string, dockerfile []byte, runnerImage string) string 
 // local cache and returns the tag to pass to `docker run`. The
 // `--build-arg RUNNER_IMAGE=...` is wired so the profile's FROM picks
 // up whichever runner image the operator configured. Concurrency-safe:
-// a per-tag mutex serialises duplicate builds.
-func (p Profile) EnsureImage(ctx context.Context, profilesDir, runnerImage string) (string, error) {
+// a per-tag mutex serialises duplicate builds. emit is called only on
+// a cache miss (before and after the docker build) so the scan log
+// shows progress during a multi-minute first build.
+func (p Profile) EnsureImage(ctx context.Context, profilesDir, runnerImage string, emit func(Event)) (string, error) {
 	if p.IsDefault() {
 		return runnerImage, nil
 	}
@@ -189,6 +192,8 @@ func (p Profile) EnsureImage(ctx context.Context, profilesDir, runnerImage strin
 	if imageExistsLocally(ctx, tag) {
 		return tag, nil
 	}
+	emit(Event{Kind: KindText, Text: "profile: building " + tag + " (first build can take several minutes)"})
+	start := time.Now()
 	buildArgs := []string{"build", "-t", tag, "-f", dockerfile}
 	if runnerImage != "" {
 		buildArgs = append(buildArgs, "--build-arg", "RUNNER_IMAGE="+runnerImage)
@@ -198,6 +203,7 @@ func (p Profile) EnsureImage(ctx context.Context, profilesDir, runnerImage strin
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return "", fmt.Errorf("docker build %s: %w\n%s", tag, err, out)
 	}
+	emit(Event{Kind: KindText, Text: "profile: built " + tag + " in " + time.Since(start).Round(time.Second).String()})
 	return tag, nil
 }
 

--- a/internal/worker/profile_test.go
+++ b/internal/worker/profile_test.go
@@ -100,27 +100,39 @@ func TestLockForTag_sameTagSameMutex(t *testing.T) {
 }
 
 func TestEnsureImage_defaultReturnsRunnerImage(t *testing.T) {
-	img, err := Profile{}.EnsureImage(context.Background(), "", "default-runner:latest")
+	var emitted int
+	img, err := Profile{}.EnsureImage(context.Background(), "", "default-runner:latest", func(Event) { emitted++ })
 	if err != nil {
 		t.Fatalf("default profile: %v", err)
 	}
 	if img != "default-runner:latest" {
 		t.Errorf("got %q, want default runner image", img)
 	}
+	if emitted != 0 {
+		t.Errorf("default profile emitted %d events, want 0", emitted)
+	}
 }
 
 func TestEnsureImage_noProfilesDir(t *testing.T) {
-	_, err := Profile{Name: "php"}.EnsureImage(context.Background(), "", "default:latest")
+	var emitted int
+	_, err := Profile{Name: "php"}.EnsureImage(context.Background(), "", "default:latest", func(Event) { emitted++ })
 	if err == nil {
 		t.Fatal("expected ErrNoProfilesDir, got nil")
+	}
+	if emitted != 0 {
+		t.Errorf("ErrNoProfilesDir path emitted %d events, want 0", emitted)
 	}
 }
 
 func TestEnsureImage_missingDockerfile(t *testing.T) {
 	dir := t.TempDir()
-	_, err := Profile{Name: "php"}.EnsureImage(context.Background(), dir, "default:latest")
+	var emitted int
+	_, err := Profile{Name: "php"}.EnsureImage(context.Background(), dir, "default:latest", func(Event) { emitted++ })
 	if err == nil {
 		t.Fatal("expected error for missing dockerfile, got nil")
+	}
+	if emitted != 0 {
+		t.Errorf("missing-dockerfile path emitted %d events, want 0", emitted)
 	}
 }
 


### PR DESCRIPTION
Fix #280.

`EnsureImage` now takes the scan's `emit` callback. On a local cache miss it writes `profile: building <tag> (first build can take several minutes)` before kicking off `docker build`, and `profile: built <tag> in <duration>` once it finishes. Cache hits stay silent so repeat scans don't get extra noise.

Previously the scan log sat on `git fetch && reset` for the full build (about five minutes for the Ruby profile) with no indication anything was happening.

Tests updated to assert the early-return paths (default profile, no profiles dir, missing Dockerfile) don't emit.