### PR TITLE
Add mitigate skill: operational mitigations with optional semgrep rule

### DIFF
--- a/docs/database.md
+++ b/docs/database.md
@@ -148,6 +148,8 @@ One row per vulnerability. Lifecycle columns are mutated through `db.WriteFindin
 | breaking_change_rationale | text | Human-readable rationale plus the list of affected dependents from the same skill run. |
 | exploited_in_wild | text | Analyst's call: `yes`, `no`, or empty (unknown). On the OSS-SIRT intake list; surfaced on the finding page, in the OSV `database_specific` block, in the CSAF audit notes, and in the markdown report. Automation never writes this. |
 | exploited_in_wild_evidence | text | Free-text source note: researcher, ticket link, traffic observation. |
+| mitigation | text | Markdown body from the `mitigate` skill: workarounds consumers can apply before the fix ships, plus detection guidance. |
+| mitigation_semgrep | text | Optional YAML semgrep rule from the same skill that flags the vulnerable pattern. Empty when no rule was warranted. |
 | trace | text | Step 1 prose. Markdown. |
 | boundary | text | Step 2. |
 | validation | text | Step 3: reproduction. |

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -134,6 +134,7 @@ Declaring `scrutineer.paths` replaces this skip list entirely: the skill sees on
 | `verify` | Verification result and miss-count update on one Finding. |
 | `breaking_change` | `breaking_change` verdict and `breaking_change_rationale` prose on one Finding, with the verdict change recorded in FindingHistory. |
 | `patch` | Suggested-fix diff and base commit on one Finding. |
+| `mitigation` | Mitigation prose and optional semgrep rule on one Finding (`mitigation`, `mitigation_semgrep` columns), with the change recorded in FindingHistory. |
 | `threat_model` | Raw on the scan row; rendered on the repository's Threat Model tab. |
 | `exposure` | One CSAF product_status verdict upserted into a `finding_dependents` row keyed by `(finding_id, dependent_id)`. |
 
@@ -183,7 +184,7 @@ The worker then runs `claude -p "Use the {name} skill in this workspace"` with t
 }
 ```
 
