### PR TITLE
Include suggested-fix diff in markdown report exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ When a repo is added, the `triage` skill is enqueued. Its SKILL.md lists the ski
 | `finding-dedup` | Compares open findings and marks overlapping reports as duplicates |
 | `verify` | Re-checks one finding against current HEAD; records reproduces / fixed / can't-reproduce |
 | `disclose` | Drafts a GHSA-shaped advisory (title, description, CVSS, CWEs, references) for one finding |
-| `patch` | Proposes a unified diff fixing one finding, written back as a note for analyst review |
+| `patch` | Proposes a unified diff fixing one finding; a diff that passes the applicability gate is stored on the finding as its suggested fix |
 | `report-upstream` | Files one finding on the upstream repository via GitHub PVR with the proposed patch attached; the action that moves a finding to `reported` |
 | `reachability` | Traces dependency sinks through application code to determine which are reachable from trust boundaries |
 | `cna-match` | Matches a repository to its CVE Numbering Authority so disclosures route to the right contact |

--- a/README.md
+++ b/README.md
@@ -156,6 +156,8 @@ Each finding from the `security-deep-dive` skill starts at **new** and moves thr
 
 Each finding page has a notes section for recording triage reasoning and communication history.
 
+A `patch` run whose diff survives the applicability gate (the diff parses, targets files that exist, touches the flagged file, and passes `git apply --check`) is stored on the finding as `suggested_fix` with its base commit, downloadable from the finding page as a `.patch` file and included in markdown report exports. To revise a fix, push your edits to a branch, scan that branch (the Branch field, or a `/tree/<branch>` URL suffix), and run `patch` against the new scan: the diff is proposed against that ref's tree, so each round of edit, push, and rescan gets a fresh proposal on top of your work.
+
 ## Exploring dependencies
 
 The Dependencies tab on a repo groups packages by name and shows all manifest files where each appears. The import button (arrow icon) next to a dependency resolves it to a repository URL via packages.ecosyste.ms and queues the full pipeline for it. Dependencies you've already imported show a link icon instead.

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -31,7 +31,7 @@ These ship in `skills/` and are loaded with `-skills ./skills`. The `triage` ski
 | `exposure` | For one (finding, dependent) pair, decides whether the dependent's published code actually reaches the upstream library finding. Emits one CSAF 2.0 product_status verdict so scrutineer can record affected vs not_affected and stamp the right VEX justification. |
 | `verify` | Re-checks one finding against current HEAD and records reproduces / fixed / cannot-reproduce. |
 | `disclose` | Drafts a GHSA-shaped advisory (title, description, CVSS, CWEs, references) for one finding. |
-| `patch` | Proposes a unified diff fixing one finding, written back as a note for analyst review. |
+| `patch` | Proposes a unified diff fixing one finding; a diff that passes the applicability gate is stored on the finding as its suggested fix. |
 | `fork` | Forks the repository into the configured org, enables private vulnerability reporting on the fork, and files each finding as a draft advisory there. Only useful when `-fork-org` is set. |
 | `report-upstream` | Files one finding on the upstream repository through GitHub's private vulnerability reporting, requests the temporary private fork, and pushes the proposed patch to it when available. github.com only. |
 

--- a/internal/web/repo_report.go
+++ b/internal/web/repo_report.go
@@ -270,6 +270,14 @@ func writeReportFinding(b *strings.Builder, gdb *gorm.DB, f db.Finding, latest *
 		fmt.Fprintf(b, "#### Disclosure draft\n\n%s\n\n", strings.TrimSpace(f.DisclosureDraft))
 	}
 
+	if f.SuggestedFix != "" {
+		fmt.Fprintf(b, "#### Suggested fix\n\n")
+		if f.SuggestedFixCommit != "" {
+			fmt.Fprintf(b, "Applies to commit `%s`.\n\n", f.SuggestedFixCommit)
+		}
+		fmt.Fprintf(b, "```diff\n%s\n```\n\n", strings.TrimSpace(f.SuggestedFix))
+	}
+
 	writeFindingNotes(b, gdb, f.ID)
 	writeFindingCommunications(b, gdb, f.ID)
 	writeFindingReferences(b, gdb, f.ID)

