### PR TITLE
Split dependency phases in dependency views

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Each finding page has a notes section for recording triage reasoning and communi
 
 ## Exploring dependencies
 
-The Dependencies tab on a repo groups packages by name and shows all manifest files where each appears. The import button (arrow icon) next to a dependency resolves it to a repository URL via packages.ecosyste.ms and queues the full pipeline for it. Dependencies you've already imported show a link icon instead.
+The Dependencies tab on a repo groups packages by name and shows all manifest files where each appears. It shows runtime dependencies by default, with a toggle for test/build/dev rows. The import button (arrow icon) next to a dependency resolves it to a repository URL via packages.ecosyste.ms and queues the full pipeline for it. Dependencies you've already imported show a link icon instead.
 
 The same applies to the Dependents tab -- you can import any dependent's repository with one click.
 

--- a/docs/database.md
+++ b/docs/database.md
@@ -234,7 +234,7 @@ Package dependencies discovered by the `dependencies` skill. Replaced wholesale 
 | ecosystem | text | PURL type, e.g. `gem`, `npm`, `golang`. Derived from `p_url` (or the source ecosystem string when no PURL was recorded). Indexed. |
 | p_url | text | Package URL. |
 | requirement | text | Version constraint from the manifest. |
-| dependency_type | text | `runtime` or `development`. |
+| dependency_type | text | Normalised dependency phase: `runtime`, `dev`, `test`, `build`, or an unrecognised source value kept verbatim. |
 | manifest_path | text | Which file declared this dependency. |
 | manifest_kind | text | `manifest` or `lockfile`. |
 | created_at | datetime | |

--- a/internal/db/ecosystem.go
+++ b/internal/db/ecosystem.go
@@ -31,6 +31,53 @@ func reconcileEcosystem(ecosystem string) string {
 	return ecosystem
 }
 
