### PR TITLE
Add revalidate skill: cheap classifier for High/Critical and imported findings

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ When a repo is added, the `triage` skill is enqueued. Its SKILL.md lists the ski
 | `security-deep-dive` | The model-backed audit producing structured findings |
 | `finding-dedup` | Compares open findings and marks overlapping reports as duplicates |
 | `verify` | Re-checks one finding against current HEAD; records reproduces / fixed / can't-reproduce |
+| `revalidate` | Cheap read-only classifier (prose + `git log`, no PoC execution) that emits true / false positive / already-fixed / uncertain; auto-enqueued for High/Critical from `security-deep-dive` and for every imported finding |
 | `breaking-change` | Static breaking-change check on the suggested-fix diff; records `breaking`/`non_breaking`/`unknown` with rationale and the affected dependents |
 | `release-watch` | After a finding reaches `fixed`, watches the upstream for a release containing the fix commit; records release tag, URL, and timestamp on the finding |
 | `disclose` | Drafts a GHSA-shaped advisory (title, description, CVSS, CWEs, references) for one finding |

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -31,6 +31,7 @@ These ship in `skills/` and are loaded with `-skills ./skills`. The `triage` ski
 | `reachability` | Traces sinks already found in this app's dependencies through the app's own code to see which are reachable from its trust boundaries. |
 | `exposure` | For one (finding, dependent) pair, decides whether the dependent's published code actually reaches the upstream library finding. Emits one CSAF 2.0 product_status verdict so scrutineer can record affected vs not_affected and stamp the right VEX justification. |
 | `verify` | Re-checks one finding against current HEAD and records reproduces / fixed / cannot-reproduce. |
+| `revalidate` | Cheap, read-only classifier. Reads a finding's prose plus `git log` over its location and emits `true_positive`/`false_positive`/`already_fixed`/`uncertain`, with an optional adjusted severity. Auto-enqueued for High/Critical findings from `security-deep-dive` and for every imported finding so the human queue is pre-sorted. |
 | `breaking-change` | Static breaking-change check: reads the finding's suggested-fix diff and the top dependents list, identifies public API surface changes, and records a verdict (`breaking`/`non_breaking`/`unknown`) with a rationale and the list of affected dependents. Read-only; reasons from the diff and dependent metadata. |
 | `release-watch` | After a finding reaches `fixed`, lists the upstream's releases and looks for one that contains `fix_commit` (or whose tag matches `fix_version`). Records the release tag, URL, and timestamp on the finding so the lifecycle visibly ends at a shipped version rather than at the commit landing. The triage skill auto-enqueues this for every `fixed` finding on each repo run. |
 | `disclose` | Drafts a GHSA-shaped advisory (title, description, CVSS, CWEs, references) for one finding. |
@@ -133,6 +134,7 @@ Declaring `scrutineer.paths` replaces this skip list entirely: the skill sees on
 | `subprojects` | Subproject rows for monorepo scoping. |
 | `posture` | Posture tier and check results on the Repository row. |
 | `verify` | Verification result and miss-count update on one Finding. |
+| `revalidate` | Cheap classifier verdict (`true_positive`/`false_positive`/`already_fixed`/`uncertain`) appended as a Note on one Finding. `true_positive` transitions a `new` finding to `enriched`; an optional `adjusted_severity` overwrites the finding's severity with the change recorded in FindingHistory. |
 | `breaking_change` | `breaking_change` verdict and `breaking_change_rationale` prose on one Finding, with the verdict change recorded in FindingHistory. |
 | `patch` | Suggested-fix diff and base commit on one Finding. |
 | `mitigation` | Mitigation prose and optional semgrep rule on one Finding (`mitigation`, `mitigation_semgrep` columns), with the change recorded in FindingHistory. |
