### PR TITLE
feat: add "Scan all" button for subprojects

### DIFF
--- a/internal/web/repo_show_test.go
+++ b/internal/web/repo_show_test.go
@@ -38,6 +38,29 @@ func getRepoPage(t *testing.T, s *Server, id uint) string {
 	return w.Body.String()
 }
 
+func TestRepoShow_scanAllButton(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	repo := db.Repository{URL: "https://example.com/r", Name: "r"}
+	s.DB.Create(&repo)
+
+	// No subprojects: the Subprojects section (and its Scan all button) is hidden.
+	body := getRepoPage(t, s, repo.ID)
+	if strings.Contains(body, "/scan-all") {
+		t.Error("repo with no subprojects should not render the Scan all button")
+	}
+
+	// With subprojects, the bulk button posts to the repo-scoped scan-all route.
+	s.DB.Create(&db.Subproject{RepositoryID: repo.ID, Path: "pkg/a", Name: "a"})
+	body = getRepoPage(t, s, repo.ID)
+	if !strings.Contains(body, fmt.Sprintf("/repositories/%d/scan-all", repo.ID)) {
+		t.Errorf("Scan all button should post to the repo-scoped scan-all route; body=%s", body)
+	}
+	if !strings.Contains(body, "Scan all") {
+		t.Error("Subprojects section should render a Scan all button label")
+	}
+}
+
 func TestRepoShow_threatModelTab_deepDiveOnly(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -246,6 +246,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("GET /repositories/{id}/blob/{commit}/{path...}", s.repoBlob)
 	mux.HandleFunc("GET /repositories/{id}/report.md", s.repoReport)
 	mux.HandleFunc("POST /repositories/{id}/scan", s.repoScan)
+	mux.HandleFunc("POST /repositories/{id}/scan-all", s.repoScanAll)
 	mux.HandleFunc("POST /repositories/{id}/delete", s.repoDelete)
 	mux.HandleFunc("POST /repositories/{id}/disclosure-channel", s.repoDisclosureChannel)
 	mux.HandleFunc("GET /scans", s.jobs)
@@ -1608,6 +1609,73 @@ func (s *Server) repoScan(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	s.redirect(w, r, fmt.Sprintf("/repositories/%d", repo.ID))
+}
+
+// repoScanAll is the bulk equivalent of the per-subproject "Scan" button: it
+// enqueues the deep-dive skill for every detected subproject on the repo, so
+// the operator doesn't have to click through the list one row at a time.
+// Subprojects that already have a queued or running deep-dive scan are skipped,
+// so re-clicking the button doesn't pile up duplicate jobs.
+func (s *Server) repoScanAll(w http.ResponseWriter, r *http.Request) {
+	repo, ok := loadByID[db.Repository](s, w, r)
+	if !ok {
+		return
+	}
+	var skill db.Skill
+	if err := s.DB.Where("name = ? AND active = ?", deepDiveSkillName, true).First(&skill).Error; err != nil {
+		setFlash(w, Flash{Category: errorKey, Title: deepDiveSkillName + " skill is not installed"})
+		s.redirect(w, r, fmt.Sprintf("/repositories/%d", repo.ID))
+		return
+	}
+
+	var subprojects []db.Subproject
+	s.DB.Where("repository_id = ?", repo.ID).Order("path").Find(&subprojects)
+
+	model := r.FormValue("model")
+	var queued, skipped, errored int
+	for _, sub := range subprojects {
+		var inflight int64
+		s.DB.Model(&db.Scan{}).
+			Where("repository_id = ? AND sub_path = ? AND skill_id = ? AND status IN ?",
+				repo.ID, sub.Path, skill.ID, []db.ScanStatus{db.ScanQueued, db.ScanRunning}).
+			Count(&inflight)
+		if inflight > 0 {
+			skipped++
+			continue
+		}
+		if _, err := s.enqueueSkillWith(r.Context(), repo.ID, skill.ID, ScanOpts{
+			Model:   model,
+			SubPath: sub.Path,
+		}); err != nil {
+			errored++
+			continue
+		}
+		queued++
+	}
+	setFlash(w, scanAllToast(queued, skipped, errored))
+	// Land on the Scans tab so the operator can watch the jobs run.
+	s.redirect(w, r, fmt.Sprintf("/repositories/%d#rt3", repo.ID))
+}
+
+func scanAllToast(queued, skipped, errored int) Flash {
+	if queued == 0 && skipped == 0 && errored == 0 {
+		return Flash{Category: successKey, Title: "No subprojects to scan"}
+	}
+	parts := []string{fmt.Sprintf("%d queued", queued)}
+	if skipped > 0 {
+		parts = append(parts, fmt.Sprintf("%d already running", skipped))
+	}
+	if errored > 0 {
+		parts = append(parts, fmt.Sprintf("%d errored", errored))
+	}
+	cat := successKey
+	switch {
+	case errored > 0:
+		cat = errorKey
+	case queued == 0:
+		cat = warningKey
+	}
+	return Flash{Category: cat, Title: "Scan all: " + strings.Join(parts, ", ")}
 }
 
 // repoDelete removes a repository and every row that hangs off it, then

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -2041,6 +2041,70 @@ func TestRepoVerifyAll_skillNotInstalled(t *testing.T) {
 	}
 }
 
