### PR TITLE
Hide closed findings by default

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -296,6 +296,19 @@ var FindingLifecycles = []FindingLifecycle{
 	FindingAcknowledged, FindingFixed, FindingPublished, FindingRejected, FindingDuplicate,
 }
 
+// ClosedFindingLifecycles are terminal or hidden-by-default findings.
+var ClosedFindingLifecycles = []FindingLifecycle{
+	FindingFixed, FindingPublished, FindingRejected, FindingDuplicate,
+}
+
+func ClosedFindingLifecycleSQLValues() string {
+	values := make([]string, 0, len(ClosedFindingLifecycles))
+	for _, status := range ClosedFindingLifecycles {
+		values = append(values, "'"+strings.ReplaceAll(string(status), "'", "''")+"'")
+	}
+	return strings.Join(values, ", ")
+}
+
 // Advisory is a known security advisory from advisories.ecosyste.ms.
 type Advisory struct {
 	ID           uint `gorm:"primarykey"`

--- a/internal/db/ecosystem.go
+++ b/internal/db/ecosystem.go
@@ -206,7 +206,7 @@ func DependencyFindings(g *gorm.DB, appRepoID uint) ([]DependencyFinding, error)
 	}
 	var findings []Finding
 	if err := g.Where("repository_id IN ?", libIDs).
