### PR TITLE
Retry invalid skill reports with schema feedback

### DIFF
--- a/docs/skills.md
+++ b/docs/skills.md
@@ -193,7 +193,7 @@ The worker then runs `claude -p "Use the {name} skill in this workspace"` with t
 
 ## schema.json
 
-If a `schema.json` sits next to `SKILL.md`, scrutineer stages it into the workspace so the model can read the expected output shape, and after the run validates `report.json` against it with a draft 2020-12 validator. By default a mismatch is logged to the scan transcript and the parser still runs, so a stricter schema does not break ingestion. Start scrutineer with `-schema-strict` (or `schema_strict: true` in the config file) to turn that warning into a scan failure with the validator output in `Scan.Error`; useful while iterating on a skill locally.
+If a `schema.json` sits next to `SKILL.md`, scrutineer stages it into the workspace so the model can read the expected output shape, and after the run validates `report.json` against it with a draft 2020-12 validator. When validation fails and the Claude session is still available, scrutineer resumes that session once with the validator output and asks it to rewrite `report.json` before parsing. If the repaired report still fails validation, the mismatch is logged to the scan transcript and the parser still runs by default, so a stricter schema does not break ingestion. Start scrutineer with `-schema-strict` (or `schema_strict: true` in the config file) to turn the remaining warning into a scan failure with the validator output in `Scan.Error`; useful while iterating on a skill locally.
 
 Bundled skills with typed output kinds carry a schema; skills with `output_kind: freeform` generally do not.
 

