### PR TITLE
chore: log discarded errors in worker partial-parse paths

### DIFF
--- a/internal/worker/exposure.go
+++ b/internal/worker/exposure.go
@@ -205,7 +205,12 @@ func (w *Worker) doExposure(ctx context.Context, scan *db.Scan, emit func(Event)
 	}
 	if err != nil {
 		if _, ok := errors.AsType[*MaxTurnsReachedError](err); ok && res.Report != "" {
-			_ = w.parseExposureOutput(&skill, scan, dep.ID, res.Report, emit)
+			// Same best-effort parse-the-partial pattern as doSkill: keep
+			// propagating the original err but surface parse failures so a
+			// silently-malformed exposure report doesn't vanish.
+			if perr := w.parseExposureOutput(&skill, scan, dep.ID, res.Report, emit); perr != nil {
+				w.Log.Warn("parse partial exposure output after max turns", "scan", scan.ID, "dependent", dep.ID, "err", perr)
+			}
 		}
 		return res.Report, err
 	}

--- a/internal/worker/skill.go
+++ b/internal/worker/skill.go
@@ -162,7 +162,7 @@ func (w *Worker) doSkill(ctx context.Context, scan *db.Scan, emit func(Event)) (
 	}
 	if err != nil {
 		if _, ok := errors.AsType[*MaxTurnsReachedError](err); ok && res.Report != "" {
-			_ = w.parseSkillOutput(&skill, scan, res.Report, emit)
+			w.parsePartialSkillReport(&skill, scan, res.Report, emit)
 		}
 		return res.Report, err
 	}
@@ -173,6 +173,16 @@ func (w *Worker) doSkill(ctx context.Context, scan *db.Scan, emit func(Event)) (
 		}
 	}
 	return res.Report, nil
+}
+
+// parsePartialSkillReport runs parseSkillOutput against a max-turns
+// partial and logs on failure. The scan is already returning a
+// MaxTurnsReachedError so the parse error has nowhere useful to
+// propagate; logging keeps a silently-malformed partial from vanishing.
+func (w *Worker) parsePartialSkillReport(skill *db.Skill, scan *db.Scan, report string, emit func(Event)) {
+	if err := w.parseSkillOutput(skill, scan, report, emit); err != nil {
+		w.Log.Warn("parse partial skill output after max turns", "scan", scan.ID, "skill", skill.Name, "err", err)
+	}
 }
 
 func (w *Worker) parseSkillOutput(skill *db.Skill, scan *db.Scan, report string, emit func(Event)) error {
@@ -287,13 +297,15 @@ func (w *Worker) parseFindingsOutput(skill *db.Skill, scan *db.Scan, report stri
 			}).Error; uerr != nil {
 				return fmt.Errorf("update finding %d: %w", existing.ID, uerr)
 			}
-			_ = w.DB.Create(&db.FindingHistory{
+			if herr := w.DB.Create(&db.FindingHistory{
 				FindingID: existing.ID,
 				Field:     "observed",
 				NewValue:  fmt.Sprintf("scan %d @ %s", scan.ID, scan.Commit),
 				Source:    db.SourceTool,
 				By:        scan.SkillName,
-			}).Error
+			}).Error; herr != nil {
+				w.Log.Warn("record observed-again finding history", "finding", existing.ID, "scan", scan.ID, "err", herr)
+			}
 			observed++
 			continue
 		}

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -1,6 +1,7 @@
 package worker
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -395,5 +396,46 @@ func TestScanEmitter_finalSaveCoversUnflushedTail(t *testing.T) {
 	gdb.First(&got, scan.ID)
 	if !strings.Contains(got.Log, "running skill fast") {
 		t.Errorf("final Save should persist the buffered log tail; got %q", got.Log)
+	}
+}
+
+// TestWorker_maxTurnsParseFailureLogged pins the contract that a partial
+// report from a max-turns run is parsed best-effort and a malformed
+// payload surfaces as a warn log instead of being silently dropped. The
+// scan still completes as ScanDone because the max-turns path treats a
+// hit cap as completion, not failure; the log line is the only signal
+// to operators that the partial wasn't usable.
+func TestWorker_maxTurnsParseFailureLogged(t *testing.T) {
+	gdb, err := db.Open(filepath.Join(t.TempDir(), "mtparse.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo := db.Repository{URL: "https://example.com/x", Name: "x"}
+	gdb.Create(&repo)
+	skill := db.Skill{Name: "maint", Description: "x", Body: "b", Active: true, Source: "ui", Version: 1, OutputKind: "maintainers", MaxTurns: 5}
+	gdb.Create(&skill)
+	scan := db.Scan{RepositoryID: repo.ID, Kind: JobSkill, Status: db.ScanQueued, SkillID: &skill.ID}
+	gdb.Create(&scan)
+
+	var logBuf bytes.Buffer
+	w := &Worker{
+		DB:             gdb,
+		Log:            slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelWarn})),
+		DataDir:        t.TempDir(),
+		Runner:         fakeRunner{skillRes: SkillResult{Report: "not json"}, skillErr: &MaxTurnsReachedError{}},
+		PrepareRepoSrc: stubPrepareRepoSrc,
+	}
+	body, _ := json.Marshal(queue.Payload{ScanID: scan.ID})
+	if err := w.wrap(w.doSkill)(context.Background(), body); err != nil {
+		t.Fatalf("wrap: %v", err)
+	}
+
+	var got db.Scan
+	gdb.First(&got, scan.ID)
+	if got.Status != db.ScanDone {
+		t.Errorf("status = %s, want done (max-turns still completes)", got.Status)
+	}
+	if !strings.Contains(logBuf.String(), "parse partial skill output after max turns") {
+		t.Errorf("expected warn log about partial parse, got: %s", logBuf.String())
 	}
 }


### PR DESCRIPTION
Three sites in the worker package were silently discarding errors with `_ = ...`. Each had a defensible reason — the surrounding code was already returning a more important error — but the practical effect was that malformed partial reports and failed audit inserts vanished without trace.

- `worker/skill.go`: the max-turns partial-parse path moves into a small `parsePartialSkillReport` helper that calls `parseSkillOutput` and logs on failure. Extracting the helper also keeps `doSkill`'s gocognit score under the threshold the linter enforces.
- `worker/exposure.go`: the equivalent partial-parse path for the exposure handler logs inline; the surrounding function isn't near the complexity threshold, so no helper was needed.
- `worker/skill.go`: the `FindingHistory` audit insert that runs for observed-again findings now logs when `DB.Create` returns an error instead of swallowing it.

None of these change control flow. The original error still propagates back to `wrap` and lands on the scan exactly as before; the only new behaviour is a warn line in the worker log when something would otherwise have been dropped.

Test: `TestWorker_maxTurnsParseFailureLogged` runs `wrap(doSkill)` with a `maintainers` skill whose fake runner returns invalid JSON and a `MaxTurnsReachedError`. It pins the existing contract that the scan still ends `ScanDone` (max-turns is treated as completion) and the new contract that the parse failure surfaces in the worker log.

The exposure-side change follows the same pattern by inspection; the audit-insert change is harder to exercise reliably without injecting a DB that fails `Create`, so it relies on code review.