### PR TITLE
fix: keep CWE-less findings distinct by title in fingerprint

### DIFF
--- a/internal/db/fingerprint.go
+++ b/internal/db/fingerprint.go
@@ -15,9 +15,13 @@ import (
 // file path from Location with any :line:col suffix stripped. File-level
 // (not line-level) matching means a finding that drifts a few lines
 // between commits still dedupes; the cost is that two distinct same-CWE
-// issues in the same file collide into one row. When both CWE and
-// Location are empty the title is folded in so freeform-style findings
-// still get a key.
+// issues in the same file collide into one row. When the CWE is empty the
+// title is folded in to keep distinct findings apart: a CWE-less finding
+// has nothing else to distinguish it from another in the same file, so
+// without the title every rule that fires on one file (e.g. zizmor's many
+// per-file audits) would collapse into a single row. Findings that carry a
+// CWE keep CWE+file matching, so line drift and title rewording still
+// dedupe.
 func FingerprintFinding(skillName, subPath, cwe, location, title string) string {
 	loc := normaliseLocation(location)
 	parts := []string{
@@ -26,7 +30,7 @@ func FingerprintFinding(skillName, subPath, cwe, location, title string) string 
 		strings.ToUpper(strings.TrimSpace(cwe)),
 		loc,
 	}
-	if cwe == "" && loc == "" {
+	if cwe == "" {
 		parts = append(parts, strings.ToLower(strings.TrimSpace(title)))
 	}
 	h := sha256.Sum256([]byte(strings.Join(parts, "|")))

--- a/internal/db/fingerprint_test.go
+++ b/internal/db/fingerprint_test.go
@@ -55,6 +55,34 @@ func TestFingerprintFinding(t *testing.T) {
 	}
 }
 
+// TestFingerprintCWELessRulesStayDistinct guards the zizmor regression: tools
+// that emit findings with a location but no CWE (zizmor, semgrep without a
+// CWE mapping) legitimately fire several distinct rules on the same workflow
+// file. The rule name (title) must keep them apart, or groupByFingerprint
+// collapses them into one row and silently drops the rest.
+func TestFingerprintCWELessRulesStayDistinct(t *testing.T) {
+	const file = ".github/workflows/foo.yml"
+
+	// Different rules in the same file -> different fingerprints.
+	artipacked := FingerprintFinding("zizmor", "", "", file+":18", "artipacked")
+	unpinned := FingerprintFinding("zizmor", "", "", file+":18", "unpinned-uses")
+	cachePoison := FingerprintFinding("zizmor", "", "", file+":2", "cache-poisoning")
+	if artipacked == unpinned || artipacked == cachePoison || unpinned == cachePoison {
+		t.Errorf("distinct CWE-less rules in the same file must not collide")
+	}
+
+	// Same rule, different lines in the same file -> still one fingerprint
+	// (per-rule folding into the locations set is intentional).
+	if artipacked != FingerprintFinding("zizmor", "", "", file+":40", "artipacked") {
+		t.Errorf("same rule + same file must dedupe regardless of line")
+	}
+
+	// Same rule, different file -> different fingerprint.
+	if artipacked == FingerprintFinding("zizmor", "", "", ".github/workflows/bar.yml:3", "artipacked") {
+		t.Errorf("same rule in a different file must change fingerprint")
+	}
+}
+
 func TestBackfillFindingFingerprints(t *testing.T) {
 	gdb, err := Open(":memory:")
 	if err != nil {


### PR DESCRIPTION
Fixes #338. The fix and tests were generated with Claude Code after analyzing and determining a root cause for the bug.

This should improve correctness of zizmor findings output on repos with many zizmor rule violations.

---

FingerprintFinding folded the title into the hash only when both CWE and location were empty. Findings that carry a location but no CWE -- every zizmor finding, and any tool finding without a CWE mapping -- therefore fingerprinted on (skill, sub-path, file) alone. Distinct rules firing on the same workflow file collided to one fingerprint, so groupByFingerprint collapsed them into a single row and silently discarded the rest (title and severity included), folding only their locations into the survivor.

Observed in real scans: a single workflow file with artipacked (Medium), excessive-permissions (Medium), unpinned-uses (High), and cache-poisoning (High) surfaced as one Medium artipacked finding; the two High findings vanished with no error. Across recent scans this dropped dozens of distinct rule-findings.

Fold the title in whenever the CWE is empty, so a CWE-less finding is distinguished by its rule name. Findings that carry a CWE are unchanged, so line drift and title rewording still dedupe as before. Add a regression test covering distinct rules in one file staying separate while same-rule hits still fold.