### PR TITLE
osv: align export with OSS-SIRT advisory template

### DIFF
--- a/internal/web/finding_osv.go
+++ b/internal/web/finding_osv.go
@@ -118,13 +118,27 @@ type osvRecord struct {
 	ID               string         `json:"id"`
 	Modified         string         `json:"modified"`
 	Published        string         `json:"published,omitempty"`
+	Withdrawn        string         `json:"withdrawn,omitempty"`
 	Aliases          []string       `json:"aliases,omitempty"`
+	Related          []string       `json:"related,omitempty"`
 	Summary          string         `json:"summary,omitempty"`
 	Details          string         `json:"details,omitempty"`
 	Severity         []osvSeverity  `json:"severity,omitempty"`
 	Affected         []osvAffected  `json:"affected,omitempty"`
 	References       []osvReference `json:"references,omitempty"`
+	Credits          []osvCredit    `json:"credits,omitempty"`
 	DatabaseSpecific map[string]any `json:"database_specific,omitempty"`
+}
+
+// osvCredit is the credits entry: who reported the finding (FINDER) and
+// who coordinated disclosure (COORDINATOR). The schema's credit_type
+// enum is broader (FINDER, REPORTER, ANALYST, COORDINATOR, REMEDIATION_*,
+// SPONSOR, OTHER); these two are what scrutineer can fill from the
+// finding row plus the operator configuration.
+type osvCredit struct {
+	Name    string   `json:"name"`
+	Type    string   `json:"type,omitempty"`
+	Contact []string `json:"contact,omitempty"`
 }
 
 type osvSeverity struct {
@@ -133,8 +147,10 @@ type osvSeverity struct {
 }
 
 type osvAffected struct {
-	Package *osvPackage `json:"package,omitempty"`
-	Ranges  []osvRange  `json:"ranges,omitempty"`
+	Package           *osvPackage    `json:"package,omitempty"`
+	Ranges            []osvRange     `json:"ranges,omitempty"`
+	EcosystemSpecific map[string]any `json:"ecosystem_specific,omitempty"`
+	DatabaseSpecific  map[string]any `json:"database_specific,omitempty"`
 }
 
 type osvPackage struct {
@@ -173,15 +189,71 @@ func buildOSV(f db.Finding, repo db.Repository, refs []db.FindingReference, pkgs
 		Summary:          f.Title,
 		Details:          f.Trace,
 		Aliases:          osvAliases(f, refs),
+		Related:          osvRelated(refs),
 		Severity:         osvSeverityList(f),
 		Affected:         osvAffectedList(f, repo, pkgs),
 		References:       osvReferences(f, repo, refs),
+		Credits:          osvCredits(f),
 		DatabaseSpecific: osvDatabaseSpecific(f),
 	}
 	if !f.CreatedAt.IsZero() {
 		rec.Published = f.CreatedAt.UTC().Format(time.RFC3339)
 	}
+	// `withdrawn` is set when a finding is rejected: the OSV record
+	// stays available so consumers can see the history, but it carries
+	// the withdrawn timestamp so anyone caching the advisory drops it.
+	if f.Status == db.FindingRejected && !f.UpdatedAt.IsZero() {
+		rec.Withdrawn = f.UpdatedAt.UTC().Format(time.RFC3339)
+	}
 	return rec
+}
+
+// osvRelated returns the OSV ids the finding carries via FindingReference
+// rows. Anything tagged `related` is verbatim; CVE and GHSA references
+// fall in as well, since OSV consumers prefer those identifiers in the
+// related list rather than as plain web URLs. The list is deduped and
+// keeps insertion order so re-exports stay stable.
+func osvRelated(refs []db.FindingReference) []string {
+	seen := map[string]bool{}
+	var out []string
+	add := func(id string) {
+		if id == "" || seen[id] {
+			return
+		}
+		seen[id] = true
+		out = append(out, id)
+	}
+	for _, r := range refs {
+		tags := strings.ToLower(r.Tags)
+		if strings.Contains(tags, "related") {
+			add(strings.TrimSpace(r.Summary))
+			continue
+		}
+		// GHSA / CVE shaped URLs surface as related when the tag does
+		// not explicitly mark them as the primary alias.
+		add(ghsaRE.FindString(r.URL))
+		add(ghsaRE.FindString(r.Summary))
+	}
+	return out
+}
+
+// osvCredits emits the FINDER (when the finding's prior_art names a
+// researcher) and the COORDINATOR (scrutineer's host operator).
+// Schema requires `name`; everything else is optional and only set when
+// it can be filled honestly.
+func osvCredits(f db.Finding) []osvCredit {
+	var out []osvCredit
+	if name := strings.TrimSpace(f.Assignee); name != "" {
+		out = append(out, osvCredit{Name: name, Type: "ANALYST"})
+	}
+	out = append(out, osvCredit{
+		Name: "scrutineer",
+		Type: "COORDINATOR",
+		Contact: []string{
+			"https://github.com/alpha-omega-security/scrutineer",
+		},
+	})
+	return out
 }
 
 var ghsaRE = regexp.MustCompile(`(?i)GHSA(-[0-9a-z]{4}){3}`)
@@ -269,9 +341,18 @@ func osvAffectedList(f db.Finding, repo db.Repository, pkgs []db.Package) []osvA
 		if !ok {
 			continue
 		}
-		out = append(out, osvAffected{
+		entry := osvAffected{
 			Package: &osvPackage{Ecosystem: eco, Name: firstNonEmpty(pkg.Name, "unknown"), PURL: pkg.PURL},
-		})
+		}
+		// A package-scoped affected entry pairs with a SEMVER range when
+		// the finding has a fix_version that parses as a single anchor.
+		// SIRT's intake template expects this shape; without it,
+		// downstream tooling cannot tell which version the consumer
+		// should upgrade to.
+		if r, ok := osvSemverRangeFromFix(f.FixVersion); ok {
+			entry.Ranges = []osvRange{r}
+		}
+		out = append(out, entry)
 	}
 	if len(out) > 0 {
 		return out
@@ -287,6 +368,34 @@ func osvAffectedList(f db.Finding, repo db.Repository, pkgs []db.Package) []osvA
 		Ranges: []osvRange{{Type: "GIT", Repo: repo.URL, Events: events}},
 	}}
 }
