### PR TITLE
worker: include rendered SKILL.md in scan.Prompt

### DIFF
--- a/internal/worker/claude.go
+++ b/internal/worker/claude.go
@@ -305,6 +305,15 @@ func buildSkillPrompt(name, outputFile string) string {
 	return p
 }
 
+// buildLoggedPrompt is what scrutineer records on scan.Prompt for the UI. It
+// pairs the activation invocation with the rendered SKILL.md so the Prompt
+// tab shows the actual instructions Claude executed (#308), not just the
+// "use the X skill" wrapper.
+func buildLoggedPrompt(skill *db.Skill) string {
+	return buildSkillPrompt(skill.Name, skill.OutputFile) +
+		"\n\n--- SKILL.md ---\n\n" + renderSkillMD(skill)
+}
+
 // buildResumePrompt is the nudge handed to a `--resume`d run. The prior
 // turns are already in context, so this just tells the agent to carry on and
 // restates the deliverable — the report file is the whole point of the run,

--- a/internal/worker/claude_test.go
+++ b/internal/worker/claude_test.go
@@ -7,7 +7,31 @@ import (
 	"slices"
 	"strings"
 	"testing"
+
+	"scrutineer/internal/db"
 )
+
+func TestBuildLoggedPrompt_includesActivationAndRenderedSkill(t *testing.T) {
+	skill := &db.Skill{
+		Name:        "metadata",
+		Description: "Identify the repository.",
+		Body:        "## Workspace\n\n- `./src` — the cloned repo.",
+		OutputFile:  "report.json",
+	}
+	got := buildLoggedPrompt(skill)
+	for _, want := range []string{
+		buildSkillPrompt("metadata", "report.json"),
+		"--- SKILL.md ---",
+		"name: metadata",
+		"description: Identify the repository.",
+		"## Workspace",
+		"./src",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("logged prompt missing %q\nfull prompt:\n%s", want, got)
+		}
+	}
+}
 
 func TestLocalClaude_RunSkill_rejectsProfileRequiringSkill(t *testing.T) {
 	work := t.TempDir()

--- a/internal/worker/exposure.go
+++ b/internal/worker/exposure.go
@@ -171,7 +171,7 @@ func (w *Worker) doExposure(ctx context.Context, scan *db.Scan, emit func(Event)
 	}
 
 	depRepo := db.Repository{URL: dep.RepositoryURL, Name: dep.Name}
-	prompt := buildSkillPrompt(skill.Name, skill.OutputFile)
+	prompt := buildLoggedPrompt(&skill)
 	scan.Prompt = prompt
 	w.DB.Model(scan).Update("prompt", prompt)
 

--- a/internal/worker/skill.go
+++ b/internal/worker/skill.go
@@ -128,7 +128,7 @@ func (w *Worker) doSkill(ctx context.Context, scan *db.Scan, emit func(Event)) (
 		return "", fmt.Errorf("stage skill: %w", err)
 	}
 
-	prompt := buildSkillPrompt(skill.Name, skill.OutputFile)
+	prompt := buildLoggedPrompt(&skill)
 	scan.Prompt = prompt
 	w.DB.Model(scan).Update("prompt", prompt)
 

--- a/internal/worker/skill_test.go
+++ b/internal/worker/skill_test.go
@@ -81,6 +81,9 @@ func TestDoSkill_findingsKind(t *testing.T) {
 	if !strings.Contains(got.Prompt, "spec-deep") || !strings.Contains(got.Prompt, "report.json") {
 		t.Errorf("prompt missing skill name or output file: %q", got.Prompt)
 	}
+	if !strings.Contains(got.Prompt, "--- SKILL.md ---") || !strings.Contains(got.Prompt, "Do the thing.") {
+		t.Errorf("prompt missing rendered SKILL.md body: %q", got.Prompt)
+	}
 }
 
 func TestDoSkill_maintainersKind(t *testing.T) {


### PR DESCRIPTION
The Prompt tab on a scan only showed the short activation wrapper ("Use the X skill on ./src..."). The actual instructions live in the SKILL.md the skill loads, which the UI never surfaced — operators had to dig into the skills page or the source tree to see what Claude actually ran.

Append the rendered SKILL.md to `scan.Prompt` at scan time so the Prompt tab shows both the wrapper and the body that was active for this run.

Closes #308