### PR TITLE
Compute VIDs for findings at scan ingest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,13 @@ RUN apk add --no-cache git
 RUN GOBIN=/out go install github.com/git-pkgs/git-pkgs@v0.15.3 && \
     GOBIN=/out go install github.com/git-pkgs/brief/cmd/brief@v0.6.0
 
+# vid links tree-sitter grammars (C), so unlike the main binary it needs
+# cgo; build-base provides gcc and musl headers, matching the musl-based
+# final image.
+FROM golang:1.26.4-alpine@sha256:f23e8b227fb4493eabe03bede4d5a32d04092da71962f1fb79b5f7d1e6c2a17f AS vid-build
+RUN apk add --no-cache build-base git
+RUN GOBIN=/out CGO_ENABLED=1 go install github.com/andrew/VID/cmd/vid@v0.1.0
+
 FROM rust:1.96-alpine@sha256:66f48b19d6e88519e2e58bebe0d945779a6a4ca41c2db17db78c9569655b50ac AS zizmor-build
 RUN apk add --no-cache build-base linux-headers
 RUN cargo install --locked --root /out zizmor@1.24.1
@@ -46,6 +53,9 @@ COPY --from=go-tools /out/* /usr/local/bin/
 
 # zizmor
 COPY --from=zizmor-build /out/bin/zizmor /usr/local/bin/zizmor
+
+# vid
+COPY --from=vid-build /out/vid /usr/local/bin/vid
 
 # Non-root user (T1/T11: reduce blast radius)
 RUN adduser -D -h /home/scrutineer scrutineer && \

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -399,6 +399,17 @@ type Finding struct {
 	MissedCount      int
 	LastMissedScanID uint
 
+	// VID identifies the code being pointed at, not the finding: a hash
+	// of the enclosing function (or file) bytes at each sink location,
+	// computed by the vid CLI (github.com/andrew/VID) against the scanned
+	// checkout. Two parties looking at the same code derive the same VID
+	// without coordinating, so it correlates findings across tools and
+	// reporters. Refreshed on re-observation so it tracks the code as it
+	// drifts; empty when the vid binary was unavailable or no location
+	// resolved to a file in the checkout. Unlike Fingerprint it is NOT
+	// used for dedup: a VID changes whenever the function's bytes change.
+	VID string `gorm:"column:vid;index"`
+
 	FindingID  string // e.g. F1, F2 within the report
 	Sinks      string // comma-joined sink IDs
 	Title      string

--- a/internal/web/api_export.go
+++ b/internal/web/api_export.go
@@ -127,6 +127,7 @@ func findingExport(f db.Finding) map[string]any {
 		statusKey:             string(f.Status),
 		"cwe":                 f.CWE,
 		"location":            f.Location,
+		"vid":                 f.VID,
 		"affected":            f.Affected,
 		"reachability":        f.Reachability,
 		"quality_tier":        f.QualityTier,

--- a/internal/web/api_export_test.go
+++ b/internal/web/api_export_test.go
@@ -287,6 +287,7 @@ func TestExportFindings_carriesDBFields(t *testing.T) {
 		ScanID: scan.ID, RepositoryID: repo.ID, Commit: "abc123", SubPath: "core",
 		Fingerprint: "fp-1", LastSeenScanID: scan.ID, LastSeenCommit: "abc123", SeenCount: 3,
 		FindingID: "F1", Title: "boom", Severity: sevHigh, Status: db.FindingTriaged,
+		VID:   "VID-aaaa-bbbb-cccc-dddd-eeee-ffff",
 		Trace: "t", Boundary: "b", Validation: "v", PriorArt: "p", Reach: "r", Rating: "x",
 		DisclosureDraft: "d",
 	})
@@ -302,7 +303,7 @@ func TestExportFindings_carriesDBFields(t *testing.T) {
 	}
 	want := []string{
 		"id", "scan_id", "repository_id", "commit", "sub_path",
-		"fingerprint", "last_seen_scan_id", "last_seen_commit", "seen_count",
+		"fingerprint", "last_seen_scan_id", "last_seen_commit", "seen_count", "vid",
 		"finding_id", "sinks", "title", "severity", "status", "cwe", "location", "affected",
 		"reachability", "quality_tier",
 		"cve_id", "cvss_vector", "cvss_score", "fix_version", "fix_commit",

--- a/internal/web/api_reads.go
+++ b/internal/web/api_reads.go
@@ -234,6 +234,7 @@ func findingSummary(f db.Finding) map[string]any {
 		statusKey:       string(f.Status),
 		"cwe":           f.CWE,
 		"location":      f.Location,
+		"vid":           f.VID,
 		"affected":      f.Affected,
 		"reachability":  f.Reachability,
 		"quality_tier":  f.QualityTier,

--- a/internal/web/templates/finding_show.html
+++ b/internal/web/templates/finding_show.html
@@ -65,6 +65,11 @@
     </dd>
   </div>
   <div>
+    <dt class="text-muted-foreground">VID</dt>
+    <dd>{{if $f.VID}}<code class="text-xs break-all"
+        title="Identifies the code at the sink, not the finding; computed from the function bytes so independent tools derive the same value">{{$f.VID}}</code>{{else}}-{{end}}</dd>
+  </div>
+  <div>
     <dt class="text-muted-foreground">Affected</dt>
     <dd>{{if $f.Affected}}{{$f.Affected}}{{else}}-{{end}}</dd>
   </div>

--- a/internal/worker/skill.go
+++ b/internal/worker/skill.go
@@ -269,6 +269,13 @@ func (w *Worker) parseFindingsOutput(skill *db.Skill, scan *db.Scan, report stri
 	}
 	scan.FindingsCount = len(findings)
 
+	// VIDs hash the code at each sink, so they can only be computed
+	// while the scanned checkout is still on disk at workRoot/src.
+	srcDir := filepath.Join(w.scanWorkRoot(scan), "src")
+	for i := range findings {
+		findings[i].VID = w.computeVID(srcDir, findings[i].Locations)
+	}
+
 	worst := ""
 	created, observed := 0, 0
 	seenThisScan := map[string]bool{}
@@ -286,7 +293,7 @@ func (w *Worker) parseFindingsOutput(skill *db.Skill, scan *db.Scan, report stri
 		err := w.DB.Where("repository_id = ? AND fingerprint = ?", scan.RepositoryID, f.Fingerprint).
 			Order("id").First(&existing).Error
 		if err == nil {
-			if uerr := w.DB.Model(&db.Finding{}).Where("id = ?", existing.ID).Updates(map[string]any{
+			updates := map[string]any{
 				"last_seen_scan_id":   scan.ID,
 				"last_seen_commit":    scan.Commit,
 				"seen_count":          existing.SeenCount + 1,
@@ -294,7 +301,14 @@ func (w *Worker) parseFindingsOutput(skill *db.Skill, scan *db.Scan, report stri
 				"last_missed_scan_id": 0,
 				"location":            f.Location,
 				"locations":           f.Locations,
-			}).Error; uerr != nil {
+			}
+			// Refresh the VID so it tracks the code as it drifts, but
+			// never wipe a stored one just because this run could not
+			// compute (vid binary missing, location gone).
+			if f.VID != "" {
+				updates["vid"] = f.VID
+			}
+			if uerr := w.DB.Model(&db.Finding{}).Where("id = ?", existing.ID).Updates(updates).Error; uerr != nil {
 				return fmt.Errorf("update finding %d: %w", existing.ID, uerr)
 			}
 			if herr := w.DB.Create(&db.FindingHistory{

--- a/internal/worker/vid.go
+++ b/internal/worker/vid.go
@@ -1,0 +1,100 @@
+package worker
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+)
+
+const vidTimeout = 30 * time.Second
+
+// vidLocRE matches a finding location ("file.rb:12", "file.rb:12-34",
+// "file.js:42:7") and captures the path and the first line number.
+// Ranges and columns collapse to the opening line, mirroring how the
+// web code browser links resolve the same strings.
+var vidLocRE = regexp.MustCompile(`^(.*?):(\d+)(?:-\d+)?(?::\d+(?:-\d+)?)?$`)
+
+// vidSinks turns a finding's newline-joined Locations into the
+// file:line arguments the vid CLI expects, keeping only entries that
+// resolve to a real file inside srcDir. Model output is untrusted, so
+// paths that escape the checkout are dropped rather than read; the
+// checkout may contain hostile symlinks, so containment is checked on
+// the symlink-resolved path, not the lexical one.
+func vidSinks(srcDir, locations string) []string {
+	root, err := filepath.EvalSymlinks(srcDir)
+	if err != nil {
+		return nil
+	}
+	seen := map[string]bool{}
+	var out []string
+	for loc := range strings.SplitSeq(locations, "\n") {
+		loc = strings.TrimPrefix(strings.TrimSpace(loc), "./")
+		m := vidLocRE.FindStringSubmatch(loc)
+		if m == nil {
+			continue
+		}
+		path, line := m[1], m[2]
+		if path == "" || !filepath.IsLocal(path) {
+			continue
+		}
+		resolved, err := filepath.EvalSymlinks(filepath.Join(srcDir, path))
+		if err != nil || !strings.HasPrefix(resolved, root+string(filepath.Separator)) {
+			continue
+		}
+		if fi, err := os.Stat(resolved); err != nil || !fi.Mode().IsRegular() {
+			continue
+		}
+		sink := path + ":" + line
+		if seen[sink] {
+			continue
+		}
+		seen[sink] = true
+		out = append(out, sink)
+	}
+	return out
+}
+
+// computeVID shells out to the vid CLI (github.com/andrew/VID) to hash
+// the code at the finding's sink locations into a portable identifier.
+// Returns "" when no location resolves to a file in srcDir, the binary
+// is missing, or the run fails; callers treat an empty VID as
+// not-computed rather than an error, since the finding itself is still
+// valid without one.
+func (w *Worker) computeVID(srcDir, locations string) string {
+	sinks := vidSinks(srcDir, locations)
+	if len(sinks) == 0 {
+		return ""
+	}
+	cmdName := w.VIDCommand
+	if cmdName == "" {
+		cmdName = "vid"
+	}
+	bin, err := exec.LookPath(cmdName)
+	if err != nil {
+		w.vidMissingOnce.Do(func() {
+			w.Log.Warn("vid binary not found, findings will not get VIDs", "command", cmdName)
+		})
+		return ""
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), vidTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin, sinks...)
+	cmd.Dir = srcDir
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		w.Log.Warn("compute vid", "sinks", strings.Join(sinks, " "), "err", err, "stderr", strings.TrimSpace(stderr.String()))
+		return ""
+	}
+	v := strings.TrimSpace(stdout.String())
+	if !strings.HasPrefix(v, "VID-") {
+		return ""
+	}
+	return v
+}

--- a/internal/worker/vid_test.go
+++ b/internal/worker/vid_test.go
@@ -1,0 +1,177 @@
+package worker
+
+import (
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"scrutineer/internal/db"
+)
+
+func writeSrcFile(t *testing.T, srcDir, rel string) {
+	t.Helper()
+	p := filepath.Join(srcDir, rel)
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p, []byte("code\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// stubVid writes an executable that prints out and exits with code,
+// recording its argv (one per line) to args.txt next to it.
+func stubVid(t *testing.T, out string, code int) string {
+	t.Helper()
+	dir := t.TempDir()
+	script := filepath.Join(dir, "vid")
+	body := fmt.Sprintf("#!/bin/sh\nprintf '%%s\\n' \"$@\" > %q\necho %q\nexit %d\n",
+		filepath.Join(dir, "args.txt"), out, code)
+	if err := os.WriteFile(script, []byte(body), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return script
+}
+
+func TestVidSinks(t *testing.T) {
+	srcDir := t.TempDir()
+	writeSrcFile(t, srcDir, "a.rb")
+	writeSrcFile(t, srcDir, "lib/b.js")
+
+	// A repo can carry hostile symlinks; lexically-local paths whose
+	// target resolves outside the checkout must be dropped, while
+	// symlinks staying inside it are fine.
+	outside := filepath.Join(t.TempDir(), "host-secret")
+	if err := os.WriteFile(outside, []byte("secret\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, filepath.Join(srcDir, "evil.rb")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("a.rb", filepath.Join(srcDir, "alias.rb")); err != nil {
+		t.Fatal(err)
+	}
+
+	locations := "a.rb:12\n" + // plain
+		"./a.rb:12\n" + // ./ prefix dedupes with the plain form
+		"lib/b.js:42:7\n" + // column stripped
+		"a.rb:30-40\n" + // range collapses to first line
+		"missing.rb:1\n" + // not on disk
+		"../escape.rb:1\n" + // escapes the checkout
+		"evil.rb:1\n" + // symlink escaping the checkout
+		"alias.rb:7\n" + // symlink staying inside the checkout
+		"lib:1\n" + // a directory
+		"no-line.rb\n" + // no line spec
+		"\n"
+	got := vidSinks(srcDir, locations)
+	want := []string{"a.rb:12", "lib/b.js:42", "a.rb:30", "alias.rb:7"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("vidSinks = %v, want %v", got, want)
+	}
+}
+
+func TestComputeVID(t *testing.T) {
+	srcDir := t.TempDir()
+	writeSrcFile(t, srcDir, "a.rb")
+	w := &Worker{Log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+
+	w.VIDCommand = stubVid(t, "VID-aaaa-bbbb-cccc-dddd-eeee-ffff", 0)
+	if got := w.computeVID(srcDir, "a.rb:12"); got != "VID-aaaa-bbbb-cccc-dddd-eeee-ffff" {
+		t.Errorf("computeVID = %q", got)
+	}
+	args, err := os.ReadFile(filepath.Join(filepath.Dir(w.VIDCommand), "args.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(args) != "a.rb:12\n" {
+		t.Errorf("vid argv = %q, want %q", args, "a.rb:12\n")
+	}
+
+	w.VIDCommand = stubVid(t, "VID-aaaa-bbbb-cccc-dddd-eeee-ffff", 1)
+	if got := w.computeVID(srcDir, "a.rb:12"); got != "" {
+		t.Errorf("failed run should yield empty VID, got %q", got)
+	}
+
+	w.VIDCommand = stubVid(t, "not a vid", 0)
+	if got := w.computeVID(srcDir, "a.rb:12"); got != "" {
+		t.Errorf("malformed output should yield empty VID, got %q", got)
+	}
+
+	w.VIDCommand = filepath.Join(t.TempDir(), "absent")
+	if got := w.computeVID(srcDir, "a.rb:12"); got != "" {
+		t.Errorf("missing binary should yield empty VID, got %q", got)
+	}
+
+	w.VIDCommand = stubVid(t, "VID-aaaa-bbbb-cccc-dddd-eeee-ffff", 0)
+	if got := w.computeVID(srcDir, "missing.rb:1"); got != "" {
+		t.Errorf("no resolvable sinks should yield empty VID, got %q", got)
+	}
+}
+
+func TestParseFindingsOutput_setsAndRefreshesVID(t *testing.T) {
+	gdb, err := db.Open(filepath.Join(t.TempDir(), "p.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo := db.Repository{URL: "https://x/r", Name: "r"}
+	gdb.Create(&repo)
+	w := &Worker{
+		DB:      gdb,
+		Log:     slog.New(slog.NewTextHandler(io.Discard, nil)),
+		DataDir: t.TempDir(),
+	}
+
+	report := `{"findings":[{"id":"F1","title":"a","severity":"High","cwe":"CWE-1","location":"a.rb:1"}]}`
+
+	s1 := &db.Scan{RepositoryID: repo.ID, Kind: JobSkill, SkillName: "x", Status: db.ScanDone, Commit: "c1"}
+	gdb.Create(s1)
+	writeSrcFile(t, filepath.Join(w.scanWorkRoot(s1), "src"), "a.rb")
+	w.VIDCommand = stubVid(t, "VID-1111-1111-1111-1111-1111-1111", 0)
+	if err := w.parseFindingsOutput(&db.Skill{}, s1, report, func(Event) {}); err != nil {
+		t.Fatal(err)
+	}
+	var f db.Finding
+	if err := gdb.First(&f).Error; err != nil {
+		t.Fatal(err)
+	}
+	if f.VID != "VID-1111-1111-1111-1111-1111-1111" {
+		t.Errorf("VID = %q, want VID-1111...", f.VID)
+	}
+
+	// Re-observation refreshes the VID from the new checkout.
+	s2 := &db.Scan{RepositoryID: repo.ID, Kind: JobSkill, SkillName: "x", Status: db.ScanDone, Commit: "c2"}
+	gdb.Create(s2)
+	writeSrcFile(t, filepath.Join(w.scanWorkRoot(s2), "src"), "a.rb")
+	w.VIDCommand = stubVid(t, "VID-2222-2222-2222-2222-2222-2222", 0)
+	if err := w.parseFindingsOutput(&db.Skill{}, s2, report, func(Event) {}); err != nil {
+		t.Fatal(err)
+	}
+	var n int64
+	gdb.Model(&db.Finding{}).Count(&n)
+	if n != 1 {
+		t.Fatalf("expected dedup to 1 finding, got %d", n)
+	}
+	if err := gdb.First(&f).Error; err != nil {
+		t.Fatal(err)
+	}
+	if f.VID != "VID-2222-2222-2222-2222-2222-2222" {
+		t.Errorf("re-seen VID = %q, want VID-2222...", f.VID)
+	}
+
+	// A scan that cannot compute (no src staged) keeps the stored VID.
+	s3 := &db.Scan{RepositoryID: repo.ID, Kind: JobSkill, SkillName: "x", Status: db.ScanDone, Commit: "c3"}
+	gdb.Create(s3)
+	if err := w.parseFindingsOutput(&db.Skill{}, s3, report, func(Event) {}); err != nil {
+		t.Fatal(err)
+	}
+	if err := gdb.First(&f).Error; err != nil {
+		t.Fatal(err)
+	}
+	if f.VID != "VID-2222-2222-2222-2222-2222-2222" {
+		t.Errorf("VID after uncomputable scan = %q, want unchanged VID-2222...", f.VID)
+	}
+}

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -72,6 +72,14 @@ type Worker struct {
 	// leaves it nil and falls through to prepareRepoSrc.
 	PrepareRepoSrc func(ctx context.Context, url, ref, workRoot string, emit func(Event)) (string, error)
 
+	// VIDCommand overrides the vid binary name for computeVID. Tests
+	// point it at a stub; empty falls through to "vid" on PATH.
+	VIDCommand string
+
+	// vidMissingOnce gates the missing-binary warning so a deployment
+	// without vid on PATH logs it once, not once per finding.
+	vidMissingOnce sync.Once
+
 	// LogFlushInterval overrides defaultLogFlushInterval. Tests set it to
 	// a tiny or huge value to assert flush behaviour without sleeping.
 	// Zero falls through to the const default.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -886,6 +886,7 @@ components:
         status:        { type: string }
         cwe:           { type: string }
         location:      { type: string }
+        vid:           { type: string, description: "Code identifier (VID-...) hashed from the sink code at the scanned commit; correlates findings across tools. Empty when not computed." }
         affected:      { type: string }
         reachability:  { type: string, enum: [reachable, harness_only, unclear] }
         quality_tier:  { type: string, enum: [high, low] }


### PR DESCRIPTION
Integrates [VID](https://github.com/andrew/VID) into the findings process. A VID identifies the code a finding points at: the `vid` CLI hashes the enclosing function (or file) bytes at each sink location, so independent tools scanning the same code derive the same identifier without coordinating.

At finding ingest the worker resolves each finding's locations against the checkout still on disk at `workRoot/src`, shells out to `vid` with the `file:line` sinks (ranges and columns collapse to the opening line, paths that escape the checkout or don't exist are dropped), and stores the result in a new `vid` column on `Finding`. Re-observed findings refresh their VID so it tracks the code as it drifts, but a run that can't compute (binary missing, location gone) never wipes a stored value.

The VID is metadata for cross-tool correlation, not a dedup key: fingerprints stay file-level and absorb line drift, while a VID changes whenever the function's bytes change. It surfaces on the finding page, in `findingSummary`/`findingExport`, and in `openapi.yaml`.

The `vid` binary links tree-sitter grammars and needs cgo, so it gets its own Docker build stage pinned to `v0.1.0`; the scrutineer binary itself stays `CGO_ENABLED=0`. Imported findings (SARIF via `/import`) don't get VIDs since there's no checkout at import time.