### PR TITLE
Bound query counts for large list pages

### DIFF
--- a/internal/web/list_performance_test.go
+++ b/internal/web/list_performance_test.go
@@ -1,0 +1,167 @@
+package web
+
+import (
+	"fmt"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"scrutineer/internal/db"
+
+	"gorm.io/gorm"
+)
+
+func TestListPagesQueryCountsStayBounded(t *testing.T) {
+	cases := []struct {
+		name string
+		path string
+		max  int64
+	}{
+		{name: "repositories", path: "/", max: 8},
+		{name: "findings", path: "/findings", max: 8},
+		{name: "scans", path: "/scans", max: 6},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			oneRow := listPageQueryCount(t, tc.path, 1)
+			manyRows := listPageQueryCount(t, tc.path, 60)
+
+			if manyRows > oneRow+1 {
+				t.Fatalf("%s query count grew with rows: 1 row=%d, 60 rows=%d", tc.path, oneRow, manyRows)
+			}
+			if manyRows > tc.max {
+				t.Fatalf("%s ran %d queries, want <= %d", tc.path, manyRows, tc.max)
+			}
+		})
+	}
+}
+
+func TestScanListStatsAggregatesCounts(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	repo := db.Repository{URL: "https://example.com/stats", Name: "stats"}
+	s.DB.Create(&repo)
+	for _, status := range []db.ScanStatus{db.ScanQueued, db.ScanQueued, db.ScanPaused, db.ScanRunning} {
+		s.DB.Create(&db.Scan{RepositoryID: repo.ID, Kind: "skill", Status: status})
+	}
+	s.DB.Create(&db.Scan{
+		RepositoryID: repo.ID,
+		Kind:         "skill",
+		Status:       db.ScanFailed,
+		Error:        "Claude plan limit reached. Pause queued scans and retry after your limit resets.",
+	})
+	s.DB.Create(&db.Scan{
+		RepositoryID: repo.ID,
+		Kind:         "skill",
+		Status:       db.ScanFailed,
+		Error:        "different failure",
+	})
+
+	stats := s.scanListStats()
+	if stats.QueuedCount != 2 || stats.PausedCount != 1 || stats.PlanLimitFailedCount != 1 {
+		t.Fatalf("scanListStats = %+v, want queued=2 paused=1 plan-limit=1", stats)
+	}
+}
+
+func BenchmarkListPagesLargeDataset(b *testing.B) {
+	s, done := newTestServer(b)
+	defer done()
+	seedListPagePerfFixtures(b, s, 500)
+
+	for _, path := range []string{"/", "/findings", "/scans"} {
+		b.Run(path, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				w := httptest.NewRecorder()
+				s.Handler().ServeHTTP(w, localReq("GET", path))
+				if w.Code != 200 {
+					b.Fatalf("%s status %d: %s", path, w.Code, w.Body)
+				}
+			}
+		})
+	}
+}
+
+func listPageQueryCount(t *testing.T, path string, rows int) int64 {
+	t.Helper()
+	s, done := newTestServer(t)
+	defer done()
+	seedListPagePerfFixtures(t, s, rows)
+	getCount := countDBQueries(t, s)
+
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq("GET", path))
+	if w.Code != 200 {
+		t.Fatalf("%s status %d: %s", path, w.Code, w.Body)
+	}
+	return getCount()
+}
+
+func countDBQueries(t testing.TB, s *Server) func() int64 {
+	t.Helper()
+	var count atomic.Int64
+	name := fmt.Sprintf("scrutineer:test-query-count:%d", time.Now().UnixNano())
+	callback := func(*gorm.DB) {
+		count.Add(1)
+	}
+	if err := s.DB.Callback().Query().Before("gorm:query").Register(name+":query", callback); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.DB.Callback().Raw().Before("gorm:raw").Register(name+":raw", callback); err != nil {
+		t.Fatal(err)
+	}
+	return count.Load
+}
+
+func seedListPagePerfFixtures(t testing.TB, s *Server, rows int) {
+	t.Helper()
+	for i := 0; i < rows; i++ {
+		repo := db.Repository{
+			URL:         fmt.Sprintf("https://example.com/repo-%03d", i),
+			Name:        fmt.Sprintf("repo-%03d", i),
+			FullName:    fmt.Sprintf("org/repo-%03d", i),
+			Owner:       "org",
+			Description: "fixture repository",
+			Languages:   "Go, Java",
+		}
+		if err := s.DB.Create(&repo).Error; err != nil {
+			t.Fatal(err)
+		}
+		scan := db.Scan{
+			RepositoryID:   repo.ID,
+			Kind:           "skill",
+			Status:         db.ScanDone,
+			StatusPriority: db.StatusPriorityFor(db.ScanDone),
+			SkillName:      deepDiveSkillName,
+			FindingsCount:  2,
+			Ref:            "main",
+		}
+		if err := s.DB.Create(&scan).Error; err != nil {
+			t.Fatal(err)
+		}
+		if err := s.DB.Create(&db.Scan{
+			RepositoryID:   repo.ID,
+			Kind:           "skill",
+			Status:         db.ScanQueued,
+			StatusPriority: db.StatusPriorityFor(db.ScanQueued),
+			SkillName:      "metadata",
+		}).Error; err != nil {
+			t.Fatal(err)
+		}
+		for j, severity := range []string{"High", "Medium"} {
+			if err := s.DB.Create(&db.Finding{
+				ScanID:       scan.ID,
+				RepositoryID: repo.ID,
+				FindingID:    fmt.Sprintf("F%d-%d", i, j),
+				Title:        fmt.Sprintf("finding %d-%d", i, j),
+				Severity:     severity,
+				Status:       db.FindingNew,
+			}).Error; err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+}

--- a/internal/web/scans.go
+++ b/internal/web/scans.go
@@ -46,9 +46,7 @@ func (s *Server) jobs(w http.ResponseWriter, r *http.Request) {
 		Limit(perPage).Offset((page.N - 1) * perPage).Find(&scans)
 
 	skillNames := s.scanSkillNames()
-	queuedCount := s.scanStatusCount(db.ScanQueued)
-	pausedCount := s.scanStatusCount(db.ScanPaused)
-	planLimitFailedCount := s.planLimitFailedCount()
+	stats := s.scanListStats()
 
 	anySubPath := false
 	for _, sc := range scans {
@@ -60,23 +58,31 @@ func (s *Server) jobs(w http.ResponseWriter, r *http.Request) {
 	s.render(w, r, "jobs.html", map[string]any{
 		"Scans": scans, "Page": page,
 		"Skill": skillName, "Status": status, "Sort": sort, "Skills": skillNames,
-		"AnySubPath": anySubPath, "QueuedCount": queuedCount, "PausedCount": pausedCount,
-		"PlanLimitFailedCount": planLimitFailedCount,
+		"AnySubPath": anySubPath, "QueuedCount": stats.QueuedCount, "PausedCount": stats.PausedCount,
+		"PlanLimitFailedCount": stats.PlanLimitFailedCount,
 	})
 }
 
-func (s *Server) scanStatusCount(status db.ScanStatus) int64 {
-	var n int64
-	s.DB.Model(&db.Scan{}).Where("status = ?", status).Count(&n)
-	return n
+type scanListStats struct {
+	QueuedCount          int64
+	PausedCount          int64
+	PlanLimitFailedCount int64
 }
 
-func (s *Server) planLimitFailedCount() int64 {
-	var n int64
+func (s *Server) scanListStats() scanListStats {
+	var stats scanListStats
 	s.DB.Model(&db.Scan{}).
-		Where("status = ? AND error LIKE ?", db.ScanFailed, "Claude plan limit reached.%").
-		Count(&n)
-	return n
+		Select(
+			"COUNT(CASE WHEN status = ? THEN 1 END) AS queued_count, "+
+				"COUNT(CASE WHEN status = ? THEN 1 END) AS paused_count, "+
+				"COUNT(CASE WHEN status = ? AND error LIKE ? THEN 1 END) AS plan_limit_failed_count",
+			db.ScanQueued,
+			db.ScanPaused,
+			db.ScanFailed,
+			"Claude plan limit reached.%",
+		).
+		Scan(&stats)
+	return stats
 }
 
 const skillNamesCacheTTL = 30 * time.Second

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -21,7 +21,7 @@ import (
 	"scrutineer/internal/worker"
 )
 
-func newTestServer(t *testing.T) (*Server, func()) {
+func newTestServer(t testing.TB) (*Server, func()) {
 	t.Helper()
 	gdb, err := db.Open("file::memory:?cache=shared")
 	if err != nil {


### PR DESCRIPTION
## Summary

Fixes #126.

This PR improves list-page performance coverage and reduces extra scan-list queries by:

- consolidating scan status/count lookups into one aggregate query
- adding regression coverage that checks query counts stay bounded for repository, findings and scans list pages
- adding a benchmark for large list-page datasets

## testing

- `go test ./internal/web -run 'TestListPagesQueryCountsStayBounded|TestScanListStatsAggregatesCounts'`
- `go test ./internal/web`
- `go test ./...`
- `go test ./internal/web -run '^$' -bench BenchmarkListPagesLargeDataset -benchtime=1x`
- `go vet ./...`
- `env GOTOOLCHAIN=local /Users/gautam/go/bin/golangci-lint run ./...`