### PR TITLE
Capture Claude session id and --resume failed scans on retry

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -157,6 +157,24 @@ type Scan struct {
 	// operator's override and the UI can show the chosen ecosystem.
 	Profile string `gorm:"index"`
 
+	// SessionID is the claude-code session this scan's run belongs to,
+	// captured from the stream-json init/result events. It is written as
+	// soon as the init event arrives (before the run finishes) so it
+	// survives a crash, and cleared once the scan reaches "done" so a
+	// deliberate re-run from the UI starts a fresh conversation. A retry
+	// of a failed scan carries this value forward so the runner can pass
+	// `claude -p --resume <id>` and continue from where it left off
+	// instead of restarting from turn 0.
+	SessionID string
+	// ResumedFromScanID points at the lineage-root scan whose claude session
+	// and workspace a retry reuses. Nil on a fresh scan. claude keys its
+	// session store by working directory, so a resuming run must execute
+	// in the same per-scan workspace path as the original; this pins that
+	// path across the whole retry chain. Always the root of the lineage,
+	// not the immediate parent, so N retries deep still resolve to one
+	// workspace.
+	ResumedFromScanID *uint `gorm:"index"`
+
 	Commit     string
 	StartedAt  *time.Time
 	FinishedAt *time.Time

--- a/internal/web/scans.go
+++ b/internal/web/scans.go
@@ -94,18 +94,37 @@ func (s *Server) scanRetry(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "scan cannot be retried: no skill reference", http.StatusBadRequest)
 		return
 	}
