### PR TITLE
feat: Add "About" section to Settings page

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,12 @@ WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
-RUN CGO_ENABLED=0 go build -o /scrutineer ./cmd/scrutineer
+# COMMIT is the git SHA being built. .git is excluded from the build context
+# (.dockerignore), so the Go VCS stamp is unavailable here; pass it explicitly
+# with `docker build --build-arg COMMIT=$(git rev-parse HEAD)` to surface it on
+# the settings page. Empty when not supplied.
+ARG COMMIT=""
+RUN CGO_ENABLED=0 go build -ldflags "-X main.commit=${COMMIT}" -o /scrutineer ./cmd/scrutineer
 
 FROM node:26-alpine@sha256:7c6af15abe4e3de859690e7db171d0d711bf37d27528eddfe625b2fe89e097f8 AS claude
 RUN npm install -g @anthropic-ai/claude-code@2.1.119

--- a/cmd/scrutineer/main.go
+++ b/cmd/scrutineer/main.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"runtime/debug"
 	"strings"
 	"syscall"
 	"time"
@@ -25,6 +26,29 @@ import (
 	"scrutineer/internal/web"
 	"scrutineer/internal/worker"
 )
+
+// commit is the git SHA scrutineer was built from, injected at build time
+// via -ldflags "-X main.commit=...". Empty in a plain `go build`/`go run`,
+// where buildCommit falls back to the VCS revision in the build info.
+var commit string
+
+// buildCommit reports the commit scrutineer was built from. It prefers the
+// ldflags-injected value (set in the Docker build, where .git is excluded
+// from the context so the VCS stamp is unavailable) and otherwise reads the
+// vcs.revision the Go toolchain records during a normal local build.
+func buildCommit() string {
+	if commit != "" {
+		return commit
+	}
+	if info, ok := debug.ReadBuildInfo(); ok {
+		for _, s := range info.Settings {
+			if s.Key == "vcs.revision" {
+				return s.Value
+			}
+		}
+	}
+	return ""
+}
 
 // skillDirs collects repeated -skills flags.
 type skillDirs []string
@@ -282,6 +306,7 @@ func run(log *slog.Logger) error {
 		return err
 	}
 	srv.SkillsRepoSHA = skillsRepoSHA
+	srv.Commit = buildCommit()
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -60,6 +60,11 @@ type Server struct {
 	// is not configured.
 	SkillsRepoSHA string
 
+	// Commit is the git SHA scrutineer itself was built from, shown on the
+	// settings page. Set once by main; empty when the build carries no VCS
+	// stamp (e.g. an ldflags-less build outside a git checkout).
+	Commit string
+
 	// resolvePURL maps a Package URL to its source repository URL via
 	// packages.ecosyste.ms. Field rather than direct call so tests can
 	// stub the network lookup.
@@ -69,6 +74,13 @@ type Server struct {
 	skillNamesMu    sync.Mutex
 	skillNamesCache []string
 	skillNamesTTL   time.Time
+
+	// toolMeta caches the scanner-tool and docker versions shown on the
+	// settings page. Gathering them shells out to docker, so it is cached
+	// behind a TTL to keep the page DB-fast on repeat loads.
+	toolMetaMu    sync.Mutex
+	toolMetaCache toolMetadata
+	toolMetaTTL   time.Time
 }
 
 // displaySeverity maps any known casing of a severity string to its

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -2929,6 +2929,28 @@ func TestSettingsShow_rendersThemeOptions(t *testing.T) {
 	}
 }
 
