### PR TITLE
Support CVSS v4.0 alongside 3.1

### DIFF
--- a/docs/database.md
+++ b/docs/database.md
@@ -135,8 +135,10 @@ One row per vulnerability. Lifecycle columns are mutated through `db.WriteFindin
 | imported_from | text | Originating tool name when the finding came in via `POST /api/v1/import`; empty for native scans. |
 | affected | text | Version range, e.g. `>=0.2.0, <=4.0.5`. |
 | cve_id | text | e.g. `CVE-2026-12345`. |
-| cvss_vector | text | e.g. `CVSS:3.1/AV:N/AC:L/...`. |
+| cvss_vector | text | CVSS v3.x base vector, e.g. `CVSS:3.1/AV:N/AC:L/...`. |
 | cvss_score | real | Derived from `cvss_vector` on write. Cleared when the vector is empty or unparseable. |
+| cvss_v4_vector | text | CVSS v4.0 base vector, e.g. `CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N`. Stored independently of `cvss_vector` because the v4 metric set and scoring formula differ. |
+| cvss_v4_score | real | Derived from `cvss_v4_vector` on write. Cleared on empty/unparseable, same as the v3 score. |
 | fix_version | text | |
 | fix_commit | text | |
 | resolution | text | `fix`, `migrate`, `workaround`, `adopt`, `wontfix`. |

--- a/internal/db/cvss.go
+++ b/internal/db/cvss.go
@@ -3,12 +3,16 @@ package db
 import (
 	gocvss30 "github.com/pandatix/go-cvss/30"
 	gocvss31 "github.com/pandatix/go-cvss/31"
+	gocvss40 "github.com/pandatix/go-cvss/40"
 )
 
 // BaseScoreFromVector computes the CVSS base score for a v3.0 or v3.1
 // vector. Returns (0, false) when the vector is empty or unparseable;
 // callers should clear cvss_score in that case rather than pinning a
-// stale value next to a fresh (or removed) vector.
+// stale value next to a fresh (or removed) vector. v4 vectors are
+// handled by ScoreFromV4Vector — the two scales are not interchangeable
+// and a single helper would mislead callers about which version they
+// got back.
 func BaseScoreFromVector(vector string) (float64, bool) {
 	if vector == "" {
 		return 0, false
@@ -20,4 +24,18 @@ func BaseScoreFromVector(vector string) (float64, bool) {
 		return v.BaseScore(), true
 	}
 	return 0, false
+}
+
+// ScoreFromV4Vector computes the CVSS v4.0 base score for a vector.
+// Returns (0, false) when the vector is empty or unparseable, matching
+// BaseScoreFromVector's contract.
+func ScoreFromV4Vector(vector string) (float64, bool) {
+	if vector == "" {
+		return 0, false
+	}
+	v, err := gocvss40.ParseVector(vector)
+	if err != nil {
+		return 0, false
+	}
+	return v.Score(), true
 }

--- a/internal/db/cvss_test.go
+++ b/internal/db/cvss_test.go
@@ -2,6 +2,32 @@ package db
 
 import "testing"
 
+func TestScoreFromV4Vector(t *testing.T) {
+	cases := []struct {
+		name   string
+		vector string
+		ok     bool
+	}{
+		{"v4 critical", "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N", true},
+		{"v4 medium", "CVSS:4.0/AV:N/AC:L/AT:N/PR:L/UI:N/VC:L/VI:L/VA:N/SC:N/SI:N/SA:N", true},
+		{"empty", "", false},
+		{"garbage", "not-a-vector", false},
+		{"v3 rejected", "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H", false},
+		{"truncated", "CVSS:4.0/AV:N/AC:L", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := ScoreFromV4Vector(tc.vector)
+			if ok != tc.ok {
+				t.Fatalf("ok = %v, want %v (score %v)", ok, tc.ok, got)
+			}
+			if ok && (got <= 0 || got > 10) {
+				t.Errorf("score %v out of [0,10]", got)
+			}
+		})
+	}
+}
+
 func TestBaseScoreFromVector(t *testing.T) {
 	cases := []struct {
 		name   string

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -446,9 +446,18 @@ type Finding struct {
 
 	// Disclosure / triage fields. Any of these may be set by a tool, a
 	// model-backed skill, or the analyst; see FindingHistory for the trail.
-	CVEID           string
+	CVEID string
+	// CVSSVector is the canonical CVSS v3.x base vector (3.0 or 3.1).
+	// CVSSv4Vector is the v4.0 base vector. Both may be populated when
+	// the analyst (or the disclose skill) carries both forward, which
+	// coordinators like the OSS-SIRT expect; v3.1 stays for legacy
+	// pipelines that have not yet adopted v4. Each vector has its own
+	// derived base-score column so the two scales do not get mixed up
+	// (4.0 changes the metric set and the base-score formula).
 	CVSSVector      string
 	CVSSScore       float64
+	CVSSv4Vector    string  `gorm:"column:cvss_v4_vector"`
+	CVSSv4Score     float64 `gorm:"column:cvss_v4_score"`
 	FixVersion      string
 	FixCommit       string
 	Resolution      FindingResolution `gorm:"index"`

--- a/internal/db/finding_helpers.go
+++ b/internal/db/finding_helpers.go
@@ -45,6 +45,9 @@ func WriteFindingField(gdb *gorm.DB, findingID uint, field, newValue string, sou
 	if field == "cvss_vector" {
 		return syncCVSSScore(gdb, &f, newValue, source, by)
 	}
+	if field == "cvss_v4_vector" {
+		return syncCVSSv4Score(gdb, &f, newValue, source, by)
+	}
 	return nil
 }
 
@@ -64,6 +67,28 @@ func syncCVSSScore(gdb *gorm.DB, f *Finding, vector string, source FindingSource
 		FindingID: f.ID,
 		Field:     "cvss_score",
 		OldValue:  strconv.FormatFloat(f.CVSSScore, 'f', -1, 64),
+		NewValue:  strconv.FormatFloat(score, 'f', -1, 64),
+		Source:    source,
+		By:        by,
+		CreatedAt: time.Now(),
+	}).Error
+}
+
+// syncCVSSv4Score is the v4 twin of syncCVSSScore. CVSS v4 changes the
+// metric set and the base-score formula, so it lives in its own
+// vector/score columns rather than overloading the v3 ones.
+func syncCVSSv4Score(gdb *gorm.DB, f *Finding, vector string, source FindingSource, by string) error {
+	score, _ := ScoreFromV4Vector(vector)
+	if f.CVSSv4Score == score {
+		return nil
+	}
+	if err := gdb.Model(&Finding{}).Where("id = ?", f.ID).Update("cvss_v4_score", score).Error; err != nil {
+		return fmt.Errorf("update cvss_v4_score: %w", err)
+	}
+	return gdb.Create(&FindingHistory{
+		FindingID: f.ID,
+		Field:     "cvss_v4_score",
+		OldValue:  strconv.FormatFloat(f.CVSSv4Score, 'f', -1, 64),
 		NewValue:  strconv.FormatFloat(score, 'f', -1, 64),
 		Source:    source,
 		By:        by,
@@ -134,6 +159,8 @@ func findingFieldAccessor(f *Finding, field string) (current, column string, err
 		return f.CVEID, "cve_id", nil
 	case "cvss_vector":
 		return f.CVSSVector, "cvss_vector", nil
+	case "cvss_v4_vector":
+		return f.CVSSv4Vector, "cvss_v4_vector", nil
 	case "fix_version":
 		return f.FixVersion, "fix_version", nil
 	case "fix_commit":

--- a/internal/db/finding_helpers_test.go
+++ b/internal/db/finding_helpers_test.go
@@ -139,6 +139,10 @@ func TestWriteFindingField_cvssVectorSyncsScore(t *testing.T) {
 	if history[1].NewValue != "9.8" || history[1].Source != SourceAnalyst || history[1].By != "me" {
 		t.Errorf("score history row: %+v", history[1])
 	}
+	if refreshed.CVSSv4Score != 0 || refreshed.CVSSv4Vector != "" {
+		t.Errorf("v4 columns mutated by v3 write: vec=%q score=%v",
+			refreshed.CVSSv4Vector, refreshed.CVSSv4Score)
+	}
 }
 
 func TestWriteFindingField_cvssV4VectorSyncsScore(t *testing.T) {

--- a/internal/db/finding_helpers_test.go
+++ b/internal/db/finding_helpers_test.go
@@ -141,6 +141,44 @@ func TestWriteFindingField_cvssVectorSyncsScore(t *testing.T) {
 	}
 }
 
+func TestWriteFindingField_cvssV4VectorSyncsScore(t *testing.T) {
+	gdb := newTestDB(t)
+	f := seedFinding(t, gdb)
+
+	const vec = "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N"
+	if err := WriteFindingField(gdb, f.ID, "cvss_v4_vector", vec, SourceAnalyst, "me"); err != nil {
+		t.Fatal(err)
+	}
+	var refreshed Finding
+	gdb.First(&refreshed, f.ID)
+	if refreshed.CVSSv4Vector != vec {
+		t.Errorf("v4 vector = %q, want %q", refreshed.CVSSv4Vector, vec)
+	}
+	if refreshed.CVSSv4Score <= 0 || refreshed.CVSSv4Score > 10 {
+		t.Errorf("v4 score = %v, want > 0 (out of [0,10])", refreshed.CVSSv4Score)
+	}
+	if refreshed.CVSSScore != 0 {
+		t.Errorf("v3 score = %v, want 0 (v4 write must not touch v3 column)", refreshed.CVSSScore)
+	}
+}
+
+func TestWriteFindingField_cvssV4VectorInvalidClearsScore(t *testing.T) {
+	gdb := newTestDB(t)
+	f := seedFinding(t, gdb)
+	gdb.Model(&Finding{}).Where("id = ?", f.ID).Updates(map[string]any{
+		"cvss_v4_vector": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N",
+		"cvss_v4_score":  9.3,
+	})
+	if err := WriteFindingField(gdb, f.ID, "cvss_v4_vector", "garbage", SourceAnalyst, ""); err != nil {
+		t.Fatal(err)
+	}
+	var refreshed Finding
+	gdb.First(&refreshed, f.ID)
+	if refreshed.CVSSv4Score != 0 {
+		t.Errorf("v4 score = %v, want 0", refreshed.CVSSv4Score)
+	}
+}
+
 func TestWriteFindingField_cvssVectorInvalidClearsScore(t *testing.T) {
 	gdb := newTestDB(t)
 	f := seedFinding(t, gdb)

--- a/internal/web/finding_forms.go
+++ b/internal/web/finding_forms.go
@@ -18,7 +18,7 @@ import (
 // reject it anyway.
 var analystFields = []string{
 	"title", "severity", "cwe", "location", "affected",
-	"cve_id", "cvss_vector", "fix_version", "fix_commit",
+	"cve_id", "cvss_vector", "cvss_v4_vector", "fix_version", "fix_commit",
 	"resolution", "disclosure_draft", "assignee",
 }
 

--- a/internal/web/finding_osv.go
+++ b/internal/web/finding_osv.go
@@ -212,16 +212,20 @@ func osvAliases(f db.Finding, refs []db.FindingReference) []string {
 	return out
 }
 
-// osvSeverityList emits the CVSS vector string (OSV's severity.score is the
-// vector, not a number). Gated on go-cvss parsing the vector: a vector it
-// accepts also satisfies the schema's CVSS_V3 score pattern, and gating here
-// keeps a malformed or truncated vector from failing validation. v4 vectors
-// fall through (go-cvss only parses 3.0/3.1) and severity is then omitted.
+// osvSeverityList emits one CVSS vector entry per version the finding
+// carries (OSV's severity.score is the vector, not a number). Each
+// entry is gated on go-cvss parsing the vector so a malformed value is
+// dropped rather than failing schema validation. When both are
+// present, v4 comes first (matching the OSS-SIRT advisory template).
 func osvSeverityList(f db.Finding) []osvSeverity {
-	if _, ok := db.BaseScoreFromVector(f.CVSSVector); !ok {
-		return nil
+	var out []osvSeverity
+	if _, ok := db.ScoreFromV4Vector(f.CVSSv4Vector); ok {
+		out = append(out, osvSeverity{Type: "CVSS_V4", Score: f.CVSSv4Vector})
 	}
-	return []osvSeverity{{Type: "CVSS_V3", Score: f.CVSSVector}}
+	if _, ok := db.BaseScoreFromVector(f.CVSSVector); ok {
+		out = append(out, osvSeverity{Type: "CVSS_V3", Score: f.CVSSVector})
+	}
+	return out
 }
 
 // osvEcosystemByPURLType maps a canonical PURL type to its OSV ecosystem name.

--- a/internal/web/finding_osv_test.go
+++ b/internal/web/finding_osv_test.go
@@ -99,6 +99,74 @@ func TestFindingOSV_cvss30Validates(t *testing.T) {
 	}
 }
 
+func TestFindingOSV_emitsBothCVSSv3AndCVSSv4(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	const v3 = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+	const v4 = "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N"
+	f := seedCSAFFinding(t, s, func(f *db.Finding) {
+		f.CVSSVector = v3
+		f.CVSSScore = 9.8
+		f.CVSSv4Vector = v4
+		f.CVSSv4Score = 9.3
+	})
+	w := getOSV(t, s, f.ID)
+	if w.Code != 200 {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+	doc := decodeCSAF(t, w.Body.Bytes())
+	sevs := doc["severity"].([]any)
+	if len(sevs) != 2 {
+		t.Fatalf("severity entries = %d, want 2 (one each for v4 and v3): %+v", len(sevs), sevs)
+	}
+	first := sevs[0].(map[string]any)
+	if first["type"] != "CVSS_V4" || first["score"] != v4 {
+		t.Errorf("first severity must be CVSS_V4 with the v4 vector: %+v", first)
+	}
+	second := sevs[1].(map[string]any)
+	if second["type"] != "CVSS_V3" || second["score"] != v3 {
+		t.Errorf("second severity must be CVSS_V3 with the v3.1 vector: %+v", second)
+	}
+}
+
+func TestFindingOSV_emitsOnlyV4WhenV3Absent(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	const v4 = "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N"
+	f := seedCSAFFinding(t, s, func(f *db.Finding) {
+		f.CVSSVector = ""
+		f.CVSSScore = 0
+		f.CVSSv4Vector = v4
+		f.CVSSv4Score = 9.3
+	})
+	w := getOSV(t, s, f.ID)
+	if w.Code != 200 {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+	doc := decodeCSAF(t, w.Body.Bytes())
+	raw, ok := doc["severity"]
+	if !ok {
+		t.Fatalf("severity key missing in OSV doc keys=%v", mapKeys(doc))
+	}
+	sevs, ok := raw.([]any)
+	if !ok || len(sevs) != 1 {
+		t.Fatalf("severity entries = %v, want 1 (v4 only)", raw)
+	}
+	if sevs[0].(map[string]any)["type"] != "CVSS_V4" {
+		t.Errorf("severity[0].type = %v", sevs[0])
+	}
+}
+
+func mapKeys(m map[string]any) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
 func TestFindingOSV_packageWithPURLBecomesAffectedPackage(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()

--- a/internal/web/templates/finding_show.html
+++ b/internal/web/templates/finding_show.html
@@ -122,8 +122,14 @@
   {{end}}
   {{if $f.CVSSVector}}
   <div class="col-span-2">
-    <dt class="text-muted-foreground">CVSS</dt>
+    <dt class="text-muted-foreground">CVSS v3</dt>
     <dd><code>{{$f.CVSSVector}}</code>{{if $f.CVSSScore}} ({{$f.CVSSScore}}){{end}}</dd>
+  </div>
+  {{end}}
+  {{if $f.CVSSv4Vector}}
+  <div class="col-span-2">
+    <dt class="text-muted-foreground">CVSS v4</dt>
+    <dd><code>{{$f.CVSSv4Vector}}</code>{{if $f.CVSSv4Score}} ({{$f.CVSSv4Score}}){{end}}</dd>
   </div>
   {{end}}
   {{if $f.FixCommit}}
@@ -339,9 +345,14 @@ git commit -m "fix: {{$f.Title}}"</pre>
           <input class="input" name="cve_id" value="{{$f.CVEID}}" placeholder="CVE-2026-12345">
         </div>
         <div class="grid gap-1 col-span-2">
-          <label class="text-xs text-muted-foreground">CVSS vector</label>
+          <label class="text-xs text-muted-foreground">CVSS v3 vector</label>
           <input class="input font-mono text-xs" name="cvss_vector" value="{{$f.CVSSVector}}"
                  placeholder="CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H">
+        </div>
+        <div class="grid gap-1 col-span-2">
+          <label class="text-xs text-muted-foreground">CVSS v4 vector</label>
+          <input class="input font-mono text-xs" name="cvss_v4_vector" value="{{$f.CVSSv4Vector}}"
+                 placeholder="CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N">
         </div>
         <div class="grid gap-1">
           <label class="text-xs text-muted-foreground">Affected versions</label>

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -279,7 +279,7 @@ paths:
                   description: |
                     Map of field name to new value. Allowed fields:
                     title, severity, status, cwe, location, affected,
-                    cve_id, cvss_vector, fix_version, fix_commit,
+                    cve_id, cvss_vector, cvss_v4_vector, fix_version, fix_commit,
                     resolution, disclosure_draft, assignee.
       responses:
         '204': { description: Updated }
@@ -891,8 +891,10 @@ components:
         reachability:  { type: string, enum: [reachable, harness_only, unclear] }
         quality_tier:  { type: string, enum: [high, low] }
         cve_id:        { type: string }
-        cvss_vector:   { type: string }
-        cvss_score:    { type: number }
+        cvss_vector:    { type: string, description: "CVSS v3.x base vector (3.0 or 3.1)." }
+        cvss_score:     { type: number, description: "Base score derived from cvss_vector." }
+        cvss_v4_vector: { type: string, description: "CVSS v4.0 base vector. Independent of cvss_vector; both may be populated." }
+        cvss_v4_score:  { type: number, description: "Base score derived from cvss_v4_vector." }
         fix_version:   { type: string }
         fix_commit:    { type: string }
         resolution:    { type: string, enum: [fix, migrate, workaround, adopt, wontfix, ""] }

--- a/skills/disclose/SKILL.md
+++ b/skills/disclose/SKILL.md
@@ -88,9 +88,11 @@ Draft disclosure content for an existing finding in a shape that maps one-to-one
 
    **`severity` / `cvss_vector_string`.** GHSA accepts exactly one of the two; prefer the CVSS vector when you can derive one confidently, fall back to the severity label otherwise.
 
-   Use CVSS 3.1. Derive each metric from the finding prose: `AV` from the attack surface described in Boundary, `AC` from how contrived the trigger is in Validation, `PR`/`UI` from whether the trigger needs authentication or human interaction, `S` from whether the impact crosses a trust boundary, and `C`/`I`/`A` from the dangerous behaviour in Rating. Write the full vector string (e.g. `CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H`). If any single metric cannot be derived from the prose, do not guess a value for it; omit `cvss_vector_string` entirely and emit the `severity` label instead.
+   Derive a 3.1 vector for the GHSA body (the GHSA form's CVSS picker accepts a 3.1 vector string). Derive each metric from the finding prose: `AV` from the attack surface described in Boundary, `AC` from how contrived the trigger is in Validation, `PR`/`UI` from whether the trigger needs authentication or human interaction, `S` from whether the impact crosses a trust boundary, and `C`/`I`/`A` from the dangerous behaviour in Rating. Write the full vector string (e.g. `CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H`). If any single metric cannot be derived from the prose, do not guess a value for it; omit `cvss_vector_string` entirely and emit the `severity` label instead.
 
-   For the severity label fallback, map scrutineer's `severity` field (`Critical`/`High`/`Medium`/`Low`) to GHSA's lowercase `critical`/`high`/`medium`/`low`. If the finding has a pre-existing `cvss_vector`, leave it alone and reuse it here — do not overwrite analyst edits.
+   Also derive a CVSS 4.0 vector and store it in `cvss_v4_vector` (the OSS-SIRT brief and downstream OSV consumers prefer v4; v3.1 stays for legacy pipelines). The metric set is wider: same base metrics, plus `VC`/`VI`/`VA` (impact on the vulnerable system) and `SC`/`SI`/`SA` (impact on subsequent systems). When the finding's blast radius stops at the vulnerable component, `SC=N SI=N SA=N`. Same rule: omit `cvss_v4_vector` rather than guess. The 4.0 form is `CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N`.
+
+   For the severity label fallback, map scrutineer's `severity` field (`Critical`/`High`/`Medium`/`Low`) to GHSA's lowercase `critical`/`high`/`medium`/`low`. If the finding has a pre-existing `cvss_vector` or `cvss_v4_vector`, leave it alone and reuse it here — do not overwrite analyst edits.
 
    **`cwe_ids[]`.** Split the finding's comma-joined `cwe` field into an array of `CWE-N` strings (GHSA accepts multiple). Do not invent CWEs not in the finding.
 
@@ -107,6 +109,7 @@ Draft disclosure content for an existing finding in a shape that maps one-to-one
      "fields": {
        "title": "<summary>",
        "cvss_vector": "CVSS:3.1/...",
+       "cvss_v4_vector": "CVSS:4.0/...",
        "affected": ">=1.0, <2.3.1",
        "fix_version": "2.3.1",
        "disclosure_draft": "<description markdown>"
@@ -115,7 +118,7 @@ Draft disclosure content for an existing finding in a shape that maps one-to-one
    }
    ```
 
