### PR TITLE
fix: Miscellaneous accessibility improvements

### DIFF
--- a/internal/web/static/app.js
+++ b/internal/web/static/app.js
@@ -2,7 +2,11 @@
   'use strict';
 
   function icons() {
-    if (window.lucide) lucide.createIcons();
+    // Icons are decorative: every interactive control has visible text or an
+    // aria-label, so hide the generated SVGs from assistive tech to avoid noise.
+    if (window.lucide) {
+      lucide.createIcons({ attrs: { 'aria-hidden': 'true', focusable: 'false' } });
+    }
   }
 
   function highlight() {

--- a/internal/web/static/theme.css
+++ b/internal/web/static/theme.css
@@ -408,3 +408,13 @@ pre.log { background: var(--muted); padding: 1rem; border-radius: var(--radius);
 .hl-on { background: color-mix(in oklch, var(--primary) 14%, transparent); }
 .hl-line:target { background: color-mix(in oklch, var(--primary) 14%, transparent); }
 
+/* ── reduced motion ── */
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+

--- a/internal/web/static/theme.css
+++ b/internal/web/static/theme.css
@@ -408,6 +408,17 @@ pre.log { background: var(--muted); padding: 1rem; border-radius: var(--radius);
 .hl-on { background: color-mix(in oklch, var(--primary) 14%, transparent); }
 .hl-line:target { background: color-mix(in oklch, var(--primary) 14%, transparent); }
 
+/* ── visually-hidden, still read by assistive tech ── */
+.sr-only {
+  position: absolute;
+  width: 1px; height: 1px;
+  padding: 0; margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 /* ── reduced motion ── */
 @media (prefers-reduced-motion: reduce) {
   *, *::before, *::after {

--- a/internal/web/templates/layout.html
+++ b/internal/web/templates/layout.html
@@ -36,7 +36,7 @@
             <span class="truncate text-xs text-muted-foreground">local</span>
           </span>
         </a>
-        <a href="/settings" class="btn-ghost p-2 size-10 flex items-center justify-center rounded-lg text-muted-foreground hover:text-foreground" data-tooltip="Settings" data-side="bottom">
+        <a href="/settings" class="btn-ghost p-2 size-10 flex items-center justify-center rounded-lg text-muted-foreground hover:text-foreground" aria-label="Settings" data-tooltip="Settings" data-side="bottom">
           <i data-lucide="settings" class="size-4"></i>
         </a>
       </div>
@@ -166,17 +166,17 @@
   {{if or (eq (status .Status) "queued") (eq (status .Status) "running")}}
     <form method="post" action="/scans/{{.ID}}/cancel" hx-post="/scans/{{.ID}}/cancel"
           hx-swap="none">
-      <button type="submit" class="btn-sm-ghost" data-tooltip="Cancel"><i data-lucide="x"></i></button>
+      <button type="submit" class="btn-sm-ghost" aria-label="Cancel scan" data-tooltip="Cancel"><i data-lucide="x"></i></button>
     </form>
   {{else if eq (status .Status) "paused"}}
     <form method="post" action="/scans/{{.ID}}/resume" hx-post="/scans/{{.ID}}/resume"
           hx-swap="none">
-      <button type="submit" class="btn-sm-ghost" data-tooltip="Resume"><i data-lucide="play"></i></button>
+      <button type="submit" class="btn-sm-ghost" aria-label="Resume scan" data-tooltip="Resume"><i data-lucide="play"></i></button>
     </form>
   {{else if and (or (eq (status .Status) "failed") (eq (status .Status) "cancelled")) .SkillID}}
     <form method="post" action="/scans/{{.ID}}/retry" hx-post="/scans/{{.ID}}/retry"
           hx-swap="none">
-      <button type="submit" class="btn-sm-ghost" data-tooltip="Retry"><i data-lucide="refresh-cw"></i></button>
+      <button type="submit" class="btn-sm-ghost" aria-label="Retry scan" data-tooltip="Retry"><i data-lucide="refresh-cw"></i></button>
     </form>
   {{end}}
 {{end}}

--- a/internal/web/templates/repo_list.html
+++ b/internal/web/templates/repo_list.html
@@ -48,7 +48,7 @@
       <tr id="repo-{{.ID}}">
         <td>
           <a href="/repositories/{{.ID}}">{{trimscheme .URL}}</a>
-          {{if .CloneError}}<span class="badge-destructive ml-1" data-tooltip="{{.CloneError}}"><i data-lucide="wifi-off"></i></span>{{end}}
+          {{if .CloneError}}<span class="badge-destructive ml-1" role="img" aria-label="Clone error: {{.CloneError}}" data-tooltip="{{.CloneError}}"><i data-lucide="wifi-off"></i></span>{{end}}
         </td>
         <td class="text-muted-foreground">{{if .Languages}}{{.Languages}}{{else}}-{{end}}</td>
         <td>{{if .LastScan}}{{.LastScan.CreatedAt.Format "15:04:05"}}{{else}}never{{end}}</td>

--- a/internal/web/templates/repo_show.html
+++ b/internal/web/templates/repo_show.html
@@ -333,7 +333,7 @@
             <td class="text-muted-foreground whitespace-normal break-all">{{if .Requirement}}{{.Requirement}}{{else}}-{{end}}</td>
             <td class="text-muted-foreground">{{.DependencyType}}</td>
             <td class="whitespace-normal text-muted-foreground text-xs">{{range $i, $m := .Manifests}}{{if $i}}, {{end}}{{$m}}{{end}}</td>
-            <td>{{if .PURL}}{{$rid := lookup $.KnownPURLs .PURL}}{{if $rid}}<a href="/repositories/{{$rid}}" class="btn-sm-ghost" data-tooltip="View repository"><i data-lucide="external-link"></i></a>{{else}}<form method="post" action="/dependencies/{{.ID}}/scan" hx-post="/dependencies/{{.ID}}/scan" hx-swap="none"><button type="submit" class="btn-sm-ghost" data-tooltip="Import repository"><i data-lucide="import"></i></button></form>{{end}}{{end}}</td>
+            <td>{{if .PURL}}{{$rid := lookup $.KnownPURLs .PURL}}{{if $rid}}<a href="/repositories/{{$rid}}" class="btn-sm-ghost" aria-label="View repository" data-tooltip="View repository"><i data-lucide="external-link"></i></a>{{else}}<form method="post" action="/dependencies/{{.ID}}/scan" hx-post="/dependencies/{{.ID}}/scan" hx-swap="none"><button type="submit" class="btn-sm-ghost" aria-label="Import repository" data-tooltip="Import repository"><i data-lucide="import"></i></button></form>{{end}}{{end}}</td>
           </tr>
         {{end}}
         </tbody>
@@ -367,7 +367,7 @@
           <td class="whitespace-normal text-muted-foreground text-xs">{{.Packages}}</td>
           <td class="text-muted-foreground">{{if .PublishedAt}}{{since .PublishedAt}}{{end}}</td>
           <td>{{if .URL}}<a href="{{.URL}}" target="_blank" rel="noopener" class="btn-sm-ghost"
-              data-tooltip="View advisory"><i data-lucide="external-link"></i></a>{{end}}</td>
+              aria-label="View advisory" data-tooltip="View advisory"><i data-lucide="external-link"></i></a>{{end}}</td>
         </tr>
       {{end}}
       </tbody>
@@ -390,7 +390,7 @@
           <td class="text-muted-foreground">{{.LatestVersion}}</td>
           <td class="text-muted-foreground">{{bignum .Downloads}}</td>
           <td class="text-muted-foreground">{{bignum .DependentRepos}} repos</td>
-          <td>{{if .RepositoryURL}}{{$rid := lookup $.KnownURLs .RepositoryURL}}{{if $rid}}<a href="/repositories/{{$rid}}" class="btn-sm-ghost" data-tooltip="View repository"><i data-lucide="external-link"></i></a>{{else}}<form method="post" action="/dependents/{{.ID}}/scan" hx-post="/dependents/{{.ID}}/scan" hx-swap="none"><button type="submit" class="btn-sm-ghost" data-tooltip="Import repository"><i data-lucide="import"></i></button></form>{{end}}{{end}}</td>
+          <td>{{if .RepositoryURL}}{{$rid := lookup $.KnownURLs .RepositoryURL}}{{if $rid}}<a href="/repositories/{{$rid}}" class="btn-sm-ghost" aria-label="View repository" data-tooltip="View repository"><i data-lucide="external-link"></i></a>{{else}}<form method="post" action="/dependents/{{.ID}}/scan" hx-post="/dependents/{{.ID}}/scan" hx-swap="none"><button type="submit" class="btn-sm-ghost" aria-label="Import repository" data-tooltip="Import repository"><i data-lucide="import"></i></button></form>{{end}}{{end}}</td>
         </tr>
       {{end}}
       </tbody>

--- a/internal/web/templates/repo_show.html
+++ b/internal/web/templates/repo_show.html
@@ -96,14 +96,14 @@
     {{if .Repo.FetchedAt}}
       {{if .Repo.Description}}<p class="mb-4 max-w-3xl">{{.Repo.Description}}</p>{{end}}
       <div class="flex flex-wrap gap-2 mb-6">
-        {{if .Repo.Languages}}<span class="badge-outline"><i data-lucide="code"></i>{{.Repo.Languages}}</span>{{end}}
-        {{if .Repo.DefaultBranch}}<span class="badge-outline"><i data-lucide="git-branch"></i>{{.Repo.DefaultBranch}}</span>{{end}}
-        {{if .Repo.Stars}}<span class="badge-outline"><i data-lucide="star"></i>{{bignum .Repo.Stars}}</span>{{end}}
-        {{if .Repo.License}}<span class="badge-outline"><i data-lucide="scale"></i>{{.Repo.License}}</span>{{end}}
+        {{if .Repo.Languages}}<span class="badge-outline"><i data-lucide="code"></i><span class="sr-only">Languages: </span>{{.Repo.Languages}}</span>{{end}}
+        {{if .Repo.DefaultBranch}}<span class="badge-outline"><i data-lucide="git-branch"></i><span class="sr-only">Default branch: </span>{{.Repo.DefaultBranch}}</span>{{end}}
+        {{if .Repo.Stars}}<span class="badge-outline"><i data-lucide="star"></i><span class="sr-only">Stars: </span>{{bignum .Repo.Stars}}</span>{{end}}
+        {{if .Repo.License}}<span class="badge-outline"><i data-lucide="scale"></i><span class="sr-only">License: </span>{{.Repo.License}}</span>{{end}}
         {{if .Repo.PushedAt}}<span class="badge-outline"><i data-lucide="clock"></i>pushed {{since .Repo.PushedAt}}</span>{{end}}
-        {{if gt .TotalCost 0.0}}<span class="badge-outline" data-tooltip="Total scan spend on this repository"><i data-lucide="coins"></i>{{usd .TotalCost}}</span>{{end}}
+        {{if gt .TotalCost 0.0}}<span class="badge-outline" data-tooltip="Total scan spend on this repository"><i data-lucide="coins"></i><span class="sr-only">Total scan spend: </span>{{usd .TotalCost}}</span>{{end}}
         {{if .Repo.Archived}}<span class="badge-destructive"><i data-lucide="archive"></i>archived</span>{{end}}
-        {{if .Repo.CloneError}}<span class="badge-destructive" data-tooltip="{{.Repo.CloneError}}"><i data-lucide="wifi-off"></i>unreachable</span>{{end}}
+        {{if .Repo.CloneError}}<span class="badge-destructive" data-tooltip="{{.Repo.CloneError}}"><i data-lucide="wifi-off"></i>unreachable<span class="sr-only">: {{.Repo.CloneError}}</span></span>{{end}}
       </div>
     {{else}}
       <p class="text-muted-foreground text-sm mb-6">Metadata not fetched yet.</p>

--- a/internal/web/templates/sbom_show.html
+++ b/internal/web/templates/sbom_show.html
@@ -205,7 +205,7 @@
           <td class="truncate"><a href="/repositories/{{$repo.ID}}" class="hover:underline">{{$repo.Name}}</a></td>
           <td class="text-muted-foreground">{{if .PublishedAt}}{{.PublishedAt.Format "2006-01-02"}}{{end}}</td>
           <td>{{if .URL}}<a href="{{.URL}}" target="_blank" rel="noopener" class="btn-sm-ghost"
-              data-tooltip="View advisory"><i data-lucide="external-link"></i></a>{{end}}</td>
+              aria-label="View advisory" data-tooltip="View advisory"><i data-lucide="external-link"></i></a>{{end}}</td>
         </tr>
       {{end}}
       </tbody>

--- a/internal/web/templates/scan_show.html
+++ b/internal/web/templates/scan_show.html
@@ -109,7 +109,7 @@
 {{$live := and (not .Status.Terminal) (ne (status .Status) "paused")}}
 {{$default := 1}}{{if $live}}{{$default = 2}}{{end}}
 <div class="tabs w-full" id="scan-tabs">
-  <nav role="tablist" aria-orientation="horizontal">
+  <nav role="tablist" aria-orientation="horizontal" aria-label="Scan output">
     <button type="button" role="tab" id="t1" aria-controls="p1"
             aria-selected="{{if eq $default 1}}true{{else}}false{{end}}">Result</button>
     <button type="button" role="tab" id="t2" aria-controls="p2"
@@ -143,10 +143,10 @@
       </table>
       <details>
         <summary class="cursor-pointer text-sm text-muted-foreground">raw report.json</summary>
-        <pre class="log mt-2">{{prettyjson .Report}}</pre>
+        <pre class="log mt-2" tabindex="0" role="region" aria-label="Raw report JSON">{{prettyjson .Report}}</pre>
       </details>
     {{else if .Report}}
-      <pre class="log">{{prettyjson .Report}}</pre>
+      <pre class="log" tabindex="0" role="region" aria-label="Report">{{prettyjson .Report}}</pre>
     {{else}}
       <p class="text-muted-foreground text-sm p-4">No result yet.</p>
     {{end}}
@@ -157,16 +157,16 @@
       <div hx-ext="sse" sse-connect="/events?scan={{.ID}}"
            sse-swap="scan-status" hx-swap="none" hx-disinherit="*"
            data-reload-on-sse="scan-status">
-        <pre class="log" sse-swap="scan-log" hx-swap="beforeend scroll:bottom">{{template "scan_log.html" .}}</pre>
+        <pre class="log" tabindex="0" role="region" aria-label="Scan log" sse-swap="scan-log" hx-swap="beforeend scroll:bottom">{{template "scan_log.html" .}}</pre>
       </div>
     {{else}}
-      <pre class="log">{{template "scan_log.html" .}}</pre>
+      <pre class="log" tabindex="0" role="region" aria-label="Scan log">{{template "scan_log.html" .}}</pre>
     {{end}}
   </div>
 
   {{if .Prompt}}
   <div role="tabpanel" id="p3" aria-labelledby="t3" hidden>
-    <pre class="log">{{.Prompt}}</pre>
+    <pre class="log" tabindex="0" role="region" aria-label="Scan prompt">{{.Prompt}}</pre>
   </div>
   {{end}}
 </div>


### PR DESCRIPTION
- Add aria-labels on icon-only buttons with no text sibling.
- Add aria-hidden on lucide icons as they're generally redundant.
- Add reduced motion config to the CSS for users with reduced motion configured.
- Improve the scan log blocks to have an aria-label, role, and allow focusing so a keyboard user can scroll the log.

Unrelated, but we should really add an auto-formatter for the HTML templates.

Generated with help from Claude Code, reviewed and tested by me.