### PR TITLE
fix: update allowed tools to include Skill in permission mode

### DIFF
--- a/internal/worker/claude.go
+++ b/internal/worker/claude.go
@@ -205,7 +205,7 @@ func buildClaudeArgs(sj SkillJob, effort string, globalMaxTurns int) []string {
 	if sj.AllowedTools != "" {
 		args = append(args,
 			"--permission-mode", "acceptEdits",
-			"--allowedTools", sj.AllowedTools,
+			"--allowedTools", sj.AllowedTools+",Skill",
 		)
 	} else {
 		args = append(args, "--permission-mode", "bypassPermissions")

--- a/internal/worker/claude_test.go
+++ b/internal/worker/claude_test.go
@@ -55,8 +55,8 @@ func TestBuildClaudeArgs_AllowedTools(t *testing.T) {
 	if got := flagValue(args, "--permission-mode"); got != "acceptEdits" {
 		t.Errorf("permission-mode = %q, want acceptEdits", got)
 	}
-	if got := flagValue(args, "--allowedTools"); got != "Read,Write,WebFetch" {
-		t.Errorf("allowedTools = %q, want Read,Write,WebFetch", got)
+	if got := flagValue(args, "--allowedTools"); got != "Read,Write,WebFetch,Skill" {
+		t.Errorf("allowedTools = %q, want Read,Write,WebFetch,Skill", got)
 	}
 	if got := flagValue(args, "--model"); got != "claude-sonnet-4-6" {
 		t.Errorf("model = %q", got)

--- a/skills/maintainers/SKILL.md
+++ b/skills/maintainers/SKILL.md
@@ -10,7 +10,6 @@ metadata:
   scrutineer.output_kind: maintainers
   scrutineer.requires_remote: true
   scrutineer.model: claude-sonnet-4-6
-  scrutineer.max_turns: 20
 ---
 
 # maintainers


### PR DESCRIPTION
I systematically ran into Claude telling that `the skill invocation failed` for every skill I ran. It seems that we're missing `Skill` in the allowed tools and the model then tries what it can with the skill name only, but often fails.

Also removed max turns of `maintainers`, I ran every time into the limit.