### PR TITLE
feat: add support for repository removal

### DIFF
--- a/internal/web/repo_delete_test.go
+++ b/internal/web/repo_delete_test.go
@@ -1,0 +1,300 @@
+package web
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"scrutineer/internal/db"
+	"scrutineer/internal/worker"
+)
+
+//nolint:maintidx // exhaustive fixture: seeds one of every linked table then asserts each is gone; splitting would scatter the coverage.
+func TestRepoDelete_removesRepoAndAllLinkedData(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	// Pin to one connection and force foreign_keys ON so this test enforces
+	// FK constraints exactly as production does — a pooled in-memory DB applies
+	// the pragma to only one connection, which silently disables enforcement.
+	sqldb, _ := s.DB.DB()
+	sqldb.SetMaxOpenConns(1)
+	if err := s.DB.Exec("PRAGMA foreign_keys=ON").Error; err != nil {
+		t.Fatal(err)
+	}
+
+	dataDir := t.TempDir()
+	s.Worker = &worker.Worker{DataDir: dataDir}
+
+	repo := db.Repository{URL: "https://github.com/acme/doomed", Name: "doomed"}
+	s.DB.Create(&repo)
+
+	// A second repo whose data must survive the delete untouched.
+	keep := db.Repository{URL: "https://github.com/acme/keep", Name: "keep"}
+	s.DB.Create(&keep)
+	keepScan := db.Scan{RepositoryID: keep.ID, Kind: "skill", Status: db.ScanDone, SkillName: deepDiveSkillName}
+	s.DB.Create(&keepScan)
+	s.DB.Create(&db.Finding{ScanID: keepScan.ID, RepositoryID: keep.ID, Title: "survivor", Severity: "High"})
+
+	scan := db.Scan{RepositoryID: repo.ID, Kind: "skill", Status: db.ScanDone, SkillName: deepDiveSkillName}
+	s.DB.Create(&scan)
+	finding := db.Finding{ScanID: scan.ID, RepositoryID: repo.ID, FindingID: "F1", Title: "doomed finding", Severity: "High"}
+	s.DB.Create(&finding)
+
+	// A finding-scoped scan (verify/patch/exposure) carries scans.finding_id,
+	// whose FK to findings is ON DELETE NO ACTION — this is what blocks naive
+	// "delete findings then scans" ordering in production.
+	verifyScan := db.Scan{RepositoryID: repo.ID, FindingID: &finding.ID, Kind: "skill",
+		Status: db.ScanDone, SkillName: "verify"}
+	s.DB.Create(&verifyScan)
+
+	// A finding-scoped scan living on a *different* repo but pointing at the
+	// doomed finding: it must survive (its repo is untouched) yet have its
+	// finding_id link cleared, or the finding delete would 787 again.
+	crossRepoScan := db.Scan{RepositoryID: keep.ID, FindingID: &finding.ID, Kind: "skill",
+		Status: db.ScanDone, SkillName: "exposure"}
+	s.DB.Create(&crossRepoScan)
+
+	s.DB.Create(&db.FindingNote{FindingID: finding.ID, Body: "note"})
+	s.DB.Create(&db.FindingCommunication{FindingID: finding.ID, Channel: "email", Direction: "outbound"})
+	s.DB.Create(&db.FindingReference{FindingID: finding.ID, URL: "https://x/ref"})
+	s.DB.Create(&db.FindingHistory{FindingID: finding.ID, Field: "status", NewValue: "new"})
+
+	dependent := db.Dependent{RepositoryID: repo.ID, Name: "downstream", Ecosystem: "npm"}
+	s.DB.Create(&dependent)
+	s.DB.Create(&db.FindingDependent{FindingID: finding.ID, DependentID: dependent.ID, Status: db.ExposureKnownAffected})
+
+	label := db.FindingLabel{Name: "wontfix"}
+	s.DB.Create(&label)
+	if err := s.DB.Model(&finding).Association("Labels").Append(&label); err != nil {
+		t.Fatal(err)
+	}
+
+	s.DB.Create(&db.Subproject{RepositoryID: repo.ID, Path: "cli"})
+	s.DB.Create(&db.Dependency{RepositoryID: repo.ID, Name: "left-pad", Ecosystem: "npm"})
+	s.DB.Create(&db.Package{RepositoryID: repo.ID, Name: "acme-pkg", Ecosystem: "npm"})
+	s.DB.Create(&db.Advisory{RepositoryID: repo.ID, Title: "CVE-2026-0001"})
+
+	maintainer := db.Maintainer{Login: "alice", Name: "Alice", Status: db.MaintainerActive}
+	s.DB.Create(&maintainer)
+	if err := s.DB.Model(&repo).Association("Maintainers").Append(&maintainer); err != nil {
+		t.Fatal(err)
+	}
+
+	upload := db.SBOMUpload{Name: "bom", Packages: []db.SBOMPackage{
+		{Name: "acme-pkg", PURL: "pkg:npm/acme-pkg", RepositoryID: &repo.ID},
+	}}
+	s.DB.Create(&upload)
+
+	// On-disk clone cache for the doomed repo.
+	cacheDir := worker.RepoCacheRoot(dataDir, repo.URL)
+	if err := os.MkdirAll(filepath.Join(cacheDir, "src"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cacheDir, "src", "file.txt"), []byte("data"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Per-scan workspaces and claude session stores left on disk (a scan that
+	// crashed before its own cleanup, or a failed scan whose store is kept).
+	doomedWS, doomedCfg := mkScanDirs(t, dataDir, scan.ID)
+	verifyWS, _ := mkScanDirs(t, dataDir, verifyScan.ID)
+	keepWS, _ := mkScanDirs(t, dataDir, keepScan.ID)
+
+	r := httptest.NewRequest("POST", fmt.Sprintf("/repositories/%d/delete", repo.ID), nil)
+	r.Host = testHost
+	r.Header.Set("Sec-Fetch-Site", "same-origin")
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, r)
+
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("status %d, want 303; body=%s", w.Code, w.Body)
+	}
+	if loc := w.Header().Get("Location"); loc != "/" {
+		t.Errorf("redirect Location = %q, want /", loc)
+	}
+
+	count := func(model any, where string, args ...any) int64 {
+		var n int64
+		s.DB.Model(model).Where(where, args...).Count(&n)
+		return n
+	}
+
+	if n := count(&db.Repository{}, "id = ?", repo.ID); n != 0 {
+		t.Errorf("repository row survived (%d)", n)
+	}
+	for name, n := range map[string]int64{
+		"scans":        count(&db.Scan{}, "repository_id = ?", repo.ID),
+		"findings":     count(&db.Finding{}, "repository_id = ?", repo.ID),
+		"subprojects":  count(&db.Subproject{}, "repository_id = ?", repo.ID),
+		"dependencies": count(&db.Dependency{}, "repository_id = ?", repo.ID),
+		"dependents":   count(&db.Dependent{}, "repository_id = ?", repo.ID),
+		"packages":     count(&db.Package{}, "repository_id = ?", repo.ID),
+		"advisories":   count(&db.Advisory{}, "repository_id = ?", repo.ID),
+		"notes":        count(&db.FindingNote{}, "finding_id = ?", finding.ID),
+		"comms":        count(&db.FindingCommunication{}, "finding_id = ?", finding.ID),
+		"refs":         count(&db.FindingReference{}, "finding_id = ?", finding.ID),
+		"history":      count(&db.FindingHistory{}, "finding_id = ?", finding.ID),
+		"findingdep":   count(&db.FindingDependent{}, "finding_id = ?", finding.ID),
+	} {
+		if n != 0 {
+			t.Errorf("%s rows survived the delete (%d)", name, n)
+		}
+	}
+
+	// The two join tables have no struct model; check them with raw SQL.
+	for _, jt := range []struct {
+		table, where string
+		id           uint
+	}{
+		{"finding_labels_join", "finding_id", finding.ID},
+		{"repository_maintainers", "repository_id", repo.ID},
+	} {
+		var n int64
+		s.DB.Raw(fmt.Sprintf("SELECT COUNT(*) FROM %s WHERE %s = ?", jt.table, jt.where), jt.id).Scan(&n)
+		if n != 0 {
+			t.Errorf("%s rows survived the delete (%d)", jt.table, n)
+		}
+	}
+
+	// Shared / independent rows must survive.
+	if n := count(&db.Maintainer{}, "id = ?", maintainer.ID); n != 1 {
+		t.Errorf("maintainer (shared entity) should survive, got %d", n)
+	}
+	if n := count(&db.FindingLabel{}, "id = ?", label.ID); n != 1 {
+		t.Errorf("label definition (shared entity) should survive, got %d", n)
+	}
+
+	// The SBOM upload and its package survive; only the repo cross-ref is nulled.
+	if n := count(&db.SBOMUpload{}, "id = ?", upload.ID); n != 1 {
+		t.Errorf("sbom upload should survive, got %d", n)
+	}
+	var pkg db.SBOMPackage
+	s.DB.First(&pkg, upload.Packages[0].ID)
+	if pkg.RepositoryID != nil {
+		t.Errorf("sbom package repository_id should be nulled, got %v", *pkg.RepositoryID)
+	}
+
+	// The unrelated repo is untouched.
+	if n := count(&db.Repository{}, "id = ?", keep.ID); n != 1 {
+		t.Errorf("unrelated repo was deleted")
+	}
+	if n := count(&db.Finding{}, "repository_id = ?", keep.ID); n != 1 {
+		t.Errorf("unrelated repo's findings were deleted")
+	}
+	// The cross-repo finding-scoped scan survives, but its dangling link is cleared.
+	var survivor db.Scan
+	if err := s.DB.First(&survivor, crossRepoScan.ID).Error; err != nil {
+		t.Errorf("cross-repo scan should survive: %v", err)
+	} else if survivor.FindingID != nil {
+		t.Errorf("cross-repo scan finding_id should be nulled, got %v", *survivor.FindingID)
+	}
+
+	// On-disk clone cache is gone.
+	if _, err := os.Stat(cacheDir); !os.IsNotExist(err) {
+		t.Errorf("clone cache dir should be removed, stat err=%v", err)
+	}
+	// The doomed repo's per-scan workspaces and session stores are gone.
+	for _, dir := range []string{doomedWS, doomedCfg, verifyWS} {
+		if _, err := os.Stat(dir); !os.IsNotExist(err) {
+			t.Errorf("scan dir %s should be removed, stat err=%v", dir, err)
+		}
+	}
+	// The unrelated repo's workspace is untouched.
+	if _, err := os.Stat(keepWS); err != nil {
+		t.Errorf("unrelated repo's scan workspace should survive: %v", err)
+	}
+}
+
+// mkScanDirs creates the on-disk per-scan workspace and claude session store
+// for id under dataDir, mirroring what a real scan leaves behind.
+func mkScanDirs(t *testing.T, dataDir string, id uint) (ws, cfg string) {
+	t.Helper()
+	ws = filepath.Join(dataDir, fmt.Sprintf("scan-%d", id))
+	cfg = filepath.Join(dataDir, "claude-config", fmt.Sprintf("scan-%d", id))
+	if err := os.MkdirAll(ws, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(cfg, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return ws, cfg
+}
+
+func TestRepoDelete_unknownIs404(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	r := httptest.NewRequest("POST", "/repositories/999999/delete", nil)
+	r.Host = testHost
+	r.Header.Set("Sec-Fetch-Site", "same-origin")
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, r)
+	if w.Code != http.StatusNotFound {
+		t.Errorf("want 404 for unknown repo, got %d", w.Code)
+	}
+}
+
+func TestRepoDiskSize_renderedInListAndSummary(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	dataDir := t.TempDir()
+	s.Worker = &worker.Worker{DataDir: dataDir}
+
+	// No FetchedAt: disk size must render in the summary regardless of
+	// whether upstream metadata has been fetched (it renders unconditionally
+	// in the list, so the detail page must match).
+	repo := db.Repository{URL: "https://github.com/acme/sized", Name: "sized"}
+	s.DB.Create(&repo)
+
+	cacheDir := worker.RepoCacheRoot(dataDir, repo.URL)
+	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cacheDir, "blob"), make([]byte, 2048), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq("GET", "/"))
+	if w.Code != 200 {
+		t.Fatalf("list status %d: %s", w.Code, w.Body)
+	}
+	row := requireRepoListRow(t, w.Body.String(), repo.ID)
+	if !strings.Contains(row, "2.0 KB") {
+		t.Errorf("repo list row missing disk size, row=%s", row)
+	}
+
+	w = httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq("GET", fmt.Sprintf("/repositories/%d", repo.ID)))
+	if w.Code != 200 {
+		t.Fatalf("detail status %d: %s", w.Code, w.Body)
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, "2.0 KB") {
+		t.Errorf("repo detail summary missing disk size")
+	}
+	if !strings.Contains(body, "On-disk size of the cached clone") {
+		t.Errorf("repo detail missing disk-size badge")
+	}
+
+	// The Delete action is present and its confirm copy matches what the
+	// handler does (CLAUDE.md: confirm text must reflect the handler).
+	if !strings.Contains(body, fmt.Sprintf("/repositories/%d/delete", repo.ID)) {
+		t.Errorf("repo detail missing delete button")
+	}
+	if !strings.Contains(body, "all its scans and findings, and its cached clone") {
+		t.Errorf("delete confirm copy does not describe what is removed")
+	}
+}
+
+func TestRepoDiskUsage_localRepoIsZero(t *testing.T) {
+	if n := worker.RepoDiskUsage(t.TempDir(), db.Repository{URL: "file:///srv/code/app"}); n != 0 {
+		t.Errorf("local repo disk usage = %d, want 0 (no managed clone)", n)
+	}
+}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -234,6 +234,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("GET /repositories/{id}/blob/{commit}/{path...}", s.repoBlob)
 	mux.HandleFunc("GET /repositories/{id}/report.md", s.repoReport)
 	mux.HandleFunc("POST /repositories/{id}/scan", s.repoScan)
