### PR TITLE
feat: add concurrency and max turns settings tuning

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Every index page has a search box plus filter and sort dropdowns; the specifics 
 - **Scans** -- every scan that has run. Queued scans can be paused/resumed, running or queued scans can be cancelled and failed ones retried.
 - **Skills** -- installed skills from disk and from the UI; view, edit, or run any of them.
 - **Usage** -- token and cost totals across all scans, broken down by skill.
-- **Settings** -- theme, colour scheme, default model, and system stats (record counts, DB size, concurrency, paths).
+- **Settings** -- theme, colour scheme, default model, runner concurrency (restarts the runner to apply, cancelling in-flight scans) and default turn cap (applied to the next scan), plus system stats (record counts, DB size, paths).
 
 ## Finding workflow
 

--- a/cmd/scrutineer/main.go
+++ b/cmd/scrutineer/main.go
@@ -260,6 +260,15 @@ func run(log *slog.Logger) error {
 		return err
 	}
 
+	// A UI-configured concurrency (Settings page) persists in the DB and
+	// applies on restart, but an explicit --concurrency flag still wins so
+	// the operator who just typed it isn't overridden. Mirrors merge().
+	if !f.set["concurrency"] {
+		if v := db.SettingInt(gdb, db.SettingConcurrency); v > 0 {
+			f.concurrency = v
+		}
+	}
+
 	q, err := queue.New(sqldb, log, f.concurrency)
 	if err != nil {
 		return fmt.Errorf("queue: %w", err)

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -831,7 +831,7 @@ func Open(dsn string) (*gorm.DB, error) {
 		&FindingCommunication{}, &FindingReference{}, &FindingHistory{},
 		&Dependency{}, &Package{}, &Dependent{}, &FindingDependent{}, &Advisory{},
 		&Maintainer{}, &Skill{}, &Subproject{},
-		&SBOMUpload{}, &SBOMPackage{}, &CNA{},
+		&SBOMUpload{}, &SBOMPackage{}, &CNA{}, &Setting{},
 	); err != nil {
 		return nil, fmt.Errorf("automigrate: %w", err)
 	}

--- a/internal/db/settings.go
+++ b/internal/db/settings.go
@@ -1,0 +1,58 @@
+package db
+
+import (
+	"strconv"
+
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// Setting is a persisted operator-tunable key/value. It backs the runtime
+// knobs the Settings page exposes (concurrency, default turn cap) so a
+// change survives a restart instead of living only in process memory.
+type Setting struct {
+	Key   string `gorm:"primarykey"`
+	Value string
+}
+
+// Setting keys.
+const (
+	SettingConcurrency     = "concurrency"
+	SettingDefaultMaxTurns = "default_max_turns"
+)
+
+// GetSetting returns the stored value for key and whether a row exists. It
+// uses Find rather than First so a missing key is a clean (zero rows) result
+// instead of a logged ErrRecordNotFound: absent keys are the common case
+// (read on every scan and settings page load).
+func GetSetting(gdb *gorm.DB, key string) (string, bool) {
+	var s Setting
+	res := gdb.Where("key = ?", key).Limit(1).Find(&s)
+	if res.Error != nil || res.RowsAffected == 0 {
+		return "", false
+	}
+	return s.Value, true
+}
+
+// SetSetting upserts key to value. SQLite has no UPDATE-or-INSERT in GORM's
+// Save for a string primary key, so it goes through an ON CONFLICT clause.
+func SetSetting(gdb *gorm.DB, key, value string) error {
+	return gdb.Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "key"}},
+		DoUpdates: clause.AssignmentColumns([]string{"value"}),
+	}).Create(&Setting{Key: key, Value: value}).Error
+}
+
+// SettingInt returns the stored value parsed as an int, or 0 when the key is
+// absent or unparseable. Callers treat 0 as "not configured".
+func SettingInt(gdb *gorm.DB, key string) int {
+	v, ok := GetSetting(gdb, key)
+	if !ok {
+		return 0
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil {
+		return 0
+	}
+	return n
+}

--- a/internal/db/settings_test.go
+++ b/internal/db/settings_test.go
@@ -1,0 +1,49 @@
+package db
+
+import "testing"
+
+func TestSetting_setGetUpsert(t *testing.T) {
+	gdb, err := Open(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, ok := GetSetting(gdb, SettingConcurrency); ok {
+		t.Fatal("expected missing key to report not found")
+	}
+	if got := SettingInt(gdb, SettingConcurrency); got != 0 {
+		t.Errorf("SettingInt(missing) = %d, want 0", got)
+	}
+
+	if err := SetSetting(gdb, SettingConcurrency, "8"); err != nil {
+		t.Fatalf("SetSetting: %v", err)
+	}
+	if v, ok := GetSetting(gdb, SettingConcurrency); !ok || v != "8" {
+		t.Errorf("GetSetting = (%q, %v), want (\"8\", true)", v, ok)
+	}
+	if got := SettingInt(gdb, SettingConcurrency); got != 8 {
+		t.Errorf("SettingInt = %d, want 8", got)
+	}
+
+	// Re-setting the same key updates in place rather than erroring on the
+	// duplicate primary key.
+	if err := SetSetting(gdb, SettingConcurrency, "16"); err != nil {
+		t.Fatalf("SetSetting upsert: %v", err)
+	}
+	if got := SettingInt(gdb, SettingConcurrency); got != 16 {
+		t.Errorf("SettingInt after upsert = %d, want 16", got)
+	}
+}
+
+func TestSettingInt_unparseable(t *testing.T) {
+	gdb, err := Open(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := SetSetting(gdb, SettingDefaultMaxTurns, "not-a-number"); err != nil {
+		t.Fatalf("SetSetting: %v", err)
+	}
+	if got := SettingInt(gdb, SettingDefaultMaxTurns); got != 0 {
+		t.Errorf("SettingInt(unparseable) = %d, want 0", got)
+	}
+}

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -9,6 +9,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"maragu.dev/goqite"
@@ -26,9 +28,20 @@ type Payload struct {
 }
 
 type Queue struct {
-	q           *goqite.Queue
-	runner      *jobs.Runner
-	Concurrency int
+	q   *goqite.Queue
+	log *slog.Logger
+
+	// concurrency is atomic so Concurrency() (read by the settings page) never
+	// blocks on mu while Reconfigure holds it for the duration of a runner
+	// swap (which includes the cancelled scan's teardown).
+	concurrency atomic.Int64
+
+	mu        sync.Mutex
+	runner    *jobs.Runner
+	handlers  map[string]jobs.Func
+	parentCtx context.Context
+	cancel    context.CancelFunc
+	wg        sync.WaitGroup
 }
 
 const (
@@ -38,6 +51,7 @@ const (
 
 // New builds a queue wired to goqite. concurrency controls how many jobs
 // the runner processes in parallel; pass 0 to use DefaultWorkerConcurrency.
+// The runner itself is built lazily in Start (and rebuilt by Reconfigure).
 func New(sqldb *sql.DB, log *slog.Logger, concurrency int) (*Queue, error) {
 	if concurrency <= 0 {
 		concurrency = DefaultWorkerConcurrency
@@ -50,22 +64,84 @@ func New(sqldb *sql.DB, log *slog.Logger, concurrency int) (*Queue, error) {
 		Name:    "scans",
 		Timeout: visibilityTimeout,
 	})
-	r := jobs.NewRunner(jobs.NewRunnerOpts{
-		Queue:        q,
-		Log:          slogAdapter{log},
-		Limit:        concurrency,
-		PollInterval: time.Second,
-		Extend:       visibilityTimeout,
-	})
-	return &Queue{q: q, runner: r, Concurrency: concurrency}, nil
+	queue := &Queue{q: q, log: log, handlers: map[string]jobs.Func{}}
+	queue.concurrency.Store(int64(concurrency))
+	return queue, nil
+}
+
+// Concurrency reports the parallelism limit the runner is currently using.
+func (q *Queue) Concurrency() int {
+	return int(q.concurrency.Load())
 }
 
 func (q *Queue) Register(name string, fn jobs.Func) {
-	q.runner.Register(name, fn)
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	q.handlers[name] = fn
 }
 
+// Start runs the job runner until ctx is cancelled, then waits for in-flight
+// jobs to drain. ctx is retained as the parent for every runner instance, so
+// a runner spawned by Reconfigure also dies with the process.
 func (q *Queue) Start(ctx context.Context) {
-	q.runner.Start(ctx)
+	q.mu.Lock()
+	q.parentCtx = ctx
+	q.startRunnerLocked()
+	q.mu.Unlock()
+
+	<-ctx.Done()
+	q.wg.Wait()
+}
+
+// startRunnerLocked builds a fresh goqite runner at the current concurrency,
+// registers the known handlers, and starts it on a child of parentCtx. The
+// caller must hold q.mu.
+func (q *Queue) startRunnerLocked() {
+	r := jobs.NewRunner(jobs.NewRunnerOpts{
+		Queue:        q.q,
+		Log:          slogAdapter{q.log},
+		Limit:        int(q.concurrency.Load()),
+		PollInterval: time.Second,
+		Extend:       visibilityTimeout,
+	})
+	for name, fn := range q.handlers {
+		r.Register(name, fn)
+	}
+	ctx, cancel := context.WithCancel(q.parentCtx)
+	q.runner = r
+	q.cancel = cancel
+	q.wg.Go(func() { r.Start(ctx) })
+}
+
+// Reconfigure swaps the runner for one with a new parallelism limit without
+// restarting the process. goqite fixes the limit at construction, so the only
+// way to change it live is to stand up a new runner: the current one is
+// cancelled first, which aborts in-flight jobs (their context derives from the
+// runner's). Queued jobs are untouched and the fresh runner picks them up.
+// Calling before Start just records the value, applied when Start builds the
+// first runner.
+func (q *Queue) Reconfigure(concurrency int) {
+	if concurrency <= 0 {
+		concurrency = DefaultWorkerConcurrency
+	}
+	q.concurrency.Store(int64(concurrency))
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	// Not started yet (value is recorded, applied when Start builds the first
+	// runner), or shutting down: bail before touching the runner. During
+	// shutdown Start is running its own q.wg.Wait(); spawning a runner here
+	// would Add to the WaitGroup mid-Wait and panic, and a new runner would be
+	// pointless anyway. The post-drain re-check catches a shutdown that begins
+	// while we drain.
+	if q.parentCtx == nil || q.parentCtx.Err() != nil {
+		return
+	}
+	q.cancel()
+	q.wg.Wait()
+	if q.parentCtx.Err() != nil {
+		return
+	}
+	q.startRunnerLocked()
 }
 
 // Enqueue puts a job on the queue. Higher priority is received first; use 0

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -1,0 +1,141 @@
+package queue
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"scrutineer/internal/db"
+)
+
+func newTestQueue(t *testing.T, concurrency int) *Queue {
+	t.Helper()
+	gdb, err := db.Open(filepath.Join(t.TempDir(), "q.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	sqldb, err := gdb.DB()
+	if err != nil {
+		t.Fatal(err)
+	}
+	q, err := New(sqldb, slog.New(slog.NewTextHandler(io.Discard, nil)), concurrency)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return q
+}
+
+func TestQueue_ReconfigureBeforeStart(t *testing.T) {
+	q := newTestQueue(t, 4)
+	if q.Concurrency() != 4 {
+		t.Fatalf("initial concurrency = %d, want 4", q.Concurrency())
+	}
+	q.Reconfigure(8)
+	if q.Concurrency() != 8 {
+		t.Errorf("after Reconfigure(8) = %d, want 8", q.Concurrency())
+	}
+	q.Reconfigure(0) // non-positive clamps to the built-in default
+	if q.Concurrency() != DefaultWorkerConcurrency {
+		t.Errorf("after Reconfigure(0) = %d, want %d", q.Concurrency(), DefaultWorkerConcurrency)
+	}
+}
+
+// TestQueue_ReconfigureDuringShutdown covers the guard that keeps Reconfigure
+// from spawning a runner (and Add-ing to the WaitGroup) once the parent ctx is
+// cancelled, which would panic against Start's shutdown Wait. After shutdown it
+// must be a safe no-op that still records the requested value.
+func TestQueue_ReconfigureDuringShutdown(t *testing.T) {
+	q := newTestQueue(t, 2)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	started := make(chan struct{}, 1)
+	q.Register("job", func(c context.Context, _ []byte) error {
+		select {
+		case started <- struct{}{}:
+		default:
+		}
+		<-c.Done()
+		return nil
+	})
+
+	startReturned := make(chan struct{})
+	go func() { q.Start(ctx); close(startReturned) }()
+	if err := q.Enqueue(ctx, "job", 1, 0); err != nil {
+		t.Fatal(err)
+	}
+	waitChan(t, started, "runner never started")
+
+	cancel() // simulate process shutdown: Start drains then returns
+	select {
+	case <-startReturned:
+	case <-time.After(3 * time.Second):
+		t.Fatal("Start did not return after shutdown")
+	}
+
+	q.Reconfigure(7) // must not panic, and records the value without a new runner
+	if q.Concurrency() != 7 {
+		t.Errorf("Concurrency = %d, want 7", q.Concurrency())
+	}
+}
+
+// TestQueue_ReconfigureLive proves the headline behaviour: changing the limit
+// while running cancels the in-flight job, applies the new limit, and the
+// fresh runner keeps processing newly enqueued jobs.
+func TestQueue_ReconfigureLive(t *testing.T) {
+	q := newTestQueue(t, 1)
+
+	started := make(chan struct{}, 1)
+	cancelled := make(chan struct{}, 1)
+	processed := make(chan uint, 4)
+	q.Register("job", func(ctx context.Context, body []byte) error {
+		var p Payload
+		_ = json.Unmarshal(body, &p)
+		if p.ScanID == 1 {
+			started <- struct{}{}
+			<-ctx.Done() // block until the runner is torn down
+			cancelled <- struct{}{}
+			return nil // return nil so goqite drops the message (no retry loop)
+		}
+		processed <- p.ScanID
+		return nil
+	})
+
+	ctx := t.Context()
+	go q.Start(ctx)
+
+	if err := q.Enqueue(ctx, "job", 1, 0); err != nil {
+		t.Fatal(err)
+	}
+	waitChan(t, started, "in-flight job never started")
+
+	q.Reconfigure(3)
+	waitChan(t, cancelled, "in-flight job was not cancelled by Reconfigure")
+	if q.Concurrency() != 3 {
+		t.Errorf("concurrency after Reconfigure = %d, want 3", q.Concurrency())
+	}
+
+	if err := q.Enqueue(ctx, "job", 2, 0); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case got := <-processed:
+		if got != 2 {
+			t.Errorf("processed scan %d, want 2", got)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("fresh runner did not process the job enqueued after Reconfigure")
+	}
+}
+
+func waitChan(t *testing.T, ch <-chan struct{}, msg string) {
+	t.Helper()
+	select {
+	case <-ch:
+	case <-time.After(3 * time.Second):
+		t.Fatal(msg)
+	}
+}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -287,6 +287,9 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("POST /settings/model", s.settingsUpdateModel)
 	mux.HandleFunc("POST /settings/effort", s.settingsUpdateEffort)
 	mux.HandleFunc("POST /settings/color-scheme", s.settingsUpdateColorScheme)
+	mux.HandleFunc("POST /settings/concurrency", s.settingsUpdateConcurrency)
+	mux.HandleFunc("POST /settings/runner/restart", s.settingsRestartRunner)
+	mux.HandleFunc("POST /settings/max-turns", s.settingsUpdateMaxTurns)
 
 	// API routes get bearer-auth middleware and skip the browser CSRF checks;
 	// skills call these from inside a scan workspace, not from a browser.

--- a/internal/web/settings_handlers_test.go
+++ b/internal/web/settings_handlers_test.go
@@ -1,0 +1,139 @@
+package web
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"scrutineer/internal/db"
+)
+
+func postForm(t *testing.T, s *Server, path string, form url.Values) *httptest.ResponseRecorder {
+	t.Helper()
+	r := httptest.NewRequest("POST", path, strings.NewReader(form.Encode()))
+	r.Host = "127.0.0.1:8080"
+	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	r.Header.Set("Sec-Fetch-Site", "same-origin")
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, r)
+	return w
+}
+
+func TestSettingsShow_rendersRunnerControls(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	if err := db.SetSetting(s.DB, db.SettingConcurrency, "9"); err != nil {
+		t.Fatal(err)
+	}
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/settings", nil)
+	r.Host = "127.0.0.1:8080"
+	s.Handler().ServeHTTP(w, r)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+	body := w.Body.String()
+	for _, want := range []string{`name="concurrency"`, `value="9"`, `name="max_turns"`, "Default turns"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("settings page missing %q", want)
+		}
+	}
+}
+
+func TestSettingsUpdateConcurrency(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	// No scans running, so a changed value applies immediately (live runner
+	// reconfigure) and redirects.
+	w := postForm(t, s, "/settings/concurrency", url.Values{"concurrency": {"12"}})
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+	if got := db.SettingInt(s.DB, db.SettingConcurrency); got != 12 {
+		t.Errorf("persisted concurrency = %d, want 12", got)
+	}
+	if got := s.Queue.Concurrency(); got != 12 {
+		t.Errorf("runner concurrency = %d, want 12 (applied immediately)", got)
+	}
+
+	for _, bad := range []string{"0", "65", "-1", "abc", ""} {
+		w := postForm(t, s, "/settings/concurrency", url.Values{"concurrency": {bad}})
+		if w.Code != http.StatusUnprocessableEntity {
+			t.Errorf("concurrency=%q: status %d, want 422", bad, w.Code)
+		}
+	}
+	// A rejected value leaves the stored one untouched.
+	if got := db.SettingInt(s.DB, db.SettingConcurrency); got != 12 {
+		t.Errorf("concurrency clobbered by invalid input = %d, want 12", got)
+	}
+}
+
+func TestSettingsUpdateConcurrency_confirmsWhenScansRunning(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	repo := db.Repository{URL: "https://example.com/x", Name: "x"}
+	s.DB.Create(&repo)
+	s.DB.Create(&db.Scan{RepositoryID: repo.ID, Kind: "skill", Status: db.ScanRunning})
+
+	before := s.Queue.Concurrency()
+	w := postForm(t, s, "/settings/concurrency", url.Values{"concurrency": {"20"}})
+	if w.Code != http.StatusOK {
+		t.Fatalf("status %d, want 200 (confirmation): %s", w.Code, w.Body)
+	}
+	body := w.Body.String()
+	for _, want := range []string{"/settings/runner/restart", "concurrency-confirm", "Restart runner"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("confirmation missing %q; body=%s", want, body)
+		}
+	}
+	if got := db.SettingInt(s.DB, db.SettingConcurrency); got != 20 {
+		t.Errorf("value should be persisted before confirm; got %d", got)
+	}
+	if got := s.Queue.Concurrency(); got != before {
+		t.Errorf("runner reconfigured before confirmation: %d (was %d)", got, before)
+	}
+}
+
+func TestSettingsRestartRunner(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	if err := db.SetSetting(s.DB, db.SettingConcurrency, "16"); err != nil {
+		t.Fatal(err)
+	}
+	w := postForm(t, s, "/settings/runner/restart", nil)
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+	if got := s.Queue.Concurrency(); got != 16 {
+		t.Errorf("runner concurrency = %d, want 16 after restart", got)
+	}
+}
+
+func TestSettingsUpdateMaxTurns(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	w := postForm(t, s, "/settings/max-turns", url.Values{"max_turns": {"50"}})
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+	if got := db.SettingInt(s.DB, db.SettingDefaultMaxTurns); got != 50 {
+		t.Errorf("persisted default_max_turns = %d, want 50", got)
+	}
+
+	for _, bad := range []string{"0", "501", "-1", "abc", ""} {
+		w := postForm(t, s, "/settings/max-turns", url.Values{"max_turns": {bad}})
+		if w.Code != http.StatusUnprocessableEntity {
+			t.Errorf("max_turns=%q: status %d, want 422", bad, w.Code)
+		}
+	}
+	if got := db.SettingInt(s.DB, db.SettingDefaultMaxTurns); got != 50 {
+		t.Errorf("max_turns clobbered by invalid input = %d, want 50", got)
+	}
+}

--- a/internal/web/static/app.js
+++ b/internal/web/static/app.js
@@ -72,6 +72,12 @@
       if (dlgToClose) { e.preventDefault(); dlgToClose.close(); return; }
     }
 
+    var dismiss = e.target.closest('[data-dismiss]');
+    if (dismiss) {
+      var toClear = document.getElementById(dismiss.getAttribute('data-dismiss'));
+      if (toClear) { e.preventDefault(); toClear.replaceChildren(); return; }
+    }
+
     var opener = e.target.closest('[data-dialog]');
     if (opener) {
       var dlg = document.getElementById(opener.getAttribute('data-dialog'));

--- a/internal/web/templates/settings.html
+++ b/internal/web/templates/settings.html
@@ -78,6 +78,34 @@
 </section>
 
 <section class="card">
+  <header>
+    <h2>Runner</h2>
+    <p class="text-muted-foreground text-sm">How scans execute. Changing concurrency restarts the runner (in-flight scans are cancelled, queued scans are kept); the default turn cap applies to the next scan.</p>
+  </header>
+  <section>
+    <div class="grid sm:grid-cols-2 gap-4">
+      <form method="post" action="/settings/concurrency" hx-post="/settings/concurrency" hx-swap="none" class="grid gap-2">
+        <label for="concurrency">Concurrency</label>
+        <div class="flex gap-2">
+          <input id="concurrency" class="input" type="number" name="concurrency" value="{{.ConcurrencyInput}}" min="1" max="64" required>
+          <button type="submit" class="btn">Save</button>
+        </div>
+        <p class="text-xs text-muted-foreground">Scans run in parallel. Currently running with {{.Concurrency}}.</p>
+      </form>
+      <form method="post" action="/settings/max-turns" hx-post="/settings/max-turns" hx-swap="none" class="grid gap-2">
+        <label for="max_turns">Default turns</label>
+        <div class="flex gap-2">
+          <input id="max_turns" class="input" type="number" name="max_turns" {{if .MaxTurns}}value="{{.MaxTurns}}"{{end}} min="1" max="500" placeholder="default: {{.DefaultMaxTurns}}" required>
+          <button type="submit" class="btn">Save</button>
+        </div>
+        <p class="text-xs text-muted-foreground">Turn cap for skills that set none. Applies to the next scan.</p>
+      </form>
+    </div>
+    <div id="concurrency-confirm"></div>
+  </section>
+</section>
+
+<section class="card">
   <header><h2>System</h2></header>
   <section>
     <div class="grid grid-cols-3 sm:grid-cols-4 lg:grid-cols-8 gap-3 text-sm">
@@ -115,10 +143,6 @@
       </div>
     </div>
     <div class="grid grid-cols-2 gap-3 text-sm mt-3">
-      <div class="bg-muted/50 rounded-lg px-3 py-2">
-        <div class="text-muted-foreground text-xs">Concurrency</div>
-        <div class="font-medium text-lg">{{.Concurrency}}</div>
-      </div>
       <div class="bg-muted/50 rounded-lg px-3 py-2">
         <div class="text-muted-foreground text-xs">Database size</div>
         <div class="font-medium text-lg">{{bytes .DBSize}}</div>
@@ -185,5 +209,17 @@
   .theme-swatch-accent[data-swatch="northern-lights"]  { background: oklch(0.83 0.11 211.96); }
   .theme-swatch-muted[data-swatch="northern-lights"]   { background: oklch(0.88 0.03 98.1); }
 </style>
+
+{{define "concurrency-confirm-oob"}}<div id="concurrency-confirm" hx-swap-oob="innerHTML">
+  <div class="rounded-lg border border-primary/40 bg-muted/50 px-4 py-3 text-sm mt-4 flex flex-wrap items-center justify-between gap-3">
+    <p class="flex-1 min-w-[16rem]">Concurrency {{.Concurrency}} saved. Restart the runner to apply it now — this cancels {{.Running}} running scan(s) (queued scans are kept). Otherwise it takes effect on the next restart.</p>
+    <div class="flex gap-2 shrink-0">
+      <form method="post" action="/settings/runner/restart" hx-post="/settings/runner/restart" hx-swap="none">
+        <button type="submit" class="btn"><i data-lucide="power"></i> Restart runner</button>
+      </form>
+      <button type="button" class="btn-outline" data-dismiss="concurrency-confirm">Not now</button>
+    </div>
+  </div>
+</div>{{end}}
 
 {{template "foot" .}}

--- a/internal/web/theme.go
+++ b/internal/web/theme.go
@@ -2,13 +2,25 @@ package web
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"slices"
+	"strconv"
 	"time"
 
 	"scrutineer/internal/config"
 	"scrutineer/internal/db"
 	"scrutineer/internal/worker"
+)
+
+// Bounds for the operator-tunable knobs on the Settings page. They guard
+// against nonsense values (a 0 or 5000-wide concurrency, a 1-turn cap that
+// fails every scan) rather than enforcing a hard system limit.
+const (
+	minConcurrency = 1
+	maxConcurrency = 64
+	minMaxTurns    = 1
+	maxMaxTurns    = 500
 )
 
 const cookieMaxAge = 365 * 24 * 60 * 60 //nolint:mnd
@@ -74,20 +86,32 @@ func (s *Server) settingsShow(w http.ResponseWriter, r *http.Request) {
 
 	meta := s.toolMetadataCached(r.Context())
 
+	// ConcurrencyInput pre-fills the form with the persisted value when set,
+	// else the value the runner is actually using now. MaxTurns is 0 when
+	// unconfigured; the template then shows an empty field whose placeholder
+	// names the built-in fallback rather than asserting an active number.
+	concurrencyInput := s.Queue.Concurrency()
+	if v := db.SettingInt(s.DB, db.SettingConcurrency); v > 0 {
+		concurrencyInput = v
+	}
+
 	s.render(w, r, "settings.html", map[string]any{
-		"Themes":        config.Themes,
-		"Models":        Models,
-		"DefaultModel":  DefaultModel(),
-		"Efforts":       Efforts,
-		"DefaultEffort": DefaultEffort(),
-		"ColorScheme":   resolveColorScheme(r),
-		"Concurrency":   s.Queue.Concurrency,
-		"Stats":         stats,
-		"DBSize":        dbSizeBytes,
-		"DBPath":        dbPath,
-		"WorkDir":       s.Worker.DataDir,
-		"Commit":        s.Commit,
-		"Meta":          meta,
+		"Themes":           config.Themes,
+		"Models":           Models,
+		"DefaultModel":     DefaultModel(),
+		"Efforts":          Efforts,
+		"DefaultEffort":    DefaultEffort(),
+		"ColorScheme":      resolveColorScheme(r),
+		"Concurrency":      s.Queue.Concurrency(),
+		"ConcurrencyInput": concurrencyInput,
+		"MaxTurns":         db.SettingInt(s.DB, db.SettingDefaultMaxTurns),
+		"DefaultMaxTurns":  worker.DefaultSkillMaxTurns,
+		"Stats":            stats,
+		"DBSize":           dbSizeBytes,
+		"DBPath":           dbPath,
+		"WorkDir":          s.Worker.DataDir,
+		"Commit":           s.Commit,
+		"Meta":             meta,
 	})
 }
 
@@ -182,5 +206,67 @@ func (s *Server) settingsUpdateColorScheme(w http.ResponseWriter, r *http.Reques
 		SameSite: http.SameSiteStrictMode,
 	})
 	setFlash(w, Flash{Category: successKey, Title: "Color scheme updated"})
