### PR TITLE
Improve scan UX for Claude plan limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Every index page has a search box plus filter and sort dropdowns; the specifics 
 - **Advisories** -- known CVEs and security advisories pulled for any scanned package.
 - **Maintainers** -- people identified as maintainers, with their linked repos and findings.
 - **SBOMs** -- uploaded CycloneDX/SPDX documents. Each component is resolved to a source repository and can be imported for scanning.
-- **Scans** -- every scan that has run. Running or queued scans can be cancelled; failed ones retried.
+- **Scans** -- every scan that has run. Queued scans can be paused/resumed, running or queued scans can be cancelled and failed ones retried.
 - **Skills** -- installed skills from disk and from the UI; view, edit, or run any of them.
 - **Usage** -- token and cost totals across all scans, broken down by skill.
 - **Settings** -- theme, colour scheme, default model, and system stats (record counts, DB size, concurrency, paths).

--- a/docs/database.md
+++ b/docs/database.md
@@ -42,8 +42,8 @@ One row per skill execution or external import. `skill_name` / `skill_version` p
 | id | integer PK | |
 | repository_id | integer FK | References `repositories.id`. Cascade delete. |
 | kind | text | `skill` for native scans, `import` for findings ingested via `POST /api/v1/import`. |
-| status | text | `queued`, `running`, `done`, `failed`, `cancelled`. Stale `running` rows are swept to `failed` on startup. |
-| status_priority | integer | Denormalised sort key for the scans index: 0 running, 1 queued, 2 terminal. |
+| status | text | `queued`, `paused`, `running`, `done`, `failed`, `cancelled`. Stale `running` rows are swept to `failed` on startup. |
+| status_priority | integer | Denormalised sort key for the scans index: 0 running, 1 queued, 2 paused, 3 terminal. |
 | model | text | Claude model ID. |
 | skill_id | integer FK | References `skills.id`. Null for legacy non-skill rows. |
 | skill_version | integer | Version of the skill at run time; the skill row's `version` bumps on every edit so older scans stay readable. |

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -90,6 +90,7 @@ type ScanStatus string
 const (
 	ScanQueued    ScanStatus = "queued"
 	ScanRunning   ScanStatus = "running"
+	ScanPaused    ScanStatus = "paused"
 	ScanDone      ScanStatus = "done"
 	ScanFailed    ScanStatus = "failed"
 	ScanCancelled ScanStatus = "cancelled"
@@ -787,14 +788,23 @@ func (s ScanStatus) Terminal() bool {
 	return s == ScanDone || s == ScanFailed || s == ScanCancelled
 }
 
+const (
+	scanPriorityRunning = iota
+	scanPriorityQueued
+	scanPriorityPaused
+	scanPriorityTerminal
+)
+
 func StatusPriorityFor(s ScanStatus) int {
 	switch s {
 	case ScanRunning:
-		return 0
+		return scanPriorityRunning
 	case ScanQueued:
-		return 1
+		return scanPriorityQueued
+	case ScanPaused:
+		return scanPriorityPaused
 	default:
-		return 2 //nolint:mnd
+		return scanPriorityTerminal
 	}
 }
 
@@ -922,7 +932,8 @@ type Subproject struct {
 func BackfillStatusPriority(gdb *gorm.DB) {
 	gdb.Exec(`UPDATE scans SET status_priority = 0 WHERE status = 'running' AND (status_priority IS NULL OR status_priority != 0)`)
 	gdb.Exec(`UPDATE scans SET status_priority = 1 WHERE status = 'queued' AND (status_priority IS NULL OR status_priority != 1)`)
-	gdb.Exec(`UPDATE scans SET status_priority = 2 WHERE status NOT IN ('running', 'queued') AND (status_priority IS NULL OR status_priority != 2)`)
+	gdb.Exec(`UPDATE scans SET status_priority = 2 WHERE status = 'paused' AND (status_priority IS NULL OR status_priority != 2)`)
+	gdb.Exec(`UPDATE scans SET status_priority = 3 WHERE status NOT IN ('running', 'queued', 'paused') AND (status_priority IS NULL OR status_priority != 3)`)
 }
 
 // BackfillFindingRepository copies Scan.RepositoryID onto Finding rows

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -160,14 +160,14 @@ func TestStatusPriority_sortOrder(t *testing.T) {
 	repo := Repository{URL: "https://example.com/sort-test", Name: "sort-test"}
 	gdb.Create(&repo)
 
-	for _, st := range []ScanStatus{ScanDone, ScanRunning, ScanQueued} {
+	for _, st := range []ScanStatus{ScanDone, ScanPaused, ScanRunning, ScanQueued} {
 		sc := Scan{RepositoryID: repo.ID, Kind: "skill", Status: st, StatusPriority: StatusPriorityFor(st)}
 		gdb.Create(&sc)
 	}
 
 	var scans []Scan
 	gdb.Order("status_priority, id desc").Find(&scans)
-	if len(scans) != 3 {
+	if len(scans) != 4 {
 		t.Fatalf("got %d scans", len(scans))
 	}
 	if scans[0].Status != ScanRunning {
@@ -176,8 +176,11 @@ func TestStatusPriority_sortOrder(t *testing.T) {
 	if scans[1].Status != ScanQueued {
 		t.Errorf("second scan status = %s, want queued", scans[1].Status)
 	}
-	if scans[2].Status != ScanDone {
-		t.Errorf("third scan status = %s, want done", scans[2].Status)
+	if scans[2].Status != ScanPaused {
+		t.Errorf("third scan status = %s, want paused", scans[2].Status)
+	}
+	if scans[3].Status != ScanDone {
+		t.Errorf("fourth scan status = %s, want done", scans[3].Status)
 	}
 	for _, sc := range scans {
 		t.Logf("id=%d status=%s priority=%d", sc.ID, sc.Status, sc.StatusPriority)

--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -176,7 +176,7 @@ func (s *Server) apiListScans(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	q := s.DB.Where("repository_id = ?", id).Order("id desc")
-	if status := r.URL.Query().Get("status"); status != "" {
+	if status := r.URL.Query().Get(statusKey); status != "" {
 		q = q.Where("status = ?", status)
 	}
 	if skill := r.URL.Query().Get("skill"); skill != "" {
@@ -363,14 +363,14 @@ func scanSummary(sc db.Scan) map[string]any {
 		"id":            sc.ID,
 		"repository_id": sc.RepositoryID,
 		"kind":          sc.Kind,
-		"status":        string(sc.Status),
+		statusKey:       string(sc.Status),
 		"model":         sc.Model,
 		"commit":        sc.Commit,
 		"skill_name":    sc.SkillName,
 		"skill_version": sc.SkillVersion,
 		"started_at":    sc.StartedAt,
 		"finished_at":   sc.FinishedAt,
-		"error":         sc.Error,
+		errorKey:        sc.Error,
 	}
 	if sc.Ref != "" {
 		m["ref"] = sc.Ref
@@ -385,5 +385,5 @@ func writeJSON(w http.ResponseWriter, code int, v any) {
 }
 
 func writeAPIError(w http.ResponseWriter, code int, msg string) {
-	writeJSON(w, code, map[string]string{"error": msg})
+	writeJSON(w, code, map[string]string{errorKey: msg})
 }

--- a/internal/web/api_export.go
+++ b/internal/web/api_export.go
@@ -52,7 +52,7 @@ func (s *Server) apiExportScans(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	q := s.DB.Model(&db.Scan{}).Order("id desc")
-	if v := r.URL.Query().Get("status"); v != "" {
+	if v := r.URL.Query().Get(statusKey); v != "" {
 		q = q.Where("status = ?", v)
 	}
 	if v := r.URL.Query().Get("skill"); v != "" {
@@ -73,7 +73,7 @@ func applyFindingFilters(q *gorm.DB, r *http.Request) *gorm.DB {
 	if v := r.URL.Query().Get("severity"); v != "" {
 		q = q.Where("severity = ?", v)
 	}
-	if v := r.URL.Query().Get("status"); v != "" {
+	if v := r.URL.Query().Get(statusKey); v != "" {
 		q = q.Where("status = ?", v)
 	}
 	return q
@@ -124,7 +124,7 @@ func findingExport(f db.Finding) map[string]any {
 		"sinks":               f.Sinks,
 		"title":               f.Title,
 		"severity":            f.Severity,
-		"status":              string(f.Status),
+		statusKey:             string(f.Status),
 		"cwe":                 f.CWE,
 		"location":            f.Location,
 		"affected":            f.Affected,
@@ -157,7 +157,7 @@ func scanExport(sc db.Scan) map[string]any {
 		"id":                 sc.ID,
 		"repository_id":      sc.RepositoryID,
 		"kind":               sc.Kind,
-		"status":             string(sc.Status),
+		statusKey:            string(sc.Status),
 		"model":              sc.Model,
 		"skill_id":           sc.SkillID,
 		"skill_version":      sc.SkillVersion,
@@ -176,7 +176,7 @@ func scanExport(sc db.Scan) map[string]any {
 		"prompt":             sc.Prompt,
 		"report":             sc.Report,
 		"log":                sc.Log,
-		"error":              sc.Error,
+		errorKey:             sc.Error,
 		"findings_count":     sc.FindingsCount,
 		"created_at":         sc.CreatedAt,
 		"updated_at":         sc.UpdatedAt,

--- a/internal/web/api_reads.go
+++ b/internal/web/api_reads.go
@@ -25,12 +25,12 @@ func (s *Server) apiListMaintainers(w http.ResponseWriter, r *http.Request) {
 	out := make([]map[string]any, 0, len(rows))
 	for _, m := range rows {
 		out = append(out, map[string]any{
-			"id":     m.ID,
-			"login":  m.Login,
-			"name":   m.Name,
-			"email":  m.Email,
-			"status": string(m.Status),
-			"notes":  m.Notes,
+			"id":      m.ID,
+			"login":   m.Login,
+			"name":    m.Name,
+			"email":   m.Email,
+			statusKey: string(m.Status),
+			"notes":   m.Notes,
 		})
 	}
 	writeJSON(w, http.StatusOK, out)
@@ -184,7 +184,7 @@ func (s *Server) apiListFindings(w http.ResponseWriter, r *http.Request) {
 	if sev := r.URL.Query().Get("severity"); sev != "" {
 		q = q.Where("severity = ?", sev)
 	}
-	if status := r.URL.Query().Get("status"); status != "" {
+	if status := r.URL.Query().Get(statusKey); status != "" {
 		q = q.Where("status = ?", status)
 	}
 	var rows []db.Finding
@@ -231,7 +231,7 @@ func findingSummary(f db.Finding) map[string]any {
 		"sinks":         f.Sinks,
 		"title":         f.Title,
 		"severity":      f.Severity,
-		"status":        string(f.Status),
+		statusKey:       string(f.Status),
 		"cwe":           f.CWE,
 		"location":      f.Location,
 		"affected":      f.Affected,

--- a/internal/web/maintainers.go
+++ b/internal/web/maintainers.go
@@ -11,7 +11,7 @@ import (
 
 func (s *Server) maintainersList(w http.ResponseWriter, r *http.Request) {
 	q := s.DB.Model(&db.Maintainer{})
-	status := r.URL.Query().Get("status")
+	status := r.URL.Query().Get(statusKey)
 	if status != "" {
 		q = q.Where("status = ?", status)
 	}
@@ -27,7 +27,7 @@ func (s *Server) maintainersList(w http.ResponseWriter, r *http.Request) {
 	switch sort {
 	case "login":
 		q = q.Order("login")
-	case "status":
+	case statusKey:
 		q = q.Order("status, name")
 	case "newest":
 		q = q.Order("id desc")

--- a/internal/web/scans.go
+++ b/internal/web/scans.go
@@ -1,6 +1,7 @@
 package web
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -18,7 +19,7 @@ func (s *Server) jobs(w http.ResponseWriter, r *http.Request) {
 	if skillName != "" {
 		q = q.Where("skill_name = ?", skillName)
 	}
-	status := r.URL.Query().Get("status")
+	status := r.URL.Query().Get(statusKey)
 	if status != "" {
 		q = q.Where("status = ?", status)
 	}
@@ -27,7 +28,7 @@ func (s *Server) jobs(w http.ResponseWriter, r *http.Request) {
 	switch sort {
 	case "skill":
 		q = q.Order("skill_name, id desc")
-	case "status":
+	case statusKey:
 		q = q.Order("status, id desc")
 	case sortRepository:
 		q = q.Joins("Repository").Order("`Repository`.name, scans.id desc")
@@ -45,6 +46,9 @@ func (s *Server) jobs(w http.ResponseWriter, r *http.Request) {
 		Limit(perPage).Offset((page.N - 1) * perPage).Find(&scans)
 
 	skillNames := s.scanSkillNames()
+	queuedCount := s.scanStatusCount(db.ScanQueued)
+	pausedCount := s.scanStatusCount(db.ScanPaused)
+	planLimitFailedCount := s.planLimitFailedCount()
 
 	anySubPath := false
 	for _, sc := range scans {
@@ -56,8 +60,23 @@ func (s *Server) jobs(w http.ResponseWriter, r *http.Request) {
 	s.render(w, r, "jobs.html", map[string]any{
 		"Scans": scans, "Page": page,
 		"Skill": skillName, "Status": status, "Sort": sort, "Skills": skillNames,
-		"AnySubPath": anySubPath,
+		"AnySubPath": anySubPath, "QueuedCount": queuedCount, "PausedCount": pausedCount,
+		"PlanLimitFailedCount": planLimitFailedCount,
 	})
+}
+
+func (s *Server) scanStatusCount(status db.ScanStatus) int64 {
+	var n int64
+	s.DB.Model(&db.Scan{}).Where("status = ?", status).Count(&n)
+	return n
+}
+
+func (s *Server) planLimitFailedCount() int64 {
+	var n int64
+	s.DB.Model(&db.Scan{}).
+		Where("status = ? AND error LIKE ?", db.ScanFailed, "Claude plan limit reached.%").
+		Count(&n)
+	return n
 }
 
 const skillNamesCacheTTL = 30 * time.Second
@@ -195,9 +214,82 @@ func (s *Server) scansRetryFailed(w http.ResponseWriter, r *http.Request) {
 	s.redirect(w, r, target)
 }
 
+func (s *Server) scansPauseQueued(w http.ResponseWriter, r *http.Request) {
+	var scans []db.Scan
+	if err := s.DB.Where("status = ?", db.ScanQueued).Find(&scans).Error; err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	now := time.Now()
+	for _, sc := range scans {
+		s.DB.Model(&db.Scan{}).Where("id = ? AND status = ?", sc.ID, db.ScanQueued).Updates(map[string]any{
+			statusKey:         db.ScanPaused,
+			"status_priority": db.StatusPriorityFor(db.ScanPaused),
+			errorKey:          "paused by user",
+			"finished_at":     &now,
+		})
+	}
+	setFlash(w, Flash{Category: successKey, Title: fmt.Sprintf("%d queued scans paused", len(scans))})
+	s.redirect(w, r, "/scans?status=paused")
+}
+
+func (s *Server) scansResumePaused(w http.ResponseWriter, r *http.Request) {
+	var scans []db.Scan
+	if err := s.DB.Where("status = ?", db.ScanPaused).Find(&scans).Error; err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	var resumed, errored int
+	for _, sc := range scans {
+		if err := s.resumeScan(r.Context(), &sc); err != nil {
+			errored++
+			continue
+		}
+		resumed++
+	}
+	cat := successKey
+	if errored > 0 {
+		cat = errorKey
+	}
+	setFlash(w, Flash{Category: cat, Title: fmt.Sprintf("%d paused scans resumed", resumed)})
+	s.redirect(w, r, "/scans?status=queued")
+}
+
+func (s *Server) scanResume(w http.ResponseWriter, r *http.Request) {
+	scan, ok := loadByID[db.Scan](s, w, r)
+	if !ok {
+		return
+	}
+	if scan.Status != db.ScanPaused {
+		http.Error(w, "scan is not paused", http.StatusBadRequest)
+		return
+	}
+	if err := s.resumeScan(r.Context(), &scan); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	s.redirect(w, r, fmt.Sprintf("/scans/%d", scan.ID))
+}
+
+func (s *Server) resumeScan(ctx context.Context, scan *db.Scan) error {
+	priority := worker.PrioScan
+	if scan.FindingID != nil {
+		priority = worker.PrioFinding
+	}
+	if err := s.Queue.Enqueue(ctx, scan.Kind, scan.ID, priority); err != nil {
+		return err
+	}
+	return s.DB.Model(&db.Scan{}).Where("id = ? AND status = ?", scan.ID, db.ScanPaused).Updates(map[string]any{
+		statusKey:         db.ScanQueued,
+		"status_priority": db.StatusPriorityFor(db.ScanQueued),
+		errorKey:          "",
+		"finished_at":     nil,
+	}).Error
+}
+
 func retryFailedToast(retried, skipped, errored int) Flash {
 	if retried == 0 && skipped == 0 && errored == 0 {
-		return Flash{Category: "success", Title: "No failed scans to retry"}
+		return Flash{Category: successKey, Title: "No failed scans to retry"}
 	}
 	parts := []string{fmt.Sprintf("%d retried", retried)}
 	if skipped > 0 {
@@ -206,12 +298,12 @@ func retryFailedToast(retried, skipped, errored int) Flash {
 	if errored > 0 {
 		parts = append(parts, fmt.Sprintf("%d errored", errored))
 	}
-	cat := "success"
+	cat := successKey
 	switch {
 	case errored > 0:
-		cat = "error"
+		cat = errorKey
 	case retried == 0:
-		cat = "warning"
+		cat = warningKey
 	}
 	return Flash{Category: cat, Title: strings.Join(parts, ", ")}
 }
@@ -225,12 +317,17 @@ func (s *Server) scanCancel(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "scan already finished", http.StatusBadRequest)
 		return
 	}
+	if scan.Status == db.ScanPaused {
+		http.Error(w, "scan is paused", http.StatusBadRequest)
+		return
+	}
 	if !s.Worker.Cancel(scan.ID) {
 		// Not in flight: mark the row so the queue handler drops it on pickup.
+		now := time.Now()
 		s.DB.Model(&scan).Updates(map[string]any{
-			"status":      db.ScanCancelled,
-			"error":       "cancelled by user",
-			"finished_at": new(time.Now()),
+			statusKey:     db.ScanCancelled,
+			errorKey:      "cancelled by user",
+			"finished_at": &now,
 		})
 	}
 	s.redirect(w, r, fmt.Sprintf("/scans/%d", scan.ID))

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -124,7 +124,7 @@ func New(gdb *gorm.DB, q *queue.Queue, log *slog.Logger, broker *Broker, w *work
 		"dur":      humanDuration,
 		"usd":      formatUSD,
 		"pct":      formatPct,
-		"status":   func(s db.ScanStatus) string { return string(s) },
+		statusKey:  func(s db.ScanStatus) string { return string(s) },
 		"fstatus":  func(s db.FindingLifecycle) string { return string(s) },
 		"sevlabel": displaySeverity,
 		"dict": func(kv ...any) map[string]any {
@@ -266,6 +266,9 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("GET /scans/{id}", s.scanShow)
 	mux.HandleFunc("GET /scans/{id}/report.md", s.scanReport)
 	mux.HandleFunc("POST /scans/{id}/retry", s.scanRetry)
+	mux.HandleFunc("POST /scans/{id}/resume", s.scanResume)
+	mux.HandleFunc("POST /scans/pause-queued", s.scansPauseQueued)
+	mux.HandleFunc("POST /scans/resume-paused", s.scansResumePaused)
 	mux.HandleFunc("POST /scans/retry-failed", s.scansRetryFailed)
 	mux.HandleFunc("POST /scans/{id}/cancel", s.scanCancel)
 	mux.HandleFunc("GET /scans/{id}/log", s.scanLog)
@@ -383,6 +386,10 @@ func (s *Server) index(w http.ResponseWriter, r *http.Request) {
 const (
 	perPage     = 20
 	defaultSort = "newest"
+	statusKey   = "status"
+	errorKey    = "error"
+	successKey  = "success"
+	warningKey  = "warning"
 	// sortRepository and sortSeverity are the shared sort options used by
 	// the findings, scans, advisories, and SBOM indexes.
 	sortRepository = "repository"
@@ -680,7 +687,7 @@ func (s *Server) findings(w http.ResponseWriter, r *http.Request) {
 	if sev != "" {
 		q = q.Where("severity = ?", sev)
 	}
-	status := r.URL.Query().Get("status")
+	status := r.URL.Query().Get(statusKey)
 	if status != "" {
 		q = q.Where("status = ?", status)
 	}
@@ -859,12 +866,12 @@ func (s *Server) findingStatus(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	status := db.FindingLifecycle(r.FormValue("status"))
+	status := db.FindingLifecycle(r.FormValue(statusKey))
 	switch status {
 	case db.FindingNew, db.FindingEnriched, db.FindingTriaged, db.FindingReady,
 		db.FindingReported, db.FindingAcknowledged, db.FindingFixed, db.FindingPublished,
 		db.FindingRejected, db.FindingDuplicate:
-		if err := db.WriteFindingField(s.DB, f.ID, "status", string(status), db.SourceAnalyst, ""); err != nil {
+		if err := db.WriteFindingField(s.DB, f.ID, statusKey, string(status), db.SourceAnalyst, ""); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
@@ -932,7 +939,7 @@ func (s *Server) repoVerifyAll(w http.ResponseWriter, r *http.Request) {
 	}
 	var skill db.Skill
 	if err := s.DB.Where("name = ? AND active = ?", verifySkillName, true).First(&skill).Error; err != nil {
-		setFlash(w, Flash{Category: "error", Title: verifySkillName + " skill is not installed"})
+		setFlash(w, Flash{Category: errorKey, Title: verifySkillName + " skill is not installed"})
 		s.redirect(w, r, fmt.Sprintf("/repositories/%d#rt4", repo.ID))
 		return
 	}
@@ -971,7 +978,7 @@ func (s *Server) repoVerifyAll(w http.ResponseWriter, r *http.Request) {
 
 func verifyAllToast(queued, skipped, errored int) Flash {
 	if queued == 0 && skipped == 0 && errored == 0 {
-		return Flash{Category: "success", Title: "No findings awaiting verification"}
+		return Flash{Category: successKey, Title: "No findings awaiting verification"}
 	}
 	parts := []string{fmt.Sprintf("%d queued", queued)}
 	if skipped > 0 {
@@ -980,12 +987,12 @@ func verifyAllToast(queued, skipped, errored int) Flash {
 	if errored > 0 {
 		parts = append(parts, fmt.Sprintf("%d errored", errored))
 	}
-	cat := "success"
+	cat := successKey
 	switch {
 	case errored > 0:
-		cat = "error"
+		cat = errorKey
 	case queued == 0:
-		cat = "warning"
+		cat = warningKey
 	}
 	return Flash{Category: cat, Title: "Verify all: " + strings.Join(parts, ", ")}
 }
@@ -1320,12 +1327,12 @@ func (s *Server) createOrTriageRepo(ctx context.Context, input RepoInput, model 
 
 func bulkToastCategory(created int, invalid []string) string {
 	if created > 0 && len(invalid) == 0 {
-		return "success"
+		return successKey
 	}
 	if created == 0 && len(invalid) > 0 {
-		return "error"
+		return errorKey
 	}
-	return "warning"
+	return warningKey
 }
 
 func bulkToastTitle(created, skipped, invalid int) string {

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -2942,6 +2942,106 @@ func TestScanCancel_terminalRejected(t *testing.T) {
 	}
 }
 
+func TestScansPauseQueued(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	repo := db.Repository{URL: "https://example.com/x.git", Name: "x"}
+	s.DB.Create(&repo)
+	queued := db.Scan{RepositoryID: repo.ID, Kind: "skill", Status: db.ScanQueued, StatusPriority: db.StatusPriorityFor(db.ScanQueued)}
+	running := db.Scan{RepositoryID: repo.ID, Kind: "skill", Status: db.ScanRunning, StatusPriority: db.StatusPriorityFor(db.ScanRunning)}
+	s.DB.Create(&queued)
+	s.DB.Create(&running)
+
+	req := httptest.NewRequest("POST", "/scans/pause-queued", nil)
+	req.Host = testHost
+	req.Header.Set("Sec-Fetch-Site", "same-origin")
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("pause status %d: %s", w.Code, w.Body)
+	}
+	if loc := w.Header().Get("Location"); loc != "/scans?status=paused" {
+		t.Errorf("redirect = %q, want paused filter", loc)
+	}
+
+	var gotQueued, gotRunning db.Scan
+	s.DB.First(&gotQueued, queued.ID)
+	s.DB.First(&gotRunning, running.ID)
+	if gotQueued.Status != db.ScanPaused {
+		t.Errorf("queued status = %s, want paused", gotQueued.Status)
+	}
+	if gotQueued.StatusPriority != db.StatusPriorityFor(db.ScanPaused) {
+		t.Errorf("paused priority = %d", gotQueued.StatusPriority)
+	}
+	if gotRunning.Status != db.ScanRunning {
+		t.Errorf("running status = %s, want running", gotRunning.Status)
+	}
+}
+
+func TestScanResumePaused(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	repo := db.Repository{URL: "https://example.com/x.git", Name: "x"}
+	s.DB.Create(&repo)
+	skill := db.Skill{Name: "deep-dive", Description: "x", Body: "b", Active: true, Source: "ui", Version: 1}
+	s.DB.Create(&skill)
+	scan := db.Scan{
+		RepositoryID: repo.ID, Kind: "skill", Status: db.ScanPaused,
+		StatusPriority: db.StatusPriorityFor(db.ScanPaused),
+		SkillID:        &skill.ID, SkillName: skill.Name, Error: "paused by user",
+	}
+	s.DB.Create(&scan)
+
+	req := httptest.NewRequest("POST", fmt.Sprintf("/scans/%d/resume", scan.ID), nil)
+	req.Host = testHost
+	req.Header.Set("Sec-Fetch-Site", "same-origin")
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("resume status %d: %s", w.Code, w.Body)
+	}
+
+	var got db.Scan
+	s.DB.First(&got, scan.ID)
+	if got.Status != db.ScanQueued {
+		t.Errorf("status = %s, want queued", got.Status)
+	}
+	if got.StatusPriority != db.StatusPriorityFor(db.ScanQueued) {
+		t.Errorf("priority = %d", got.StatusPriority)
+	}
+	if got.Error != "" {
+		t.Errorf("error = %q, want cleared", got.Error)
+	}
+}
+
+func TestJobs_showsPlanLimitPauseActions(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	repo := db.Repository{URL: "https://example.com/x.git", Name: "x"}
+	s.DB.Create(&repo)
+	s.DB.Create(&db.Scan{RepositoryID: repo.ID, Kind: "skill", Status: db.ScanQueued, StatusPriority: db.StatusPriorityFor(db.ScanQueued)})
+	s.DB.Create(&db.Scan{
+		RepositoryID: repo.ID, Kind: "skill", Status: db.ScanFailed,
+		StatusPriority: db.StatusPriorityFor(db.ScanFailed),
+		Error:          "Claude plan limit reached. Pause queued scans and retry after your limit resets.",
+	})
+
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq("GET", "/scans"))
+	if w.Code != 200 {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+	body := w.Body.String()
+	for _, want := range []string{"Claude plan limit reached", "/scans/pause-queued"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("missing %q in jobs body", want)
+		}
+	}
+}
+
 func TestSubprojectsRenderedOnRepoPage(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()

--- a/internal/web/sse.go
+++ b/internal/web/sse.go
@@ -127,9 +127,9 @@ func (s *Server) renderScanStatus(scanID uint) string {
 	s.DB.Model(&db.Finding{}).Where("scan_id = ?", scan.ID).Count(&n)
 	scan.FindingsCount = int(n)
 
-	cat := "success"
+	cat := successKey
 	if scan.Status != db.ScanDone {
-		cat = "error"
+		cat = errorKey
 	}
 	flash := Flash{
 		Category:    cat,

--- a/internal/web/templates/jobs.html
+++ b/internal/web/templates/jobs.html
@@ -5,6 +5,20 @@
     <i data-lucide="list-checks"></i> Scans
   </h2>
   <div class="flex items-center gap-2">
+    {{if .QueuedCount}}
+      <form method="post" action="/scans/pause-queued"
+            hx-post="/scans/pause-queued" hx-swap="none"
+            hx-confirm="Pause every queued scan? Running scans will continue.">
+        <button type="submit" class="btn-outline"><i data-lucide="pause"></i> Pause queued</button>
+      </form>
+    {{end}}
+    {{if .PausedCount}}
+      <form method="post" action="/scans/resume-paused"
+            hx-post="/scans/resume-paused" hx-swap="none"
+            hx-confirm="Resume every paused scan?">
+        <button type="submit" class="btn-outline"><i data-lucide="play"></i> Resume paused</button>
+      </form>
+    {{end}}
     {{if and (eq .Status "failed") .Page.Total}}
       <form method="post" action="/scans/retry-failed?skill={{.Skill}}"
             hx-post="/scans/retry-failed?skill={{.Skill}}" hx-swap="none"
@@ -37,7 +51,7 @@
       <div data-popover aria-hidden="true" data-align="end">
         <div role="menu">
           <a role="menuitem" href="/scans?skill={{.Skill}}&sort={{.Sort}}">All statuses</a>
-          {{range (list "queued" "running" "done" "failed" "cancelled")}}
+          {{range (list "queued" "paused" "running" "done" "failed" "cancelled")}}
             <a role="menuitem" href="/scans?skill={{$.Skill}}&status={{.}}&sort={{$.Sort}}"
                {{if eq . $.Status}}aria-current="true"{{end}}>{{.}}</a>
           {{end}}
@@ -61,6 +75,16 @@
     </div>
   </div>
 </div>
+
+{{if and .PlanLimitFailedCount .QueuedCount}}
+  <div class="alert-destructive mb-6">
+    <i data-lucide="triangle-alert"></i>
+    <section>
+      <strong>Claude plan limit reached.</strong>
+      Pause queued scans so they do not keep starting, then resume them after the limit resets.
+    </section>
+  </div>
+{{end}}
 
 {{if .Scans}}
   <table class="table">

--- a/internal/web/templates/layout.html
+++ b/internal/web/templates/layout.html
@@ -168,6 +168,11 @@
           hx-swap="none">
       <button type="submit" class="btn-sm-ghost" data-tooltip="Cancel"><i data-lucide="x"></i></button>
     </form>
+  {{else if eq (status .Status) "paused"}}
+    <form method="post" action="/scans/{{.ID}}/resume" hx-post="/scans/{{.ID}}/resume"
+          hx-swap="none">
+      <button type="submit" class="btn-sm-ghost" data-tooltip="Resume"><i data-lucide="play"></i></button>
+    </form>
   {{else if and (or (eq (status .Status) "failed") (eq (status .Status) "cancelled")) .SkillID}}
     <form method="post" action="/scans/{{.ID}}/retry" hx-post="/scans/{{.ID}}/retry"
           hx-swap="none">
@@ -200,6 +205,7 @@
   {{if eq . "done"}}<span class="badge-secondary"><i data-lucide="check"></i> complete</span>
   {{else if eq . "failed"}}<span class="badge-destructive"><i data-lucide="x"></i> failed</span>
   {{else if eq . "cancelled"}}<span class="badge-outline"><i data-lucide="circle-slash"></i> cancelled</span>
+  {{else if eq . "paused"}}<span class="badge-outline"><i data-lucide="pause"></i> paused</span>
   {{else if eq . "running"}}<span class="badge-primary"><i data-lucide="loader-circle" class="animate-spin"></i> running</span>
   {{else if eq . "active"}}<span class="badge-secondary"><i data-lucide="circle-check"></i> active</span>
   {{else if eq . "inactive"}}<span class="badge-outline"><i data-lucide="moon"></i> inactive</span>

--- a/internal/web/templates/scan_show.html
+++ b/internal/web/templates/scan_show.html
@@ -22,6 +22,11 @@
             hx-post="/scans/{{.ID}}/cancel" hx-swap="none">
         <button type="submit" class="btn-outline"><i data-lucide="x"></i> Cancel</button>
       </form>
+      {{else if eq (status .Status) "paused"}}
+      <form method="post" action="/scans/{{.ID}}/resume"
+            hx-post="/scans/{{.ID}}/resume" hx-swap="none">
+        <button type="submit" class="btn-outline"><i data-lucide="play"></i> Resume</button>
+      </form>
       {{else}}
       <form method="post" action="/scans/{{.ID}}/retry"
             hx-post="/scans/{{.ID}}/retry" hx-swap="none">
@@ -101,7 +106,7 @@
   </div>
 {{end}}
 
-{{$live := not .Status.Terminal}}
+{{$live := and (not .Status.Terminal) (ne (status .Status) "paused")}}
 {{$default := 1}}{{if $live}}{{$default = 2}}{{end}}
 <div class="tabs w-full" id="scan-tabs">
   <nav role="tablist" aria-orientation="horizontal">

--- a/internal/web/theme.go
+++ b/internal/web/theme.go
@@ -140,7 +140,7 @@ func (s *Server) settingsUpdateTheme(w http.ResponseWriter, r *http.Request) {
 		HttpOnly: true,
 		SameSite: http.SameSiteStrictMode,
 	})
-	setFlash(w, Flash{Category: "success", Title: "Theme updated"})
+	setFlash(w, Flash{Category: successKey, Title: "Theme updated"})
 	s.redirect(w, r, "/settings")
 }
 
@@ -151,7 +151,7 @@ func (s *Server) settingsUpdateModel(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	SetDefaultModel(model)
-	setFlash(w, Flash{Category: "success", Title: "Default model updated"})
+	setFlash(w, Flash{Category: successKey, Title: "Default model updated"})
 	s.redirect(w, r, "/settings")
 }
 
@@ -168,6 +168,6 @@ func (s *Server) settingsUpdateColorScheme(w http.ResponseWriter, r *http.Reques
 		MaxAge:   cookieMaxAge,
 		SameSite: http.SameSiteStrictMode,
 	})
-	setFlash(w, Flash{Category: "success", Title: "Color scheme updated"})
+	setFlash(w, Flash{Category: successKey, Title: "Color scheme updated"})
 	s.redirect(w, r, "/settings")
 }

--- a/internal/worker/claude.go
+++ b/internal/worker/claude.go
@@ -132,10 +132,17 @@ func (l LocalClaude) RunSkill(ctx context.Context, sj SkillJob, emit func(Event)
 	}
 
 	emit(Event{Kind: KindText, Text: "$ claude -p <skill:" + sj.Name + ">"})
+	planLimitText := ""
+	wrappedEmit := func(e Event) {
+		if planLimitText == "" {
+			planLimitText = claudePlanLimitText(e.Text)
+		}
+		emit(e)
+	}
 	args := buildClaudeArgs(sj, l.Effort, l.MaxTurns)
-	hitMaxTurns, sessionID, waitErr := l.runClaudeOnce(ctx, args, work, emit)
+	hitMaxTurns, sessionID, waitErr := l.runClaudeOnce(ctx, args, work, wrappedEmit)
 
-	if waitErr != nil && sj.ResumeSessionID != "" && sessionID == "" {
+	if waitErr != nil && sj.ResumeSessionID != "" && sessionID == "" && planLimitText == "" {
 		// The resume never produced a session event, so claude could not
 		// load the saved conversation (expired or pruned). Restart fresh in
 		// the same workspace so the retry lineage isn't permanently wedged
@@ -144,7 +151,7 @@ func (l LocalClaude) RunSkill(ctx context.Context, sj SkillJob, emit func(Event)
 		fresh := sj
 		fresh.ResumeSessionID = ""
 		args = buildClaudeArgs(fresh, l.Effort, l.MaxTurns)
-		hitMaxTurns, sessionID, waitErr = l.runClaudeOnce(ctx, args, work, emit)
+		hitMaxTurns, sessionID, waitErr = l.runClaudeOnce(ctx, args, work, wrappedEmit)
 	}
 
 	res := SkillResult{Commit: commit, SessionID: sessionID}
@@ -154,6 +161,9 @@ func (l LocalClaude) RunSkill(ctx context.Context, sj SkillJob, emit func(Event)
 	if waitErr != nil {
 		if hitMaxTurns {
 			return res, &MaxTurnsReachedError{}
+		}
+		if planLimitText != "" {
+			return res, &ClaudePlanLimitError{Detail: planLimitText}
 		}
 		return res, fmt.Errorf("claude exited: %w", waitErr)
 	}

--- a/internal/worker/claude_limit.go
+++ b/internal/worker/claude_limit.go
@@ -1,0 +1,41 @@
+package worker
+
+import "strings"
+
+// ClaudePlanLimitError is returned when claude-code reports an account or plan
+// limit rather than a skill failure. The scan still fails, but the UI can show
+// a clear operator action instead of a generic process-exit error.
+type ClaudePlanLimitError struct {
+	Detail string
+}
+
+func (e *ClaudePlanLimitError) Error() string {
+	if e.Detail == "" {
+		return "Claude plan limit reached. Pause queued scans and retry after your limit resets."
+	}
+	return "Claude plan limit reached. Pause queued scans and retry after your limit resets. " + e.Detail
+}
+
+func claudePlanLimitText(s string) string {
+	text := strings.TrimSpace(s)
+	if text == "" {
+		return ""
+	}
+	lower := strings.ToLower(text)
+	for _, phrase := range []string{
+		"usage limit",
+		"session limit",
+		"plan limit",
+		"rate limit",
+		"rate_limit",
+		"too many requests",
+		"quota exceeded",
+		"credit balance",
+		"429",
+	} {
+		if strings.Contains(lower, phrase) {
+			return text
+		}
+	}
+	return ""
+}

--- a/internal/worker/claude_test.go
+++ b/internal/worker/claude_test.go
@@ -162,6 +162,21 @@ func TestLocalClaude_ResumeFallsBackToFresh(t *testing.T) {
 	}
 }
 
+func TestClaudePlanLimitText(t *testing.T) {
+	for _, text := range []string{
+		"Claude usage limit reached. Your limit will reset later.",
+		"API Error: 429 Too Many Requests",
+		"quota exceeded for this account",
+	} {
+		if got := claudePlanLimitText(text); got == "" {
+			t.Errorf("claudePlanLimitText(%q) did not match", text)
+		}
+	}
+	if got := claudePlanLimitText("syntax error in generated report"); got != "" {
+		t.Errorf("claudePlanLimitText returned false positive %q", got)
+	}
+}
+
 func flagValue(args []string, flag string) string {
 	for i, a := range args {
 		if a == flag && i+1 < len(args) {

--- a/internal/worker/docker.go
+++ b/internal/worker/docker.go
@@ -139,9 +139,16 @@ func (d DockerRunner) RunSkill(ctx context.Context, sj SkillJob, emit func(Event
 	}
 	emit(Event{Kind: KindText, Text: logLine})
 
-	hitMaxTurns, sessionID, waitErr := d.runDockerOnce(ctx, dockerBase, sj, emit)
+	planLimitText := ""
+	wrappedEmit := func(e Event) {
+		if planLimitText == "" {
+			planLimitText = claudePlanLimitText(e.Text)
+		}
+		emit(e)
+	}
+	hitMaxTurns, sessionID, waitErr := d.runDockerOnce(ctx, dockerBase, sj, wrappedEmit)
 
-	if waitErr != nil && sj.ResumeSessionID != "" && sessionID == "" {
+	if waitErr != nil && sj.ResumeSessionID != "" && sessionID == "" && planLimitText == "" {
 		// The resume produced no session event, so claude could not load the
 		// saved conversation (gone from the mounted store). Restart fresh in
 		// the same /work + config mount so the retry lineage isn't wedged on
@@ -149,7 +156,7 @@ func (d DockerRunner) RunSkill(ctx context.Context, sj SkillJob, emit func(Event
 		emit(Event{Kind: KindText, Text: "resume of session " + sj.ResumeSessionID + " failed; restarting fresh"})
 		fresh := sj
 		fresh.ResumeSessionID = ""
-		hitMaxTurns, sessionID, waitErr = d.runDockerOnce(ctx, dockerBase, fresh, emit)
+		hitMaxTurns, sessionID, waitErr = d.runDockerOnce(ctx, dockerBase, fresh, wrappedEmit)
 	}
 
 	res := SkillResult{Commit: commit, Profile: profile, SessionID: sessionID}
@@ -159,6 +166,9 @@ func (d DockerRunner) RunSkill(ctx context.Context, sj SkillJob, emit func(Event
 	if waitErr != nil {
 		if hitMaxTurns {
 			return res, &MaxTurnsReachedError{}
+		}
+		if planLimitText != "" {
+			return res, &ClaudePlanLimitError{Detail: planLimitText}
 		}
 		return res, fmt.Errorf("docker exited: %w", waitErr)
 	}

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -194,7 +194,7 @@ func (w *Worker) wrap(h handler) func(context.Context, []byte) error {
 		if err := w.DB.Preload("Repository").First(&scan, p.ScanID).Error; err != nil {
 			return fmt.Errorf("load scan %d: %w", p.ScanID, err)
 		}
-		if scan.Status.Terminal() {
+		if scan.Status != db.ScanQueued {
 			w.Log.Info("dropping stale job", "scan", scan.ID, "status", scan.Status)
 			return nil
 		}
@@ -230,39 +230,7 @@ func (w *Worker) wrap(h handler) func(context.Context, []byte) error {
 
 		report, err := h(ctx, &scan, emit)
 
-		scan.FinishedAt = new(time.Now())
-		switch {
-		case errors.Is(ctx.Err(), context.DeadlineExceeded):
-			scan.Status = db.ScanFailed
-			scan.Error = fmt.Sprintf("scan timed out after %s", timeout)
-			emit(Event{Kind: KindError, Text: scan.Error})
-		case errors.Is(ctx.Err(), context.Canceled):
-			scan.Status = db.ScanCancelled
-			scan.Error = "cancelled by user"
-			emit(Event{Kind: KindError, Text: "cancelled by user"})
-		case err != nil:
-			if _, ok := errors.AsType[*MaxTurnsReachedError](err); ok {
-				scan.Status = db.ScanDone
-				scan.Report = report
-				emit(Event{Kind: KindText, Text: "scan completed (hit max turns cap)"})
-			} else if _, ok := errors.AsType[*FailOnThresholdError](err); ok {
-				scan.Status = db.ScanFailed
-				scan.Report = report
-				scan.Error = err.Error()
-				emit(Event{Kind: KindError, Text: err.Error()})
-			} else if _, ok := errors.AsType[*SchemaValidationError](err); ok {
-				scan.Status = db.ScanFailed
-				scan.Report = report
-				scan.Error = err.Error()
-			} else {
-				scan.Status = db.ScanFailed
-				scan.Error = err.Error()
-				emit(Event{Kind: KindError, Text: err.Error()})
-			}
-		default:
-			scan.Status = db.ScanDone
-			scan.Report = report
-		}
+		finishScan(ctx, &scan, report, err, timeout, emit)
 		if scan.Status == db.ScanDone {
 			w.clearSessionStore(&scan)
 		}
@@ -278,5 +246,49 @@ func (w *Worker) wrap(h handler) func(context.Context, []byte) error {
 		w.publish(scan.ID, scan.RepositoryID, "scan-status", string(scan.Status))
 		w.Log.Info("job finished", "scan", scan.ID, "kind", scan.Kind, "status", scan.Status)
 		return nil
+	}
+}
+
+func finishScan(ctx context.Context, scan *db.Scan, report string, err error, timeout time.Duration, emit func(Event)) {
+	scan.FinishedAt = new(time.Now())
+	switch {
+	case errors.Is(ctx.Err(), context.DeadlineExceeded):
+		scan.Status = db.ScanFailed
+		scan.Error = fmt.Sprintf("scan timed out after %s", timeout)
+		emit(Event{Kind: KindError, Text: scan.Error})
+	case errors.Is(ctx.Err(), context.Canceled):
+		scan.Status = db.ScanCancelled
+		scan.Error = "cancelled by user"
+		emit(Event{Kind: KindError, Text: scan.Error})
+	case err != nil:
+		finishErroredScan(scan, report, err, emit)
+	default:
+		scan.Status = db.ScanDone
+		scan.Report = report
+	}
+}
+
+func finishErroredScan(scan *db.Scan, report string, err error, emit func(Event)) {
+	scan.Status = db.ScanFailed
+	scan.Error = err.Error()
+	_, maxTurns := errors.AsType[*MaxTurnsReachedError](err)
+	_, failOnThreshold := errors.AsType[*FailOnThresholdError](err)
+	_, schemaValidation := errors.AsType[*SchemaValidationError](err)
+	_, planLimit := errors.AsType[*ClaudePlanLimitError](err)
+	switch {
+	case maxTurns:
+		scan.Status = db.ScanDone
+		scan.Report = report
+		scan.Error = ""
+		emit(Event{Kind: KindText, Text: "scan completed (hit max turns cap)"})
+	case failOnThreshold:
+		scan.Report = report
+		emit(Event{Kind: KindError, Text: scan.Error})
+	case schemaValidation:
+		scan.Report = report
+	case planLimit:
+		emit(Event{Kind: KindError, Text: scan.Error})
+	default:
+		emit(Event{Kind: KindError, Text: scan.Error})
 	}
 }

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -141,6 +142,74 @@ func TestWorker_maxTurnsReachedCompletesNotFails(t *testing.T) {
 	}
 	if got.Report != `{"partial":true}` {
 		t.Errorf("report = %q, want partial report preserved", got.Report)
+	}
+}
+
+func TestWorker_claudePlanLimitUsesHelpfulError(t *testing.T) {
+	gdb, err := db.Open(filepath.Join(t.TempDir(), "limit.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo := db.Repository{URL: "https://example.com/x", Name: "x"}
+	gdb.Create(&repo)
+	skill := db.Skill{Name: "limited", Description: "x", Body: "b", Active: true, Source: "ui", Version: 1}
+	gdb.Create(&skill)
+	scan := db.Scan{RepositoryID: repo.ID, Kind: JobSkill, Status: db.ScanQueued, SkillID: &skill.ID}
+	gdb.Create(&scan)
+
+	w := &Worker{
+		DB:             gdb,
+		Log:            slog.New(slog.NewTextHandler(io.Discard, nil)),
+		DataDir:        t.TempDir(),
+		Runner:         fakeRunner{skillErr: &ClaudePlanLimitError{Detail: "usage limit reached"}},
+		PrepareRepoSrc: stubPrepareRepoSrc,
+	}
+	body, _ := json.Marshal(queue.Payload{ScanID: scan.ID})
+	if err := w.wrap(w.doSkill)(context.Background(), body); err != nil {
+		t.Fatalf("wrap: %v", err)
+	}
+
+	var got db.Scan
+	gdb.First(&got, scan.ID)
+	if got.Status != db.ScanFailed {
+		t.Errorf("status = %s, want failed", got.Status)
+	}
+	if !strings.Contains(got.Error, "Claude plan limit reached") {
+		t.Errorf("error = %q", got.Error)
+	}
+}
+
+func TestWorker_skipsPausedScan(t *testing.T) {
+	gdb, err := db.Open(filepath.Join(t.TempDir(), "paused.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo := db.Repository{URL: "https://example.com/x", Name: "x"}
+	gdb.Create(&repo)
+	skill := db.Skill{Name: "paused", Description: "x", Body: "b", Active: true, Source: "ui", Version: 1}
+	gdb.Create(&skill)
+	scan := db.Scan{RepositoryID: repo.ID, Kind: JobSkill, Status: db.ScanPaused, SkillID: &skill.ID}
+	gdb.Create(&scan)
+
+	w := &Worker{
+		DB:             gdb,
+		Log:            slog.New(slog.NewTextHandler(io.Discard, nil)),
+		DataDir:        t.TempDir(),
+		Runner:         fakeRunner{skillErr: errors.New("should not run")},
+		PrepareRepoSrc: stubPrepareRepoSrc,
+	}
+	body, _ := json.Marshal(queue.Payload{ScanID: scan.ID})
+	if err := w.wrap(w.doSkill)(context.Background(), body); err != nil {
+		t.Fatalf("wrap: %v", err)
+	}
+
+	var got db.Scan
+	gdb.First(&got, scan.ID)
+	if got.Status != db.ScanPaused {
+		t.Errorf("status = %s, want paused", got.Status)
+	}
+	if got.Error != "" {
+		t.Errorf("paused scan should not run; error = %q", got.Error)
 	}
 }
 


### PR DESCRIPTION
closes #293

## Summary

Improves the operator experience when Claude plan/session limits are hit during scan runs...

Changes include:

- Add a new `paused` scan status.
- Add **Pause queued** and **Resume paused** actions on the Scans page.
- Add per-scan resume support for paused scans.
- Make workers safely ignore paused/stale queue messages.
- Detect Claude usage/session/rate-limit style failures and surface a clearer error message.
- Show a Scans page warning when Claude plan-limit failures exist while scans are still queued.

## Testing

- `go test ./internal/db ./internal/worker ./internal/web`
- `go test ./...`
- `git diff --check`