+func TestSettingsShow_rendersAboutAndScannerFindings(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	s.Commit = "abcdef1234567890"
+
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq("GET", "/settings"))
+	if w.Code != 200 {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+	body := w.Body.String()
+	for _, want := range []string{"Scanner findings", "About", "Scrutineer commit", "Claude Code", "Semgrep", "Zizmor", "Docker"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("settings page missing %q", want)
+		}
+	}
+	// Commit is rendered short (first 12 chars).
+	if !strings.Contains(body, "abcdef123456") {
+		t.Error("settings page missing shortened commit SHA")
+	}
+}
+
 func TestSettingsUpdateTheme_setsCookie(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()

--- a/internal/web/templates/settings.html
+++ b/internal/web/templates/settings.html
@@ -118,6 +118,29 @@
   </section>
 </section>
 
+<section class="card">
+  <header>
+    <h2>About</h2>
+    <p class="text-muted-foreground text-sm">Versions of Scrutineer and the analysis tools that run inside the runner image. Scanner versions are read from the running image and may be unavailable when Docker is not in use.</p>
+  </header>
+  <section>
+    {{define "metarow"}}
+      <div class="bg-muted/50 rounded-lg px-3 py-2">
+        <div class="text-muted-foreground text-xs">{{.Label}}</div>
+        <div class="font-mono text-sm truncate" title="{{.Value}}">{{if .Value}}{{.Value}}{{else}}unavailable{{end}}</div>
+      </div>
+    {{end}}
+    <div class="grid grid-cols-2 sm:grid-cols-3 gap-3 text-sm">
+      {{template "metarow" (dict "Label" "Scrutineer commit" "Value" (short .Commit))}}
+      {{template "metarow" (dict "Label" "Claude Code" "Value" .Meta.Claude)}}
+      {{template "metarow" (dict "Label" "Semgrep" "Value" .Meta.Semgrep)}}
+      {{template "metarow" (dict "Label" "Zizmor" "Value" .Meta.Zizmor)}}
+      {{template "metarow" (dict "Label" "Docker" "Value" .Meta.Docker)}}
+      {{template "metarow" (dict "Label" "Runner image" "Value" .Meta.RunnerImage)}}
+    </div>
+  </section>
+</section>
+
 </div>
 
 <style>

--- a/internal/web/templates/settings.html
+++ b/internal/web/templates/settings.html
@@ -63,7 +63,7 @@
 <section class="card">
   <header><h2>System</h2></header>
   <section>
-    <div class="grid grid-cols-3 sm:grid-cols-4 lg:grid-cols-7 gap-3 text-sm">
+    <div class="grid grid-cols-3 sm:grid-cols-4 lg:grid-cols-8 gap-3 text-sm">
       <div class="bg-muted/50 rounded-lg px-3 py-2">
         <div class="text-muted-foreground text-xs">Repositories</div>
         <div class="font-medium text-lg">{{bignum .Stats.Repos}}</div>
@@ -75,6 +75,10 @@
       <div class="bg-muted/50 rounded-lg px-3 py-2">
         <div class="text-muted-foreground text-xs">Findings</div>
         <div class="font-medium text-lg">{{bignum .Stats.Findings}}</div>
+      </div>
+      <div class="bg-muted/50 rounded-lg px-3 py-2">
+        <div class="text-muted-foreground text-xs">Scanner findings</div>
+        <div class="font-medium text-lg">{{bignum .Stats.ScannerFindings}}</div>
       </div>
       <div class="bg-muted/50 rounded-lg px-3 py-2">
         <div class="text-muted-foreground text-xs">Packages</div>

--- a/internal/web/theme.go
+++ b/internal/web/theme.go
@@ -1,11 +1,14 @@
 package web
 
 import (
+	"context"
 	"net/http"
 	"slices"
+	"time"
 
 	"scrutineer/internal/config"
 	"scrutineer/internal/db"
+	"scrutineer/internal/worker"
 )
 
 const cookieMaxAge = 365 * 24 * 60 * 60 //nolint:mnd
@@ -69,6 +72,8 @@ func (s *Server) settingsShow(w http.ResponseWriter, r *http.Request) {
 	var dbPath string
 	s.DB.Raw("SELECT file FROM pragma_database_list WHERE name = 'main'").Scan(&dbPath)
 
+	meta := s.toolMetadataCached(r.Context())
+
 	s.render(w, r, "settings.html", map[string]any{
 		"Themes":       config.Themes,
 		"Models":       Models,
@@ -79,7 +84,46 @@ func (s *Server) settingsShow(w http.ResponseWriter, r *http.Request) {
 		"DBSize":       dbSizeBytes,
 		"DBPath":       dbPath,
 		"WorkDir":      s.Worker.DataDir,
+		"Commit":       s.Commit,
+		"Meta":         meta,
 	})
+}
+
+// toolMetadata is the runtime version info shown on the settings page:
+// the scanner tools baked into the runner image plus the host docker
+// daemon and the runner image name itself.
+type toolMetadata struct {
+	worker.RunnerToolVersions
+	Docker      string
+	RunnerImage string
+}
+
+// toolMetadataTTL bounds how long a gathered version set is reused. Versions
+// only change when the operator pulls a new image or restarts docker, so a
+// generous TTL keeps the settings page DB-fast without going stale for long.
+const toolMetadataTTL = 5 * time.Minute
+
+// toolMetadataTimeout caps the docker shell-outs so a hung or missing daemon
+// degrades to "unavailable" instead of stalling the settings page.
+const toolMetadataTimeout = 5 * time.Second
+
+func (s *Server) toolMetadataCached(ctx context.Context) toolMetadata {
+	s.toolMetaMu.Lock()
+	defer s.toolMetaMu.Unlock()
+	if time.Now().Before(s.toolMetaTTL) {
+		return s.toolMetaCache
+	}
+	ctx, cancel := context.WithTimeout(ctx, toolMetadataTimeout)
+	defer cancel()
+	image := worker.RunnerImageName(s.Worker.Runner)
+	meta := toolMetadata{
+		RunnerToolVersions: worker.QueryRunnerToolVersions(ctx, image),
+		Docker:             worker.DockerServerVersion(ctx),
+		RunnerImage:        image,
+	}
+	s.toolMetaCache = meta
+	s.toolMetaTTL = time.Now().Add(toolMetadataTTL)
+	return meta
 }
 
 func (s *Server) settingsUpdateTheme(w http.ResponseWriter, r *http.Request) {

--- a/internal/web/theme.go
+++ b/internal/web/theme.go
@@ -5,6 +5,7 @@ import (
 	"slices"
 
 	"scrutineer/internal/config"
+	"scrutineer/internal/db"
 )
 
 const cookieMaxAge = 365 * 24 * 60 * 60 //nolint:mnd
@@ -42,17 +43,21 @@ func resolveColorScheme(r *http.Request) string {
 
 func (s *Server) settingsShow(w http.ResponseWriter, r *http.Request) {
 	var stats struct {
-		Repos       int64
-		Scans       int64
-		Findings    int64
-		Packages    int64
-		Advisories  int64
-		Maintainers int64
-		Skills      int64
+		Repos           int64
+		Scans           int64
+		Findings        int64
+		ScannerFindings int64
+		Packages        int64
+		Advisories      int64
+		Maintainers     int64
+		Skills          int64
 	}
 	s.DB.Table("repositories").Count(&stats.Repos)
 	s.DB.Table("scans").Count(&stats.Scans)
-	s.DB.Table("findings").Count(&stats.Findings)
+	// Split findings the same way the repo page does: deep-dive (curated
+	// audit) findings versus tool-scanner output (zizmor, semgrep, …).
+	s.DB.Model(&db.Finding{}).Where("scan_id IN (?)", deepDiveScanIDs(s.DB)).Count(&stats.Findings)
+	s.DB.Model(&db.Finding{}).Where("scan_id NOT IN (?)", deepDiveScanIDs(s.DB)).Count(&stats.ScannerFindings)
 	s.DB.Table("packages").Count(&stats.Packages)
 	s.DB.Table("advisories").Count(&stats.Advisories)
 	s.DB.Table("maintainers").Count(&stats.Maintainers)

--- a/internal/worker/versions.go
+++ b/internal/worker/versions.go
@@ -1,0 +1,90 @@
+package worker
+
+import (
+	"context"
+	"os/exec"
+	"regexp"
+	"strings"
+)
+
+// RunnerImageName returns the docker image the given runner uses for scans,
+// or "" when the runner is not the docker runner (e.g. LocalClaude under
+// --no-docker), where there is no fixed image to interrogate.
+func RunnerImageName(r SkillRunner) string {
+	if d, ok := r.(DockerRunner); ok {
+		return d.image()
+	}
+	return ""
+}
+
+// DockerServerVersion returns the docker daemon's server version, or "" if
+// docker is unavailable or the command fails. Mirrors DockerAvailable's
+// shell-out style; the caller supplies a context so the settings page can
+// bound how long it waits.
+func DockerServerVersion(ctx context.Context) string {
+	out, err := exec.CommandContext(ctx, "docker", "version", "--format", "{{.Server.Version}}").Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// RunnerToolVersions holds the versions of the analysis tools baked into the
+// runner image. Any field is "" when its tool could not be queried.
+type RunnerToolVersions struct {
+	Zizmor  string
+	Semgrep string
+	Claude  string
+}
+
+// queryToolsScript prints each tool's version as a key=value line so the
+// output parses unambiguously regardless of each tool's own format. stderr
+// is dropped so update notices and warnings don't pollute the value.
+const queryToolsScript = `echo "zizmor=$(zizmor --version 2>/dev/null)"; ` +
+	`echo "semgrep=$(semgrep --version 2>/dev/null)"; ` +
+	`echo "claude=$(claude --version 2>/dev/null)"`
+
+// QueryRunnerToolVersions starts one short-lived container off the runner
+// image and reads back the versions of the scanner tools it ships. The
+// deployed image is the source of truth (it can drift from the Dockerfile's
+// pinned ARGs), so we interrogate the image rather than parse the Dockerfile.
+//
+// --pull never means a missing image fails fast instead of triggering a slow
+// registry pull, so the settings page never blocks on a download. The caller
+// must pass a context with a timeout to bound a hung daemon. Returns a zero
+// value (all fields "") for an empty image name or any failure.
+func QueryRunnerToolVersions(ctx context.Context, image string) RunnerToolVersions {
+	if image == "" {
+		return RunnerToolVersions{}
+	}
+	out, err := exec.CommandContext(ctx, "docker", "run", "--rm",
+		"--pull", "never", "--entrypoint", "sh", "--", image, "-c", queryToolsScript).Output()
+	if err != nil {
+		return RunnerToolVersions{}
+	}
+	return parseToolVersions(string(out))
+}
+
+// versionRe matches the first dotted-numeric version token in a string, so
+// "zizmor 1.24.1" and "2.1.123 (Claude Code)" both reduce to the bare number.
+var versionRe = regexp.MustCompile(`\d+\.\d+[\w.\-+]*`)
+
+func parseToolVersions(out string) RunnerToolVersions {
+	var v RunnerToolVersions
+	for line := range strings.SplitSeq(strings.TrimSpace(out), "\n") {
+		key, val, ok := strings.Cut(strings.TrimSpace(line), "=")
+		if !ok {
+			continue
+		}
+		val = versionRe.FindString(val)
+		switch key {
+		case "zizmor":
+			v.Zizmor = val
+		case "semgrep":
+			v.Semgrep = val
+		case "claude":
+			v.Claude = val
+		}
+	}
+	return v
+}

--- a/internal/worker/versions_test.go
+++ b/internal/worker/versions_test.go
@@ -1,0 +1,42 @@
+package worker
+
+import "testing"
+
+func TestParseToolVersions(t *testing.T) {
+	out := "zizmor=zizmor 1.24.1\n" +
+		"semgrep=1.116.0\n" +
+		"claude=2.1.123 (Claude Code)\n"
+	got := parseToolVersions(out)
+	if got.Zizmor != "1.24.1" {
+		t.Errorf("Zizmor = %q, want 1.24.1", got.Zizmor)
+	}
+	if got.Semgrep != "1.116.0" {
+		t.Errorf("Semgrep = %q, want 1.116.0", got.Semgrep)
+	}
+	if got.Claude != "2.1.123" {
+		t.Errorf("Claude = %q, want 2.1.123", got.Claude)
+	}
+}
+
+func TestParseToolVersions_missingTools(t *testing.T) {
+	// A tool that is absent prints an empty value after the "=".
+	got := parseToolVersions("zizmor=\nsemgrep=\nclaude=\n")
+	if got != (RunnerToolVersions{}) {
+		t.Errorf("expected zero value for empty versions, got %+v", got)
+	}
+}
+
+func TestRunnerImageName(t *testing.T) {
+	if got := RunnerImageName(DockerRunner{Image: "example/runner:1"}); got != "example/runner:1" {
+		t.Errorf("RunnerImageName(custom) = %q, want example/runner:1", got)
+	}
+	if got := RunnerImageName(DockerRunner{}); got != DefaultRunnerImage {
+		t.Errorf("RunnerImageName(default) = %q, want %q", got, DefaultRunnerImage)
+	}
+	if got := RunnerImageName(LocalClaude{}); got != "" {
+		t.Errorf("RunnerImageName(local) = %q, want empty", got)
+	}
+	if got := RunnerImageName(nil); got != "" {
+		t.Errorf("RunnerImageName(nil) = %q, want empty", got)
+	}
+}


### PR DESCRIPTION
And also split "Findings" from "Scanner Findings" in the statistics.

Updated Settings content:

<img width="1192" height="677" alt="Screenshot 2026-05-31 at 8 05 54 PM" src="https://github.com/user-attachments/assets/df711650-b11b-4838-8bcd-484954cbfea2" />

Generated with Claude Code, reviewed and tested by me. I'm unsure if there are any security considerations to make about this information being available inside scrutineer, but I don't think there's any real problem with it?

Also, `Runner image` is just "ghcr.io/alpha-omega-security/scrutineer-runner:latest" which feels... goofy. We could probably fix that to specify the SHA somehow?