### PR TITLE
Add configurable model tiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Every index page has a search box plus filter and sort dropdowns; the specifics 
 - **Scans** -- every scan that has run. Queued scans can be paused/resumed, running or queued scans can be cancelled and failed ones retried.
 - **Skills** -- installed skills from disk and from the UI; view, edit, or run any of them.
 - **Usage** -- token and cost totals across all scans, broken down by skill.
-- **Settings** -- theme, colour scheme, default model, runner concurrency (restarts the runner to apply, cancelling in-flight scans) and default turn cap (applied to the next scan), plus system stats (record counts, DB size, paths).
+- **Settings** -- theme, colour scheme, model tiers, runner concurrency (restarts the runner to apply, cancelling in-flight scans) and default turn cap (applied to the next scan), plus system stats (record counts, DB size, paths).
 
 ## Finding workflow
 
@@ -242,7 +242,7 @@ For deployments that treat skill prompts as untrusted, pass `--hardened` (or `ha
 
 Every flag above can be set in a YAML config file instead. The loader checks `./scrutineer.yaml` by default; override with `-config path/to/file`. Command-line flags always win. See [scrutineer.sample.yaml](scrutineer.sample.yaml) for the full shape.
 
-The config file can also replace the model pick list and pin the default model:
+The config file can also replace the model pick list and pin the fallback default model used by the high tier:
 
     default_model: claude-sonnet-4-6
     models:
@@ -250,6 +250,8 @@ The config file can also replace the model pick list and pin the default model:
         id:   claude-sonnet-4-6
       - name: Opus
         id:   claude-opus-4-7
+
+Scrutineer resolves skill models through tiers. `metadata` defaults to the `mid` tier, `security-deep-dive` defaults to the `max` tier, and other skills default to `high`. The Settings page lets you map each tier to any configured model. A skill can still pin `scrutineer.model` to an exact model id, or to a tier name (`mid`, `high`, `max`).
 
 ## Sandboxed Claude Code configs
 

--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ The config file can also replace the model pick list and pin the fallback defaul
       - name: Opus
         id:   claude-opus-4-7
 
-Scrutineer resolves skill models through tiers. `metadata` defaults to the `mid` tier, `security-deep-dive` defaults to the `max` tier, and other skills default to `high`. The Settings page lets you map each tier to any configured model. A skill can still pin `scrutineer.model` to an exact model id, or to a tier name (`mid`, `high`, `max`).
+Scrutineer resolves skill models through tiers. Skills default to the `high` tier unless their `SKILL.md` metadata pins `scrutineer.model` to another tier or exact model id. Bundled lightweight skills such as `metadata` use `mid`, while `security-deep-dive` uses `max`. The Settings page lets you map each tier to any configured model.
 
 ## Sandboxed Claude Code configs
 

--- a/cmd/scrutineer/main.go
+++ b/cmd/scrutineer/main.go
@@ -285,7 +285,7 @@ func run(log *slog.Logger) error {
 		return fmt.Errorf("queue: %w", err)
 	}
 
-	skills.ModelValidator = web.ValidModel
+	skills.ModelValidator = web.ValidModelPreference
 	skills.ProfileValidator = worker.IsNamedProfile
 	skillsRepoSHA, err := loadSkills(log, gdb, f.dataDir, f.skillLocal, f.skillsRepo, f.fullClone())
 	if err != nil {

--- a/docs/database.md
+++ b/docs/database.md
@@ -46,7 +46,7 @@ One row per skill execution or external import. `skill_name` / `skill_version` p
 | kind | text | `skill` for native scans, `import` for findings ingested via `POST /api/v1/import`. |
 | status | text | `queued`, `paused`, `running`, `done`, `failed`, `cancelled`. Stale `running` rows are swept to `failed` on startup. |
 | status_priority | integer | Denormalised sort key for the scans index: 0 running, 1 queued, 2 paused, 3 terminal. |
-| model | text | Claude model ID. |
+| model | text | Claude model ID resolved from the explicit scan model, skill model preference, or skill default model tier at enqueue time. |
 | effort | text | Claude `--effort` level (`low`–`max`) snapshotted from the runtime setting at enqueue. Empty on legacy rows; the runner falls back to its configured default. |
 | skill_id | integer FK | References `skills.id`. Null for legacy non-skill rows. |
 | skill_version | integer | Version of the skill at run time; the skill row's `version` bumps on every edit so older scans stay readable. |

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -90,7 +90,7 @@ metadata:
 | `metadata.scrutineer.output_file` | string | Path, relative to the workspace, the skill writes its result to. Almost always `report.json`. |
 | `metadata.scrutineer.output_kind` | string | Picks the parser scrutineer runs over `output_file` after the scan. See the table below. |
 | `metadata.scrutineer.max_turns` | int | Per-skill cap on `claude --max-turns`. Overrides the global `-max-turns` flag for this skill only. |
-| `metadata.scrutineer.model` | string | Model tier (`mid`, `high`, `max`) or model id from the configured list. Overrides the skill's default tier. Ignored with a warning if it is not a known tier or configured model. |
+| `metadata.scrutineer.model` | string | Model tier (`mid`, `high`, `max`) or model id from the configured list. Omit to use the `high` tier. Ignored with a warning if it is not a known tier or configured model. |
 | `metadata.scrutineer.min_confidence` | `low` `medium` `high` | Findings below this confidence are dropped before they reach the database. |
 | `metadata.scrutineer.report_on` | `Low` `Medium` `High` `Critical` | Lowest severity that produces a Finding row. Lower-severity hits are recorded on the scan but not surfaced. |
 | `metadata.scrutineer.fail_on` | `Low` `Medium` `High` `Critical` | If any finding meets or exceeds this severity, the scan is marked failed. Useful for CI-style gating. |

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -67,7 +67,7 @@ metadata:
   scrutineer.output_file: report.json
   scrutineer.output_kind: findings
   scrutineer.max_turns: 30
-  scrutineer.model: claude-sonnet-4-6
+  scrutineer.model: high
   scrutineer.min_confidence: medium
   scrutineer.report_on: Medium
   scrutineer.fail_on: Critical
@@ -90,7 +90,7 @@ metadata:
 | `metadata.scrutineer.output_file` | string | Path, relative to the workspace, the skill writes its result to. Almost always `report.json`. |
 | `metadata.scrutineer.output_kind` | string | Picks the parser scrutineer runs over `output_file` after the scan. See the table below. |
 | `metadata.scrutineer.max_turns` | int | Per-skill cap on `claude --max-turns`. Overrides the global `-max-turns` flag for this skill only. |
-| `metadata.scrutineer.model` | string | Model id from the configured list. Overrides the server default for this skill only. Ignored with a warning if not in the list. |
+| `metadata.scrutineer.model` | string | Model tier (`mid`, `high`, `max`) or model id from the configured list. Overrides the skill's default tier. Ignored with a warning if it is not a known tier or configured model. |
 | `metadata.scrutineer.min_confidence` | `low` `medium` `high` | Findings below this confidence are dropped before they reach the database. |
 | `metadata.scrutineer.report_on` | `Low` `Medium` `High` `Critical` | Lowest severity that produces a Finding row. Lower-severity hits are recorded on the scan but not surfaced. |
 | `metadata.scrutineer.fail_on` | `Low` `Medium` `High` `Critical` | If any finding meets or exceeds this severity, the scan is marked failed. Useful for CI-style gating. |

--- a/internal/db/settings.go
+++ b/internal/db/settings.go
@@ -19,6 +19,9 @@ type Setting struct {
 const (
 	SettingConcurrency     = "concurrency"
 	SettingDefaultMaxTurns = "default_max_turns"
+	SettingModelTierMid    = "model_tier_mid"
+	SettingModelTierHigh   = "model_tier_high"
+	SettingModelTierMax    = "model_tier_max"
 )
 
 // GetSetting returns the stored value for key and whether a row exists. It

--- a/internal/skills/parse.go
+++ b/internal/skills/parse.go
@@ -104,9 +104,9 @@ var OutputKinds = map[string]bool{
 var nameRE = regexp.MustCompile(`^[a-z0-9]+(-[a-z0-9]+)*$`)
 
 // ModelValidator gates the scrutineer.model metadata key. When non-nil, a
-// skill declaring a model the validator rejects gets a warning and the
-// field is left empty (the scan falls back to the server default). Wired
-// from main.go after the model list is configured.
+// skill declaring a model preference the validator rejects gets a warning and
+// the field is left empty (the scan falls back to the skill's default tier).
+// Wired from main.go after the model list is configured.
 var ModelValidator func(string) bool
 
 // ProfileValidator gates the scrutineer.requires_profile metadata key.
@@ -355,7 +355,7 @@ func (p *Parsed) extractMetadataKeys() {
 			if ModelValidator == nil || ModelValidator(m) {
 				p.Model = m
 			} else {
-				p.Warnings = append(p.Warnings, fmt.Sprintf("model %q is not in the configured model list, ignoring", m))
+				p.Warnings = append(p.Warnings, fmt.Sprintf("model preference %q is not a configured model or tier, ignoring", m))
 			}
 		}
 	}

--- a/internal/skills/parse.go
+++ b/internal/skills/parse.go
@@ -105,7 +105,7 @@ var nameRE = regexp.MustCompile(`^[a-z0-9]+(-[a-z0-9]+)*$`)
 
 // ModelValidator gates the scrutineer.model metadata key. When non-nil, a
 // skill declaring a model preference the validator rejects gets a warning and
-// the field is left empty (the scan falls back to the skill's default tier).
+// the field is left empty (the scan falls back to the high tier).
 // Wired from main.go after the model list is configured.
 var ModelValidator func(string) bool
 

--- a/internal/skills/parse_test.go
+++ b/internal/skills/parse_test.go
@@ -307,6 +307,38 @@ body
 	}
 }
 
+func TestParseFile_modelTier(t *testing.T) {
+	old := ModelValidator
+	t.Cleanup(func() { ModelValidator = old })
+	ModelValidator = func(s string) bool { return s == "high" }
+
+	dir := t.TempDir()
+	path := writeSkill(t, dir, "tiered", `---
+name: tiered
+description: Skill with a model tier.
+metadata:
+  scrutineer.model: high
+---
+
+body
+`)
+	p, err := ParseFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.Model != "high" {
+		t.Errorf("model = %q, want high", p.Model)
+	}
+
+	m, err := p.ToModel("local")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m.Model != "high" {
+		t.Errorf("db.Skill.Model = %q, want high", m.Model)
+	}
+}
+
 func TestParseFile_modelInvalidIgnoredWithWarning(t *testing.T) {
 	old := ModelValidator
 	t.Cleanup(func() { ModelValidator = old })

--- a/internal/web/models.go
+++ b/internal/web/models.go
@@ -129,6 +129,10 @@ func ModelTierValues(gdb *gorm.DB) map[string]string {
 }
 
 func builtinModelForTier(tier string) string {
+	// Built-in tiers assume the built-in Anthropic-flavoured model ids and
+	// ordering. If operators replace Models with a multi-vendor list that
+	// lacks "sonnet" or "opus", the tier intentionally falls back to
+	// DefaultModel unless they configure the tier in Settings.
 	switch tier {
 	case ModelTierMid:
 		if id := firstModelContaining("sonnet"); id != "" {
@@ -160,23 +164,12 @@ func lastModelContaining(needle string) string {
 	return ""
 }
 
-func defaultModelTierForSkill(skillName string) string {
-	switch skillName {
-	case "metadata":
-		return ModelTierMid
-	case deepDiveSkillName:
-		return ModelTierMax
-	default:
-		return ModelTierHigh
-	}
-}
-
-func resolveModelPreference(gdb *gorm.DB, skillName, preference string) string {
+func resolveModelPreference(gdb *gorm.DB, preference string) string {
 	if ValidModel(preference) {
 		return preference
 	}
 	if ValidModelTier(preference) {
 		return ModelForTier(gdb, preference)
 	}
-	return ModelForTier(gdb, defaultModelTierForSkill(skillName))
+	return ModelForTier(gdb, ModelTierHigh)
 }

--- a/internal/web/models.go
+++ b/internal/web/models.go
@@ -1,9 +1,37 @@
 package web
 
+import (
+	"strings"
+
+	"scrutineer/internal/db"
+
+	"gorm.io/gorm"
+)
+
 // Model is a display-name → claude model id pair offered in the UI.
 type Model struct {
 	Name string
 	ID   string
+}
+
+// ModelTier is an operator-facing role whose concrete model can be swapped
+// in Settings without editing every skill that uses that role.
+type ModelTier struct {
+	Name        string
+	Value       string
+	Description string
+}
+
+const (
+	ModelTierMid  = "mid"
+	ModelTierHigh = "high"
+	ModelTierMax  = "max"
+)
+
+var ModelTiers = []ModelTier{
+	{Name: "Mid", Value: ModelTierMid, Description: "Fast model for lightweight data gathering."},
+	{Name: "High", Value: ModelTierHigh, Description: "Default model for most analysis skills."},
+	{Name: "Max", Value: ModelTierMax, Description: "Best available model for deep security review."},
 }
 
 // Models is the pick list. The first entry is the default unless
@@ -50,4 +78,105 @@ func ValidModel(id string) bool {
 		}
 	}
 	return false
+}
+
+func ValidModelTier(tier string) bool {
+	for _, t := range ModelTiers {
+		if t.Value == tier {
+			return true
+		}
+	}
+	return false
+}
+
+func ValidModelPreference(value string) bool {
+	return ValidModel(value) || ValidModelTier(value)
+}
+
+func modelTierSettingKey(tier string) string {
+	switch tier {
+	case ModelTierMid:
+		return db.SettingModelTierMid
+	case ModelTierHigh:
+		return db.SettingModelTierHigh
+	case ModelTierMax:
+		return db.SettingModelTierMax
+	default:
+		return ""
+	}
+}
+
+func ModelForTier(gdb *gorm.DB, tier string) string {
+	if !ValidModelTier(tier) {
+		tier = ModelTierHigh
+	}
+	if gdb != nil {
+		if key := modelTierSettingKey(tier); key != "" {
+			if model, ok := db.GetSetting(gdb, key); ok && ValidModel(model) {
+				return model
+			}
+		}
+	}
+	return builtinModelForTier(tier)
+}
+
+func ModelTierValues(gdb *gorm.DB) map[string]string {
+	values := make(map[string]string, len(ModelTiers))
+	for _, tier := range ModelTiers {
+		values[tier.Value] = ModelForTier(gdb, tier.Value)
+	}
+	return values
+}
+
+func builtinModelForTier(tier string) string {
+	switch tier {
+	case ModelTierMid:
+		if id := firstModelContaining("sonnet"); id != "" {
+			return id
+		}
+	case ModelTierMax:
+		if id := lastModelContaining("opus"); id != "" {
+			return id
+		}
+	}
+	return DefaultModel()
+}
+
+func firstModelContaining(needle string) string {
+	for _, model := range Models {
+		if strings.Contains(strings.ToLower(model.ID), needle) {
+			return model.ID
+		}
+	}
+	return ""
+}
+
+func lastModelContaining(needle string) string {
+	for i := len(Models) - 1; i >= 0; i-- {
+		if strings.Contains(strings.ToLower(Models[i].ID), needle) {
+			return Models[i].ID
+		}
+	}
+	return ""
+}
+
+func defaultModelTierForSkill(skillName string) string {
+	switch skillName {
+	case "metadata":
+		return ModelTierMid
+	case deepDiveSkillName:
+		return ModelTierMax
+	default:
+		return ModelTierHigh
+	}
+}
+
+func resolveModelPreference(gdb *gorm.DB, skillName, preference string) string {
+	if ValidModel(preference) {
+		return preference
+	}
+	if ValidModelTier(preference) {
+		return ModelForTier(gdb, preference)
+	}
+	return ModelForTier(gdb, defaultModelTierForSkill(skillName))
 }

--- a/internal/web/models_test.go
+++ b/internal/web/models_test.go
@@ -1,0 +1,35 @@
+package web
+
+import "testing"
+
+func TestModelTiers(t *testing.T) {
+	if !ValidModelTier(ModelTierMid) || !ValidModelTier(ModelTierHigh) || !ValidModelTier(ModelTierMax) {
+		t.Fatal("built-in model tiers should be valid")
+	}
+	if ValidModelTier("ultra") {
+		t.Fatal("unknown tier should not be valid")
+	}
+	if got := builtinModelForTier(ModelTierMid); got != "claude-sonnet-4-6" {
+		t.Errorf("mid tier default = %q, want sonnet", got)
+	}
+	if got := builtinModelForTier(ModelTierHigh); got != DefaultModel() {
+		t.Errorf("high tier default = %q, want DefaultModel()", got)
+	}
+	if got := builtinModelForTier(ModelTierMax); got != "claude-opus-4-8" {
+		t.Errorf("max tier default = %q, want latest opus", got)
+	}
+}
+
+func TestDefaultModelTierForSkill(t *testing.T) {
+	tests := map[string]string{
+		"metadata":          ModelTierMid,
+		deepDiveSkillName:   ModelTierMax,
+		"maintainers":       ModelTierHigh,
+		"totally-new-skill": ModelTierHigh,
+	}
+	for skill, want := range tests {
+		if got := defaultModelTierForSkill(skill); got != want {
+			t.Errorf("defaultModelTierForSkill(%q) = %q, want %q", skill, got, want)
+		}
+	}
+}

--- a/internal/web/models_test.go
+++ b/internal/web/models_test.go
@@ -2,12 +2,12 @@ package web
 
 import "testing"
 
-func withTestModels(t *testing.T, models []Model, defaultModel string) {
+func withTestModels(t *testing.T, models []Model) {
 	t.Helper()
 	oldModels := Models
 	oldDefault := defaultModelOverride
 	Models = models
-	defaultModelOverride = defaultModel
+	defaultModelOverride = ""
 	t.Cleanup(func() {
 		Models = oldModels
 		defaultModelOverride = oldDefault
@@ -20,7 +20,7 @@ func TestModelTiers(t *testing.T) {
 		{Name: "Sonnet", ID: "test-sonnet"},
 		{Name: "Opus A", ID: "test-opus-a"},
 		{Name: "Opus B", ID: "test-opus-b"},
-	}, "")
+	})
 
 	if !ValidModelTier(ModelTierMid) || !ValidModelTier(ModelTierHigh) || !ValidModelTier(ModelTierMax) {
 		t.Fatal("built-in model tiers should be valid")
@@ -43,7 +43,7 @@ func TestModelTiersFallbackToDefaultModelWithCustomModelList(t *testing.T) {
 	withTestModels(t, []Model{
 		{Name: "Default", ID: "vendor-default"},
 		{Name: "Small", ID: "vendor-small"},
-	}, "")
+	})
 
 	for _, tier := range []string{ModelTierMid, ModelTierHigh, ModelTierMax} {
 		if got := builtinModelForTier(tier); got != "vendor-default" {
@@ -57,7 +57,7 @@ func TestResolveModelPreference(t *testing.T) {
 		{Name: "High", ID: "test-high"},
 		{Name: "Sonnet", ID: "test-sonnet"},
 		{Name: "Opus", ID: "test-opus"},
-	}, "")
+	})
 
 	if got := resolveModelPreference(nil, "test-opus"); got != "test-opus" {
 		t.Errorf("exact model = %q, want test-opus", got)

--- a/internal/web/models_test.go
+++ b/internal/web/models_test.go
@@ -2,34 +2,70 @@ package web
 
 import "testing"
 
+func withTestModels(t *testing.T, models []Model, defaultModel string) {
+	t.Helper()
+	oldModels := Models
+	oldDefault := defaultModelOverride
+	Models = models
+	defaultModelOverride = defaultModel
+	t.Cleanup(func() {
+		Models = oldModels
+		defaultModelOverride = oldDefault
+	})
+}
+
 func TestModelTiers(t *testing.T) {
+	withTestModels(t, []Model{
+		{Name: "High", ID: "test-high"},
+		{Name: "Sonnet", ID: "test-sonnet"},
+		{Name: "Opus A", ID: "test-opus-a"},
+		{Name: "Opus B", ID: "test-opus-b"},
+	}, "")
+
 	if !ValidModelTier(ModelTierMid) || !ValidModelTier(ModelTierHigh) || !ValidModelTier(ModelTierMax) {
 		t.Fatal("built-in model tiers should be valid")
 	}
 	if ValidModelTier("ultra") {
 		t.Fatal("unknown tier should not be valid")
 	}
-	if got := builtinModelForTier(ModelTierMid); got != "claude-sonnet-4-6" {
+	if got := builtinModelForTier(ModelTierMid); got != "test-sonnet" {
 		t.Errorf("mid tier default = %q, want sonnet", got)
 	}
 	if got := builtinModelForTier(ModelTierHigh); got != DefaultModel() {
 		t.Errorf("high tier default = %q, want DefaultModel()", got)
 	}
-	if got := builtinModelForTier(ModelTierMax); got != "claude-opus-4-8" {
+	if got := builtinModelForTier(ModelTierMax); got != "test-opus-b" {
 		t.Errorf("max tier default = %q, want latest opus", got)
 	}
 }
 
-func TestDefaultModelTierForSkill(t *testing.T) {
-	tests := map[string]string{
-		"metadata":          ModelTierMid,
-		deepDiveSkillName:   ModelTierMax,
-		"maintainers":       ModelTierHigh,
-		"totally-new-skill": ModelTierHigh,
-	}
-	for skill, want := range tests {
-		if got := defaultModelTierForSkill(skill); got != want {
-			t.Errorf("defaultModelTierForSkill(%q) = %q, want %q", skill, got, want)
+func TestModelTiersFallbackToDefaultModelWithCustomModelList(t *testing.T) {
+	withTestModels(t, []Model{
+		{Name: "Default", ID: "vendor-default"},
+		{Name: "Small", ID: "vendor-small"},
+	}, "")
+
+	for _, tier := range []string{ModelTierMid, ModelTierHigh, ModelTierMax} {
+		if got := builtinModelForTier(tier); got != "vendor-default" {
+			t.Errorf("builtinModelForTier(%q) = %q, want vendor-default", tier, got)
 		}
+	}
+}
+
+func TestResolveModelPreference(t *testing.T) {
+	withTestModels(t, []Model{
+		{Name: "High", ID: "test-high"},
+		{Name: "Sonnet", ID: "test-sonnet"},
+		{Name: "Opus", ID: "test-opus"},
+	}, "")
+
+	if got := resolveModelPreference(nil, "test-opus"); got != "test-opus" {
+		t.Errorf("exact model = %q, want test-opus", got)
+	}
+	if got := resolveModelPreference(nil, ModelTierMid); got != "test-sonnet" {
+		t.Errorf("tier model = %q, want test-sonnet", got)
+	}
+	if got := resolveModelPreference(nil, "not-configured"); got != "test-high" {
+		t.Errorf("invalid preference fallback = %q, want high tier default", got)
 	}
 }

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -1906,7 +1906,8 @@ func (s *Server) enqueueSkillScoped(ctx context.Context, repoID, skillID uint, f
 // enqueueSkillWith creates a skill scan using the given ScanOpts. Empty
 // fields default cleanly: unset FindingID means not-finding-scoped, empty
 // SubPath means root-scoped. Model precedence is: explicit opts.Model >
-// the skill's preferred Model > server default. Effort precedence is:
+// the skill's preferred Model > the skill's default tier. Concrete model IDs
+// win as-is; tier names resolve through Settings. Effort precedence is:
 // explicit opts.Effort > the runtime default effort.
 func (s *Server) enqueueSkillWith(ctx context.Context, repoID, skillID uint, opts ScanOpts) (uint, error) {
 	var repo db.Repository
@@ -1924,13 +1925,10 @@ func (s *Server) enqueueSkillWith(ctx context.Context, repoID, skillID uint, opt
 	if err := worker.ValidateGitRef(opts.Ref); err != nil {
 		return 0, fmt.Errorf("%w: %v", ErrInvalidRef, err)
 	}
-	if !ValidModel(opts.Model) {
-		if hasSkill && ValidModel(sk.Model) {
-			opts.Model = sk.Model
-		} else {
-			opts.Model = DefaultModel()
-		}
+	if !ValidModelPreference(opts.Model) && hasSkill {
+		opts.Model = sk.Model
 	}
+	opts.Model = resolveModelPreference(s.DB, sk.Name, opts.Model)
 	if !ValidEffort(opts.Effort) {
 		opts.Effort = DefaultEffort()
 	}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -1906,8 +1906,8 @@ func (s *Server) enqueueSkillScoped(ctx context.Context, repoID, skillID uint, f
 // enqueueSkillWith creates a skill scan using the given ScanOpts. Empty
 // fields default cleanly: unset FindingID means not-finding-scoped, empty
 // SubPath means root-scoped. Model precedence is: explicit opts.Model >
-// the skill's preferred Model > the skill's default tier. Concrete model IDs
-// win as-is; tier names resolve through Settings. Effort precedence is:
+// the skill's preferred Model > the high tier. Concrete model IDs win as-is;
+// tier names resolve through Settings. Effort precedence is:
 // explicit opts.Effort > the runtime default effort.
 func (s *Server) enqueueSkillWith(ctx context.Context, repoID, skillID uint, opts ScanOpts) (uint, error) {
 	var repo db.Repository
@@ -1928,7 +1928,7 @@ func (s *Server) enqueueSkillWith(ctx context.Context, repoID, skillID uint, opt
 	if !ValidModelPreference(opts.Model) && hasSkill {
 		opts.Model = sk.Model
 	}
-	opts.Model = resolveModelPreference(s.DB, sk.Name, opts.Model)
+	opts.Model = resolveModelPreference(s.DB, opts.Model)
 	if !ValidEffort(opts.Effort) {
 		opts.Effort = DefaultEffort()
 	}

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -1768,14 +1768,32 @@ func TestEnqueueSkillWith_modelPrecedence(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()
 
+	if err := db.SetSetting(s.DB, db.SettingModelTierMid, "claude-sonnet-4-6"); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.SetSetting(s.DB, db.SettingModelTierHigh, "claude-opus-4-7"); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.SetSetting(s.DB, db.SettingModelTierMax, "claude-opus-4-8"); err != nil {
+		t.Fatal(err)
+	}
 	repo := db.Repository{URL: "https://github.com/foo/bar", Name: "bar"}
 	s.DB.Create(&repo)
 	withModel := db.Skill{Name: "lite", Body: "b", OutputFile: "r.json", OutputKind: "freeform",
 		Version: 1, Active: true, Source: "ui", Model: "claude-sonnet-4-6"}
 	s.DB.Create(&withModel)
+	withTier := db.Skill{Name: "tiered", Body: "b", OutputFile: "r.json", OutputKind: "freeform",
+		Version: 1, Active: true, Source: "ui", Model: ModelTierMid}
+	s.DB.Create(&withTier)
 	noModel := db.Skill{Name: "heavy", Body: "b", OutputFile: "r.json", OutputKind: "freeform",
 		Version: 1, Active: true, Source: "ui"}
 	s.DB.Create(&noModel)
+	metadata := db.Skill{Name: "metadata", Body: "b", OutputFile: "r.json", OutputKind: "freeform",
+		Version: 1, Active: true, Source: "ui"}
+	s.DB.Create(&metadata)
+	deepDive := db.Skill{Name: deepDiveSkillName, Body: "b", OutputFile: "r.json", OutputKind: "freeform",
+		Version: 1, Active: true, Source: "ui"}
+	s.DB.Create(&deepDive)
 
 	cases := []struct {
 		name    string
@@ -1783,10 +1801,14 @@ func TestEnqueueSkillWith_modelPrecedence(t *testing.T) {
 		opts    ScanOpts
 		want    string
 	}{
-		{"explicit scan model wins", withModel.ID, ScanOpts{Model: "claude-opus-4-7"}, "claude-opus-4-7"},
+		{"explicit scan model wins", withTier.ID, ScanOpts{Model: "claude-opus-4-8"}, "claude-opus-4-8"},
+		{"explicit scan tier wins", withModel.ID, ScanOpts{Model: ModelTierMax}, "claude-opus-4-8"},
 		{"skill model fills empty scan model", withModel.ID, ScanOpts{}, "claude-sonnet-4-6"},
 		{"skill model fills invalid scan model", withModel.ID, ScanOpts{Model: "garbage"}, "claude-sonnet-4-6"},
-		{"server default when nothing set", noModel.ID, ScanOpts{}, DefaultModel()},
+		{"skill tier resolves through settings", withTier.ID, ScanOpts{}, "claude-sonnet-4-6"},
+		{"generic skill defaults to high tier", noModel.ID, ScanOpts{}, "claude-opus-4-7"},
+		{"metadata defaults to mid tier", metadata.ID, ScanOpts{}, "claude-sonnet-4-6"},
+		{"deep dive defaults to max tier", deepDive.ID, ScanOpts{}, "claude-opus-4-8"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -1765,22 +1765,29 @@ func TestFindingPatchRunEnqueuesPatchSkill(t *testing.T) {
 }
 
 func TestEnqueueSkillWith_modelPrecedence(t *testing.T) {
+	withTestModels(t, []Model{
+		{Name: "Test High", ID: "test-high"},
+		{Name: "Test Mid", ID: "test-mid"},
+		{Name: "Test Max", ID: "test-max"},
+		{Name: "Test Exact", ID: "test-exact"},
+	})
+
 	s, done := newTestServer(t)
 	defer done()
 
-	if err := db.SetSetting(s.DB, db.SettingModelTierMid, "claude-sonnet-4-6"); err != nil {
+	if err := db.SetSetting(s.DB, db.SettingModelTierMid, "test-mid"); err != nil {
 		t.Fatal(err)
 	}
-	if err := db.SetSetting(s.DB, db.SettingModelTierHigh, "claude-opus-4-7"); err != nil {
+	if err := db.SetSetting(s.DB, db.SettingModelTierHigh, "test-high"); err != nil {
 		t.Fatal(err)
 	}
-	if err := db.SetSetting(s.DB, db.SettingModelTierMax, "claude-opus-4-8"); err != nil {
+	if err := db.SetSetting(s.DB, db.SettingModelTierMax, "test-max"); err != nil {
 		t.Fatal(err)
 	}
 	repo := db.Repository{URL: "https://github.com/foo/bar", Name: "bar"}
 	s.DB.Create(&repo)
 	withModel := db.Skill{Name: "lite", Body: "b", OutputFile: "r.json", OutputKind: "freeform",
-		Version: 1, Active: true, Source: "ui", Model: "claude-sonnet-4-6"}
+		Version: 1, Active: true, Source: "ui", Model: "test-exact"}
 	s.DB.Create(&withModel)
 	withTier := db.Skill{Name: "tiered", Body: "b", OutputFile: "r.json", OutputKind: "freeform",
 		Version: 1, Active: true, Source: "ui", Model: ModelTierMid}
@@ -1801,14 +1808,14 @@ func TestEnqueueSkillWith_modelPrecedence(t *testing.T) {
 		opts    ScanOpts
 		want    string
 	}{
-		{"explicit scan model wins", withTier.ID, ScanOpts{Model: "claude-opus-4-8"}, "claude-opus-4-8"},
-		{"explicit scan tier wins", withModel.ID, ScanOpts{Model: ModelTierMax}, "claude-opus-4-8"},
-		{"skill model fills empty scan model", withModel.ID, ScanOpts{}, "claude-sonnet-4-6"},
-		{"skill model fills invalid scan model", withModel.ID, ScanOpts{Model: "garbage"}, "claude-sonnet-4-6"},
-		{"skill tier resolves through settings", withTier.ID, ScanOpts{}, "claude-sonnet-4-6"},
-		{"generic skill defaults to high tier", noModel.ID, ScanOpts{}, "claude-opus-4-7"},
-		{"metadata metadata uses mid tier", metadata.ID, ScanOpts{}, "claude-sonnet-4-6"},
-		{"deep dive metadata uses max tier", deepDive.ID, ScanOpts{}, "claude-opus-4-8"},
+		{"explicit scan model wins", withTier.ID, ScanOpts{Model: "test-max"}, "test-max"},
+		{"explicit scan tier wins", withModel.ID, ScanOpts{Model: ModelTierMax}, "test-max"},
+		{"skill model fills empty scan model", withModel.ID, ScanOpts{}, "test-exact"},
+		{"skill model fills invalid scan model", withModel.ID, ScanOpts{Model: "garbage"}, "test-exact"},
+		{"skill tier resolves through settings", withTier.ID, ScanOpts{}, "test-mid"},
+		{"generic skill defaults to high tier", noModel.ID, ScanOpts{}, "test-high"},
+		{"metadata skill uses mid tier", metadata.ID, ScanOpts{}, "test-mid"},
+		{"deep dive skill uses max tier", deepDive.ID, ScanOpts{}, "test-max"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -1789,10 +1789,10 @@ func TestEnqueueSkillWith_modelPrecedence(t *testing.T) {
 		Version: 1, Active: true, Source: "ui"}
 	s.DB.Create(&noModel)
 	metadata := db.Skill{Name: "metadata", Body: "b", OutputFile: "r.json", OutputKind: "freeform",
-		Version: 1, Active: true, Source: "ui"}
+		Version: 1, Active: true, Source: "ui", Model: ModelTierMid}
 	s.DB.Create(&metadata)
 	deepDive := db.Skill{Name: deepDiveSkillName, Body: "b", OutputFile: "r.json", OutputKind: "freeform",
-		Version: 1, Active: true, Source: "ui"}
+		Version: 1, Active: true, Source: "ui", Model: ModelTierMax}
 	s.DB.Create(&deepDive)
 
 	cases := []struct {
@@ -1807,8 +1807,8 @@ func TestEnqueueSkillWith_modelPrecedence(t *testing.T) {
 		{"skill model fills invalid scan model", withModel.ID, ScanOpts{Model: "garbage"}, "claude-sonnet-4-6"},
 		{"skill tier resolves through settings", withTier.ID, ScanOpts{}, "claude-sonnet-4-6"},
 		{"generic skill defaults to high tier", noModel.ID, ScanOpts{}, "claude-opus-4-7"},
-		{"metadata defaults to mid tier", metadata.ID, ScanOpts{}, "claude-sonnet-4-6"},
-		{"deep dive defaults to max tier", deepDive.ID, ScanOpts{}, "claude-opus-4-8"},
+		{"metadata metadata uses mid tier", metadata.ID, ScanOpts{}, "claude-sonnet-4-6"},
+		{"deep dive metadata uses max tier", deepDive.ID, ScanOpts{}, "claude-opus-4-8"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/web/settings_handlers_test.go
+++ b/internal/web/settings_handlers_test.go
@@ -36,10 +36,39 @@ func TestSettingsShow_rendersRunnerControls(t *testing.T) {
 		t.Fatalf("status %d: %s", w.Code, w.Body)
 	}
 	body := w.Body.String()
-	for _, want := range []string{`name="concurrency"`, `value="9"`, `name="max_turns"`, "Default turns"} {
+	for _, want := range []string{`name="tier" value="mid"`, `name="concurrency"`, `value="9"`, `name="max_turns"`, "Default turns"} {
 		if !strings.Contains(body, want) {
 			t.Errorf("settings page missing %q", want)
 		}
+	}
+}
+
+func TestSettingsUpdateModelTier(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	w := postForm(t, s, "/settings/model", url.Values{
+		"tier":  {ModelTierMid},
+		"model": {"claude-sonnet-4-6"},
+	})
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+	if got := ModelForTier(s.DB, ModelTierMid); got != "claude-sonnet-4-6" {
+		t.Errorf("mid tier model = %q, want claude-sonnet-4-6", got)
+	}
+
+	for _, form := range []url.Values{
+		{"tier": {"unknown"}, "model": {"claude-sonnet-4-6"}},
+		{"tier": {ModelTierMid}, "model": {"not-a-model"}},
+	} {
+		w := postForm(t, s, "/settings/model", form)
+		if w.Code != http.StatusUnprocessableEntity {
+			t.Errorf("form=%v: status %d, want 422", form, w.Code)
+		}
+	}
+	if got := ModelForTier(s.DB, ModelTierMid); got != "claude-sonnet-4-6" {
+		t.Errorf("invalid update clobbered mid tier = %q", got)
 	}
 }
 

--- a/internal/web/skills_handlers.go
+++ b/internal/web/skills_handlers.go
@@ -157,7 +157,7 @@ func parseMaxTurns(s string) int {
 
 // parseSkillModel keeps the form value only if it's a configured model ID or
 // model tier. Anything else is silently dropped so the scan falls back to the
-// skill's default tier at enqueue time.
+// high tier at enqueue time.
 func parseSkillModel(s string) string {
 	s = strings.TrimSpace(s)
 	if !ValidModelPreference(s) {

--- a/internal/web/skills_handlers.go
+++ b/internal/web/skills_handlers.go
@@ -46,6 +46,7 @@ func (s *Server) skillNew(w http.ResponseWriter, r *http.Request) {
 		"Action": "/skills",
 		"Verb":   "Create",
 		"Models": Models,
+		"Tiers":  ModelTiers,
 	})
 }
 
@@ -61,6 +62,7 @@ func (s *Server) skillEdit(w http.ResponseWriter, r *http.Request) {
 		"Action": "/skills/" + strconv.Itoa(int(skill.ID)),
 		"Verb":   "Save",
 		"Models": Models,
+		"Tiers":  ModelTiers,
 	})
 }
 
@@ -153,12 +155,12 @@ func parseMaxTurns(s string) int {
 	return n
 }
 
-// parseSkillModel keeps the form value only if it's in the configured Models
-// list. Anything else (typo, blank, model removed from config) is silently
-// dropped so the scan falls back to the server default at enqueue time.
+// parseSkillModel keeps the form value only if it's a configured model ID or
+// model tier. Anything else is silently dropped so the scan falls back to the
+// skill's default tier at enqueue time.
 func parseSkillModel(s string) string {
 	s = strings.TrimSpace(s)
-	if !ValidModel(s) {
+	if !ValidModelPreference(s) {
 		return ""
 	}
 	return s

--- a/internal/web/skills_handlers_test.go
+++ b/internal/web/skills_handlers_test.go
@@ -163,6 +163,7 @@ func TestParseSkillModel(t *testing.T) {
 		{"", ""},
 		{"   ", ""},
 		{"garbage", ""},
+		{ModelTierHigh, ModelTierHigh},
 		{"claude-sonnet-4-6", "claude-sonnet-4-6"},
 		{" claude-opus-4-7 ", "claude-opus-4-7"},
 	}

--- a/internal/web/templates/settings.html
+++ b/internal/web/templates/settings.html
@@ -44,16 +44,22 @@
 </section>
 
 <section class="card">
-  <header><h2>Default model</h2></header>
+  <header><h2>Model tiers</h2></header>
   <section>
-    <div class="flex flex-wrap gap-3">
-      {{$model := .DefaultModel}}
-      {{range .Models}}
-      <form method="post" action="/settings/model" hx-post="/settings/model" hx-swap="none">
-        <input type="hidden" name="model" value="{{.ID}}">
-        <button type="submit" class="rounded-lg border px-4 py-3 text-center hover:bg-muted transition-colors cursor-pointer {{if eq .ID $model}}border-primary bg-muted/50{{else}}border-transparent{{end}}">
-          <span class="text-sm font-medium">{{.Name}}</span>
-        </button>
+    <div class="grid sm:grid-cols-3 gap-4">
+      {{range .ModelTiers}}
+      {{$tier := .Value}}
+      {{$current := index $.TierModels $tier}}
+      <form method="post" action="/settings/model" hx-post="/settings/model" hx-swap="none" class="grid gap-2">
+        <input type="hidden" name="tier" value="{{$tier}}">
+        <label for="model_{{$tier}}">{{.Name}}</label>
+        <select id="model_{{$tier}}" class="input" name="model">
+          {{range $.Models}}
+          <option value="{{.ID}}"{{if eq .ID $current}} selected{{end}}>{{.Name}}</option>
+          {{end}}
+        </select>
+        <p class="text-xs text-muted-foreground">{{.Description}}</p>
+        <button type="submit" class="btn justify-self-start">Save</button>
       </form>
       {{end}}
     </div>

--- a/internal/web/templates/skill_form.html
+++ b/internal/web/templates/skill_form.html
@@ -49,15 +49,22 @@
       <p class="text-xs text-muted-foreground">Per-skill turn cap for claude-code. 0 = use default (30).</p>
     </div>
     <div class="grid gap-2">
-      <label for="model">Preferred model</label>
+      <label for="model">Model preference</label>
       <select id="model" class="input" name="model">
-        <option value=""{{if eq .Model ""}} selected{{end}}>— use server default —</option>
+        <option value=""{{if eq .Model ""}} selected{{end}}>— use skill default tier —</option>
         {{$cur := .Model}}
+        <optgroup label="Tiers">
+          {{range $.Tiers}}
+          <option value="{{.Value}}"{{if eq .Value $cur}} selected{{end}}>{{.Name}}</option>
+          {{end}}
+        </optgroup>
+        <optgroup label="Models">
         {{range $.Models}}
         <option value="{{.ID}}"{{if eq .ID $cur}} selected{{end}}>{{.Name}}</option>
         {{end}}
+        </optgroup>
       </select>
-      <p class="text-xs text-muted-foreground">Wins over the server default; an explicit per-scan model still wins over this.</p>
+      <p class="text-xs text-muted-foreground">Wins over the skill default tier; an explicit per-scan model still wins over this.</p>
     </div>
   </div>
 

--- a/internal/web/templates/skill_show.html
+++ b/internal/web/templates/skill_show.html
@@ -21,7 +21,7 @@
   <div><dt class="text-muted-foreground">Output kind</dt><dd>{{if .OutputKind}}{{.OutputKind}}{{else}}<span class="text-muted-foreground">none</span>{{end}}</dd></div>
   <div><dt class="text-muted-foreground">Output file</dt><dd>{{if .OutputFile}}{{.OutputFile}}{{else}}<span class="text-muted-foreground">none</span>{{end}}</dd></div>
   <div><dt class="text-muted-foreground">Max turns</dt><dd>{{if .MaxTurns}}{{.MaxTurns}}{{else}}<span class="text-muted-foreground">default (30)</span>{{end}}</dd></div>
-  <div><dt class="text-muted-foreground">Preferred model</dt><dd>{{if .Model}}{{.Model}}{{else}}<span class="text-muted-foreground">server default</span>{{end}}</dd></div>
+  <div><dt class="text-muted-foreground">Model preference</dt><dd>{{if .Model}}{{.Model}}{{else}}<span class="text-muted-foreground">skill default tier</span>{{end}}</dd></div>
   {{if .License}}<div><dt class="text-muted-foreground">License</dt><dd>{{.License}}</dd></div>{{end}}
   {{if .Compatibility}}<div class="col-span-2"><dt class="text-muted-foreground">Compatibility</dt><dd>{{.Compatibility}}</dd></div>{{end}}
 </dl>

--- a/internal/web/theme.go
+++ b/internal/web/theme.go
@@ -98,7 +98,8 @@ func (s *Server) settingsShow(w http.ResponseWriter, r *http.Request) {
 	s.render(w, r, "settings.html", map[string]any{
 		"Themes":           config.Themes,
 		"Models":           Models,
-		"DefaultModel":     DefaultModel(),
+		"ModelTiers":       ModelTiers,
+		"TierModels":       ModelTierValues(s.DB),
 		"Efforts":          Efforts,
 		"DefaultEffort":    DefaultEffort(),
 		"ColorScheme":      resolveColorScheme(r),
@@ -174,6 +175,20 @@ func (s *Server) settingsUpdateModel(w http.ResponseWriter, r *http.Request) {
 	model := r.FormValue("model")
 	if !ValidModel(model) {
 		http.Error(w, "unknown model", http.StatusUnprocessableEntity)
+		return
+	}
+	tier := r.FormValue("tier")
+	if tier != "" {
+		if !ValidModelTier(tier) {
+			http.Error(w, "unknown model tier", http.StatusUnprocessableEntity)
+			return
+		}
+		if err := db.SetSetting(s.DB, modelTierSettingKey(tier), model); err != nil {
+			http.Error(w, "could not save setting", http.StatusInternalServerError)
+			return
+		}
+		setFlash(w, Flash{Category: successKey, Title: "Model tier updated"})
+		s.redirect(w, r, "/settings")
 		return
 	}
 	SetDefaultModel(model)

--- a/internal/worker/skill.go
+++ b/internal/worker/skill.go
@@ -278,10 +278,17 @@ func (w *Worker) parseFindingsOutput(skill *db.Skill, scan *db.Scan, report stri
 	findings := rep.toFindings(scan.ID, scan.RepositoryID, scan.Commit, scan.SubPath)
 	findings = groupByFingerprint(findings, scan.SkillName)
 
-	var dropped int
-	findings, dropped = filterFindingsByMinConfidence(findings, skill.MinConfidence)
-	if dropped > 0 {
-		emit(Event{Kind: KindText, Text: fmt.Sprintf("dropped %d finding(s) below min_confidence=%s", dropped, skill.MinConfidence)})
+	if skill.MinConfidence != "" {
+		kept := findings[:0]
+		for _, f := range findings {
+			if db.ConfidenceAtLeast(f.Confidence, skill.MinConfidence) {
+				kept = append(kept, f)
+			}
+		}
+		if dropped := len(findings) - len(kept); dropped > 0 {
+			emit(Event{Kind: KindText, Text: fmt.Sprintf("dropped %d finding(s) below min_confidence=%s", dropped, skill.MinConfidence)})
+		}
+		findings = kept
 	}
 	scan.FindingsCount = len(findings)
 
@@ -305,13 +312,18 @@ func (w *Worker) parseFindingsOutput(skill *db.Skill, scan *db.Scan, report stri
 		f.SeenCount = 1
 		seenThisScan[f.Fingerprint] = true
 
-		wasObserved, err := w.saveOrObserveFinding(scan, f)
-		if err != nil {
-			return err
-		}
-		if wasObserved {
+		var existing db.Finding
+		err := w.DB.Where("repository_id = ? AND fingerprint = ?", scan.RepositoryID, f.Fingerprint).
+			Order("id").First(&existing).Error
+		if err == nil {
+			if uerr := w.reobserveFinding(&existing, f, scan); uerr != nil {
+				return uerr
+			}
 			observed++
 			continue
+		}
+		if cerr := w.DB.Create(f).Error; cerr != nil {
+			return fmt.Errorf("save finding: %w", cerr)
 		}
 		created++
 		if w.OnFindingCreated != nil {
@@ -328,35 +340,6 @@ func (w *Worker) parseFindingsOutput(skill *db.Skill, scan *db.Scan, report stri
 		return &FailOnThresholdError{Worst: worst, Threshold: skill.FailOn}
 	}
 	return nil
-}
-
-func filterFindingsByMinConfidence(findings []db.Finding, minConfidence string) ([]db.Finding, int) {
-	if minConfidence == "" {
-		return findings, 0
-	}
-	kept := findings[:0]
-	for _, f := range findings {
-		if db.ConfidenceAtLeast(f.Confidence, minConfidence) {
-			kept = append(kept, f)
-		}
-	}
-	return kept, len(findings) - len(kept)
-}
-
-func (w *Worker) saveOrObserveFinding(scan *db.Scan, f *db.Finding) (bool, error) {
-	var existing db.Finding
-	err := w.DB.Where("repository_id = ? AND fingerprint = ?", scan.RepositoryID, f.Fingerprint).
-		Order("id").First(&existing).Error
-	if err != nil {
-		if cerr := w.DB.Create(f).Error; cerr != nil {
-			return false, fmt.Errorf("save finding: %w", cerr)
-		}
-		return false, nil
-	}
-	if err := w.reobserveFinding(&existing, f, scan); err != nil {
-		return false, err
-	}
-	return true, nil
 }
 
 // reobserveFinding handles the dedup branch in parseFindingsOutput:

--- a/internal/worker/skill.go
+++ b/internal/worker/skill.go
@@ -278,17 +278,10 @@ func (w *Worker) parseFindingsOutput(skill *db.Skill, scan *db.Scan, report stri
 	findings := rep.toFindings(scan.ID, scan.RepositoryID, scan.Commit, scan.SubPath)
 	findings = groupByFingerprint(findings, scan.SkillName)
 
-	if skill.MinConfidence != "" {
-		kept := findings[:0]
-		for _, f := range findings {
-			if db.ConfidenceAtLeast(f.Confidence, skill.MinConfidence) {
-				kept = append(kept, f)
-			}
-		}
-		if dropped := len(findings) - len(kept); dropped > 0 {
-			emit(Event{Kind: KindText, Text: fmt.Sprintf("dropped %d finding(s) below min_confidence=%s", dropped, skill.MinConfidence)})
-		}
-		findings = kept
+	var dropped int
+	findings, dropped = filterFindingsByMinConfidence(findings, skill.MinConfidence)
+	if dropped > 0 {
+		emit(Event{Kind: KindText, Text: fmt.Sprintf("dropped %d finding(s) below min_confidence=%s", dropped, skill.MinConfidence)})
 	}
 	scan.FindingsCount = len(findings)
 
@@ -312,18 +305,13 @@ func (w *Worker) parseFindingsOutput(skill *db.Skill, scan *db.Scan, report stri
 		f.SeenCount = 1
 		seenThisScan[f.Fingerprint] = true
 
-		var existing db.Finding
-		err := w.DB.Where("repository_id = ? AND fingerprint = ?", scan.RepositoryID, f.Fingerprint).
-			Order("id").First(&existing).Error
-		if err == nil {
-			if uerr := w.reobserveFinding(&existing, f, scan); uerr != nil {
-				return uerr
-			}
+		wasObserved, err := w.saveOrObserveFinding(scan, f)
+		if err != nil {
+			return err
+		}
+		if wasObserved {
 			observed++
 			continue
-		}
-		if cerr := w.DB.Create(f).Error; cerr != nil {
-			return fmt.Errorf("save finding: %w", cerr)
 		}
 		created++
 		if w.OnFindingCreated != nil {
@@ -340,6 +328,35 @@ func (w *Worker) parseFindingsOutput(skill *db.Skill, scan *db.Scan, report stri
 		return &FailOnThresholdError{Worst: worst, Threshold: skill.FailOn}
 	}
 	return nil
+}
+
+func filterFindingsByMinConfidence(findings []db.Finding, minConfidence string) ([]db.Finding, int) {
+	if minConfidence == "" {
+		return findings, 0
+	}
+	kept := findings[:0]
+	for _, f := range findings {
+		if db.ConfidenceAtLeast(f.Confidence, minConfidence) {
+			kept = append(kept, f)
+		}
+	}
+	return kept, len(findings) - len(kept)
+}
+
+func (w *Worker) saveOrObserveFinding(scan *db.Scan, f *db.Finding) (bool, error) {
+	var existing db.Finding
+	err := w.DB.Where("repository_id = ? AND fingerprint = ?", scan.RepositoryID, f.Fingerprint).
+		Order("id").First(&existing).Error
+	if err != nil {
+		if cerr := w.DB.Create(f).Error; cerr != nil {
+			return false, fmt.Errorf("save finding: %w", cerr)
+		}
+		return false, nil
+	}
+	if err := w.reobserveFinding(&existing, f, scan); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 // reobserveFinding handles the dedup branch in parseFindingsOutput:

--- a/scrutineer.sample.yaml
+++ b/scrutineer.sample.yaml
@@ -95,9 +95,10 @@
 #     id:   claude-opus-4-7
 
 # Pin the default model id. When set, this wins over the "first entry
-# in models wins" rule. A skill can declare its own preferred model
-# (scrutineer.model in SKILL.md metadata); per-skill wins over this
-# default, and an explicit per-scan model wins over both.
+# in models wins" rule for the high tier. The Settings page can map
+# each tier (mid, high, max) to a configured model. A skill can declare
+# scrutineer.model in SKILL.md metadata as either a tier or exact model,
+# and an explicit per-scan model wins over the skill preference.
 # default_model: claude-sonnet-4-6
 
 # GitHub organisation the fork skill stages scanned repositories into as

--- a/skills/maintainers/SKILL.md
+++ b/skills/maintainers/SKILL.md
@@ -8,7 +8,7 @@ metadata:
   scrutineer.output_file: report.json
   scrutineer.output_kind: maintainers
   scrutineer.requires_remote: true
-  scrutineer.model: claude-sonnet-4-6
+  scrutineer.model: mid
 ---
 
 # maintainers

--- a/skills/metadata/SKILL.md
+++ b/skills/metadata/SKILL.md
@@ -8,6 +8,7 @@ metadata:
   scrutineer.output_file: report.json
   scrutineer.output_kind: repo_metadata
   scrutineer.requires_remote: true
+  scrutineer.model: mid
 ---
 
 # metadata

--- a/skills/security-deep-dive/SKILL.md
+++ b/skills/security-deep-dive/SKILL.md
@@ -7,6 +7,7 @@ metadata:
   scrutineer.output_file: report.json
   scrutineer.output_kind: findings
   scrutineer.max_turns: 120
+  scrutineer.model: max
 ---
 
 # security-deep-dive

--- a/skills/semgrep/SKILL.md
+++ b/skills/semgrep/SKILL.md
@@ -7,7 +7,7 @@ metadata:
   scrutineer.version: 1
   scrutineer.output_file: report.json
   scrutineer.output_kind: findings
-  scrutineer.model: claude-sonnet-4-6
+  scrutineer.model: mid
 ---
 
 # semgrep

--- a/skills/zizmor/SKILL.md
+++ b/skills/zizmor/SKILL.md
@@ -7,7 +7,7 @@ metadata:
   scrutineer.version: 1
   scrutineer.output_file: report.json
   scrutineer.output_kind: findings
-  scrutineer.model: claude-sonnet-4-6
+  scrutineer.model: mid
 ---
 
 # zizmor


### PR DESCRIPTION
## Summary

Fixes #330.

This PR adds configurable model tiers so skills can target roles like `mid`, `high` or `max` instead of hardcoding a specific model ID.

Changes include:

- add `mid`, `high` and `max` model tiers
- add Settings controls to map each tier to a configured model
- resolve scan models by precedence:
  - explicit scan model or tier
  - skill model or tier
  - skill default tier
- default `metadata` to `mid`
- default `security-deep-dive` to `max`
- default other skills to `high`
- keep exact model IDs backwards-compatible
- update bundled Sonnet-pinned skills to use the `mid` tier
- update docs and tests

## Testing

- `go test ./internal/web ./internal/skills -run 'TestModelTiers|TestDefaultModelTierForSkill|TestSettingsShow_rendersRunnerControls|TestSettingsUpdateModelTier|TestEnqueueSkillWith_modelPrecedence|TestParseSkillModel|TestParseFile_model|TestParseFile_modelTier|TestParseFile_modelInvalidIgnoredWithWarning'`
- `go test ./...`
- `go vet ./...`
- `env GOTOOLCHAIN=local /Users/gautam/go/bin/golangci-lint run ./...`