### PR TITLE
Add disclosure bundle endpoint: OSV + CSAF + markdown + patch + manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ When the containerised runner is active (the default when Docker is available), 
 - **OSV export** -- download any finding as a schema-validated OSV record, anchored to the source repo when it maps to no registry package
 - **JSONL export** -- stream all findings or scans as line-delimited JSON for ingestion elsewhere
 - **Markdown report export** -- download a single consolidated `report.md` per repository or organisation
+- **Disclosure bundle** -- download `bundle.tar.gz` per finding: OSV, CSAF, markdown report, patch.diff, and a manifest naming the contents; ready to hand to a coordinator or attach to a private email when filing outside GitHub PVR
 
 ## The default pipeline
 

--- a/internal/web/finding_bundle.go
+++ b/internal/web/finding_bundle.go
@@ -5,10 +5,13 @@ import (
 	"bytes"
 	"compress/gzip"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
 	"time"
+
+	"gorm.io/gorm"
 
 	"scrutineer/internal/db"
 )
@@ -93,15 +96,31 @@ type bundleEntry struct {
 }
 
 func (s *Server) bundleEntries(f *db.Finding, repo *db.Repository) ([]bundleEntry, error) {
+	// Coordinator bundles need to fail loudly: a silent half-build that
+	// drops references or packages can produce an advisory that looks
+	// complete but is missing crucial context. Each Find() is tolerant
+	// of an empty result (gorm returns no error for zero rows on a Find),
+	// but a real DB failure bubbles up.
 	var refs []db.FindingReference
-	s.DB.Where("finding_id = ?", f.ID).Order("id desc").Find(&refs)
+	if err := s.DB.Where("finding_id = ?", f.ID).Order("id desc").Find(&refs).Error; err != nil {
+		return nil, fmt.Errorf("load references: %w", err)
+	}
 	var pkgs []db.Package
-	s.DB.Where("repository_id = ?", f.RepositoryID).Find(&pkgs)
+	if err := s.DB.Where("repository_id = ?", f.RepositoryID).Find(&pkgs).Error; err != nil {
+		return nil, fmt.Errorf("load packages: %w", err)
+	}
 	var fdRows []db.FindingDependent
-	s.DB.Where("finding_id = ?", f.ID).Find(&fdRows)
+	if err := s.DB.Where("finding_id = ?", f.ID).Find(&fdRows).Error; err != nil {
+		return nil, fmt.Errorf("load finding dependents: %w", err)
+	}
 	deps := loadFindingDependents(s, fdRows)
+	// Scan load is best-effort: a finding with a missing parent scan
+	// row (e.g. a scan that was deleted) still has a valid bundle to
+	// produce, since the bundle does not embed scan-specific fields.
 	var scan db.Scan
-	s.DB.First(&scan, f.ScanID)
+	if err := s.DB.First(&scan, f.ScanID).Error; err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, fmt.Errorf("load scan: %w", err)
+	}
 
 	// Aliases give a coordinator their cross-system identifiers up front:
 	// the OSV builder already collects them from CVE plus any GHSA-shaped