+const (
+	DependencyRuntime = "runtime"
+	DependencyDev     = "dev"
+	DependencyTest    = "test"
+	DependencyBuild   = "build"
+)
+
+// NormalizeDependencyType reduces git-pkgs and ecosystem-specific dependency
+// phase names to the four buckets scrutineer uses in UI filters and reachability.
+func NormalizeDependencyType(raw string) string {
+	s := strings.ToLower(strings.TrimSpace(raw))
+	s = strings.ReplaceAll(s, "_", "-")
+	s = strings.ReplaceAll(s, " ", "-")
+	switch s {
+	case "", "runtime", "production", "prod", "dependencies", "dependency", "direct", "indirect", "normal", "required", "requires", "compile", "peer", "optional":
+		return DependencyRuntime
+	case "development", "dev", "dev-dependencies", "development-dependencies", "devdependency", "devdependencies":
+		return DependencyDev
+	case "test", "tests", "testing", "test-requires", "test-require", "test-requirements", "test-dependencies", "testdependency", "testdependencies":
+		return DependencyTest
+	case "build", "build-requires", "build-require", "build-requirements", "build-dependencies", "builddependency", "builddependencies", "configure", "configure-requires", "configure-require", "configure-requirements":
+		return DependencyBuild
+	}
+	switch {
+	case strings.Contains(s, "test"):
+		return DependencyTest
+	case strings.Contains(s, "build") || strings.Contains(s, "configure"):
+		return DependencyBuild
+	case strings.Contains(s, "dev") || strings.Contains(s, "development"):
+		return DependencyDev
+	default:
+		return s
+	}
+}
+
+// DependencyVisibleByDefault reports whether a dependency should be treated as
+// part of the shipped/runtime graph. Unknown values stay visible so new
+// ecosystems do not disappear until their phase mapping is taught explicitly.
+func DependencyVisibleByDefault(raw string) bool {
+	switch NormalizeDependencyType(raw) {
+	case DependencyDev, DependencyTest, DependencyBuild:
+		return false
+	default:
+		return true
+	}
+}
+
 // canonicalType reduces a PURL type or ecosystem string to the one PURL type
 // both sources agree on.
 func canonicalType(token string) string {
@@ -94,7 +141,8 @@ type DependencyFinding struct {
 // the live Findings on the matched library repositories. The join key is the
 // parsed PURL (type, namespace, name) on both sides, so the two sources agree
 // without a write-time alias map. Self-matches and findings already marked
-// fixed/rejected/duplicate are excluded.
+// fixed/rejected/duplicate are excluded. Dev/test/build dependencies are not
+// considered reachable dependency edges.
 func DependencyFindings(g *gorm.DB, appRepoID uint) ([]DependencyFinding, error) {
 	var deps []Dependency
 	if err := g.Where("repository_id = ?", appRepoID).Find(&deps).Error; err != nil {
@@ -104,6 +152,9 @@ func DependencyFindings(g *gorm.DB, appRepoID uint) ([]DependencyFinding, error)
 	type key struct{ eco, namespace, name string }
 	want := map[key]Dependency{}
 	for _, d := range deps {
+		if !DependencyVisibleByDefault(d.DependencyType) {
+			continue
+		}
 		eco, ns, name := ecosystemKey(d.PURL, d.Ecosystem, d.Name)
 		k := key{eco, ns, name}
 		if cur, ok := want[k]; !ok || preferDep(d, cur) {
@@ -181,11 +232,10 @@ func DependencyFindings(g *gorm.DB, appRepoID uint) ([]DependencyFinding, error)
 }
 
 // preferDep picks the more informative of two Dependency rows for the same
-// package: a lockfile row (concrete requirement) beats a manifest row, and
-// a runtime dependency beats a development one.
+// package: a runtime-like dependency beats a non-runtime one, and a lockfile
+// row with a concrete requirement beats a manifest range.
 func preferDep(a, b Dependency) bool {
-	const runtime = "runtime"
-	aRT, bRT := a.DependencyType == runtime, b.DependencyType == runtime
+	aRT, bRT := DependencyVisibleByDefault(a.DependencyType), DependencyVisibleByDefault(b.DependencyType)
 	if aRT != bRT {
 		return aRT
 	}

--- a/internal/db/ecosystem.go
+++ b/internal/db/ecosystem.go
@@ -141,8 +141,9 @@ type DependencyFinding struct {
 // the live Findings on the matched library repositories. The join key is the
 // parsed PURL (type, namespace, name) on both sides, so the two sources agree
 // without a write-time alias map. Self-matches and findings already marked
-// fixed/rejected/duplicate are excluded. Dev/test/build dependencies are not
-// considered reachable dependency edges.
+// fixed/rejected/duplicate are excluded. Dependency phase is returned to the
+// caller but does not filter reachability: build dependencies can still be
+// supply-chain edges, and the UI layer owns phase filtering for display.
 func DependencyFindings(g *gorm.DB, appRepoID uint) ([]DependencyFinding, error) {
 	var deps []Dependency
 	if err := g.Where("repository_id = ?", appRepoID).Find(&deps).Error; err != nil {
@@ -152,9 +153,6 @@ func DependencyFindings(g *gorm.DB, appRepoID uint) ([]DependencyFinding, error)
 	type key struct{ eco, namespace, name string }
 	want := map[key]Dependency{}
 	for _, d := range deps {
-		if !DependencyVisibleByDefault(d.DependencyType) {
-			continue
-		}
 		eco, ns, name := ecosystemKey(d.PURL, d.Ecosystem, d.Name)
 		k := key{eco, ns, name}
 		if cur, ok := want[k]; !ok || preferDep(d, cur) {

--- a/internal/db/ecosystem_test.go
+++ b/internal/db/ecosystem_test.go
@@ -138,7 +138,7 @@ func TestDependencyFindingsPURLJoin(t *testing.T) {
 	}
 }
 
-func TestDependencyFindingsIgnoresNonRuntimeDependencies(t *testing.T) {
+func TestDependencyFindingsIncludesNonRuntimeDependencies(t *testing.T) {
 	gdb, err := Open("file::memory:")
 	if err != nil {
 		t.Fatal(err)
@@ -162,8 +162,11 @@ func TestDependencyFindingsIgnoresNonRuntimeDependencies(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(rows) != 0 {
-		t.Fatalf("rows=%d want=0 for test-only dependency: %+v", len(rows), rows)
+	if len(rows) != 1 {
+		t.Fatalf("rows=%d want=1 for test-only dependency: %+v", len(rows), rows)
+	}
+	if rows[0].DependencyType != DependencyTest {
+		t.Fatalf("DependencyType = %q, want %q", rows[0].DependencyType, DependencyTest)
 	}
 }
 

--- a/internal/db/ecosystem_test.go
+++ b/internal/db/ecosystem_test.go
@@ -45,6 +45,27 @@ func TestEcosystemType(t *testing.T) {
 	}
 }
 
+func TestNormalizeDependencyType(t *testing.T) {
+	cases := []struct {
+		raw, want string
+	}{
+		{"", DependencyRuntime},
+		{"direct", DependencyRuntime},
+		{"runtime", DependencyRuntime},
+		{"development", DependencyDev},
+		{"devDependencies", DependencyDev},
+		{"test_requires", DependencyTest},
+		{"build-requires", DependencyBuild},
+		{"configure_requires", DependencyBuild},
+		{"plugin", "plugin"},
+	}
+	for _, tc := range cases {
+		if got := NormalizeDependencyType(tc.raw); got != tc.want {
+			t.Errorf("NormalizeDependencyType(%q) = %q, want %q", tc.raw, got, tc.want)
+		}
+	}
+}
+
 // TestEcosystemKeyReconcilesSources guards the DependencyFindings join: it
 // matches a Dependency row to a Package row by the key ecosystemKey produces.
 // git-pkgs (Dependency) and ecosyste.ms (Package) spell some ecosystems
@@ -114,6 +135,35 @@ func TestDependencyFindingsPURLJoin(t *testing.T) {
 	}
 	if rows[0].Title != "path traversal" || rows[0].LibRepoURL != "https://example.com/mux" {
 		t.Errorf("unexpected row %+v", rows[0])
+	}
+}
+
+func TestDependencyFindingsIgnoresNonRuntimeDependencies(t *testing.T) {
+	gdb, err := Open("file::memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	sqldb, _ := gdb.DB()
+	defer func() { _ = sqldb.Close() }()
+
+	app := Repository{URL: "https://example.com/app", Name: "app"}
+	lib := Repository{URL: "https://example.com/test-helper", Name: "test-helper"}
+	gdb.Create(&app)
+	gdb.Create(&lib)
+
+	gdb.Create(&Dependency{RepositoryID: app.ID, Name: "test-helper", Ecosystem: "npm", ManifestPath: "package.json", DependencyType: DependencyTest})
+	gdb.Create(&Package{RepositoryID: lib.ID, Name: "test-helper", Ecosystem: "npm"})
+
+	scan := Scan{RepositoryID: lib.ID, Kind: "skill", Status: ScanDone}
+	gdb.Create(&scan)
+	gdb.Create(&Finding{ScanID: scan.ID, RepositoryID: lib.ID, Title: "dev-only bug", Severity: "High", Status: FindingNew})
+
+	rows, err := DependencyFindings(gdb, app.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 0 {
+		t.Fatalf("rows=%d want=0 for test-only dependency: %+v", len(rows), rows)
 	}
 }
 

--- a/internal/web/repo_show_test.go
+++ b/internal/web/repo_show_test.go
@@ -30,8 +30,13 @@ const threatModelReport = `{
 
 func getRepoPage(t *testing.T, s *Server, id uint) string {
 	t.Helper()
+	return getRepoPagePath(t, s, fmt.Sprintf("/repositories/%d", id))
+}
+
+func getRepoPagePath(t *testing.T, s *Server, path string) string {
+	t.Helper()
 	w := httptest.NewRecorder()
-	s.Handler().ServeHTTP(w, localReq("GET", fmt.Sprintf("/repositories/%d", id)))
+	s.Handler().ServeHTTP(w, localReq("GET", path))
 	if w.Code != 200 {
 		t.Fatalf("status %d: %s", w.Code, w.Body)
 	}
@@ -148,6 +153,36 @@ func TestRepoShow_dependenciesTab_plainManifestWithoutDoneScan(t *testing.T) {
 	}
 	if !strings.Contains(body, "package.json") {
 		t.Errorf("expected manifest path to still render as text")
+	}
+}
+
+func TestRepoShow_dependenciesTab_hidesNonRuntimeByDefault(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	repo := db.Repository{URL: "https://example.com/r", Name: "r"}
+	s.DB.Create(&repo)
+	s.DB.Create(&db.Dependency{RepositoryID: repo.ID, Name: "runtime-lib", Ecosystem: "npm",
+		DependencyType: db.DependencyRuntime, ManifestPath: "package.json", ManifestKind: "manifest"})
+	s.DB.Create(&db.Dependency{RepositoryID: repo.ID, Name: "test-helper", Ecosystem: "npm",
+		DependencyType: db.DependencyTest, ManifestPath: "package.json", ManifestKind: "manifest"})
+
+	body := getRepoPage(t, s, repo.ID)
+	if !strings.Contains(body, "runtime-lib") {
+		t.Errorf("runtime dependency should render in default view")
+	}
+	if strings.Contains(body, "test-helper") {
+		t.Errorf("test dependency should be hidden by default")
+	}
+	if !strings.Contains(body, "Include test/build/dev") {
+		t.Errorf("default view should render non-runtime toggle")
+	}
+
+	body = getRepoPagePath(t, s, fmt.Sprintf("/repositories/%d?deps=all", repo.ID))
+	if !strings.Contains(body, "test-helper") {
+		t.Errorf("deps=all should render non-runtime dependencies")
+	}
+	if !strings.Contains(body, "Runtime only") {
+		t.Errorf("deps=all should render runtime-only toggle")
 	}
 }
 

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -1506,9 +1506,11 @@ func (s *Server) repoShow(w http.ResponseWriter, r *http.Request) {
 	s.DB.Joins("JOIN repository_maintainers ON repository_maintainers.maintainer_id = maintainers.id").
 		Where("repository_maintainers.repository_id = ?", repo.ID).Find(&maintainers)
 
+	showAllDeps := r.URL.Query().Get("deps") == "all"
 	var rawDeps []db.Dependency
 	s.DB.Where("repository_id = ?", repo.ID).Order("ecosystem, name, manifest_kind desc").Find(&rawDeps)
-	deps := groupDeps(rawDeps)
+	visibleDeps, hiddenDeps := filterRepoDeps(rawDeps, showAllDeps)
+	deps := groupDeps(visibleDeps)
 
 	var depsCommit string
 	if len(deps) > 0 {
@@ -1585,6 +1587,7 @@ func (s *Server) repoShow(w http.ResponseWriter, r *http.Request) {
 		"DepsCommit":      depsCommit,
 		"Deps":            deps, "Pkgs": pkgs, "Dependents": dependents, "Advisories": advisories, "Maintainers": maintainers, "ThreatModel": threatModel,
 		"KnownURLs": knownURLs, "KnownPURLs": knownPURLs,
+		"ShowAllDeps": showAllDeps, "HiddenDeps": hiddenDeps,
 		"Skills":        activeSkills,
 		"Subprojects":   subprojects,
 		"SubScanCount":  subScanCount,
@@ -1959,10 +1962,8 @@ func groupDeps(deps []db.Dependency) []DepGroup {
 			order = append(order, k)
 		}
 		g.Manifests = append(g.Manifests, d.ManifestPath)
-		// Prefer lockfile version (exact) over manifest (range)
-		if d.ManifestKind == "lockfile" && g.ManifestKind != "lockfile" {
-			g.Requirement = d.Requirement
-			g.ManifestKind = d.ManifestKind
+		if preferDependencyForGroup(d, g.Dependency) {
+			g.Dependency = d
 		}
 	}
 	out := make([]DepGroup, 0, len(order))
@@ -1970,6 +1971,30 @@ func groupDeps(deps []db.Dependency) []DepGroup {
 		out = append(out, *m[k])
 	}
 	return out
+}
+
+func filterRepoDeps(deps []db.Dependency, includeNonRuntime bool) ([]db.Dependency, int) {
+	if includeNonRuntime {
+		return deps, 0
+	}
+	out := make([]db.Dependency, 0, len(deps))
+	hidden := 0
+	for _, d := range deps {
+		if db.DependencyVisibleByDefault(d.DependencyType) {
+			out = append(out, d)
+		} else {
+			hidden++
+		}
+	}
+	return out, hidden
+}
+
+func preferDependencyForGroup(a, b db.Dependency) bool {
+	aRuntime, bRuntime := db.DependencyVisibleByDefault(a.DependencyType), db.DependencyVisibleByDefault(b.DependencyType)
+	if aRuntime != bRuntime {
+		return aRuntime
+	}
+	return a.ManifestKind == "lockfile" && b.ManifestKind != "lockfile"
 }
 
 func (s *Server) lookupKnownPURLs(deps []DepGroup) map[string]uint {

--- a/internal/web/templates/repo_show.html
+++ b/internal/web/templates/repo_show.html
@@ -340,6 +340,19 @@
   {{end}}
 
   <div role="tabpanel" id="rp5" aria-labelledby="rt5" hidden>
+    {{if or .Deps .HiddenDeps}}
+      <div class="flex items-center justify-between gap-3 mb-3">
+        <p class="text-sm text-muted-foreground">
+          {{if .ShowAllDeps}}Showing all dependency phases.{{else}}Showing runtime dependencies.{{end}}
+          {{if .HiddenDeps}}{{.HiddenDeps}} test/build/dev row(s) hidden.{{end}}
+        </p>
+        {{if .ShowAllDeps}}
+          <a class="btn-sm-outline" href="/repositories/{{.Repo.ID}}#rt5">Runtime only</a>
+        {{else if .HiddenDeps}}
+          <a class="btn-sm-outline" href="/repositories/{{.Repo.ID}}?deps=all#rt5">Include test/build/dev</a>
+        {{end}}
+      </div>
+    {{end}}
     {{if .Deps}}
       <table class="table w-full">
         <thead><tr>
@@ -359,6 +372,8 @@
         {{end}}
         </tbody>
       </table>
+    {{else if .HiddenDeps}}
+      <p class="text-muted-foreground text-sm p-4">No runtime dependencies in the default view.</p>
     {{else}}
       <p class="text-muted-foreground text-sm p-4">No dependencies indexed yet. The git-pkgs job populates this.</p>
     {{end}}

--- a/internal/worker/skill_parsers.go
+++ b/internal/worker/skill_parsers.go
@@ -261,6 +261,7 @@ func (w *Worker) parseDependenciesOutput(scan *db.Scan, report string, emit func
 		if depType == "" {
 			depType = d.DependencyType
 		}
+		depType = db.NormalizeDependencyType(depType)
 		rows = append(rows, db.Dependency{
 			RepositoryID:   scan.RepositoryID,
 			Name:           d.Name,

--- a/internal/worker/skill_parsers_test.go
+++ b/internal/worker/skill_parsers_test.go
@@ -310,16 +310,22 @@ func TestParseVerify_inconclusiveLeavesStatus(t *testing.T) {
 func TestParseDependencies_acceptsTypeOrDependencyType(t *testing.T) {
 	report := `{"dependencies":[
 		{"name":"a","ecosystem":"npm","type":"runtime","manifest_path":"package.json"},
-		{"name":"b","ecosystem":"npm","dependency_type":"development","manifest_path":"package.json"}
+		{"name":"b","ecosystem":"npm","dependency_type":"development","manifest_path":"package.json"},
+		{"name":"c","ecosystem":"cpan","dependency_type":"test_requires","manifest_path":"META.json"},
+		{"name":"d","ecosystem":"cpan","dependency_type":"configure_requires","manifest_path":"META.json"}
 	]}`
 	repo, gdb := runSkillWithReport(t, "dependencies", report)
 	var rows []db.Dependency
 	gdb.Where("repository_id = ?", repo.ID).Find(&rows)
-	if len(rows) != 2 {
-		t.Fatalf("rows = %d, want 2", len(rows))
+	if len(rows) != 4 {
+		t.Fatalf("rows = %d, want 4", len(rows))
 	}
-	gotTypes := map[string]string{rows[0].Name: rows[0].DependencyType, rows[1].Name: rows[1].DependencyType}
-	if gotTypes["a"] != "runtime" || gotTypes["b"] != "development" {
+	gotTypes := map[string]string{}
+	for _, row := range rows {
+		gotTypes[row.Name] = row.DependencyType
+	}
+	if gotTypes["a"] != db.DependencyRuntime || gotTypes["b"] != db.DependencyDev ||
+		gotTypes["c"] != db.DependencyTest || gotTypes["d"] != db.DependencyBuild {
 		t.Errorf("types: %+v", gotTypes)
 	}
 }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -847,7 +847,7 @@ components:
         ecosystem:       { type: string }
         purl:            { type: string }
         requirement:     { type: string }
-        dependency_type: { type: string }
+        dependency_type: { type: string, description: 'Normalised phase: runtime, dev, test, build, or an unrecognised source value.' }
         manifest_path:   { type: string }
         manifest_kind:   { type: string }
 
@@ -859,7 +859,7 @@ components:
         ecosystem:             { type: string }
         requirement:           { type: string }
         manifest_path:         { type: string }
-        dependency_type:       { type: string }
+        dependency_type:       { type: string, description: 'Normalised phase: runtime, dev, test, build, or an unrecognised source value.' }
         finding_id:            { type: integer, format: int64 }
         library_repository_id: { type: integer, format: int64 }
         library_repository_url: { type: string, format: uri }

--- a/skills/dependencies/SKILL.md
+++ b/skills/dependencies/SKILL.md
@@ -20,7 +20,7 @@ metadata:
 
 # dependencies
 
-Wrap `git-pkgs list --format json` so scrutineer can read the result as a dependencies report.
+Wrap `git-pkgs list --format json` so scrutineer can read the result as a dependencies report. Preserve dependency phase/type fields from git-pkgs; scrutineer normalizes common aliases to `runtime`, `dev`, `test`, or `build`.
 
 ## Workspace
 
@@ -43,6 +43,6 @@ bash scripts/index.sh > ./report.json
 
 If the script exits non-zero, read its stderr, then write a short `{"dependencies": [], "error": "..."}` document to `./report.json` so the caller sees why no dependencies were indexed.
 
-The wrapper already emits the exact schema the parser expects — no post-processing needed.
+The wrapper already emits the exact schema the parser expects — no post-processing needed. Do not merge test, build, development, and runtime dependencies together; keep the phase/type field on each row when git-pkgs reports one.
 
 Do not inspect manifests yourself, infer dependencies from files that `git-pkgs` did not report, or hand-author dependency rows. If the wrapper returns `{"dependencies":[]}`, write that exact report and stop. Missing coverage in `git-pkgs` should produce an empty dependency report, not model-authored package data.

--- a/skills/dependencies/schema.json
+++ b/skills/dependencies/schema.json
@@ -17,7 +17,10 @@
           "ecosystem":       { "type": "string" },
           "purl":            { "type": "string" },
           "requirement":     { "type": "string" },
-          "dependency_type": { "type": "string" },
+          "dependency_type": {
+            "type": "string",
+            "description": "Dependency phase. Scrutineer normalizes common aliases to runtime, dev, test, or build."
+          },
           "manifest_path":   { "type": "string" },
           "manifest_kind":   { "type": "string" }
         }


### PR DESCRIPTION
Closes #44

## Summary

Splits dependency phases so runtime dependencies are handled separately from test, build and development prerequisites.

## Changes

- Normalize dependency phase/type values to `runtime`, `dev`, `test` or `build`
- Preserve unknown dependency types instead of hiding them
- Keep test/build/dev dependencies in dependency-finding reachability matching (they are still supply-chain edges); the phase is returned to the caller instead
- Show runtime dependencies by default on the repository Dependencies tab
- Add a toggle to include test/build/dev dependency rows
- Update dependency skill docs/schema, OpenAPI, README and database docs
- Add regression tests for parser normalization, dependency matching and UI filtering

## Testing

- `go test ./internal/db ./internal/worker ./internal/web`
- `go test ./...`
- `git diff --check`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run`