+	mux.HandleFunc("POST /repositories/{id}/delete", s.repoDelete)
 	mux.HandleFunc("POST /repositories/{id}/disclosure-channel", s.repoDisclosureChannel)
 	mux.HandleFunc("GET /scans", s.jobs)
 	mux.HandleFunc("GET /orgs", s.orgsList)
@@ -429,6 +430,7 @@ type repoRow struct {
 	db.Repository
 	LastScan      *db.Scan
 	FindingsTotal int
+	DiskBytes     int64
 }
 
 // distinctLanguages returns the sorted set of individual language names
@@ -548,6 +550,7 @@ func (s *Server) repoList(w http.ResponseWriter, r *http.Request) {
 			Repository:    repo,
 			LastScan:      lastScans[repo.ID],
 			FindingsTotal: findingCounts[repo.ID],
+			DiskBytes:     worker.RepoDiskUsage(s.Worker.DataDir, repo),
 		})
 	}
 	languages := distinctLanguages(s.DB)
@@ -1496,6 +1499,7 @@ func (s *Server) repoShow(w http.ResponseWriter, r *http.Request) {
 		"NewFindingCount": int(newFindings),
 		"FailedScans":     failedScans,
 		"TotalCost":       totalCost,
+		"DiskBytes":       worker.RepoDiskUsage(s.Worker.DataDir, repo),
 		"TMCommit":        tmCommit,
 		"Deps":            deps, "Pkgs": pkgs, "Dependents": dependents, "Advisories": advisories, "Maintainers": maintainers, "ThreatModel": threatModel,
 		"KnownURLs": knownURLs, "KnownPURLs": knownPURLs,
@@ -1529,6 +1533,96 @@ func (s *Server) repoScan(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	s.redirect(w, r, fmt.Sprintf("/repositories/%d", repo.ID))
+}
+
+// repoDelete removes a repository and every row that hangs off it, then
+// drops its on-disk clone cache. Every linked table is deleted explicitly
+// inside one transaction rather than leaning on ON DELETE CASCADE, which is
+// unreliable here: sqlite's foreign_keys pragma is per-connection and set on
+// only one pooled connection. The order matters because foreign_keys *is*
+// enforced on the connection that ends up serving the delete in production:
+//   - scans.finding_id -> findings.id is NO ACTION (verify/patch scans are
+//     finding-scoped), so that link is nulled first or findings can't go.
+//   - finding_labels_join.finding_id is also NO ACTION, so the join rows go
+//     before the findings they reference.
+//   - findings are deleted before scans (findings.scan_id is the cascade
+//     direction; the reverse link was already nulled).
+//
+// Maintainers are shared across repos, so only the join rows go; matched SBOM
+// packages belong to their upload, so their cross-reference is nulled rather
+// than deleted. The filesystem removal runs after the commit so a failed
+// transaction never strands a live repo row with its clone deleted.
+func (s *Server) repoDelete(w http.ResponseWriter, r *http.Request) {
+	repo, ok := loadByID[db.Repository](s, w, r)
+	if !ok {
+		return
+	}
+
+	// Collected before the transaction deletes the scan rows: each scan's
+	// per-scan workspace and claude session store under DataDir are reclaimed
+	// after the commit.
+	var scanIDs []uint
+	s.DB.Model(&db.Scan{}).Where("repository_id = ?", repo.ID).Pluck("id", &scanIDs)
+
+	err := s.DB.Transaction(func(tx *gorm.DB) error {
+		// Match scans by the *finding's* repo, not the scan's own: a finding-
+		// scoped scan can in principle live on a different repository_id than
+		// the finding it points at, and any scan referencing a doomed finding
+		// must have its NO ACTION link cleared or the finding delete 787s. The
+		// subquery also avoids materialising a (possibly >999) id list.
+		const findingsOfRepo = "finding_id IN (SELECT id FROM findings WHERE repository_id = ?)"
+		if err := tx.Model(&db.Scan{}).Where(findingsOfRepo, repo.ID).
+			Update("finding_id", nil).Error; err != nil {
+			return err
+		}
+		// Finding children. notes/comms/refs/history cascade from a finding
+		// delete, but are removed here too so the cleanup stays correct even
+		// when foreign_keys happens to be off on the serving connection.
+		if err := tx.Exec("DELETE FROM finding_labels_join WHERE "+findingsOfRepo, repo.ID).Error; err != nil {
+			return err
+		}
+		for _, child := range []any{
+			&db.FindingNote{}, &db.FindingCommunication{}, &db.FindingReference{},
+			&db.FindingHistory{}, &db.FindingDependent{},
+		} {
+			if err := tx.Where(findingsOfRepo, repo.ID).Delete(child).Error; err != nil {
+				return err
+			}
+		}
+		for _, child := range []any{
+			&db.Finding{}, &db.Scan{}, &db.Subproject{}, &db.Dependency{},
+			&db.Dependent{}, &db.Package{}, &db.Advisory{},
+		} {
+			if err := tx.Where("repository_id = ?", repo.ID).Delete(child).Error; err != nil {
+				return err
+			}
+		}
+		if err := tx.Model(&db.SBOMPackage{}).Where("repository_id = ?", repo.ID).
+			Update("repository_id", nil).Error; err != nil {
+			return err
+		}
+		if err := tx.Exec("DELETE FROM repository_maintainers WHERE repository_id = ?", repo.ID).Error; err != nil {
+			return err
+		}
+		return tx.Delete(&repo).Error
+	})
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	if err := os.RemoveAll(worker.RepoCacheRoot(s.Worker.DataDir, repo.URL)); err != nil {
+		s.Log.Error("repoDelete: remove clone cache", "repo", repo.ID, "err", err)
+	}
+	for _, id := range scanIDs {
+		if err := s.Worker.RemoveScanArtifacts(id); err != nil {
+			s.Log.Error("repoDelete: remove scan workspace", "scan", id, "err", err)
+		}
+	}
+
+	setFlash(w, Flash{Category: "success", Title: "Repository deleted",
+		Description: repo.Name + " and all its scans, findings and cached clone were removed."})
+	s.redirect(w, r, "/")
 }
 
 // repoDisclosureChannel lets the analyst overwrite (or clear) the

--- a/internal/web/templates/repo_list.html
+++ b/internal/web/templates/repo_list.html
@@ -41,7 +41,7 @@
 {{if .Rows}}
   <table class="table">
     <thead>
-      <tr><th>Repository</th><th>Language</th><th>Last scan</th><th>Status</th><th>Findings</th><th></th></tr>
+      <tr><th>Repository</th><th>Language</th><th>Last scan</th><th>Status</th><th>Findings</th><th>Size</th><th></th></tr>
     </thead>
     <tbody>
     {{range .Rows}}
@@ -54,6 +54,7 @@
         <td>{{if .LastScan}}{{.LastScan.CreatedAt.Format "15:04:05"}}{{else}}never{{end}}</td>
         <td>{{if .LastScan}}{{template "status-badge" (status .LastScan.Status)}}{{end}}</td>
         <td>{{template "findings-badge" .FindingsTotal}}</td>
+        <td class="text-muted-foreground">{{if .DiskBytes}}{{bytes .DiskBytes}}{{else}}-{{end}}</td>
         <td>
           <form method="post" action="/repositories/{{.ID}}/scan"
                 hx-post="/repositories/{{.ID}}/scan" hx-swap="none">

--- a/internal/web/templates/repo_show.html
+++ b/internal/web/templates/repo_show.html
@@ -42,6 +42,11 @@
     <a href="/repositories/{{.Repo.ID}}/report.md" class="btn-outline" download>
       <i data-lucide="download"></i> Export report
     </a>
+    <form method="post" action="/repositories/{{.Repo.ID}}/delete"
+          hx-post="/repositories/{{.Repo.ID}}/delete" hx-swap="none"
+          hx-confirm="Permanently delete {{.Repo.Name}}? This removes the repository, all its scans and findings, and its cached clone on disk. This cannot be undone.">
+      <button class="btn-destructive" type="submit"><i data-lucide="trash-2"></i> Delete</button>
+    </form>
     <form method="post" action="/repositories/{{.Repo.ID}}/scan"
           hx-post="/repositories/{{.Repo.ID}}/scan" hx-swap="none">
       <button class="btn" type="submit"><i data-lucide="play"></i> New scan</button>
@@ -95,18 +100,27 @@
   <div role="tabpanel" id="rp1" aria-labelledby="rt1">
     {{if .Repo.FetchedAt}}
       {{if .Repo.Description}}<p class="mb-4 max-w-3xl">{{.Repo.Description}}</p>{{end}}
-      <div class="flex flex-wrap gap-2 mb-6">
-        {{if .Repo.Languages}}<span class="badge-outline"><i data-lucide="code"></i><span class="sr-only">Languages: </span>{{.Repo.Languages}}</span>{{end}}
-        {{if .Repo.DefaultBranch}}<span class="badge-outline"><i data-lucide="git-branch"></i><span class="sr-only">Default branch: </span>{{.Repo.DefaultBranch}}</span>{{end}}
-        {{if .Repo.Stars}}<span class="badge-outline"><i data-lucide="star"></i><span class="sr-only">Stars: </span>{{bignum .Repo.Stars}}</span>{{end}}
-        {{if .Repo.License}}<span class="badge-outline"><i data-lucide="scale"></i><span class="sr-only">License: </span>{{.Repo.License}}</span>{{end}}
-        {{if .Repo.PushedAt}}<span class="badge-outline"><i data-lucide="clock"></i>pushed {{since .Repo.PushedAt}}</span>{{end}}
-        {{if gt .TotalCost 0.0}}<span class="badge-outline" data-tooltip="Total scan spend on this repository"><i data-lucide="coins"></i><span class="sr-only">Total scan spend: </span>{{usd .TotalCost}}</span>{{end}}
-        {{if .Repo.Archived}}<span class="badge-destructive"><i data-lucide="archive"></i>archived</span>{{end}}
-        {{if .Repo.CloneError}}<span class="badge-destructive" data-tooltip="{{.Repo.CloneError}}"><i data-lucide="wifi-off"></i>unreachable<span class="sr-only">: {{.Repo.CloneError}}</span></span>{{end}}
-      </div>
     {{else}}
       <p class="text-muted-foreground text-sm mb-6">Metadata not fetched yet.</p>
+    {{end}}
+
+    {{/* One badge row. Metadata badges depend on the fetch; the disk-usage
+         badge depends only on a clone existing, so it shares the row but is
+         shown independently — same visibility rule as the repo list. */}}
+    {{if or .Repo.FetchedAt .DiskBytes}}
+      <div class="flex flex-wrap gap-2 mb-6">
+        {{if .Repo.FetchedAt}}
+          {{if .Repo.Languages}}<span class="badge-outline"><i data-lucide="code"></i><span class="sr-only">Languages: </span>{{.Repo.Languages}}</span>{{end}}
+          {{if .Repo.DefaultBranch}}<span class="badge-outline"><i data-lucide="git-branch"></i><span class="sr-only">Default branch: </span>{{.Repo.DefaultBranch}}</span>{{end}}
+          {{if .Repo.Stars}}<span class="badge-outline"><i data-lucide="star"></i><span class="sr-only">Stars: </span>{{bignum .Repo.Stars}}</span>{{end}}
+          {{if .Repo.License}}<span class="badge-outline"><i data-lucide="scale"></i><span class="sr-only">License: </span>{{.Repo.License}}</span>{{end}}
+          {{if .Repo.PushedAt}}<span class="badge-outline"><i data-lucide="clock"></i>pushed {{since .Repo.PushedAt}}</span>{{end}}
+          {{if gt .TotalCost 0.0}}<span class="badge-outline" data-tooltip="Total scan spend on this repository"><i data-lucide="coins"></i><span class="sr-only">Total scan spend: </span>{{usd .TotalCost}}</span>{{end}}
+          {{if .Repo.Archived}}<span class="badge-destructive"><i data-lucide="archive"></i>archived</span>{{end}}
+          {{if .Repo.CloneError}}<span class="badge-destructive" data-tooltip="{{.Repo.CloneError}}"><i data-lucide="wifi-off"></i>unreachable<span class="sr-only">: {{.Repo.CloneError}}</span></span>{{end}}
+        {{end}}
+        {{if .DiskBytes}}<span class="badge-outline" data-tooltip="On-disk size of the cached clone"><i data-lucide="hard-drive"></i>{{bytes .DiskBytes}}</span>{{end}}
+      </div>
     {{end}}
 
     <div class="mb-4 max-w-3xl">

--- a/internal/worker/repo_cache.go
+++ b/internal/worker/repo_cache.go
@@ -22,6 +22,18 @@ func RepoCacheRoot(dataDir, url string) string {
 	return filepath.Join(dataDir, "repo-cache", hex.EncodeToString(sum[:]))
 }
 
+// RepoDiskUsage returns the on-disk size in bytes of the persistent
+// clone cache for repo. Local repositories keep no managed copy (their
+// source stays at LocalPath), and a repo that has never been scanned has
+// no cache directory yet — both cases report 0.
+func RepoDiskUsage(dataDir string, repo db.Repository) int64 {
+	if repo.IsLocal() {
+		return 0
+	}
+	n, _ := dirSize(RepoCacheRoot(dataDir, repo.URL))
+	return n
+}
+
 // prepareRepoSrc updates the per-URL cache under a lock, copies the
 // tree into workRoot/src, and returns the cache HEAD commit. Shallow
 // by default; the code browser unshallows on demand when a historical

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -112,7 +112,27 @@ func (w *Worker) scanWorkRoot(scan *db.Scan) string {
 // by the lineage root so a retry finds the original run's session. The
 // local runner ignores it and uses the host's own ~/.claude.
 func (w *Worker) claudeConfigDir(scan *db.Scan) string {
-	return filepath.Join(w.DataDir, "claude-config", fmt.Sprintf("scan-%d", workspaceScanID(scan)))
+	return w.claudeConfigDirID(workspaceScanID(scan))
+}
+
+func (w *Worker) claudeConfigDirID(scanID uint) string {
+	return filepath.Join(w.DataDir, "claude-config", fmt.Sprintf("scan-%d", scanID))
+}
+
+// RemoveScanArtifacts deletes the on-disk per-scan workspace and claude
+// session store for scanID. A terminal scan removes its own workspace and a
+// done scan its session store, so this reclaims space left by scans still
+// holding a workspace (queued/running, or crashed before cleanup) and by
+// failed scans whose session store is kept for --resume. It is a no-op when
+// the directories are already gone. Passing every scan id of a repository
+// covers resume lineages too: a retry reuses its root's workspace id, and the
+// root scan is itself in the repo, while the retry's own id maps to a
+// directory that was never created.
+func (w *Worker) RemoveScanArtifacts(scanID uint) error {
+	return errors.Join(
+		os.RemoveAll(w.workRoot(scanID)),
+		os.RemoveAll(w.claudeConfigDirID(scanID)),
+	)
 }
 
 // applyResume fills a SkillJob's session-resume inputs from the scan: the


### PR DESCRIPTION
Allows removing a repository and its related data. Space used by the repository appears in the repositories list and in the summary page.

<img width="1024" height="278" alt="Capture d’écran 2026-06-02 à 11 12 21" src="https://github.com/user-attachments/assets/47496d92-9a3a-4ccd-8ea9-9410d1afdbdb" />

A cache or a persistance of the disk size could be useful if you ever come across performance issues. But I think it's fine with 20 repos per page?

<img width="1024" height="278" alt="Capture d’écran 2026-06-02 à 11 12 34" src="https://github.com/user-attachments/assets/547f8393-0132-4116-bc9a-0d92b3c1eef3" />