+	s.redirect(w, r, "/settings")
+}
+
+func (s *Server) settingsUpdateConcurrency(w http.ResponseWriter, r *http.Request) {
+	n, err := strconv.Atoi(r.FormValue("concurrency"))
+	if err != nil || n < minConcurrency || n > maxConcurrency {
+		http.Error(w, "concurrency must be between 1 and 64", http.StatusUnprocessableEntity)
+		return
+	}
+	if err := db.SetSetting(s.DB, db.SettingConcurrency, strconv.Itoa(n)); err != nil {
+		http.Error(w, "could not save setting", http.StatusInternalServerError)
+		return
+	}
+	if n == s.Queue.Concurrency() {
+		setFlash(w, Flash{Category: successKey, Title: "Concurrency saved"})
+		s.redirect(w, r, "/settings")
+		return
+	}
+	// The runner's limit is fixed at construction, so applying a new value
+	// means standing up a fresh runner, which aborts whatever is mid-flight.
+	// With nothing running there's nothing to lose, so apply immediately;
+	// otherwise ask before cancelling.
+	var running int64
+	s.DB.Model(&db.Scan{}).Where("status = ?", db.ScanRunning).Count(&running)
+	if running == 0 {
+		s.Queue.Reconfigure(n)
+		setFlash(w, Flash{Category: successKey, Title: "Concurrency applied", Description: fmt.Sprintf("Runner now runs %d scans in parallel.", n)})
+		s.redirect(w, r, "/settings")
+		return
+	}
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	if execErr := s.tmpl.ExecuteTemplate(w, "concurrency-confirm-oob", map[string]any{
+		"Concurrency": n,
+		"Running":     running,
+	}); execErr != nil {
+		s.Log.Error("render concurrency-confirm-oob", "err", execErr)
+	}
+}
+
+// settingsRestartRunner rebuilds the runner at the saved concurrency, applying
+// it live. In-flight scans are cancelled by the swap; queued scans survive.
+func (s *Server) settingsRestartRunner(w http.ResponseWriter, r *http.Request) {
+	n := db.SettingInt(s.DB, db.SettingConcurrency)
+	if n <= 0 {
+		n = s.Queue.Concurrency()
+	}
+	s.Queue.Reconfigure(n)
+	setFlash(w, Flash{Category: successKey, Title: "Runner restarted", Description: fmt.Sprintf("Now running %d scans in parallel; in-flight scans were cancelled.", n)})
+	s.redirect(w, r, "/settings")
+}
+
+func (s *Server) settingsUpdateMaxTurns(w http.ResponseWriter, r *http.Request) {
+	n, err := strconv.Atoi(r.FormValue("max_turns"))
+	if err != nil || n < minMaxTurns || n > maxMaxTurns {
+		http.Error(w, "default turns must be between 1 and 500", http.StatusUnprocessableEntity)
+		return
+	}
+	if err := db.SetSetting(s.DB, db.SettingDefaultMaxTurns, strconv.Itoa(n)); err != nil {
+		http.Error(w, "could not save setting", http.StatusInternalServerError)
+		return
+	}
+	setFlash(w, Flash{Category: successKey, Title: "Default turns updated", Description: "Applies to the next scan."})
 	s.redirect(w, r, "/settings")
 }

