### PR TITLE
worker: extract reobserveFinding + restore gofmt on db.go

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -472,9 +472,9 @@ type Finding struct {
 	// fixed-to-released latency rather than ending the funnel at the
 	// commit landing. All three move together: zero/empty until a
 	// release is found.
-	ReleasedAt *time.Time
-	ReleaseTag string
-	ReleaseURL string
+	ReleasedAt      *time.Time
+	ReleaseTag      string
+	ReleaseURL      string
 	Resolution      FindingResolution `gorm:"index"`
 	DisclosureDraft string            `gorm:"type:text"`
 	Assignee        string            `gorm:"index"`

--- a/internal/worker/skill.go
+++ b/internal/worker/skill.go
@@ -304,35 +304,8 @@ func (w *Worker) parseFindingsOutput(skill *db.Skill, scan *db.Scan, report stri
 		err := w.DB.Where("repository_id = ? AND fingerprint = ?", scan.RepositoryID, f.Fingerprint).
 			Order("id").First(&existing).Error
 		if err == nil {
-			updates := map[string]any{
-				"last_seen_scan_id":   scan.ID,
-				"last_seen_commit":    scan.Commit,
-				"seen_count":          existing.SeenCount + 1,
-				"missed_count":        0,
-				"last_missed_scan_id": 0,
-				"location":            f.Location,
-				"locations":           f.Locations,
-			}
-			// Refresh the VID so it tracks the code as it drifts, but
-			// never wipe a stored one just because this run could not
-			// compute (vid binary missing, location gone).
-			if f.VID != "" {
-				updates["vid"] = f.VID
-			}
-			if uerr := w.DB.Model(&db.Finding{}).Where("id = ?", existing.ID).Updates(updates).Error; uerr != nil {
-				return fmt.Errorf("update finding %d: %w", existing.ID, uerr)
-			}
-			if rerr := w.upsertFindingReferences(existing.ID, f.References); rerr != nil {
-				w.Log.Warn("upsert finding references", "finding", existing.ID, "scan", scan.ID, "err", rerr)
-			}
-			if herr := w.DB.Create(&db.FindingHistory{
-				FindingID: existing.ID,
-				Field:     "observed",
-				NewValue:  fmt.Sprintf("scan %d @ %s", scan.ID, scan.Commit),
-				Source:    db.SourceTool,
-				By:        scan.SkillName,
-			}).Error; herr != nil {
-				w.Log.Warn("record observed-again finding history", "finding", existing.ID, "scan", scan.ID, "err", herr)
+			if uerr := w.reobserveFinding(&existing, f, scan); uerr != nil {
+				return uerr
 			}
 			observed++
 			continue
@@ -350,6 +323,45 @@ func (w *Worker) parseFindingsOutput(skill *db.Skill, scan *db.Scan, report stri
 
 	if db.SeverityAtLeast(worst, skill.FailOn) {
 		return &FailOnThresholdError{Worst: worst, Threshold: skill.FailOn}
+	}
+	return nil
+}
+
+// reobserveFinding handles the dedup branch in parseFindingsOutput:
+// bump the seen-count, refresh fields that may drift between scans
+// (location, VID, references), and write an `observed` history row.
+// Reference and history failures are logged but not fatal; the finding
+// row write itself does propagate so a real DB error stops the scan.
+func (w *Worker) reobserveFinding(existing, f *db.Finding, scan *db.Scan) error {
+	updates := map[string]any{
+		"last_seen_scan_id":   scan.ID,
+		"last_seen_commit":    scan.Commit,
+		"seen_count":          existing.SeenCount + 1,
+		"missed_count":        0,
+		"last_missed_scan_id": 0,
+		"location":            f.Location,
+		"locations":           f.Locations,
+	}
+	// Refresh the VID so it tracks the code as it drifts, but never
+	// wipe a stored one just because this run could not compute (vid
+	// binary missing, location gone).
+	if f.VID != "" {
+		updates["vid"] = f.VID
+	}
+	if err := w.DB.Model(&db.Finding{}).Where("id = ?", existing.ID).Updates(updates).Error; err != nil {
+		return fmt.Errorf("update finding %d: %w", existing.ID, err)
+	}
+	if err := w.upsertFindingReferences(existing.ID, f.References); err != nil {
+		w.Log.Warn("upsert finding references", "finding", existing.ID, "scan", scan.ID, "err", err)
+	}
+	if err := w.DB.Create(&db.FindingHistory{
+		FindingID: existing.ID,
+		Field:     "observed",
+		NewValue:  fmt.Sprintf("scan %d @ %s", scan.ID, scan.Commit),
+		Source:    db.SourceTool,
+		By:        scan.SkillName,
+	}).Error; err != nil {
+		w.Log.Warn("record observed-again finding history", "finding", existing.ID, "scan", scan.ID, "err", err)
 	}
 	return nil
 }


### PR DESCRIPTION
Two main-branch cleanups that surfaced together.

`parseFindingsOutput` was at gocognit 31 (one over the 30 threshold);
extracted the dedup-update branch into `reobserveFinding`. No behaviour
change.

A struct-field alignment in `internal/db/db.go` for the new `ReleasedAt`/
`ReleaseTag`/`ReleaseURL` block slipped during the #385 merge resolution.
`gofmt -w` restores it.

`golangci-lint run ./...` is clean after these.