-   Only include fields you want to change. If the finding already had a non-empty `cvss_vector`, `affected`, `fix_version`, or `title`, leave those keys out of the body so the analyst's value is preserved. `disclosure_draft` may be overwritten — a re-run is allowed to produce a fresh draft.
+   Only include fields you want to change. If the finding already had a non-empty `cvss_vector`, `cvss_v4_vector`, `affected`, `fix_version`, or `title`, leave those keys out of the body so the analyst's value is preserved. `disclosure_draft` may be overwritten — a re-run is allowed to produce a fresh draft.
 
    **POST each reference** — for every URL cited in the description, `POST {api_base}/findings/{finding_id}/references` with:
 


### PR DESCRIPTION
Closes #367.

CVSS v4 changes the metric set (adds AT, splits impact into Vulnerable-system VC/VI/VA and Subsequent-system SC/SI/SA) and the base-score formula, so it cannot share a column with v3. Disclosure coordinators (the OSS-SIRT among them) expect both — v4 going forward, v3.1 for legacy pipelines that have not migrated. This PR makes both stick.

- `db.ScoreFromV4Vector` parses with `go-cvss/40` (already a transitive dep through the v3.x packages); returns `(0, false)` on empty or unparseable input, mirroring `BaseScoreFromVector`. The two helpers stay separate: a single helper that returned a score with no version tag would mislead callers about which scale they got.
- `Finding.CVSSv4Vector` and `Finding.CVSSv4Score` are new columns (explicit `column:cvss_v4_vector` and `column:cvss_v4_score` tags so the snake_case stays readable). Editable through `findingFieldAccessor`; writes through `WriteFindingField` trigger `syncCVSSv4Score`, mirroring the v3 sync helper.
- OSV severity list now emits one entry per version the finding carries, with v4 first when both are present (matching the OSS-SIRT advisory template). The OSV schema's CVSS_V4 score pattern already accepts a base-only vector, so no extra gating beyond go-cvss parsing.
- `skills/disclose/SKILL.md` instructs the model to derive both vectors and to omit either rather than guess. The 4.0 metric set is laid out: same base metrics, plus VC/VI/VA on the vulnerable system and SC/SI/SA on subsequent systems (defaults to all-N when the blast radius stops at the component). The skill's `PATCH /findings/{id}` body now includes `cvss_v4_vector` alongside `cvss_vector`.
- Finding edit form shows v3 and v4 as separate input fields and the metadata header renders the two on separate lines. `analystFields` accepts `cvss_v4_vector`.
- CSAF stays v3-only: the CSAF 2.0 schema's `scores` block uses `cvss_v3`, and v4 is not a first-class type there.
- Tests cover ScoreFromV4Vector (six cases including v3 rejection and truncation), WriteFindingField for `cvss_v4_vector` (score sync + invalid clears, plus a check that the v4 write does not touch the v3 score column), and the OSV emission in both directions (both present, v4-only).
- Docs: `docs/database.md` Finding columns, `openapi.yaml` Finding schema and PATCH allowed-fields list.