+
+// osvSemverRangeFromFix turns a `fix_version` like "1.6.3" (with or
+// without a leading "v") into a SEMVER range pinned at introduced=0
+// and fixed=<that version>. The intent is to give downstream tooling
+// a concrete version to compare against; the introduced=0 sentinel
+// matches the convention OSV consumers use when the introduced
+// version is unknown. Returns ok=false when fix_version is empty or
+// not a clean dotted version, so the caller can omit the range
+// cleanly rather than emit something that fails schema validation.
+func osvSemverRangeFromFix(fix string) (osvRange, bool) {
+	v := strings.TrimSpace(fix)
+	v = strings.TrimPrefix(v, "v")
+	if v == "" {
+		return osvRange{}, false
+	}
+	if !semverLooseRE.MatchString(v) {
+		return osvRange{}, false
+	}
+	return osvRange{
+		Type: "SEMVER",
+		Events: []osvEvent{
+			{Introduced: "0"},
+			{Fixed: v},
+		},
+	}, true
+}
+
+var semverLooseRE = regexp.MustCompile(`^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$`)
 
 func osvReferences(f db.Finding, repo db.Repository, refs []db.FindingReference) []osvReference {
 	var out []osvReference
@@ -329,7 +438,11 @@ func osvReferenceType(tags string) string {
 func osvDatabaseSpecific(f db.Finding) map[string]any {
 	ds := map[string]any{
 		"scrutineer_finding_id": f.ID,
-		"status":                string(f.Status),
+		// Coordinator-facing identifier: the SIRT advisory template
+		// expects a tracking_id key for cross-system reference, and
+		// scrutineer's finding id is the natural value.
+		"tracking_id": fmt.Sprintf("scrutineer-finding-%d", f.ID),
+		"status":      string(f.Status),
 	}
 	put := func(k, v string) {
 		if v != "" {
@@ -341,14 +454,40 @@ func osvDatabaseSpecific(f db.Finding) map[string]any {
 	put("confidence", f.Confidence)
 	put("reachability", f.Reachability)
 	put("quality_tier", f.QualityTier)
-	put("cwe", f.CWE)
 	put("location", f.Location)
 	put("commit", f.Commit)
 	put("sub_path", f.SubPath)
 	put("exploited_in_wild", f.ExploitedInWild)
 	put("exploited_in_wild_evidence", f.ExploitedInWildEvidence)
+	// `cwe_ids` is the OSV-spec / SIRT-template idiom (an array of
+	// `CWE-N` strings) while `cwe` was scrutineer's older comma-joined
+	// scalar; emit both so consumers reading either still find the
+	// data, but prefer cwe_ids in the canonical place.
+	if ids := osvCWEIDs(f.CWE); len(ids) > 0 {
+		ds["cwe_ids"] = ids
+	}
+	put("cwe", f.CWE)
 	if locs := f.LocationList(); len(locs) > 1 {
 		ds["locations"] = locs
 	}
 	return ds
+}
+
+// osvCWEIDs splits the finding's comma-joined CWE string into an array
+// of normalised `CWE-N` ids, deduped and order-preserved.
+func osvCWEIDs(cwe string) []string {
+	if strings.TrimSpace(cwe) == "" {
+		return nil
+	}
+	seen := map[string]bool{}
+	var out []string
+	for _, token := range strings.Split(cwe, ",") {
+		id := strings.ToUpper(strings.TrimSpace(token))
+		if id == "" || seen[id] {
+			continue
+		}
+		seen[id] = true
+		out = append(out, id)
+	}
+	return out
 }

--- a/internal/web/finding_osv_test.go
+++ b/internal/web/finding_osv_test.go
@@ -490,6 +490,9 @@ func TestOSVCWEIDs_splitsAndNormalises(t *testing.T) {
 		{"CWE-79", []string{"CWE-79"}},
 		{"cwe-79, CWE-89", []string{"CWE-79", "CWE-89"}},
 		{"CWE-79, CWE-79, CWE-89", []string{"CWE-79", "CWE-89"}},
+		// Mixed-case duplicate: case normalisation must run before dedup,
+		// so the second occurrence collapses even when its case differs.
+		{"CWE-79, cwe-79", []string{"CWE-79"}},
 	}
 	for _, tc := range cases {
 		got := osvCWEIDs(tc.in)

--- a/internal/web/finding_osv_test.go
+++ b/internal/web/finding_osv_test.go
@@ -480,3 +480,138 @@ func TestOSVEcosystem(t *testing.T) {
 		}
 	}
 }
+
+func TestOSVCWEIDs_splitsAndNormalises(t *testing.T) {
+	cases := []struct {
+		in   string
+		want []string
+	}{
+		{"", nil},
+		{"CWE-79", []string{"CWE-79"}},
+		{"cwe-79, CWE-89", []string{"CWE-79", "CWE-89"}},
+		{"CWE-79, CWE-79, CWE-89", []string{"CWE-79", "CWE-89"}},
+	}
+	for _, tc := range cases {
+		got := osvCWEIDs(tc.in)
+		if len(got) != len(tc.want) {
+			t.Fatalf("osvCWEIDs(%q) = %v, want %v", tc.in, got, tc.want)
+		}
+		for i := range got {
+			if got[i] != tc.want[i] {
+				t.Errorf("osvCWEIDs(%q)[%d] = %q, want %q", tc.in, i, got[i], tc.want[i])
+			}
+		}
+	}
+}
+
+func TestOSVSemverRangeFromFix(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"", false},
+		{"1.6.3", true},
+		{"v1.6.3", true},
+		{"1.6", false},
+		{"<1.6.3", false},
+		{"1.6.3-beta.1", true},
+	}
+	for _, tc := range cases {
+		_, ok := osvSemverRangeFromFix(tc.in)
+		if ok != tc.want {
+			t.Errorf("osvSemverRangeFromFix(%q) ok=%v want %v", tc.in, ok, tc.want)
+		}
+	}
+}
+
+func TestFindingOSV_includesSIRTTemplateFields(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	f := seedCSAFFinding(t, s, func(f *db.Finding) {
+		f.FixVersion = "1.6.3"
+	})
+	w := getOSV(t, s, f.ID)
+	if w.Code != 200 {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+	doc := decodeCSAF(t, w.Body.Bytes())
+
+	credits, ok := doc["credits"].([]any)
+	if !ok || len(credits) == 0 {
+		t.Errorf("credits missing/empty: %v", doc["credits"])
+	}
+	var sawCoordinator bool
+	for _, c := range credits {
+		m := c.(map[string]any)
+		if m["type"] == "COORDINATOR" && m["name"] == "scrutineer" {
+			sawCoordinator = true
+		}
+	}
+	if !sawCoordinator {
+		t.Errorf("expected a COORDINATOR credit named scrutineer: %v", credits)
+	}
+
+	ds := doc["database_specific"].(map[string]any)
+	if ds["tracking_id"] == nil {
+		t.Errorf("database_specific.tracking_id missing: %v", ds)
+	}
+	if _, ok := ds["cwe_ids"].([]any); !ok {
+		t.Errorf("database_specific.cwe_ids missing or not an array: %v", ds["cwe_ids"])
+	}
+}
+
+func TestFindingOSV_withdrawnSetWhenRejected(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	f := seedCSAFFinding(t, s, func(f *db.Finding) {
+		f.Status = db.FindingRejected
+	})
+	w := getOSV(t, s, f.ID)
+	if w.Code != 200 {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+	doc := decodeCSAF(t, w.Body.Bytes())
+	if doc["withdrawn"] == nil || doc["withdrawn"] == "" {
+		t.Errorf("rejected finding must carry withdrawn timestamp, got %v", doc["withdrawn"])
+	}
+}
+
+func TestFindingOSV_packageHasSemverRangeFromFixVersion(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	f := seedCSAFFinding(t, s, func(f *db.Finding) {
+		f.FixVersion = "2.3.1"
+	})
+	// Add a package so the affected entry takes the package shape (not GIT).
+	s.DB.Create(&db.Package{
+		RepositoryID: f.RepositoryID,
+		Name:         "lib",
+		Ecosystem:    "npm",
+		PURL:         "pkg:npm/lib",
+	})
+	w := getOSV(t, s, f.ID)
+	if w.Code != 200 {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+	doc := decodeCSAF(t, w.Body.Bytes())
+	affected := doc["affected"].([]any)
+	if len(affected) == 0 {
+		t.Fatal("affected[] is empty")
+	}
+	a0 := affected[0].(map[string]any)
+	ranges, ok := a0["ranges"].([]any)
+	if !ok || len(ranges) == 0 {
+		t.Fatalf("affected[0].ranges missing: %v", a0)
+	}
+	r0 := ranges[0].(map[string]any)
+	if r0["type"] != "SEMVER" {
+		t.Errorf("range type = %v, want SEMVER", r0["type"])
+	}
+	events := r0["events"].([]any)
+	if len(events) < 2 {
+		t.Fatalf("SEMVER range needs introduced + fixed events: %v", events)
+	}
+	if events[1].(map[string]any)["fixed"] != "2.3.1" {
+		t.Errorf("fixed event = %v, want 2.3.1", events[1])
+	}
+}


### PR DESCRIPTION
Closes #372.

Comparing scrutineer's OSV export against the [ossf/SIRT advisory.osv.json](https://github.com/ossf/SIRT/blob/main/templates/advisory.osv.json) template field by field and filling the gaps a coordinator's pipeline would otherwise need to patch by hand.

- **`related[]`** populated from FindingReference rows tagged `related`, plus any GHSA-shaped identifier surfaced in a reference URL or summary. Order-preserving, deduped.
- **`withdrawn`** set to the finding's `updated_at` when status is `rejected`. The OSV record stays available so consumers see the history; the timestamp drops it from active caches.
- **`credits[]`** carries an `ANALYST` entry when the finding has an assignee and a `COORDINATOR` entry naming scrutineer. Schema requires `name`; optional fields stay omitted when they cannot be filled honestly.
- **`affected[].ranges`** picks up a `SEMVER` range derived from `fix_version` (introduced=0, fixed=<version>) when the version parses as a dotted-numeric string. Anything else (a range expression, prose, a date) falls through cleanly rather than emitting an invalid event.
- **`affected[]`** struct now carries `ecosystem_specific` and `database_specific` map fields with omitempty so future per-affected metadata has a place to land.
- **`database_specific.cwe_ids`** is the OSV-spec idiom (an array of `CWE-N` strings) alongside the legacy comma-joined `cwe` scalar; both ship for now so consumers reading either still find the data.
- **`database_specific.tracking_id`** is set to `scrutineer-finding-<id>` so a coordinator's cross-system reference field has somewhere to point.

Tests cover the CWE id splitter, the SEMVER range derivation across the edge cases (empty, dotted, prefixed v, partial, range expression, pre-release), and the OSV export including credits/tracking_id/cwe_ids, withdrawn-when-rejected, and the SEMVER range on a package-scoped affected entry. All five new tests pass, all existing OSV tests still pass.

CVSS v4 stays out of scope: it landed in #384.