--- a/internal/worker/exposure.go
+++ b/internal/worker/exposure.go
@@ -185,7 +185,7 @@ func (w *Worker) doExposure(ctx context.Context, scan *db.Scan, emit func(Event)
 		SkillDir:        skillDir,
 		OutputFile:      skill.OutputFile,
 		Ref:             scan.Ref,
-		MaxTurns:        skill.MaxTurns,
+		MaxTurns:        w.resolveMaxTurns(skill.MaxTurns),
 		AllowedTools:    skill.AllowedTools,
 		SrcReady:        true,
 		Profile:         scan.Profile,

--- a/internal/worker/max_turns_test.go
+++ b/internal/worker/max_turns_test.go
@@ -1,0 +1,70 @@
+package worker
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"path/filepath"
+	"testing"
+
+	"scrutineer/internal/db"
+	"scrutineer/internal/queue"
+)
+
+// captureRunner records the SkillJob it was handed so a test can assert how
+// the worker resolved per-scan inputs.
+type captureRunner struct{ sj SkillJob }
+
+func (c *captureRunner) RunSkill(_ context.Context, sj SkillJob, _ func(Event)) (SkillResult, error) {
+	c.sj = sj
+	return SkillResult{}, nil
+}
+
+func TestWorker_resolvesDefaultMaxTurns(t *testing.T) {
+	tests := []struct {
+		name         string
+		skillMaxTurn int
+		setting      string // "" = leave the DB setting unset
+		want         int
+	}{
+		{"unset falls back to runner default", 0, "", 0},
+		{"live default applies when skill sets none", 0, "42", 42},
+		{"per-skill cap wins over live default", 7, "42", 7},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gdb, err := db.Open(filepath.Join(t.TempDir(), "mt.db"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			repo := db.Repository{URL: "https://example.com/x", Name: "x"}
+			gdb.Create(&repo)
+			skill := db.Skill{Name: "s", Description: "d", Body: "b", Active: true, Source: "ui", Version: 1, MaxTurns: tc.skillMaxTurn}
+			gdb.Create(&skill)
+			scan := db.Scan{RepositoryID: repo.ID, Kind: JobSkill, Status: db.ScanQueued, SkillID: &skill.ID}
+			gdb.Create(&scan)
+			if tc.setting != "" {
+				if err := db.SetSetting(gdb, db.SettingDefaultMaxTurns, tc.setting); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			runner := &captureRunner{}
+			w := &Worker{
+				DB:             gdb,
+				Log:            slog.New(slog.NewTextHandler(io.Discard, nil)),
+				DataDir:        t.TempDir(),
+				Runner:         runner,
+				PrepareRepoSrc: stubPrepareRepoSrc,
+			}
+			body, _ := json.Marshal(queue.Payload{ScanID: scan.ID})
+			if err := w.wrap(w.doSkill)(context.Background(), body); err != nil {
+				t.Fatalf("wrap: %v", err)
+			}
+			if runner.sj.MaxTurns != tc.want {
+				t.Errorf("sj.MaxTurns = %d, want %d", runner.sj.MaxTurns, tc.want)
+			}
+		})
+	}
+}

--- a/internal/worker/skill.go
+++ b/internal/worker/skill.go
@@ -142,7 +142,7 @@ func (w *Worker) doSkill(ctx context.Context, scan *db.Scan, emit func(Event)) (
 		SkillDir:        skillDir,
 		OutputFile:      skill.OutputFile,
 		Ref:             scan.Ref,
-		MaxTurns:        skill.MaxTurns,
+		MaxTurns:        w.resolveMaxTurns(skill.MaxTurns),
 		AllowedTools:    skill.AllowedTools,
 		SrcReady:        true,
 		Profile:         scan.Profile,

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -88,6 +88,18 @@ func (w *Worker) workRoot(scanID uint) string {
 	return filepath.Join(w.DataDir, fmt.Sprintf("scan-%d", scanID))
 }
 
+// resolveMaxTurns picks a scan's turn cap: the skill's own cap when it sets
+// one, else the operator-configured default read live from settings so a
+// change on the Settings page applies to the next scan without a restart. A
+// 0 result leaves the runner's startup default (the --max-turns flag) as the
+// downstream fallback.
+func (w *Worker) resolveMaxTurns(skillMaxTurns int) int {
+	if skillMaxTurns > 0 {
+		return skillMaxTurns
+	}
+	return db.SettingInt(w.DB, db.SettingDefaultMaxTurns)
+}
+
 // workspaceScanID returns the scan id whose workspace path a run should
 // use. A fresh scan uses its own id; a retry that resumes a session reuses
 // the lineage-root id so claude executes in the same working directory the


### PR DESCRIPTION
Adds two "knobs" in the settings to quickly customize concurrency and max turns:

<img width="1012" height="660" alt="Capture d’écran 2026-06-01 à 15 05 04" src="https://github.com/user-attachments/assets/aafb391c-5069-4ea0-934d-50604627eec0" />

Because concurrency requires a runner reboot, it is done automatically. If scans are running, a warning is displayed:

<img width="1008" height="267" alt="Capture d’écran 2026-06-01 à 15 05 20" src="https://github.com/user-attachments/assets/2bb3e0fb-744b-4a30-aa44-c3002f8d3bef" />