+func TestRepoScanAll(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	repo := db.Repository{URL: "https://github.com/foo/bar", Name: "bar"}
+	s.DB.Create(&repo)
+	deepDive := db.Skill{Name: deepDiveSkillName, Body: "b", OutputFile: "r.json",
+		OutputKind: "freeform", Version: 1, Active: true, Source: "ui"}
+	s.DB.Create(&deepDive)
+
+	// Three subprojects; one of them already has an in-flight deep-dive scan
+	// and must be skipped so the button is idempotent.
+	for _, p := range []string{"a", "b", "skipme"} {
+		s.DB.Create(&db.Subproject{RepositoryID: repo.ID, Path: p, Name: p})
+	}
+	s.DB.Create(&db.Scan{RepositoryID: repo.ID, Kind: "skill", Status: db.ScanRunning,
+		SkillName: deepDiveSkillName, SkillID: new(deepDive.ID), SubPath: "skipme"})
+
+	req := httptest.NewRequest("POST", fmt.Sprintf("/repositories/%d/scan-all", repo.ID), nil)
+	req.Host = testHost
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+
+	// One queued deep-dive scan per subproject without an in-flight scan.
+	var queued []db.Scan
+	s.DB.Where("skill_name = ? AND status = ?", deepDiveSkillName, db.ScanQueued).Find(&queued)
+	if len(queued) != 2 {
+		t.Fatalf("queued scans = %d, want 2", len(queued))
+	}
+	paths := map[string]bool{}
+	for _, sc := range queued {
+		paths[sc.SubPath] = true
+	}
+	if !paths["a"] || !paths["b"] || paths["skipme"] {
+		t.Errorf("queued sub_paths = %v, want {a, b} only", paths)
+	}
+	if f := flashFrom(t, w); !strings.Contains(f.Title, "2 queued") || !strings.Contains(f.Title, "1 already running") {
+		t.Errorf("flash = %q, want 2 queued / 1 already running", f.Title)
+	}
+}
+
+func TestRepoScanAll_skillNotInstalled(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	repo := db.Repository{URL: "https://github.com/foo/bar", Name: "bar"}
+	s.DB.Create(&repo)
+	s.DB.Create(&db.Subproject{RepositoryID: repo.ID, Path: "a", Name: "a"})
+
+	req := httptest.NewRequest("POST", fmt.Sprintf("/repositories/%d/scan-all", repo.ID), nil)
+	req.Host = testHost
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+
+	var n int64
+	s.DB.Model(&db.Scan{}).Count(&n)
+	if n != 0 {
+		t.Errorf("scans created = %d, want 0 when skill missing", n)
+	}
+	if f := flashFrom(t, w); f.Category != "error" {
+		t.Errorf("flash category = %q, want error", f.Category)
+	}
+}
+
 func TestFindingPatchDownload(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()

--- a/internal/web/templates/repo_show.html
+++ b/internal/web/templates/repo_show.html
@@ -146,7 +146,14 @@
     </div>
 
     {{if .Subprojects}}
-      <h3 class="font-medium mb-2">Subprojects <span class="text-muted-foreground text-xs">({{len .Subprojects}})</span></h3>
+      <div class="flex items-center justify-between gap-2 mb-2">
+        <h3 class="font-medium">Subprojects <span class="text-muted-foreground text-xs">({{len .Subprojects}})</span></h3>
+        <form method="post" action="/repositories/{{.Repo.ID}}/scan-all"
+              hx-post="/repositories/{{.Repo.ID}}/scan-all" hx-swap="none"
+              hx-confirm="Enqueue a deep-dive scan for all {{len .Subprojects}} subproject(s)?">
+          <button type="submit" class="btn-sm-outline"><i data-lucide="play"></i> Scan all</button>
+        </form>
+      </div>
       <p class="text-sm text-muted-foreground mb-2">Detected scannable units inside this repository. Each can be scanned independently with its own findings stream.</p>
       <table class="table w-full mb-6">
         <thead><tr>


### PR DESCRIPTION
Generated with Claude Code, tested and reviewed by me.

Add a bulk "Scan all" button to the Subprojects section of the repository view that enqueues a deep-dive scan for every detected subproject at once.

Closes #284.

<img width="1197" height="85" alt="Screenshot 2026-06-06 at 10 52 33 PM" src="https://github.com/user-attachments/assets/2df1d0ce-de29-43a7-bd66-bb388e419c16" />

<img width="392" height="145" alt="Screenshot 2026-06-06 at 10 52 37 PM" src="https://github.com/user-attachments/assets/95d51011-2e21-4108-9a35-acf291855e89" />
