### PR TITLE
fix: Code rendering not respecting dark mode

### DIFF
--- a/internal/web/static/theme-init.js
+++ b/internal/web/static/theme-init.js
@@ -1,14 +1,34 @@
 (function () {
   var scheme = (document.cookie.match(/(?:^|; )color_scheme=(\w+)/) || [])[1] || 'system';
   var mq = matchMedia('(prefers-color-scheme: dark)');
-  var apply = function () {
-    var dark = scheme === 'dark' || (scheme === 'system' && mq.matches);
-    document.documentElement.classList.toggle('dark', dark);
+  var isDark = function () {
+    return scheme === 'dark' || (scheme === 'system' && mq.matches);
+  };
+  // Toggle the .dark class before first paint to avoid a flash of the
+  // light theme.
+  var applyClass = function () {
+    document.documentElement.classList.toggle('dark', isDark());
+  };
+  // The hljs light/dark stylesheets are declared later in <head>, so they
+  // do not exist yet on this first synchronous run. Enable the right one
+  // once they are in the DOM, otherwise the light theme stays active in
+  // dark mode and code renders dark-on-dark.
+  var applyHljs = function () {
+    var dark = isDark();
     var hl = document.getElementById('hljs-light');
     var hd = document.getElementById('hljs-dark');
     if (hl) hl.disabled = dark;
     if (hd) hd.disabled = !dark;
   };
-  apply();
+  var apply = function () {
+    applyClass();
+    applyHljs();
+  };
+  applyClass();
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', applyHljs);
+  } else {
+    applyHljs();
+  }
   mq.addEventListener('change', apply);
 })();


### PR DESCRIPTION
For the inital page load code was rendered for light mode, make the repositories/$id/blob pages bright white and the inline code samples dark-on-dark unreadable