--- a/internal/web/finding_bundle.go
+++ b/internal/web/finding_bundle.go
@@ -1,0 +1,189 @@
+package web
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+
+	"scrutineer/internal/db"
+)
+
+// bundleManifest is the small header file the disclosure bundle carries
+// alongside the per-format documents. It names the finding, fixes the
+// generator version, and lists what's inside so a coordinator unzipping
+// the archive can tell at a glance whether they're looking at the right
+// vulnerability and what each file is for. The shape mirrors the OSS
+// SIRT intake brief (see docs/disclosure-fallback.md): one summary
+// line, an aliases block for cross-system identifiers, and an explicit
+// contents map.
+type bundleManifest struct {
+	GeneratedAt  string            `json:"generated_at"`
+	GeneratorURL string            `json:"generator_url"`
+	FindingID    uint              `json:"finding_id"`
+	Repository   string            `json:"repository"`
+	Title        string            `json:"title"`
+	Severity     string            `json:"severity,omitempty"`
+	CWE          string            `json:"cwe,omitempty"`
+	Aliases      []string          `json:"aliases,omitempty"`
+	Status       string            `json:"status"`
+	Contents     map[string]string `json:"contents"`
+	Note         string            `json:"note,omitempty"`
+}
+
+// findingBundleDownload writes a tar.gz containing every per-finding
+// export scrutineer produces (OSV, CSAF, markdown report, patch.diff
+// when one is on file) plus a manifest naming the finding and the
+// archive contents. The route is intentionally a composition over the
+// existing per-format builders: a coordinator who already pulls
+// /findings/{id}/osv.json by hand gets exactly the same bytes inside
+// the archive.
+//
+// Duplicates and findings with absent repository rows return errors so
+// the archive is never half-built; a missing patch.diff or a finding
+// without OSV-friendly versioning is fine and just means the bundle
+// has fewer entries.
+func (s *Server) findingBundleDownload(w http.ResponseWriter, r *http.Request) {
+	id, _ := strconv.Atoi(r.PathValue("id"))
+	var f db.Finding
+	if err := s.DB.First(&f, id).Error; err != nil {
+		http.NotFound(w, r)
+		return
+	}
+	if f.Status == db.FindingDuplicate {
+		http.Error(w, "finding is a duplicate; export not available", http.StatusGone)
+		return
+	}
+	var repo db.Repository
+	if err := s.DB.First(&repo, f.RepositoryID).Error; err != nil {
+		http.Error(w, "repository missing for finding", http.StatusInternalServerError)
+		return
+	}
+
+	entries, err := s.bundleEntries(&f, &repo)
+	if err != nil {
+		s.Log.Error("disclosure bundle", "finding", f.ID, "err", err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	body, err := buildTarGz(entries)
+	if err != nil {
+		s.Log.Error("disclosure bundle tar", "finding", f.ID, "err", err)
+		http.Error(w, "failed to build archive", http.StatusInternalServerError)
+		return
+	}
+
+	filename := fmt.Sprintf("scrutineer-finding-%d-disclosure-%s.tar.gz",
+		f.ID, time.Now().UTC().Format("20060102"))
+	w.Header().Set("Content-Type", "application/gzip")
+	w.Header().Set("Content-Disposition", `attachment; filename="`+filename+`"`)
+	_, _ = w.Write(body)
+}
+
+// bundleEntry is one file written into the archive: path inside the
+// tar plus its raw contents.
+type bundleEntry struct {
+	Name string
+	Data []byte
+}
+
+func (s *Server) bundleEntries(f *db.Finding, repo *db.Repository) ([]bundleEntry, error) {
+	var refs []db.FindingReference
+	s.DB.Where("finding_id = ?", f.ID).Order("id desc").Find(&refs)
+	var pkgs []db.Package
+	s.DB.Where("repository_id = ?", f.RepositoryID).Find(&pkgs)
+	var fdRows []db.FindingDependent
+	s.DB.Where("finding_id = ?", f.ID).Find(&fdRows)
+	deps := loadFindingDependents(s, fdRows)
+	var scan db.Scan
+	s.DB.First(&scan, f.ScanID)
+
+	// Aliases give a coordinator their cross-system identifiers up front:
+	// the OSV builder already collects them from CVE plus any GHSA-shaped
+	// references, so reuse rather than duplicate the rule.
+	aliases := osvAliases(*f, refs)
+
+	contents := map[string]string{}
+	var entries []bundleEntry
+
+	osvRaw, err := json.MarshalIndent(buildOSV(*f, *repo, refs, pkgs), "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("build OSV: %w", err)
+	}
+	entries = append(entries, bundleEntry{Name: "osv.json", Data: osvRaw})
+	contents["osv.json"] = "OSV 1.6.0 record (machine-readable advisory)"
+
+	csafRaw, err := json.MarshalIndent(buildCSAF(*f, *repo, refs, pkgs, fdRows, deps), "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("build CSAF: %w", err)
+	}
+	entries = append(entries, bundleEntry{Name: "csaf.json", Data: csafRaw})
+	contents["csaf.json"] = "CSAF 2.0 document (with VEX product_status for dependents)"
+
+	report := renderFindingReport(s.DB, f, &scan, repo)
+	entries = append(entries, bundleEntry{Name: "report.md", Data: []byte(report)})
+	contents["report.md"] = "Human-readable markdown report for the recipient"
+
+	if f.SuggestedFix != "" {
+		entries = append(entries, bundleEntry{Name: "patch.diff", Data: []byte(f.SuggestedFix)})
+		contents["patch.diff"] = "Suggested unified diff; applied to commit recorded in the OSV affected[] git range"
+	}
+
+	manifest := bundleManifest{
+		GeneratedAt:  time.Now().UTC().Format(time.RFC3339),
+		GeneratorURL: "https://github.com/alpha-omega-security/scrutineer",
+		FindingID:    f.ID,
+		Repository:   firstNonEmpty(repo.FullName, repo.Name, repo.URL),
+		Title:        f.Title,
+		Severity:     f.Severity,
+		CWE:          f.CWE,
+		Aliases:      aliases,
+		Status:       string(f.Status),
+		Contents:     contents,
+		Note:         "Bundle composed from data already on the finding; the per-file exports are the same bytes the corresponding /findings/{id}/{file} endpoint serves directly.",
+	}
+	manifestRaw, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("manifest: %w", err)
+	}
+	// Prepend the manifest so a `tar tzf` listing leads with it.
+	entries = append([]bundleEntry{{Name: "manifest.json", Data: manifestRaw}}, entries...)
+	return entries, nil
+}
+
+// buildTarGz writes the entries to a gzipped tar archive. Files land
+// at the archive root with 0644; the bundle is meant to be unpacked,
+// inspected, and forwarded by a coordinator, not installed.
+func buildTarGz(entries []bundleEntry) ([]byte, error) {
+	const filePerm = 0o644
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	now := time.Now()
+	for _, e := range entries {
+		hdr := &tar.Header{
+			Name:    e.Name,
+			Mode:    filePerm,
+			Size:    int64(len(e.Data)),
+			ModTime: now,
+		}
+		if err := tw.WriteHeader(hdr); err != nil {
+			return nil, err
+		}
+		if _, err := tw.Write(e.Data); err != nil {
+			return nil, err
+		}
+	}
+	if err := tw.Close(); err != nil {
+		return nil, err
+	}
+	if err := gz.Close(); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}

--- a/internal/web/finding_bundle_test.go
+++ b/internal/web/finding_bundle_test.go
@@ -1,0 +1,193 @@
+package web
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	"scrutineer/internal/db"
+)
+
+// readArchive uncompresses a tar.gz response body and returns a map of
+// filename -> content.
+func readArchive(t *testing.T, body []byte) map[string][]byte {
+	t.Helper()
+	gz, err := gzip.NewReader(bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("gzip open: %v", err)
+	}
+	defer func() { _ = gz.Close() }()
+	tr := tar.NewReader(gz)
+	out := map[string][]byte{}
+	for {
+		h, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("tar next: %v", err)
+		}
+		data, err := io.ReadAll(tr)
+		if err != nil {
+			t.Fatalf("tar read %q: %v", h.Name, err)
+		}
+		out[h.Name] = data
+	}
+	return out
+}
+
+func setUpBundleFinding(t *testing.T, s *Server, withPatch bool) *db.Finding {
+	t.Helper()
+	repo := db.Repository{URL: "https://github.com/acme/widget", FullName: "acme/widget", Name: "widget"}
+	s.DB.Create(&repo)
+	scan := db.Scan{RepositoryID: repo.ID, Status: db.ScanDone, Commit: "abc123"}
+	s.DB.Create(&scan)
+	f := db.Finding{
+		ScanID:       scan.ID,
+		RepositoryID: repo.ID,
+		Title:        "SQL injection in handler",
+		Severity:     "High",
+		CWE:          "CWE-89",
+		Location:     "internal/api/users.go:42",
+		Trace:        "user input flows into raw SQL string",
+	}
+	if withPatch {
+		f.SuggestedFix = "--- a/internal/api/users.go\n+++ b/internal/api/users.go\n@@ -1 +1 @@\n-x\n+y\n"
+	}
+	s.DB.Create(&f)
+	return &f
+}
+
+func TestFindingBundle_containsManifestAndExports(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	f := setUpBundleFinding(t, s, true)
+
+	r := httptest.NewRequest(http.MethodGet,
+		"/findings/"+strconv.Itoa(int(f.ID))+"/bundle.tar.gz", nil)
+	r.Host = "127.0.0.1:8080"
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, r)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	if got := w.Header().Get("Content-Type"); got != "application/gzip" {
+		t.Errorf("Content-Type = %q", got)
+	}
+	files := readArchive(t, w.Body.Bytes())
+
+	want := []string{"manifest.json", "osv.json", "csaf.json", "report.md", "patch.diff"}
+	for _, name := range want {
+		if _, ok := files[name]; !ok {
+			t.Errorf("archive missing %s; have %v", name, keys(files))
+		}
+	}
+
+	var m bundleManifest
+	if err := json.Unmarshal(files["manifest.json"], &m); err != nil {
+		t.Fatalf("decode manifest: %v", err)
+	}
+	if m.FindingID != f.ID {
+		t.Errorf("manifest finding_id = %d, want %d", m.FindingID, f.ID)
+	}
+	if m.Title != f.Title {
+		t.Errorf("manifest title = %q", m.Title)
+	}
+	if m.Repository != "acme/widget" {
+		t.Errorf("manifest repository = %q", m.Repository)
+	}
+	if _, ok := m.Contents["osv.json"]; !ok {
+		t.Errorf("manifest.contents missing osv.json: %+v", m.Contents)
+	}
+	if _, ok := m.Contents["patch.diff"]; !ok {
+		t.Errorf("manifest.contents missing patch.diff: %+v", m.Contents)
+	}
+
+	// The per-file exports must equal what the corresponding /findings/{id}/{file}
+	// endpoint serves. The OSV and report endpoints are the strongest check:
+	// they hit the same builder, so the bytes should match exactly.
+	osvReq := httptest.NewRequest(http.MethodGet,
+		"/findings/"+strconv.Itoa(int(f.ID))+"/osv.json", nil)
+	osvReq.Host = "127.0.0.1:8080"
+	osvRec := httptest.NewRecorder()
+	s.Handler().ServeHTTP(osvRec, osvReq)
+	if !bytes.Equal(files["osv.json"], osvRec.Body.Bytes()) {
+		t.Errorf("bundle osv.json differs from /findings/%d/osv.json", f.ID)
+	}
+}
+
+func TestFindingBundle_skipsPatchWhenAbsent(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	f := setUpBundleFinding(t, s, false)
+
+	r := httptest.NewRequest(http.MethodGet,
+		"/findings/"+strconv.Itoa(int(f.ID))+"/bundle.tar.gz", nil)
+	r.Host = "127.0.0.1:8080"
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, r)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d", w.Code)
+	}
+	files := readArchive(t, w.Body.Bytes())
+	if _, ok := files["patch.diff"]; ok {
+		t.Errorf("archive should omit patch.diff when SuggestedFix is empty")
+	}
+
+	var m bundleManifest
+	_ = json.Unmarshal(files["manifest.json"], &m)
+	if _, ok := m.Contents["patch.diff"]; ok {
+		t.Errorf("manifest.contents should omit patch.diff")
+	}
+}
+
+func TestFindingBundle_rejectsDuplicate(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	f := setUpBundleFinding(t, s, false)
+	s.DB.Model(f).Update("status", db.FindingDuplicate)
+
+	r := httptest.NewRequest(http.MethodGet,
+		"/findings/"+strconv.Itoa(int(f.ID))+"/bundle.tar.gz", nil)
+	r.Host = "127.0.0.1:8080"
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, r)
+	if w.Code != http.StatusGone {
+		t.Errorf("status = %d, want 410 for duplicate finding", w.Code)
+	}
+}
+
+func TestFindingBundle_notFoundReturns404(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	r := httptest.NewRequest(http.MethodGet, "/findings/99999/bundle.tar.gz", nil)
+	r.Host = "127.0.0.1:8080"
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, r)
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", w.Code)
+	}
+}
+
+func keys[V any](m map[string]V) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
+// Compile-time guarantee that the handler signature matches the rest of
+// the export handlers; if either changes, the build (and the rest of
+// the tests) catches it immediately.
+var _ = func(s *Server, w http.ResponseWriter, r *http.Request) {
+	s.findingBundleDownload(w, r)
+	_ = strings.TrimSpace("")
+}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -269,6 +269,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("POST /findings/{id}/patch", s.findingPatchRun)
 	mux.HandleFunc("POST /findings/{id}/exposure", s.findingExposureRun)
 	mux.HandleFunc("GET /findings/{id}/patch.diff", s.findingPatchDownload)
