### PR TITLE
Smoke test curl in runner image

### DIFF
--- a/.github/workflows/runner-image.yml
+++ b/.github/workflows/runner-image.yml
@@ -60,6 +60,7 @@ jobs:
         run: |
           set -euxo pipefail
           docker run --rm scrutineer-runner:ci claude --version
+          docker run --rm scrutineer-runner:ci curl --version
           docker run --rm scrutineer-runner:ci semgrep --version
           docker run --rm scrutineer-runner:ci zizmor --version
           docker run --rm scrutineer-runner:ci git-pkgs --version

--- a/Dockerfile.runner
+++ b/Dockerfile.runner
@@ -38,6 +38,7 @@ RUN python3 -m venv /opt/semgrep && \
     ln -s /opt/semgrep/bin/semgrep /usr/local/bin/semgrep && \
     ln -s /opt/semgrep/bin/pysemgrep /usr/local/bin/pysemgrep && \
     python3 --version && \
+    curl --version && \
     gh --version && \
     semgrep --version && \
     pysemgrep --version


### PR DESCRIPTION
Closes #283
## Summary

The default runner image is expected to include `curl`, but the build and CI smoke tests did not verify that it is present in the final image. This adds explicit `curl --version` checks so the runner image fails early if `curl` is removed or broken in a future change...

## Changes

- Added `curl --version` to the `Dockerfile.runner` build-time smoke checks.
- Added `curl --version` to the runner image GitHub Actions smoke test.

## Testing

```bash
git diff --check
go test ./...
docker build -t scrutineer-runner:issue-283 -f Dockerfile.runner .
```
Smoke-tested the built image:
```
docker run --rm scrutineer-runner:issue-283 claude --version
docker run --rm scrutineer-runner:issue-283 curl --version
docker run --rm scrutineer-runner:issue-283 semgrep --version
docker run --rm scrutineer-runner:issue-283 zizmor --version
docker run --rm scrutineer-runner:issue-283 git-pkgs --version
docker run --rm scrutineer-runner:issue-283 brief --version
docker run --rm scrutineer-runner:issue-283 git --version
```