### PR TITLE
Add finding deduplication skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ When a repo is added, the `triage` skill is enqueued. Its SKILL.md lists the ski
 | `semgrep` | Static analysis mapped into findings shape |
 | `zizmor` | GitHub Actions workflow audit mapped into findings shape |
 | `security-deep-dive` | The model-backed audit producing structured findings |
+| `finding-dedup` | Compares open findings and marks overlapping reports as duplicates |
 | `verify` | Re-checks one finding against current HEAD; records reproduces / fixed / can't-reproduce |
 | `disclose` | Drafts a GHSA-shaped advisory (title, description, CVSS, CWEs, references) for one finding |
 | `patch` | Proposes a unified diff fixing one finding, written back as a note for analyst review |

--- a/docs/database.md
+++ b/docs/database.md
@@ -91,7 +91,7 @@ One row per installed skill. Loaded from `skills/` directories on disk or the UI
 | body | text | Markdown body after the frontmatter. The prompt. |
 | schema_json | text | Optional schema.json contents. |
 | output_file | text | Relative path the skill writes to. Promoted from metadata. |
-| output_kind | text | Parser key: `findings`, `maintainers`, `packages`, `advisories`, `dependents`, `dependencies`, `repo_metadata`, `repo_overview`, `subprojects`, `posture`, `verify`, `patch`, `threat_model`, `exposure`, `freeform`. Promoted from metadata. |
+| output_kind | text | Parser key: `findings`, `maintainers`, `packages`, `advisories`, `dependents`, `dependencies`, `finding_dedup`, `repo_metadata`, `repo_overview`, `subprojects`, `posture`, `verify`, `patch`, `threat_model`, `exposure`, `freeform`. Promoted from metadata. |
 | version | integer | Bumps on every save. |
 | active | boolean | |
 | requires_remote | boolean | When true, scrutineer refuses to enqueue this skill against a local-directory repository (file:// URL). Set via `scrutineer.requires_remote: true` in SKILL.md frontmatter. Use for skills that depend on a forge URL or remote-only data (advisories, dependents, exposure, fork, maintainers, metadata, packages, report-upstream). |

--- a/docs/development.md
+++ b/docs/development.md
@@ -17,7 +17,7 @@
 | `internal/worker/docker.go` | DockerRunner (ephemeral container per scan) |
 | `internal/worker/clone.go` | git clone/fetch helpers, URL validation |
 | `internal/worker/skill.go` | doSkill: stage skill + context, invoke claude, dispatch output to the right parser |
-| `internal/worker/skill_parsers.go` | one parser per output_kind: findings, maintainers, packages, advisories, dependents, dependencies, repo_metadata, verify |
+| `internal/worker/skill_parsers.go` | one parser per output_kind: findings, maintainers, packages, advisories, dependents, dependencies, finding_dedup, repo_metadata, verify |
 | `internal/worker/stream.go` | claude stream-json line parser |
 | `internal/worker/findings.go` | structured report parser used by `output_kind=findings` |
 | `internal/worker/metadata.go` | FetchPackagesByPURL helper used by the web import button |

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -26,6 +26,7 @@ These ship in `skills/` and are loaded with `-skills ./skills`. The `triage` ski
 | `zizmor` | Audits GitHub Actions workflows and maps hits into the findings shape. |
 | `threat-model` | Derives the project's security contract from source and docs: components, entry-point trust table, claimed and disclaimed properties, and disposition labels. Loaded by `security-deep-dive` so it does not re-derive boundaries per run. |
 | `security-deep-dive` | The model-driven audit. Inventories trust boundaries and sinks, then runs a six-step trace/boundary/validate/prior-art/reach/rate analysis on each. |
+| `finding-dedup` | Compares open findings in one repository and marks findings that describe the same underlying vulnerability as duplicates. |
 | `reachability` | Traces sinks already found in this app's dependencies through the app's own code to see which are reachable from its trust boundaries. |
 | `exposure` | For one (finding, dependent) pair, decides whether the dependent's published code actually reaches the upstream library finding. Emits one CSAF 2.0 product_status verdict so scrutineer can record affected vs not_affected and stamp the right VEX justification. |
 | `verify` | Re-checks one finding against current HEAD and records reproduces / fixed / cannot-reproduce. |
@@ -124,6 +125,7 @@ Declaring `scrutineer.paths` replaces this skip list entirely: the skill sees on
 | `advisories` | Advisory rows. |
 | `dependents` | Dependent rows. |
 | `dependencies` | Dependency rows. |
+| `finding_dedup` | Duplicate decisions applied to existing Finding rows through status history and notes. |
 | `maintainers` | Maintainer rows. |
 | `subprojects` | Subproject rows for monorepo scoping. |
 | `posture` | Posture tier and check results on the Repository row. |

--- a/internal/skills/parse.go
+++ b/internal/skills/parse.go
@@ -87,6 +87,7 @@ var OutputKinds = map[string]bool{
 	"advisories":    true,
 	"dependents":    true,
 	"dependencies":  true,
+	"finding_dedup": true,
 	"verify":        true,
 	"subprojects":   true,
 	"repo_overview": true,

--- a/internal/web/templates/skill_form.html
+++ b/internal/web/templates/skill_form.html
@@ -37,7 +37,7 @@
       <label for="output_kind">Output kind</label>
       <input id="output_kind" class="input" type="text" name="output_kind"
              value="{{.OutputKind}}" placeholder="findings / freeform">
-      <p class="text-xs text-muted-foreground">Parser key. Currently: findings, freeform.</p>
+      <p class="text-xs text-muted-foreground">Parser key such as findings, verify, patch, finding_dedup, or freeform.</p>
     </div>
   </div>
 

--- a/internal/worker/skill.go
+++ b/internal/worker/skill.go
@@ -209,6 +209,8 @@ func (w *Worker) parseSkillOutput(skill *db.Skill, scan *db.Scan, report string,
 		return w.parseDependentsOutput(scan, report, emit)
 	case "dependencies":
 		return w.parseDependenciesOutput(scan, report, emit)
+	case "finding_dedup":
+		return w.parseFindingDedupOutput(scan, report, emit)
 	case "verify":
 		return w.parseVerifyOutput(scan, report, emit)
 	case "subprojects":

--- a/internal/worker/skill_parsers.go
+++ b/internal/worker/skill_parsers.go
@@ -11,6 +11,8 @@ import (
 
 const insertBatchSize = 50
 
+const findingDedupSkill = "finding-dedup"
+
 // parseRepoMetadataOutput updates the Repository columns that previously
 // came from the metadata Go handler. Shape matches the subset of
 // repos.ecosyste.ms fields scrutineer actually uses; the skill picks them
@@ -464,6 +466,88 @@ func (w *Worker) parseVerifyOutput(scan *db.Scan, report string, emit func(Event
 	}
 
 	emit(Event{Kind: KindText, Text: "finding " + fmt.Sprint(f.ID) + " -> " + result.Status})
+	return nil
+}
+
+func (w *Worker) parseFindingDedupOutput(scan *db.Scan, report string, emit func(Event)) error {
+	var result struct {
+		Duplicates []struct {
+			CanonicalID  uint   `json:"canonical_id"`
+			DuplicateIDs []uint `json:"duplicate_ids"`
+			Reason       string `json:"reason"`
+		} `json:"duplicates"`
+	}
+	if err := json.Unmarshal([]byte(report), &result); err != nil {
+		return fmt.Errorf("parse finding_dedup report: %w", err)
+	}
+	if len(result.Duplicates) == 0 {
+		emit(Event{Kind: KindText, Text: "finding-dedup: no duplicates reported"})
+		return nil
+	}
+
+	marked, skipped := 0, 0
+	for _, group := range result.Duplicates {
+		canonical, ok := w.dedupFinding(scan.RepositoryID, group.CanonicalID)
+		if !ok || !dedupCandidateOpen(canonical.Status) {
+			skipped += len(group.DuplicateIDs)
+			continue
+		}
+		for _, duplicateID := range group.DuplicateIDs {
+			if duplicateID == 0 || duplicateID == canonical.ID {
+				skipped++
+				continue
+			}
+			duplicate, ok := w.dedupFinding(scan.RepositoryID, duplicateID)
+			if !ok || !dedupCandidateOpen(duplicate.Status) {
+				skipped++
+				continue
+			}
+			if err := db.WriteFindingField(w.DB, duplicate.ID, "status", string(db.FindingDuplicate), db.SourceModel, findingDedupSkill); err != nil {
+				return fmt.Errorf("mark finding %d duplicate: %w", duplicate.ID, err)
+			}
+			if err := w.addDedupNote(duplicate.ID, canonical.ID, group.Reason); err != nil {
+				return err
+			}
+			marked++
+		}
+	}
+
+	emit(Event{Kind: KindText, Text: fmt.Sprintf("finding-dedup: marked %d duplicate(s), skipped %d", marked, skipped)})
+	return nil
+}
+
+func (w *Worker) dedupFinding(repoID, findingID uint) (db.Finding, bool) {
+	if findingID == 0 {
+		return db.Finding{}, false
+	}
+	var f db.Finding
+	if err := w.DB.First(&f, findingID).Error; err != nil {
+		return db.Finding{}, false
+	}
+	if f.RepositoryID != repoID {
+		return db.Finding{}, false
+	}
+	return f, true
+}
+
+func dedupCandidateOpen(status db.FindingLifecycle) bool {
+	switch status {
+	case db.FindingNew, db.FindingEnriched, db.FindingTriaged, db.FindingReady, db.FindingReported, db.FindingAcknowledged:
+		return true
+	default:
+		return false
+	}
+}
+
+func (w *Worker) addDedupNote(duplicateID, canonicalID uint, reason string) error {
+	var b strings.Builder
+	fmt.Fprintf(&b, "finding-dedup: duplicates finding #%d", canonicalID)
+	if strings.TrimSpace(reason) != "" {
+		fmt.Fprintf(&b, "\n\n%s", strings.TrimSpace(reason))
+	}
+	if _, err := db.AddFindingNote(w.DB, duplicateID, b.String(), findingDedupSkill); err != nil {
+		return fmt.Errorf("record dedup note for finding %d: %w", duplicateID, err)
+	}
 	return nil
 }
 

--- a/internal/worker/skill_parsers_test.go
+++ b/internal/worker/skill_parsers_test.go
@@ -307,6 +307,79 @@ func TestParseVerify_inconclusiveLeavesStatus(t *testing.T) {
 	}
 }
 
+func TestParseFindingDedup_marksDuplicatesWithHistoryAndNote(t *testing.T) {
+	gdb, err := db.Open(filepath.Join(t.TempDir(), "dedup.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo := db.Repository{URL: "https://example.com/x", Name: "x"}
+	gdb.Create(&repo)
+	scan := db.Scan{RepositoryID: repo.ID, Kind: JobSkill, Status: db.ScanDone, SkillName: "finding-dedup"}
+	gdb.Create(&scan)
+	canonical := db.Finding{ScanID: scan.ID, RepositoryID: repo.ID, FindingID: "F1", Title: "canonical", Severity: "High", Status: db.FindingTriaged}
+	duplicate := db.Finding{ScanID: scan.ID, RepositoryID: repo.ID, FindingID: "F2", Title: "duplicate", Severity: "High", Status: db.FindingNew}
+	gdb.Create(&canonical)
+	gdb.Create(&duplicate)
+
+	w := &Worker{DB: gdb, Log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	report := `{"duplicates":[{"canonical_id":` + strconv.Itoa(int(canonical.ID)) + `,"duplicate_ids":[` + strconv.Itoa(int(duplicate.ID)) + `],"reason":"same sink and dataflow; only the line range differs"}]}`
+	if err := w.parseFindingDedupOutput(&scan, report, func(Event) {}); err != nil {
+		t.Fatal(err)
+	}
+
+	var refreshed db.Finding
+	gdb.First(&refreshed, duplicate.ID)
+	if refreshed.Status != db.FindingDuplicate {
+		t.Fatalf("status = %s, want duplicate", refreshed.Status)
+	}
+	var hist db.FindingHistory
+	if err := gdb.Where("finding_id = ? AND field = ?", duplicate.ID, "status").First(&hist).Error; err != nil {
+		t.Fatalf("missing status history: %v", err)
+	}
+	if hist.By != findingDedupSkill || hist.NewValue != string(db.FindingDuplicate) {
+		t.Fatalf("history = %+v", hist)
+	}
+	notes := findingNotes(gdb, duplicate.ID)
+	if len(notes) == 0 || !strings.Contains(notes[0].Body, "duplicates finding #") {
+		t.Fatalf("missing dedup note: %+v", notes)
+	}
+}
+
+func TestParseFindingDedup_skipsClosedAndCrossRepoFindings(t *testing.T) {
+	gdb, err := db.Open(filepath.Join(t.TempDir(), "dedup-skip.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo := db.Repository{URL: "https://example.com/x", Name: "x"}
+	otherRepo := db.Repository{URL: "https://example.com/y", Name: "y"}
+	gdb.Create(&repo)
+	gdb.Create(&otherRepo)
+	scan := db.Scan{RepositoryID: repo.ID, Kind: JobSkill, Status: db.ScanDone, SkillName: "finding-dedup"}
+	gdb.Create(&scan)
+	canonical := db.Finding{ScanID: scan.ID, RepositoryID: repo.ID, FindingID: "F1", Title: "canonical", Severity: "High", Status: db.FindingTriaged}
+	closed := db.Finding{ScanID: scan.ID, RepositoryID: repo.ID, FindingID: "F2", Title: "closed", Severity: "High", Status: db.FindingFixed}
+	crossRepo := db.Finding{ScanID: scan.ID, RepositoryID: otherRepo.ID, FindingID: "F3", Title: "cross", Severity: "High", Status: db.FindingNew}
+	gdb.Create(&canonical)
+	gdb.Create(&closed)
+	gdb.Create(&crossRepo)
+
+	w := &Worker{DB: gdb, Log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	report := `{"duplicates":[{"canonical_id":` + strconv.Itoa(int(canonical.ID)) + `,"duplicate_ids":[` + strconv.Itoa(int(closed.ID)) + `,` + strconv.Itoa(int(crossRepo.ID)) + `],"reason":"same issue"}]}`
+	if err := w.parseFindingDedupOutput(&scan, report, func(Event) {}); err != nil {
+		t.Fatal(err)
+	}
+
+	var gotClosed, gotCross db.Finding
+	gdb.First(&gotClosed, closed.ID)
+	gdb.First(&gotCross, crossRepo.ID)
+	if gotClosed.Status != db.FindingFixed {
+		t.Fatalf("closed finding status changed: %s", gotClosed.Status)
+	}
+	if gotCross.Status != db.FindingNew {
+		t.Fatalf("cross-repo finding status changed: %s", gotCross.Status)
+	}
+}
+
 func TestParseDependencies_acceptsTypeOrDependencyType(t *testing.T) {
 	report := `{"dependencies":[
 		{"name":"a","ecosystem":"npm","type":"runtime","manifest_path":"package.json"},

--- a/skills/finding-dedup/SKILL.md
+++ b/skills/finding-dedup/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: finding-dedup
+description: Compare open findings in one repository and mark findings that describe the same underlying vulnerability as duplicates.
+license: MIT
+compatibility: Needs network access to the scrutineer API (http://host:port/api). Repository-scoped; compares existing finding rows and does not create new findings.
+metadata:
+  scrutineer.version: 1
+  scrutineer.output_file: report.json
+  scrutineer.output_kind: finding_dedup
+---
+
+# finding-dedup
+
+Find duplicate findings that fingerprinting missed because their line ranges, sink lists, or multi-file locations differed. A duplicate is a finding that describes the same root cause, same vulnerable code path, and same security impact as another open finding in this repository.
+
+## Workspace
+
+- `./context.json` - has `scrutineer.api_base`, `scrutineer.token`, and `scrutineer.repository_id`
+- `./src` - repository checkout for spot-checking referenced files when the finding prose is ambiguous
+- `./report.json` - write the deduplication decision here
+- `./schema.json` - output shape
+
+## What to do
+
+1. Read `./context.json`. If the `scrutineer` block is missing, write `{"duplicates":[]}` and exit.
+
+2. Fetch active findings with the bearer token:
+   - `GET {api_base}/repositories/{repository_id}/findings?status=new`
+   - `GET {api_base}/repositories/{repository_id}/findings?status=enriched`
+   - `GET {api_base}/repositories/{repository_id}/findings?status=triaged`
+   - `GET {api_base}/repositories/{repository_id}/findings?status=ready`
+   - `GET {api_base}/repositories/{repository_id}/findings?status=reported`
+   - `GET {api_base}/repositories/{repository_id}/findings?status=acknowledged`
+
+3. For pairs that look similar from title, location, CWE, sink, or prose fields, fetch details with `GET {api_base}/findings/{id}`. Compare:
+   - root cause and vulnerable operation
+   - source-to-sink trace
+   - trust boundary and attacker control
+   - validation or reproduction
+   - affected package/version scope
+   - impact rating
+
+4. Mark a duplicate only when the findings are the same underlying vulnerability. Do not group findings that merely share a CWE, sink type, file, or helper function but have different attacker-controlled inputs, different exploit paths, or different impacts.
+
+5. Choose one canonical finding for each duplicate group. Prefer the lowest database `id` among the open findings unless a later finding has materially better evidence. Never choose a finding with status `fixed`, `published`, `rejected`, or `duplicate` as canonical.
+
+## Output
+
+Write `./report.json`:
+
+```json
+{
+  "duplicates": [
+    {
+      "canonical_id": 123,
+      "duplicate_ids": [124, 125],
+      "reason": "Same vulnerable parser branch and same untrusted field reaches the same allocation without a bounds check; the reports differ only by line range."
+    }
+  ]
+}
+```
+
+Use database `id` values, not per-scan `finding_id` values like `F1`. If there are no duplicates, write `{"duplicates":[]}`.
+
+Scrutineer validates that every id belongs to this repository and only changes open findings. Accepted duplicate findings are moved to lifecycle status `duplicate`, and a note is appended explaining which canonical finding they duplicate.

--- a/skills/finding-dedup/schema.json
+++ b/skills/finding-dedup/schema.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "finding dedup report",
+  "type": "object",
+  "required": ["duplicates"],
+  "additionalProperties": false,
+  "properties": {
+    "duplicates": {
+      "type": "array",
+      "description": "Groups of open findings that describe the same underlying vulnerability.",
+      "items": {
+        "type": "object",
+        "required": ["canonical_id", "duplicate_ids", "reason"],
+        "additionalProperties": false,
+        "properties": {
+          "canonical_id": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Database id of the finding that should remain active."
+          },
+          "duplicate_ids": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true,
+            "items": {
+              "type": "integer",
+              "minimum": 1
+            },
+            "description": "Database ids of open findings to mark duplicate."
+          },
+          "reason": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Why these findings are the same underlying vulnerability."
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
closes #348 
## Summary

Adds a repository-scoped `finding-dedup` skill that compares open findings and marks overlapping reports as duplicates when they describe the same underlying vulnerability.

## Changes

- Add bundled `skills/finding-dedup` skill with JSON schema
- Add new `finding_dedup` output kind and worker parser
- Mark duplicate findings through `db.WriteFindingField` so status history is preserved
- Add a note to duplicate findings pointing to the canonical finding
- Skip invalid, cross-repository, self-referential and closed findings
- Document the new skill and parser kind

## Testing

- `go test ./internal/worker ./internal/skills`
- `go test ./...`
- `git diff --check`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run`