-`finding_id` is only present for finding-scoped skills (`verify`, `breaking-change`, `disclose`, `patch`, `exposure`). `dependent_id` is only set on `exposure` runs and points to the dependent whose code is under audit; `./src` is then a copy of that dependent's clone, not of the finding's repository. `scan_ref` is empty when the scan is on the default branch. `scan_subpath` is set when the operator scoped the scan to a monorepo sub-folder; skills that walk source honour it, skills that query external APIs by repository URL ignore it. `fork_org` is absent unless `-fork-org` is configured. `packages` is a convenience copy of the package rows when the `packages` skill has already run; otherwise it is omitted.
+`finding_id` is only present for finding-scoped skills (`verify`, `breaking-change`, `disclose`, `patch`, `mitigate`, `exposure`). `dependent_id` is only set on `exposure` runs and points to the dependent whose code is under audit; `./src` is then a copy of that dependent's clone, not of the finding's repository. `scan_ref` is empty when the scan is on the default branch. `scan_subpath` is set when the operator scoped the scan to a monorepo sub-folder; skills that walk source honour it, skills that query external APIs by repository URL ignore it. `fork_org` is absent unless `-fork-org` is configured. `packages` is a convenience copy of the package rows when the `packages` skill has already run; otherwise it is omitted.
 
 ## schema.json
 

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -491,6 +491,16 @@ type Finding struct {
 	// Free-text; empty when the analyst has not weighed in.
 	ExploitedInWildEvidence string `gorm:"type:text"`
 
+	// Mitigation is the body of operational mitigation guidance the
+	// `mitigate` skill drafts: workarounds consumers can apply now
+	// (config flags, input restrictions, safe defaults), plus detection
+	// guidance for what to log and what to alert on while the fix is in
+	// flight. Markdown. MitigationSemgrep is the optional semgrep rule
+	// the same skill emits when the vulnerable pattern is structural
+	// enough to flag reliably; YAML, empty when no rule was warranted.
+	Mitigation        string `gorm:"type:text"`
+	MitigationSemgrep string `gorm:"type:text"`
+
 	// Per-step prose from the six-step audit checklist.
 	Trace      string `gorm:"type:text"`
 	Boundary   string `gorm:"type:text"`

--- a/internal/db/finding_helpers.go
+++ b/internal/db/finding_helpers.go
@@ -156,6 +156,10 @@ func findingFieldAccessor(f *Finding, field string) (current, column string, err
 		return f.ExploitedInWild, "exploited_in_wild", nil
 	case "exploited_in_wild_evidence":
 		return f.ExploitedInWildEvidence, "exploited_in_wild_evidence", nil
+	case "mitigation":
+		return f.Mitigation, "mitigation", nil
+	case "mitigation_semgrep":
+		return f.MitigationSemgrep, "mitigation_semgrep", nil
 	default:
 		return "", "", fmt.Errorf("field %q is not editable", field)
 	}

--- a/internal/skills/parse.go
+++ b/internal/skills/parse.go
@@ -90,6 +90,7 @@ var OutputKinds = map[string]bool{
 	"finding_dedup":   true,
 	"verify":          true,
 	"breaking_change": true,
+	"mitigation":      true,
 	"subprojects":     true,
 	"repo_overview":   true,
 	"posture":         true,

--- a/internal/web/repo_report.go
+++ b/internal/web/repo_report.go
@@ -276,6 +276,13 @@ func writeReportFinding(b *strings.Builder, gdb *gorm.DB, f db.Finding, latest *
 		fmt.Fprintf(b, "#### Disclosure draft\n\n%s\n\n", strings.TrimSpace(f.DisclosureDraft))
 	}
 
+	if f.Mitigation != "" {
+		fmt.Fprintf(b, "#### Mitigation\n\n%s\n\n", strings.TrimSpace(f.Mitigation))
+		if f.MitigationSemgrep != "" {
+			fmt.Fprintf(b, "##### Semgrep rule\n\n```yaml\n%s\n```\n\n", strings.TrimSpace(f.MitigationSemgrep))
+		}
+	}
+
 	if f.SuggestedFix != "" {
 		fmt.Fprintf(b, "#### Suggested fix\n\n")
 		if f.SuggestedFixCommit != "" {

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -267,6 +267,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("POST /findings/{id}/verify", s.findingVerify)
 	mux.HandleFunc("POST /repositories/{id}/verify-all", s.repoVerifyAll)
 	mux.HandleFunc("POST /findings/{id}/disclose", s.findingDisclose)
+	mux.HandleFunc("POST /findings/{id}/mitigate", s.findingMitigate)
 	mux.HandleFunc("POST /findings/{id}/patch", s.findingPatchRun)
 	mux.HandleFunc("POST /findings/{id}/exposure", s.findingExposureRun)
 	mux.HandleFunc("GET /findings/{id}/patch.diff", s.findingPatchDownload)
@@ -969,6 +970,9 @@ const discloseSkillName = "disclose"
 // patchSkillName is the skill the Propose patch button runs.
 const patchSkillName = "patch"
 
+// mitigateSkillName is the skill the Draft mitigation button runs.
+const mitigateSkillName = "mitigate"
+
 func (s *Server) findingVerify(w http.ResponseWriter, r *http.Request) {
 	s.runFindingSkill(w, r, verifySkillName)
 }
@@ -979,6 +983,10 @@ func (s *Server) findingDisclose(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) findingPatchRun(w http.ResponseWriter, r *http.Request) {
 	s.runFindingSkill(w, r, patchSkillName)
+}
+
+func (s *Server) findingMitigate(w http.ResponseWriter, r *http.Request) {
+	s.runFindingSkill(w, r, mitigateSkillName)
 }
 
 func (s *Server) runFindingSkill(w http.ResponseWriter, r *http.Request, name string) {

--- a/internal/web/templates/finding_show.html
+++ b/internal/web/templates/finding_show.html
@@ -275,6 +275,26 @@
   </details>
   {{end}}
 
+  {{if $f.Mitigation}}
+  <details open class="group border-b">
+    <summary class="w-full outline-none rounded-md focus-visible:ring-ring/50 focus-visible:ring-[3px]">
+      <h3 class="flex flex-1 items-center justify-between gap-4 py-4 text-sm font-medium hover:underline">
+        Mitigation guidance
+        <i data-lucide="chevron-down" class="text-muted-foreground size-4 shrink-0 transition-transform duration-200 group-open:rotate-180"></i>
+      </h3>
+    </summary>
+    <section class="pb-4 grid gap-3">
+      <div class="prose prose-sm">{{md $f.Mitigation}}</div>
+      {{if $f.MitigationSemgrep}}
+      <div class="grid gap-1">
+        <div class="text-xs text-muted-foreground">Semgrep rule</div>
+        <pre class="log overflow-x-auto"><code>{{$f.MitigationSemgrep}}</code></pre>
+      </div>
+      {{end}}
+    </section>
+  </details>
+  {{end}}
+
   {{if .Patch}}{{$p := .Patch}}{{$ps := .PatchScan}}
   <details open class="group border-b">
     <summary class="w-full outline-none rounded-md focus-visible:ring-ring/50 focus-visible:ring-[3px]">

--- a/internal/web/templates/finding_workflow.html
+++ b/internal/web/templates/finding_workflow.html
@@ -73,6 +73,10 @@
                 hx-post="/findings/{{$id}}/patch">
           <i data-lucide="wrench"></i> Propose patch
         </button>
+        <button type="submit" class="btn-outline" formaction="/findings/{{$id}}/mitigate"
+                hx-post="/findings/{{$id}}/mitigate">
+          <i data-lucide="shield"></i> Draft mitigation
+        </button>
         <button type="submit" name="status" value="ready" class="btn-outline"
                 hx-post="/findings/{{$id}}/status">
           Mark ready

--- a/internal/worker/skill.go
+++ b/internal/worker/skill.go
@@ -218,6 +218,8 @@ func (w *Worker) parseSkillOutput(skill *db.Skill, scan *db.Scan, report string,
 		return w.parseVerifyOutput(scan, report, emit)
 	case "breaking_change":
 		return w.parseBreakingChangeOutput(scan, report, emit)
+	case "mitigation":
+		return w.parseMitigationOutput(scan, report, emit)
 	case "subprojects":
 		return w.parseSubprojectsOutput(scan, report, emit)
 	case "repo_overview":

--- a/internal/worker/skill_parsers.go
+++ b/internal/worker/skill_parsers.go
@@ -546,6 +546,37 @@ func (w *Worker) parseBreakingChangeOutput(scan *db.Scan, report string, emit fu
 	return nil
 }
 
+// parseMitigationOutput stores the operational mitigation guidance and
+// the optional semgrep rule the mitigate skill emits. Both go to the
+// finding through WriteFindingField so analyst edits and re-runs both
+// land in FindingHistory. An empty guidance body is a hard error: the
+// skill is meant to produce something or write nothing at all.
+func (w *Worker) parseMitigationOutput(scan *db.Scan, report string, emit func(Event)) error {
+	if scan.FindingID == nil {
+		return fmt.Errorf("mitigate scan has no finding_id")
+	}
+	var result struct {
+		Guidance    string `json:"guidance"`
+		SemgrepRule string `json:"semgrep_rule"`
+	}
+	if err := json.Unmarshal([]byte(report), &result); err != nil {
+		return fmt.Errorf("parse mitigation report: %w", err)
+	}
+	guidance := strings.TrimSpace(result.Guidance)
+	if guidance == "" {
+		return fmt.Errorf("mitigate report has empty guidance")
+	}
+	if err := db.WriteFindingField(w.DB, *scan.FindingID, "mitigation", guidance, db.SourceModel, "mitigate"); err != nil {
+		return fmt.Errorf("update mitigation: %w", err)
+	}
+	rule := strings.TrimSpace(result.SemgrepRule)
+	if err := db.WriteFindingField(w.DB, *scan.FindingID, "mitigation_semgrep", rule, db.SourceModel, "mitigate"); err != nil {
+		return fmt.Errorf("update mitigation_semgrep: %w", err)
+	}
+	emit(Event{Kind: KindText, Text: fmt.Sprintf("finding %d mitigation drafted (%d bytes, semgrep=%v)", *scan.FindingID, len(guidance), rule != "")})
+	return nil
+}
+
 func (w *Worker) parseFindingDedupOutput(scan *db.Scan, report string, emit func(Event)) error {
 	var result struct {
 		Duplicates []struct {

--- a/internal/worker/skill_parsers_test.go
+++ b/internal/worker/skill_parsers_test.go
@@ -359,6 +359,52 @@ func TestParseBreakingChange_rejectsUnknownVerdict(t *testing.T) {
 	}
 }
 
+func TestParseMitigation_writesGuidanceAndRule(t *testing.T) {
+	report := `{
+		"guidance": "## Workarounds\n\nDisable the eval flag.\n\n## Detection\n\nWatch for stack frames matching foo.eval.",
+		"semgrep_rule": "rules:\n  - id: foo-eval\n    pattern: foo.eval(...)\n    message: 'foo.eval is vulnerable to CVE-2026-XXXX'\n    severity: ERROR\n    languages: [go]"
+	}`
+	f, gdb := runSkillWithFinding(t, "mitigation", report, db.FindingTriaged)
+	if !strings.Contains(f.Mitigation, "Workarounds") {
+		t.Errorf("Mitigation missing workarounds section: %q", f.Mitigation)
+	}
+	if !strings.Contains(f.MitigationSemgrep, "foo-eval") {
+		t.Errorf("MitigationSemgrep missing rule id: %q", f.MitigationSemgrep)
+	}
+	var hist db.FindingHistory
+	if err := gdb.Where("finding_id = ? AND field = ?", f.ID, "mitigation").First(&hist).Error; err != nil {
+		t.Fatalf("missing mitigation history: %v", err)
+	}
+	if hist.By != "mitigate" {
+		t.Errorf("history.By = %q, want mitigate", hist.By)
+	}
+}
+
+func TestParseMitigation_emptySemgrepClearsRule(t *testing.T) {
+	report := `{"guidance":"## Workarounds\n\nset debug=false","semgrep_rule":""}`
+	f, _ := runSkillWithFinding(t, "mitigation", report, db.FindingTriaged)
+	if f.MitigationSemgrep != "" {
+		t.Errorf("MitigationSemgrep should remain empty, got %q", f.MitigationSemgrep)
+	}
+	if f.Mitigation == "" {
+		t.Errorf("Mitigation should be populated")
+	}
+}
+
+func TestParseMitigation_rejectsEmptyGuidance(t *testing.T) {
+	w := &Worker{}
+	scan := &db.Scan{}
+	if err := w.parseMitigationOutput(scan, `{"guidance":"  "}`, func(Event) {}); err == nil || !strings.Contains(err.Error(), "finding_id") {
+		t.Fatalf("expected missing finding_id error, got %v", err)
+	}
+	fid := uint(1)
+	scan.FindingID = &fid
+	err := w.parseMitigationOutput(scan, `{"guidance":"   "}`, func(Event) {})
+	if err == nil || !strings.Contains(err.Error(), "empty guidance") {
+		t.Errorf("expected empty-guidance error, got %v", err)
+	}
+}
+
 func TestParseFindingDedup_marksDuplicatesWithHistoryAndNote(t *testing.T) {
 	gdb, err := db.Open(filepath.Join(t.TempDir(), "dedup.db"))
 	if err != nil {

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -916,6 +916,8 @@ components:
         assignee:      { type: string }
         exploited_in_wild: { type: string, enum: [yes, no, ""], description: "Analyst's call on whether this finding is being exploited in the wild. Empty means unknown. Automation never sets this." }
         exploited_in_wild_evidence: { type: string }
+        mitigation:    { type: string, description: "Markdown body of operational mitigation guidance from the mitigate skill: workarounds, detection, optionally a semgrep rule (see mitigation_semgrep)." }
+        mitigation_semgrep: { type: string, description: "Optional YAML semgrep rule from the mitigate skill. Empty when no rule was warranted." }
 
     FindingDetail:
       allOf:

--- a/skills/mitigate/SKILL.md
+++ b/skills/mitigate/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: mitigate
+description: Draft operational mitigations for a finding consumers can apply before a fix ships. Workarounds (config flags, input restrictions, safe defaults), detection guidance (what to log and what pattern to alert on), and optionally a semgrep rule that flags the same pattern in other code bases. Distinct from disclose, which drafts the public advisory, and from patch, which proposes the code fix.
+license: MIT
+compatibility: Read-only against `./src`; needs network access to the scrutineer skill API to read the finding.
+metadata:
+  scrutineer.version: 1
+  scrutineer.output_file: report.json
+  scrutineer.output_kind: mitigation
+  scrutineer.model: claude-sonnet-4-6
+  scrutineer.requires_remote: true
+---
+
+# mitigate
+
+A finding has been confirmed and disclosure is in flight, but a fix is not out yet. Consumers running the affected code right now need guidance: how to harden the deployment, what to log so they can detect exploitation, and (where it fits) a semgrep rule that flags the same shape in their own code so they can audit beyond this one library.
+
+This skill drafts that guidance. It is distinct from the disclose skill (which drafts the GHSA advisory) and from the patch skill (which proposes the upstream fix). Mitigations live alongside the advisory; they are what consumers do while waiting for the fix to ship, and what defenders watch for while the issue is live.
+
+## Workspace
+
+- `./src` — the repository at the scanned commit; read-only
+- `./context.json` — has `scrutineer.api_base`, `scrutineer.token`, `scrutineer.finding_id`, `scrutineer.repository_id`
+- `./report.json` — write the mitigation guidance here
+- `./schema.json` — output shape
+
+## Inputs
+
+Fetch the finding so you know what you are mitigating:
+
+```
+GET {api_base}/findings/{finding_id}
+Authorization: Bearer {token}
+```
+
+Read `title`, `severity`, `location`, `cwe`, and the six-step prose (especially `boundary` for the trigger and `validation` for the reproduction). Those describe what an attacker must do and what they get; mitigation is the inverse — what a defender does to make the attack expensive or visible.
+
+## Procedure
+
+1. **Identify the entry point.** From the boundary and validation steps, find the smallest deployment-level surface attackers reach the sink through: an HTTP route, a config flag that opens a feature, a CLI subcommand, a public method on a library export. Mitigations attach there.
+
+2. **Draft workarounds.** Each workaround is a concrete change a consumer can apply now without an upstream fix. Examples by class:
+   - Config flag: "set `debug.eval = false` in production; disabling this loses the eval REPL but blocks the injection."
+   - Input restriction: a reverse proxy rule that caps body size below the overflow threshold, a WAF rule that drops requests with the trigger pattern.
+   - Safe default: a wrapper module that calls the vulnerable function with the dangerous parameter forced to a safe value.
+   - Process restriction: drop a Linux capability, run the worker as a non-root user, jail the binary in a seccomp profile.
+
+   Each workaround names the cost ("blocks the eval REPL") so the consumer can decide. Do not draft a workaround when the trade is not worth making.
+
+3. **Draft detection guidance.** What does an exploitation attempt look like in logs, telemetry, or runtime traces? Be concrete: a stack frame name, a request shape, an error class. If the application emits no useful signal today, say what it should log to make this detectable (and where in the code to add it).
+
+4. **Generate a semgrep rule, optionally.** When the vulnerable pattern is structural — a particular sink called with unchecked input, a deprecated API still in use, a specific config combination — write a semgrep rule that flags it. Use the `p/r2c-internal-cmd-injection` style: one rule per id, with a `pattern` or `patterns` block, `message`, `severity`, `languages`, and `metadata.references` pointing at the finding's commit and advisory if available. Validate the rule against `./src` to confirm it matches the finding's location and does not over-match obvious safe call sites. If you cannot write a rule that distinguishes the bug from safe usages, do not write one — a noisy rule is worse than no rule.
+
+5. **Keep it specific.** "Apply input validation" is not mitigation guidance, it is a tautology. Name the function, the field, the threshold, the config key, the commit, the file.
+
+## Output
+
+Write `./report.json` matching `./schema.json`:
+
+```json
+{
+  "guidance": "markdown body covering workarounds and detection",
+  "semgrep_rule": "optional YAML for a single semgrep rule"
+}
+```
+
+`guidance` is markdown; use sub-headings for the sections (`## Workarounds`, `## Detection`). `semgrep_rule` is a complete YAML document including `rules:`; omit the field rather than emit a stub.
+
+Scrutineer writes both to the finding (`mitigation` and `mitigation_semgrep` columns) with the changes recorded in finding history. The mitigation panel on the finding page renders the markdown and the rule together; the disclosure draft includes the mitigation section so the advisory and the workarounds travel as one piece.

--- a/skills/mitigate/schema.json
+++ b/skills/mitigate/schema.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "mitigate report",
+  "type": "object",
+  "required": ["guidance"],
+  "additionalProperties": false,
+  "properties": {
+    "guidance": {
+      "type": "string",
+      "description": "Markdown body covering workarounds (config flags, input restrictions, safe defaults, process restrictions) and detection guidance (what to log, what shape to alert on)."
+    },
+    "semgrep_rule": {
+      "type": "string",
+      "description": "Optional YAML for a single semgrep rule that flags the vulnerable pattern. Omit rather than emit a stub or noisy rule."
+    }
+  }
+}


### PR DESCRIPTION
Closes #366.

A new finding-scoped `mitigate` skill drafts the workarounds consumers can apply before a fix ships, the detection guidance to flag exploitation while the fix is in flight, and optionally a semgrep rule that names the vulnerable pattern. Distinct from `disclose` (which drafts the GHSA advisory) and from `patch` (which proposes the upstream fix).

- `skills/mitigate/` with SKILL.md and schema. Output kind `mitigation`; Sonnet, `requires_remote: true`. The body prompts for concrete workarounds with named trade-offs (a config flag plus the feature lost, a WAF rule plus the throughput cost), concrete detection signals (stack frames, request shapes, error classes), and a strict policy on semgrep rules: validate against `./src` first, omit rather than emit a noisy one.
- `Finding.Mitigation` (text) and `Finding.MitigationSemgrep` (text) columns added through AutoMigrate. Both editable through `findingFieldAccessor` so analyst edits and re-runs carry history.
- `parseMitigationOutput`: writes both fields via `db.WriteFindingField` (`source=model_suggested`, by `mitigate`); rejects an empty guidance body as a hard error.
- UI: a "Mitigation guidance" panel on the finding page renders the markdown and the semgrep rule together. A "Draft mitigation" button joins "Draft disclosure" and "Propose patch" in the triaged-status workflow.
- Exports: the markdown report ships a `#### Mitigation` section with a fenced `yaml` block for the rule when present.
- Docs: `README.md`, `docs/skills.md` (skill row + output-kind row + finding-scoped list), `docs/database.md` Finding columns, `openapi.yaml` Finding schema.
- Three parser tests cover the happy path (guidance + rule + history row by `mitigate`), an empty-semgrep run (rule cleared, guidance persisted), and rejection of empty guidance or missing finding_id.