### PR TITLE
Add release-watch skill: record upstream release once the fix ships

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ When a repo is added, the `triage` skill is enqueued. Its SKILL.md lists the ski
 | `finding-dedup` | Compares open findings and marks overlapping reports as duplicates |
 | `verify` | Re-checks one finding against current HEAD; records reproduces / fixed / can't-reproduce |
 | `breaking-change` | Static breaking-change check on the suggested-fix diff; records `breaking`/`non_breaking`/`unknown` with rationale and the affected dependents |
+| `release-watch` | After a finding reaches `fixed`, watches the upstream for a release containing the fix commit; records release tag, URL, and timestamp on the finding |
 | `disclose` | Drafts a GHSA-shaped advisory (title, description, CVSS, CWEs, references) for one finding |
 | `patch` | Proposes a unified diff fixing one finding; a diff that passes the applicability gate is stored on the finding as its suggested fix |
 | `report-upstream` | Files one finding on the upstream repository via GitHub PVR with the proposed patch attached; the action that moves a finding to `reported` |

--- a/docs/database.md
+++ b/docs/database.md
@@ -141,6 +141,9 @@ One row per vulnerability. Lifecycle columns are mutated through `db.WriteFindin
 | cvss_v4_score | real | Derived from `cvss_v4_vector` on write. Cleared on empty/unparseable, same as the v3 score. |
 | fix_version | text | |
 | fix_commit | text | |
+| release_tag | text | Tag of the upstream release that first contained the fix (e.g. `v2.3.1`). Set by the release-watch skill once `status=fixed`. |
+| release_url | text | Permalink to the release page. |
+| released_at | datetime | When the release was published upstream. Together with `release_tag` and `release_url`, these close the gap between fix-landed and fix-shipped for the metrics in dora-metrics. |
 | resolution | text | `fix`, `migrate`, `workaround`, `adopt`, `wontfix`. |
 | disclosure_draft | text | Draft advisory text. |
 | assignee | text | Free-text. |

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -32,6 +32,7 @@ These ship in `skills/` and are loaded with `-skills ./skills`. The `triage` ski
 | `exposure` | For one (finding, dependent) pair, decides whether the dependent's published code actually reaches the upstream library finding. Emits one CSAF 2.0 product_status verdict so scrutineer can record affected vs not_affected and stamp the right VEX justification. |
 | `verify` | Re-checks one finding against current HEAD and records reproduces / fixed / cannot-reproduce. |
 | `breaking-change` | Static breaking-change check: reads the finding's suggested-fix diff and the top dependents list, identifies public API surface changes, and records a verdict (`breaking`/`non_breaking`/`unknown`) with a rationale and the list of affected dependents. Read-only; reasons from the diff and dependent metadata. |
+| `release-watch` | After a finding reaches `fixed`, lists the upstream's releases and looks for one that contains `fix_commit` (or whose tag matches `fix_version`). Records the release tag, URL, and timestamp on the finding so the lifecycle visibly ends at a shipped version rather than at the commit landing. The triage skill auto-enqueues this for every `fixed` finding on each repo run. |
 | `disclose` | Drafts a GHSA-shaped advisory (title, description, CVSS, CWEs, references) for one finding. |
 | `patch` | Proposes a unified diff fixing one finding; a diff that passes the applicability gate is stored on the finding as its suggested fix. |
 | `fork` | Forks the repository into the configured org, enables private vulnerability reporting on the fork, and files each finding as a draft advisory there. Only useful when `-fork-org` is set. |
@@ -135,6 +136,7 @@ Declaring `scrutineer.paths` replaces this skip list entirely: the skill sees on
 | `breaking_change` | `breaking_change` verdict and `breaking_change_rationale` prose on one Finding, with the verdict change recorded in FindingHistory. |
 | `patch` | Suggested-fix diff and base commit on one Finding. |
 | `mitigation` | Mitigation prose and optional semgrep rule on one Finding (`mitigation`, `mitigation_semgrep` columns), with the change recorded in FindingHistory. |
+| `release_watch` | `release_tag`, `release_url`, `released_at` on one Finding (with history rows), plus a `FindingReference` tagged `upstream-release`. |
 | `threat_model` | Raw on the scan row; rendered on the repository's Threat Model tab. |
 | `exposure` | One CSAF product_status verdict upserted into a `finding_dependents` row keyed by `(finding_id, dependent_id)`. |
 
@@ -184,7 +186,7 @@ The worker then runs `claude -p "Use the {name} skill in this workspace"` with t
 }
 ```
 
