### PR TITLE
fix: correct python site-packages path to 3.14 in main Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ COPY --from=claude /usr/local/lib/node_modules /usr/local/lib/node_modules
 COPY --from=claude /usr/local/bin/claude /usr/local/bin/claude
 
 # semgrep
-COPY --from=python-tools /usr/local/lib/python3.13/site-packages /usr/local/lib/python3.13/site-packages
+COPY --from=python-tools /usr/local/lib/python3.14/site-packages /usr/local/lib/python3.14/site-packages
 COPY --from=python-tools /usr/local/bin/semgrep* /usr/local/bin/
 COPY --from=python-tools /usr/local/bin/pysemgrep /usr/local/bin/
 


### PR DESCRIPTION
## Problem

The main `Dockerfile` fails to build on a fresh checkout:

```
COPY --from=python-tools /usr/local/lib/python3.13/site-packages /usr/local/lib/python3.13/site-packages
ERROR: failed to compute cache key: "/usr/local/lib/python3.13/site-packages": not found
```

The `python-tools` stage is based on `python:3.14.5-alpine` (line 16), and the final stage is also `python:3.14.5-alpine` (line 28), so semgrep's packages live under `…/python3.14/site-packages`. The `COPY` at line 40 still points at the old `python3.13` path — left over from the base-image bump — so the build aborts.

## Fix

Point the `COPY` at `python3.14/site-packages` to match the interpreter version. One-line change.

## Testing

`docker build -t scrutineer .` completes successfully after the change (previously failed at the semgrep `COPY` step). This is the same class of interpreter/site-packages drift fixed earlier for the runner image in #61.