--- a/internal/worker/claude.go
+++ b/internal/worker/claude.go
@@ -75,6 +75,10 @@ type SkillJob struct {
 	// conversation with full history instead of restarting from turn 0.
 	// The runner falls back to a fresh run if the session can't be found.
 	ResumeSessionID string
+	// ResumePrompt, when non-empty, replaces the default generic resume
+	// prompt. It lets callers resume the same conversation with targeted
+	// corrective instructions, such as rewriting an invalid report.json.
+	ResumePrompt string
 	// ClaudeConfigDir is a host directory the docker runner mounts as the
 	// container's CLAUDE_CONFIG_DIR so the resumable session store persists
 	// across container restarts. Empty disables the mount (the local runner
@@ -266,7 +270,11 @@ func buildClaudeArgs(sj SkillJob, effort string, globalMaxTurns int) []string {
 	}
 	args = append(args, "--max-turns", strconv.Itoa(effectiveMaxTurns(sj.MaxTurns, globalMaxTurns)))
 	if sj.ResumeSessionID != "" {
-		args = append(args, buildResumePrompt(sj.Name, sj.OutputFile))
+		if sj.ResumePrompt != "" {
+			args = append(args, sj.ResumePrompt)
+		} else {
+			args = append(args, buildResumePrompt(sj.Name, sj.OutputFile))
+		}
 	} else {
 		args = append(args, buildSkillPrompt(sj.Name, sj.OutputFile))
 	}

--- a/internal/worker/claude.go
+++ b/internal/worker/claude.go
@@ -17,6 +17,8 @@ import (
 // metadata nor the global config set a value.
 const DefaultSkillMaxTurns = 30
 
+const resumePromptNoFreshFallbackText = "not restarting repair prompt fresh"
+
 // MaxTurnsReachedError is returned when claude-code exits after hitting the
 // --max-turns cap. The caller should treat this as a soft completion.
 type MaxTurnsReachedError struct{}
@@ -148,6 +150,10 @@ func (l LocalClaude) RunSkill(ctx context.Context, sj SkillJob, emit func(Event)
 	hitMaxTurns, sessionID, waitErr := l.runClaudeOnce(ctx, args, work, wrappedEmit)
 
 	if waitErr != nil && sj.ResumeSessionID != "" && sessionID == "" && planLimitText == "" {
+		if sj.ResumePrompt != "" {
+			emit(Event{Kind: KindText, Text: "resume of session " + sj.ResumeSessionID + " failed; " + resumePromptNoFreshFallbackText})
+			return SkillResult{Commit: commit}, fmt.Errorf("claude exited: %w", waitErr)
+		}
 		// The resume never produced a session event, so claude could not
 		// load the saved conversation (expired or pruned). Restart fresh in
 		// the same workspace so the retry lineage isn't permanently wedged

--- a/internal/worker/claude_test.go
+++ b/internal/worker/claude_test.go
@@ -158,6 +158,21 @@ func TestBuildClaudeArgs_Resume(t *testing.T) {
 	}
 }
 
+func TestBuildClaudeArgs_CustomResumePrompt(t *testing.T) {
+	sj := SkillJob{
+		Name:            "metadata",
+		Model:           "claude-opus-4-8",
+		OutputFile:      "report.json",
+		ResumeSessionID: "abc-123",
+		ResumePrompt:    "repair the schema mismatch",
+	}
+	args := buildClaudeArgs(sj, "", 0)
+
+	if got := args[len(args)-1]; got != sj.ResumePrompt {
+		t.Errorf("final arg = %q, want custom resume prompt", got)
+	}
+}
+
 func TestBuildClaudeArgs_NoResumeWhenUnset(t *testing.T) {
 	sj := SkillJob{Name: "metadata", Model: "claude-opus-4-8", OutputFile: "report.json"}
 	args := buildClaudeArgs(sj, "", 0)

--- a/internal/worker/claude_test.go
+++ b/internal/worker/claude_test.go
@@ -237,6 +237,61 @@ func TestLocalClaude_ResumeFallsBackToFresh(t *testing.T) {
 	}
 }
 
+func TestLocalClaude_ResumePromptDoesNotFallbackToFresh(t *testing.T) {
+	bin := t.TempDir()
+	script := "#!/bin/sh\n" +
+		"for a in \"$@\"; do\n" +
+		"  if [ \"$a\" = \"--resume\" ]; then\n" +
+		"    echo 'No conversation found with session ID: x'\n" +
+		"    echo '{\"type\":\"result\",\"subtype\":\"error_during_execution\",\"is_error\":true,\"num_turns\":0}'\n" +
+		"    exit 1\n" +
+		"  fi\n" +
+		"done\n" +
+		"printf '{\"fresh\":true}' > report.json\n" +
+		"echo '{\"type\":\"system\",\"subtype\":\"init\",\"session_id\":\"fresh-sess\"}'\n" +
+		"echo '{\"type\":\"result\",\"subtype\":\"success\",\"result\":\"ok\",\"num_turns\":1}'\n" +
+		"exit 0\n"
+	if err := os.WriteFile(filepath.Join(bin, "claude"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	work := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(work, "src"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	sj := SkillJob{
+		Name:            "deep",
+		Model:           "m",
+		WorkRoot:        work,
+		SrcReady:        true,
+		OutputFile:      "report.json",
+		ResumeSessionID: "dead-session",
+		ResumePrompt:    "repair report.json",
+	}
+	var sawNoFreshLog bool
+	res, err := LocalClaude{}.RunSkill(context.Background(), sj, func(e Event) {
+		if e.Kind == KindText && strings.Contains(e.Text, resumePromptNoFreshFallbackText) {
+			sawNoFreshLog = true
+		}
+	})
+	if err == nil {
+		t.Fatal("RunSkill succeeded, want resume failure without fresh fallback")
+	}
+	if !sawNoFreshLog {
+		t.Error("expected log explaining repair resume was not restarted fresh")
+	}
+	if res.SessionID != "" {
+		t.Errorf("SessionID = %q, want empty", res.SessionID)
+	}
+	if res.Report != "" {
+		t.Errorf("Report = %q, want empty because fresh fallback must not run", res.Report)
+	}
+	if _, err := os.Stat(filepath.Join(work, "report.json")); !os.IsNotExist(err) {
+		t.Fatalf("fresh fallback wrote report.json; stat err = %v", err)
+	}
+}
+
 func TestClaudePlanLimitText(t *testing.T) {
 	for _, text := range []string{
 		"Claude usage limit reached. Your limit will reset later.",

--- a/internal/worker/docker.go
+++ b/internal/worker/docker.go
@@ -165,6 +165,10 @@ func (d DockerRunner) RunSkill(ctx context.Context, sj SkillJob, emit func(Event
 	hitMaxTurns, sessionID, waitErr := d.runDockerOnce(ctx, dockerBase, sj, wrappedEmit)
 
 	if waitErr != nil && sj.ResumeSessionID != "" && sessionID == "" && planLimitText == "" {
+		if sj.ResumePrompt != "" {
+			emit(Event{Kind: KindText, Text: "resume of session " + sj.ResumeSessionID + " failed; " + resumePromptNoFreshFallbackText})
+			return SkillResult{Commit: commit, Profile: profile}, fmt.Errorf("docker exited: %w", waitErr)
+		}
 		// The resume produced no session event, so claude could not load the
 		// saved conversation (gone from the mounted store). Restart fresh in
 		// the same /work + config mount so the retry lineage isn't wedged on

--- a/internal/worker/schema_validate_test.go
+++ b/internal/worker/schema_validate_test.go
@@ -224,7 +224,7 @@ func TestDoSkill_schemaMismatchResumesForRepair(t *testing.T) {
 	if got.Report != `{"tier":"ready","summary":"fixed"}` {
 		t.Errorf("Report = %q, want repaired report", got.Report)
 	}
-	if !strings.Contains(got.Log, "asking claude to repair report.json") {
+	if !strings.Contains(got.Log, "report.json failed validation; asking claude to repair it") {
 		t.Errorf("Log should mention repair attempt, got %q", got.Log)
 	}
 
@@ -251,14 +251,54 @@ func TestDoSkill_schemaRepairStillInvalidFailsStrict(t *testing.T) {
 	if got.Status != db.ScanFailed {
 		t.Fatalf("Status = %s, want failed", got.Status)
 	}
-	if got.Report != `{"tier":"wrong"}` {
-		t.Errorf("Report = %q, want last repaired report", got.Report)
+	if got.Report != `{"tier":{"x":1}}` {
+		t.Errorf("Report = %q, want original report after invalid repair", got.Report)
 	}
 	if !strings.Contains(got.Error, "schema validation") {
 		t.Errorf("Error = %q, want schema validation error", got.Error)
 	}
 	if len(runner.jobs) != 2 {
 		t.Errorf("RunSkill calls = %d, want 2", len(runner.jobs))
+	}
+	if count := strings.Count(got.Log, "does not validate against schema.json"); count != 1 {
+		t.Errorf("schema validation detail logged %d times, want 1; log:\n%s", count, got.Log)
+	}
+}
+
+func TestDoSkill_schemaRepairErrorFallsBackInWarnMode(t *testing.T) {
+	original := `{"tier":"ready","summary":"ok","extra":1}`
+	runner := &sequenceRunner{
+		results: []SkillResult{
+			{SessionID: "sess-1", Report: original},
+			{SessionID: "sess-1"},
+		},
+		errs: []error{nil, errors.New("cli flake")},
+	}
+	w, repoID, scanID := newQueuedSchemaSkillWorker(t, false, runner)
+	body, _ := json.Marshal(queue.Payload{ScanID: scanID})
+	if err := w.wrap(w.doSkill)(context.Background(), body); err != nil {
+		t.Fatalf("wrap should save and return nil, got %v", err)
+	}
+
+	var got db.Scan
+	w.DB.First(&got, scanID)
+	if got.Status != db.ScanDone {
+		t.Fatalf("Status = %s, want done: %s", got.Status, got.Error)
+	}
+	if got.Report != original {
+		t.Errorf("Report = %q, want original report after repair error", got.Report)
+	}
+	if !strings.Contains(got.Log, "repair attempt for report.json failed: cli flake; parsing original output") {
+		t.Errorf("Log should mention best-effort repair failure, got %q", got.Log)
+	}
+	if count := strings.Count(got.Log, "does not validate against schema.json"); count != 1 {
+		t.Errorf("schema validation detail logged %d times, want 1; log:\n%s", count, got.Log)
+	}
+
+	var repo db.Repository
+	w.DB.First(&repo, repoID)
+	if repo.Posture != "ready" {
+		t.Errorf("repo.Posture = %q, want ready from original report", repo.Posture)
 	}
 }
 
@@ -285,6 +325,26 @@ func TestParseSkillOutput_schemaStrictFails(t *testing.T) {
 	if repo.Posture != "" {
 		t.Errorf("repo.Posture = %q, want empty (parser should not have run)", repo.Posture)
 	}
+}
+
+func TestParseSkillOutput_schemaMessageUsesOutputFile(t *testing.T) {
+	w, skill, scan := newSchemaTestWorker(t, false)
+	skill.OutputFile = "custom-output.json"
+
+	var events []Event
+	err := w.parseSkillOutput(skill, scan, `{"tier":"ready","summary":"ok","extra":1}`, func(e Event) { events = append(events, e) })
+	if err != nil {
+		t.Fatalf("warn mode should not fail on schema mismatch: %v", err)
+	}
+	for _, e := range events {
+		if e.Kind == KindError && strings.Contains(e.Text, "schema:") {
+			if !strings.Contains(e.Text, "custom-output.json does not validate against schema.json") {
+				t.Errorf("schema message should use output file, got %q", e.Text)
+			}
+			return
+		}
+	}
+	t.Fatal("expected schema error event")
 }
 
 func TestParseSkillOutput_schemaStrictPassesThrough(t *testing.T) {

--- a/internal/worker/schema_validate_test.go
+++ b/internal/worker/schema_validate_test.go
@@ -106,6 +106,54 @@ func newSchemaTestWorker(t *testing.T, strict bool) (*Worker, *db.Skill, *db.Sca
 	return w, &skill, &scan
 }
 
+type sequenceRunner struct {
+	results []SkillResult
+	errs    []error
+	jobs    []SkillJob
+}
+
+func (r *sequenceRunner) RunSkill(_ context.Context, sj SkillJob, emit func(Event)) (SkillResult, error) {
+	r.jobs = append(r.jobs, sj)
+	emit(Event{Kind: KindText, Text: "running skill " + sj.Name})
+	idx := len(r.jobs) - 1
+	var res SkillResult
+	if idx < len(r.results) {
+		res = r.results[idx]
+	}
+	var err error
+	if idx < len(r.errs) {
+		err = r.errs[idx]
+	}
+	return res, err
+}
+
+func newQueuedSchemaSkillWorker(t *testing.T, strict bool, runner SkillRunner) (*Worker, uint, uint) {
+	t.Helper()
+	gdb, err := db.Open(filepath.Join(t.TempDir(), "p.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo := db.Repository{URL: "https://example.com/x", Name: "x"}
+	gdb.Create(&repo)
+	skill := db.Skill{
+		Name: "posture-test", Description: "d", Body: "b",
+		OutputFile: "report.json", OutputKind: "posture",
+		SchemaJSON: testSchema, Version: 1, Active: true, Source: "ui",
+	}
+	gdb.Create(&skill)
+	scan := db.Scan{RepositoryID: repo.ID, Kind: JobSkill, Status: db.ScanQueued,
+		SkillID: &skill.ID, Model: "fake"}
+	gdb.Create(&scan)
+	w := &Worker{
+		DB: gdb, Log: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		DataDir:        t.TempDir(),
+		SchemaStrict:   strict,
+		Runner:         runner,
+		PrepareRepoSrc: stubPrepareRepoSrc,
+	}
+	return w, repo.ID, scan.ID
+}
+
 func TestParseSkillOutput_schemaWarnAndContinue(t *testing.T) {
 	w, skill, scan := newSchemaTestWorker(t, false)
 
@@ -138,6 +186,79 @@ func TestParseSkillOutput_schemaWarnAndContinue(t *testing.T) {
 	w.DB.First(&repo, scan.RepositoryID)
 	if repo.Posture != "ready" {
 		t.Errorf("repo.Posture = %q, want ready (parser should have run)", repo.Posture)
+	}
+}
+
+func TestDoSkill_schemaMismatchResumesForRepair(t *testing.T) {
+	runner := &sequenceRunner{results: []SkillResult{
+		{SessionID: "sess-1", Report: `{"tier":{"x":1}}`},
+		{SessionID: "sess-1", Report: `{"tier":"ready","summary":"fixed"}`},
+	}}
+	w, repoID, scanID := newQueuedSchemaSkillWorker(t, true, runner)
+	body, _ := json.Marshal(queue.Payload{ScanID: scanID})
+	if err := w.wrap(w.doSkill)(context.Background(), body); err != nil {
+		t.Fatalf("wrap should save and return nil, got %v", err)
+	}
+
+	if len(runner.jobs) != 2 {
+		t.Fatalf("RunSkill calls = %d, want 2", len(runner.jobs))
+	}
+	if runner.jobs[0].ResumeSessionID != "" {
+		t.Errorf("fresh run ResumeSessionID = %q, want empty", runner.jobs[0].ResumeSessionID)
+	}
+	repairJob := runner.jobs[1]
+	if repairJob.ResumeSessionID != "sess-1" {
+		t.Errorf("repair ResumeSessionID = %q, want sess-1", repairJob.ResumeSessionID)
+	}
+	for _, want := range []string{"schema.json", "report.json", "/tier", "Previous invalid"} {
+		if !strings.Contains(repairJob.ResumePrompt, want) {
+			t.Errorf("repair prompt should mention %q; got %q", want, repairJob.ResumePrompt)
+		}
+	}
+
+	var got db.Scan
+	w.DB.First(&got, scanID)
+	if got.Status != db.ScanDone {
+		t.Fatalf("Status = %s, want done: %s", got.Status, got.Error)
+	}
+	if got.Report != `{"tier":"ready","summary":"fixed"}` {
+		t.Errorf("Report = %q, want repaired report", got.Report)
+	}
+	if !strings.Contains(got.Log, "asking claude to repair report.json") {
+		t.Errorf("Log should mention repair attempt, got %q", got.Log)
+	}
+
+	var fresh db.Repository
+	w.DB.First(&fresh, repoID)
+	if fresh.Posture != "ready" {
+		t.Errorf("repo.Posture = %q, want ready", fresh.Posture)
+	}
+}
+
+func TestDoSkill_schemaRepairStillInvalidFailsStrict(t *testing.T) {
+	runner := &sequenceRunner{results: []SkillResult{
+		{SessionID: "sess-1", Report: `{"tier":{"x":1}}`},
+		{SessionID: "sess-1", Report: `{"tier":"wrong"}`},
+	}}
+	w, _, scanID := newQueuedSchemaSkillWorker(t, true, runner)
+	body, _ := json.Marshal(queue.Payload{ScanID: scanID})
+	if err := w.wrap(w.doSkill)(context.Background(), body); err != nil {
+		t.Fatalf("wrap should save and return nil, got %v", err)
+	}
+
+	var got db.Scan
+	w.DB.First(&got, scanID)
+	if got.Status != db.ScanFailed {
+		t.Fatalf("Status = %s, want failed", got.Status)
+	}
+	if got.Report != `{"tier":"wrong"}` {
+		t.Errorf("Report = %q, want last repaired report", got.Report)
+	}
+	if !strings.Contains(got.Error, "schema validation") {
+		t.Errorf("Error = %q, want schema validation error", got.Error)
+	}
+	if len(runner.jobs) != 2 {
+		t.Errorf("RunSkill calls = %d, want 2", len(runner.jobs))
 	}
 }
 

--- a/internal/worker/schema_validate_test.go
+++ b/internal/worker/schema_validate_test.go
@@ -109,6 +109,7 @@ func newSchemaTestWorker(t *testing.T, strict bool) (*Worker, *db.Skill, *db.Sca
 type sequenceRunner struct {
 	results []SkillResult
 	errs    []error
+	events  [][]Event
 	jobs    []SkillJob
 }
 
@@ -116,6 +117,11 @@ func (r *sequenceRunner) RunSkill(_ context.Context, sj SkillJob, emit func(Even
 	r.jobs = append(r.jobs, sj)
 	emit(Event{Kind: KindText, Text: "running skill " + sj.Name})
 	idx := len(r.jobs) - 1
+	if idx < len(r.events) {
+		for _, e := range r.events[idx] {
+			emit(e)
+		}
+	}
 	var res SkillResult
 	if idx < len(r.results) {
 		res = r.results[idx]
@@ -193,6 +199,17 @@ func TestDoSkill_schemaMismatchResumesForRepair(t *testing.T) {
 	runner := &sequenceRunner{results: []SkillResult{
 		{SessionID: "sess-1", Report: `{"tier":{"x":1}}`},
 		{SessionID: "sess-1", Report: `{"tier":"ready","summary":"fixed"}`},
+	}, events: [][]Event{
+		{
+			{Kind: KindResult, CostUSD: 1.25, Turns: 8, Usage: Usage{
+				InputTokens: 100, OutputTokens: 20, CacheReadTokens: 300, CacheWriteTokens: 40,
+			}},
+		},
+		{
+			{Kind: KindResult, CostUSD: 0.25, Turns: 2, Usage: Usage{
+				InputTokens: 30, OutputTokens: 10, CacheReadTokens: 70, CacheWriteTokens: 5,
+			}},
+		},
 	}}
 	w, repoID, scanID := newQueuedSchemaSkillWorker(t, true, runner)
 	body, _ := json.Marshal(queue.Payload{ScanID: scanID})
@@ -210,6 +227,9 @@ func TestDoSkill_schemaMismatchResumesForRepair(t *testing.T) {
 	if repairJob.ResumeSessionID != "sess-1" {
 		t.Errorf("repair ResumeSessionID = %q, want sess-1", repairJob.ResumeSessionID)
 	}
+	if repairJob.MaxTurns != schemaRepairMaxTurns {
+		t.Errorf("repair MaxTurns = %d, want %d", repairJob.MaxTurns, schemaRepairMaxTurns)
+	}
 	for _, want := range []string{"schema.json", "report.json", "/tier", "Previous invalid"} {
 		if !strings.Contains(repairJob.ResumePrompt, want) {
 			t.Errorf("repair prompt should mention %q; got %q", want, repairJob.ResumePrompt)
@@ -226,6 +246,16 @@ func TestDoSkill_schemaMismatchResumesForRepair(t *testing.T) {
 	}
 	if !strings.Contains(got.Log, "report.json failed validation; asking claude to repair it") {
 		t.Errorf("Log should mention repair attempt, got %q", got.Log)
+	}
+	if got.CostUSD != 1.50 {
+		t.Errorf("CostUSD = %.2f, want 1.50", got.CostUSD)
+	}
+	if got.Turns != 10 {
+		t.Errorf("Turns = %d, want 10", got.Turns)
+	}
+	if got.InputTokens != 130 || got.OutputTokens != 30 || got.CacheReadTokens != 370 || got.CacheWriteTokens != 45 {
+		t.Errorf("usage = in:%d out:%d read:%d write:%d, want in:130 out:30 read:370 write:45",
+			got.InputTokens, got.OutputTokens, got.CacheReadTokens, got.CacheWriteTokens)
 	}
 
 	var fresh db.Repository

--- a/internal/worker/skill.go
+++ b/internal/worker/skill.go
@@ -17,7 +17,7 @@ const (
 	filePerm                  = 0o644
 	defaultSkillOutputFile    = "report.json"
 	skillSchemaFile           = "schema.json"
-	schemaRepairMaxAttempts   = 1
+	schemaRepairMaxTurns      = 4
 	schemaRepairReportMaxSize = 4000
 )
 
@@ -227,36 +227,35 @@ func (w *Worker) repairSchemaReport(ctx context.Context, skill *db.Skill, scan *
 		return "", false
 	}
 
-	for attempt := 1; attempt <= schemaRepairMaxAttempts; attempt++ {
-		emit(Event{Kind: KindText, Text: fmt.Sprintf("schema: %s failed validation; asking claude to repair it (attempt %d/%d)", outputFile, attempt, schemaRepairMaxAttempts)})
-		repairJob := sj
-		repairJob.ResumeSessionID = scan.SessionID
-		repairJob.ResumePrompt = buildSchemaRepairPrompt(skill, detail, report)
-		res, err := w.Runner.RunSkill(ctx, repairJob, emit)
-		if res.SessionID != "" && res.SessionID != scan.SessionID {
-			scan.SessionID = res.SessionID
-		}
-		if res.Commit != "" {
-			scan.Commit = res.Commit
-		}
-		if res.Profile != "" && res.Profile != scan.Profile {
-			scan.Profile = res.Profile
-			w.DB.Model(scan).Update("profile", res.Profile)
-		}
-		if err != nil {
-			emit(Event{Kind: KindError, Text: fmt.Sprintf("schema: repair attempt for %s failed: %v; parsing original output", outputFile, err)})
-			return "", false
-		}
-		if res.Report == "" {
-			emit(Event{Kind: KindError, Text: fmt.Sprintf("schema: repair attempt did not produce %s; parsing original output", outputFile)})
-			return "", false
-		}
-		if detail = validateReportSchema(skill.SchemaJSON, res.Report); detail == "" {
-			emit(Event{Kind: KindText, Text: fmt.Sprintf("schema: repaired %s validates", outputFile)})
-			return res.Report, true
-		}
-		emit(Event{Kind: KindText, Text: fmt.Sprintf("schema: repaired %s still does not validate; parsing original output", outputFile)})
+	emit(Event{Kind: KindText, Text: fmt.Sprintf("schema: %s failed validation; asking claude to repair it", outputFile)})
+	repairJob := sj
+	repairJob.ResumeSessionID = scan.SessionID
+	repairJob.ResumePrompt = buildSchemaRepairPrompt(skill, detail, report)
+	repairJob.MaxTurns = schemaRepairMaxTurns
+	res, err := w.Runner.RunSkill(ctx, repairJob, emit)
+	if res.SessionID != "" && res.SessionID != scan.SessionID {
+		scan.SessionID = res.SessionID
 	}
+	if res.Commit != "" {
+		scan.Commit = res.Commit
+	}
+	if res.Profile != "" && res.Profile != scan.Profile {
+		scan.Profile = res.Profile
+		w.DB.Model(scan).Update("profile", res.Profile)
+	}
+	if err != nil {
+		emit(Event{Kind: KindError, Text: fmt.Sprintf("schema: repair attempt for %s failed: %v; parsing original output", outputFile, err)})
+		return "", false
+	}
+	if res.Report == "" {
+		emit(Event{Kind: KindError, Text: fmt.Sprintf("schema: repair attempt did not produce %s; parsing original output", outputFile)})
+		return "", false
+	}
+	if detail = validateReportSchema(skill.SchemaJSON, res.Report); detail == "" {
+		emit(Event{Kind: KindText, Text: fmt.Sprintf("schema: repaired %s validates", outputFile)})
+		return res.Report, true
+	}
+	emit(Event{Kind: KindText, Text: fmt.Sprintf("schema: repaired %s still does not validate; parsing original output", outputFile)})
 	return "", false
 }
 

--- a/internal/worker/skill.go
+++ b/internal/worker/skill.go
@@ -208,9 +208,12 @@ func (w *Worker) parsePartialSkillReport(skill *db.Skill, scan *db.Scan, report 
 }
 
 func (w *Worker) repairAndParseSkillOutput(ctx context.Context, skill *db.Skill, scan *db.Scan, sj SkillJob, report string, emit func(Event)) (string, error) {
-	report, err := w.repairSchemaReport(ctx, skill, scan, sj, report, emit)
-	if err != nil {
-		return report, err
+	if skill.SchemaJSON != "" {
+		if detail := validateReportSchema(skill.SchemaJSON, report); detail != "" {
+			if repairedReport, ok := w.repairSchemaReport(ctx, skill, scan, sj, report, detail, emit); ok {
+				report = repairedReport
+			}
+		}
 	}
 	if err := w.parseSkillOutput(skill, scan, report, emit); err != nil {
 		return report, err
@@ -218,25 +221,17 @@ func (w *Worker) repairAndParseSkillOutput(ctx context.Context, skill *db.Skill,
 	return report, nil
 }
 
-func (w *Worker) repairSchemaReport(ctx context.Context, skill *db.Skill, scan *db.Scan, sj SkillJob, report string, emit func(Event)) (string, error) {
-	if skill.SchemaJSON == "" {
-		return report, nil
-	}
-	detail := validateReportSchema(skill.SchemaJSON, report)
-	if detail == "" {
-		return report, nil
-	}
-	emit(Event{Kind: KindError, Text: fmt.Sprintf("schema: %s does not validate against %s:\n%s", defaultSkillOutputFile, skillSchemaFile, detail)})
+func (w *Worker) repairSchemaReport(ctx context.Context, skill *db.Skill, scan *db.Scan, sj SkillJob, report, detail string, emit func(Event)) (string, bool) {
+	outputFile := skillOutputFile(skill)
 	if scan.SessionID == "" {
-		return report, nil
+		return "", false
 	}
 
-	repairedReport := report
 	for attempt := 1; attempt <= schemaRepairMaxAttempts; attempt++ {
-		emit(Event{Kind: KindText, Text: fmt.Sprintf("schema: asking claude to repair %s (attempt %d/%d)", defaultSkillOutputFile, attempt, schemaRepairMaxAttempts)})
+		emit(Event{Kind: KindText, Text: fmt.Sprintf("schema: %s failed validation; asking claude to repair it (attempt %d/%d)", outputFile, attempt, schemaRepairMaxAttempts)})
 		repairJob := sj
 		repairJob.ResumeSessionID = scan.SessionID
-		repairJob.ResumePrompt = buildSchemaRepairPrompt(skill, detail, repairedReport)
+		repairJob.ResumePrompt = buildSchemaRepairPrompt(skill, detail, report)
 		res, err := w.Runner.RunSkill(ctx, repairJob, emit)
 		if res.SessionID != "" && res.SessionID != scan.SessionID {
 			scan.SessionID = res.SessionID
@@ -249,29 +244,24 @@ func (w *Worker) repairSchemaReport(ctx context.Context, skill *db.Skill, scan *
 			w.DB.Model(scan).Update("profile", res.Profile)
 		}
 		if err != nil {
-			if res.Report != "" {
-				repairedReport = res.Report
-			}
-			return repairedReport, err
+			emit(Event{Kind: KindError, Text: fmt.Sprintf("schema: repair attempt for %s failed: %v; parsing original output", outputFile, err)})
+			return "", false
 		}
-		if res.Report != "" {
-			repairedReport = res.Report
-			detail = validateReportSchema(skill.SchemaJSON, repairedReport)
-			if detail == "" {
-				emit(Event{Kind: KindText, Text: fmt.Sprintf("schema: repaired %s validates", defaultSkillOutputFile)})
-				return repairedReport, nil
-			}
-			emit(Event{Kind: KindError, Text: fmt.Sprintf("schema: repaired %s still does not validate against %s:\n%s", defaultSkillOutputFile, skillSchemaFile, detail)})
+		if res.Report == "" {
+			emit(Event{Kind: KindError, Text: fmt.Sprintf("schema: repair attempt did not produce %s; parsing original output", outputFile)})
+			return "", false
 		}
+		if detail = validateReportSchema(skill.SchemaJSON, res.Report); detail == "" {
+			emit(Event{Kind: KindText, Text: fmt.Sprintf("schema: repaired %s validates", outputFile)})
+			return res.Report, true
+		}
+		emit(Event{Kind: KindText, Text: fmt.Sprintf("schema: repaired %s still does not validate; parsing original output", outputFile)})
 	}
-	return repairedReport, nil
+	return "", false
 }
 
 func buildSchemaRepairPrompt(skill *db.Skill, detail, report string) string {
-	outputFile := skill.OutputFile
-	if outputFile == "" {
-		outputFile = defaultSkillOutputFile
-	}
+	outputFile := skillOutputFile(skill)
 	return fmt.Sprintf(`Your previous %q skill run wrote ./%s, but it failed validation against ./%s.
 
 Validation errors:
@@ -281,6 +271,17 @@ Rewrite only ./%s with JSON that validates against ./%s. Preserve the facts from
 
 Previous invalid ./%s:
 %s`, skill.Name, outputFile, skillSchemaFile, detail, outputFile, skillSchemaFile, outputFile, truncateSchemaRepairReport(report))
+}
+
+func skillOutputFile(skill *db.Skill) string {
+	if skill.OutputFile != "" {
+		return skill.OutputFile
+	}
+	return defaultSkillOutputFile
+}
+
+func schemaValidationEvent(skill *db.Skill, detail string) Event {
+	return Event{Kind: KindError, Text: fmt.Sprintf("schema: %s does not validate against %s:\n%s", skillOutputFile(skill), skillSchemaFile, detail)}
 }
 
 func truncateSchemaRepairReport(report string) string {
@@ -294,7 +295,7 @@ func truncateSchemaRepairReport(report string) string {
 func (w *Worker) parseSkillOutput(skill *db.Skill, scan *db.Scan, report string, emit func(Event)) error {
 	if skill.SchemaJSON != "" {
 		if detail := validateReportSchema(skill.SchemaJSON, report); detail != "" {
-			emit(Event{Kind: KindError, Text: "schema: report.json does not validate against schema.json:\n" + detail})
+			emit(schemaValidationEvent(skill, detail))
 			if w.SchemaStrict {
 				return &SchemaValidationError{Skill: skill.Name, Detail: detail}
 			}

--- a/internal/worker/skill.go
+++ b/internal/worker/skill.go
@@ -13,7 +13,13 @@ import (
 	"scrutineer/internal/skills"
 )
 
-const filePerm = 0o644
+const (
+	filePerm                  = 0o644
+	defaultSkillOutputFile    = "report.json"
+	skillSchemaFile           = "schema.json"
+	schemaRepairMaxAttempts   = 1
+	schemaRepairReportMaxSize = 4000
+)
 
 // skillContext is the JSON document scrutineer writes to ./context.json in
 // every skill workspace before invoking claude. Skills that need to know who
@@ -180,12 +186,15 @@ func (w *Worker) doSkill(ctx context.Context, scan *db.Scan, emit func(Event)) (
 		return res.Report, err
 	}
 
-	if res.Report != "" {
-		if err := w.parseSkillOutput(&skill, scan, res.Report, emit); err != nil {
-			return res.Report, err
+	report := res.Report
+	if report != "" {
+		var err error
+		report, err = w.repairAndParseSkillOutput(ctx, &skill, scan, sj, report, emit)
+		if err != nil {
+			return report, err
 		}
 	}
-	return res.Report, nil
+	return report, nil
 }
 
 // parsePartialSkillReport runs parseSkillOutput against a max-turns
@@ -196,6 +205,90 @@ func (w *Worker) parsePartialSkillReport(skill *db.Skill, scan *db.Scan, report 
 	if err := w.parseSkillOutput(skill, scan, report, emit); err != nil {
 		w.Log.Warn("parse partial skill output after max turns", "scan", scan.ID, "skill", skill.Name, "err", err)
 	}
+}
+
+func (w *Worker) repairAndParseSkillOutput(ctx context.Context, skill *db.Skill, scan *db.Scan, sj SkillJob, report string, emit func(Event)) (string, error) {
+	report, err := w.repairSchemaReport(ctx, skill, scan, sj, report, emit)
+	if err != nil {
+		return report, err
+	}
+	if err := w.parseSkillOutput(skill, scan, report, emit); err != nil {
+		return report, err
+	}
+	return report, nil
+}
+
+func (w *Worker) repairSchemaReport(ctx context.Context, skill *db.Skill, scan *db.Scan, sj SkillJob, report string, emit func(Event)) (string, error) {
+	if skill.SchemaJSON == "" {
+		return report, nil
+	}
+	detail := validateReportSchema(skill.SchemaJSON, report)
+	if detail == "" {
+		return report, nil
+	}
+	emit(Event{Kind: KindError, Text: fmt.Sprintf("schema: %s does not validate against %s:\n%s", defaultSkillOutputFile, skillSchemaFile, detail)})
+	if scan.SessionID == "" {
+		return report, nil
+	}
+
+	repairedReport := report
+	for attempt := 1; attempt <= schemaRepairMaxAttempts; attempt++ {
+		emit(Event{Kind: KindText, Text: fmt.Sprintf("schema: asking claude to repair %s (attempt %d/%d)", defaultSkillOutputFile, attempt, schemaRepairMaxAttempts)})
+		repairJob := sj
+		repairJob.ResumeSessionID = scan.SessionID
+		repairJob.ResumePrompt = buildSchemaRepairPrompt(skill, detail, repairedReport)
+		res, err := w.Runner.RunSkill(ctx, repairJob, emit)
+		if res.SessionID != "" && res.SessionID != scan.SessionID {
+			scan.SessionID = res.SessionID
+		}
+		if res.Commit != "" {
+			scan.Commit = res.Commit
+		}
+		if res.Profile != "" && res.Profile != scan.Profile {
+			scan.Profile = res.Profile
+			w.DB.Model(scan).Update("profile", res.Profile)
+		}
+		if err != nil {
+			if res.Report != "" {
+				repairedReport = res.Report
+			}
+			return repairedReport, err
+		}
+		if res.Report != "" {
+			repairedReport = res.Report
+			detail = validateReportSchema(skill.SchemaJSON, repairedReport)
+			if detail == "" {
+				emit(Event{Kind: KindText, Text: fmt.Sprintf("schema: repaired %s validates", defaultSkillOutputFile)})
+				return repairedReport, nil
+			}
+			emit(Event{Kind: KindError, Text: fmt.Sprintf("schema: repaired %s still does not validate against %s:\n%s", defaultSkillOutputFile, skillSchemaFile, detail)})
+		}
+	}
+	return repairedReport, nil
+}
+
+func buildSchemaRepairPrompt(skill *db.Skill, detail, report string) string {
+	outputFile := skill.OutputFile
+	if outputFile == "" {
+		outputFile = defaultSkillOutputFile
+	}
+	return fmt.Sprintf(`Your previous %q skill run wrote ./%s, but it failed validation against ./%s.
+
+Validation errors:
+%s
+
+Rewrite only ./%s with JSON that validates against ./%s. Preserve the facts from the previous run, do not restart the analysis, and do not write prose outside the JSON file.
+
+Previous invalid ./%s:
+%s`, skill.Name, outputFile, skillSchemaFile, detail, outputFile, skillSchemaFile, outputFile, truncateSchemaRepairReport(report))
+}
+
+func truncateSchemaRepairReport(report string) string {
+	report = strings.TrimSpace(report)
+	if len(report) <= schemaRepairReportMaxSize {
+		return report
+	}
+	return report[:schemaRepairReportMaxSize] + "\n... truncated ..."
 }
 
 func (w *Worker) parseSkillOutput(skill *db.Skill, scan *db.Scan, report string, emit func(Event)) error {

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -235,12 +235,12 @@ func (w *Worker) scanEmitter(scan *db.Scan) func(Event) {
 			lastFlush = time.Now()
 		}
 		if e.Kind == KindResult {
-			scan.CostUSD = e.CostUSD
-			scan.Turns = e.Turns
-			scan.InputTokens = e.Usage.InputTokens
-			scan.OutputTokens = e.Usage.OutputTokens
-			scan.CacheReadTokens = e.Usage.CacheReadTokens
-			scan.CacheWriteTokens = e.Usage.CacheWriteTokens
+			scan.CostUSD += e.CostUSD
+			scan.Turns += e.Turns
+			scan.InputTokens += e.Usage.InputTokens
+			scan.OutputTokens += e.Usage.OutputTokens
+			scan.CacheReadTokens += e.Usage.CacheReadTokens
+			scan.CacheWriteTokens += e.Usage.CacheWriteTokens
 		}
 		w.publish(scan.ID, scan.RepositoryID, "scan-log", line+"\n")
 	}


### PR DESCRIPTION
## Summary

Fixes #261.

Adds a schema repair retry for skill runs when `report.json` does not validate against the skill's `schema.json`.

## Changes

- Validate skill output before parsing and detect schema mismatches early
- Resume the existing Claude session once with the schema validation errors
- Ask Claude to rewrite only `report.json` using the validator feedback
- Preserve existing behavior after the retry:
  - default mode logs the schema mismatch and continues parsing
  - `-schema-strict` still fails the scan if the repaired output is invalid
- Add tests for successful schema repair and strict-mode repair failure
- Document the schema repair behavior in `docs/skills.md`

## Testing

- `go test ./internal/worker`
- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `golangci-lint run ./...`