### PR TITLE
fix: validate git refs and redact base URL userinfo

### DIFF
--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -244,6 +244,10 @@ func (s *Server) apiRunSkill(w http.ResponseWriter, r *http.Request) {
 			writeAPIError(w, http.StatusBadRequest, err.Error())
 			return
 		}
+		if errors.Is(err, ErrInvalidRef) {
+			writeAPIError(w, http.StatusBadRequest, err.Error())
+			return
+		}
 		writeAPIError(w, http.StatusInternalServerError, err.Error())
 		return
 	}

--- a/internal/web/api_test.go
+++ b/internal/web/api_test.go
@@ -432,6 +432,34 @@ func TestAPIRunSkill_profileMismatchRejected(t *testing.T) {
 	}
 }
 
+func TestAPIRunSkill_badRefRejectedAt400(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	repo, scan := seedRunningScan(t, s)
+
+	skill := db.Skill{Name: "metadata", Description: "m", Body: "b", OutputFile: "report.json", Version: 1, Active: true, Source: "ui"}
+	s.DB.Create(&skill)
+
+	path := "/api/repositories/" + strconv.FormatUint(uint64(repo.ID), 10) + "/skills/metadata/run"
+	r := httptest.NewRequest("POST", path, strings.NewReader(`{"ref":"--upload-pack=/bin/sh"}`))
+	r.Host = testHost
+	r.Header.Set("Authorization", "Bearer "+scan.APIToken)
+	r.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, r)
+	if w.Code != 400 {
+		t.Fatalf("status %d, want 400. body=%s", w.Code, w.Body)
+	}
+	if !strings.Contains(w.Body.String(), "invalid git ref") {
+		t.Errorf("response body should name the failure, got %s", w.Body)
+	}
+	var count int64
+	s.DB.Model(&db.Scan{}).Where("skill_id = ?", skill.ID).Count(&count)
+	if count != 0 {
+		t.Errorf("rejected enqueue still created %d scans, want 0", count)
+	}
+}
+
 func TestAPIRunFindingSkill_scopesFindingID(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -39,6 +39,12 @@ var ErrSkillRequiresRemote = errors.New("skill requires a remote repository")
 // instead of a ghost scan failing on the worker.
 var ErrSkillProfileMismatch = errors.New("skill requires a different runner profile")
 
+// ErrInvalidRef is returned by enqueueSkillWith when opts.Ref fails the
+// shared ref-charset validation. Mirrors ErrSkillProfileMismatch so the
+// API path rejects a bad ref at the boundary (400) instead of enqueueing
+// a scan that will fail later at git-clone time.
+var ErrInvalidRef = errors.New("invalid git ref")
+
 //go:embed templates/*.html
 var tmplFS embed.FS
 
@@ -1749,6 +1755,9 @@ func (s *Server) enqueueSkillWith(ctx context.Context, repoID, skillID uint, opt
 	}
 	if hasSkill && sk.RequiresProfile != "" && opts.Profile != "" && opts.Profile != sk.RequiresProfile {
 		return 0, fmt.Errorf("%w: %q needs %q, got %q", ErrSkillProfileMismatch, sk.Name, sk.RequiresProfile, opts.Profile)
+	}
+	if err := worker.ValidateGitRef(opts.Ref); err != nil {
+		return 0, fmt.Errorf("%w: %v", ErrInvalidRef, err)
 	}
 	if !ValidModel(opts.Model) {
 		if hasSkill && ValidModel(sk.Model) {

--- a/internal/worker/clone.go
+++ b/internal/worker/clone.go
@@ -84,8 +84,43 @@ func validateGitURL(u string) error {
 	return nil
 }
 
+// ValidateGitRef restricts refs to a conservative branch/tag-name charset
+// before they flow into the fetchRef path. The clone code already passes
+// ref after a `--` argv stopper, which blocks `-`-prefixed option-shaped
+// values; this validator adds the rest: `..` rejected so git's refspec
+// resolver cannot treat the value as a range, plus a strict allow-list
+// for the body so spaces, control characters, and shell metacharacters
+// cannot reach git as an "exotic but legal" ref. Exported so the web
+// layer can reject bad input at the API boundary rather than letting a
+// scan get enqueued and then fail at clone time.
+func ValidateGitRef(ref string) error {
+	if ref == "" {
+		return nil
+	}
+	if strings.HasPrefix(ref, "-") {
+		return fmt.Errorf("invalid ref %q: must not start with -", ref)
+	}
+	if strings.Contains(ref, "..") {
+		return fmt.Errorf(`invalid ref %q: must not contain ".."`, ref)
+	}
+	for _, r := range ref {
+		switch {
+		case r >= 'a' && r <= 'z',
+			r >= 'A' && r <= 'Z',
+			r >= '0' && r <= '9',
+			r == '.', r == '_', r == '/', r == '-':
+		default:
+			return fmt.Errorf("invalid ref %q: contains disallowed character %q", ref, r)
+		}
+	}
+	return nil
+}
+
 func cloneOrFetch(ctx context.Context, url, dst string, fullClone bool, ref string, emit func(Event)) error {
 	if err := validateGitURL(url); err != nil {
+		return err
+	}
+	if err := ValidateGitRef(ref); err != nil {
 		return err
 	}
 	if _, err := os.Stat(filepath.Join(dst, ".git")); err == nil {

--- a/internal/worker/clone_test.go
+++ b/internal/worker/clone_test.go
@@ -2,12 +2,15 @@ package worker
 
 import (
 	"context"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"slices"
 	"strings"
 	"testing"
+
+	"scrutineer/internal/db"
 )
 
 func TestPrepareLocalSrc(t *testing.T) {
@@ -207,5 +210,89 @@ func TestValidateGitURL(t *testing.T) {
 		if err := validateGitURL(u); err == nil {
 			t.Errorf("should reject %q", u)
 		}
+	}
+}
+
+func TestValidateGitRef(t *testing.T) {
+	good := []string{
+		"",
+		"main",
+		"master",
+		"release/1.0",
+		"v1.2.3",
+		"feature/abc_def-1",
+		"users/alice/topic.branch",
+	}
+	for _, r := range good {
+		if err := ValidateGitRef(r); err != nil {
+			t.Errorf("should allow %q: %v", r, err)
+		}
+	}
+
+	bad := []string{
+		"-upload-pack=/bin/sh",
+		"--all",
+		"foo..bar",
+		"../etc/passwd",
+		"branch with space",
+		"branch;rm -rf /",
+		"branch\nmain",
+		"head@{0}",
+		"refs/heads/main^",
+		"branch~1",
+	}
+	for _, r := range bad {
+		if err := ValidateGitRef(r); err == nil {
+			t.Errorf("should reject %q", r)
+		}
+	}
+}
+
+// TestCloneOrFetchRejectsBadRefBeforeNetwork pins the contract that a bad
+// ref short-circuits cloneOrFetch before any git invocation runs. The dst
+// has no .git directory, so without the validation gate the function would
+// fall through to `git clone` and try to reach example.invalid.
+func TestCloneOrFetchRejectsBadRefBeforeNetwork(t *testing.T) {
+	dst := t.TempDir()
+	err := cloneOrFetch(context.Background(), "https://example.invalid/repo", dst, false, "--upload-pack=/bin/sh", func(Event) {
+		t.Errorf("emit must not be called when validation rejects the ref")
+	})
+	if err == nil {
+		t.Fatal("expected error for bad ref")
+	}
+	if !strings.Contains(err.Error(), "invalid ref") {
+		t.Errorf("error %q should mention invalid ref", err)
+	}
+}
+
+// TestCloneOrFetchRejectsBadURL keeps the URL gate covered through the
+// same entry point so a future refactor that re-orders the validators
+// trips this test rather than silently changing the order users see.
+func TestCloneOrFetchRejectsBadURL(t *testing.T) {
+	err := cloneOrFetch(context.Background(), "ssh://git@example.invalid/repo", t.TempDir(), false, "main", func(Event) {})
+	if err == nil {
+		t.Fatal("expected error for non-https URL")
+	}
+	if !strings.Contains(err.Error(), "https://") {
+		t.Errorf("error %q should mention https requirement", err)
+	}
+}
+
+// TestEnsureCloneWrapsValidationError confirms that ensureClone preserves
+// the wrap-as-RepoUnreachableError pattern when the inner cloneOrFetch
+// rejects bad input. The outer code branches on this error type to flip
+// repositories into the unreachable state, so it must keep working
+// regardless of which validator failed.
+func TestEnsureCloneWrapsValidationError(t *testing.T) {
+	_, err := ensureClone(context.Background(), db.Repository{URL: "https://example.invalid/repo"}, t.TempDir(), false, "--all", func(Event) {})
+	if err == nil {
+		t.Fatal("expected error for bad ref")
+	}
+	var ru *RepoUnreachableError
+	if !errors.As(err, &ru) {
+		t.Fatalf("error %T = %v, want *RepoUnreachableError wrapping the validation failure", err, err)
+	}
+	if !strings.Contains(ru.Error(), "invalid ref") {
+		t.Errorf("RepoUnreachableError.Error() = %q, should mention invalid ref", ru.Error())
 	}
 }

--- a/internal/worker/docker.go
+++ b/internal/worker/docker.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -58,6 +59,21 @@ func (d DockerRunner) image() string {
 		return d.Image
 	}
 	return DefaultRunnerImage
+}
+
+// redactURLUserinfo strips embedded credentials from a URL before logging.
+// Anthropic-compatible base URLs sometimes carry a token in userinfo
+// (https://user:tok@proxy/...); we still want to surface that auth was
+// configured, so the username is replaced with "REDACTED" rather than
+// dropped entirely. Inputs that fail to parse as URLs or that carry no
+// userinfo round-trip unchanged.
+func redactURLUserinfo(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil || u.User == nil {
+		return raw
+	}
+	u.User = url.User("REDACTED")
+	return u.String()
 }
 
 // HardenedWorkspaceCapBytes caps the per-scan workspace footprint that
@@ -135,7 +151,7 @@ func (d DockerRunner) RunSkill(ctx context.Context, sj SkillJob, emit func(Event
 
 	logLine := "$ docker run --rm " + image + " <skill:" + sj.Name + ">"
 	if d.AnthropicBaseURL != "" {
-		logLine += " [ANTHROPIC_BASE_URL=" + d.AnthropicBaseURL + "]"
+		logLine += " [ANTHROPIC_BASE_URL=" + redactURLUserinfo(d.AnthropicBaseURL) + "]"
 	}
 	emit(Event{Kind: KindText, Text: logLine})
 

--- a/internal/worker/docker_test.go
+++ b/internal/worker/docker_test.go
@@ -156,3 +156,21 @@ func TestDirSize_IgnoresIrregularEntries(t *testing.T) {
 		t.Errorf("dirSize = %d, want 256 (symlinks must not be counted)", n)
 	}
 }
+
+func TestRedactURLUserinfo(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"https://proxy.example.com/v1", "https://proxy.example.com/v1"},
+		{"https://user:secret@proxy.example.com/v1", "https://REDACTED@proxy.example.com/v1"},
+		{"https://onlyuser@proxy.example.com/v1", "https://REDACTED@proxy.example.com/v1"},
+		{"not a url", "not a url"},
+		{"", ""},
+	}
+	for _, c := range cases {
+		got := redactURLUserinfo(c.in)
+		if got != c.want {
+			t.Errorf("redactURLUserinfo(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
Two boundary-validation fixes that came out of a deeper code-quality pass.

`worker.ValidateGitRef` restricts branch/tag input to `[A-Za-z0-9._/-]+`, rejects leading `-` and `..`, then runs at two layers:

- the API handler (`apiRunSkill`) maps a bad ref to 400 via a new `ErrInvalidRef` sentinel, so callers get immediate feedback instead of a ghost scan that fails at clone time
- `cloneOrFetch` revalidates before any `git` invocation, so any future caller that bypasses the API gate is still safe

exec uses argv so there is no shell-injection vector here, but git's refspec resolver treats `..` as a range and `-`-prefixed values as options in some contexts, so the charset gate removes the ambiguity.

`redactURLUserinfo` strips embedded credentials from `ANTHROPIC_BASE_URL` before it appears in the docker run log line. Userinfo gets replaced with `REDACTED` rather than dropped, so it stays visible that auth was configured.

Tests:

- `TestValidateGitRef`: 7 good + 10 bad cases (`--all`, `foo..bar`, spaces, semicolons, `head@{0}`, `^`, `~1`)
- `TestCloneOrFetchRejectsBadRefBeforeNetwork`: bad ref short-circuits before any git invocation runs
- `TestCloneOrFetchRejectsBadURL`: keeps the existing URL gate covered through the same entry point
- `TestEnsureCloneWrapsValidationError`: validation failures still wrap as `*RepoUnreachableError`
- `TestAPIRunSkill_badRefRejectedAt400`: end-to-end through the HTTP handler, no scan row created
- `TestRedactURLUserinfo`: bare URL, user+password, user-only, unparseable, empty