### PR TITLE
worker: mirror skill scripts to workspace root

### DIFF
--- a/docs/skills.md
+++ b/docs/skills.md
@@ -152,6 +152,7 @@ When a scan starts, the worker creates `./data/work/scan-{id}/` with:
     ./context.json               who you are scanning and how to call scrutineer back
     ./.claude/skills/{name}/     this skill's SKILL.md, schema.json, and any aux files
     ./schema.json                copy of the skill's schema for the model to read
+    ./scripts/                   copy of the skill's scripts/, so `bash scripts/foo.sh` resolves from cwd
     ./report.json                the skill writes its output here
 
 `./src/` is copied from a per-URL persistent clone under `./data/work/repo-cache/<sha256(url)>/src/` so the second scan of the same repository only fetches the delta. The cache is always full-history; the code browser at `/repositories/{id}/blob/{commit}/{path}` resolves historical commits against it via `git show`.

--- a/internal/worker/skill.go
+++ b/internal/worker/skill.go
@@ -939,6 +939,13 @@ func copyAux(src, dst string) error {
 		if info.IsDir() {
 			return os.MkdirAll(target, dirPerm)
 		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			link, err := os.Readlink(path)
+			if err != nil {
+				return err
+			}
+			return os.Symlink(link, target)
+		}
 		b, err := os.ReadFile(path)
 		if err != nil {
 			return err

--- a/internal/worker/skill.go
+++ b/internal/worker/skill.go
@@ -531,7 +531,7 @@ func mergeLocations(base string, more ...string) string {
 	seen := map[string]bool{}
 	var out []string
 	add := func(s string) {
-		for _, e := range strings.Split(s, "\n") {
+		for e := range strings.SplitSeq(s, "\n") {
 			e = strings.TrimSpace(e)
 			if e == "" || seen[e] {
 				continue

--- a/internal/worker/skill.go
+++ b/internal/worker/skill.go
@@ -919,37 +919,24 @@ func stageContext(workRoot, apiBase, forkOrg, metadataDir string, scan *db.Scan,
 	return os.WriteFile(filepath.Join(workRoot, "context.json"), b, filePerm)
 }
 
-// copyAux walks src looking for any files other than SKILL.md and schema.json
-// (which are staged from the DB row) and copies them into dst at the same
-// relative path. This preserves scripts/ and references/ for skills that
-// bundle them.
+// copyAux copies every top-level entry in src other than SKILL.md and
+// schema.json (which are staged from the DB row) into dst, recursively.
+// Delegates to copyTree so symlink and permission handling lives in one
+// place; this preserves scripts/ and references/ for skills that bundle
+// them.
 func copyAux(src, dst string) error {
-	return filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
-		if err != nil {
+	entries, err := os.ReadDir(src)
+	if err != nil {
+		return err
+	}
+	for _, e := range entries {
+		name := e.Name()
+		if name == "SKILL.md" || name == "schema.json" {
+			continue
+		}
+		if err := copyTree(filepath.Join(src, name), filepath.Join(dst, name)); err != nil {
 			return err
 		}
-		rel, err := filepath.Rel(src, path)
-		if err != nil {
-			return err
-		}
-		if rel == "." || rel == "SKILL.md" || rel == "schema.json" {
-			return nil
-		}
-		target := filepath.Join(dst, rel)
-		if info.IsDir() {
-			return os.MkdirAll(target, dirPerm)
-		}
-		if info.Mode()&os.ModeSymlink != 0 {
-			link, err := os.Readlink(path)
-			if err != nil {
-				return err
-			}
-			return os.Symlink(link, target)
-		}
-		b, err := os.ReadFile(path)
-		if err != nil {
-			return err
-		}
-		return os.WriteFile(target, b, info.Mode())
-	})
+	}
+	return nil
 }

--- a/internal/worker/skill.go
+++ b/internal/worker/skill.go
@@ -792,7 +792,8 @@ func stageSkill(skill *db.Skill, workRoot, dst string) error {
 // workRoot/scripts/ so the `bash scripts/foo.sh` / `python3 scripts/foo.py`
 // instructions every SKILL.md uses resolve from the workspace root on the
 // first try, without the model having to glob for them. Same pattern as
-// schema.json (#221).
+// schema.json (#221). The destination is cleared first so a retry after a
+// skill edit doesn't run a mix of old and new scripts.
 func mirrorScripts(src, workRoot string) error {
 	srcScripts := filepath.Join(src, "scripts")
 	info, err := os.Stat(srcScripts)
@@ -805,28 +806,11 @@ func mirrorScripts(src, workRoot string) error {
 	if !info.IsDir() {
 		return nil
 	}
-	return copyDir(srcScripts, filepath.Join(workRoot, "scripts"))
-}
-
-func copyDir(src, dst string) error {
-	return filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-		rel, err := filepath.Rel(src, path)
-		if err != nil {
-			return err
-		}
-		target := filepath.Join(dst, rel)
-		if info.IsDir() {
-			return os.MkdirAll(target, dirPerm)
-		}
-		b, err := os.ReadFile(path)
-		if err != nil {
-			return err
-		}
-		return os.WriteFile(target, b, info.Mode())
-	})
+	dst := filepath.Join(workRoot, "scripts")
+	if err := os.RemoveAll(dst); err != nil {
+		return err
+	}
+	return copyTree(srcScripts, dst)
 }
 
 // renderSkillMD rebuilds a SKILL.md from the stored fields. The frontmatter

--- a/internal/worker/skill.go
+++ b/internal/worker/skill.go
@@ -781,8 +781,52 @@ func stageSkill(skill *db.Skill, workRoot, dst string) error {
 		if err := copyAux(skill.SourcePath, dst); err != nil {
 			return fmt.Errorf("copy aux files: %w", err)
 		}
+		if err := mirrorScripts(skill.SourcePath, workRoot); err != nil {
+			return fmt.Errorf("mirror scripts: %w", err)
+		}
 	}
 	return nil
+}
+
+// mirrorScripts copies the skill's scripts/ directory (if any) to
+// workRoot/scripts/ so the `bash scripts/foo.sh` / `python3 scripts/foo.py`
+// instructions every SKILL.md uses resolve from the workspace root on the
+// first try, without the model having to glob for them. Same pattern as
+// schema.json (#221).
+func mirrorScripts(src, workRoot string) error {
+	srcScripts := filepath.Join(src, "scripts")
+	info, err := os.Stat(srcScripts)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if !info.IsDir() {
+		return nil
+	}
+	return copyDir(srcScripts, filepath.Join(workRoot, "scripts"))
+}
+
+func copyDir(src, dst string) error {
+	return filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(dst, rel)
+		if info.IsDir() {
+			return os.MkdirAll(target, dirPerm)
+		}
+		b, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		return os.WriteFile(target, b, info.Mode())
+	})
 }
 
 // renderSkillMD rebuilds a SKILL.md from the stored fields. The frontmatter

--- a/internal/worker/skill_test.go
+++ b/internal/worker/skill_test.go
@@ -420,6 +420,12 @@ func TestStageSkill_remirrorClearsStaleScripts(t *testing.T) {
 	if _, err := os.Lstat(filepath.Join(work, "scripts", "dangling")); err != nil {
 		t.Errorf("dangling symlink should be recreated, not dropped or fatal: %v", err)
 	}
+	// copyAux stages the same scripts/ into .claude/skills/{name}/ before
+	// mirrorScripts runs; it must also recreate the dangling link rather
+	// than choke on it.
+	if _, err := os.Lstat(filepath.Join(work, ".claude", "skills", "s", "scripts", "dangling")); err != nil {
+		t.Errorf("copyAux dropped dangling symlink under .claude/skills: %v", err)
+	}
 }
 
 func TestStageSkill_noScriptsDirIsNoop(t *testing.T) {

--- a/internal/worker/skill_test.go
+++ b/internal/worker/skill_test.go
@@ -337,6 +337,63 @@ func TestStageSkill_writesMarkdownAndSchema(t *testing.T) {
 	}
 }
 
+func TestStageSkill_mirrorsScriptsToWorkRoot(t *testing.T) {
+	// On-disk skill with a scripts/ dir: stageSkill should copy it to the
+	// workspace root so `bash scripts/...` resolves from cwd, not from
+	// .claude/skills/{name}/scripts/.
+	src := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(src, "scripts"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "scripts", "run.sh"), []byte("#!/bin/sh\necho hi\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "scripts", "helper.py"), []byte("print('x')\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "SKILL.md"), []byte("# placeholder\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	work := t.TempDir()
+	skill := &db.Skill{Name: "s", Description: "d", Body: "body", SourcePath: src, Source: "disk"}
+	if err := stageSkill(skill, work, filepath.Join(work, ".claude", "skills", "s")); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, rel := range []string{"scripts/run.sh", "scripts/helper.py"} {
+		if _, err := os.Stat(filepath.Join(work, rel)); err != nil {
+			t.Errorf("expected %s at work root: %v", rel, err)
+		}
+	}
+	// File mode of executable scripts should be preserved so `bash` /
+	// direct invocation works.
+	info, err := os.Stat(filepath.Join(work, "scripts", "run.sh"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm()&0o100 == 0 {
+		t.Errorf("run.sh executable bit lost: %v", info.Mode())
+	}
+}
+
+func TestStageSkill_noScriptsDirIsNoop(t *testing.T) {
+	// A skill without scripts/ on disk must not error out and must not
+	// leave a stray empty scripts/ at work root.
+	src := t.TempDir()
+	if err := os.WriteFile(filepath.Join(src, "SKILL.md"), []byte("# placeholder\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	work := t.TempDir()
+	skill := &db.Skill{Name: "s", Description: "d", Body: "body", SourcePath: src, Source: "disk"}
+	if err := stageSkill(skill, work, filepath.Join(work, ".claude", "skills", "s")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(work, "scripts")); !os.IsNotExist(err) {
+		t.Errorf("expected no scripts/ dir at work root, got err=%v", err)
+	}
+}
+
 func TestStageContext_includesRef(t *testing.T) {
 	dir := t.TempDir()
 	repo := &db.Repository{URL: "https://example.com/x", Name: "x"}

--- a/internal/worker/skill_test.go
+++ b/internal/worker/skill_test.go
@@ -377,6 +377,51 @@ func TestStageSkill_mirrorsScriptsToWorkRoot(t *testing.T) {
 	}
 }
 
+func TestStageSkill_remirrorClearsStaleScripts(t *testing.T) {
+	// A retry restages into the same workspace. After the skill's scripts/
+	// changed on disk, the mirror must not leave a removed script behind,
+	// and a dangling symlink in scripts/ must not abort staging.
+	src := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(src, "scripts"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "SKILL.md"), []byte("# placeholder\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "scripts", "old.sh"), []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	work := t.TempDir()
+	skill := &db.Skill{Name: "s", Description: "d", Body: "body", SourcePath: src, Source: "disk"}
+	if err := stageSkill(skill, work, filepath.Join(work, ".claude", "skills", "s")); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.Remove(filepath.Join(src, "scripts", "old.sh")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "scripts", "new.sh"), []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("does-not-exist", filepath.Join(src, "scripts", "dangling")); err != nil {
+		t.Fatal(err)
+	}
+	if err := stageSkill(skill, work, filepath.Join(work, ".claude", "skills", "s")); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := os.Stat(filepath.Join(work, "scripts", "old.sh")); !os.IsNotExist(err) {
+		t.Errorf("stale old.sh survived remirror, err=%v", err)
+	}
+	if _, err := os.Stat(filepath.Join(work, "scripts", "new.sh")); err != nil {
+		t.Errorf("new.sh not mirrored: %v", err)
+	}
+	if _, err := os.Lstat(filepath.Join(work, "scripts", "dangling")); err != nil {
+		t.Errorf("dangling symlink should be recreated, not dropped or fatal: %v", err)
+	}
+}
+
 func TestStageSkill_noScriptsDirIsNoop(t *testing.T) {
 	// A skill without scripts/ on disk must not error out and must not
 	// leave a stray empty scripts/ at work root.


### PR DESCRIPTION
`stageSkill` already copies `scripts/` into `.claude/skills/{name}/scripts/`, but every SKILL.md (sbom, dependencies, semgrep, zizmor) tells Claude to run them as `bash scripts/foo.sh` from cwd, which is workRoot. The script isn't there, so Claude has to glob to find it — same failure mode #221 hit with `schema.json`.

Mirror `scripts/` to `workRoot/scripts/` on stage so the relative paths in SKILL.md resolve on the first try, and the executable bit is preserved so the scripts stay invocable.

Closes #305