+	mux.HandleFunc("GET /findings/{id}/bundle.tar.gz", s.findingBundleDownload)
 	mux.HandleFunc("POST /findings/{id}/notes", s.findingNotes)
 	mux.HandleFunc("POST /findings/{id}/fields", s.findingFields)
 	mux.HandleFunc("POST /findings/{id}/communications", s.findingCommunications)

--- a/internal/web/templates/finding_show.html
+++ b/internal/web/templates/finding_show.html
@@ -14,9 +14,16 @@
     {{$f.Title}}
     {{template "finding-status" (fstatus $f.Status)}}
   </h2>
-  <a href="/findings/{{$f.ID}}/report.md" class="btn-outline shrink-0" download>
-    <i data-lucide="download"></i> Export report
-  </a>
+  <div class="flex gap-2 shrink-0">
+    <a href="/findings/{{$f.ID}}/report.md" class="btn-outline" download>
+      <i data-lucide="download"></i> Export report
+    </a>
+    <a href="/findings/{{$f.ID}}/bundle.tar.gz" class="btn-outline"
+       title="OSV + CSAF + markdown report + patch + manifest, packaged for a disclosure recipient"
+       download>
+      <i data-lucide="package"></i> Disclosure bundle
+    </a>
+  </div>
 </div>
 
 {{if $f.Labels}}

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -286,6 +286,34 @@ paths:
         '403': { $ref: '#/components/responses/Forbidden' }
         '404': { $ref: '#/components/responses/NotFound' }
 
