### PR TITLE
perf: batch scan log DB writes

### DIFF
--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -35,6 +35,15 @@ const (
 // more than this; a scan that does is almost always wedged.
 const DefaultScanTimeout = time.Hour
 
+// defaultLogFlushInterval bounds how long a scan's log can lag behind the
+// in-memory accumulator. Each emitted event used to UPDATE the whole
+// scans.log TEXT column, so a token-heavy scan fired thousands of full
+// rewrites; batching to once every couple of seconds collapses that to a
+// trickle. Real-time UI updates flow through publish() on every event and
+// are independent of this cadence; wrap()'s closing Save flushes the
+// final buffered tail regardless of how long ago the last write was.
+const defaultLogFlushInterval = 2 * time.Second
+
 type Worker struct {
 	DB          *gorm.DB
 	Log         *slog.Logger
@@ -62,6 +71,18 @@ type Worker struct {
 	// step in doSkill. Tests set it to skip the network; production
 	// leaves it nil and falls through to prepareRepoSrc.
 	PrepareRepoSrc func(ctx context.Context, url, ref, workRoot string, emit func(Event)) (string, error)
+
+	// LogFlushInterval overrides defaultLogFlushInterval. Tests set it to
+	// a tiny or huge value to assert flush behaviour without sleeping.
+	// Zero falls through to the const default.
+	LogFlushInterval time.Duration
+}
+
+func (w *Worker) logFlushInterval() time.Duration {
+	if w.LogFlushInterval > 0 {
+		return w.LogFlushInterval
+	}
+	return defaultLogFlushInterval
 }
 
 // Cancel aborts an in-flight scan. Returns true if a running job was found and
@@ -161,13 +182,17 @@ func (w *Worker) applyResume(scan *db.Scan, sj *SkillJob, emit func(Event)) {
 }
 
 // scanEmitter returns the emit callback handed to a job handler. It appends
-// each event to the scan log (persisting incrementally so the UI streams it)
-// and snapshots result-event token usage. Session events are special: they
-// carry no log line and instead persist the claude session id the moment it
-// appears so a crash mid-run leaves the scan resumable. The in-memory struct
-// is kept in sync too — wrap's final Save(&scan) writes every column and
-// would otherwise clobber a column-only update with a stale value.
+// each event to scan.Log in memory and streams it live to subscribers via
+// publish(); DB persistence is batched to logFlushInterval so a token-heavy
+// scan does not rewrite the whole log TEXT column on every event. wrap's
+// final Save(&scan) flushes the tail along with every other column, so a
+// scan that finishes between flushes still lands its full log. Session
+// events bypass batching: a session id is small, terminal-only changes,
+// and must hit the DB the moment it appears so a crash mid-run leaves the
+// scan resumable.
 func (w *Worker) scanEmitter(scan *db.Scan) func(Event) {
+	interval := w.logFlushInterval()
+	lastFlush := time.Now()
 	return func(e Event) {
 		if e.Kind == KindSession {
 			if e.SessionID != "" && e.SessionID != scan.SessionID {
@@ -178,7 +203,10 @@ func (w *Worker) scanEmitter(scan *db.Scan) func(Event) {
 		}
 		line := FormatEvent(e)
 		scan.Log += line + "\n"
-		w.DB.Model(&db.Scan{}).Where("id = ?", scan.ID).Update("log", scan.Log)
+		if time.Since(lastFlush) >= interval {
+			w.DB.Model(&db.Scan{}).Where("id = ?", scan.ID).Update("log", scan.Log)
+			lastFlush = time.Now()
+		}
 		if e.Kind == KindResult {
 			scan.CostUSD = e.CostUSD
 			scan.Turns = e.Turns

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -260,3 +260,140 @@ func TestWorker_workspaceCleanup(t *testing.T) {
 		t.Errorf("workspace %s not removed after failed scan", failRoot)
 	}
 }
+
+// TestScanEmitter_batchesDBWrites pins the batching behaviour: with a long
+// flush interval, in-memory scan.Log grows on every event but the DB log
+// column stays at the value from the most recent flush. SSE publish fires
+// on every event regardless of the flush cadence so the live UI stays
+// real-time. wrap()'s final Save persists scan.Log along with every other
+// column, so a scan that finishes mid-batch still lands its full log.
+func TestScanEmitter_batchesDBWrites(t *testing.T) {
+	gdb, err := db.Open(filepath.Join(t.TempDir(), "emit.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo := db.Repository{URL: "https://example.com/x", Name: "x"}
+	gdb.Create(&repo)
+	scan := db.Scan{RepositoryID: repo.ID, Kind: JobSkill, Status: db.ScanRunning}
+	gdb.Create(&scan)
+
+	var published int
+	w := &Worker{
+		DB:               gdb,
+		Log:              slog.New(slog.NewTextHandler(io.Discard, nil)),
+		LogFlushInterval: time.Hour,
+		OnEvent:          func(_, _ uint, _, _ string) { published++ },
+	}
+	emit := w.scanEmitter(&scan)
+
+	for i := 0; i < 5; i++ {
+		emit(Event{Kind: "text", Text: "line"})
+	}
+
+	if strings.Count(scan.Log, "line") != 5 {
+		t.Errorf("in-memory scan.Log should hold all 5 events, got %q", scan.Log)
+	}
+	if published != 5 {
+		t.Errorf("publish should fire on every event regardless of flush cadence: got %d, want 5", published)
+	}
+	var row db.Scan
+	gdb.First(&row, scan.ID)
+	if row.Log != "" {
+		t.Errorf("DB log should be empty until interval elapses, got %q", row.Log)
+	}
+}
+
+// TestScanEmitter_flushesWhenIntervalElapses checks the positive case:
+// a zero-or-tiny interval triggers the DB UPDATE on every event so a
+// stuck/long-running scan still streams its log to disk.
+func TestScanEmitter_flushesWhenIntervalElapses(t *testing.T) {
+	gdb, err := db.Open(filepath.Join(t.TempDir(), "emit_short.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo := db.Repository{URL: "https://example.com/x", Name: "x"}
+	gdb.Create(&repo)
+	scan := db.Scan{RepositoryID: repo.ID, Kind: JobSkill, Status: db.ScanRunning}
+	gdb.Create(&scan)
+
+	w := &Worker{
+		DB:               gdb,
+		Log:              slog.New(slog.NewTextHandler(io.Discard, nil)),
+		LogFlushInterval: time.Nanosecond,
+	}
+	emit := w.scanEmitter(&scan)
+	// Sleep past the interval so the very first event triggers a flush.
+	time.Sleep(time.Microsecond)
+	emit(Event{Kind: "text", Text: "first"})
+
+	var row db.Scan
+	gdb.First(&row, scan.ID)
+	if !strings.Contains(row.Log, "first") {
+		t.Errorf("DB log should be flushed after interval elapses, got %q", row.Log)
+	}
+}
+
+// TestScanEmitter_sessionWritesBypassBatching confirms that a session id
+// hits the DB on the event it arrives in even when the log-flush window
+// is open. A crash between batched flushes must still leave the scan
+// resumable via the persisted session id.
+func TestScanEmitter_sessionWritesBypassBatching(t *testing.T) {
+	gdb, err := db.Open(filepath.Join(t.TempDir(), "emit_session.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo := db.Repository{URL: "https://example.com/x", Name: "x"}
+	gdb.Create(&repo)
+	scan := db.Scan{RepositoryID: repo.ID, Kind: JobSkill, Status: db.ScanRunning}
+	gdb.Create(&scan)
+
+	w := &Worker{
+		DB:               gdb,
+		Log:              slog.New(slog.NewTextHandler(io.Discard, nil)),
+		LogFlushInterval: time.Hour,
+	}
+	emit := w.scanEmitter(&scan)
+	emit(Event{Kind: KindSession, SessionID: "sess-123"})
+
+	var row db.Scan
+	gdb.First(&row, scan.ID)
+	if row.SessionID != "sess-123" {
+		t.Errorf("session id should persist immediately, got %q", row.SessionID)
+	}
+}
+
+// TestScanEmitter_finalSaveCoversUnflushedTail walks the full wrap() path
+// with a long flush interval to prove the closing Save persists the
+// buffered log tail. Without that, a scan that finishes in under
+// LogFlushInterval would land in the DB with an empty log column.
+func TestScanEmitter_finalSaveCoversUnflushedTail(t *testing.T) {
+	gdb, err := db.Open(filepath.Join(t.TempDir(), "tail.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo := db.Repository{URL: "https://example.com/x", Name: "x"}
+	gdb.Create(&repo)
+	skill := db.Skill{Name: "fast", Description: "x", Body: "b", Active: true, Source: "ui", Version: 1}
+	gdb.Create(&skill)
+	scan := db.Scan{RepositoryID: repo.ID, Kind: JobSkill, Status: db.ScanQueued, SkillID: &skill.ID}
+	gdb.Create(&scan)
+
+	w := &Worker{
+		DB:               gdb,
+		Log:              slog.New(slog.NewTextHandler(io.Discard, nil)),
+		DataDir:          t.TempDir(),
+		Runner:           fakeRunner{skillRes: SkillResult{Report: ""}},
+		PrepareRepoSrc:   stubPrepareRepoSrc,
+		LogFlushInterval: time.Hour,
+	}
+	body, _ := json.Marshal(queue.Payload{ScanID: scan.ID})
+	if err := w.wrap(w.doSkill)(context.Background(), body); err != nil {
+		t.Fatalf("wrap: %v", err)
+	}
+
+	var got db.Scan
+	gdb.First(&got, scan.ID)
+	if !strings.Contains(got.Log, "running skill fast") {
+		t.Errorf("final Save should persist the buffered log tail; got %q", got.Log)
+	}
+}


### PR DESCRIPTION
Every event emitted during a scan (each LLM token, tool use, status change) used to fire `UPDATE scans SET log = ? WHERE id = ?` with the entire accumulated log. A token-heavy scan emits thousands of events, so SQLite was rewriting the whole `log` TEXT column thousands of times per scan.

`scanEmitter` now appends to `scan.Log` in memory on every event and only writes the column when at least `defaultLogFlushInterval` (2s) has elapsed since the last flush. The real-time UI is unaffected: `publish()` still fires on every event, so SSE subscribers see every line immediately. `wrap()`'s closing `Save(&scan)` already persists `scan.Log` along with every other column, so a scan that finishes between flushes still lands its full log with no additional write call.

`KindSession` events deliberately bypass batching: a session id is a small, terminal-only field and must reach the DB the moment it arrives, otherwise a crash mid-run would leave a scan that cannot be `--resume`d.

Tests:

- `TestScanEmitter_batchesDBWrites`: with a long flush interval, 5 events accumulate in `scan.Log` in memory, the DB `log` column stays empty, and the SSE `publish` callback fires 5 times.
- `TestScanEmitter_flushesWhenIntervalElapses`: with a nanosecond interval, the first event hits the DB.
- `TestScanEmitter_sessionWritesBypassBatching`: with a long interval, a `KindSession` event still writes `session_id` immediately so resume survives a crash.
- `TestScanEmitter_finalSaveCoversUnflushedTail`: full `wrap()` path with a long interval proves the closing `Save` lands the buffered log tail.

The `Worker.LogFlushInterval` field is the test seam; production leaves it zero and uses the const default.