--- a/internal/web/scan_report_test.go
+++ b/internal/web/scan_report_test.go
@@ -42,8 +42,10 @@ func seedScanWithFindings(t *testing.T, s *Server) (db.Repository, db.Scan) {
 		ScanID: scan.ID, RepositoryID: repo.ID, Commit: scan.Commit,
 		FindingID: "F1", Title: "python.lang.security.use-defused-xml",
 		Severity: "High", Status: db.FindingNew, CWE: "CWE-611",
-		Location: "src/typestubs/py_serializable/__init__.pyi:5",
-		Trace:    "xml.etree.ElementTree is vulnerable to XXE",
+		Location:           "src/typestubs/py_serializable/__init__.pyi:5",
+		Trace:              "xml.etree.ElementTree is vulnerable to XXE",
+		SuggestedFix:       "--- a/src/parse.py\n+++ b/src/parse.py\n@@ -1 +1 @@\n-import xml.etree.ElementTree\n+import defusedxml.ElementTree\n",
+		SuggestedFixCommit: "deadbeef1234567",
 	}
 	// medium is the grouped multi-location case from #193 — same rule
 	// firing at several template positions, collapsed into one row.
@@ -105,6 +107,11 @@ func TestScanReport_findingsDispatch(t *testing.T) {
 		"python.lang.security.use-defused-xml",
 		"#### Trace",
 		"xml.etree.ElementTree is vulnerable to XXE",
+		// Gated suggested-fix diff is included with its base commit
+		"#### Suggested fix",
+		"Applies to commit `deadbeef1234567`.",
+		"```diff\n--- a/src/parse.py",
+		"+import defusedxml.ElementTree",
 		"### Finding #",
 		"generic.html-templates.security.var-in-href",
 		"template variable in href",
@@ -124,6 +131,13 @@ func TestScanReport_findingsDispatch(t *testing.T) {
 	if strings.Count(body, "#### Additional locations") != 1 {
 		t.Errorf("expected exactly one Additional locations block (multi-location finding only), got %d",
 			strings.Count(body, "#### Additional locations"))
+	}
+
+	// Only the High finding carries a gated diff; the Medium one has no
+	// SuggestedFix and must not get an empty section.
+	if strings.Count(body, "#### Suggested fix") != 1 {
+		t.Errorf("expected exactly one Suggested fix block, got %d",
+			strings.Count(body, "#### Suggested fix"))
 	}
 
 	// Additional locations must be naturally sorted: index.html comes

--- a/skills/patch/SKILL.md
+++ b/skills/patch/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: patch
-description: Propose a code patch for a finding. Produces a unified diff against the current HEAD plus a short rationale, written back as a finding note so the analyst can review, adjust, and open a PR themselves. The skill never pushes to the remote.
+description: Propose a code patch for a finding. Produces a unified diff against the scanned ref plus a short rationale; a diff that passes the worker's applicability gate is stored on the finding as its suggested fix, and a summary note is posted for analyst review. The skill never pushes to the remote.
 license: MIT
-compatibility: Needs network access to the scrutineer API (http://host:port/api). Finding-scoped; runs against ./src at HEAD.
+compatibility: Needs network access to the scrutineer API (http://host:port/api). Finding-scoped; runs against ./src at the scanned ref's HEAD.
 metadata:
   scrutineer.version: 1
   scrutineer.output_file: report.json
@@ -15,7 +15,7 @@ Propose a minimal code patch that fixes a confirmed finding. You are not shippin
 
 ## Workspace
 
-- `./src` — the repository at its current HEAD, on the default branch, writable
+- `./src` — the repository at the scanned ref (the default branch unless the scan was started on a branch), writable
 - `./context.json` — has `scrutineer.api_base`, `scrutineer.token`, `scrutineer.repository_id`, `scrutineer.scan_id`, `scrutineer.finding_id` (required; this skill only makes sense finding-scoped)
 - `./report.json` — write the patch + rationale here
 - `./schema.json` — shape of `report.json`
@@ -53,7 +53,7 @@ Propose a minimal code patch that fixes a confirmed finding. You are not shippin
    }
    ```
 
-   The note lives on the finding page; the full diff lives in `report.json` and is viewable on the scan page.
+   The note lives on the finding page; the full diff lives in `report.json` and is viewable on the scan page. A diff that passes the worker's applicability gate is also stored on the finding as `suggested_fix` and served from the finding page as a `.patch` download.
 
 6. Do not PATCH any editable fields on the finding. Specifically:
    - Do not set `fix_commit` — that field means a shipped upstream fix, not a proposal. The analyst sets it after their PR merges.


### PR DESCRIPTION
Closes the last checkbox on #64.

`writeReportFinding` now renders a "Suggested fix" section when a finding carries a gated diff: the base commit and the diff in a fenced `diff` block. The renderer is shared, so the org, repo, and scan markdown exports all pick it up. Findings without a gated diff get no section.

Also adds the doc note from the issue thread: the README finding workflow now describes the scan-branch-then-patch revision round, where pushing edits to a branch and rescanning gets a fresh `patch` proposal against that ref's tree.

While here, refreshes the stale `patch` skill descriptions: the frontmatter, workspace notes, and the skill tables in README and docs/skills.md still said the diff was only written back as a note and that the skill ran on the default branch, predating the applicability gate and `scan_ref`.