### PR TITLE
Hide dependent
  exposure for zizmor findings

### DIFF
--- a/internal/web/finding_exposure.go
+++ b/internal/web/finding_exposure.go
@@ -29,6 +29,10 @@ func (s *Server) findingExposureRun(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "scan for finding not found", http.StatusInternalServerError)
 		return
 	}
+	if !findingSupportsExposure(scan) {
+		http.Error(w, "dependent exposure is not supported for this finding", http.StatusUnprocessableEntity)
+		return
+	}
 	var skill db.Skill
 	if err := s.DB.Where("name = ? AND active = ?", exposureSkillName, true).First(&skill).Error; err != nil {
 		http.Error(w, "exposure skill is not installed", http.StatusPreconditionFailed)

--- a/internal/web/finding_exposure_test.go
+++ b/internal/web/finding_exposure_test.go
@@ -2,6 +2,7 @@ package web
 
 import (
 	"fmt"
+	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -68,6 +69,30 @@ func TestFindingExposureRun_noDependents422(t *testing.T) {
 	s.Handler().ServeHTTP(w, localReq("POST", fmt.Sprintf("/findings/%d/exposure", f.ID)))
 	if w.Code != 422 {
 		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+}
+
+func TestFindingExposureRun_rejectsZizmorFindings(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	repo := db.Repository{URL: "https://github.com/example/lib.git", Name: "lib"}
+	s.DB.Create(&repo)
+	scan := db.Scan{RepositoryID: repo.ID, Kind: worker.JobSkill, Status: db.ScanDone, SkillName: zizmorSkillName}
+	s.DB.Create(&scan)
+	f := db.Finding{ScanID: scan.ID, RepositoryID: repo.ID, Title: "workflow issue", Severity: "High"}
+	s.DB.Create(&f)
+	s.DB.Create(&db.Skill{Name: exposureSkillName, Body: "x", Active: true, OutputFile: "report.json", OutputKind: "exposure"})
+	s.DB.Create(&db.Dependent{RepositoryID: repo.ID, Name: "a",
+		RepositoryURL: "https://github.com/example/a", DependentRepos: 1})
+
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq("POST", fmt.Sprintf("/findings/%d/exposure", f.ID)))
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+	if !strings.Contains(w.Body.String(), "not supported") {
+		t.Errorf("body = %q", w.Body.String())
 	}
 }
 

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -797,6 +797,7 @@ const (
 	// tab when present; repos that predate it fall back to the boundaries
 	// section of the deep-dive report so older scans keep rendering.
 	threatModelSkillName = "threat-model"
+	zizmorSkillName      = "zizmor"
 )
 
 // deepDiveFindingsCountSQL is a correlated subselect that counts deep-dive
@@ -815,6 +816,10 @@ const deepDiveFindingsCountSQL = `SELECT COUNT(*) FROM findings f
 func deepDiveScanIDs(gdb *gorm.DB) *gorm.DB {
 	return gdb.Model(&db.Scan{}).Select("id").
 		Where("skill_name = ? OR skill_name = '' OR skill_name IS NULL", deepDiveSkillName)
+}
+
+func findingSupportsExposure(scan db.Scan) bool {
+	return scan.SkillName != zizmorSkillName
 }
 
 func (s *Server) addRepoAndScan(w http.ResponseWriter, r *http.Request, repoURL string) {
@@ -1147,6 +1152,7 @@ func (s *Server) findingShow(w http.ResponseWriter, r *http.Request) {
 		"AllLabels":      labels,
 		"Selected":       selected,
 		"Exposures":      exposures,
+		"ShowExposure":   findingSupportsExposure(scan),
 	}
 	if id, c, ok := LookupCWE(f.CWE); ok {
 		data["CWE"] = map[string]any{"ID": id, "Name": c.Name, "Description": c.Description}

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -1150,6 +1150,28 @@ func TestFindingShow_rendersMissedCount(t *testing.T) {
 	}
 }
 
+func TestFindingShow_hidesExposureForZizmorFindings(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	repo := db.Repository{URL: "https://example.com/r", Name: "r"}
+	s.DB.Create(&repo)
+	scan := db.Scan{RepositoryID: repo.ID, Kind: "skill", Status: db.ScanDone, SkillName: zizmorSkillName}
+	s.DB.Create(&scan)
+	f := db.Finding{ScanID: scan.ID, RepositoryID: repo.ID, Title: "workflow issue", Severity: "High"}
+	s.DB.Create(&f)
+
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq("GET", fmt.Sprintf("/findings/%d", f.ID)))
+	body := w.Body.String()
+	if w.Code != http.StatusOK {
+		t.Fatalf("status %d: %s", w.Code, body)
+	}
+	if strings.Contains(body, "Dependent exposure") || strings.Contains(body, "/exposure") {
+		t.Error("zizmor findings should not render dependent exposure controls")
+	}
+}
+
 func TestOrgReport_rendersFindingsAcrossRepos(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()

--- a/internal/web/templates/finding_show.html
+++ b/internal/web/templates/finding_show.html
@@ -215,6 +215,7 @@
   </details>
   {{end}}
 
+  {{if .ShowExposure}}
   <details open class="group border-b">
     <summary class="w-full outline-none rounded-md focus-visible:ring-ring/50 focus-visible:ring-[3px]">
       <h3 class="flex flex-1 items-center justify-between gap-4 py-4 text-sm font-medium hover:underline">
@@ -251,6 +252,7 @@
       {{end}}
     </section>
   </details>
+  {{end}}
 
   {{if .Patch}}{{$p := .Patch}}{{$ps := .PatchScan}}
   <details open class="group border-b">


### PR DESCRIPTION
Closes #253
## Summary

This hides the dependent exposure UI for findings produced by the `zizmor` skill, since dependent exposure is not generally relevant for GitHub Actions workflow scanner findings...

## Changes

- Added a shared `findingSupportsExposure` check.
- Hid the “Dependent exposure” section on finding pages when the source scan is `zizmor`.
- Rejected direct exposure POST requests for `zizmor` findings with `422`.
- Added regression coverage for both rendering and direct POST behavior.

## Testing

```bash
go test ./internal/web
go test ./...
```