### PR TITLE
Add Rust ecosystem profile and support

### DIFF
--- a/docker/profiles/rust/Dockerfile
+++ b/docker/profiles/rust/Dockerfile
@@ -10,8 +10,8 @@ ARG RUST_STABLE_VERSION=1.96
 ARG RUST_NIGHTLY_VERSION=nightly-2026-06-24
 
 USER root
-RUN apt update \
- && apt install -y --no-install-recommends \
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
         build-essential \
         pkg-config \
         gcc-multilib \

--- a/docker/profiles/rust/Dockerfile
+++ b/docker/profiles/rust/Dockerfile
@@ -14,7 +14,6 @@ RUN apt-get update \
  && apt-get install -y --no-install-recommends \
         build-essential \
         pkg-config \
-        gcc-multilib \
         ca-certificates \
         autoconf \
         automake \
@@ -24,9 +23,13 @@ RUN apt-get update \
         wget \
  && rm -rf /var/lib/apt/lists/*
 
-# Add rust to the container
+# Add rust to the container. MIRI_SYSROOT is pinned so the sysroot built
+# below as root is the one the runner user finds at scan time (the worker
+# runs with HOME=/tmp, which is noexec, so the default ~/.cache/miri
+# location would force a rebuild that then fails to execute).
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
+    MIRI_SYSROOT=/usr/local/miri-sysroot \
     PATH=/usr/local/cargo/bin:$PATH \
     RUSTUP_VERSION=${RUSTUP_VERSION} \
     RUST_STABLE_VERSION=${RUST_STABLE_VERSION} \
@@ -80,10 +83,14 @@ RUN set -eux; \
     cargo --version; \
     rustc --version;
 
-# Install nightly
+# Install the pinned nightly with rust-src (for -Zbuild-std / sanitizers)
+# and miri, then run miri's one-time sysroot build so scans don't pay it.
+# The bare `nightly` channel is deliberately not installed; select this
+# toolchain with `+${RUST_NIGHTLY_VERSION}` (exported via ENV above).
 RUN rustup toolchain install ${RUST_NIGHTLY_VERSION} \
-       --component rust-src
-RUN rustup component add --toolchain nightly-x86_64-unknown-linux-gnu miri \
-       && cargo +nightly miri setup
+        --component rust-src \
+        --component miri \
+ && cargo +${RUST_NIGHTLY_VERSION} miri setup \
+ && chmod -R a+w $RUSTUP_HOME $CARGO_HOME $MIRI_SYSROOT
 
 USER runner

--- a/docker/profiles/rust/Dockerfile
+++ b/docker/profiles/rust/Dockerfile
@@ -1,0 +1,89 @@
+# docker pull ghcr.io/alpha-omega-security/scrutineer-runner:latest && \
+# docker build -t scrutineer-profile-rust:latest docker/profiles/rust
+
+ARG RUNNER_IMAGE=ghcr.io/alpha-omega-security/scrutineer-runner:latest
+
+FROM ${RUNNER_IMAGE}
+
+ARG RUSTUP_VERSION=1.29.0
+ARG RUST_STABLE_VERSION=1.96
+ARG RUST_NIGHTLY_VERSION=nightly-2026-06-24
+
+USER root
+RUN apt update \
+ && apt install -y --no-install-recommends \
+        build-essential \
+        pkg-config \
+        gcc-multilib \
+        ca-certificates \
+        autoconf \
+        automake \
+        libssl-dev \
+        libssh-dev \
+        git \
+        wget \
+ && rm -rf /var/lib/apt/lists/*
+
+# Add rust to the container
+ENV RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    PATH=/usr/local/cargo/bin:$PATH \
+    RUSTUP_VERSION=${RUSTUP_VERSION} \
+    RUST_STABLE_VERSION=${RUST_STABLE_VERSION} \
+    RUST_NIGHTLY_VERSION=${RUST_NIGHTLY_VERSION}
+
+# Install rust
+RUN set -eux; \
+    \
+    arch="$(dpkg --print-architecture)"; \
+    case "$arch" in \
+        'amd64') \
+            rustArch='x86_64-unknown-linux-gnu'; \
+            rustupSha256='4acc9acc76d5079515b46346a485974457b5a79893cfb01112423c89aeb5aa10'; \
+            ;; \
+        'armhf') \
+            rustArch='armv7-unknown-linux-gnueabihf'; \
+            rustupSha256='124e02253af9128f9e27ea1ac929cbb73cf44cf35469d0f594a1b62f7b71fea1'; \
+            ;; \
+        'arm64') \
+            rustArch='aarch64-unknown-linux-gnu'; \
+            rustupSha256='9732d6c5e2a098d3521fca8145d826ae0aaa067ef2385ead08e6feac88fa5792'; \
+            ;; \
+        'i386') \
+            rustArch='i686-unknown-linux-gnu'; \
+            rustupSha256='5140e82096f96d1d8077f00eb312648e0e5106d101c9918d086f72cbc69bb3a1'; \
+            ;; \
+        'ppc64el') \
+            rustArch='powerpc64le-unknown-linux-gnu'; \
+            rustupSha256='4bfff85bd3967d988e14567aa9cc6ab0ea386f0ffeff0f9f14d23f0103bf1f97'; \
+            ;; \
+        's390x') \
+            rustArch='s390x-unknown-linux-gnu'; \
+            rustupSha256='66c2c132428b6b77803facb02cbdf33b89d20c00bd20da142be8cb651f2e7cd8'; \
+            ;; \
+        *) \
+            echo >&2 "unsupported architecture: $arch"; \
+            exit 1; \
+            ;; \
+    esac; \
+    \
+    url="https://static.rust-lang.org/rustup/archive/${RUSTUP_VERSION}/${rustArch}/rustup-init"; \
+    wget --progress=dot:giga "$url"; \
+    echo "${rustupSha256} *rustup-init" | sha256sum -c -; \
+    \
+    chmod +x rustup-init; \
+    ./rustup-init -y --no-modify-path --profile minimal --default-toolchain ${RUST_STABLE_VERSION} --default-host ${rustArch}; \
+    rm rustup-init; \
+    chmod -R a+w $RUSTUP_HOME $CARGO_HOME; \
+    \
+    rustup --version; \
+    cargo --version; \
+    rustc --version;
+
+# Install nightly
+RUN rustup toolchain install ${RUST_NIGHTLY_VERSION} \
+       --component rust-src
+RUN rustup component add --toolchain nightly-x86_64-unknown-linux-gnu miri \
+       && cargo +nightly miri setup
+
+USER runner

--- a/docker/profiles/rust/PROFILE.md
+++ b/docker/profiles/rust/PROFILE.md
@@ -1,0 +1,67 @@
+# Rust scanning container
+
+The repository under `./src` is a Rust project.
+
+## Runtime
+
+- **rustup** - Rust toolchains and  tools are installed using the `rustup` tool. Both the latest stable and nightly are installed.
+- **Rust 1.96** - `cargo` / `rustc` (a pinned rust toolchain installed with `rustup`). 
+- `cargo` - The rust package manager and compiling tool to use. Use this tool for building and running Rust projects.
+- `rustc` - The underlying rust compiler invoked by `cargo`
+- C toolchain (`build-essential`, `pkg-config`) plus the `openssl`/`libssh` dev headers
+- `miri` - an Undefined Behavior detection tool for Rust. It can run binaries and test suites of cargo projects and detect unsafe code that fails to uphold its safety requirements.
+
+## Operating procedure
+
+### Additional Knowledge
+
+- Some rust packages have the `-sys` name extension. This is a standard, and not a rule, but suggests the package imports external
+  C dependecies. You can also identify this if a `build.rs` file exists. In these cases, it means this crate also imports this external
+  C code. Make sure to give special attention to these cases, as they suggest FFI boundaries and sources of undefined behavior both in the
+  third party dependecy and in the Rust usage of it. This means there is a boundary of different safety garuntees which requires 
+  special attention.
+- Rust code specifically has `unsafe` code which ignores Rust safety rules. Please consider both memory-safety vulnerabilities and other
+- standard vulnerabilities in these cases. In pure Rust code, you are focusing more on logic and design vulnerabilities.
+
+### Code scanning preparations
+
+Download a given .crate file and extract it as the source code. Inspect the extracted Cargo.toml file - a project may be a 
+library or a binary, so you need to determine whether you need to use integration tests or directly invoking the binary if 
+performing tests. 
+
+For libraries, you may need to create your own new project with `cargo new`, which utilizes the library. You can also create 
+integration tests for the same purpose. Always prioritize an integration test over a new test project.
+
+For binaries, leverage creating new integration tests for scanning and identification. 
+
+Miri is installed, and should be used to scan and identify for cases of undefined behavior. 
+
+
+### Address Sanitizer Support
+ASAN is available for builds during inspection, and can be instantiated during a build using an environmental variable RUSTFLAGS='-Zsanitizer=<flags>'
+
+To enable a sanitizer compile with `-Zsanitizer=address`, `-Zsanitizer=cfi`, `-Zsanitizer=dataflow`,`-Zsanitizer=hwaddress`,`-Zsanitizer=leak`,`-Zsanitizer=memory`, 
+`-Zsanitizer=memtag`, `-Zsanitizer=realtime`, `-Zsanitizer=shadow-call-stack` or `-Zsanitizer=thread`. You might also need the `--target` and build-std flags. 
+If you’re working with other languages that are also instrumented with sanitizers, you might need the external-clangrt flag. See the section on working with 
+other languages.
+
+You may need to use `build-std` for sanitizer support, which is invoked via `-Z build-std`
+
+### Creating reproducers
+
+Every finding ships with a reproducer — a small piece of code that, when run in this container, actually triggers the
+issue. Paste the exact command you ran and the verbatim output (error message, return value, observable side effect)
+into the finding. Reasoning-only or "this would" reproducers do not count; if you couldn't run it here, say so
+explicitly instead of inventing one.
+
+- Use cargo script when able to create a complete reproduction. This should be a single contained .rs file which can be executed with `cargo poc.rs`
+- Generate a test case which triggers the exploit. This can be done as an integration test in the project. 
+- When the vulnerability is undefined behavior or an unsafe code segment, make sure a test case is generated which miri will identify.
+
+## Scope
+
+You should inspect this source for vulnerabilities that exist directly within its source. Third-party dependencies
+vulnerabilities should be excluded from scanning. However, if you identify known vulnerabilities in dependencies, 
+such as vulnerablilities in imported C libraries in sys crates, please report them as a finding. When a third party
+C dependency is being imported via a `-sys` crate or you identify a `build.rs` building and linking C code, consider 
+the boundary to this code and the dependency as in scope.

--- a/docker/profiles/rust/PROFILE.md
+++ b/docker/profiles/rust/PROFILE.md
@@ -8,15 +8,18 @@ The repository under `./src` is a Rust project, built with Cargo. The job is to 
   both on PATH and writable.
 - **Rust 1.96 (stable)** — the default toolchain. `cargo` drives builds, tests, and runs; `rustc` is the compiler it
   invokes. Use stable for normal building, testing, and reproducing.
-- **Nightly (`nightly-2026-06-24`)** with the `rust-src` component — required for the `-Z` flags that the rest of this
-  profile relies on (sanitizers, `-Zbuild-std`, Miri). Select it per-invocation with `cargo +nightly` / `rustc
-  +nightly`.
-- **Miri** — installed on the nightly toolchain and already initialized (`cargo +nightly miri setup`). It interprets
-  MIR to catch undefined behaviour (out-of-bounds, use-after-free, invalid aliasing, data races, uninitialized reads)
-  that compiles and runs cleanly under a normal build.
-- **C toolchain** — `build-essential` (gcc/g++), `pkg-config`, `autoconf`/`automake`, and `gcc-multilib` for 32-bit
-  (`i686`) targets, plus the `openssl` (`libssl-dev`) and `libssh` (`libssh-dev`) development headers. This is what lets
-  `-sys` crates and `build.rs` scripts compile and link their C/FFI code in-place.
+- **Nightly** with the `rust-src` component — required for the `-Z` flags that the rest of this profile relies on
+  (sanitizers, `-Zbuild-std`, Miri). The pinned toolchain name is exported as `$RUST_NIGHTLY_VERSION`
+  (e.g. `nightly-2026-06-24`); select it per-invocation with `cargo +$RUST_NIGHTLY_VERSION` /
+  `rustc +$RUST_NIGHTLY_VERSION`. The bare `nightly` channel is not installed.
+- **Miri** — installed on the nightly toolchain and already initialized (`cargo +$RUST_NIGHTLY_VERSION miri setup`).
+  It interprets MIR to catch undefined behaviour (out-of-bounds, use-after-free, invalid aliasing, data races,
+  uninitialized reads) that compiles and runs cleanly under a normal build. Miri can also interpret for a foreign
+  target with `--target <triple>`, which is useful for pointer-width- or endianness-dependent bugs without
+  cross-compiling.
+- **C toolchain** — `build-essential` (gcc/g++), `pkg-config`, `autoconf`/`automake`, plus the `openssl`
+  (`libssl-dev`) and `libssh` (`libssh-dev`) development headers. This is what lets `-sys` crates and `build.rs`
+  scripts compile and link their C/FFI code in-place.
 
 Dependencies and Cargo's caches resolve under `CARGO_HOME=/usr/local/cargo`, which is on an exec-capable path, so the
 test and example binaries Cargo builds can run. There is no bundled `clang`; sanitizer builds use the LLVM runtime that
@@ -57,8 +60,9 @@ Note any `[features]`, since vulnerable code may sit behind a non-default featur
   `target/debug/` against crafted input.
 
 Dependencies resolve from `Cargo.toml`/`Cargo.lock`; there is no separate install step — Cargo fetches crates on first
-build. If a fetch fails with a network error the scan is offline: work from the source and vendored crates already
-present and note which checks you had to skip.
+build. A downloaded `.crate` file (e.g. under `$CARGO_HOME/registry/cache` or fetched from crates.io) is a gzipped
+tarball: `tar -xzf foo-1.2.3.crate` unpacks it. If a fetch fails with a network error the scan is offline: work from
+the source and vendored crates already present and note which checks you had to skip.
 
 ### Sanitizers
 
@@ -68,7 +72,7 @@ Rust's sanitizers are nightly-only and need std rebuilt with instrumentation, so
 ```bash
 cd src
 RUSTFLAGS="-Zsanitizer=address" \
-  cargo +nightly test -Zbuild-std --target x86_64-unknown-linux-gnu
+  cargo +$RUST_NIGHTLY_VERSION test -Zbuild-std --target x86_64-unknown-linux-gnu
 ```
 
 Supported `-Zsanitizer` kinds include `address`, `leak`, `memory`, `thread`, `hwaddress`, `memtag`, `cfi`, `dataflow`,
@@ -90,8 +94,8 @@ instead of inventing one.
 - **Standalone crate:** `cargo new /tmp/poc`, add the target as a dependency (`path` or version) in its `Cargo.toml`,
   write the trigger in `src/main.rs`, and `cargo run --manifest-path /tmp/poc/Cargo.toml`.
 - **Undefined behaviour / `unsafe`:** write a test that exercises the suspect code and run it under Miri —
-  `cargo +nightly miri test --test poc`. A Miri error is strong evidence of UB; note that Miri can't execute most FFI,
-  so for `-sys`/C boundaries fall back to an AddressSanitizer build instead.
+  `cargo +$RUST_NIGHTLY_VERSION miri test --test poc`. A Miri error is strong evidence of UB; note that Miri can't
+  execute most FFI, so for `-sys`/C boundaries fall back to an AddressSanitizer build instead.
 - **Memory corruption in `unsafe`/FFI:** reproduce under AddressSanitizer (see Sanitizers) and quote the report.
 - Drive the vulnerable function directly with the malicious input rather than booting the whole program — it keeps the
   reproducer minimal and the evidence trivial to verify.

--- a/docker/profiles/rust/PROFILE.md
+++ b/docker/profiles/rust/PROFILE.md
@@ -1,67 +1,104 @@
 # Rust scanning container
 
-The repository under `./src` is a Rust project.
+The repository under `./src` is a Rust project, built with Cargo. The job is to find **security vulnerabilities** in it.
 
 ## Runtime
 
-- **rustup** - Rust toolchains and  tools are installed using the `rustup` tool. Both the latest stable and nightly are installed.
-- **Rust 1.96** - `cargo` / `rustc` (a pinned rust toolchain installed with `rustup`). 
-- `cargo` - The rust package manager and compiling tool to use. Use this tool for building and running Rust projects.
-- `rustc` - The underlying rust compiler invoked by `cargo`
-- C toolchain (`build-essential`, `pkg-config`) plus the `openssl`/`libssh` dev headers
-- `miri` - an Undefined Behavior detection tool for Rust. It can run binaries and test suites of cargo projects and detect unsafe code that fails to uphold its safety requirements.
+- **rustup 1.29** — manages toolchains and components; `RUSTUP_HOME=/usr/local/rustup`, `CARGO_HOME=/usr/local/cargo`,
+  both on PATH and writable.
+- **Rust 1.96 (stable)** — the default toolchain. `cargo` drives builds, tests, and runs; `rustc` is the compiler it
+  invokes. Use stable for normal building, testing, and reproducing.
+- **Nightly (`nightly-2026-06-24`)** with the `rust-src` component — required for the `-Z` flags that the rest of this
+  profile relies on (sanitizers, `-Zbuild-std`, Miri). Select it per-invocation with `cargo +nightly` / `rustc
+  +nightly`.
+- **Miri** — installed on the nightly toolchain and already initialized (`cargo +nightly miri setup`). It interprets
+  MIR to catch undefined behaviour (out-of-bounds, use-after-free, invalid aliasing, data races, uninitialized reads)
+  that compiles and runs cleanly under a normal build.
+- **C toolchain** — `build-essential` (gcc/g++), `pkg-config`, `autoconf`/`automake`, and `gcc-multilib` for 32-bit
+  (`i686`) targets, plus the `openssl` (`libssl-dev`) and `libssh` (`libssh-dev`) development headers. This is what lets
+  `-sys` crates and `build.rs` scripts compile and link their C/FFI code in-place.
+
+Dependencies and Cargo's caches resolve under `CARGO_HOME=/usr/local/cargo`, which is on an exec-capable path, so the
+test and example binaries Cargo builds can run. There is no bundled `clang`; sanitizer builds use the LLVM runtime that
+ships with the nightly `rust-src` (see below). If you need to instrument linked C code with a matching clang runtime
+(`-Zexternal-clangrt`), install `clang` with `apt-get` first.
 
 ## Operating procedure
 
-### Additional Knowledge
+### Background
 
-- Some rust packages have the `-sys` name extension. This is a standard, and not a rule, but suggests the package imports external
-  C dependecies. You can also identify this if a `build.rs` file exists. In these cases, it means this crate also imports this external
-  C code. Make sure to give special attention to these cases, as they suggest FFI boundaries and sources of undefined behavior both in the
-  third party dependecy and in the Rust usage of it. This means there is a boundary of different safety garuntees which requires 
-  special attention.
-- Rust code specifically has `unsafe` code which ignores Rust safety rules. Please consider both memory-safety vulnerabilities and other
-- standard vulnerabilities in these cases. In pure Rust code, you are focusing more on logic and design vulnerabilities.
+- A `-sys` crate suffix or a `build.rs` build script usually means external C/FFI code is compiled and linked in. Treat
+  that boundary as a prime target: scrutinize both the upstream C dependency and how the Rust side calls into it
+  (pointer/length handling, ownership of returned buffers, error-code checks).
+- In `unsafe` blocks, look for the classic memory-safety failures — out-of-bounds, use-after-free, double-free, invalid
+  `transmute`, aliasing violations, integer overflow feeding an allocation or index, and broken invariants that safe
+  callers can violate. In safe Rust, focus on logic and design flaws: panics on attacker input (DoS), path traversal,
+  deserialization, command/SQL injection, `unwrap`/`expect` on untrusted data, and incorrect auth/crypto.
 
 ### Code scanning preparations
 
-Download a given .crate file and extract it as the source code. Inspect the extracted Cargo.toml file - a project may be a 
-library or a binary, so you need to determine whether you need to use integration tests or directly invoking the binary if 
-performing tests. 
+Inspect the manifest to learn the shape of the project, then warm the build so dependencies resolve and any `-sys`
+crates compile:
 
-For libraries, you may need to create your own new project with `cargo new`, which utilizes the library. You can also create 
-integration tests for the same purpose. Always prioritize an integration test over a new test project.
+```bash
+cd src
+cargo metadata --no-deps --format-version 1   # crate names, targets, whether it's a workspace
+cargo build --all-targets                     # compile lib, bins, examples, and tests
+```
 
-For binaries, leverage creating new integration tests for scanning and identification. 
+`Cargo.toml` tells you what you're scanning: a `[lib]` table (or a top-level `src/lib.rs`) is a library, `[[bin]]`
+entries (or `src/main.rs`) are binaries, and `[workspace]` means multiple member crates — build and reason about each.
+Note any `[features]`, since vulnerable code may sit behind a non-default feature that must be enabled with
+`--features <name>` (or `--all-features`) to compile and reach it.
 
-Miri is installed, and should be used to scan and identify for cases of undefined behavior. 
+- **Libraries:** add an integration test under `tests/` that calls the public API, or scaffold a consumer crate with
+  `cargo new /tmp/consumer` and add the target as a path dependency (`mylib = { path = "../src" }`).
+- **Binaries:** prefer an integration test that drives the vulnerable code path, or run the built binary from
+  `target/debug/` against crafted input.
 
+Dependencies resolve from `Cargo.toml`/`Cargo.lock`; there is no separate install step — Cargo fetches crates on first
+build. If a fetch fails with a network error the scan is offline: work from the source and vendored crates already
+present and note which checks you had to skip.
 
-### Address Sanitizer Support
-ASAN is available for builds during inspection, and can be instantiated during a build using an environmental variable RUSTFLAGS='-Zsanitizer=<flags>'
+### Sanitizers
 
-To enable a sanitizer compile with `-Zsanitizer=address`, `-Zsanitizer=cfi`, `-Zsanitizer=dataflow`,`-Zsanitizer=hwaddress`,`-Zsanitizer=leak`,`-Zsanitizer=memory`, 
-`-Zsanitizer=memtag`, `-Zsanitizer=realtime`, `-Zsanitizer=shadow-call-stack` or `-Zsanitizer=thread`. You might also need the `--target` and build-std flags. 
-If you’re working with other languages that are also instrumented with sanitizers, you might need the external-clangrt flag. See the section on working with 
-other languages.
+Rust's sanitizers are nightly-only and need std rebuilt with instrumentation, so they require an explicit `--target` and
+`-Zbuild-std` (the `rust-src` component is already installed):
 
-You may need to use `build-std` for sanitizer support, which is invoked via `-Z build-std`
+```bash
+cd src
+RUSTFLAGS="-Zsanitizer=address" \
+  cargo +nightly test -Zbuild-std --target x86_64-unknown-linux-gnu
+```
+
+Supported `-Zsanitizer` kinds include `address`, `leak`, `memory`, `thread`, `hwaddress`, `memtag`, `cfi`, `dataflow`,
+`realtime`, and `shadow-call-stack`. AddressSanitizer (`address`) is the workhorse for `unsafe`/FFI memory bugs;
+ThreadSanitizer (`thread`) for data races; MemorySanitizer (`memory`) for uninitialized reads. For builds that also
+instrument linked C code, add `-Zexternal-clangrt` (requires `clang`, see Runtime). Quote the sanitizer's `SUMMARY:`
+line and the top of its stack as evidence.
 
 ### Creating reproducers
 
-Every finding ships with a reproducer — a small piece of code that, when run in this container, actually triggers the
-issue. Paste the exact command you ran and the verbatim output (error message, return value, observable side effect)
-into the finding. Reasoning-only or "this would" reproducers do not count; if you couldn't run it here, say so
-explicitly instead of inventing one.
+Every finding ships with a reproducer — code that, run in this container, actually triggers the issue. Paste the exact
+command you ran and the verbatim output (panic message, sanitizer report, Miri diagnostic, observable side effect) into
+the finding. Reasoning-only or "this would" reproducers do not count; if you couldn't run it here, say so explicitly
+instead of inventing one.
 
-- Use cargo script when able to create a complete reproduction. This should be a single contained .rs file which can be executed with `cargo poc.rs`
-- Generate a test case which triggers the exploit. This can be done as an integration test in the project. 
-- When the vulnerability is undefined behavior or an unsafe code segment, make sure a test case is generated which miri will identify.
+- **Integration test (preferred):** drop `tests/poc.rs` next to the project and run
+  `cargo test --test poc -- --nocapture`. The test output is the evidence. Add `--features <name>` if the sink is
+  feature-gated.
+- **Standalone crate:** `cargo new /tmp/poc`, add the target as a dependency (`path` or version) in its `Cargo.toml`,
+  write the trigger in `src/main.rs`, and `cargo run --manifest-path /tmp/poc/Cargo.toml`.
+- **Undefined behaviour / `unsafe`:** write a test that exercises the suspect code and run it under Miri —
+  `cargo +nightly miri test --test poc`. A Miri error is strong evidence of UB; note that Miri can't execute most FFI,
+  so for `-sys`/C boundaries fall back to an AddressSanitizer build instead.
+- **Memory corruption in `unsafe`/FFI:** reproduce under AddressSanitizer (see Sanitizers) and quote the report.
+- Drive the vulnerable function directly with the malicious input rather than booting the whole program — it keeps the
+  reproducer minimal and the evidence trivial to verify.
 
-## Scope
+## Out of scope
 
-You should inspect this source for vulnerabilities that exist directly within its source. Third-party dependencies
-vulnerabilities should be excluded from scanning. However, if you identify known vulnerabilities in dependencies, 
-such as vulnerablilities in imported C libraries in sys crates, please report them as a finding. When a third party
-C dependency is being imported via a `-sys` crate or you identify a `build.rs` building and linking C code, consider 
-the boundary to this code and the dependency as in scope.
+- Third-party dependencies under `CARGO_HOME` (`/usr/local/cargo/registry`) — not the target of this scan unless a
+  finding specifically pivots through one. Still report *known-vulnerable* dependencies, especially C libraries pulled
+  in by `-sys` crates: when a `-sys` crate or `build.rs` builds and links C code, that boundary and the linked library
+  are in scope.

--- a/internal/worker/profile.go
+++ b/internal/worker/profile.go
@@ -100,6 +100,7 @@ var builtinProfiles = []Profile{
 	{Name: "java", Ecosystems: []string{"Maven", "Gradle"}},
 	{Name: "dotnet", Ecosystem: "NuGet"},
 	{Name: "beam", Ecosystems: []string{"Mix", "rebar3"}},
+	{Name: "rust", Ecosystem: "Cargo"},
 	{
 		// Last: brief reports no package manager for C/C++, so this is a
 		// fallback for repos that match no language ecosystem above but
@@ -116,7 +117,6 @@ var builtinProfiles = []Profile{
 			{Path: "meson.build"},
 		},
 	},
-	{Name: "rust", Ecosystem: "Cargo"},
 }
 
 // ProfileByName returns the registered profile, or the default profile

--- a/internal/worker/profile.go
+++ b/internal/worker/profile.go
@@ -116,6 +116,7 @@ var builtinProfiles = []Profile{
 			{Path: "meson.build"},
 		},
 	},
+	{Name: "rust", Ecosystem: "Cargo"},
 }
 
 // ProfileByName returns the registered profile, or the default profile

--- a/internal/worker/profile_test.go
+++ b/internal/worker/profile_test.go
@@ -282,8 +282,18 @@ func TestMatchProfile(t *testing.T) {
 			want: "php",
 		},
 		{
-			name: "truly unknown manager falls back",
+			name: "cargo matches rust",
 			json: `{"package_managers":[{"name":"Cargo"}]}`,
+			want: "rust",
+		},
+		{
+			name: "cargo case-insensitive",
+			json: `{"package_managers":[{"name":"cargo"}]}`,
+			want: "rust",
+		},
+		{
+			name: "truly unknown manager falls back",
+			json: `{"package_managers":[{"name":"Conan"}]}`,
 			want: "",
 		},
 		{

--- a/internal/worker/profile_test.go
+++ b/internal/worker/profile_test.go
@@ -92,6 +92,7 @@ func writeMarkerFile(t *testing.T, dir, name string) {
 	}
 }
 
+//nolint:maintidx // exhaustive table: one case per builtinProfiles entry plus precedence/fallback edges; splitting would scatter the coverage.
 func TestMatchProfile(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/internal/worker/profile_test.go
+++ b/internal/worker/profile_test.go
@@ -282,6 +282,17 @@ func TestMatchProfile(t *testing.T) {
 			want: "php",
 		},
 		{
+			// rust is registered before the c-cpp fallback, so a Cargo
+			// crate that also ships a Makefile (common for -sys crates and
+			// build.rs-driven C builds) still routes to the rust profile.
+			name: "cargo wins over a c-cpp build file",
+			json: `{"package_managers":[{"name":"Cargo"}]}`,
+			setup: func(t *testing.T, dir string) {
+				writeMarkerFile(t, dir, "Makefile")
+			},
+			want: "rust",
+		},
+		{
 			name: "cargo matches rust",
 			json: `{"package_managers":[{"name":"Cargo"}]}`,
 			want: "rust",

--- a/skills/security-deep-dive/SKILL.md
+++ b/skills/security-deep-dive/SKILL.md
@@ -123,8 +123,6 @@ For round-trip pairs, the reproduction is the round-trip. Construct values conta
 
 If the reproduction fails — the sink is gated by a check you missed, the input is sanitised on the way in, the type system prevents it — write what stopped it and move to the next sink.
 
-Rust .crate files are gzipped tarballs.
-
 ### Step 4: Prior art
 
 Check scrutineer's advisory cache first: `GET {api_base}/repositories/{repository_id}/advisories`. Every advisory already published against this repository's packages shows up here, with CVSS, classification, packages affected, and the original URL. Anything that overlaps with your finding is prior art — cite the advisory uuid and url.

--- a/skills/security-deep-dive/SKILL.md
+++ b/skills/security-deep-dive/SKILL.md
@@ -123,6 +123,8 @@ For round-trip pairs, the reproduction is the round-trip. Construct values conta
 
 If the reproduction fails — the sink is gated by a check you missed, the input is sanitised on the way in, the type system prevents it — write what stopped it and move to the next sink.
 
+Rust .crate files are gzipped tarballs.
+
 ### Step 4: Prior art
 
 Check scrutineer's advisory cache first: `GET {api_base}/repositories/{repository_id}/advisories`. Every advisory already published against this repository's packages shows up here, with CVSS, classification, packages affected, and the original URL. Anything that overlaps with your finding is prior art — cite the advisory uuid and url.


### PR DESCRIPTION
PR includes two changes:
- Addition of a rust runner profile 
- Added additional language to the extraction skill. The tooling was struggling extracting crate file sources, so we needed to specify they are tar files.