-		Where("status NOT IN ?", []FindingLifecycle{FindingFixed, FindingRejected, FindingDuplicate}).
+		Where("status NOT IN ?", ClosedFindingLifecycles).
 		Order("CASE severity WHEN 'Critical' THEN 0 WHEN 'High' THEN 1 WHEN 'Medium' THEN 2 ELSE 3 END, repository_id").
 		Find(&findings).Error; err != nil {
 		return nil, err

--- a/internal/web/sboms.go
+++ b/internal/web/sboms.go
@@ -136,8 +136,7 @@ func (s *Server) sbomShow(w http.ResponseWriter, r *http.Request) {
 		// Deep-dive findings only — the SBOM "Findings" tab is a
 		// downstream-impact view, where lint output from per-repo scanners
 		// (zizmor, semgrep) would be misleading at this level.
-		q := s.DB.Where("repository_id IN ? AND status NOT IN ?", repoIDs,
-			[]db.FindingLifecycle{db.FindingRejected, db.FindingDuplicate}).
+		q := s.DB.Where("repository_id IN ? AND status NOT IN ?", repoIDs, closedFindingStatuses).
 			Where("scan_id IN (?)", deepDiveScanIDs(s.DB))
 		if sev := r.URL.Query().Get("severity"); sev != "" {
 			q = q.Where("severity = ?", sev)

--- a/internal/web/sboms.go
+++ b/internal/web/sboms.go
@@ -136,7 +136,7 @@ func (s *Server) sbomShow(w http.ResponseWriter, r *http.Request) {
 		// Deep-dive findings only — the SBOM "Findings" tab is a
 		// downstream-impact view, where lint output from per-repo scanners
 		// (zizmor, semgrep) would be misleading at this level.
-		q := s.DB.Where("repository_id IN ? AND status NOT IN ?", repoIDs, closedFindingStatuses).
+		q := s.DB.Where("repository_id IN ? AND status NOT IN ?", repoIDs, db.ClosedFindingLifecycles).
 			Where("scan_id IN (?)", deepDiveScanIDs(s.DB))
 		if sev := r.URL.Query().Get("severity"); sev != "" {
 			q = q.Where("severity = ?", sev)

--- a/internal/web/sboms_test.go
+++ b/internal/web/sboms_test.go
@@ -156,7 +156,10 @@ func TestSBOMShow_aggregatesFindings(t *testing.T) {
 	scan := db.Scan{RepositoryID: repo.ID, Kind: "skill", Status: db.ScanDone}
 	s.DB.Create(&scan)
 	s.DB.Create(&db.Finding{ScanID: scan.ID, RepositoryID: repo.ID, Title: "rce-in-r", Severity: "High", Status: db.FindingTriaged})
-	s.DB.Create(&db.Finding{ScanID: scan.ID, RepositoryID: repo.ID, Title: "noise", Severity: "Low", Status: db.FindingRejected})
+	s.DB.Create(&db.Finding{ScanID: scan.ID, RepositoryID: repo.ID, Title: "fixed-noise", Severity: "Low", Status: db.FindingFixed})
+	s.DB.Create(&db.Finding{ScanID: scan.ID, RepositoryID: repo.ID, Title: "published-noise", Severity: "Low", Status: db.FindingPublished})
+	s.DB.Create(&db.Finding{ScanID: scan.ID, RepositoryID: repo.ID, Title: "rejected-noise", Severity: "Low", Status: db.FindingRejected})
+	s.DB.Create(&db.Finding{ScanID: scan.ID, RepositoryID: repo.ID, Title: "duplicate-noise", Severity: "Low", Status: db.FindingDuplicate})
 
 	other := db.Repository{URL: "https://example.com/other", Name: "other"}
 	s.DB.Create(&other)
@@ -176,8 +179,10 @@ func TestSBOMShow_aggregatesFindings(t *testing.T) {
 	if !strings.Contains(body, "rce-in-r") {
 		t.Errorf("finding from linked repo not shown")
 	}
-	if strings.Contains(body, "noise") {
-		t.Errorf("rejected finding should be hidden")
+	for _, hidden := range []string{"fixed-noise", "published-noise", "rejected-noise", "duplicate-noise"} {
+		if strings.Contains(body, hidden) {
+			t.Errorf("closed finding %q should be hidden", hidden)
+		}
 	}
 	if strings.Contains(body, "unrelated") {
 		t.Errorf("finding from unlinked repo should not be shown")

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -553,7 +553,7 @@ func (s *Server) repoList(w http.ResponseWriter, r *http.Request) {
 			Select("repository_id, COUNT(*) AS n").
 			Where("repository_id IN ?", repoIDs).
 			Where("scan_id IN (?)", deepDiveScanIDs(s.DB)).
-			Where("status NOT IN ?", repoListClosedFindingStatuses).
+			Where("status NOT IN ?", closedFindingStatuses).
 			Group("repository_id").
 			Scan(&counts)
 		for _, c := range counts {
@@ -697,8 +697,7 @@ func firstNonEmpty(vals ...string) string {
 // tab stays reachable.
 func loadRepoFindings(gdb *gorm.DB, repoID uint, category string) ([]db.Finding, []db.Finding, map[uint]string, map[uint]string) {
 	var all []db.Finding
-	gdb.Where("repository_id = ? AND status NOT IN ?", repoID,
-		[]db.FindingLifecycle{db.FindingRejected, db.FindingDuplicate}).
+	gdb.Where("repository_id = ? AND status NOT IN ?", repoID, closedFindingStatuses).
 		Order(severityOrder).Order("id desc").Find(&all)
 
 	scanSkill := map[uint]string{}
@@ -747,6 +746,8 @@ func (s *Server) findings(w http.ResponseWriter, r *http.Request) {
 	status := r.URL.Query().Get(statusKey)
 	if status != "" {
 		q = q.Where("status = ?", status)
+	} else {
+		q = q.Where("status NOT IN ?", closedFindingStatuses)
 	}
 	category := r.URL.Query().Get("category")
 	if category != "" {
@@ -796,11 +797,14 @@ func (s *Server) findings(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	var missedTotal int64
-	s.DB.Model(&db.Finding{}).Where("missed_count > 0").Count(&missedTotal)
+	s.DB.Model(&db.Finding{}).
+		Where("missed_count > 0 AND status NOT IN ?", closedFindingStatuses).
+		Count(&missedTotal)
 
 	var scannerTotal int64
 	s.DB.Model(&db.Finding{}).
 		Where("scan_id NOT IN (?)", deepDiveScanIDs(s.DB)).
+		Where("status NOT IN ?", closedFindingStatuses).
 		Count(&scannerTotal)
 
 	s.render(w, r, "findings.html", map[string]any{
@@ -887,7 +891,7 @@ const deepDiveFindingsCountSQL = `SELECT COUNT(*) FROM findings f
 	      AND f.scan_id IN (SELECT id FROM scans
 	        WHERE skill_name = '` + deepDiveSkillName + `' OR skill_name = '' OR skill_name IS NULL)`
 
-var repoListClosedFindingStatuses = []db.FindingLifecycle{
+var closedFindingStatuses = []db.FindingLifecycle{
 	db.FindingFixed, db.FindingPublished, db.FindingRejected, db.FindingDuplicate,
 }
 

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -415,12 +415,13 @@ func (s *Server) index(w http.ResponseWriter, r *http.Request) {
 }
 
 const (
-	perPage     = 20
-	defaultSort = "newest"
-	statusKey   = "status"
-	errorKey    = "error"
-	successKey  = "success"
-	warningKey  = "warning"
+	perPage        = 20
+	defaultSort    = "newest"
+	statusKey      = "status"
+	allStatusValue = "all"
+	errorKey       = "error"
+	successKey     = "success"
+	warningKey     = "warning"
 	// sortRepository and sortSeverity are the shared sort options used by
 	// the findings, scans, advisories, and SBOM indexes.
 	sortRepository = "repository"
@@ -553,7 +554,7 @@ func (s *Server) repoList(w http.ResponseWriter, r *http.Request) {
 			Select("repository_id, COUNT(*) AS n").
 			Where("repository_id IN ?", repoIDs).
 			Where("scan_id IN (?)", deepDiveScanIDs(s.DB)).
-			Where("status NOT IN ?", closedFindingStatuses).
+			Where("status NOT IN ?", db.ClosedFindingLifecycles).
 			Group("repository_id").
 			Scan(&counts)
 		for _, c := range counts {
@@ -697,7 +698,7 @@ func firstNonEmpty(vals ...string) string {
 // tab stays reachable.
 func loadRepoFindings(gdb *gorm.DB, repoID uint, category string) ([]db.Finding, []db.Finding, map[uint]string, map[uint]string) {
 	var all []db.Finding
-	gdb.Where("repository_id = ? AND status NOT IN ?", repoID, closedFindingStatuses).
+	gdb.Where("repository_id = ? AND status NOT IN ?", repoID, db.ClosedFindingLifecycles).
 		Order(severityOrder).Order("id desc").Find(&all)
 
 	scanSkill := map[uint]string{}
@@ -731,43 +732,17 @@ func loadRepoFindings(gdb *gorm.DB, repoID uint, category string) ([]db.Finding,
 }
 
 func (s *Server) findings(w http.ResponseWriter, r *http.Request) {
-	q := s.DB.Model(&db.Finding{})
 	// Default to deep-dive findings only; scanner skills (zizmor, semgrep)
 	// are noisy enough to drown out the audit list. ?scanners=1 includes
 	// them and is exposed as a toggle in the UI.
 	scanners := r.URL.Query().Get("scanners") == "1"
-	if !scanners {
-		q = q.Where("scan_id IN (?)", deepDiveScanIDs(s.DB))
-	}
+	q := s.findingsIndexQuery(r, scanners, true)
 	sev := r.URL.Query().Get("severity")
-	if sev != "" {
-		q = q.Where("severity = ?", sev)
-	}
 	status := r.URL.Query().Get(statusKey)
-	if status != "" {
-		q = q.Where("status = ?", status)
-	} else {
-		q = q.Where("status NOT IN ?", closedFindingStatuses)
-	}
 	category := r.URL.Query().Get("category")
-	if category != "" {
-		q = applyCWECategoryFilter(q, category)
-	}
 	owner := r.URL.Query().Get("owner")
-	if owner != "" {
-		q = q.Where("repository_id IN (?)",
-			s.DB.Model(&db.Repository{}).Select("id").Where("owner = ?", owner))
-	}
 	missed := r.URL.Query().Get("missed") == "1"
-	if missed {
-		q = q.Where("missed_count > 0")
-	}
 	search := strings.TrimSpace(r.URL.Query().Get("q"))
-	if search != "" {
-		like := "%" + search + "%"
-		q = q.Where("title LIKE ? OR location LIKE ? OR cwe LIKE ? OR cve_id LIKE ? OR ghsa_id LIKE ? OR affected LIKE ?",
-			like, like, like, like, like, like)
-	}
 
 	sort := r.URL.Query().Get("sort")
 	switch sort {
@@ -797,14 +772,13 @@ func (s *Server) findings(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	var missedTotal int64
-	s.DB.Model(&db.Finding{}).
-		Where("missed_count > 0 AND status NOT IN ?", closedFindingStatuses).
+	s.findingsIndexQuery(r, scanners, false).
+		Where("missed_count > 0").
 		Count(&missedTotal)
 
 	var scannerTotal int64
-	s.DB.Model(&db.Finding{}).
+	s.findingsIndexQuery(r, true, true).
 		Where("scan_id NOT IN (?)", deepDiveScanIDs(s.DB)).
-		Where("status NOT IN ?", closedFindingStatuses).
 		Count(&scannerTotal)
 
 	s.render(w, r, "findings.html", map[string]any{
@@ -815,6 +789,44 @@ func (s *Server) findings(w http.ResponseWriter, r *http.Request) {
 		"Scanners": scanners, "ScannerTotal": scannerTotal,
 		"Status": status, "Statuses": db.FindingLifecycles,
 	})
+}
+
+func (s *Server) findingsIndexQuery(r *http.Request, includeScanners, includeMissed bool) *gorm.DB {
+	q := s.DB.Model(&db.Finding{})
+	if !includeScanners {
+		q = q.Where("scan_id IN (?)", deepDiveScanIDs(s.DB))
+	}
+	if sev := r.URL.Query().Get("severity"); sev != "" {
+		q = q.Where("severity = ?", sev)
+	}
+	q = applyFindingStatusFilter(q, r.URL.Query().Get(statusKey))
+	if category := r.URL.Query().Get("category"); category != "" {
+		q = applyCWECategoryFilter(q, category)
+	}
+	if owner := r.URL.Query().Get("owner"); owner != "" {
+		q = q.Where("repository_id IN (?)",
+			s.DB.Model(&db.Repository{}).Select("id").Where("owner = ?", owner))
+	}
+	if includeMissed && r.URL.Query().Get("missed") == "1" {
+		q = q.Where("missed_count > 0")
+	}
+	if search := strings.TrimSpace(r.URL.Query().Get("q")); search != "" {
+		like := "%" + search + "%"
+		q = q.Where("title LIKE ? OR location LIKE ? OR cwe LIKE ? OR cve_id LIKE ? OR ghsa_id LIKE ? OR affected LIKE ?",
+			like, like, like, like, like, like)
+	}
+	return q
+}
+
+func applyFindingStatusFilter(q *gorm.DB, status string) *gorm.DB {
+	switch status {
+	case "":
+		return q.Where("status NOT IN ?", db.ClosedFindingLifecycles)
+	case allStatusValue:
+		return q
+	default:
+		return q.Where("status = ?", status)
+	}
 }
 
 func (s *Server) depScan(w http.ResponseWriter, r *http.Request) {
@@ -885,15 +897,11 @@ const (
 // findings for the surrounding repositories row. Used in the repos list
 // "findings" sort. Tool-scanner skills are excluded so the ordering matches
 // the counts shown in the Findings column.
-const deepDiveFindingsCountSQL = `SELECT COUNT(*) FROM findings f
+var deepDiveFindingsCountSQL = `SELECT COUNT(*) FROM findings f
 	    WHERE f.repository_id = repositories.id
-	      AND f.status NOT IN ('fixed', 'published', 'rejected', 'duplicate')
+	      AND f.status NOT IN (` + db.ClosedFindingLifecycleSQLValues() + `)
 	      AND f.scan_id IN (SELECT id FROM scans
 	        WHERE skill_name = '` + deepDiveSkillName + `' OR skill_name = '' OR skill_name IS NULL)`
-
-var closedFindingStatuses = []db.FindingLifecycle{
-	db.FindingFixed, db.FindingPublished, db.FindingRejected, db.FindingDuplicate,
-}
 
 // deepDiveScanIDs returns a GORM subquery selecting scan IDs that belong to
 // the curated audit (security-deep-dive) or to legacy/empty skill_name rows.

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -771,15 +771,7 @@ func (s *Server) findings(w http.ResponseWriter, r *http.Request) {
 			break
 		}
 	}
-	var missedTotal int64
-	s.findingsIndexQuery(r, scanners, false).
-		Where("missed_count > 0").
-		Count(&missedTotal)
-
-	var scannerTotal int64
-	s.findingsIndexQuery(r, true, true).
-		Where("scan_id NOT IN (?)", deepDiveScanIDs(s.DB)).
-		Count(&scannerTotal)
+	missedTotal, scannerTotal := s.findingToggleCounts(r, scanners)
 
 	s.render(w, r, "findings.html", map[string]any{
 		"Findings": rows, "Page": page, "Severity": sev, "Sort": sort,
@@ -816,6 +808,78 @@ func (s *Server) findingsIndexQuery(r *http.Request, includeScanners, includeMis
 			like, like, like, like, like, like)
 	}
 	return q
+}
+
+func (s *Server) findingToggleCounts(r *http.Request, scanners bool) (int64, int64) {
+	missedWhere, missedArgs := findingIndexWhereSQL(r, scanners, false)
+	missedWhere = append(missedWhere, "missed_count > 0")
+
+	scannerWhere, scannerArgs := findingIndexWhereSQL(r, true, true)
+	scannerWhere = append(scannerWhere, "scan_id NOT IN (SELECT id FROM scans WHERE skill_name = ? OR skill_name = '' OR skill_name IS NULL)")
+	scannerArgs = append(scannerArgs, deepDiveSkillName)
+
+	var counts struct {
+		MissedTotal  int64
+		ScannerTotal int64
+	}
+	sql := fmt.Sprintf(
+		"SELECT (SELECT COUNT(*) FROM findings WHERE %s) AS missed_total, (SELECT COUNT(*) FROM findings WHERE %s) AS scanner_total",
+		strings.Join(missedWhere, " AND "),
+		strings.Join(scannerWhere, " AND "),
+	)
+	args := make([]any, 0, len(missedArgs)+len(scannerArgs))
+	args = append(args, missedArgs...)
+	args = append(args, scannerArgs...)
+	s.DB.Raw(sql, args...).Scan(&counts)
+	return counts.MissedTotal, counts.ScannerTotal
+}
+
+func findingIndexWhereSQL(r *http.Request, includeScanners, includeMissed bool) ([]string, []any) {
+	where := []string{"1 = 1"}
+	var args []any
+	if !includeScanners {
+		where = append(where, "scan_id IN (SELECT id FROM scans WHERE skill_name = ? OR skill_name = '' OR skill_name IS NULL)")
+		args = append(args, deepDiveSkillName)
+	}
+	if sev := r.URL.Query().Get("severity"); sev != "" {
+		where = append(where, "severity = ?")
+		args = append(args, sev)
+	}
+	switch status := r.URL.Query().Get(statusKey); status {
+	case "":
+		where = append(where, "status NOT IN ("+db.ClosedFindingLifecycleSQLValues()+")")
+	case allStatusValue:
+	default:
+		where = append(where, "status = ?")
+		args = append(args, status)
+	}
+	if category := r.URL.Query().Get("category"); category != "" {
+		switch {
+		case category == UncategorizedCWE && len(categorizedIDs) == 0:
+			where = append(where, "cwe = ''")
+		case category == UncategorizedCWE:
+			where = append(where, "(cwe = '' OR cwe NOT IN ?)")
+			args = append(args, categorizedIDs)
+		case len(CWEsInCategory(category)) == 0:
+			where = append(where, "1 = 0")
+		default:
+			where = append(where, "cwe IN ?")
+			args = append(args, CWEsInCategory(category))
+		}
+	}
+	if owner := r.URL.Query().Get("owner"); owner != "" {
+		where = append(where, "repository_id IN (SELECT id FROM repositories WHERE owner = ?)")
+		args = append(args, owner)
+	}
+	if includeMissed && r.URL.Query().Get("missed") == "1" {
+		where = append(where, "missed_count > 0")
+	}
+	if search := strings.TrimSpace(r.URL.Query().Get("q")); search != "" {
+		like := "%" + search + "%"
+		where = append(where, "(title LIKE ? OR location LIKE ? OR cwe LIKE ? OR cve_id LIKE ? OR ghsa_id LIKE ? OR affected LIKE ?)")
+		args = append(args, like, like, like, like, like, like)
+	}
+	return where, args
 }
 
 func applyFindingStatusFilter(q *gorm.DB, status string) *gorm.DB {

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -827,12 +827,16 @@ func TestFindings_statusFilter(t *testing.T) {
 			t.Errorf("default listing should hide closed finding %q", title)
 		}
 	}
+	if !strings.Contains(body, ">Open</a>") || !strings.Contains(body, "status=all") {
+		t.Error("status dropdown should expose Open and status=all options")
+	}
 
 	cases := []struct {
 		status  string
 		want    []string
 		missing []string
 	}{
+		{"all", []string{"fresh finding", "triaged finding", "fixed finding", "published finding", "rejected finding", "duplicate finding"}, nil},
 		{"new", []string{"fresh finding"}, []string{"triaged finding", "fixed finding", "published finding", "rejected finding", "duplicate finding"}},
 		{"triaged", []string{"triaged finding"}, []string{"fresh finding", "fixed finding", "published finding", "rejected finding", "duplicate finding"}},
 		{"fixed", []string{"fixed finding"}, []string{"fresh finding", "triaged finding", "published finding", "rejected finding", "duplicate finding"}},
@@ -1153,6 +1157,8 @@ func TestFindings_missedFilterAndBadge(t *testing.T) {
 		Severity: "High"})
 	s.DB.Create(&db.Finding{ScanID: scan.ID, RepositoryID: repo.ID, Title: "possibly-fixed finding",
 		Severity: "High", MissedCount: 2, LastMissedScanID: scan.ID})
+	s.DB.Create(&db.Finding{ScanID: scan.ID, RepositoryID: repo.ID, Title: "closed-missed finding",
+		Severity: "High", Status: db.FindingFixed, MissedCount: 1, LastMissedScanID: scan.ID})
 
 	// Unfiltered: both visible, missed one shows the count, toolbar shows total.
 	w := httptest.NewRecorder()
@@ -1165,7 +1171,7 @@ func TestFindings_missedFilterAndBadge(t *testing.T) {
 		t.Error("missed-count marker not rendered on row")
 	}
 	if !strings.Contains(body, "Not seen on rescan (1)") {
-		t.Error("toolbar should show total findings with missed_count > 0")
+		t.Error("toolbar should show total open findings with missed_count > 0")
 	}
 
 	// ?missed=1: only the missed finding.
@@ -1178,9 +1184,23 @@ func TestFindings_missedFilterAndBadge(t *testing.T) {
 	if !strings.Contains(body, "possibly-fixed finding") {
 		t.Error("?missed=1 should show findings with missed_count > 0")
 	}
+	if strings.Contains(body, "closed-missed finding") {
+		t.Error("?missed=1 should still hide closed findings by default")
+	}
 	// Severity/sort links preserve the missed filter.
 	if !strings.Contains(body, "severity=High&status=&category=&sort=newest&missed=1") {
 		t.Error("severity dropdown links should carry missed=1")
+	}
+
+	// Explicit closed-status filters count and list closed missed findings.
+	w = httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq("GET", "/findings?status=fixed&missed=1"))
+	body = w.Body.String()
+	if !strings.Contains(body, "closed-missed finding") || strings.Contains(body, "possibly-fixed finding") {
+		t.Errorf("fixed missed filter should show only fixed missed findings: %s", body)
+	}
+	if !strings.Contains(body, "Not seen on rescan (1)") {
+		t.Error("missed badge should count fixed missed findings under status=fixed")
 	}
 }
 
@@ -1199,6 +1219,10 @@ func TestFindings_scannerToggle(t *testing.T) {
 	s.DB.Create(&db.Finding{ScanID: dd.ID, RepositoryID: repo.ID, Title: "audit-finding", Severity: "High"})
 	s.DB.Create(&db.Finding{ScanID: sg.ID, RepositoryID: repo.ID, Title: "semgrep-finding", Severity: "High"})
 	s.DB.Create(&db.Finding{ScanID: zz.ID, RepositoryID: repo.ID, Title: "zizmor-finding", Severity: "High"})
+	s.DB.Create(&db.Finding{ScanID: dd.ID, RepositoryID: repo.ID, Title: "fixed-audit-finding",
+		Severity: "High", Status: db.FindingFixed})
+	s.DB.Create(&db.Finding{ScanID: sg.ID, RepositoryID: repo.ID, Title: "fixed-semgrep-finding",
+		Severity: "High", Status: db.FindingFixed})
 
 	// Default: scanner findings hidden, audit visible. Toggle advertises the
 	// total scanner count so the operator knows what they're suppressing.
@@ -1223,6 +1247,17 @@ func TestFindings_scannerToggle(t *testing.T) {
 		if !strings.Contains(body, want) {
 			t.Errorf("?scanners=1 should include %q", want)
 		}
+	}
+
+	// Explicit closed-status filters count matching scanner findings too.
+	w = httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq("GET", "/findings?status=fixed"))
+	body = w.Body.String()
+	if !strings.Contains(body, "fixed-audit-finding") || strings.Contains(body, "fixed-semgrep-finding") {
+		t.Errorf("status=fixed should show fixed audit findings and hide scanner rows by default: %s", body)
+	}
+	if !strings.Contains(body, "Include scanners (1)") {
+		t.Error("scanner badge should count fixed scanner findings under status=fixed")
 	}
 }
 

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -804,16 +804,41 @@ func TestFindings_statusFilter(t *testing.T) {
 		Severity: "High", Status: db.FindingTriaged})
 	s.DB.Create(&db.Finding{ScanID: scan.ID, RepositoryID: repo.ID, Title: "fixed finding",
 		Severity: "High", Status: db.FindingFixed})
+	s.DB.Create(&db.Finding{ScanID: scan.ID, RepositoryID: repo.ID, Title: "published finding",
+		Severity: "High", Status: db.FindingPublished})
+	s.DB.Create(&db.Finding{ScanID: scan.ID, RepositoryID: repo.ID, Title: "rejected finding",
+		Severity: "High", Status: db.FindingRejected})
+	s.DB.Create(&db.Finding{ScanID: scan.ID, RepositoryID: repo.ID, Title: "duplicate finding",
+		Severity: "High", Status: db.FindingDuplicate})
+
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq("GET", "/findings"))
+	if w.Code != 200 {
+		t.Fatalf("default status code %d", w.Code)
+	}
+	body := w.Body.String()
+	for _, title := range []string{"fresh finding", "triaged finding"} {
+		if !strings.Contains(body, ">"+title+"</a>") {
+			t.Errorf("default listing missing %q", title)
+		}
+	}
+	for _, title := range []string{"fixed finding", "published finding", "rejected finding", "duplicate finding"} {
+		if strings.Contains(body, ">"+title+"</a>") {
+			t.Errorf("default listing should hide closed finding %q", title)
+		}
+	}
 
 	cases := []struct {
 		status  string
 		want    []string
 		missing []string
 	}{
-		{"new", []string{"fresh finding"}, []string{"triaged finding", "fixed finding"}},
-		{"triaged", []string{"triaged finding"}, []string{"fresh finding", "fixed finding"}},
-		{"fixed", []string{"fixed finding"}, []string{"fresh finding", "triaged finding"}},
-		{"rejected", nil, []string{"fresh finding", "triaged finding", "fixed finding"}},
+		{"new", []string{"fresh finding"}, []string{"triaged finding", "fixed finding", "published finding", "rejected finding", "duplicate finding"}},
+		{"triaged", []string{"triaged finding"}, []string{"fresh finding", "fixed finding", "published finding", "rejected finding", "duplicate finding"}},
+		{"fixed", []string{"fixed finding"}, []string{"fresh finding", "triaged finding", "published finding", "rejected finding", "duplicate finding"}},
+		{"published", []string{"published finding"}, []string{"fresh finding", "triaged finding", "fixed finding", "rejected finding", "duplicate finding"}},
+		{"rejected", []string{"rejected finding"}, []string{"fresh finding", "triaged finding", "fixed finding", "published finding", "duplicate finding"}},
+		{"duplicate", []string{"duplicate finding"}, []string{"fresh finding", "triaged finding", "fixed finding", "published finding", "rejected finding"}},
 	}
 	for _, tc := range cases {
 		w := httptest.NewRecorder()
@@ -836,9 +861,9 @@ func TestFindings_statusFilter(t *testing.T) {
 	}
 
 	// The status filter is preserved across the other filter links.
-	w := httptest.NewRecorder()
+	w = httptest.NewRecorder()
 	s.Handler().ServeHTTP(w, localReq("GET", "/findings?status=new"))
-	body := w.Body.String()
+	body = w.Body.String()
 	if !strings.Contains(body, "severity=High&status=new&category=") {
 		t.Error("severity dropdown links should carry status=new")
 	}
@@ -2262,11 +2287,13 @@ func TestRepoShow_findingsTabAggregatesAcrossScans(t *testing.T) {
 	repo := db.Repository{URL: "https://example.com/agg", Name: "agg"}
 	s.DB.Create(&repo)
 
-	// Older deep-dive scan with two findings, one of which is rejected.
+	// Older deep-dive scan with findings in active and closed states.
 	older := db.Scan{RepositoryID: repo.ID, Kind: "skill", SkillName: deepDiveSkillName, Status: db.ScanDone}
 	s.DB.Create(&older)
 	s.DB.Create(&db.Finding{ScanID: older.ID, RepositoryID: repo.ID, Title: "old-high", Severity: "High", Status: db.FindingNew})
 	s.DB.Create(&db.Finding{ScanID: older.ID, RepositoryID: repo.ID, Title: "old-noise", Severity: "Low", Status: db.FindingRejected})
+	s.DB.Create(&db.Finding{ScanID: older.ID, RepositoryID: repo.ID, Title: "old-fixed", Severity: "High", Status: db.FindingFixed})
+	s.DB.Create(&db.Finding{ScanID: older.ID, RepositoryID: repo.ID, Title: "old-published", Severity: "High", Status: db.FindingPublished})
 
 	// A non-deep-dive skill also produced a finding.
 	other := db.Scan{RepositoryID: repo.ID, Kind: "skill", SkillName: "secrets", Status: db.ScanDone}
@@ -2291,8 +2318,10 @@ func TestRepoShow_findingsTabAggregatesAcrossScans(t *testing.T) {
 	if !strings.Contains(body, "leaked-key") {
 		t.Errorf("finding from non-deep-dive skill not shown")
 	}
-	if strings.Contains(body, "old-noise") {
-		t.Errorf("rejected finding should be hidden from the tab")
+	for _, hidden := range []string{"old-noise", "old-fixed", "old-published"} {
+		if strings.Contains(body, hidden) {
+			t.Errorf("closed finding %q should be hidden from the tab", hidden)
+		}
 	}
 	// Deep-dive output and tool-scanner output render in separate tabs so the
 	// curated audit list isn't drowned out by lint noise.

--- a/internal/web/templates/findings.html
+++ b/internal/web/templates/findings.html
@@ -63,12 +63,15 @@
     <div class="dropdown-menu">
       <button type="button" class="btn-outline" aria-haspopup="menu" aria-expanded="false">
         <i data-lucide="circle-dot"></i>
-        {{if .Status}}{{.Status}}{{else}}Status{{end}}
+        {{if eq .Status "all"}}All statuses{{else if .Status}}{{.Status}}{{else}}Open{{end}}
         <i data-lucide="chevron-down"></i>
       </button>
       <div data-popover aria-hidden="true" data-align="end">
         <div role="menu">
-          <a role="menuitem" href="/findings?q={{.Q}}&severity={{.Severity}}&category={{.Category}}&sort={{.Sort}}&missed={{$mp}}&scanners={{$sc}}">All statuses</a>
+          <a role="menuitem" href="/findings?q={{.Q}}&severity={{.Severity}}&category={{.Category}}&sort={{.Sort}}&missed={{$mp}}&scanners={{$sc}}"
+             {{if not .Status}}aria-current="true"{{end}}>Open</a>
+          <a role="menuitem" href="/findings?q={{.Q}}&severity={{.Severity}}&status=all&category={{.Category}}&sort={{.Sort}}&missed={{$mp}}&scanners={{$sc}}"
+             {{if eq .Status "all"}}aria-current="true"{{end}}>All statuses</a>
           {{range .Statuses}}
             <a role="menuitem" href="/findings?q={{$.Q}}&severity={{$.Severity}}&status={{.}}&category={{$.Category}}&sort={{$.Sort}}&missed={{$mp}}&scanners={{$sc}}"
                {{if eq (printf "%s" .) $.Status}}aria-current="true"{{end}}>{{.}}</a>

--- a/internal/web/templates/repo_show.html
+++ b/internal/web/templates/repo_show.html
@@ -219,7 +219,7 @@
     <div class="flex items-center justify-between mb-4 gap-2">
       <p class="text-sm text-muted-foreground">
         Open findings from the security-deep-dive audit.
-        Rejected and duplicate findings are hidden.{{if .ScannerFindings}} See the
+        Fixed, published, rejected, and duplicate findings are hidden.{{if .ScannerFindings}} See the
         Scanners tab for zizmor/semgrep output.{{end}}
       </p>
       <div class="flex items-center gap-2 shrink-0">

--- a/internal/worker/skill.go
+++ b/internal/worker/skill.go
@@ -473,16 +473,13 @@ func (e *FailOnThresholdError) Error() string {
 // published, rejected, duplicate) are left alone. Returns the number of
 // rows touched so the scan log can report it.
 func (w *Worker) markNotObserved(scan *db.Scan, seen map[string]bool) int {
-	closed := []db.FindingLifecycle{
-		db.FindingFixed, db.FindingPublished, db.FindingRejected, db.FindingDuplicate,
-	}
 	sameSkill := w.DB.Model(&db.Scan{}).Select("id").
 		Where("repository_id = ? AND skill_name = ?", scan.RepositoryID, scan.SkillName)
 	var prior []db.Finding
 	w.DB.Where("repository_id = ? AND sub_path = ?", scan.RepositoryID, scan.SubPath).
 		Where("scan_id IN (?)", sameSkill).
 		Where("scan_id <> ?", scan.ID).
-		Where("status NOT IN ?", closed).
+		Where("status NOT IN ?", db.ClosedFindingLifecycles).
 		Find(&prior)
 
 	missed := 0


### PR DESCRIPTION
## Summary

Fixes #244.

Hides closed findings from the default Findings views so fixed/rejected/resolved noise does not crowd out items that
still need investigation.

## Changes

- Hide `fixed`, `published`, `rejected` and `duplicate` findings by default on the global Findings index
- Keep explicit status filters working, so closed findings can still be viewed with filters like `?status=fixed`
- Hide the same closed statuses from the repository Findings tab
- Update repository Findings tab copy to describe the hidden statuses
- Add tests for default hiding and explicit status filtering

## Testing

- `go test ./internal/web`
- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `golangci-lint run ./...`