### PR TITLE
Handle empty git-pkgs
  dependency output

### DIFF
--- a/internal/worker/dependencies_script_test.go
+++ b/internal/worker/dependencies_script_test.go
@@ -1,0 +1,108 @@
+package worker
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDependenciesScriptNormalizesEmptyGitPkgsOutput(t *testing.T) {
+	cases := []struct {
+		name string
+		mode string
+		want string
+	}{
+		{"null", "null", `{"dependencies":[]}` + "\n"},
+		{"empty", "empty", `{"dependencies":[]}` + "\n"},
+		{"array", "array", `{"dependencies":[{"name":"left-pad","ecosystem":"npm"}]}` + "\n"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := runDependenciesScript(t, tc.mode)
+			if err != nil {
+				t.Fatalf("script failed: %v\n%s", err, out)
+			}
+			if out != tc.want {
+				t.Fatalf("output = %q, want %q", out, tc.want)
+			}
+			schema, err := os.ReadFile("../../skills/dependencies/schema.json")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := validateReportSchema(string(schema), out); got != "" {
+				t.Fatalf("script output failed schema validation: %s\n%s", got, out)
+			}
+		})
+	}
+}
+
+func TestDependenciesScriptRejectsNonArrayGitPkgsOutput(t *testing.T) {
+	out, err := runDependenciesScript(t, "object")
+	if err == nil {
+		t.Fatalf("script succeeded with non-array output: %s", out)
+	}
+	if !strings.Contains(out, "want array") {
+		t.Fatalf("output = %q, want array error", out)
+	}
+}
+
+func runDependenciesScript(t *testing.T, mode string) (string, error) {
+	t.Helper()
+	script, err := filepath.Abs("../../skills/dependencies/scripts/index.sh")
+	if err != nil {
+		t.Fatal(err)
+	}
+	root := t.TempDir()
+	if err := os.Mkdir(filepath.Join(root, "src"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	bin := filepath.Join(root, "bin")
+	if err := os.Mkdir(bin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	fakeGitPkgs := filepath.Join(bin, "git-pkgs")
+	if err := os.WriteFile(fakeGitPkgs, []byte(`#!/usr/bin/env bash
+set -euo pipefail
+case "$1" in
+  init)
+    exit 0
+    ;;
+  list)
+    case "${GIT_PKGS_LIST_OUTPUT:-array}" in
+      null)
+        printf 'null\n'
+        ;;
+      empty)
+        ;;
+      object)
+        printf '{"name":"left-pad"}\n'
+        ;;
+      array)
+        printf '[{"name":"left-pad","ecosystem":"npm"}]\n'
+        ;;
+      *)
+        echo "unknown mode: ${GIT_PKGS_LIST_OUTPUT}" >&2
+        exit 2
+        ;;
+    esac
+    ;;
+  *)
+    echo "unexpected git-pkgs command: $*" >&2
+    exit 2
+    ;;
+esac
+`), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command("bash", script)
+	cmd.Dir = root
+	cmd.Env = append(os.Environ(),
+		"PATH="+bin+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"GIT_PKGS_LIST_OUTPUT="+mode,
+	)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}

--- a/internal/worker/schema_bundled_test.go
+++ b/internal/worker/schema_bundled_test.go
@@ -55,6 +55,14 @@ func TestBundledSchemas_compileAndAcceptSamples(t *testing.T) {
 			`{"error":"git-pkgs: exit 1"}`,
 		},
 		{
+			"../../skills/dependencies/schema.json",
+			`{"dependencies":[]}`,
+		},
+		{
+			"../../skills/dependencies/schema.json",
+			`{"dependencies":[],"error":"git-pkgs not found on PATH"}`,
+		},
+		{
 			"../../skills/threat-model/schema.json",
 			`{"spec_version":1,"repository":"https://github.com/o/r","commit":"abc1234",
 			  "date":"2026-05-08","scope_subpath":null,"description":"x",
@@ -109,6 +117,7 @@ func TestBundledSchemas_rejectBadShapes(t *testing.T) {
 		{"../../skills/sbom/schema.json", `{"bomFormat":"SPDX","specVersion":"1.5"}`, "/bomFormat"},
 		{"../../skills/sbom/schema.json", `{"specVersion":"1.5"}`, "bomFormat"},
 		{"../../skills/sbom/schema.json", `{}`, "oneOf"},
+		{"../../skills/dependencies/schema.json", `{"dependencies":null}`, "/dependencies"},
 		{"../../skills/threat-model/schema.json", `{"spec_version":2}`, "/spec_version"},
 		{"../../skills/threat-model/schema.json",
 			`{"spec_version":1,"repository":"https://x","commit":"abc1234","date":"2026-01-01",

--- a/skills/dependencies/SKILL.md
+++ b/skills/dependencies/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: dependencies
-description: Index every dependency declared in the repository's manifest and lockfile files (package.json, Gemfile, go.mod, requirements.txt, etc.) and record each one with its manifest path, ecosystem, and requirement string. Use to populate the Dependencies tab.
+description: Index dependencies reported by git-pkgs for the repository's manifest and lockfile files (package.json, Gemfile, go.mod, requirements.txt, etc.) and record each one with its manifest path, ecosystem, and requirement string. Use to populate the Dependencies tab.
 license: MIT
-compatibility: Requires the `git-pkgs` CLI (https://github.com/ecosyste-ms/git-pkgs) on PATH.
+compatibility: Requires `git-pkgs` (https://github.com/ecosyste-ms/git-pkgs) and `python3` on PATH.
 metadata:
   scrutineer.version: 1
   scrutineer.output_file: report.json
@@ -22,7 +22,7 @@ Wrap `git-pkgs list --format json` so scrutineer can read the result as a depend
 
 ## Available scripts
 
-- `scripts/index.sh` — runs `git-pkgs init` then `git-pkgs list --format json` inside `./src` and wraps the array in `{"dependencies": [...]}`.
+- `scripts/index.sh` — runs `git-pkgs init` then `git-pkgs list --format json` inside `./src`, normalises empty or `null` output to an empty array, and writes `{"dependencies": [...]}`.
 
 ## What to do
 
@@ -35,3 +35,5 @@ bash scripts/index.sh > ./report.json
 If the script exits non-zero, read its stderr, then write a short `{"dependencies": [], "error": "..."}` document to `./report.json` so the caller sees why no dependencies were indexed.
 
 The wrapper already emits the exact schema the parser expects — no post-processing needed.
+
+Do not inspect manifests yourself, infer dependencies from files that `git-pkgs` did not report, or hand-author dependency rows. If the wrapper returns `{"dependencies":[]}`, write that exact report and stop. Missing coverage in `git-pkgs` should produce an empty dependency report, not model-authored package data.

--- a/skills/dependencies/schema.json
+++ b/skills/dependencies/schema.json
@@ -5,6 +5,7 @@
   "required": ["dependencies"],
   "additionalProperties": false,
   "properties": {
+    "error": { "type": "string" },
     "dependencies": {
       "type": "array",
       "items": {

--- a/skills/dependencies/scripts/index.sh
+++ b/skills/dependencies/scripts/index.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
-# Index every dependency manifest in the clone and wrap git-pkgs's array
-# output in the `{"dependencies": [...]}` envelope the scrutineer parser
-# expects. Exits non-zero with an informative message if git-pkgs is missing.
+# Index every dependency manifest in the clone and wrap git-pkgs's output in
+# the `{"dependencies": [...]}` envelope the scrutineer parser expects. Exits
+# non-zero with an informative message if git-pkgs is missing or emits a
+# non-array JSON value other than null.
 set -euo pipefail
 
 if ! command -v git-pkgs >/dev/null 2>&1; then
@@ -18,6 +19,18 @@ git fetch --unshallow --quiet >/dev/null 2>&1 || true
 git-pkgs init --no-hooks >/dev/null
 
 # Wrap the array in a top-level object so the output matches schema.json.
-printf '{"dependencies": '
-git-pkgs list --format json
-printf '}\n'
+# Older git-pkgs builds can emit null or nothing when they find no manifests;
+# both mean "no dependencies" here, not permission to infer rows by hand.
+git-pkgs list --format json | python3 -c 'import json, sys
+raw = sys.stdin.read().strip()
+if raw == "" or raw == "null":
+    deps = []
+else:
+    deps = json.loads(raw)
+if deps is None:
+    deps = []
+if not isinstance(deps, list):
+    raise SystemExit(f"git-pkgs list returned {type(deps).__name__}, want array")
+json.dump({"dependencies": deps}, sys.stdout, separators=(",", ":"))
+sys.stdout.write("\n")
+'


### PR DESCRIPTION
Closes #255

## Summary

The `dependencies` skill could produce invalid or misleading reports when `git-pkgs list --format json` returned `null` or no output. In that case, the model could try to inspect manifests itself and hand-author dependency rows, which could introduce non-canonical ecosystem names or missing PURLs...

This keeps the dependency report strictly tied to `git-pkgs` output.

## Changes

- Normalized `git-pkgs` `null` or empty output to `{"dependencies":[]}`.
- Rejected non-array JSON from `git-pkgs list` instead of wrapping it into an invalid report.
- Updated the dependency skill instructions to explicitly prohibit hand-authored dependency rows.
- Allowed the documented `error` field in `skills/dependencies/schema.json`.
- Added tests for wrapper output normalization and schema validation.

## Testing

```bash
bash -n skills/dependencies/scripts/index.sh
go test ./internal/worker
git diff --check
go test ./...
```