### PR TITLE
skill: bump security-deep-dive default max_turns to 120

### DIFF
--- a/skills/security-deep-dive/SKILL.md
+++ b/skills/security-deep-dive/SKILL.md
@@ -6,6 +6,7 @@ metadata:
   scrutineer.version: 1
   scrutineer.output_file: report.json
   scrutineer.output_kind: findings
+  scrutineer.max_turns: 120
 ---
 
 # security-deep-dive


### PR DESCRIPTION
30 turns isn't enough to finish a deep-dive on most repos, including single Ruby gems. Bump the per-skill default so operators don't have to raise it on every scan.

Closes #329