### PR TITLE
worker: carry skill-emitted references onto findings

### DIFF
--- a/internal/worker/findings.go
+++ b/internal/worker/findings.go
@@ -32,6 +32,8 @@ type scanFinding struct {
 	ReachChecked int      `json:"reach_checked"`
 	ReachExposed int      `json:"reach_exposed"`
 
+	References []scanReference `json:"references"`
+
 	// Per-step markdown (security-deep-dive schema)
 	Trace      string `json:"trace"`
 	Boundary   string `json:"boundary"`
@@ -43,6 +45,14 @@ type scanFinding struct {
 	// Legacy fields (old schema)
 	Summary string `json:"summary"`
 	Details string `json:"details"`
+}
+
+// scanReference is an external URL a skill attaches to a finding (rule docs,
+// upstream advisory, blog post). Materialises as a db.FindingReference row.
+type scanReference struct {
+	URL     string `json:"url"`
+	Summary string `json:"summary"`
+	Tags    string `json:"tags"`
 }
 
 func parseReport(raw []byte) (scanReport, error) {
@@ -78,6 +88,23 @@ func (r scanReport) toFindings(scanID, repoID uint, commit, subPath string) []db
 			PriorArt:     f.PriorArt,
 			Reach:        f.Reach,
 			Rating:       f.Rating,
+			References:   toReferences(f.References),
+		})
+	}
+	return out
+}
+
+func toReferences(refs []scanReference) []db.FindingReference {
+	out := make([]db.FindingReference, 0, len(refs))
+	for _, r := range refs {
+		url := strings.TrimSpace(r.URL)
+		if url == "" {
+			continue
+		}
+		out = append(out, db.FindingReference{
+			URL:     url,
+			Summary: strings.TrimSpace(r.Summary),
+			Tags:    strings.TrimSpace(r.Tags),
 		})
 	}
 	return out

--- a/internal/worker/findings_dedup_test.go
+++ b/internal/worker/findings_dedup_test.go
@@ -11,6 +11,61 @@ import (
 	"scrutineer/internal/db"
 )
 
+func TestParseFindingsOutput_referencesCreatedOnNewAndUpsertedOnReobserve(t *testing.T) {
+	gdb, err := db.Open(filepath.Join(t.TempDir(), "p.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo := db.Repository{URL: "https://x/r", Name: "r"}
+	gdb.Create(&repo)
+	w := &Worker{DB: gdb, Log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+
+	scan1 := &db.Scan{RepositoryID: repo.ID, Kind: JobSkill, SkillName: "zizmor", Status: db.ScanDone, Commit: "aaa"}
+	gdb.Create(scan1)
+	report1 := `{"findings":[{
+		"id":"F1","title":"artipacked","severity":"Medium","location":".github/workflows/x.yml:18",
+		"references":[{"url":"https://docs.zizmor.sh/audits/#artipacked","summary":"zizmor docs: artipacked","tags":"docs"}]
+	}]}`
+	if err := w.parseFindingsOutput(&db.Skill{}, scan1, report1, func(Event) {}); err != nil {
+		t.Fatal(err)
+	}
+
+	var refs []db.FindingReference
+	gdb.Find(&refs)
+	if len(refs) != 1 || refs[0].URL != "https://docs.zizmor.sh/audits/#artipacked" || refs[0].Tags != "docs" {
+		t.Fatalf("after first scan: refs = %+v, want one docs reference", refs)
+	}
+
+	// Re-observe the same finding with the same docs reference plus a new one;
+	// only the new URL should be inserted, the existing row is not duplicated.
+	scan2 := &db.Scan{RepositoryID: repo.ID, Kind: JobSkill, SkillName: "zizmor", Status: db.ScanDone, Commit: "bbb"}
+	gdb.Create(scan2)
+	report2 := `{"findings":[{
+		"id":"F1","title":"artipacked","severity":"Medium","location":".github/workflows/x.yml:18",
+		"references":[
+			{"url":"https://docs.zizmor.sh/audits/#artipacked","summary":"zizmor docs: artipacked","tags":"docs"},
+			{"url":"https://example.com/blog/artipacked","summary":"blog","tags":"article"}
+		]
+	}]}`
+	if err := w.parseFindingsOutput(&db.Skill{}, scan2, report2, func(Event) {}); err != nil {
+		t.Fatal(err)
+	}
+
+	gdb.Order("url").Find(&refs)
+	if len(refs) != 2 {
+		t.Fatalf("after re-observe: %d references, want 2 (existing + new)", len(refs))
+	}
+	if refs[0].URL != "https://docs.zizmor.sh/audits/#artipacked" || refs[1].URL != "https://example.com/blog/artipacked" {
+		t.Errorf("references not upserted as expected: %+v", refs)
+	}
+
+	var n int64
+	gdb.Model(&db.Finding{}).Count(&n)
+	if n != 1 {
+		t.Errorf("expected dedup: 1 finding row, got %d", n)
+	}
+}
+
 func TestParseFindingsOutput_minConfidenceDropsBelowThreshold(t *testing.T) {
 	gdb, err := db.Open(filepath.Join(t.TempDir(), "p.db"))
 	if err != nil {

--- a/internal/worker/findings_test.go
+++ b/internal/worker/findings_test.go
@@ -31,6 +31,38 @@ func TestToFindings_carriesReachabilityAndQualityTier(t *testing.T) {
 	}
 }
 
+func TestToFindings_carriesReferences(t *testing.T) {
+	raw := []byte(`{
+	  "findings": [{
+	    "id": "F1", "title": "artipacked", "severity": "Medium",
+	    "location": ".github/workflows/x.yml:18",
+	    "references": [
+	      {"url": "https://docs.zizmor.sh/audits/#artipacked", "summary": "zizmor docs: artipacked", "tags": "docs"},
+	      {"url": "  ", "summary": "blank"},
+	      {"url": "https://example.com/  ", "summary": " trimmed "}
+	    ]
+	  }]
+	}`)
+	rep, err := parseReport(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := rep.toFindings(1, 1, "abc", "")
+	if len(got) != 1 {
+		t.Fatalf("got %d findings, want 1", len(got))
+	}
+	refs := got[0].References
+	if len(refs) != 2 {
+		t.Fatalf("references = %d, want 2 (blank URL dropped)", len(refs))
+	}
+	if refs[0].URL != "https://docs.zizmor.sh/audits/#artipacked" || refs[0].Tags != "docs" {
+		t.Errorf("first reference = %+v", refs[0])
+	}
+	if refs[1].URL != "https://example.com/" || refs[1].Summary != "trimmed" {
+		t.Errorf("second reference whitespace not trimmed: %+v", refs[1])
+	}
+}
+
 func TestParseReport_toleratesNonStringTopLevelFields(t *testing.T) {
 	// #172: models sometimes copy context.json's repository object (and invent
 	// an artefact object) into report.json. Only findings[] is consumed, so

--- a/internal/worker/skill.go
+++ b/internal/worker/skill.go
@@ -297,6 +297,9 @@ func (w *Worker) parseFindingsOutput(skill *db.Skill, scan *db.Scan, report stri
 			}).Error; uerr != nil {
 				return fmt.Errorf("update finding %d: %w", existing.ID, uerr)
 			}
+			if rerr := w.upsertFindingReferences(existing.ID, f.References); rerr != nil {
+				w.Log.Warn("upsert finding references", "finding", existing.ID, "scan", scan.ID, "err", rerr)
+			}
 			if herr := w.DB.Create(&db.FindingHistory{
 				FindingID: existing.ID,
 				Field:     "observed",
@@ -322,6 +325,34 @@ func (w *Worker) parseFindingsOutput(skill *db.Skill, scan *db.Scan, report stri
 
 	if db.SeverityAtLeast(worst, skill.FailOn) {
 		return &FailOnThresholdError{Worst: worst, Threshold: skill.FailOn}
+	}
+	return nil
+}
+
+// upsertFindingReferences inserts any reference URLs not already on the
+// finding. Used in the dedup branch so a re-observed finding picks up new
+// or migration-added references without duplicating ones already present.
+func (w *Worker) upsertFindingReferences(findingID uint, refs []db.FindingReference) error {
+	if len(refs) == 0 {
+		return nil
+	}
+	var existingURLs []string
+	if err := w.DB.Model(&db.FindingReference{}).
+		Where("finding_id = ?", findingID).
+		Pluck("url", &existingURLs).Error; err != nil {
+		return err
+	}
+	have := make(map[string]bool, len(existingURLs))
+	for _, u := range existingURLs {
+		have[u] = true
+	}
+	for _, r := range refs {
+		if have[r.URL] {
+			continue
+		}
+		if _, err := db.AddFindingReference(w.DB, findingID, r.URL, r.Tags, r.Summary); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/skills/zizmor/schema.json
+++ b/skills/zizmor/schema.json
@@ -19,7 +19,19 @@
           "location": { "type": "string" },
           "locations": { "type": "array", "items": { "type": "string" } },
           "trace":    { "type": "string" },
-          "rating":   { "type": "string" }
+          "rating":   { "type": "string" },
+          "references": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["url"],
+              "properties": {
+                "url":     { "type": "string", "format": "uri" },
+                "summary": { "type": "string" },
+                "tags":    { "type": "string" }
+              }
+            }
+          }
         }
       }
     }

--- a/skills/zizmor/scripts/scan.py
+++ b/skills/zizmor/scripts/scan.py
@@ -74,6 +74,11 @@ def main():
             "locations": locations,
             "trace": desc,
             "rating": f"{severity} from zizmor rule {ident}{suffix}",
+            "references": [{
+                "url": f"https://docs.zizmor.sh/audits/#{ident}",
+                "summary": f"zizmor docs: {ident}",
+                "tags": "docs",
+            }],
         })
 
     print(json.dumps({"findings": findings}))


### PR DESCRIPTION
Skills can now include a `references` array per finding (`{url, summary, tags}`); the parser materialises each entry as a `FindingReference` row so they appear in the References sidebar on the finding page.

zizmor populates this with the rule's docs URL (`https://docs.zizmor.sh/audits/#<ident>`) so analysts have a one-click jump to the audit's documentation instead of guessing from the rule name.

The dedup branch upserts references — a re-observed finding picks up any URLs not already attached, without duplicating ones already present.

Closes #314