### PR TITLE
fix: gate patches by file and validate against a clean HEAD

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -436,9 +436,9 @@ type Finding struct {
 	DisclosureDraft string            `gorm:"type:text"`
 	Assignee        string            `gorm:"index"`
 	// SuggestedFix is a unified diff from the patch skill that has passed
-	// the applicability gate (parses, targets real files, overlaps
-	// Location, git apply --check clean). Empty when no patch has run or
-	// the gate rejected it. SuggestedFixCommit is the sha it applies to.
+	// the applicability gate (parses, targets real files, touches a file
+	// named in Location, git apply --check clean). Empty when no patch has
+	// run or the gate rejected it. SuggestedFixCommit is the sha it applies to.
 	SuggestedFix       string `gorm:"type:text"`
 	SuggestedFixCommit string
 

--- a/internal/web/finding_patch.go
+++ b/internal/web/finding_patch.go
@@ -48,7 +48,7 @@ func (s *Server) latestPatchScan(findingID uint) (*db.Scan, *patchReport, error)
 // findingPatchDownload serves Finding.SuggestedFix as a .patch file. The
 // column is only ever populated by parsePatchOutput after the applicability
 // gate passes, so a download is always a diff that parsed, targeted real
-// files, overlapped Location, and survived git apply --check.
+// files, touched a file named in Location, and survived git apply --check.
 func (s *Server) findingPatchDownload(w http.ResponseWriter, r *http.Request) {
 	f, ok := loadByID[db.Finding](s, w, r)
 	if !ok {

--- a/internal/worker/patch_gate.go
+++ b/internal/worker/patch_gate.go
@@ -200,6 +200,16 @@ func locationPaths(location string) []string {
 }
 
 func gitApplyCheck(srcDir, diff string) (string, error) {
+	// The patch skill captures its diff with `git diff HEAD` and leaves the
+	// edits applied in srcDir; it never reverts. Re-applying an already-applied
+	// diff always fails, so reset the per-scan copy to HEAD first. reset --hard
+	// clears the skill's `git add -N` index entries; clean -fd drops any new
+	// files it created so a /dev/null hunk can recreate them.
+	for _, args := range [][]string{{"reset", "-q", "--hard", "HEAD"}, {"clean", "-qfd"}} {
+		if out, err := exec.Command("git", append([]string{"-C", srcDir}, args...)...).CombinedOutput(); err != nil {
+			return string(out), err
+		}
+	}
 	cmd := exec.Command("git", "-C", srcDir, "apply", "--check", "-")
 	cmd.Stdin = strings.NewReader(diff)
 	var out bytes.Buffer

--- a/internal/worker/patch_gate.go
+++ b/internal/worker/patch_gate.go
@@ -9,7 +9,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
-	"strconv"
+	"slices"
 	"strings"
 
 	"scrutineer/internal/db"
@@ -69,8 +69,8 @@ func (w *Worker) parsePatchOutput(scan *db.Scan, report string, emit func(Event)
 }
 
 // gatePatch returns "" when the diff is acceptable, otherwise a one-line
-// reason. Checks: diff parses; every target file exists under srcDir; at
-// least one hunk overlaps the line in location; git apply --check accepts it.
+// reason. Checks: diff parses; every target file exists under srcDir; the
+// diff touches a file named in location; git apply --check accepts it.
 func gatePatch(srcDir, location, diff string) string {
 	files, err := parseUnifiedDiff(diff)
 	if err != nil {
@@ -89,7 +89,7 @@ func gatePatch(srcDir, location, diff string) string {
 		}
 	}
 
-	if reason := checkLocationOverlap(files, location); reason != "" {
+	if reason := checkLocationFile(files, location); reason != "" {
 		return reason
 	}
 
@@ -100,51 +100,38 @@ func gatePatch(srcDir, location, diff string) string {
 	return ""
 }
 
-func checkLocationOverlap(files []diffFile, location string) string {
-	locPath, start, end, ok := parseLocation(location)
-	if !ok {
+// checkLocationFile returns "" when the diff touches at least one file named
+// in location, otherwise a one-line reason. It matches on file, not line: a
+// fix often lands in a shared helper far from the flagged sink, so requiring a
+// hunk to overlap the exact line wrongly rejects correct choke-point patches.
+// git apply --check still guarantees the diff applies.
+func checkLocationFile(files []diffFile, location string) string {
+	want := locationPaths(location)
+	if want == nil {
 		return ""
 	}
 	for _, df := range files {
-		if df.Path != locPath {
-			continue
-		}
-		if start == 0 {
+		if slices.Contains(want, df.Path) {
 			return ""
 		}
-		for _, h := range df.Hunks {
-			if h.OldStart <= end && h.OldStart+h.OldCount-1 >= start {
-				return ""
-			}
-		}
 	}
-	if start == 0 {
-		return "no hunk touches " + locPath
-	}
-	return fmt.Sprintf("no hunk overlaps %s:%d", locPath, start)
+	return "no patched file matches location " + location
 }
 
 type diffFile struct {
 	Path    string
 	NewFile bool
-	Hunks   []diffHunk
 }
 
-type diffHunk struct {
-	OldStart int
-	OldCount int
-}
-
-var hunkRE = regexp.MustCompile(`^@@ -(\d+)(?:,(\d+))? \+\d+(?:,\d+)? @@`)
+var hunkRE = regexp.MustCompile(`^@@ -\d+(?:,\d+)? \+\d+(?:,\d+)? @@`)
 
 const maxDiffLineBytes = 4 << 20
 
-// parseUnifiedDiff extracts target file paths and old-side hunk ranges from
-// a unified diff. It is deliberately minimal: enough to drive the gate, not
-// a general diff library.
+// parseUnifiedDiff extracts target file paths from a unified diff, rejecting
+// paths that escape the workspace and malformed hunk headers. It is
+// deliberately minimal: enough to drive the gate, not a general diff library.
 func parseUnifiedDiff(diff string) ([]diffFile, error) {
 	var files []diffFile
-	var cur *diffFile
 	sawFrom := false
 	newFile := false
 
@@ -173,22 +160,14 @@ func parseUnifiedDiff(diff string) ([]diffFile, error) {
 				return nil, fmt.Errorf("diff target escapes workspace: %q", path)
 			}
 			files = append(files, diffFile{Path: path, NewFile: newFile})
-			cur = &files[len(files)-1]
 			newFile = false
 		case strings.HasPrefix(line, "@@ "):
-			if cur == nil {
+			if len(files) == 0 {
 				return nil, fmt.Errorf("hunk header before any file header")
 			}
-			m := hunkRE.FindStringSubmatch(line)
-			if m == nil {
+			if !hunkRE.MatchString(line) {
 				return nil, fmt.Errorf("bad hunk header: %q", line)
 			}
-			start, _ := strconv.Atoi(m[1])
-			count := 1
-			if m[2] != "" {
-				count, _ = strconv.Atoi(m[2])
-			}
-			cur.Hunks = append(cur.Hunks, diffHunk{OldStart: start, OldCount: count})
 		}
 	}
 	if err := sc.Err(); err != nil {
@@ -197,29 +176,27 @@ func parseUnifiedDiff(diff string) ([]diffFile, error) {
 	return files, nil
 }
 
-// parseLocation accepts "path/to/file.ext:N", "path/to/file.ext:N-M", or a
-// bare path. Returns ok=false for anything else (empty, multiple colons that
-// don't end in a line spec); callers treat that as "no overlap check".
-func parseLocation(loc string) (path string, start, end int, ok bool) {
-	loc = strings.TrimSpace(loc)
-	if loc == "" {
-		return "", 0, 0, false
+// locPathRE matches a "path:N" reference inside a Finding.Location. The path
+// class excludes the comma, parenthesis and trailing range that surround it in
+// composite locations, so "logentry.go:106-135)" yields just "logentry.go".
+var locPathRE = regexp.MustCompile(`([^\s,:()]+):\d+`)
+
+// locationPaths returns the file paths a Finding.Location names. A location
+// may list several files with line ranges and a "(data path: a -> b)" trace,
+// e.g. "pkg/a.go:10-20, pkg/b.go:5 (data path: pkg/c.go -> pkg/d.go:30)"; we
+// pull out every "path:line" reference. A location carrying no such reference
+// is treated as a single bare path. Returns nil for an empty location.
+func locationPaths(location string) []string {
+	var paths []string
+	for _, m := range locPathRE.FindAllStringSubmatch(location, -1) {
+		paths = append(paths, m[1])
 	}
-	i := strings.LastIndexByte(loc, ':')
-	if i < 0 {
-		return loc, 0, 0, true
-	}
-	spec := loc[i+1:]
-	if lo, hi, found := strings.Cut(spec, "-"); found {
-		a, errA := strconv.Atoi(lo)
-		b, errB := strconv.Atoi(hi)
-		if errA == nil && errB == nil && a > 0 && b >= a {
-			return loc[:i], a, b, true
+	if paths == nil {
+		if loc := strings.TrimSpace(location); loc != "" {
+			paths = append(paths, loc)
 		}
-	} else if n, err := strconv.Atoi(spec); err == nil && n > 0 {
-		return loc[:i], n, n, true
 	}
-	return loc, 0, 0, true
+	return paths
 }
 
 func gitApplyCheck(srcDir, diff string) (string, error) {

--- a/internal/worker/patch_gate_test.go
+++ b/internal/worker/patch_gate_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
@@ -22,31 +23,28 @@ func TestParseUnifiedDiff(t *testing.T) {
 		{
 			"single file single hunk",
 			"--- a/pkg/foo.go\n+++ b/pkg/foo.go\n@@ -10,3 +10,4 @@ func x() {\n a\n-b\n+c\n+d\n",
-			[]diffFile{{Path: "pkg/foo.go", Hunks: []diffHunk{{OldStart: 10, OldCount: 3}}}},
+			[]diffFile{{Path: "pkg/foo.go"}},
 		},
 		{
 			"multi file",
 			"diff --git a/a.go b/a.go\n--- a/a.go\n+++ b/a.go\n@@ -1 +1 @@\n-x\n+y\n" +
 				"diff --git a/b.go b/b.go\n--- a/b.go\n+++ b/b.go\n@@ -5,2 +5,3 @@\n a\n-b\n+c\n+d\n",
-			[]diffFile{
-				{Path: "a.go", Hunks: []diffHunk{{OldStart: 1, OldCount: 1}}},
-				{Path: "b.go", Hunks: []diffHunk{{OldStart: 5, OldCount: 2}}},
-			},
+			[]diffFile{{Path: "a.go"}, {Path: "b.go"}},
 		},
 		{
 			"new file",
 			"--- /dev/null\n+++ b/new.go\n@@ -0,0 +1,3 @@\n+a\n+b\n+c\n",
-			[]diffFile{{Path: "new.go", NewFile: true, Hunks: []diffHunk{{OldStart: 0, OldCount: 0}}}},
+			[]diffFile{{Path: "new.go", NewFile: true}},
 		},
 		{
 			"deleted file",
 			"--- a/gone.go\n+++ /dev/null\n@@ -1,2 +0,0 @@\n-a\n-b\n",
-			[]diffFile{{Path: "", Hunks: []diffHunk{{OldStart: 1, OldCount: 2}}}},
+			[]diffFile{{Path: ""}},
 		},
 		{
 			"timestamp after path",
 			"--- a/x.go\t2026-01-01\n+++ b/x.go\t2026-01-02\n@@ -3 +3 @@\n-a\n+b\n",
-			[]diffFile{{Path: "x.go", Hunks: []diffHunk{{OldStart: 3, OldCount: 1}}}},
+			[]diffFile{{Path: "x.go"}},
 		},
 	}
 	for _, tc := range tests {
@@ -55,21 +53,8 @@ func TestParseUnifiedDiff(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if len(got) != len(tc.want) {
-				t.Fatalf("files = %d, want %d: %+v", len(got), len(tc.want), got)
-			}
-			for i := range got {
-				if got[i].Path != tc.want[i].Path || got[i].NewFile != tc.want[i].NewFile {
-					t.Errorf("file[%d] = %+v, want %+v", i, got[i], tc.want[i])
-				}
-				if len(got[i].Hunks) != len(tc.want[i].Hunks) {
-					t.Fatalf("file[%d] hunks = %d, want %d", i, len(got[i].Hunks), len(tc.want[i].Hunks))
-				}
-				for j := range got[i].Hunks {
-					if got[i].Hunks[j] != tc.want[i].Hunks[j] {
-						t.Errorf("file[%d] hunk[%d] = %+v, want %+v", i, j, got[i].Hunks[j], tc.want[i].Hunks[j])
-					}
-				}
+			if !slices.Equal(got, tc.want) {
+				t.Errorf("parseUnifiedDiff = %+v, want %+v", got, tc.want)
 			}
 		})
 	}
@@ -96,53 +81,51 @@ func TestParseUnifiedDiff_errors(t *testing.T) {
 	}
 }
 
-func TestParseLocation(t *testing.T) {
+func TestLocationPaths(t *testing.T) {
 	tests := []struct {
-		in         string
-		path       string
-		start, end int
-		ok         bool
+		in   string
+		want []string
 	}{
-		{"pkg/foo.go:42", "pkg/foo.go", 42, 42, true},
-		{"pkg/foo.go:10-20", "pkg/foo.go", 10, 20, true},
-		{"pkg/foo.go", "pkg/foo.go", 0, 0, true},
-		{"", "", 0, 0, false},
-		{"a/b/c.rs:abc", "a/b/c.rs:abc", 0, 0, true},
-		{"a/b/c.rs:5-2", "a/b/c.rs:5-2", 0, 0, true},
-		{"  pkg/foo.go:7  ", "pkg/foo.go", 7, 7, true},
+		{"pkg/foo.go:42", []string{"pkg/foo.go"}},
+		{"pkg/foo.go:10-20", []string{"pkg/foo.go"}},
+		{"pkg/foo.go", []string{"pkg/foo.go"}},
+		{"", nil},
+		{"  pkg/foo.go:7  ", []string{"pkg/foo.go"}},
+		// Composite location from a deep-dive finding: several flagged files
+		// plus a "(data path: ...)" trace. Every path:line reference is pulled
+		// out and the trailing ")" must not leak into the last path.
+		{
+			"internal/ui/logtable.go:227-352, internal/ui/logsidepanel.go:206 (data path: internal/fetcher/lognetlistener.go -> internal/fetcher/logentry.go:106-135)",
+			[]string{"internal/ui/logtable.go", "internal/ui/logsidepanel.go", "internal/fetcher/logentry.go"},
+		},
 	}
 	for _, tc := range tests {
-		path, start, end, ok := parseLocation(tc.in)
-		if path != tc.path || start != tc.start || end != tc.end || ok != tc.ok {
-			t.Errorf("parseLocation(%q) = (%q,%d,%d,%v), want (%q,%d,%d,%v)",
-				tc.in, path, start, end, ok, tc.path, tc.start, tc.end, tc.ok)
+		if got := locationPaths(tc.in); !slices.Equal(got, tc.want) {
+			t.Errorf("locationPaths(%q) = %v, want %v", tc.in, got, tc.want)
 		}
 	}
 }
 
-func TestCheckLocationOverlap(t *testing.T) {
-	files := []diffFile{
-		{Path: "pkg/foo.go", Hunks: []diffHunk{{OldStart: 10, OldCount: 5}}},
-		{Path: "pkg/bar.go", Hunks: []diffHunk{{OldStart: 100, OldCount: 1}}},
-	}
+func TestCheckLocationFile(t *testing.T) {
+	files := []diffFile{{Path: "pkg/foo.go"}, {Path: "pkg/bar.go"}}
 	tests := []struct {
 		loc  string
 		want string
 	}{
 		{"pkg/foo.go:12", ""},
-		{"pkg/foo.go:10", ""},
-		{"pkg/foo.go:14", ""},
-		{"pkg/foo.go:8-11", ""},
-		{"pkg/foo.go:50", "no hunk overlaps pkg/foo.go:50"},
+		{"pkg/foo.go:50", ""},
 		{"pkg/foo.go", ""},
-		{"pkg/other.go:5", "no hunk overlaps pkg/other.go:5"},
-		{"pkg/other.go", "no hunk touches pkg/other.go"},
+		{"pkg/bar.go:100", ""},
 		{"", ""},
+		// File named in the location is patched even though the flagged line
+		// (:99) sits far from the hunk: a choke-point fix must still pass.
+		{"pkg/zzz.go:1, pkg/foo.go:99 (data path: pkg/a.go -> pkg/b.go:2)", ""},
+		{"pkg/other.go:5", "no patched file matches location pkg/other.go:5"},
+		{"pkg/other.go", "no patched file matches location pkg/other.go"},
 	}
 	for _, tc := range tests {
-		got := checkLocationOverlap(files, tc.loc)
-		if got != tc.want {
-			t.Errorf("checkLocationOverlap(%q) = %q, want %q", tc.loc, got, tc.want)
+		if got := checkLocationFile(files, tc.loc); got != tc.want {
+			t.Errorf("checkLocationFile(%q) = %q, want %q", tc.loc, got, tc.want)
 		}
 	}
 }
@@ -197,8 +180,14 @@ func TestGatePatch(t *testing.T) {
 	if r := gatePatch(src, rel+":12", diff); r != "" {
 		t.Errorf("pass case rejected: %q", r)
 	}
-	if r := gatePatch(src, rel+":3", diff); !strings.Contains(r, "no hunk overlaps") {
-		t.Errorf("expected overlap rejection, got %q", r)
+	// File-level match: a fix to pkg/foo.go passes even when the flagged line
+	// (:3) sits far from the hunk (line 12). This is the choke-point case the
+	// old line-overlap gate wrongly rejected.
+	if r := gatePatch(src, rel+":3", diff); r != "" {
+		t.Errorf("file-level pass case rejected: %q", r)
+	}
+	if r := gatePatch(src, "pkg/unrelated.go:12", diff); !strings.Contains(r, "no patched file matches location") {
+		t.Errorf("expected unrelated-location rejection, got %q", r)
 	}
 	if r := gatePatch(src, "pkg/missing.go:12",
 		"--- a/pkg/missing.go\n+++ b/pkg/missing.go\n@@ -1 +1 @@\n-x\n+y\n"); !strings.Contains(r, "missing file") {

--- a/internal/worker/patch_gate_test.go
+++ b/internal/worker/patch_gate_test.go
@@ -131,11 +131,12 @@ func TestCheckLocationFile(t *testing.T) {
 }
 
 // gateRepo creates a git repo under dir with one file pkg/foo.go containing
-// numbered lines 1..20, edits targetLine, captures a real `git diff`, then
+// numbered lines 1..20, edits line 12, captures a real `git diff`, then
 // resets the working tree. The returned diff is what the patch skill would
 // produce, so git apply --check accepts it without --unidiff-zero.
-func gateRepo(t *testing.T, dir string, targetLine int) (relPath, diff string) {
+func gateRepo(t *testing.T, dir string) (relPath, diff string) {
 	t.Helper()
+	const targetLine = 12
 	relPath = "pkg/foo.go"
 	full := filepath.Join(dir, relPath)
 	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
@@ -175,7 +176,7 @@ func gateRepo(t *testing.T, dir string, targetLine int) (relPath, diff string) {
 
 func TestGatePatch(t *testing.T) {
 	src := t.TempDir()
-	rel, diff := gateRepo(t, src, 12)
+	rel, diff := gateRepo(t, src)
 
 	if r := gatePatch(src, rel+":12", diff); r != "" {
 		t.Errorf("pass case rejected: %q", r)
@@ -203,6 +204,24 @@ func TestGatePatch(t *testing.T) {
 	newFileDiff := "--- /dev/null\n+++ b/pkg/foo_test.go\n@@ -0,0 +1 @@\n+test\n" + diff
 	if r := gatePatch(src, rel+":12", newFileDiff); r != "" {
 		t.Errorf("new-file alongside fix rejected: %q", r)
+	}
+}
+
+func TestGatePatch_dirtyWorkspaceFromSkill(t *testing.T) {
+	// The real patch skill captures its diff with `git diff HEAD` and leaves
+	// the edits applied in the workspace (it never reverts). The gate must
+	// reset to HEAD before git apply --check, otherwise re-applying an
+	// already-applied diff fails. gateRepo resets the tree, so reproduce the
+	// skill's behaviour by re-applying the diff to dirty it first.
+	src := t.TempDir()
+	rel, diff := gateRepo(t, src)
+	apply := exec.Command("git", "-C", src, "apply", "-")
+	apply.Stdin = strings.NewReader(diff)
+	if out, err := apply.CombinedOutput(); err != nil {
+		t.Fatalf("seed dirty workspace: %v: %s", err, out)
+	}
+	if r := gatePatch(src, rel+":12", diff); r != "" {
+		t.Errorf("gate rejected a valid patch against a skill-dirtied workspace: %q", r)
 	}
 }
 
@@ -236,7 +255,7 @@ func TestParsePatchOutput_passWritesColumnsAndHistory(t *testing.T) {
 		t.Fatal(err)
 	}
 	src := filepath.Join(w.workRoot(sc.ID), "src")
-	_, diff := gateRepo(t, src, 12)
+	_, diff := gateRepo(t, src)
 	report := fmt.Sprintf(`{"patch":%q,"base_commit":"abc123"}`, diff)
 
 	var events []string
@@ -268,7 +287,7 @@ func TestParsePatchOutput_gateRejectLeavesColumnsEmpty(t *testing.T) {
 		t.Fatal(err)
 	}
 	src := filepath.Join(w.workRoot(sc.ID), "src")
-	gateRepo(t, src, 12)
+	gateRepo(t, src)
 	report := `{"patch":"--- a/pkg/missing.go\n+++ b/pkg/missing.go\n@@ -1 +1 @@\n-x\n+y\n","base_commit":"abc"}`
 
 	var events []string


### PR DESCRIPTION
The gate mis-parsed composite finding Locations and ran `git apply --check` against the workspace the skill leaves dirty, so no `suggested_fix` was ever stored.