+	sessionID, resumeOf := resumeOpts(scan)
 	newID, err := s.enqueueSkillWith(r.Context(), scan.RepositoryID, *scan.SkillID, ScanOpts{
-		Model:     scan.Model,
-		FindingID: scan.FindingID,
-		SubPath:   scan.SubPath,
-		Ref:       scan.Ref,
-		Profile:   scan.Profile,
+		Model:             scan.Model,
+		FindingID:         scan.FindingID,
+		SubPath:           scan.SubPath,
+		Ref:               scan.Ref,
+		Profile:           scan.Profile,
+		SessionID:         sessionID,
+		ResumedFromScanID: resumeOf,
 	})
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 	s.redirect(w, r, fmt.Sprintf("/scans/%d", newID))
+}
+
+// resumeOpts decides whether a retry of scan should resume its claude
+// session. Only a failed scan that captured a session is resumable; a done
+// or cancelled scan, or one that never reached the model, retries fresh.
+// ResumedFromScanID is pinned to the lineage root so a chain of retries all
+// reuse one workspace and session rather than forking a new one each time.
+func resumeOpts(scan db.Scan) (sessionID string, resumeOf *uint) {
+	if scan.Status != db.ScanFailed || scan.SessionID == "" {
+		return "", nil
+	}
+	root := scan.ID
+	if scan.ResumedFromScanID != nil && *scan.ResumedFromScanID != 0 {
+		root = *scan.ResumedFromScanID
+	}
+	return scan.SessionID, &root
 }
 
 func (s *Server) scansRetryFailed(w http.ResponseWriter, r *http.Request) {
@@ -127,7 +146,7 @@ func (s *Server) scansRetryFailed(w http.ResponseWriter, r *http.Request) {
 	// (repository, skill, sub_path, ref, finding_id) tuple already in
 	// queued/running/done.
 	var scans []db.Scan
-	err := q.Select("id, repository_id, skill_id, model, finding_id, sub_path, ref, profile").
+	err := q.Select("id, repository_id, skill_id, model, finding_id, sub_path, ref, profile, status, session_id, resumed_from_scan_id").
 		Where(`NOT EXISTS (
 			SELECT 1 FROM scans n
 			WHERE n.id > scans.id
@@ -146,12 +165,15 @@ func (s *Server) scansRetryFailed(w http.ResponseWriter, r *http.Request) {
 
 	var retried, errored int
 	for _, sc := range scans {
+		sessionID, resumeOf := resumeOpts(sc)
 		if _, err := s.enqueueSkillWith(r.Context(), sc.RepositoryID, *sc.SkillID, ScanOpts{
-			Model:     sc.Model,
-			FindingID: sc.FindingID,
-			SubPath:   sc.SubPath,
-			Ref:       sc.Ref,
-			Profile:   sc.Profile,
+			Model:             sc.Model,
+			FindingID:         sc.FindingID,
+			SubPath:           sc.SubPath,
+			Ref:               sc.Ref,
+			Profile:           sc.Profile,
+			SessionID:         sessionID,
+			ResumedFromScanID: resumeOf,
 		}); err != nil {
 			errored++
 			continue

--- a/internal/web/scans_test.go
+++ b/internal/web/scans_test.go
@@ -1,0 +1,58 @@
+package web
+
+import (
+	"testing"
+
+	"scrutineer/internal/db"
+)
+
+func TestResumeOpts(t *testing.T) {
+	uintPtr := func(v uint) *uint { return &v }
+
+	cases := []struct {
+		name       string
+		scan       db.Scan
+		wantSID    string
+		wantResume *uint
+	}{
+		{
+			name:    "failed with session resumes from its own id",
+			scan:    db.Scan{ID: 7, Status: db.ScanFailed, SessionID: "s1"},
+			wantSID: "s1", wantResume: uintPtr(7),
+		},
+		{
+			name:    "failed retry keeps the lineage root",
+			scan:    db.Scan{ID: 9, Status: db.ScanFailed, SessionID: "s1", ResumedFromScanID: uintPtr(7)},
+			wantSID: "s1", wantResume: uintPtr(7),
+		},
+		{
+			name: "done scan retries fresh",
+			scan: db.Scan{ID: 7, Status: db.ScanDone, SessionID: ""},
+		},
+		{
+			name: "failed but no session retries fresh",
+			scan: db.Scan{ID: 7, Status: db.ScanFailed, SessionID: ""},
+		},
+		{
+			name: "cancelled scan retries fresh even with a session",
+			scan: db.Scan{ID: 7, Status: db.ScanCancelled, SessionID: "s1"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sid, resume := resumeOpts(tc.scan)
+			if sid != tc.wantSID {
+				t.Errorf("sessionID = %q, want %q", sid, tc.wantSID)
+			}
+			switch {
+			case tc.wantResume == nil && resume != nil:
+				t.Errorf("resumeOf = %v, want nil", *resume)
+			case tc.wantResume != nil && resume == nil:
+				t.Errorf("resumeOf = nil, want %d", *tc.wantResume)
+			case tc.wantResume != nil && *resume != *tc.wantResume:
+				t.Errorf("resumeOf = %d, want %d", *resume, *tc.wantResume)
+			}
+		})
+	}
+}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -1533,6 +1533,12 @@ type ScanOpts struct {
 	SubPath     string
 	Ref         string
 	Profile     string
+	// SessionID and ResumedFromScanID carry a failed scan's claude session
+	// into its retry so the new run continues the conversation with
+	// `claude -p --resume` instead of restarting from turn 0. Both empty
+	// on a normal (non-resuming) enqueue. See scanRetry.
+	SessionID         string
+	ResumedFromScanID *uint
 }
 
 func (s *Server) enqueueSkill(ctx context.Context, repoID, skillID uint, model string) (uint, error) {
@@ -1574,20 +1580,22 @@ func (s *Server) enqueueSkillWith(ctx context.Context, repoID, skillID uint, opt
 		kind = worker.JobExposure
 	}
 	scan := db.Scan{
-		RepositoryID:   repoID,
-		Kind:           kind,
-		Status:         db.ScanQueued,
-		StatusPriority: db.StatusPriorityFor(db.ScanQueued),
-		Model:          opts.Model,
-		SkillID:        &skillID,
-		SkillName:      sk.Name,
-		FindingID:      opts.FindingID,
-		DependentID:    opts.DependentID,
-		SubPath:        opts.SubPath,
-		Ref:            opts.Ref,
-		Profile:        opts.Profile,
-		SkillsRepoSHA:  s.SkillsRepoSHA,
-		APIToken:       NewAPIToken(),
+		RepositoryID:      repoID,
+		Kind:              kind,
+		Status:            db.ScanQueued,
+		StatusPriority:    db.StatusPriorityFor(db.ScanQueued),
+		Model:             opts.Model,
+		SkillID:           &skillID,
+		SkillName:         sk.Name,
+		FindingID:         opts.FindingID,
+		DependentID:       opts.DependentID,
+		SubPath:           opts.SubPath,
+		Ref:               opts.Ref,
+		Profile:           opts.Profile,
+		SessionID:         opts.SessionID,
+		ResumedFromScanID: opts.ResumedFromScanID,
+		SkillsRepoSHA:     s.SkillsRepoSHA,
+		APIToken:          NewAPIToken(),
 	}
 	if err := s.DB.Create(&scan).Error; err != nil {
 		return 0, err

--- a/internal/worker/claude.go
+++ b/internal/worker/claude.go
@@ -133,7 +133,7 @@ func (l LocalClaude) RunSkill(ctx context.Context, sj SkillJob, emit func(Event)
 
 	emit(Event{Kind: KindText, Text: "$ claude -p <skill:" + sj.Name + ">"})
 	args := buildClaudeArgs(sj, l.Effort, l.MaxTurns)
-	waitErr, hitMaxTurns, sessionID := l.runClaudeOnce(ctx, args, work, emit)
+	hitMaxTurns, sessionID, waitErr := l.runClaudeOnce(ctx, args, work, emit)
 
 	if waitErr != nil && sj.ResumeSessionID != "" && sessionID == "" {
 		// The resume never produced a session event, so claude could not
@@ -144,7 +144,7 @@ func (l LocalClaude) RunSkill(ctx context.Context, sj SkillJob, emit func(Event)
 		fresh := sj
 		fresh.ResumeSessionID = ""
 		args = buildClaudeArgs(fresh, l.Effort, l.MaxTurns)
-		waitErr, hitMaxTurns, sessionID = l.runClaudeOnce(ctx, args, work, emit)
+		hitMaxTurns, sessionID, waitErr = l.runClaudeOnce(ctx, args, work, emit)
 	}
 
 	res := SkillResult{Commit: commit, SessionID: sessionID}
@@ -164,18 +164,18 @@ func (l LocalClaude) RunSkill(ctx context.Context, sj SkillJob, emit func(Event)
 // output through emit, and reports the wait error, whether the run hit the
 // max-turns cap, and the session id from the init event (empty when no init
 // event arrived, e.g. a --resume that could not find the conversation).
-func (l LocalClaude) runClaudeOnce(ctx context.Context, args []string, work string, emit func(Event)) (waitErr error, hitMaxTurns bool, sessionID string) {
+func (l LocalClaude) runClaudeOnce(ctx context.Context, args []string, work string, emit func(Event)) (hitMaxTurns bool, sessionID string, waitErr error) {
 	cmd := exec.CommandContext(ctx, "claude", args...)
 	cmd.Dir = work
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
-		return err, false, ""
+		return false, "", err
 	}
 	cmd.Stderr = cmd.Stdout
 	if err := cmd.Start(); err != nil {
-		return fmt.Errorf("start claude: %w", err), false, ""
+		return false, "", fmt.Errorf("start claude: %w", err)
 	}
 
 	wrappedEmit := func(e Event) {
@@ -192,7 +192,7 @@ func (l LocalClaude) runClaudeOnce(ctx context.Context, args []string, work stri
 	if cmd.Process != nil {
 		_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGTERM)
 	}
-	return waitErr, hitMaxTurns, sessionID
+	return hitMaxTurns, sessionID, waitErr
 }
 
 // maxReportBytes caps how much of a skill's report.json scrutineer will

--- a/internal/worker/claude.go
+++ b/internal/worker/claude.go
@@ -69,6 +69,16 @@ type SkillJob struct {
 	// runner fails the scan if the resolved profile does not match.
 	// Empty means no constraint. Mirrors db.Skill.RequiresProfile.
 	RequiresProfile string
+	// ResumeSessionID, when non-empty, makes the runner invoke
+	// `claude -p --resume <id>` so a retried scan continues the previous
+	// conversation with full history instead of restarting from turn 0.
+	// The runner falls back to a fresh run if the session can't be found.
+	ResumeSessionID string
+	// ClaudeConfigDir is a host directory the docker runner mounts as the
+	// container's CLAUDE_CONFIG_DIR so the resumable session store persists
+	// across container restarts. Empty disables the mount (the local runner
+	// ignores it and relies on the host's own ~/.claude).
+	ClaudeConfigDir string
 }
 
 type SkillResult struct {
@@ -78,6 +88,11 @@ type SkillResult struct {
 	// default runner image ran. The worker persists this on the scan
 	// so retries and the UI can show what was picked.
 	Profile string
+	// SessionID is the claude session this run belonged to, as seen in the
+	// stream. The worker already persists it live via the emit callback;
+	// this is a backstop so the final save reflects the latest value (e.g.
+	// after a resume-fallback started a fresh session).
+	SessionID string
 }
 
 type LocalClaude struct {
@@ -116,36 +131,23 @@ func (l LocalClaude) RunSkill(ctx context.Context, sj SkillJob, emit func(Event)
 		_ = os.Remove(outPath)
 	}
 
-	args := buildClaudeArgs(sj, l.Effort, l.MaxTurns)
-	cmd := exec.CommandContext(ctx, "claude", args...)
-	cmd.Dir = work
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-
-	stdout, err := cmd.StdoutPipe()
-	if err != nil {
-		return SkillResult{}, err
-	}
-	cmd.Stderr = cmd.Stdout
-
 	emit(Event{Kind: KindText, Text: "$ claude -p <skill:" + sj.Name + ">"})
-	if err := cmd.Start(); err != nil {
-		return SkillResult{}, fmt.Errorf("start claude: %w", err)
+	args := buildClaudeArgs(sj, l.Effort, l.MaxTurns)
+	waitErr, hitMaxTurns, sessionID := l.runClaudeOnce(ctx, args, work, emit)
+
+	if waitErr != nil && sj.ResumeSessionID != "" && sessionID == "" {
+		// The resume never produced a session event, so claude could not
+		// load the saved conversation (expired or pruned). Restart fresh in
+		// the same workspace so the retry lineage isn't permanently wedged
+		// on a dead session id.
+		emit(Event{Kind: KindText, Text: "resume of session " + sj.ResumeSessionID + " failed; restarting fresh"})
+		fresh := sj
+		fresh.ResumeSessionID = ""
+		args = buildClaudeArgs(fresh, l.Effort, l.MaxTurns)
+		waitErr, hitMaxTurns, sessionID = l.runClaudeOnce(ctx, args, work, emit)
 	}
 
-	hitMaxTurns := false
-	wrappedEmit := func(e Event) {
-		if e.Kind == KindError && e.Text == "hit max turns" {
-			hitMaxTurns = true
-		}
-		emit(e)
-	}
-	ParseStream(stdout, wrappedEmit)
-	waitErr := cmd.Wait()
-	if cmd.Process != nil {
-		_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGTERM)
-	}
-
-	res := SkillResult{Commit: commit}
+	res := SkillResult{Commit: commit, SessionID: sessionID}
 	if outPath != "" {
 		res.Report = readCappedReport(outPath, emit)
 	}
@@ -156,6 +158,41 @@ func (l LocalClaude) RunSkill(ctx context.Context, sj SkillJob, emit func(Event)
 		return res, fmt.Errorf("claude exited: %w", waitErr)
 	}
 	return res, nil
+}
+
+// runClaudeOnce starts one `claude -p` invocation in work, streams its
+// output through emit, and reports the wait error, whether the run hit the
+// max-turns cap, and the session id from the init event (empty when no init
+// event arrived, e.g. a --resume that could not find the conversation).
+func (l LocalClaude) runClaudeOnce(ctx context.Context, args []string, work string, emit func(Event)) (waitErr error, hitMaxTurns bool, sessionID string) {
+	cmd := exec.CommandContext(ctx, "claude", args...)
+	cmd.Dir = work
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return err, false, ""
+	}
+	cmd.Stderr = cmd.Stdout
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("start claude: %w", err), false, ""
+	}
+
+	wrappedEmit := func(e Event) {
+		switch {
+		case e.Kind == KindError && e.Text == "hit max turns":
+			hitMaxTurns = true
+		case e.Kind == KindSession && e.SessionID != "":
+			sessionID = e.SessionID
+		}
+		emit(e)
+	}
+	ParseStream(stdout, wrappedEmit)
+	waitErr = cmd.Wait()
+	if cmd.Process != nil {
+		_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGTERM)
+	}
+	return waitErr, hitMaxTurns, sessionID
 }
 
 // maxReportBytes caps how much of a skill's report.json scrutineer will
@@ -213,8 +250,15 @@ func buildClaudeArgs(sj SkillJob, effort string, globalMaxTurns int) []string {
 	if effort != "" {
 		args = append(args, "--effort", effort)
 	}
+	if sj.ResumeSessionID != "" {
+		args = append(args, "--resume", sj.ResumeSessionID)
+	}
 	args = append(args, "--max-turns", strconv.Itoa(effectiveMaxTurns(sj.MaxTurns, globalMaxTurns)))
-	args = append(args, buildSkillPrompt(sj.Name, sj.OutputFile))
+	if sj.ResumeSessionID != "" {
+		args = append(args, buildResumePrompt(sj.Name, sj.OutputFile))
+	} else {
+		args = append(args, buildSkillPrompt(sj.Name, sj.OutputFile))
+	}
 	return args
 }
 
@@ -235,6 +279,18 @@ func effectiveMaxTurns(perSkill, global int) int {
 // claude which skill to use and where the repo lives.
 func buildSkillPrompt(name, outputFile string) string {
 	p := fmt.Sprintf("Use the %q skill on the repository cloned at ./src.", name)
+	if outputFile != "" {
+		p += fmt.Sprintf(" Write your structured output to ./%s as the skill specifies.", outputFile)
+	}
+	return p
+}
+
+// buildResumePrompt is the nudge handed to a `--resume`d run. The prior
+// turns are already in context, so this just tells the agent to carry on and
+// restates the deliverable — the report file is the whole point of the run,
+// and a resumed agent should not forget to write it.
+func buildResumePrompt(name, outputFile string) string {
+	p := fmt.Sprintf("Continue the %q skill on the repository at ./src from where you left off.", name)
 	if outputFile != "" {
 		p += fmt.Sprintf(" Write your structured output to ./%s as the skill specifies.", outputFile)
 	}

--- a/internal/worker/claude_test.go
+++ b/internal/worker/claude_test.go
@@ -2,6 +2,8 @@ package worker
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"slices"
 	"strings"
 	"testing"
@@ -66,6 +68,97 @@ func TestBuildClaudeArgs_AllowedTools(t *testing.T) {
 	}
 	if got := flagValue(args, "--max-turns"); got != "50" {
 		t.Errorf("max-turns = %q, want per-skill 50", got)
+	}
+}
+
+func TestBuildClaudeArgs_Resume(t *testing.T) {
+	sj := SkillJob{
+		Name:            "security-deep-dive",
+		Model:           "claude-opus-4-8",
+		OutputFile:      "report.json",
+		ResumeSessionID: "abc-123",
+	}
+	args := buildClaudeArgs(sj, "", 0)
+
+	if got := flagValue(args, "--resume"); got != "abc-123" {
+		t.Errorf("--resume = %q, want abc-123", got)
+	}
+	// A resumed run carries on the prior conversation, so it must not
+	// re-send the original activation prompt.
+	last := args[len(args)-1]
+	if last == buildSkillPrompt(sj.Name, sj.OutputFile) {
+		t.Errorf("resume should not reuse the activation prompt, got %q", last)
+	}
+	if last != buildResumePrompt(sj.Name, sj.OutputFile) {
+		t.Errorf("final arg = %q, want the resume prompt", last)
+	}
+	// The deliverable still has to be restated so a resumed agent writes it.
+	if !strings.Contains(last, "report.json") {
+		t.Errorf("resume prompt %q should restate the output file", last)
+	}
+}
+
+func TestBuildClaudeArgs_NoResumeWhenUnset(t *testing.T) {
+	sj := SkillJob{Name: "metadata", Model: "claude-opus-4-8", OutputFile: "report.json"}
+	args := buildClaudeArgs(sj, "", 0)
+	if slices.Contains(args, "--resume") {
+		t.Errorf("did not expect --resume in %v", args)
+	}
+}
+
+// TestLocalClaude_ResumeFallsBackToFresh drives RunSkill against a fake
+// claude that fails any --resume (as the real binary does when the session
+// is gone: an error line, no init event, exit 1) but succeeds on a fresh
+// run. The runner must detect the missing init and restart without --resume
+// so a lost session doesn't permanently wedge the retry lineage.
+func TestLocalClaude_ResumeFallsBackToFresh(t *testing.T) {
+	bin := t.TempDir()
+	script := "#!/bin/sh\n" +
+		"for a in \"$@\"; do\n" +
+		"  if [ \"$a\" = \"--resume\" ]; then\n" +
+		"    echo 'No conversation found with session ID: x'\n" +
+		"    echo '{\"type\":\"result\",\"subtype\":\"error_during_execution\",\"is_error\":true,\"session_id\":\"throwaway\",\"num_turns\":0}'\n" +
+		"    exit 1\n" +
+		"  fi\n" +
+		"done\n" +
+		"echo '{\"type\":\"system\",\"subtype\":\"init\",\"session_id\":\"fresh-sess\"}'\n" +
+		"echo '{\"type\":\"result\",\"subtype\":\"success\",\"result\":\"ok\",\"num_turns\":1}'\n" +
+		"printf '{\"done\":true}' > report.json\n" +
+		"exit 0\n"
+	if err := os.WriteFile(filepath.Join(bin, "claude"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	work := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(work, "src"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	sj := SkillJob{
+		Name:            "deep",
+		Model:           "m",
+		WorkRoot:        work,
+		SrcReady:        true,
+		OutputFile:      "report.json",
+		ResumeSessionID: "dead-session",
+	}
+	var sawFallback bool
+	res, err := LocalClaude{}.RunSkill(context.Background(), sj, func(e Event) {
+		if e.Kind == KindText && strings.Contains(e.Text, "restarting fresh") {
+			sawFallback = true
+		}
+	})
+	if err != nil {
+		t.Fatalf("RunSkill: %v", err)
+	}
+	if !sawFallback {
+		t.Error("expected a resume-fallback log line")
+	}
+	if res.SessionID != "fresh-sess" {
+		t.Errorf("SessionID = %q, want the fresh run's id", res.SessionID)
+	}
+	if res.Report != `{"done":true}` {
+		t.Errorf("Report = %q, want the fresh run's output", res.Report)
 	}
 }
 

--- a/internal/worker/docker.go
+++ b/internal/worker/docker.go
@@ -139,7 +139,7 @@ func (d DockerRunner) RunSkill(ctx context.Context, sj SkillJob, emit func(Event
 	}
 	emit(Event{Kind: KindText, Text: logLine})
 
-	waitErr, hitMaxTurns, sessionID := d.runDockerOnce(ctx, dockerBase, sj, emit)
+	hitMaxTurns, sessionID, waitErr := d.runDockerOnce(ctx, dockerBase, sj, emit)
 
 	if waitErr != nil && sj.ResumeSessionID != "" && sessionID == "" {
 		// The resume produced no session event, so claude could not load the
@@ -149,7 +149,7 @@ func (d DockerRunner) RunSkill(ctx context.Context, sj SkillJob, emit func(Event
 		emit(Event{Kind: KindText, Text: "resume of session " + sj.ResumeSessionID + " failed; restarting fresh"})
 		fresh := sj
 		fresh.ResumeSessionID = ""
-		waitErr, hitMaxTurns, sessionID = d.runDockerOnce(ctx, dockerBase, fresh, emit)
+		hitMaxTurns, sessionID, waitErr = d.runDockerOnce(ctx, dockerBase, fresh, emit)
 	}
 
 	res := SkillResult{Commit: commit, Profile: profile, SessionID: sessionID}
@@ -170,7 +170,7 @@ func (d DockerRunner) RunSkill(ctx context.Context, sj SkillJob, emit func(Event
 // through emit, and reporting the wait error, whether the run hit the
 // max-turns cap, and the session id from the init event (empty when no init
 // event arrived, e.g. a --resume that could not find the conversation).
-func (d DockerRunner) runDockerOnce(ctx context.Context, dockerBase []string, sj SkillJob, emit func(Event)) (waitErr error, hitMaxTurns bool, sessionID string) {
+func (d DockerRunner) runDockerOnce(ctx context.Context, dockerBase []string, sj SkillJob, emit func(Event)) (hitMaxTurns bool, sessionID string, waitErr error) {
 	claudeArgs := append([]string{"claude"}, buildClaudeArgs(sj, d.Effort, d.MaxTurns)...)
 	dockerArgs := append(append([]string{}, dockerBase...), claudeArgs...)
 
@@ -180,11 +180,11 @@ func (d DockerRunner) runDockerOnce(ctx context.Context, dockerBase []string, sj
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
-		return err, false, ""
+		return false, "", err
 	}
 	cmd.Stderr = cmd.Stdout
 	if err := cmd.Start(); err != nil {
-		return fmt.Errorf("start docker: %w", err), false, ""
+		return false, "", fmt.Errorf("start docker: %w", err)
 	}
 
 	wrappedEmit := func(e Event) {
@@ -201,7 +201,7 @@ func (d DockerRunner) runDockerOnce(ctx context.Context, dockerBase []string, sj
 	if cmd.Process != nil {
 		_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGTERM)
 	}
-	return waitErr, hitMaxTurns, sessionID
+	return hitMaxTurns, sessionID, waitErr
 }
 
 // buildDockerArgs assembles the `docker run` flags for a skill invocation.

--- a/internal/worker/docker.go
+++ b/internal/worker/docker.go
@@ -122,12 +122,16 @@ func (d DockerRunner) RunSkill(ctx context.Context, sj SkillJob, emit func(Event
 		_ = os.Remove(outPath)
 	}
 
+	// docker treats a non-absolute -v source as a named volume (which
+	// rejects '/'), so the config dir must be absolutised like absWork.
+	var absConfig string
 	if sj.ClaudeConfigDir != "" {
-		if err := os.MkdirAll(sj.ClaudeConfigDir, dirPerm); err != nil {
+		absConfig, _ = filepath.Abs(sj.ClaudeConfigDir)
+		if err := os.MkdirAll(absConfig, dirPerm); err != nil {
 			return SkillResult{Commit: commit, Profile: profile}, fmt.Errorf("create claude config dir: %w", err)
 		}
 	}
-	dockerBase := d.buildDockerArgs(absWork, image, perScanNetwork, sj.ClaudeConfigDir)
+	dockerBase := d.buildDockerArgs(absWork, image, perScanNetwork, absConfig)
 
 	logLine := "$ docker run --rm " + image + " <skill:" + sj.Name + ">"
 	if d.AnthropicBaseURL != "" {

--- a/internal/worker/docker.go
+++ b/internal/worker/docker.go
@@ -122,42 +122,33 @@ func (d DockerRunner) RunSkill(ctx context.Context, sj SkillJob, emit func(Event
 		_ = os.Remove(outPath)
 	}
 
-	claudeArgs := append([]string{"claude"}, buildClaudeArgs(sj, d.Effort, d.MaxTurns)...)
-	dockerArgs := append(d.buildDockerArgs(absWork, image, perScanNetwork), claudeArgs...)
-
-	cmd := exec.CommandContext(ctx, "docker", dockerArgs...)
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-	cmd.Env = os.Environ()
-
-	stdout, err := cmd.StdoutPipe()
-	if err != nil {
-		return SkillResult{}, err
+	if sj.ClaudeConfigDir != "" {
+		if err := os.MkdirAll(sj.ClaudeConfigDir, dirPerm); err != nil {
+			return SkillResult{Commit: commit, Profile: profile}, fmt.Errorf("create claude config dir: %w", err)
+		}
 	}
-	cmd.Stderr = cmd.Stdout
+	dockerBase := d.buildDockerArgs(absWork, image, perScanNetwork, sj.ClaudeConfigDir)
 
 	logLine := "$ docker run --rm " + image + " <skill:" + sj.Name + ">"
 	if d.AnthropicBaseURL != "" {
 		logLine += " [ANTHROPIC_BASE_URL=" + d.AnthropicBaseURL + "]"
 	}
 	emit(Event{Kind: KindText, Text: logLine})
-	if err := cmd.Start(); err != nil {
-		return SkillResult{}, fmt.Errorf("start docker: %w", err)
+
+	waitErr, hitMaxTurns, sessionID := d.runDockerOnce(ctx, dockerBase, sj, emit)
+
+	if waitErr != nil && sj.ResumeSessionID != "" && sessionID == "" {
+		// The resume produced no session event, so claude could not load the
+		// saved conversation (gone from the mounted store). Restart fresh in
+		// the same /work + config mount so the retry lineage isn't wedged on
+		// a dead session id.
+		emit(Event{Kind: KindText, Text: "resume of session " + sj.ResumeSessionID + " failed; restarting fresh"})
+		fresh := sj
+		fresh.ResumeSessionID = ""
+		waitErr, hitMaxTurns, sessionID = d.runDockerOnce(ctx, dockerBase, fresh, emit)
 	}
 
-	hitMaxTurns := false
-	wrappedEmit := func(e Event) {
-		if e.Kind == KindError && e.Text == "hit max turns" {
-			hitMaxTurns = true
-		}
-		emit(e)
-	}
-	ParseStream(stdout, wrappedEmit)
-	waitErr := cmd.Wait()
-	if cmd.Process != nil {
-		_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGTERM)
-	}
-
-	res := SkillResult{Commit: commit, Profile: profile}
+	res := SkillResult{Commit: commit, Profile: profile, SessionID: sessionID}
 	if outPath != "" {
 		res.Report = readCappedReport(outPath, emit)
 	}
@@ -170,12 +161,51 @@ func (d DockerRunner) RunSkill(ctx context.Context, sj SkillJob, emit func(Event
 	return res, nil
 }
 
+// runDockerOnce launches one container for the given skill job, appending
+// the in-container `claude` command to dockerBase, streaming its output
+// through emit, and reporting the wait error, whether the run hit the
+// max-turns cap, and the session id from the init event (empty when no init
+// event arrived, e.g. a --resume that could not find the conversation).
+func (d DockerRunner) runDockerOnce(ctx context.Context, dockerBase []string, sj SkillJob, emit func(Event)) (waitErr error, hitMaxTurns bool, sessionID string) {
+	claudeArgs := append([]string{"claude"}, buildClaudeArgs(sj, d.Effort, d.MaxTurns)...)
+	dockerArgs := append(append([]string{}, dockerBase...), claudeArgs...)
+
+	cmd := exec.CommandContext(ctx, "docker", dockerArgs...)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Env = os.Environ()
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return err, false, ""
+	}
+	cmd.Stderr = cmd.Stdout
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("start docker: %w", err), false, ""
+	}
+
+	wrappedEmit := func(e Event) {
+		switch {
+		case e.Kind == KindError && e.Text == "hit max turns":
+			hitMaxTurns = true
+		case e.Kind == KindSession && e.SessionID != "":
+			sessionID = e.SessionID
+		}
+		emit(e)
+	}
+	ParseStream(stdout, wrappedEmit)
+	waitErr = cmd.Wait()
+	if cmd.Process != nil {
+		_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGTERM)
+	}
+	return waitErr, hitMaxTurns, sessionID
+}
+
 // buildDockerArgs assembles the `docker run` flags for a skill invocation.
 // Returns the args up to and including the image name; the caller appends
 // the in-container command. Split out of RunSkill to keep its cognitive
 // complexity manageable as new toggles (hardened mode, proxy, profiles)
 // accumulate.
-func (d DockerRunner) buildDockerArgs(absWork, image, perScanNetwork string) []string {
+func (d DockerRunner) buildDockerArgs(absWork, image, perScanNetwork, claudeConfigDir string) []string {
 	gwTarget := "host-gateway"
 	if d.Hardened {
 		// Each --internal network has its own subnet and gateway, so the
@@ -208,6 +238,17 @@ func (d DockerRunner) buildDockerArgs(absWork, image, perScanNetwork string) []s
 		"-v", absWork + ":/work",
 		"-w", "/work",
 		"--add-host", HostGatewayAlias + ":" + gwTarget,
+	}
+	if claudeConfigDir != "" {
+		// Persist the resumable claude session store outside the container.
+		// Without this it lands in the /tmp tmpfs and dies with the
+		// container, so --resume on a retry would find nothing. The bind
+		// mount stays writable even under hardened mode's --read-only
+		// rootfs, so resume works there too.
+		args = append(args,
+			"-v", claudeConfigDir+":/claude-config",
+			"-e", "CLAUDE_CONFIG_DIR=/claude-config",
+		)
 	}
 	if d.Hardened {
 		// Read-only rootfs + no-new-privileges close the residual paths a

--- a/internal/worker/docker_test.go
+++ b/internal/worker/docker_test.go
@@ -9,6 +9,37 @@ import (
 	"testing"
 )
 
+func TestBuildDockerArgs_ClaudeConfigMount(t *testing.T) {
+	d := DockerRunner{}
+
+	with := d.buildDockerArgs("/work/abs", "img:latest", "", "/data/claude-config/scan-7")
+	if !hasAdjacent(with, "-v", "/data/claude-config/scan-7:/claude-config") {
+		t.Errorf("expected the config dir bind mount in %v", with)
+	}
+	if !hasAdjacent(with, "-e", "CLAUDE_CONFIG_DIR=/claude-config") {
+		t.Errorf("expected CLAUDE_CONFIG_DIR env in %v", with)
+	}
+
+	// No config dir → no mount and no env, so default scans are unchanged.
+	without := d.buildDockerArgs("/work/abs", "img:latest", "", "")
+	for _, a := range without {
+		if strings.Contains(a, "/claude-config") || strings.HasPrefix(a, "CLAUDE_CONFIG_DIR=") {
+			t.Errorf("did not expect any claude-config args, got %q in %v", a, without)
+		}
+	}
+}
+
+// hasAdjacent reports whether args contains flag immediately followed by val,
+// matching how docker run takes `-v host:container` / `-e KEY=VAL` pairs.
+func hasAdjacent(args []string, flag, val string) bool {
+	for i := 0; i+1 < len(args); i++ {
+		if args[i] == flag && args[i+1] == val {
+			return true
+		}
+	}
+	return false
+}
+
 func TestDirSize_SumsRegularFilesAcrossSubdirs(t *testing.T) {
 	root := t.TempDir()
 	sub := filepath.Join(root, "nested", "deep")

--- a/internal/worker/exposure.go
+++ b/internal/worker/exposure.go
@@ -140,7 +140,7 @@ func (w *Worker) doExposure(ctx context.Context, scan *db.Scan, emit func(Event)
 		"skill_version": skill.Version,
 	})
 
-	workRoot := w.workRoot(scan.ID)
+	workRoot := w.scanWorkRoot(scan)
 	if err := validateSkillPaths(skill.Name, skill.OutputFile); err != nil {
 		return "", err
 	}
@@ -190,7 +190,11 @@ func (w *Worker) doExposure(ctx context.Context, scan *db.Scan, emit func(Event)
 		Profile:         scan.Profile,
 		RequiresProfile: skill.RequiresProfile,
 	}
+	w.applyResume(scan, &sj, emit)
 	res, err := w.Runner.RunSkill(ctx, sj, emit)
+	if res.SessionID != "" && res.SessionID != scan.SessionID {
+		scan.SessionID = res.SessionID
+	}
 	if res.Commit != "" {
 		scan.Commit = res.Commit
 	}

--- a/internal/worker/skill.go
+++ b/internal/worker/skill.go
@@ -87,7 +87,7 @@ func (w *Worker) doSkill(ctx context.Context, scan *db.Scan, emit func(Event)) (
 	// successful completion; failed/cancelled dirs are left so the
 	// operator can inspect what the skill saw. The clone itself lives in
 	// the persistent repo-cache and is copied in by prepareRepoSrc.
-	workRoot := w.workRoot(scan.ID)
+	workRoot := w.scanWorkRoot(scan)
 	if err := validateSkillPaths(skill.Name, skill.OutputFile); err != nil {
 		return "", err
 	}
@@ -147,7 +147,11 @@ func (w *Worker) doSkill(ctx context.Context, scan *db.Scan, emit func(Event)) (
 		Profile:         scan.Profile,
 		RequiresProfile: skill.RequiresProfile,
 	}
+	w.applyResume(scan, &sj, emit)
 	res, err := w.Runner.RunSkill(ctx, sj, emit)
+	if res.SessionID != "" && res.SessionID != scan.SessionID {
+		scan.SessionID = res.SessionID
+	}
 	if res.Commit != "" {
 		scan.Commit = res.Commit
 	}

--- a/internal/worker/stream.go
+++ b/internal/worker/stream.go
@@ -14,6 +14,7 @@ const (
 	KindTool     = "tool"
 	KindResult   = "result"
 	KindError    = "error"
+	KindSession  = "session"
 
 	lineLimit = 300
 )
@@ -21,12 +22,13 @@ const (
 // Event is one line of activity from a claude -p stream-json run, flattened
 // into something a human can read in a log view.
 type Event struct {
-	Kind    string
-	Tool    string // for KindTool
-	Text    string
-	CostUSD float64 // for KindResult
-	Turns   int     // for KindResult
-	Usage   Usage   // for KindResult
+	Kind      string
+	Tool      string // for KindTool
+	Text      string
+	CostUSD   float64 // for KindResult
+	Turns     int     // for KindResult
+	Usage     Usage   // for KindResult
+	SessionID string  // for KindSession
 }
 
 // Usage is the token breakdown from a result event.
@@ -38,15 +40,16 @@ type Usage struct {
 }
 
 type streamMessage struct {
-	Type     string          `json:"type"`
-	Subtype  string          `json:"subtype"`
-	Message  *assistantMsg   `json:"message"`
-	Result   json.RawMessage `json:"result"`
-	CostUSD  *float64        `json:"total_cost_usd"`
-	Duration *int64          `json:"duration_ms"`
-	NumTurns *int            `json:"num_turns"`
-	Usage    *Usage          `json:"usage"`
-	Error    json.RawMessage `json:"error"`
+	Type      string          `json:"type"`
+	Subtype   string          `json:"subtype"`
+	SessionID string          `json:"session_id"`
+	Message   *assistantMsg   `json:"message"`
+	Result    json.RawMessage `json:"result"`
+	CostUSD   *float64        `json:"total_cost_usd"`
+	Duration  *int64          `json:"duration_ms"`
+	NumTurns  *int            `json:"num_turns"`
+	Usage     *Usage          `json:"usage"`
+	Error     json.RawMessage `json:"error"`
 }
 
 type assistantMsg struct {
@@ -80,6 +83,19 @@ func ParseStream(r io.Reader, emit func(Event)) {
 			continue
 		}
 		switch msg.Type {
+		case "system":
+			// The init system message is the first line of a run and is the
+			// only reliable place to read the session id. Capturing it here
+			// lets the worker persist it before the run finishes, so a crash
+			// mid-run is resumable. It is also the signal a `--resume`
+			// actually loaded the conversation: a resume that fails to find
+			// the session emits no init at all (just an error and a result
+			// carrying a brand-new throwaway session id), so the runner must
+			// not treat the result's session id as "resume succeeded" — only
+			// this init event counts.
+			if msg.Subtype == "init" && msg.SessionID != "" {
+				emit(Event{Kind: KindSession, SessionID: msg.SessionID})
+			}
 		case "assistant":
 			emitAssistant(msg.Message, emit)
 		case "result":
@@ -178,6 +194,8 @@ func FormatEvent(e Event) string {
 		return fmt.Sprintf("[%s] %s", strings.ToLower(e.Tool), truncate(e.Text))
 	case KindResult:
 		return fmt.Sprintf("[result] cost=$%.4f turns=%d %s", e.CostUSD, e.Turns, truncate(e.Text))
+	case KindSession:
+		return "[session] " + e.SessionID
 	case KindError:
 		return "[error] " + e.Text
 	default:

--- a/internal/worker/stream_test.go
+++ b/internal/worker/stream_test.go
@@ -41,6 +41,50 @@ not json at all
 	}
 }
 
+func TestParseStream_SessionID(t *testing.T) {
+	in := `
+{"type":"system","subtype":"init","session_id":"sess-abc","tools":[]}
+{"type":"assistant","message":{"content":[{"type":"text","text":"hi"}]}}
+{"type":"result","subtype":"success","session_id":"sess-abc","result":"ok","num_turns":2}
+`
+	var sessions []string
+	ParseStream(strings.NewReader(in), func(e Event) {
+		if e.Kind == KindSession {
+			sessions = append(sessions, e.SessionID)
+		}
+	})
+
+	// Only the init message yields a session event; the result's session id
+	// is deliberately ignored so a failed --resume (which emits no init but
+	// a result carrying a throwaway id) isn't mistaken for a loaded session.
+	if len(sessions) != 1 {
+		t.Fatalf("want 1 session event, got %d: %v", len(sessions), sessions)
+	}
+	if sessions[0] != "sess-abc" {
+		t.Errorf("session id = %q, want sess-abc", sessions[0])
+	}
+}
+
+func TestParseStream_FailedResumeEmitsNoSession(t *testing.T) {
+	// A --resume that can't find the conversation emits no init event, just
+	// an error line and a result with a fresh throwaway session id. The
+	// runner relies on seeing no session event here to fall back to a fresh
+	// run, so this must produce zero KindSession events.
+	in := `No conversation found with session ID: dead
+{"type":"result","subtype":"error_during_execution","is_error":true,"session_id":"throwaway-id","num_turns":0}`
+	for _, e := range collectEvents(in) {
+		if e.Kind == KindSession {
+			t.Errorf("unexpected session event: %+v", e)
+		}
+	}
+}
+
+func collectEvents(in string) []Event {
+	var got []Event
+	ParseStream(strings.NewReader(in), func(e Event) { got = append(got, e) })
+	return got
+}
+
 func TestFormatEvent(t *testing.T) {
 	e := Event{Kind: "tool", Tool: "Read", Text: "/tmp/x"}
 	if s := FormatEvent(e); s != "[read] /tmp/x" {

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -128,6 +128,48 @@ func (w *Worker) applyResume(scan *db.Scan, sj *SkillJob, emit func(Event)) {
 	}
 }
 
+// scanEmitter returns the emit callback handed to a job handler. It appends
+// each event to the scan log (persisting incrementally so the UI streams it)
+// and snapshots result-event token usage. Session events are special: they
+// carry no log line and instead persist the claude session id the moment it
+// appears so a crash mid-run leaves the scan resumable. The in-memory struct
+// is kept in sync too — wrap's final Save(&scan) writes every column and
+// would otherwise clobber a column-only update with a stale value.
+func (w *Worker) scanEmitter(scan *db.Scan) func(Event) {
+	return func(e Event) {
+		if e.Kind == KindSession {
+			if e.SessionID != "" && e.SessionID != scan.SessionID {
+				scan.SessionID = e.SessionID
+				w.DB.Model(&db.Scan{}).Where("id = ?", scan.ID).Update("session_id", e.SessionID)
+			}
+			return
+		}
+		line := FormatEvent(e)
+		scan.Log += line + "\n"
+		w.DB.Model(&db.Scan{}).Where("id = ?", scan.ID).Update("log", scan.Log)
+		if e.Kind == KindResult {
+			scan.CostUSD = e.CostUSD
+			scan.Turns = e.Turns
+			scan.InputTokens = e.Usage.InputTokens
+			scan.OutputTokens = e.Usage.OutputTokens
+			scan.CacheReadTokens = e.Usage.CacheReadTokens
+			scan.CacheWriteTokens = e.Usage.CacheWriteTokens
+		}
+		w.publish(scan.ID, scan.RepositoryID, "scan-log", line+"\n")
+	}
+}
+
+// clearSessionStore wipes a finished scan's resume state so its next
+// deliberate re-run starts fresh: it drops the session id and tears down the
+// persisted claude session store. Only called on "done" — a failed scan
+// keeps both so a UI retry can --resume instead of restarting from turn 0.
+func (w *Worker) clearSessionStore(scan *db.Scan) {
+	scan.SessionID = ""
+	if rmErr := os.RemoveAll(w.claudeConfigDir(scan)); rmErr != nil {
+		w.Log.Warn("session store cleanup failed", "scan", scan.ID, "err", rmErr)
+	}
+}
+
 func (w *Worker) Register(q *queue.Queue) {
 	q.Register(JobSkill, w.wrap(w.doSkill))
 	q.Register(JobExposure, w.wrap(w.doExposure))
@@ -184,33 +226,7 @@ func (w *Worker) wrap(h handler) func(context.Context, []byte) error {
 			return err
 		}
 
-		emit := func(e Event) {
-			// Session events carry no log line; they exist to persist the
-			// claude session id the moment it appears so a crash mid-run
-			// leaves the scan resumable. Keep the in-memory struct in sync
-			// too: wrap's final Save(&scan) writes every column and would
-			// otherwise clobber the column-only update below with a stale
-			// (empty) value.
-			if e.Kind == KindSession {
-				if e.SessionID != "" && e.SessionID != scan.SessionID {
-					scan.SessionID = e.SessionID
-					w.DB.Model(&db.Scan{}).Where("id = ?", scan.ID).Update("session_id", e.SessionID)
-				}
-				return
-			}
-			line := FormatEvent(e)
-			scan.Log += line + "\n"
-			w.DB.Model(&db.Scan{}).Where("id = ?", scan.ID).Update("log", scan.Log)
-			if e.Kind == KindResult {
-				scan.CostUSD = e.CostUSD
-				scan.Turns = e.Turns
-				scan.InputTokens = e.Usage.InputTokens
-				scan.OutputTokens = e.Usage.OutputTokens
-				scan.CacheReadTokens = e.Usage.CacheReadTokens
-				scan.CacheWriteTokens = e.Usage.CacheWriteTokens
-			}
-			w.publish(scan.ID, scan.RepositoryID, "scan-log", line+"\n")
-		}
+		emit := w.scanEmitter(&scan)
 
 		report, err := h(ctx, &scan, emit)
 
@@ -247,15 +263,8 @@ func (w *Worker) wrap(h handler) func(context.Context, []byte) error {
 			scan.Status = db.ScanDone
 			scan.Report = report
 		}
-		// A finished scan starts fresh on its next deliberate re-run, so
-		// drop the resume session id and tear down its persisted claude
-		// session store. A failed scan keeps both so a UI retry can
-		// --resume the conversation instead of restarting from turn 0.
 		if scan.Status == db.ScanDone {
-			scan.SessionID = ""
-			if rmErr := os.RemoveAll(w.claudeConfigDir(&scan)); rmErr != nil {
-				w.Log.Warn("session store cleanup failed", "scan", scan.ID, "err", rmErr)
-			}
+			w.clearSessionStore(&scan)
 		}
 		scan.StatusPriority = db.StatusPriorityFor(scan.Status)
 		if saveErr := w.DB.Save(&scan).Error; saveErr != nil {

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -88,6 +88,46 @@ func (w *Worker) workRoot(scanID uint) string {
 	return filepath.Join(w.DataDir, fmt.Sprintf("scan-%d", scanID))
 }
 
+// workspaceScanID returns the scan id whose workspace path a run should
+// use. A fresh scan uses its own id; a retry that resumes a session reuses
+// the lineage-root id so claude executes in the same working directory the
+// original run did — claude keys its resumable session store by cwd, so a
+// different path means --resume can't find the conversation.
+func workspaceScanID(scan *db.Scan) uint {
+	if scan.ResumedFromScanID != nil && *scan.ResumedFromScanID != 0 {
+		return *scan.ResumedFromScanID
+	}
+	return scan.ID
+}
+
+// scanWorkRoot is workRoot resolved through the resume lineage.
+func (w *Worker) scanWorkRoot(scan *db.Scan) string {
+	return w.workRoot(workspaceScanID(scan))
+}
+
+// claudeConfigDir is the host directory holding the claude session store
+// for this scan's lineage. The docker runner mounts it as CLAUDE_CONFIG_DIR
+// so the conversation survives a container exit; it lives outside the
+// per-scan workspace (which is deleted when the scan finishes) and is keyed
+// by the lineage root so a retry finds the original run's session. The
+// local runner ignores it and uses the host's own ~/.claude.
+func (w *Worker) claudeConfigDir(scan *db.Scan) string {
+	return filepath.Join(w.DataDir, "claude-config", fmt.Sprintf("scan-%d", workspaceScanID(scan)))
+}
+
+// applyResume fills a SkillJob's session-resume inputs from the scan: the
+// claude session id to --resume (set on a retry that carries one forward
+// from a failed run) and the persistent config dir the docker runner mounts
+// so the session store survives a container exit. A fresh scan has an empty
+// SessionID, so the runner just starts a new conversation.
+func (w *Worker) applyResume(scan *db.Scan, sj *SkillJob, emit func(Event)) {
+	sj.ClaudeConfigDir = w.claudeConfigDir(scan)
+	if scan.SessionID != "" {
+		sj.ResumeSessionID = scan.SessionID
+		emit(Event{Kind: KindText, Text: "resuming claude session " + scan.SessionID})
+	}
+}
+
 func (w *Worker) Register(q *queue.Queue) {
 	q.Register(JobSkill, w.wrap(w.doSkill))
 	q.Register(JobExposure, w.wrap(w.doExposure))
@@ -145,6 +185,19 @@ func (w *Worker) wrap(h handler) func(context.Context, []byte) error {
 		}
 
 		emit := func(e Event) {
+			// Session events carry no log line; they exist to persist the
+			// claude session id the moment it appears so a crash mid-run
+			// leaves the scan resumable. Keep the in-memory struct in sync
+			// too: wrap's final Save(&scan) writes every column and would
+			// otherwise clobber the column-only update below with a stale
+			// (empty) value.
+			if e.Kind == KindSession {
+				if e.SessionID != "" && e.SessionID != scan.SessionID {
+					scan.SessionID = e.SessionID
+					w.DB.Model(&db.Scan{}).Where("id = ?", scan.ID).Update("session_id", e.SessionID)
+				}
+				return
+			}
 			line := FormatEvent(e)
 			scan.Log += line + "\n"
 			w.DB.Model(&db.Scan{}).Where("id = ?", scan.ID).Update("log", scan.Log)
@@ -194,12 +247,22 @@ func (w *Worker) wrap(h handler) func(context.Context, []byte) error {
 			scan.Status = db.ScanDone
 			scan.Report = report
 		}
+		// A finished scan starts fresh on its next deliberate re-run, so
+		// drop the resume session id and tear down its persisted claude
+		// session store. A failed scan keeps both so a UI retry can
+		// --resume the conversation instead of restarting from turn 0.
+		if scan.Status == db.ScanDone {
+			scan.SessionID = ""
+			if rmErr := os.RemoveAll(w.claudeConfigDir(&scan)); rmErr != nil {
+				w.Log.Warn("session store cleanup failed", "scan", scan.ID, "err", rmErr)
+			}
+		}
 		scan.StatusPriority = db.StatusPriorityFor(scan.Status)
 		if saveErr := w.DB.Save(&scan).Error; saveErr != nil {
 			return saveErr
 		}
 		if scan.Status.Terminal() {
-			if rmErr := os.RemoveAll(w.workRoot(scan.ID)); rmErr != nil {
+			if rmErr := os.RemoveAll(w.scanWorkRoot(&scan)); rmErr != nil {
 				w.Log.Warn("workspace cleanup failed", "scan", scan.ID, "err", rmErr)
 			}
 		}

--- a/internal/worker/worker_resume_test.go
+++ b/internal/worker/worker_resume_test.go
@@ -1,0 +1,127 @@
+package worker
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"path/filepath"
+	"testing"
+
+	"scrutineer/internal/db"
+	"scrutineer/internal/queue"
+)
+
+// recordingRunner captures the SkillJob it was handed and optionally emits a
+// session event so the worker's persist path is exercised.
+type recordingRunner struct {
+	emitSession string
+	res         SkillResult
+	err         error
+	got         SkillJob
+}
+
+func (r *recordingRunner) RunSkill(_ context.Context, sj SkillJob, emit func(Event)) (SkillResult, error) {
+	r.got = sj
+	if r.emitSession != "" {
+		emit(Event{Kind: KindSession, SessionID: r.emitSession})
+	}
+	return r.res, r.err
+}
+
+func newResumeTestWorker(t *testing.T, runner SkillRunner) (*Worker, *db.Skill, uint) {
+	t.Helper()
+	gdb, err := db.Open(filepath.Join(t.TempDir(), "r.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo := db.Repository{URL: "https://example.com/x", Name: "x"}
+	gdb.Create(&repo)
+	skill := db.Skill{Name: "deep", Description: "x", Body: "b", Active: true, Source: "ui", Version: 1}
+	gdb.Create(&skill)
+	w := &Worker{
+		DB:             gdb,
+		Log:            slog.New(slog.NewTextHandler(io.Discard, nil)),
+		DataDir:        t.TempDir(),
+		Runner:         runner,
+		PrepareRepoSrc: stubPrepareRepoSrc,
+	}
+	return w, &skill, repo.ID
+}
+
+func runScan(t *testing.T, w *Worker, scanID uint) db.Scan {
+	t.Helper()
+	body, _ := json.Marshal(queue.Payload{ScanID: scanID})
+	if err := w.wrap(w.doSkill)(context.Background(), body); err != nil {
+		t.Fatalf("wrap: %v", err)
+	}
+	var got db.Scan
+	w.DB.First(&got, scanID)
+	return got
+}
+
+func TestWorker_SessionClearedOnDone(t *testing.T) {
+	runner := &recordingRunner{emitSession: "sess-1", res: SkillResult{Report: "", SessionID: "sess-1"}}
+	w, skill, repoID := newResumeTestWorker(t, runner)
+	scan := db.Scan{RepositoryID: repoID, Kind: JobSkill, Status: db.ScanQueued, SkillID: &skill.ID}
+	w.DB.Create(&scan)
+
+	// A fresh scan must not ask the runner to resume.
+	got := runScan(t, w, scan.ID)
+	if runner.got.ResumeSessionID != "" {
+		t.Errorf("fresh scan passed ResumeSessionID=%q", runner.got.ResumeSessionID)
+	}
+	if got.Status != db.ScanDone {
+		t.Fatalf("status = %s, want done", got.Status)
+	}
+	if got.SessionID != "" {
+		t.Errorf("session id = %q, want cleared on done", got.SessionID)
+	}
+}
+
+func TestWorker_SessionKeptOnFailure(t *testing.T) {
+	runner := &recordingRunner{emitSession: "sess-1", err: errors.New("boom")}
+	w, skill, repoID := newResumeTestWorker(t, runner)
+	scan := db.Scan{RepositoryID: repoID, Kind: JobSkill, Status: db.ScanQueued, SkillID: &skill.ID}
+	w.DB.Create(&scan)
+
+	got := runScan(t, w, scan.ID)
+	if got.Status != db.ScanFailed {
+		t.Fatalf("status = %s, want failed", got.Status)
+	}
+	// A failed scan keeps the session so a retry can resume it.
+	if got.SessionID != "sess-1" {
+		t.Errorf("session id = %q, want sess-1 preserved", got.SessionID)
+	}
+}
+
+func TestWorker_ResumeReusesLineageWorkspace(t *testing.T) {
+	const rootID = uint(7)
+	runner := &recordingRunner{res: SkillResult{Report: ""}}
+	w, skill, repoID := newResumeTestWorker(t, runner)
+	resumeOf := rootID
+	scan := db.Scan{
+		RepositoryID:      repoID,
+		Kind:              JobSkill,
+		Status:            db.ScanQueued,
+		SkillID:           &skill.ID,
+		SessionID:         "sess-1",
+		ResumedFromScanID: &resumeOf,
+	}
+	w.DB.Create(&scan)
+
+	runScan(t, w, scan.ID)
+
+	if runner.got.ResumeSessionID != "sess-1" {
+		t.Errorf("ResumeSessionID = %q, want sess-1", runner.got.ResumeSessionID)
+	}
+	// The runner must execute in the lineage root's workspace, not the new
+	// scan's, so claude finds the cwd-keyed session it stored originally.
+	if want := w.workRoot(rootID); runner.got.WorkRoot != want {
+		t.Errorf("WorkRoot = %q, want lineage root %q", runner.got.WorkRoot, want)
+	}
+	if want := filepath.Join(w.DataDir, "claude-config", "scan-7"); runner.got.ClaudeConfigDir != want {
+		t.Errorf("ClaudeConfigDir = %q, want %q", runner.got.ClaudeConfigDir, want)
+	}
+}


### PR DESCRIPTION
Implements #160.

Generated with Claude Code, reviewed and tested by me (though I'm not particularly familiar with Go, so take that with a grain of salt). I'm unsure if this needs special handling for hardened mode.

Confirmed it works by starting a scan, killing the Scrutineer server mid-run, and then hitting "Retry" and seeing it successfully resume the same session:

<img width="1236" height="434" alt="Screenshot 2026-05-31 at 7 28 39 PM" src="https://github.com/user-attachments/assets/a87b3174-472f-451a-ab19-334713cd1e3a" />

---

A long skill (e.g. `security-deep-dive`) that hit an API timeout at turn 130 used to restart from turn 0 on retry, losing everything. claude-code supports `--resume <session-id>`; this wires it through so a retry of a failed scan continues the conversation with full history.

## What it does
- Captures `session_id` from the stream-json **init** event and persists it on the scan the moment it appears, so it survives a crash. Cleared on `done` (a deliberate re-run starts fresh); kept on `failed` (a retry can resume).
- The UI **Retry** button (and retry-all-failed) carries a failed scan's session into the new run. claude keys its session store by **working directory**, so the retry reuses the lineage-root workspace path (`ResumedFromScanID`) to keep cwd stable across the retry chain.
- The **docker** runner mounts a persistent per-lineage `CLAUDE_CONFIG_DIR` so the session store survives a container exit (works under hardened mode's `--read-only` rootfs). The **local** runner relies on the host `~/.claude`.
- **Resume-failure fallback:** if `--resume` can't find the session (expired/pruned — no init event, exit 1), the runner restarts once *fresh* in the same call, so a lost session doesn't permanently wedge the retry lineage.

## Note on the trigger (divergence from the issue text)
The issue framed this around goqite redelivering a failed job. In practice `wrap()` returns `nil` to goqite on handler errors *specifically* to suppress auto-retry (`internal/worker/worker.go`), so redelivery never fires — and a crash + restart path is killed by `SweepRunning` + the terminal-drop. So the trigger here is an **explicit UI retry** instead. This avoids reversing the deliberate no-auto-retry contract and spending API budget without a human in the loop. (#20 can stay focused on repos too large for a single context even with resume.)

## Verified
- `--resume` is cwd-scoped (confirmed empirically): the session `.jsonl` lives at `$CLAUDE_CONFIG_DIR/projects/<encoded-cwd>/`, and resume fails from a different cwd — hence the lineage-stable workspace.
- A *failed* `--resume` echoes a throwaway `session_id` in its `result` event but emits no `system/init`; capturing from init only (and using "no init seen" as the fallback signal) handles this correctly.
- Positional prompt + `--resume` parses and loads the conversation.

## Tests
Stream capture, failed-resume-emits-no-session, `buildClaudeArgs` resume, an end-to-end local fallback driving a fake `claude`, docker config-mount, worker persist/clear/lineage, and web `resumeOpts`. `go build`, `go vet`, and `go test ./...` all pass.

## Known wart (out of scope)
Config dirs and local `~/.claude` transcripts for lineages that fail and are *never* retried accumulate; a startup sweep could clean those later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)