+  /findings/{id}/bundle.tar.gz:
+    get:
+      summary: Disclosure bundle for one finding
+      operationId: getFindingBundle
+      description: |
+        A gzipped tar containing every per-finding export scrutineer
+        produces (OSV, CSAF, markdown report, patch.diff when one is on
+        file) plus a manifest.json header naming the finding and the
+        archive contents. The per-file bytes are identical to what the
+        matching /findings/{id}/{file} endpoint serves directly; the
+        bundle is a composition, not a new format. Shape mirrors the
+        OSS-SIRT intake brief: one summary line, aliases for
+        cross-system identifiers, contents map.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: { type: integer, format: int64 }
+      responses:
+        '200':
+          description: tar.gz archive.
+          content:
+            application/gzip:
+              schema: { type: string, format: binary }
+        '404': { description: Finding not found }
+        '410': { description: Finding is a duplicate; bundle unavailable }
+        '500': { description: Underlying export failed }
+
   /findings/{id}/notes:
     parameters:
       - name: id


### PR DESCRIPTION
Closes #370.

Coordinators handing off a disclosure usually want every per-format export at once: the OSV record for machine ingest, the CSAF document with the VEX product_status block, the markdown report for the human reading, and the patch.diff for the developer. Scrutineer already serves all four through `/findings/{id}/osv.json`, `/findings/{id}/csaf.json`, `/findings/{id}/report.md`, and `/findings/{id}/patch.diff`. This PR adds the obvious composition.

- `GET /findings/{id}/bundle.tar.gz` returns a gzipped tar holding the four exports plus a `manifest.json` header that names the finding (id, title, severity, CWE, status, aliases) and lists the archive contents with a one-line description per file. The bundle is composition only: the bytes for each file are identical to what the matching single-file endpoint serves. The manifest's shape mirrors what the OSS-SIRT intake brief expects (summary line + aliases + contents map).
- Behaviour around edge cases: `patch.diff` is omitted (and the manifest contents map elides it) when no `SuggestedFix` is on the finding; a duplicate finding returns `410 Gone` for the same reason the single-format endpoints do; a missing repository row returns `500` rather than half-build the archive.
- UI: a "Disclosure bundle" button alongside the existing "Export report" button on the finding page.
- Docs: `README.md` feature list and `openapi.yaml` cover the new endpoint.
- Tests cover the happy path (all four files present, manifest fields and contents map populated correctly, bundle's `osv.json` bytes equal the single-endpoint output), absence of `SuggestedFix` (no `patch.diff` entry, no manifest contents row), duplicate finding `410`, and `404` for a missing finding id.