### PR TITLE
Add exploited-in-wild analyst field on findings

### DIFF
--- a/docs/database.md
+++ b/docs/database.md
@@ -146,6 +146,8 @@ One row per vulnerability. Lifecycle columns are mutated through `db.WriteFindin
 | suggested_fix_commit | text | Sha the suggested_fix applies cleanly against. |
 | breaking_change | text | `breaking`, `non_breaking`, or `unknown`; verdict of the `breaking-change` skill on the suggested fix. Empty when the skill has not run. |
 | breaking_change_rationale | text | Human-readable rationale plus the list of affected dependents from the same skill run. |
+| exploited_in_wild | text | Analyst's call: `yes`, `no`, or empty (unknown). On the OSS-SIRT intake list; surfaced on the finding page, in the OSV `database_specific` block, in the CSAF audit notes, and in the markdown report. Automation never writes this. |
+| exploited_in_wild_evidence | text | Free-text source note: researcher, ticket link, traffic observation. |
 | trace | text | Step 1 prose. Markdown. |
 | boundary | text | Step 2. |
 | validation | text | Step 3: reproduction. |

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -477,6 +477,20 @@ type Finding struct {
 	BreakingChange          string `gorm:"index"`
 	BreakingChangeRationale string `gorm:"type:text"`
 
+	// ExploitedInWild is the analyst's call on whether this finding is
+	// known to be exploited at the time of disclosure. One of `yes`,
+	// `no`, or empty (`unknown`). Disclosure coordinators ask for this
+	// (the OSS-SIRT intake list includes it) and a `yes` changes triage
+	// priority. Automation never sets this column: a model guess at
+	// exploitation is worse than no answer. Updates flow through
+	// WriteFindingField with source=analyst so the timestamp lives in
+	// FindingHistory.
+	ExploitedInWild string `gorm:"index"`
+	// ExploitedInWildEvidence is the source note for the value above:
+	// who reported it, the ticket or article link, what the analyst saw.
+	// Free-text; empty when the analyst has not weighed in.
+	ExploitedInWildEvidence string `gorm:"type:text"`
+
 	// Per-step prose from the six-step audit checklist.
 	Trace      string `gorm:"type:text"`
 	Boundary   string `gorm:"type:text"`

--- a/internal/db/finding_helpers.go
+++ b/internal/db/finding_helpers.go
@@ -152,6 +152,10 @@ func findingFieldAccessor(f *Finding, field string) (current, column string, err
 		return f.BreakingChange, "breaking_change", nil
 	case "breaking_change_rationale":
 		return f.BreakingChangeRationale, "breaking_change_rationale", nil
+	case "exploited_in_wild":
+		return f.ExploitedInWild, "exploited_in_wild", nil
+	case "exploited_in_wild_evidence":
+		return f.ExploitedInWildEvidence, "exploited_in_wild_evidence", nil
 	default:
 		return "", "", fmt.Errorf("field %q is not editable", field)
 	}

--- a/internal/web/finding_csaf.go
+++ b/internal/web/finding_csaf.go
@@ -613,6 +613,17 @@ func buildAuditNotes(f db.Finding) []csafNote {
 		}
 		out = append(out, csafNote{Category: "details", Title: s.title, Text: s.text})
 	}
+	// Exploitation status surfaces as a CSAF note rather than under a
+	// `threats` block: the latter is reserved for impact descriptors
+	// the spec accepts at write time, while a free-text exploitation
+	// note travels reliably to coordinators that scan note titles.
+	if f.ExploitedInWild != "" {
+		text := "Exploited in wild: " + f.ExploitedInWild
+		if e := strings.TrimSpace(f.ExploitedInWildEvidence); e != "" {
+			text += "\n\n" + e
+		}
+		out = append(out, csafNote{Category: "details", Title: "exploited_in_wild", Text: text})
+	}
 	return out
 }
 

--- a/internal/web/finding_exploited_test.go
+++ b/internal/web/finding_exploited_test.go
@@ -93,6 +93,29 @@ func TestFindingExploitedInWild_clearsBackToUnknown(t *testing.T) {
 	}
 }
 
+// `yes` with no evidence text is accepted: the analyst marks the
+// finding as exploited but has not yet pasted the source link or
+// reporter note. The status is the meaningful field for downstream
+// triage; evidence is a follow-up.
+func TestFindingExploitedInWild_yesWithoutEvidenceAccepted(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	f := newFindingForExploitedTest(t, s)
+
+	w := postExploitedForm(t, s, f.ID, "yes", "")
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	var got db.Finding
+	s.DB.First(&got, f.ID)
+	if got.ExploitedInWild != "yes" {
+		t.Errorf("ExploitedInWild = %q, want yes", got.ExploitedInWild)
+	}
+	if got.ExploitedInWildEvidence != "" {
+		t.Errorf("evidence = %q, want empty", got.ExploitedInWildEvidence)
+	}
+}
+
 func TestOSVExport_includesExploitedInWild(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()

--- a/internal/web/finding_exploited_test.go
+++ b/internal/web/finding_exploited_test.go
@@ -1,0 +1,144 @@
+package web
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	"scrutineer/internal/db"
+)
+
+// postExploitedForm posts a form-encoded request to the exploitation
+// handler, mimicking the browser form on the finding page.
+func postExploitedForm(t *testing.T, s *Server, findingID uint, status, evidence string) *httptest.ResponseRecorder {
+	t.Helper()
+	body := "exploited_in_wild=" + status + "&exploited_in_wild_evidence=" + evidence
+	r := httptest.NewRequest(http.MethodPost,
+		"/findings/"+strconv.FormatUint(uint64(findingID), 10)+"/exploited-in-wild",
+		strings.NewReader(body))
+	r.Host = "127.0.0.1:8080"
+	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, r)
+	return w
+}
+
+func newFindingForExploitedTest(t *testing.T, s *Server) *db.Finding {
+	t.Helper()
+	repo := db.Repository{URL: "https://example.com/r", Name: "r"}
+	s.DB.Create(&repo)
+	scan := db.Scan{RepositoryID: repo.ID, Status: db.ScanDone}
+	s.DB.Create(&scan)
+	f := db.Finding{ScanID: scan.ID, RepositoryID: repo.ID, Title: "t", Severity: "High"}
+	s.DB.Create(&f)
+	return &f
+}
+
+func TestFindingExploitedInWild_yesPersistsAndRecordsHistory(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	f := newFindingForExploitedTest(t, s)
+
+	w := postExploitedForm(t, s, f.ID, "yes", "https%3A%2F%2Fexample.com%2Fbug")
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	var got db.Finding
+	s.DB.First(&got, f.ID)
+	if got.ExploitedInWild != "yes" {
+		t.Errorf("ExploitedInWild = %q, want yes", got.ExploitedInWild)
+	}
+	if got.ExploitedInWildEvidence == "" {
+		t.Errorf("evidence dropped; got empty")
+	}
+	var hist db.FindingHistory
+	if err := s.DB.Where("finding_id = ? AND field = ?", f.ID, "exploited_in_wild").First(&hist).Error; err != nil {
+		t.Fatalf("missing history row: %v", err)
+	}
+	if hist.Source != db.SourceAnalyst || hist.NewValue != "yes" {
+		t.Errorf("history = %+v", hist)
+	}
+}
+
+func TestFindingExploitedInWild_rejectsBogusValue(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	f := newFindingForExploitedTest(t, s)
+	w := postExploitedForm(t, s, f.ID, "maybe", "")
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d, want 422", w.Code)
+	}
+	var got db.Finding
+	s.DB.First(&got, f.ID)
+	if got.ExploitedInWild != "" {
+		t.Errorf("ExploitedInWild = %q, want empty (unchanged)", got.ExploitedInWild)
+	}
+}
+
+func TestFindingExploitedInWild_clearsBackToUnknown(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	f := newFindingForExploitedTest(t, s)
+	postExploitedForm(t, s, f.ID, "yes", "rep")
+	w := postExploitedForm(t, s, f.ID, "", "")
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("status = %d", w.Code)
+	}
+	var got db.Finding
+	s.DB.First(&got, f.ID)
+	if got.ExploitedInWild != "" {
+		t.Errorf("ExploitedInWild = %q, want empty", got.ExploitedInWild)
+	}
+}
+
+func TestOSVExport_includesExploitedInWild(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	f := newFindingForExploitedTest(t, s)
+	s.DB.Model(f).Updates(map[string]any{
+		"exploited_in_wild":          "yes",
+		"exploited_in_wild_evidence": "reported by acme research, 2026-06-02",
+	})
+	r := httptest.NewRequest(http.MethodGet,
+		"/findings/"+strconv.FormatUint(uint64(f.ID), 10)+"/osv.json", nil)
+	r.Host = "127.0.0.1:8080"
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, r)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, "exploited_in_wild") || !strings.Contains(body, `"yes"`) {
+		t.Errorf("OSV missing exploited_in_wild: %s", body)
+	}
+	if !strings.Contains(body, "acme research") {
+		t.Errorf("OSV missing evidence: %s", body)
+	}
+}
+
+func TestCSAFExport_includesExploitedInWildNote(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	f := newFindingForExploitedTest(t, s)
+	s.DB.Model(f).Updates(map[string]any{
+		"exploited_in_wild":          "yes",
+		"exploited_in_wild_evidence": "in-the-wild traffic observed",
+	})
+	r := httptest.NewRequest(http.MethodGet,
+		"/findings/"+strconv.FormatUint(uint64(f.ID), 10)+"/csaf.json", nil)
+	r.Host = "127.0.0.1:8080"
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, r)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, "exploited_in_wild") {
+		t.Errorf("CSAF missing exploited_in_wild title: %s", body)
+	}
+	if !strings.Contains(body, "in-the-wild traffic") {
+		t.Errorf("CSAF missing evidence: %s", body)
+	}
+}

--- a/internal/web/finding_osv.go
+++ b/internal/web/finding_osv.go
@@ -341,6 +341,8 @@ func osvDatabaseSpecific(f db.Finding) map[string]any {
 	put("location", f.Location)
 	put("commit", f.Commit)
 	put("sub_path", f.SubPath)
+	put("exploited_in_wild", f.ExploitedInWild)
+	put("exploited_in_wild_evidence", f.ExploitedInWildEvidence)
 	if locs := f.LocationList(); len(locs) > 1 {
 		ds["locations"] = locs
 	}

--- a/internal/web/repo_report.go
+++ b/internal/web/repo_report.go
@@ -215,6 +215,7 @@ func writeReportFinding(b *strings.Builder, gdb *gorm.DB, f db.Finding, latest *
 		{"Location", "`" + f.Location + "`"},
 		{"Sinks", f.Sinks},
 		{"Affected", f.Affected},
+		{"Exploited in wild", f.ExploitedInWild},
 		{"CVE", f.CVEID},
 		{"CVSS", f.CVSSVector},
 		{"Fix version", f.FixVersion},
@@ -265,6 +266,11 @@ func writeReportFinding(b *strings.Builder, gdb *gorm.DB, f db.Finding, latest *
 	writeProse(b, "#### Prior art", f.PriorArt)
 	writeProse(b, "#### Reach", f.Reach)
 	writeProse(b, "#### Rating", f.Rating)
+
+	if f.ExploitedInWild != "" && f.ExploitedInWildEvidence != "" {
+		fmt.Fprintf(b, "#### Exploitation status\n\nExploited in wild: **%s**.\n\n%s\n\n",
+			f.ExploitedInWild, strings.TrimSpace(f.ExploitedInWildEvidence))
+	}
 
 	if f.DisclosureDraft != "" {
 		fmt.Fprintf(b, "#### Disclosure draft\n\n%s\n\n", strings.TrimSpace(f.DisclosureDraft))

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -263,6 +263,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("GET /findings/{id}/csaf.json", s.findingCSAF)
 	mux.HandleFunc("GET /findings/{id}/osv.json", s.findingOSV)
 	mux.HandleFunc("POST /findings/{id}/status", s.findingStatus)
+	mux.HandleFunc("POST /findings/{id}/exploited-in-wild", s.findingExploitedInWild)
 	mux.HandleFunc("POST /findings/{id}/verify", s.findingVerify)
 	mux.HandleFunc("POST /repositories/{id}/verify-all", s.repoVerifyAll)
 	mux.HandleFunc("POST /findings/{id}/disclose", s.findingDisclose)
@@ -923,6 +924,37 @@ func (s *Server) findingStatus(w http.ResponseWriter, r *http.Request) {
 		}
 	default:
 		http.Error(w, "invalid status", http.StatusUnprocessableEntity)
+		return
+	}
+	s.redirect(w, r, fmt.Sprintf("/findings/%d", f.ID))
+}
+
+// findingExploitedInWild handles the analyst form on the finding page
+// for marking whether the finding is being exploited in the wild. The
+// status is a closed enum (yes / no / empty for unknown); the evidence
+// field is free text and may stand alone (an analyst recording context
+// without yet committing to yes/no). Both writes go through
+// WriteFindingField so the change history records who set them and
+// when.
+func (s *Server) findingExploitedInWild(w http.ResponseWriter, r *http.Request) {
+	f, ok := loadByID[db.Finding](s, w, r)
+	if !ok {
+		return
+	}
+	status := strings.TrimSpace(r.FormValue("exploited_in_wild"))
+	switch status {
+	case "", "yes", "no":
+	default:
+		http.Error(w, "exploited_in_wild must be yes, no, or empty", http.StatusUnprocessableEntity)
+		return
+	}
+	evidence := strings.TrimSpace(r.FormValue("exploited_in_wild_evidence"))
+	if err := db.WriteFindingField(s.DB, f.ID, "exploited_in_wild", status, db.SourceAnalyst, ""); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if err := db.WriteFindingField(s.DB, f.ID, "exploited_in_wild_evidence", evidence, db.SourceAnalyst, ""); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 	s.redirect(w, r, fmt.Sprintf("/findings/%d", f.ID))

--- a/internal/web/templates/finding_show.html
+++ b/internal/web/templates/finding_show.html
@@ -150,6 +150,17 @@
     <dd>{{$f.Assignee}}</dd>
   </div>
   {{end}}
+  {{if eq $f.ExploitedInWild "yes"}}
+  <div>
+    <dt class="text-muted-foreground">Exploited in wild</dt>
+    <dd><span class="badge-destructive">yes</span></dd>
+  </div>
+  {{else if eq $f.ExploitedInWild "no"}}
+  <div>
+    <dt class="text-muted-foreground">Exploited in wild</dt>
+    <dd><span class="badge-outline">no</span></dd>
+  </div>
+  {{end}}
 </dl>
 
 <section class="accordion">

--- a/internal/web/templates/finding_workflow.html
+++ b/internal/web/templates/finding_workflow.html
@@ -114,5 +114,31 @@
       {{end}}
     </form>
   </section>
+
+  <details class="mt-4 border-t pt-3" {{if eq .ExploitedInWild "yes"}}open{{end}}>
+    <summary class="text-xs text-muted-foreground cursor-pointer hover:underline flex items-center gap-2">
+      <i data-lucide="bug"></i>
+      Exploitation status
+      {{if eq .ExploitedInWild "yes"}}<span class="badge-destructive ml-auto">yes</span>{{else if eq .ExploitedInWild "no"}}<span class="badge-outline ml-auto">no</span>{{else}}<span class="text-muted-foreground ml-auto">unknown</span>{{end}}
+    </summary>
+    <form method="post" action="/findings/{{$id}}/exploited-in-wild" class="grid gap-2 mt-3 text-sm">
+      <div class="flex items-center gap-2">
+        <label class="text-xs text-muted-foreground w-24">Exploited?</label>
+        <select class="input" name="exploited_in_wild">
+          <option value=""{{if eq .ExploitedInWild ""}} selected{{end}}>unknown</option>
+          <option value="yes"{{if eq .ExploitedInWild "yes"}} selected{{end}}>yes</option>
+          <option value="no"{{if eq .ExploitedInWild "no"}} selected{{end}}>no</option>
+        </select>
+      </div>
+      <div class="grid gap-1">
+        <label class="text-xs text-muted-foreground">Evidence / source</label>
+        <textarea class="input text-xs" name="exploited_in_wild_evidence" rows="2"
+                  placeholder="Where this came from — researcher report, CERT advisory, in-the-wild traffic, etc.">{{.ExploitedInWildEvidence}}</textarea>
+      </div>
+      <div class="flex justify-end">
+        <button type="submit" class="btn-sm">Save exploitation status</button>
+      </div>
+    </form>
+  </details>
 </div>
 {{end}}

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -914,6 +914,8 @@ components:
         fix_commit:    { type: string }
         resolution:    { type: string, enum: [fix, migrate, workaround, adopt, wontfix, ""] }
         assignee:      { type: string }
+        exploited_in_wild: { type: string, enum: [yes, no, ""], description: "Analyst's call on whether this finding is being exploited in the wild. Empty means unknown. Automation never sets this." }
+        exploited_in_wild_evidence: { type: string }
 
     FindingDetail:
       allOf:


### PR DESCRIPTION
Closes #368.

Disclosure recipients ask whether an issue is being exploited at the time of contact — it changes their triage priority and is on the OSS-SIRT intake list. Findings now carry the answer as a structured analyst-entered field with an evidence note.

- `Finding.ExploitedInWild` (`yes` / `no` / empty for unknown, indexed) and `Finding.ExploitedInWildEvidence` (free-text source). Both editable through `findingFieldAccessor` so history captures the timestamp and source on every write.
- `POST /findings/{id}/exploited-in-wild` browser handler: the value is gated to the three legal options before write, the evidence is free text. Writes through `WriteFindingField` with `source=analyst`, so the history row records the analyst as author. Automation never sets these fields.
- UI: a collapsible "Exploitation status" panel under the workflow card on the finding page, opening by default when the finding is flagged `yes`. A badge in the finding header surfaces `yes` and `no` at a glance.
- Exports include the field:
  - **OSV**: `database_specific.exploited_in_wild` and `database_specific.exploited_in_wild_evidence`.
  - **CSAF**: a `details` note titled `exploited_in_wild` carrying status and evidence (CSAF's `threats` block is reserved for impact descriptors the spec accepts at write time).
  - **Markdown report**: row in the metadata table, plus a dedicated `Exploitation status` section when evidence is recorded.
- Docs: `docs/database.md` Finding columns and `openapi.yaml` Finding schema cover both fields.
- Tests cover the happy path (status + evidence persist, FindingHistory row recorded with `source=analyst`), rejection of a bogus enum value (422, original value unchanged), clearing back to unknown, and inclusion in OSV and CSAF exports.