### PR TITLE
Bump claude-code to 2.1.173

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ARG COMMIT=""
 RUN CGO_ENABLED=0 go build -ldflags "-X main.commit=${COMMIT}" -o /scrutineer ./cmd/scrutineer
 
 FROM node:26-alpine@sha256:144769ec3f32e8ee36b3cfde91e82bee25d9367b20f31a151f3f7eea3a2a8541 AS claude
-RUN npm install -g @anthropic-ai/claude-code@2.1.160
+RUN npm install -g @anthropic-ai/claude-code@2.1.173
 
 FROM python:3.14.5-alpine@sha256:5a824eb82cc75361f98611f3cfc5091ea33f10a6ccea4d4ebdabbc523b9a1614 AS python-tools
 RUN pip install --no-cache-dir semgrep==1.116.0 "setuptools<81"

--- a/Dockerfile.runner
+++ b/Dockerfile.runner
@@ -2,7 +2,7 @@
 # tools, not the web server or database. Built separately:
 #   docker build -t scrutineer-runner -f Dockerfile.runner .
 
-ARG CLAUDE_VERSION=2.1.160
+ARG CLAUDE_VERSION=2.1.173
 ARG SEMGREP_VERSION=1.116.0
 
 FROM golang:1.26.4-bookworm@sha256:5d2b868674b57c9e48cdd39e891acce4196b6926ca6d11e9c270a8f85106203d AS go-tools
@@ -46,8 +46,8 @@ RUN python3 -m venv /opt/semgrep && \
 ARG TARGETARCH
 RUN set -eux; \
     case "${TARGETARCH}" in \
-      amd64) arch=x64;   sha=827cf45f8be2290deb55edeadd7252921e486e8bc4bedd182649390dc87f4b47 ;; \
-      arm64) arch=arm64; sha=06244908bde09bdb1d807d02b5932be10520eb33b42111423fb48c6d8184742e ;; \
+      amd64) arch=x64;   sha=b3d1afba5c02fa0fed43150e9470e556cf0cfc3a5c27d836a199d54051c96390 ;; \
+      arm64) arch=arm64; sha=2f0038e9f7b3ee049e7db202b4f10af7d2e62af542b7fd7d1f542ea04166a4fe ;; \
       *) echo "unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;; \
     esac; \
     curl -fsSL -o /tmp/claude.tgz \

--- a/threatmodel.md
+++ b/threatmodel.md
@@ -118,7 +118,7 @@ No rate limiting on `POST /repositories`, no cap on clone size, no timeout on th
 
 ### T11: Image supply chain (partially mitigated)
 
-Tool versions are pinned: `claude-code@2.1.160`, `semgrep==1.116.0`, `git-pkgs@v0.15.3`, `brief@v0.6.0`, `zizmor@1.24.1`. The final stage is `debian:bookworm-slim`; the `golang:1.26-bookworm` and `rust:1.88-bookworm` builder stages are pinned by sha256 digest. The container runs as non-root user `runner`. The runner image is built in CI, smoke-tested, and published to GHCR; users pull a known-good artifact rather than rebuilding against live registries.
+Tool versions are pinned: `claude-code@2.1.173`, `semgrep==1.116.0`, `git-pkgs@v0.15.3`, `brief@v0.6.0`, `zizmor@1.24.1`. The final stage is `debian:bookworm-slim`; the `golang:1.26-bookworm` and `rust:1.88-bookworm` builder stages are pinned by sha256 digest. The container runs as non-root user `runner`. The runner image is built in CI, smoke-tested, and published to GHCR; users pull a known-good artifact rather than rebuilding against live registries.
 
 Supply-chain surface in the final stage:
 - `apt` pulls from Debian's official mirrors plus the GitHub CLI repo at `cli.github.com/packages` (signed-by keyring under `/etc/apt/keyrings/`). `gh` is used at scan time by the `fork` and `report-upstream` skills.


### PR DESCRIPTION
Closes #335.

Bumps the pinned `@anthropic-ai/claude-code` from 2.1.160 to 2.1.173 in both images (npm install in `Dockerfile`, tarball + sha256 pins in `Dockerfile.runner`), and updates the version note in `threatmodel.md`. 2.1.163's changelog includes the fix for `claude -p` hanging after its final result when a backgrounded command never exits, which matches the stuck `packages` runs reported in the issue.

Checksums are from the release's `SHASUMS256.txt`; the runner build verifies them.