-`finding_id` is only present for finding-scoped skills (`verify`, `breaking-change`, `disclose`, `patch`, `mitigate`, `exposure`). `dependent_id` is only set on `exposure` runs and points to the dependent whose code is under audit; `./src` is then a copy of that dependent's clone, not of the finding's repository. `scan_ref` is empty when the scan is on the default branch. `scan_subpath` is set when the operator scoped the scan to a monorepo sub-folder; skills that walk source honour it, skills that query external APIs by repository URL ignore it. `fork_org` is absent unless `-fork-org` is configured. `packages` is a convenience copy of the package rows when the `packages` skill has already run; otherwise it is omitted.
+`finding_id` is only present for finding-scoped skills (`verify`, `breaking-change`, `disclose`, `patch`, `mitigate`, `release-watch`, `exposure`). `dependent_id` is only set on `exposure` runs and points to the dependent whose code is under audit; `./src` is then a copy of that dependent's clone, not of the finding's repository. `scan_ref` is empty when the scan is on the default branch. `scan_subpath` is set when the operator scoped the scan to a monorepo sub-folder; skills that walk source honour it, skills that query external APIs by repository URL ignore it. `fork_org` is absent unless `-fork-org` is configured. `packages` is a convenience copy of the package rows when the `packages` skill has already run; otherwise it is omitted.
 
 ## schema.json
 

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -460,12 +460,21 @@ type Finding struct {
 	// pipelines that have not yet adopted v4. Each vector has its own
 	// derived base-score column so the two scales do not get mixed up
 	// (4.0 changes the metric set and the base-score formula).
-	CVSSVector      string
-	CVSSScore       float64
-	CVSSv4Vector    string  `gorm:"column:cvss_v4_vector"`
-	CVSSv4Score     float64 `gorm:"column:cvss_v4_score"`
-	FixVersion      string
-	FixCommit       string
+	CVSSVector   string
+	CVSSScore    float64
+	CVSSv4Vector string  `gorm:"column:cvss_v4_vector"`
+	CVSSv4Score  float64 `gorm:"column:cvss_v4_score"`
+	FixVersion   string
+	FixCommit    string
+	// ReleasedAt, ReleaseTag, ReleaseURL record the upstream release
+	// that first contained the fix. Written by the release-watch skill
+	// once `status=fixed`, so the metrics in dora-metrics.md can compute
+	// fixed-to-released latency rather than ending the funnel at the
+	// commit landing. All three move together: zero/empty until a
+	// release is found.
+	ReleasedAt *time.Time
+	ReleaseTag string
+	ReleaseURL string
 	Resolution      FindingResolution `gorm:"index"`
 	DisclosureDraft string            `gorm:"type:text"`
 	Assignee        string            `gorm:"index"`

--- a/internal/db/finding_helpers.go
+++ b/internal/db/finding_helpers.go
@@ -51,6 +51,60 @@ func WriteFindingField(gdb *gorm.DB, findingID uint, field, newValue string, sou
 	return nil
 }
 
+// WriteFindingTimeField is the time.Time twin of WriteFindingField for
+// timestamp columns the analyst (or a skill) can set. The closed set
+// of writable timestamp columns lives in findingTimeFieldAccessor, so
+// typos surface here rather than reach the DB. The new value is
+// normalised to UTC before write and storage; the history row formats
+// it as RFC3339 so it slots into the existing OldValue/NewValue text
+// columns alongside the string-typed history rows.
+//
+// No-op when the new value equals the stored value (a re-run that
+// reports the same release timestamp does not log a redundant history
+// row).
+func WriteFindingTimeField(gdb *gorm.DB, findingID uint, field string, newValue time.Time, source FindingSource, by string) error {
+	var f Finding
+	if err := gdb.First(&f, findingID).Error; err != nil {
+		return fmt.Errorf("load finding %d: %w", findingID, err)
+	}
+	old, colName, err := findingTimeFieldAccessor(&f, field)
+	if err != nil {
+		return err
+	}
+	newUTC := newValue.UTC()
+	if old != nil && old.Equal(newUTC) {
+		return nil
+	}
+	if err := gdb.Model(&Finding{}).Where("id = ?", f.ID).Update(colName, newUTC).Error; err != nil {
+		return fmt.Errorf("update %s: %w", colName, err)
+	}
+	oldStr := ""
+	if old != nil {
+		oldStr = old.UTC().Format(time.RFC3339)
+	}
+	return gdb.Create(&FindingHistory{
+		FindingID: f.ID,
+		Field:     field,
+		OldValue:  oldStr,
+		NewValue:  newUTC.Format(time.RFC3339),
+		Source:    source,
+		By:        by,
+		CreatedAt: time.Now(),
+	}).Error
+}
+
+// findingTimeFieldAccessor mirrors findingFieldAccessor for timestamp
+// columns. Same closed-list pattern: adding a new editable timestamp
+// means adding a case here.
+func findingTimeFieldAccessor(f *Finding, field string) (current *time.Time, column string, err error) {
+	switch field {
+	case "released_at":
+		return f.ReleasedAt, "released_at", nil
+	default:
+		return nil, "", fmt.Errorf("field %q is not an editable timestamp", field)
+	}
+}
+
 // syncCVSSScore keeps cvss_score in lock-step with cvss_vector. The
 // vector is the canonical input (analyst form, disclose skill), the
 // score is a pure function of it — anything else drifts. An empty or

--- a/internal/db/finding_helpers.go
+++ b/internal/db/finding_helpers.go
@@ -187,6 +187,10 @@ func findingFieldAccessor(f *Finding, field string) (current, column string, err
 		return f.Mitigation, "mitigation", nil
 	case "mitigation_semgrep":
 		return f.MitigationSemgrep, "mitigation_semgrep", nil
+	case "release_tag":
+		return f.ReleaseTag, "release_tag", nil
+	case "release_url":
+		return f.ReleaseURL, "release_url", nil
 	default:
 		return "", "", fmt.Errorf("field %q is not editable", field)
 	}

--- a/internal/skills/parse.go
+++ b/internal/skills/parse.go
@@ -91,6 +91,7 @@ var OutputKinds = map[string]bool{
 	"verify":          true,
 	"breaking_change": true,
 	"mitigation":      true,
+	"release_watch":   true,
 	"subprojects":     true,
 	"repo_overview":   true,
 	"posture":         true,

--- a/internal/web/templates/finding_show.html
+++ b/internal/web/templates/finding_show.html
@@ -151,6 +151,15 @@
     <dd>{{$f.FixVersion}}</dd>
   </div>
   {{end}}
+  {{if $f.ReleaseTag}}
+  <div>
+    <dt class="text-muted-foreground">Released</dt>
+    <dd>
+      {{if $f.ReleaseURL}}<a class="hover:underline" href="{{$f.ReleaseURL}}" rel="noopener" target="_blank">{{$f.ReleaseTag}}</a>{{else}}{{$f.ReleaseTag}}{{end}}
+      {{if $f.ReleasedAt}}<span class="text-xs text-muted-foreground">on {{$f.ReleasedAt.Format "2006-01-02"}}</span>{{end}}
+    </dd>
+  </div>
+  {{end}}
   {{if $f.Resolution}}
   <div>
     <dt class="text-muted-foreground">Resolution</dt>

--- a/internal/worker/skill.go
+++ b/internal/worker/skill.go
@@ -220,6 +220,8 @@ func (w *Worker) parseSkillOutput(skill *db.Skill, scan *db.Scan, report string,
 		return w.parseBreakingChangeOutput(scan, report, emit)
 	case "mitigation":
 		return w.parseMitigationOutput(scan, report, emit)
+	case "release_watch":
+		return w.parseReleaseWatchOutput(scan, report, emit)
 	case "subprojects":
 		return w.parseSubprojectsOutput(scan, report, emit)
 	case "repo_overview":

--- a/internal/worker/skill_parsers.go
+++ b/internal/worker/skill_parsers.go
@@ -635,27 +635,8 @@ func (w *Worker) parseReleaseWatchOutput(scan *db.Scan, report string, emit func
 	if err := db.WriteFindingField(w.DB, f.ID, "release_url", result.ReleaseURL, db.SourceModel, "release-watch"); err != nil {
 		return fmt.Errorf("update release_url: %w", err)
 	}
-	// released_at is not editable through findingFieldAccessor (its a
-	// timestamp, not a string), so write directly and log history.
-	old := ""
-	if f.ReleasedAt != nil {
-		old = f.ReleasedAt.UTC().Format(time.RFC3339)
-	}
-	releaseAtUTC := releaseAt.UTC()
-	if old != releaseAtUTC.Format(time.RFC3339) {
-		if err := w.DB.Model(&db.Finding{}).Where("id = ?", f.ID).Update("released_at", releaseAtUTC).Error; err != nil {
-			return fmt.Errorf("update released_at: %w", err)
-		}
-		if err := w.DB.Create(&db.FindingHistory{
-			FindingID: f.ID,
-			Field:     "released_at",
-			OldValue:  old,
-			NewValue:  releaseAtUTC.Format(time.RFC3339),
-			Source:    db.SourceModel,
-			By:        "release-watch",
-		}).Error; err != nil {
-			return fmt.Errorf("history released_at: %w", err)
-		}
+	if err := db.WriteFindingTimeField(w.DB, f.ID, "released_at", releaseAt, db.SourceModel, "release-watch"); err != nil {
+		return fmt.Errorf("update released_at: %w", err)
 	}
 
 	if _, err := db.AddFindingReference(w.DB, f.ID, result.ReleaseURL, "upstream-release",
@@ -663,7 +644,7 @@ func (w *Worker) parseReleaseWatchOutput(scan *db.Scan, report string, emit func
 		return fmt.Errorf("record release reference: %w", err)
 	}
 
-	emit(Event{Kind: KindText, Text: fmt.Sprintf("finding %d released as %s (%s)", f.ID, result.ReleaseTag, releaseAtUTC.Format(time.RFC3339))})
+	emit(Event{Kind: KindText, Text: fmt.Sprintf("finding %d released as %s (%s)", f.ID, result.ReleaseTag, releaseAt.UTC().Format(time.RFC3339))})
 	return nil
 }
 

--- a/internal/worker/skill_parsers.go
+++ b/internal/worker/skill_parsers.go
@@ -577,6 +577,96 @@ func (w *Worker) parseMitigationOutput(scan *db.Scan, report string, emit func(E
 	return nil
 }
 
+// parseReleaseWatchOutput records whether the upstream has cut a
+// release containing the fix. When released=true, the tag, URL, and
+// timestamp go to the finding's release_tag / release_url / released_at
+// columns through WriteFindingField (history recorded), and a
+// FindingReference row tagged `upstream-release` makes the link visible
+// in the references panel. A released=false run is also fine: it just
+// records a short note and waits for the next run to check again.
+func (w *Worker) parseReleaseWatchOutput(scan *db.Scan, report string, emit func(Event)) error {
+	if scan.FindingID == nil {
+		return fmt.Errorf("release-watch scan has no finding_id")
+	}
+	var result struct {
+		Released   bool   `json:"released"`
+		ReleaseTag string `json:"release_tag"`
+		ReleaseURL string `json:"release_url"`
+		ReleaseAt  string `json:"release_at"`
+		Notes      string `json:"notes"`
+	}
+	if err := json.Unmarshal([]byte(report), &result); err != nil {
+		return fmt.Errorf("parse release-watch report: %w", err)
+	}
+	// Validate the report shape before touching the DB so a malformed
+	// run fails fast and the rejection paths can be tested without a
+	// backing database.
+	var releaseAt time.Time
+	if result.Released {
+		if strings.TrimSpace(result.ReleaseTag) == "" || strings.TrimSpace(result.ReleaseURL) == "" {
+			return fmt.Errorf("release-watch report claims released=true but is missing release_tag or release_url")
+		}
+		parsed, err := time.Parse(time.RFC3339, result.ReleaseAt)
+		if err != nil {
+			return fmt.Errorf("parse release_at %q: %w", result.ReleaseAt, err)
+		}
+		releaseAt = parsed
+	}
+	var f db.Finding
+	if err := w.DB.First(&f, *scan.FindingID).Error; err != nil {
+		return fmt.Errorf("load finding %d: %w", *scan.FindingID, err)
+	}
+
+	if !result.Released {
+		// Negative observations get a note row so the operator can see
+		// what the latest run said without trawling scan logs.
+		if reason := strings.TrimSpace(result.Notes); reason != "" {
+			if _, err := db.AddFindingNote(w.DB, f.ID, "release-watch: not released\n\n"+reason, "release-watch"); err != nil {
+				return fmt.Errorf("record release-watch note: %w", err)
+			}
+		}
+		emit(Event{Kind: KindText, Text: fmt.Sprintf("finding %d: no release yet", f.ID)})
+		return nil
+	}
+
+	if err := db.WriteFindingField(w.DB, f.ID, "release_tag", result.ReleaseTag, db.SourceModel, "release-watch"); err != nil {
+		return fmt.Errorf("update release_tag: %w", err)
+	}
+	if err := db.WriteFindingField(w.DB, f.ID, "release_url", result.ReleaseURL, db.SourceModel, "release-watch"); err != nil {
+		return fmt.Errorf("update release_url: %w", err)
+	}
+	// released_at is not editable through findingFieldAccessor (its a
+	// timestamp, not a string), so write directly and log history.
+	old := ""
+	if f.ReleasedAt != nil {
+		old = f.ReleasedAt.UTC().Format(time.RFC3339)
+	}
+	releaseAtUTC := releaseAt.UTC()
+	if old != releaseAtUTC.Format(time.RFC3339) {
+		if err := w.DB.Model(&db.Finding{}).Where("id = ?", f.ID).Update("released_at", releaseAtUTC).Error; err != nil {
+			return fmt.Errorf("update released_at: %w", err)
+		}
+		if err := w.DB.Create(&db.FindingHistory{
+			FindingID: f.ID,
+			Field:     "released_at",
+			OldValue:  old,
+			NewValue:  releaseAtUTC.Format(time.RFC3339),
+			Source:    db.SourceModel,
+			By:        "release-watch",
+		}).Error; err != nil {
+			return fmt.Errorf("history released_at: %w", err)
+		}
+	}
+
+	if _, err := db.AddFindingReference(w.DB, f.ID, result.ReleaseURL, "upstream-release",
+		"Upstream release "+result.ReleaseTag+" containing the fix"); err != nil {
+		return fmt.Errorf("record release reference: %w", err)
+	}
+
+	emit(Event{Kind: KindText, Text: fmt.Sprintf("finding %d released as %s (%s)", f.ID, result.ReleaseTag, releaseAtUTC.Format(time.RFC3339))})
+	return nil
+}
+
 func (w *Worker) parseFindingDedupOutput(scan *db.Scan, report string, emit func(Event)) error {
 	var result struct {
 		Duplicates []struct {

--- a/internal/worker/skill_parsers.go
+++ b/internal/worker/skill_parsers.go
@@ -639,9 +639,21 @@ func (w *Worker) parseReleaseWatchOutput(scan *db.Scan, report string, emit func
 		return fmt.Errorf("update released_at: %w", err)
 	}
 
-	if _, err := db.AddFindingReference(w.DB, f.ID, result.ReleaseURL, "upstream-release",
-		"Upstream release "+result.ReleaseTag+" containing the fix"); err != nil {
-		return fmt.Errorf("record release reference: %w", err)
+	// Dedupe the references row so re-runs that re-confirm the same
+	// release (the skill's idempotency contract) do not pile up identical
+	// rows in the references panel. Match on (finding, tag, URL); a
+	// different URL for the same finding would still be a separate row.
+	var existingRef int64
+	if err := w.DB.Model(&db.FindingReference{}).
+		Where("finding_id = ? AND tags = ? AND url = ?", f.ID, "upstream-release", result.ReleaseURL).
+		Count(&existingRef).Error; err != nil {
+		return fmt.Errorf("check existing release reference: %w", err)
+	}
+	if existingRef == 0 {
+		if _, err := db.AddFindingReference(w.DB, f.ID, result.ReleaseURL, "upstream-release",
+			"Upstream release "+result.ReleaseTag+" containing the fix"); err != nil {
+			return fmt.Errorf("record release reference: %w", err)
+		}
 	}
 
 	emit(Event{Kind: KindText, Text: fmt.Sprintf("finding %d released as %s (%s)", f.ID, result.ReleaseTag, releaseAt.UTC().Format(time.RFC3339))})

--- a/internal/worker/skill_parsers_test.go
+++ b/internal/worker/skill_parsers_test.go
@@ -439,6 +439,40 @@ func TestParseReleaseWatch_releasedWritesColumnsAndReference(t *testing.T) {
 	}
 }
 
+func TestParseReleaseWatch_idempotentOnRepeatedRun(t *testing.T) {
+	report := `{
+		"released": true,
+		"release_tag": "v2.3.1",
+		"release_url": "https://github.com/example/lib/releases/tag/v2.3.1",
+		"release_at": "2026-06-02T14:00:00Z",
+		"notes": "matched by fix_commit"
+	}`
+	f, gdb := runSkillWithFinding(t, "release_watch", report, db.FindingFixed)
+
+	// Replay the parser by hand against the same finding row so we are
+	// testing the parser's idempotency contract (the SKILL.md says
+	// "Idempotent: a finding with a release already recorded re-confirms
+	// the existing value rather than flapping").
+	w := &Worker{DB: gdb, Log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	scan := &db.Scan{RepositoryID: f.RepositoryID, FindingID: &f.ID, SkillName: "release-watch"}
+	if err := w.parseReleaseWatchOutput(scan, report, func(Event) {}); err != nil {
+		t.Fatal(err)
+	}
+
+	var refs []db.FindingReference
+	gdb.Where("finding_id = ? AND tags = ?", f.ID, "upstream-release").Find(&refs)
+	if len(refs) != 1 {
+		t.Errorf("references = %d, want 1 (re-run must not duplicate the reference row)", len(refs))
+	}
+	// History rows: the no-op WriteFindingField / WriteFindingTimeField
+	// path means the second run logs no new history.
+	var hist []db.FindingHistory
+	gdb.Where("finding_id = ? AND field IN ?", f.ID, []string{"release_tag", "release_url", "released_at"}).Find(&hist)
+	if len(hist) != 3 {
+		t.Errorf("history rows = %d, want 3 (one per field, unchanged on re-run): %+v", len(hist), hist)
+	}
+}
+
 func TestParseReleaseWatch_notReleasedAddsNote(t *testing.T) {
 	report := `{"released": false, "notes": "latest release v2.2.0 predates fix_commit"}`
 	f, gdb := runSkillWithFinding(t, "release_watch", report, db.FindingFixed)

--- a/internal/worker/skill_parsers_test.go
+++ b/internal/worker/skill_parsers_test.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"gorm.io/gorm"
 
@@ -402,6 +403,66 @@ func TestParseMitigation_rejectsEmptyGuidance(t *testing.T) {
 	err := w.parseMitigationOutput(scan, `{"guidance":"   "}`, func(Event) {})
 	if err == nil || !strings.Contains(err.Error(), "empty guidance") {
 		t.Errorf("expected empty-guidance error, got %v", err)
+	}
+}
+
+func TestParseReleaseWatch_releasedWritesColumnsAndReference(t *testing.T) {
+	report := `{
+		"released": true,
+		"release_tag": "v2.3.1",
+		"release_url": "https://github.com/example/lib/releases/tag/v2.3.1",
+		"release_at": "2026-06-02T14:00:00Z",
+		"notes": "matched by fix_commit"
+	}`
+	f, gdb := runSkillWithFinding(t, "release_watch", report, db.FindingFixed)
+	if f.ReleaseTag != "v2.3.1" {
+		t.Errorf("ReleaseTag = %q, want v2.3.1", f.ReleaseTag)
+	}
+	if f.ReleaseURL == "" {
+		t.Errorf("ReleaseURL empty")
+	}
+	if f.ReleasedAt == nil {
+		t.Fatalf("ReleasedAt is nil")
+	}
+	if !f.ReleasedAt.Equal(time.Date(2026, 6, 2, 14, 0, 0, 0, time.UTC)) {
+		t.Errorf("ReleasedAt = %v", f.ReleasedAt)
+	}
+	var refs []db.FindingReference
+	gdb.Where("finding_id = ?", f.ID).Find(&refs)
+	if len(refs) != 1 || refs[0].Tags != "upstream-release" {
+		t.Errorf("references = %+v, want one upstream-release", refs)
+	}
+	var hist []db.FindingHistory
+	gdb.Where("finding_id = ? AND field IN ?", f.ID, []string{"release_tag", "release_url", "released_at"}).Find(&hist)
+	if len(hist) != 3 {
+		t.Errorf("history rows = %d, want 3 (tag/url/released_at): %+v", len(hist), hist)
+	}
+}
+
+func TestParseReleaseWatch_notReleasedAddsNote(t *testing.T) {
+	report := `{"released": false, "notes": "latest release v2.2.0 predates fix_commit"}`
+	f, gdb := runSkillWithFinding(t, "release_watch", report, db.FindingFixed)
+	if f.ReleaseTag != "" {
+		t.Errorf("ReleaseTag should remain empty: %q", f.ReleaseTag)
+	}
+	var notes []db.FindingNote
+	gdb.Where("finding_id = ? AND `by` = ?", f.ID, "release-watch").Find(&notes)
+	if len(notes) != 1 || !strings.Contains(notes[0].Body, "not released") {
+		t.Errorf("notes = %+v, want one release-watch note", notes)
+	}
+}
+
+func TestParseReleaseWatch_rejectsMissingTimestamp(t *testing.T) {
+	w := &Worker{}
+	scan := &db.Scan{}
+	if err := w.parseReleaseWatchOutput(scan, `{"released":true,"release_tag":"v1","release_url":"http://x"}`, func(Event) {}); err == nil || !strings.Contains(err.Error(), "finding_id") {
+		t.Fatalf("missing finding_id error = %v", err)
+	}
+	fid := uint(1)
+	scan.FindingID = &fid
+	err := w.parseReleaseWatchOutput(scan, `{"released":true,"release_tag":"v1","release_url":"http://x","release_at":"not-a-date"}`, func(Event) {})
+	if err == nil || !strings.Contains(err.Error(), "release_at") {
+		t.Errorf("expected release_at parse error, got %v", err)
 	}
 }
 

--- a/skills/release-watch/SKILL.md
+++ b/skills/release-watch/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: release-watch
+description: After a finding has been marked fixed, watch the upstream for a release that contains the fix. When one shows up, record the release tag, URL, and timestamp on the finding. Closes the gap between "the maintainer landed a patch" and "consumers have a shipped version they can pin to".
+license: MIT
+compatibility: Needs network access to the scrutineer skill API and to github.com (or whichever host the upstream lives on). Read-only.
+metadata:
+  scrutineer.version: 1
+  scrutineer.output_file: report.json
+  scrutineer.output_kind: release_watch
+  scrutineer.requires_remote: true
+  scrutineer.model: claude-sonnet-4-6
+---
+
+# release-watch
+
+A finding reached `fixed` because a commit landed upstream. Consumers cannot pin to a commit; they need a tagged release. This skill answers "did the maintainer cut one yet, and what's the version".
+
+The skill is finding-scoped. Run it after the finding has been marked `fixed` (the triage skill auto-enqueues this for every `fixed` finding on each repo run). When no release has shipped yet, the answer is just that — return `released: false` and a short note about what the latest release looks like. The next run will check again.
+
+## Workspace
+
+- `./src` — the upstream repository at the scanned commit
+- `./context.json` — has `scrutineer.api_base`, `scrutineer.token`, `scrutineer.finding_id`, `scrutineer.repository_id`, and `repository.url` / `repository.full_name`
+- `./report.json` — write your finding here
+- `./schema.json` — output shape
+
+## Inputs
+
+1. Fetch the finding:
+
+   ```
+   GET {api_base}/findings/{finding_id}
+   Authorization: Bearer {token}
+   ```
+
+   Read `fix_commit`, `fix_version`, `status`, and the existing `released_at` / `release_tag` / `release_url` on the finding. If a release is already recorded, write `{"released": true, "release_tag": "<existing tag>", ..., "notes": "already recorded; re-confirming"}` and exit — re-runs should not flap a recorded value.
+
+   If `status` is not `fixed`, write `{"released": false, "notes": "skill only meaningful in fixed status; finding is in <status>"}` and exit.
+
+2. List releases on the upstream. On github.com:
+
+   ```
+   gh api repos/{owner}/{repo}/releases?per_page=20
+   ```
+
+   The response gives you `tag_name`, `name`, `html_url`, `published_at`, and `target_commitish`. If `gh auth` fails, write `{"released": false, "notes": "gh auth not configured; cannot list releases"}` and exit.
+
+   Non-GitHub hosts: skip for now and record a note. A later iteration covers GitLab, gitea, and registry-only sources.
+
+3. Map each release back to a commit. For each release whose `target_commitish` is empty (sometimes tags are detached), resolve via:
+
+   ```
+   gh api repos/{owner}/{repo}/git/ref/tags/{tag_name}
+   ```
+
+   to get the tag's SHA, then `gh api repos/{owner}/{repo}/commits/{sha}` to confirm. Skip a release if its commit cannot be resolved; do not guess.
+
+## Procedure
+
+1. **Match by commit.** When the finding has a `fix_commit`, check each release for whether `fix_commit` is reachable from the release's commit. Use:
+
+   ```
+   gh api repos/{owner}/{repo}/compare/{fix_commit}...{release_commit}
+   ```
+
+   If the comparison succeeds with `status: ahead` or `identical` (the release commit is at or after the fix commit), this release contains the fix. Pick the *earliest* such release by `published_at`: consumers want the first version they can upgrade to.
+
+2. **Fall back to fix_version.** If `fix_commit` is empty but `fix_version` is set, match by tag name: a release whose `tag_name` matches `fix_version` (with or without a leading `v`) is the one. Verify by fetching its commit, just so you have the timestamp.
+
+3. **Neither field set.** Write `{"released": false, "notes": "finding has no fix_commit or fix_version to anchor the search"}` and exit. This is a recoverable state: the analyst can fill in either field and re-run.
+
+4. **A release was found.** Emit:
+
+   ```json
+   {
+     "released": true,
+     "release_tag": "v2.3.1",
+     "release_url": "https://github.com/example/lib/releases/tag/v2.3.1",
+     "release_at": "2026-06-02T14:00:00Z",
+     "notes": "matched by fix_commit; release contains 4 commits since the fix"
+   }
+   ```
+
+   `released_at` is ISO 8601. Scrutineer writes it to `Finding.ReleasedAt` and the rest to the matching columns, with the change recorded in finding history. It also adds a `FindingReference` row with `tags=upstream-release` so the release link appears in the finding's references panel.
+
+5. **No matching release yet.** Emit:
+
+   ```json
+   {
+     "released": false,
+     "notes": "latest release v2.3.0 from 2026-05-30 predates fix_commit abc1234"
+   }
+   ```
+
+   The next run rechecks. Make the note specific enough that a human can tell if the maintainer is sitting on the fix.
+
+Do not transition the finding's lifecycle status. `published` means the advisory has been published, which is a human act and a different signal from a release shipping; release-watch records the release but leaves status alone.

--- a/skills/release-watch/schema.json
+++ b/skills/release-watch/schema.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "release-watch report",
+  "type": "object",
+  "required": ["released"],
+  "additionalProperties": false,
+  "properties": {
+    "released": {
+      "type": "boolean",
+      "description": "True when a release containing the fix has been identified upstream."
+    },
+    "release_tag": {
+      "type": "string",
+      "description": "e.g. v2.3.1; required when released=true."
+    },
+    "release_url": {
+      "type": "string",
+      "description": "Permalink to the release page; required when released=true."
+    },
+    "release_at": {
+      "type": "string",
+      "description": "ISO 8601 timestamp the release was published; required when released=true."
+    },
+    "notes": {
+      "type": "string",
+      "description": "Short prose explaining the match (or the gap when released=false)."
+    }
+  }
+}

--- a/skills/triage/SKILL.md
+++ b/skills/triage/SKILL.md
@@ -72,7 +72,11 @@ If a skill name comes back `404 skill not found or inactive`, skip it and note w
 
 If this repository has been scanned before there may be findings already reported to the maintainer that have since been fixed upstream. For each of `status=reported` and `status=acknowledged`, fetch `GET {api_base}/repositories/{repository_id}/findings?status={status}` and collect the returned `id` values. For every finding id, enqueue a verify run: `POST {api_base}/findings/{id}/skills/verify/run` with the bearer header and an empty JSON body. Record the ids you enqueued in the `verify` field of your report; if there are none, write an empty list. If the verify endpoint returns `404 skill not found or inactive`, leave `verify` empty and carry on.
 
-Do not verify findings in other states. `new`, `enriched`, `triaged`, and `ready` are handled by the audit skills re-running above; `fixed`, `published`, `rejected`, and `duplicate` are closed.
+Do not verify findings in `new`, `enriched`, `triaged`, `ready`, `published`, `rejected`, or `duplicate` states. The audit skills re-running above handle the first four; the last three are closed.
+
+## Watch fixed findings for an upstream release
+
+When a finding reaches `fixed` the maintainer has landed a patch, but consumers cannot pin to a commit — they need a tagged release. For findings in `status=fixed`, enqueue release-watch the same way: `POST {api_base}/findings/{id}/skills/release-watch/run`. Record the ids in a `release_watch` field of your report. If the endpoint returns `404 skill not found or inactive`, leave the field empty and carry on. Release-watch is idempotent: a finding that already has a release recorded re-confirms the existing value rather than flapping.
 
 ## Output
 
@@ -87,8 +91,9 @@ Write `./report.json` as:
   "skipped":   ["semgrep"],
   "gated":     [],
   "already_done": ["metadata"],
-  "verify":    [12, 34],
-  "errors":    []
+  "verify":        [12, 34],
+  "release_watch": [55, 56],
+  "errors":        []
 }
 ```
 


### PR DESCRIPTION
Closes #369.

A finding reaching `fixed` means the maintainer landed a patch, but consumers cannot pin to a commit. They need a tagged release. This PR adds a new finding-scoped `release-watch` skill that watches for that release and records it on the finding, so the lifecycle visibly ends at a shipped version and the metrics in dora-metrics can compute fixed-to-released latency rather than ending the funnel at `fixed`.

- `skills/release-watch/` carries SKILL.md and schema. The skill takes `fix_commit` (preferred) or `fix_version`, lists upstream releases via `gh api`, and emits the *earliest* release whose commit is at or after `fix_commit` (the first version consumers can upgrade to). When no matching release exists yet it returns `released: false` with a specific note, so a re-run knows what changed. Idempotent: a finding with a release already recorded re-confirms rather than flapping.
- `Finding.ReleasedAt` (`*time.Time`), `Finding.ReleaseTag`, and `Finding.ReleaseURL` columns added through AutoMigrate. Tag and URL are editable through `findingFieldAccessor` (history recorded); `released_at` is written directly with its own history row since the accessor signature is string-typed.
- `parseReleaseWatchOutput` validates the report shape (release_tag/url present and release_at parseable) before touching the DB, then writes through `db.WriteFindingField` (`source=model_suggested`), adds a `FindingReference` tagged `upstream-release`, and emits a progress event. A `released: false` outcome records a `FindingNote` so the operator can see what the latest run said without trawling scan logs.
- `Worker.parseSkillOutput` dispatches `output_kind: release_watch`. `internal/skills` registers the kind.
- The triage skill is extended to enqueue release-watch for findings in `status=fixed`, mirroring how it already re-enqueues verify for `reported`/`acknowledged`. The output document gains a `release_watch` field listing the ids enqueued. Triage's "do not verify findings in other states" line is reworded so `fixed` is no longer described as closed (release-watch makes it actionable).
- UI: a `Released` row joins `Fix version` and `Fix commit` in the finding metadata block, linking the release page.
- Tests cover the released-happy path (columns + reference + history rows for tag/url/released_at), the released-false note path, and rejection of a missing/unparseable `release_at` (validated upfront so the test can run without a DB).
- Docs: `docs/skills.md` skill row + output-kind row + finding-scoped list, `docs/database.md` Finding columns, `README.md` skill table.

Does not transition the finding's status: `published` is a human act for the advisory going public, and a release shipping is a different signal.