@@ -186,7 +188,7 @@ The worker then runs `claude -p "Use the {name} skill in this workspace"` with t
 }
 ```
 
-`finding_id` is only present for finding-scoped skills (`verify`, `breaking-change`, `disclose`, `patch`, `mitigate`, `release-watch`, `exposure`). `dependent_id` is only set on `exposure` runs and points to the dependent whose code is under audit; `./src` is then a copy of that dependent's clone, not of the finding's repository. `scan_ref` is empty when the scan is on the default branch. `scan_subpath` is set when the operator scoped the scan to a monorepo sub-folder; skills that walk source honour it, skills that query external APIs by repository URL ignore it. `fork_org` is absent unless `-fork-org` is configured. `packages` is a convenience copy of the package rows when the `packages` skill has already run; otherwise it is omitted.
+`finding_id` is only present for finding-scoped skills (`verify`, `revalidate`, `breaking-change`, `disclose`, `patch`, `mitigate`, `release-watch`, `exposure`). `dependent_id` is only set on `exposure` runs and points to the dependent whose code is under audit; `./src` is then a copy of that dependent's clone, not of the finding's repository. `scan_ref` is empty when the scan is on the default branch. `scan_subpath` is set when the operator scoped the scan to a monorepo sub-folder; skills that walk source honour it, skills that query external APIs by repository URL ignore it. `fork_org` is absent unless `-fork-org` is configured. `packages` is a convenience copy of the package rows when the `packages` skill has already run; otherwise it is omitted.
 
 ## schema.json
 

--- a/internal/skills/parse.go
+++ b/internal/skills/parse.go
@@ -89,6 +89,7 @@ var OutputKinds = map[string]bool{
 	"dependencies":    true,
 	"finding_dedup":   true,
 	"verify":          true,
+	"revalidate":      true,
 	"breaking_change": true,
 	"mitigation":      true,
 	"release_watch":   true,

--- a/internal/web/import.go
+++ b/internal/web/import.go
@@ -1,6 +1,7 @@
 package web
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -239,6 +240,12 @@ func (s *Server) importFindings(scan *db.Scan, res ingest.Result) (created []uin
 			continue
 		}
 		created = append(created, f.ID)
+		// Imported findings carry an external tool's unvalidated severity
+		// claim, so revalidate runs over every newly-imported finding
+		// regardless of severity (not just High/Critical, as it does for
+		// security-deep-dive output).
+		fcopy := f
+		s.enqueueRevalidateForFinding(context.Background(), &fcopy)
 	}
 	return created, observed
 }

--- a/internal/web/import_test.go
+++ b/internal/web/import_test.go
@@ -139,3 +139,114 @@ func TestImportFindings_keepsSuggestedFixGated(t *testing.T) {
 		t.Errorf("Trace = %q, want original description retained", f.Trace)
 	}
 }
+
+func TestImportFindings_enqueuesRevalidate(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	repo := db.Repository{URL: "https://example.com/r", Name: "r"}
+	s.DB.Create(&repo)
+	scan := db.Scan{RepositoryID: repo.ID, Status: db.ScanDone, Commit: "abc"}
+	s.DB.Create(&scan)
+	revalidate := db.Skill{Name: "revalidate", OutputFile: "report.json", OutputKind: "revalidate", Version: 1, Active: true}
+	s.DB.Create(&revalidate)
+
+	res := ingest.Result{
+		Tool: "external-scanner",
+		Findings: []ingest.Finding{
+			{Title: "high", Severity: "High", Location: "a.go:1"},
+			{Title: "low", Severity: "Low", Location: "b.go:1"},
+		},
+	}
+	if created, _ := s.importFindings(&scan, res); len(created) != 2 {
+		t.Fatalf("created %d findings, want 2", len(created))
+	}
+
+	// Every imported finding gets a revalidate run regardless of severity:
+	// import severity is an unvalidated external claim, so even Low is
+	// worth revalidating.
+	var queued int64
+	s.DB.Model(&db.Scan{}).
+		Where("skill_id = ? AND status = ?", revalidate.ID, db.ScanQueued).
+		Count(&queued)
+	if queued != 2 {
+		t.Errorf("queued revalidate scans = %d, want 2 (one per imported finding)", queued)
+	}
+}
+
+func TestImportFindings_skipsRevalidateWhenSkillAbsent(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	repo := db.Repository{URL: "https://example.com/r", Name: "r"}
+	s.DB.Create(&repo)
+	scan := db.Scan{RepositoryID: repo.ID, Status: db.ScanDone, Commit: "abc"}
+	s.DB.Create(&scan)
+	// No revalidate skill registered. Import must still succeed.
+	res := ingest.Result{Tool: "x", Findings: []ingest.Finding{{Title: "t", Severity: "High", Location: "a.go:1"}}}
+	if created, _ := s.importFindings(&scan, res); len(created) != 1 {
+		t.Fatalf("created = %d, want 1", len(created))
+	}
+}
+
+func TestAutoEnqueueRevalidate_onlyHighAndCriticalFromDeepDive(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	repo := db.Repository{URL: "https://example.com/r", Name: "r"}
+	s.DB.Create(&repo)
+	revalidate := db.Skill{Name: "revalidate", OutputFile: "report.json", OutputKind: "revalidate", Version: 1, Active: true}
+	s.DB.Create(&revalidate)
+
+	cases := []struct {
+		name       string
+		skill      string
+		severity   string
+		wantQueued bool
+	}{
+		{"deep-dive Critical", "security-deep-dive", "Critical", true},
+		{"deep-dive High", "security-deep-dive", "High", true},
+		{"deep-dive Medium", "security-deep-dive", "Medium", false},
+		{"deep-dive Low", "security-deep-dive", "Low", false},
+		{"semgrep High", "semgrep", "High", false},
+		{"zizmor Critical", "zizmor", "Critical", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			scan := db.Scan{RepositoryID: repo.ID, Status: db.ScanDone, SkillName: c.skill}
+			s.DB.Create(&scan)
+			f := db.Finding{ScanID: scan.ID, RepositoryID: repo.ID, Title: "t", Severity: c.severity}
+			s.DB.Create(&f)
+			s.autoEnqueueRevalidate(&scan, &f)
+			var queued int64
+			s.DB.Model(&db.Scan{}).
+				Where("finding_id = ? AND skill_id = ? AND status = ?", f.ID, revalidate.ID, db.ScanQueued).
+				Count(&queued)
+			gotQueued := queued > 0
+			if gotQueued != c.wantQueued {
+				t.Errorf("queued=%v, want %v", gotQueued, c.wantQueued)
+			}
+		})
+	}
+}
+
+func TestAutoEnqueueRevalidate_doesNotDoubleQueue(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	repo := db.Repository{URL: "https://example.com/r", Name: "r"}
+	s.DB.Create(&repo)
+	revalidate := db.Skill{Name: "revalidate", OutputFile: "report.json", OutputKind: "revalidate", Version: 1, Active: true}
+	s.DB.Create(&revalidate)
+	scan := db.Scan{RepositoryID: repo.ID, Status: db.ScanDone, SkillName: "security-deep-dive"}
+	s.DB.Create(&scan)
+	f := db.Finding{ScanID: scan.ID, RepositoryID: repo.ID, Title: "t", Severity: "High"}
+	s.DB.Create(&f)
+
+	s.autoEnqueueRevalidate(&scan, &f)
+	s.autoEnqueueRevalidate(&scan, &f)
+
+	var queued int64
+	s.DB.Model(&db.Scan{}).
+		Where("finding_id = ? AND skill_id = ?", f.ID, revalidate.ID).
+		Count(&queued)
+	if queued != 1 {
+		t.Errorf("queued = %d, want 1 (re-queue guard)", queued)
+	}
+}

--- a/internal/web/revalidate_enqueue.go
+++ b/internal/web/revalidate_enqueue.go
@@ -1,0 +1,74 @@
+package web
+
+import (
+	"context"
+
+	"gorm.io/gorm"
+
+	"scrutineer/internal/db"
+)
+
+// revalidateSkillName is the cheap finding classifier auto-enqueued for
+// High/Critical findings from security-deep-dive and for every finding
+// created via the /v1/import path. See skills/revalidate/SKILL.md.
+const revalidateSkillName = "revalidate"
+
+// autoEnqueueRevalidate is wired onto Worker.OnFindingCreated. The worker
+// calls it after persisting each fresh Finding row from a findings-emitting
+// scan. We only act for High/Critical findings produced by
+// security-deep-dive: smaller scanners (semgrep, zizmor) and finding-scoped
+// re-runs go straight to a human, and lower severities are not worth the
+// model spend at this stage of the funnel. Re-running deep-dive on the same
+// repo bumps the existing finding's seen_count rather than creating a new
+// one, so we never enqueue against an observed-again row.
+//
+// Errors are logged and swallowed: failing to enqueue the pre-sort step
+// must never fail the upstream scan.
+func (s *Server) autoEnqueueRevalidate(scan *db.Scan, f *db.Finding) {
+	if scan == nil || f == nil {
+		return
+	}
+	if scan.SkillName != deepDiveSkillName {
+		return
+	}
+	if !db.SeverityAtLeast(f.Severity, "High") {
+		return
+	}
+	s.enqueueRevalidateForFinding(context.Background(), f)
+}
+
+// enqueueRevalidateForFinding looks up the active revalidate skill and
+// enqueues a finding-scoped run. No revalidate skill means no auto-sort,
+// which is fine; the workflow degrades to "every finding goes to a human"
+// rather than failing the upstream scan. A revalidate run already queued
+// or in flight for this finding is also a no-op so re-imports and rescans
+// do not pile up duplicate work.
+func (s *Server) enqueueRevalidateForFinding(ctx context.Context, f *db.Finding) {
+	var skill db.Skill
+	if err := s.DB.Where("name = ? AND active = ?", revalidateSkillName, true).First(&skill).Error; err != nil {
+		return
+	}
+	if s.hasOpenRevalidate(f.ID, skill.ID) {
+		return
+	}
+	fid := f.ID
+	if _, err := s.enqueueSkillWith(ctx, f.RepositoryID, skill.ID, ScanOpts{FindingID: &fid}); err != nil {
+		s.Log.Warn("auto-enqueue revalidate",
+			"finding", f.ID, "repo", f.RepositoryID, "skill", revalidateSkillName, "err", err)
+	}
+}
+
+// hasOpenRevalidate returns true when a queued or running revalidate scan
+// already exists for the finding. Avoids piling duplicate work onto the
+// queue when the same finding is observed by both an import and a rescan,
+// or when two findings parsers race in tests.
+func (s *Server) hasOpenRevalidate(findingID, skillID uint) bool {
+	var n int64
+	if err := s.DB.Model(&db.Scan{}).
+		Where("finding_id = ? AND skill_id = ? AND status IN ?",
+			findingID, skillID, []db.ScanStatus{db.ScanQueued, db.ScanRunning}).
+		Count(&n).Error; err != nil && err != gorm.ErrRecordNotFound {
+		return false
+	}
+	return n > 0
+}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -228,8 +228,12 @@ func New(gdb *gorm.DB, q *queue.Queue, log *slog.Logger, broker *Broker, w *work
 	if _, err := getCSAFSchema(); err != nil {
 		return nil, fmt.Errorf("load csaf schema: %w", err)
 	}
-	return &Server{DB: gdb, Queue: q, Log: log, Broker: broker, Worker: w, tmpl: t,
-		resolvePURL: resolvePURLRepo, listBranches: worker.ListRemoteBranches}, nil
+	s := &Server{DB: gdb, Queue: q, Log: log, Broker: broker, Worker: w, tmpl: t,
+		resolvePURL: resolvePURLRepo, listBranches: worker.ListRemoteBranches}
+	if w != nil {
+		w.OnFindingCreated = s.autoEnqueueRevalidate
+	}
+	return s, nil
 }
 
 func (s *Server) Handler() http.Handler {

--- a/internal/worker/skill.go
+++ b/internal/worker/skill.go
@@ -216,6 +216,8 @@ func (w *Worker) parseSkillOutput(skill *db.Skill, scan *db.Scan, report string,
 		return w.parseFindingDedupOutput(scan, report, emit)
 	case "verify":
 		return w.parseVerifyOutput(scan, report, emit)
+	case "revalidate":
+		return w.parseRevalidateOutput(scan, report, emit)
 	case "breaking_change":
 		return w.parseBreakingChangeOutput(scan, report, emit)
 	case "mitigation":
@@ -314,6 +316,9 @@ func (w *Worker) parseFindingsOutput(skill *db.Skill, scan *db.Scan, report stri
 			return fmt.Errorf("save finding: %w", cerr)
 		}
 		created++
+		if w.OnFindingCreated != nil {
+			w.OnFindingCreated(scan, f)
+		}
 	}
 
 	missed := w.markNotObserved(scan, seenThisScan)

--- a/internal/worker/skill_parsers.go
+++ b/internal/worker/skill_parsers.go
@@ -660,6 +660,85 @@ func (w *Worker) parseReleaseWatchOutput(scan *db.Scan, report string, emit func
 	return nil
 }
 
+// parseRevalidateOutput records the cheap classifier verdict for a
+// finding. The verdict and reason become a FindingNote; an adjusted
+// severity overwrites the finding's severity (with the change recorded
+// in finding history via WriteFindingField); status transitions
+// new -> enriched only on true_positive. Rejection of false positives
+// stays a human act, so false_positive does not transition status.
+func (w *Worker) parseRevalidateOutput(scan *db.Scan, report string, emit func(Event)) error {
+	if scan.FindingID == nil {
+		return fmt.Errorf("revalidate scan has no finding_id")
+	}
+	var result struct {
+		Verdict                string `json:"verdict"`
+		Reason                 string `json:"reason"`
+		AdjustedSeverity       string `json:"adjusted_severity"`
+		AdjustedSeverityReason string `json:"adjusted_severity_reason"`
+	}
+	if err := json.Unmarshal([]byte(report), &result); err != nil {
+		return fmt.Errorf("parse revalidate report: %w", err)
+	}
+	switch result.Verdict {
+	case "true_positive", "false_positive", "already_fixed", "uncertain":
+	default:
+		return fmt.Errorf("revalidate verdict %q is not one of true_positive|false_positive|already_fixed|uncertain", result.Verdict)
+	}
+	var f db.Finding
+	if err := w.DB.First(&f, *scan.FindingID).Error; err != nil {
+		return fmt.Errorf("load finding %d: %w", *scan.FindingID, err)
+	}
+
+	// Cache the verdict on the finding so the audit queue can filter
+	// without scanning finding_notes (#362). Written before the status
+	// transition so a true_positive promotion sits on top of the verdict
+	// row in finding history.
+	if err := db.WriteFindingField(w.DB, f.ID, "last_revalidate_verdict", result.Verdict, db.SourceModel, "revalidate"); err != nil {
+		return fmt.Errorf("update last_revalidate_verdict: %w", err)
+	}
+
+	// Status transition: only true_positive promotes new -> enriched.
+	// false_positive does not auto-reject; the analyst owns rejection.
+	if result.Verdict == "true_positive" && f.Status == db.FindingNew {
+		if err := db.WriteFindingField(w.DB, f.ID, "status", string(db.FindingEnriched), db.SourceModel, "revalidate"); err != nil {
+			return fmt.Errorf("update status: %w", err)
+		}
+	}
+
+	// Severity adjustment, with history. WriteFindingField is a no-op
+	// when the value is unchanged, so an "adjusted" severity that
+	// matches the original leaves the audit trail clean.
+	if result.AdjustedSeverity != "" {
+		switch result.AdjustedSeverity {
+		case "Critical", "High", "Medium", "Low":
+		default:
+			return fmt.Errorf("revalidate adjusted_severity %q is not one of Critical|High|Medium|Low", result.AdjustedSeverity)
+		}
+		if err := db.WriteFindingField(w.DB, f.ID, "severity", result.AdjustedSeverity, db.SourceModel, "revalidate"); err != nil {
+			return fmt.Errorf("update severity: %w", err)
+		}
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "revalidate: %s\n", result.Verdict)
+	if reason := strings.TrimSpace(result.Reason); reason != "" {
+		fmt.Fprintf(&b, "\n%s\n", reason)
+	}
+	if result.AdjustedSeverity != "" {
+		fmt.Fprintf(&b, "\nseverity %s -> %s", f.Severity, result.AdjustedSeverity)
+		if r := strings.TrimSpace(result.AdjustedSeverityReason); r != "" {
+			fmt.Fprintf(&b, ": %s", r)
+		}
+		b.WriteString("\n")
+	}
+	if _, err := db.AddFindingNote(w.DB, f.ID, b.String(), "revalidate"); err != nil {
+		return fmt.Errorf("record revalidate note: %w", err)
+	}
+
+	emit(Event{Kind: KindText, Text: "finding " + fmt.Sprint(f.ID) + " -> " + result.Verdict})
+	return nil
+}
+
 func (w *Worker) parseFindingDedupOutput(scan *db.Scan, report string, emit func(Event)) error {
 	var result struct {
 		Duplicates []struct {

--- a/internal/worker/skill_parsers_test.go
+++ b/internal/worker/skill_parsers_test.go
@@ -360,6 +360,72 @@ func TestParseBreakingChange_rejectsUnknownVerdict(t *testing.T) {
 	}
 }
 
+func TestParseRevalidate_truePositiveMovesNewToEnriched(t *testing.T) {
+	report := `{"verdict":"true_positive","reason":"sink at line 42 still reaches user input; git log shows no guard added"}`
+	f, gdb := runSkillWithFinding(t, "revalidate", report, db.FindingNew)
+	if f.Status != db.FindingEnriched {
+		t.Errorf("status = %s, want enriched", f.Status)
+	}
+	notes := findingNotes(gdb, f.ID)
+	if len(notes) == 0 || !strings.Contains(notes[0].Body, "true_positive") {
+		t.Errorf("notes missing revalidate verdict: %+v", notes)
+	}
+}
+
+func TestParseRevalidate_falsePositiveDoesNotAutoReject(t *testing.T) {
+	report := `{"verdict":"false_positive","reason":"the path lives under test/ fixtures; threat model disclaims it"}`
+	f, gdb := runSkillWithFinding(t, "revalidate", report, db.FindingNew)
+	if f.Status != db.FindingNew {
+		t.Errorf("status = %s, want new (analyst owns rejection)", f.Status)
+	}
+	notes := findingNotes(gdb, f.ID)
+	if len(notes) == 0 || !strings.Contains(notes[0].Body, "false_positive") {
+		t.Errorf("notes missing revalidate verdict: %+v", notes)
+	}
+}
+
+func TestParseRevalidate_uncertainLeavesStatus(t *testing.T) {
+	report := `{"verdict":"uncertain","reason":"validation prose is missing the trigger; cannot decide from git log alone"}`
+	f, _ := runSkillWithFinding(t, "revalidate", report, db.FindingNew)
+	if f.Status != db.FindingNew {
+		t.Errorf("status = %s, want new (unchanged)", f.Status)
+	}
+}
+
+func TestParseRevalidate_adjustedSeverityWritesFieldAndHistory(t *testing.T) {
+	report := `{"verdict":"true_positive","reason":"sink still live","adjusted_severity":"Medium","adjusted_severity_reason":"requires authenticated session"}`
+	f, gdb := runSkillWithFinding(t, "revalidate", report, db.FindingNew)
+	if f.Severity != "Medium" {
+		t.Errorf("severity = %s, want Medium (the adjusted value)", f.Severity)
+	}
+	var hist db.FindingHistory
+	if err := gdb.Where("finding_id = ? AND field = ?", f.ID, "severity").First(&hist).Error; err != nil {
+		t.Fatalf("missing severity history row: %v", err)
+	}
+	if hist.By != "revalidate" || hist.NewValue != "Medium" {
+		t.Errorf("history = %+v", hist)
+	}
+	notes := findingNotes(gdb, f.ID)
+	if len(notes) == 0 || !strings.Contains(notes[0].Body, "-> Medium") {
+		t.Errorf("note missing severity transition: %+v", notes)
+	}
+}
+
+func TestParseRevalidate_rejectsUnknownVerdict(t *testing.T) {
+	w := &Worker{}
+	scan := &db.Scan{}
+	err := w.parseRevalidateOutput(scan, `{"verdict":"true_positive","reason":"x"}`, func(Event) {})
+	if err == nil || !strings.Contains(err.Error(), "finding_id") {
+		t.Fatalf("missing-finding error = %v", err)
+	}
+	fid := uint(1)
+	scan.FindingID = &fid
+	err = w.parseRevalidateOutput(scan, `{"verdict":"banana","reason":"x"}`, func(Event) {})
+	if err == nil || !strings.Contains(err.Error(), "verdict") {
+		t.Errorf("unknown-verdict error = %v", err)
+	}
+}
+
 func TestParseMitigation_writesGuidanceAndRule(t *testing.T) {
 	report := `{
 		"guidance": "## Workarounds\n\nDisable the eval flag.\n\n## Detection\n\nWatch for stack frames matching foo.eval.",

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -45,14 +45,20 @@ const DefaultScanTimeout = time.Hour
 const defaultLogFlushInterval = 2 * time.Second
 
 type Worker struct {
-	DB          *gorm.DB
-	Log         *slog.Logger
-	DataDir     string // workspace root for clones
-	APIBase     string // base URL for the scrutineer skill API (http://host:port/api)
-	ForkOrg     string // github org the fork skill targets; empty disables it
-	Runner      SkillRunner
-	OnEvent     func(scanID, repoID uint, name, data string) // optional SSE bridge
-	ScanTimeout time.Duration
+	DB      *gorm.DB
+	Log     *slog.Logger
+	DataDir string // workspace root for clones
+	APIBase string // base URL for the scrutineer skill API (http://host:port/api)
+	ForkOrg string // github org the fork skill targets; empty disables it
+	Runner  SkillRunner
+	OnEvent func(scanID, repoID uint, name, data string) // optional SSE bridge
+	// OnFindingCreated, when non-nil, is called after a findings-emitting
+	// scan persists a fresh Finding row. The web layer wires it up to
+	// auto-enqueue a revalidate scan over High/Critical findings from
+	// security-deep-dive. The worker has no queue access of its own;
+	// this callback is the seam.
+	OnFindingCreated func(scan *db.Scan, finding *db.Finding)
+	ScanTimeout      time.Duration
 	// SchemaStrict makes a report.json that fails validation against the
 	// skill's schema.json fail the scan. When false the validator output
 	// is emitted to the log and the kind-specific parser still runs.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -559,7 +559,7 @@ paths:
 
   /findings/{id}/skills/{name}/run:
     post:
-      summary: Enqueue a finding-scoped skill (verify, patch, disclose)
+      summary: Enqueue a finding-scoped skill (verify, revalidate, patch, disclose)
       operationId: runFindingSkill
       description: |
         The authenticated scan's repository must own the finding. The scan

--- a/skills/revalidate/SKILL.md
+++ b/skills/revalidate/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: revalidate
+description: Cheap finding classifier. Reads a finding's six-step trace plus git history at its location and decides true_positive, false_positive, already_fixed, or uncertain, with an optional adjusted severity. Read-only; never executes the reproduction. Run automatically over High and Critical findings from security-deep-dive so the human queue is pre-sorted, and over imported findings whose severity is an external tool's unvalidated claim.
+license: MIT
+compatibility: Needs network access to the scrutineer API (http://host:port/api). Read-only against ./src; runs git log over the finding's location and never executes any reproduction.
+metadata:
+  scrutineer.version: 1
+  scrutineer.output_file: report.json
+  scrutineer.output_kind: revalidate
+  scrutineer.model: claude-sonnet-4-6
+---
+
+# revalidate
+
+A scan finished; a new High or Critical finding landed, or a finding came in from an external import. Before it sits in the human queue, judge it cheaply: is this likely a real bug, almost certainly noise, already fixed by a later commit, or do we need a human to look? This is the cheap pre-sort that keeps `verify` (and human attention) focused on findings worth either.
+
+This skill never runs the finding's reproduction. Use the prose, the code at the location, and the git log over that file. If you cannot decide from those alone, that is `uncertain` — say why, and a human will pick it up.
+
+## Workspace
+
+- `./src` — the repository at its current HEAD
+- `./context.json` — has `scrutineer.api_base`, `scrutineer.token`, `scrutineer.repository_id`, and `scrutineer.finding_id` (required; this skill only makes sense finding-scoped)
+- `./report.json` — write the report here
+- `./schema.json` — output shape
+
+## What to do
+
+1. Read `./context.json`. If `scrutineer.finding_id` is missing, write `{"verdict": "uncertain", "reason": "no finding_id in context.json; revalidate is finding-scoped"}` and exit.
+
+2. Fetch the finding: `GET {api_base}/findings/{finding_id}` with `Authorization: Bearer {token}`. You get title, severity, location, cwe, affected, imported_from, and the six-step prose (trace, boundary, validation, prior_art, reach, rating). If the fetch returns non-200, write `{"verdict": "uncertain", "reason": "fetch failed: <status>"}` and exit.
+
+3. Read the location and load the file. `Location` is `path:line` or `path:line:column`; strip the line and column to get the file path, relative to `./src`. If the file does not exist, that may be `already_fixed` (the code was deleted in a commit that addressed this) — check the git log before deciding.
+
+4. Read the git log over that file since the original scan:
+
+   ```
+   git -C ./src log -p -- <file>
+   ```
+
+   Bound it by date if there is too much. Look for commits since the scanned commit (it's in the finding's `commit` field) that touch the relevant lines, add a guard, sanitise input, remove the sink, or rename the function out of existence.
+
+5. Decide one of:
+
+   - **true_positive** — the prose describes a real issue, the code at the location still matches the trace, and nothing in the git log has changed it. This is worth a human's time, and probably a `verify` run.
+   - **false_positive** — the prose describes something the code does not actually do, or the threat-model contract disclaims this (the disclaimed-properties list in any loaded threat model is the canonical source). Examples: a finding against test fixtures, a finding that confuses two functions with the same name, a finding against a deprecated path the project marks as no-warranty.
+   - **already_fixed** — the file or the relevant lines have changed since the scanned commit in a way that addresses the trace. Cite the commit SHA and what changed in `reason`.
+   - **uncertain** — you cannot decide on prose plus git history alone. Maybe the trace is incomplete; maybe the fix is partial; maybe the code is genuinely opaque without running it. Be specific about what would let a human decide.
+
+6. Optionally adjust the severity. If the prose pitches the finding higher or lower than the evidence supports, set `adjusted_severity` to one of `Critical`/`High`/`Medium`/`Low`, with one line of justification in `adjusted_severity_reason`. Apply scrutineer's precondition rubric, not CVSS:
+
+   - **Critical**: works on a fresh install with no preconditions. Any precondition disqualifies it.
+   - **High**: realistic preconditions a normal deployment satisfies.
+   - **Medium**: significant attacker positioning, unusual configuration, or a chain of conditions.
+   - **Low**: unrealistic preconditions, or mitigated by the default deployment.
+
+   Leave the severity alone if the original looks right; this is "I want to challenge the grade", not a mandatory step. Adjusting toward `Low` is fine when the prose mentions strong preconditions the original rating ignored.
+
+## Output
+
+Write `./report.json` matching `./schema.json`:
+
+```json
+{
+  "verdict": "true_positive" | "false_positive" | "already_fixed" | "uncertain",
+  "reason": "one paragraph",
+  "adjusted_severity": "Critical" | "High" | "Medium" | "Low",
+  "adjusted_severity_reason": "one line"
+}
+```
+
+`adjusted_severity` and `adjusted_severity_reason` are optional and either both present or both absent.
+
+Scrutineer applies this:
+
+- `verdict` and `reason` are appended to the finding's notes as a timestamped revalidate record.
+- `true_positive` moves a `new` finding to `enriched`. Any other verdict leaves status alone (rejection is a human act).
+- `adjusted_severity` overwrites the finding's severity field, with the change recorded in finding history (so the original is preserved and auditable). The analyst can always change it back.
+
+If you cannot decide cleanly, say so in `reason`; an `uncertain` verdict with a sharp question is more useful than a confident wrong guess.

--- a/skills/revalidate/schema.json
+++ b/skills/revalidate/schema.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "revalidate report",
+  "type": "object",
+  "required": ["verdict", "reason"],
+  "additionalProperties": false,
+  "properties": {
+    "verdict": {
+      "type": "string",
+      "enum": ["true_positive", "false_positive", "already_fixed", "uncertain"],
+      "description": "Cheap classifier outcome from prose plus git history. Never asserts true_positive from the reproduction running; this skill does not execute."
+    },
+    "reason": {
+      "type": "string",
+      "description": "One paragraph of justification, citing the file, line, and any commit SHA that supports the decision."
+    },
+    "adjusted_severity": {
+      "type": "string",
+      "enum": ["Critical", "High", "Medium", "Low"],
+      "description": "Optional severity override using the precondition rubric. Omit to leave the original severity in place."
+    },
+    "adjusted_severity_reason": {
+      "type": "string",
+      "description": "One line explaining the adjustment. Required when adjusted_severity is set."
+    }
+  },
+  "dependentRequired": {
+    "adjusted_severity": ["adjusted_severity_reason"],
+    "adjusted_severity_reason": ["adjusted_severity"]
+  }
+}


### PR DESCRIPTION
Closes #159.

A new `revalidate` skill that reads a finding's six-step prose plus `git log` over its location and emits `true_positive | false_positive | already_fixed | uncertain`. It is read-only — never executes the reproduction — and runs on Sonnet via the `scrutineer.model` frontmatter. Auto-enqueued for High/Critical findings from `security-deep-dive` and for every imported finding, so the human queue is pre-sorted.

- `skills/revalidate/` carries the SKILL.md and schema. The skill applies scrutineer's precondition rubric (not CVSS) for any severity adjustment and treats the report body as untrusted input.
- `parseRevalidateOutput` records the verdict as a FindingNote, transitions `new` to `enriched` only on `true_positive` (rejection stays a human act, so `false_positive` does not transition), and overwrites the finding's severity when `adjusted_severity` is present, with the change recorded in FindingHistory through `db.WriteFindingField`.
- A new `OnFindingCreated` callback on `Worker` is the seam: the worker has DB access but no queue access, so the web layer registers `Server.autoEnqueueRevalidate` to enqueue revalidate runs for High/Critical findings from `security-deep-dive`. Imported findings get a run regardless of severity, since their severity is an external tool's unvalidated claim — directly from `Server.importFindings`. A re-queue guard prevents duplicates when the same finding is observed by both an import and a rescan.
- Output kind `revalidate` is registered in `internal/skills/parse.go` and dispatched in `internal/worker/skill.go`.
- Skill tables in README.md and docs/skills.md list it; openapi.yaml's finding-scoped run summary mentions it; the `finding_id`-bearing skill list in docs/skills.md includes it.

Distinct from #111: that hardens `verify` (executes the PoC, fresh checkout, scored rubric). This runs before anyone looks, costs cents, and never executes target code.