### PR TITLE
skill: drop allowed-tools from network-fetching skills

### DIFF
--- a/skills/advisories/SKILL.md
+++ b/skills/advisories/SKILL.md
@@ -3,7 +3,6 @@ name: advisories
 description: Fetch published GHSA and CVE advisories affecting any package this repository produces, via advisories.ecosyste.ms.
 license: MIT
 compatibility: Needs network access to advisories.ecosyste.ms.
-allowed-tools: Read,Write,WebFetch,Grep,Glob,LS
 metadata:
   scrutineer.version: 1
   scrutineer.output_file: report.json

--- a/skills/dependents/SKILL.md
+++ b/skills/dependents/SKILL.md
@@ -3,7 +3,6 @@ name: dependents
 description: Fetch the top runtime dependents for each of this repository's published packages, ranked, so reach skills have a shortlist.
 license: MIT
 compatibility: Needs network access to packages.ecosyste.ms.
-allowed-tools: Read,Write,WebFetch,Grep,Glob,LS
 metadata:
   scrutineer.version: 1
   scrutineer.output_file: report.json

--- a/skills/exposure/SKILL.md
+++ b/skills/exposure/SKILL.md
@@ -2,7 +2,6 @@
 name: exposure
 description: For one (finding, dependent) pair, decide whether the dependent's code reaches the upstream finding. Emits a CSAF 2.0 product_status verdict with VEX justification.
 license: MIT
-allowed-tools: Read,Write,Glob,Grep,WebFetch,LS
 metadata:
   scrutineer.version: 1
   scrutineer.output_file: report.json

--- a/skills/maintainers/SKILL.md
+++ b/skills/maintainers/SKILL.md
@@ -3,7 +3,6 @@ name: maintainers
 description: Identify the real maintainers of a repository and the best way to contact them about a security issue. Distinguishes active leads from occasional contributors and bots, using commit history, issue activity, and registry ownership. Use when preparing a disclosure and needing to know who to reach.
 license: MIT
 compatibility: Needs network access to commits.ecosyste.ms, issues.ecosyste.ms, and packages.ecosyste.ms.
-allowed-tools: Read,Write,WebFetch,Grep,Glob,LS
 metadata:
   scrutineer.version: 1
   scrutineer.output_file: report.json

--- a/skills/metadata/SKILL.md
+++ b/skills/metadata/SKILL.md
@@ -3,7 +3,6 @@ name: metadata
 description: Fetch repository metadata (description, default branch, languages, license, stars, archived, icon) from repos.ecosyste.ms and save it on the repository row.
 license: MIT
 compatibility: Needs network access to repos.ecosyste.ms.
-allowed-tools: Read,Write,WebFetch,Grep,Glob,LS
 metadata:
   scrutineer.version: 1
   scrutineer.output_file: report.json

--- a/skills/packages/SKILL.md
+++ b/skills/packages/SKILL.md
@@ -3,7 +3,6 @@ name: packages
 description: Look up every package this repository publishes across all registries via packages.ecosyste.ms, with downloads, dependent counts, latest version, and registry URL.
 license: MIT
 compatibility: Needs network access to packages.ecosyste.ms.
-allowed-tools: Read,Write,WebFetch,Grep,Glob,LS
 metadata:
   scrutineer.version: 1
   scrutineer.output_file: report.json


### PR DESCRIPTION
In headless mode there's no operator to approve a permission prompt, so any Bash use inside a skill that declares `allowed-tools` hangs the scan until it fails. The constraint enforces nothing — it just trades "don't shell out" for "fail silently if you do". The other 17 skills already run with the full tool set under bypassPermissions and behave fine.

Drop the field from `advisories`, `dependents`, `exposure`, `maintainers`, `metadata`, and `packages` so they take the same path.

Closes #340