### PR TITLE
chore(skills): trim short-tier skill descriptions

### DIFF
--- a/skills/advisories/SKILL.md
+++ b/skills/advisories/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: advisories
-description: Fetch the published security advisories that affect any package produced by this repository. Use to populate the Advisories tab with existing GHSA and CVE records so analysts can see what is already public before triaging new findings.
+description: Fetch published GHSA and CVE advisories affecting any package this repository produces, via advisories.ecosyste.ms.
 license: MIT
 compatibility: Needs network access to advisories.ecosyste.ms.
 allowed-tools: Read,Write,WebFetch,Grep,Glob,LS

--- a/skills/cna-match/SKILL.md
+++ b/skills/cna-match/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cna-match
-description: Determine which CVE Numbering Authority (if any) covers this repository, so disclosures can be routed to the CNA's security contact rather than only the maintainer. Reads scrutineer's cached CNA list and matches the repo's owner, project name, and published packages against each CNA's published scope.
+description: Match the repository to a CVE Numbering Authority so disclosures route to the CNA's security contact when one covers the repo.
 license: MIT
 metadata:
   scrutineer.version: 1

--- a/skills/dependencies/SKILL.md
+++ b/skills/dependencies/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dependencies
-description: Index dependencies reported by git-pkgs for the repository's manifest and lockfile files (package.json, Gemfile, go.mod, requirements.txt, etc.) and record each one with its manifest path, ecosystem, and requirement string. Use to populate the Dependencies tab.
+description: Index the repository's dependencies via `git-pkgs list`, recording manifest path, ecosystem, and requirement per entry.
 license: MIT
 compatibility: Requires `git-pkgs` (https://github.com/ecosyste-ms/git-pkgs) and `python3` on PATH.
 metadata:

--- a/skills/dependents/SKILL.md
+++ b/skills/dependents/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dependents
-description: For each published package of this repository, fetch the top runtime dependents so later exposure-analysis skills have a ranked shortlist to work against. Use after the packages skill has populated which packages exist.
+description: Fetch the top runtime dependents for each of this repository's published packages, ranked, so reach skills have a shortlist.
 license: MIT
 compatibility: Needs network access to packages.ecosyste.ms.
 allowed-tools: Read,Write,WebFetch,Grep,Glob,LS

--- a/skills/exposure/SKILL.md
+++ b/skills/exposure/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: exposure
-description: For one (finding, dependent) pair, decide whether the dependent's published code actually reaches the upstream library finding. Emit one CSAF 2.0 product_status verdict so scrutineer can record affected vs not_affected and stamp the right VEX justification.
+description: For one (finding, dependent) pair, decide whether the dependent's code reaches the upstream finding. Emits a CSAF 2.0 product_status verdict with VEX justification.
 license: MIT
 allowed-tools: Read,Write,Glob,Grep,WebFetch,LS
 metadata:

--- a/skills/metadata/SKILL.md
+++ b/skills/metadata/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: metadata
-description: Fetch high-level repository metadata (description, default branch, languages, license, stars, forks, archived status, icon) and save it against the scan's repository row. Use as the first scan on a new repository or to refresh after upstream changes.
+description: Fetch repository metadata (description, default branch, languages, license, stars, archived, icon) from repos.ecosyste.ms and save it on the repository row.
 license: MIT
 compatibility: Needs network access to repos.ecosyste.ms.
 allowed-tools: Read,Write,WebFetch,Grep,Glob,LS

--- a/skills/packages/SKILL.md
+++ b/skills/packages/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: packages
-description: Look up every published package that corresponds to a repository, across all registries, and record download counts, dependent counts, latest version, and registry URL. Use to populate the Packages tab.
+description: Look up every package this repository publishes across all registries via packages.ecosyste.ms, with downloads, dependent counts, latest version, and registry URL.
 license: MIT
 compatibility: Needs network access to packages.ecosyste.ms.
 allowed-tools: Read,Write,WebFetch,Grep,Glob,LS

--- a/skills/repo-overview/SKILL.md
+++ b/skills/repo-overview/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: repo-overview
-description: Produce a structured plain-language overview of what a repository does, who maintains it, its activity level, and the shape of its codebase. Use when you want a quick orientation before deeper analysis.
+description: Run `brief --json` to produce a structured overview of the repository. Used by other skills as orientation.
 license: MIT
 compatibility: Requires the `brief` CLI (https://github.com/ecosyste-ms/brief) on PATH.
 metadata:
@@ -33,10 +33,4 @@ If `scan_subpath` points at a directory that does not exist under `./src`, write
 brief --json ./src > ./report.json
 ```
 
-That is the whole workflow. If `brief` exits non-zero, read its stderr and write a short `{"error": "..."}` JSON document to `./report.json` so the caller can see what went wrong rather than getting an empty file.
-
-## Notes
-
-- `brief` is pinned by the deployment (container image or host install). Do not try to install it here.
-- Do not post-process the output. The consumer of this report expects brief's native schema.
-- If the tool is missing, say so clearly in the error JSON rather than inventing content.
+That is the whole workflow. If `brief` exits non-zero (including when it is missing), read its stderr and write a short `{"error": "..."}` JSON document to `./report.json` so the caller can see what went wrong rather than getting an empty file. Do not post-process brief's output; the consumer expects its native schema. Do not try to install `brief`; it is pinned by the deployment.

--- a/skills/sbom/SKILL.md
+++ b/skills/sbom/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sbom
-description: Generate a CycloneDX Software Bill of Materials for the repository. Use when you want a standard-format inventory of components for downstream tooling, compliance, or archival. Stored verbatim on the scan.
+description: Generate a CycloneDX SBOM for the repository via `git-pkgs sbom`. Stored verbatim on the scan.
 license: MIT
 compatibility: Requires the `git-pkgs` CLI on PATH.
 metadata:

--- a/skills/semgrep/SKILL.md
+++ b/skills/semgrep/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: semgrep
-description: Run semgrep static analysis with the security-audit and secrets rulesets, then map each hit into scrutineer's findings shape so it surfaces alongside model-driven audits. Use as a fast deterministic pass before or alongside deeper skills.
+description: Run semgrep's `p/security-audit` and `p/secrets` rulesets and map hits into the findings shape.
 license: MIT
 compatibility: Requires `semgrep` (https://semgrep.dev) and `python3` on PATH.
 metadata:
@@ -30,4 +30,4 @@ Run semgrep against `./src` using the `p/security-audit` and `p/secrets` ruleset
 python3 scripts/scan.py > ./report.json
 ```
 
-The script self-reports tool-missing errors into the JSON envelope so failures are visible on the scan page rather than silent. Don't post-process its output.
+Don't post-process its output. Tool-missing errors are reported into the JSON envelope so failures are visible on the scan page.

--- a/skills/verify/SKILL.md
+++ b/skills/verify/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: verify
-description: Independently verify a specific finding by re-running its reproduction against the current repository state. Records whether the finding still reproduces, was fixed upstream, or could not be reproduced. Use on a finding before investing analyst time in disclosure.
+description: Re-run a finding's reproduction against current HEAD and record whether it is confirmed, fixed, or inconclusive.
 license: MIT
 compatibility: Needs network access to the scrutineer API (http://host:port/api). Expects the finding's reproduction instructions to be runnable against ./src with commonly available tooling.
 metadata:

--- a/skills/zizmor/SKILL.md
+++ b/skills/zizmor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: zizmor
-description: Audit the repository's GitHub Actions workflows for common security issues (credential mishandling, untrusted inputs, template injection, overly permissive tokens) and convert findings to scrutineer's shape. Use on any repo with a .github/workflows directory.
+description: Audit GitHub Actions workflows with zizmor and map hits into the findings shape.
 license: MIT
 compatibility: Requires `zizmor` (https://github.com/zizmorcore/zizmor) and `python3` on PATH.
 metadata:
@@ -30,4 +30,4 @@ Run zizmor against `./src/.github/workflows` and map each issue into scrutineer'
 python3 scripts/scan.py > ./report.json
 ```
 
-The script handles missing workflows directories, a missing zizmor binary, and zizmor's non-zero "I found something" exit code gracefully — don't add retry or error handling on top. If stderr is noisy that's fine, scrutineer only reads the JSON on stdout.
+The script handles missing workflows directories, a missing zizmor binary, and zizmor's non-zero "I found something" exit code gracefully — don't add retry or error handling on top.


### PR DESCRIPTION
Tighten frontmatter `description` on twelve short skills (`metadata`, `packages`, `advisories`, `dependents`, `dependencies`, `sbom`, `repo-overview`, `zizmor`, `semgrep`, `verify`, `exposure`, `cna-match`).

The worker stages one skill per scan workspace and invokes `claude -p` with an activation prompt that names the target skill, so the discovery context only needs to be intelligible on the `/skills` page; the longer "Use when..." marketing on each description doesn't earn the per-turn tax.

Also drops a few defensive-instruction repetitions in `zizmor`, `semgrep`, and `repo-overview` bodies that said the same thing twice.

No behavioural change to any skill's procedure or output shape.