### PR TITLE
fork: rewrite for private staging repo with configurable metadata dir

### DIFF
--- a/cmd/scrutineer/main.go
+++ b/cmd/scrutineer/main.go
@@ -96,6 +96,7 @@ type flags struct {
 	maxTurns         int
 	anthropicBaseURL string
 	forkOrg          string
+	metadataDir      string
 	schemaStrict     bool
 	skillLocal       skillDirs
 
@@ -180,6 +181,9 @@ func (f *flags) merge(cfg *config.Config) {
 	}
 	if cfg.ForkOrg != "" && !f.set["fork-org"] {
 		f.forkOrg = cfg.ForkOrg
+	}
+	if cfg.MetadataDir != "" {
+		f.metadataDir = cfg.MetadataDir
 	}
 	if cfg.SchemaStrict != nil && !f.set["schema-strict"] {
 		f.schemaStrict = *cfg.SchemaStrict
@@ -309,6 +313,7 @@ func run(log *slog.Logger) error {
 		DataDir:      filepath.Join(f.dataDir, "work"),
 		APIBase:      apiBase,
 		ForkOrg:      f.forkOrg,
+		MetadataDir:  f.metadataDir,
 		Runner:       runner,
 		ScanTimeout:  f.scanTimeout,
 		SchemaStrict: f.schemaStrict,

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -183,12 +183,13 @@ The worker then runs `claude -p "Use the {name} skill in this workspace"` with t
     "dependent_id": 11,
     "scan_ref": "release/2.x",
     "scan_subpath": "packages/core",
-    "fork_org": "your-security-forks"
+    "fork_org": "your-security-forks",
+    "metadata_dir": ".scrutineer/"
   }
 }
 ```
 
-`finding_id` is only present for finding-scoped skills (`verify`, `revalidate`, `breaking-change`, `disclose`, `patch`, `mitigate`, `release-watch`, `exposure`). `dependent_id` is only set on `exposure` runs and points to the dependent whose code is under audit; `./src` is then a copy of that dependent's clone, not of the finding's repository. `scan_ref` is empty when the scan is on the default branch. `scan_subpath` is set when the operator scoped the scan to a monorepo sub-folder; skills that walk source honour it, skills that query external APIs by repository URL ignore it. `fork_org` is absent unless `-fork-org` is configured. `packages` is a convenience copy of the package rows when the `packages` skill has already run; otherwise it is omitted.
+`finding_id` is only present for finding-scoped skills (`verify`, `revalidate`, `breaking-change`, `disclose`, `patch`, `mitigate`, `release-watch`, `exposure`). `dependent_id` is only set on `exposure` runs and points to the dependent whose code is under audit; `./src` is then a copy of that dependent's clone, not of the finding's repository. `scan_ref` is empty when the scan is on the default branch. `scan_subpath` is set when the operator scoped the scan to a monorepo sub-folder; skills that walk source honour it, skills that query external APIs by repository URL ignore it. `fork_org` is absent unless `-fork-org` is configured. `metadata_dir` is the directory inside a staging repo where scrutineer keeps its per-project metadata (`.scrutineer/` by default); operators with a different consortium-flavoured convention set `metadata_dir` in scrutineer.yaml. `packages` is a convenience copy of the package rows when the `packages` skill has already run; otherwise it is omitted.
 
 ## schema.json
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -67,6 +67,12 @@ type Config struct {
 	// Empty disables the fork skill (it will refuse to run without a target
 	// org).
 	ForkOrg string `yaml:"fork_org"`
+	// MetadataDir is the path inside a staging repo where scrutineer keeps
+	// its per-project metadata (repo-level metadata.yaml plus one directory
+	// per finding). Empty defaults to `.scrutineer/`. Operators with a
+	// different consortium-flavoured convention can override it (e.g.
+	// `.ossprey/`), which keeps the rest of the codebase neutral.
+	MetadataDir string `yaml:"metadata_dir"`
 	// SchemaStrict makes a skill report that fails JSON-schema validation
 	// fail the scan. When false (the default) the validator output is
 	// emitted to the scan log and the kind-specific parser still runs.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -62,9 +62,10 @@ type Config struct {
 	// Theme selects the colour scheme: "claude" (default), "ocean-breeze",
 	// "catppuccin", "sunset-horizon", "midnight-bloom", or "northern-lights".
 	Theme string `yaml:"theme"`
-	// ForkOrg is the GitHub organisation the fork skill forks scanned
-	// repositories into and files draft advisories against. Empty disables
-	// the fork skill (it will refuse to run without a target org).
+	// ForkOrg is the GitHub organisation the fork skill stages scanned
+	// repositories into as private repos and files finding issues against.
+	// Empty disables the fork skill (it will refuse to run without a target
+	// org).
 	ForkOrg string `yaml:"fork_org"`
 	// SchemaStrict makes a skill report that fails JSON-schema validation
 	// fail the scan. When false (the default) the validator output is

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -67,6 +67,7 @@ clone: full
 scan_timeout: 30m
 max_turns: 200
 fork_org: fork-central
+metadata_dir: .ossprey/
 `)
 	c, err := Load(path)
 	if err != nil {
@@ -101,6 +102,9 @@ fork_org: fork-central
 	}
 	if c.ForkOrg != "fork-central" {
 		t.Errorf("fork_org=%q, want fork-central", c.ForkOrg)
+	}
+	if c.MetadataDir != ".ossprey/" {
+		t.Errorf("metadata_dir=%q, want .ossprey/", c.MetadataDir)
 	}
 }
 

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -55,9 +55,11 @@ type Repository struct {
 	Posture        string `gorm:"index"`
 	PostureSummary string
 
-	// Fork is the full_name (owner/name) of this repository's fork inside
-	// the configured fork_org. Written by the fork skill so later runs and
-	// the UI can find the staging fork without re-resolving the name.
+	// Fork is the full_name (owner/name) of this repository's private
+	// staging repo inside the configured fork_org. Written by the fork
+	// skill so later runs and the UI can find it without re-resolving the
+	// name. Named `Fork` for legacy reasons; semantically a staging repo,
+	// not a GitHub fork relationship.
 	Fork string
 
 	// CloneError is set when the last clone/fetch attempt failed (repo

--- a/internal/worker/exposure.go
+++ b/internal/worker/exposure.go
@@ -166,7 +166,7 @@ func (w *Worker) doExposure(ctx context.Context, scan *db.Scan, emit func(Event)
 	if err := stageSkill(&skill, workRoot, skillDir); err != nil {
 		return "", fmt.Errorf("stage skill: %w", err)
 	}
-	if err := stageContext(workRoot, w.APIBase, w.ForkOrg, scan, &scan.Repository); err != nil {
+	if err := stageContext(workRoot, w.APIBase, w.ForkOrg, w.metadataDir(), scan, &scan.Repository); err != nil {
 		return "", fmt.Errorf("stage context: %w", err)
 	}
 

--- a/internal/worker/skill.go
+++ b/internal/worker/skill.go
@@ -43,10 +43,20 @@ type skillContextScrutineer struct {
 	// support). Empty means the repo root. Skills that walk files honour
 	// this; skills that query external APIs ignore it.
 	ScanSubPath string `json:"scan_subpath,omitempty"`
-	// ForkOrg is the GitHub organisation the fork skill forks into and
-	// files draft advisories against. Absent when fork_org is unconfigured.
+	// ForkOrg is the GitHub organisation the fork skill stages scanned
+	// repositories into. Absent when fork_org is unconfigured.
 	ForkOrg string `json:"fork_org,omitempty"`
+	// MetadataDir is the path inside a staging repo where scrutineer
+	// metadata lives (`.scrutineer/` by default). Always written so
+	// skills can build paths without re-applying the default.
+	MetadataDir string `json:"metadata_dir"`
 }
+
+// DefaultMetadataDir is the value used when scrutineer.yaml does not
+// configure `metadata_dir`. Keep it scrutineer-flavoured; an operator
+// who wants a consortium-flavoured directory (e.g. `.ossprey/`) sets
+// metadata_dir explicitly.
+const DefaultMetadataDir = ".scrutineer/"
 
 type skillContextRepo struct {
 	URL           string `json:"url"`
@@ -121,7 +131,7 @@ func (w *Worker) doSkill(ctx context.Context, scan *db.Scan, emit func(Event)) (
 	}
 
 	skillDir := filepath.Join(workRoot, ".claude", "skills", skill.Name)
-	if err := stageContext(workRoot, w.APIBase, w.ForkOrg, scan, &scan.Repository); err != nil {
+	if err := stageContext(workRoot, w.APIBase, w.ForkOrg, w.metadataDir(), scan, &scan.Repository); err != nil {
 		return "", fmt.Errorf("stage context: %w", err)
 	}
 	if err := stageSkill(&skill, workRoot, skillDir); err != nil {
@@ -738,7 +748,17 @@ func stageImportPayload(workRoot string, payload []byte) error {
 // rely on. Kept small and boring on purpose: skills that need more detail
 // can read it from the clone. The scrutineer block gives skills enough to
 // call back into the host API (list scans, trigger more skills).
-func stageContext(workRoot, apiBase, forkOrg string, scan *db.Scan, repo *db.Repository) error {
+// metadataDir returns the per-staging-repo metadata directory the
+// worker should hand to skills. Empty config falls back to the default
+// so callers never have to repeat the constant.
+func (w *Worker) metadataDir() string {
+	if w.MetadataDir == "" {
+		return DefaultMetadataDir
+	}
+	return w.MetadataDir
+}
+
+func stageContext(workRoot, apiBase, forkOrg, metadataDir string, scan *db.Scan, repo *db.Repository) error {
 	if err := os.MkdirAll(workRoot, dirPerm); err != nil {
 		return err
 	}
@@ -751,11 +771,12 @@ func stageContext(workRoot, apiBase, forkOrg string, scan *db.Scan, repo *db.Rep
 			DefaultBranch: repo.DefaultBranch,
 		},
 		Scrutineer: skillContextScrutineer{
-			APIBase: apiBase,
-			ScanID:  scan.ID,
-			Token:   scan.APIToken,
-			RepoID:  scan.RepositoryID,
-			ForkOrg: forkOrg,
+			APIBase:     apiBase,
+			ScanID:      scan.ID,
+			Token:       scan.APIToken,
+			RepoID:      scan.RepositoryID,
+			ForkOrg:     forkOrg,
+			MetadataDir: metadataDir,
 		},
 	}
 	if scan.SkillID != nil {

--- a/internal/worker/skill_test.go
+++ b/internal/worker/skill_test.go
@@ -255,7 +255,7 @@ func TestStageContext_writesRepoFacts(t *testing.T) {
 		DefaultBranch: "main",
 	}
 	scan := &db.Scan{ID: 7, RepositoryID: 3, APIToken: "tok"}
-	if err := stageContext(dir, "http://127.0.0.1:8080/api", "", scan, repo); err != nil {
+	if err := stageContext(dir, "http://127.0.0.1:8080/api", "", "", scan, repo); err != nil {
 		t.Fatal(err)
 	}
 	b, err := os.ReadFile(filepath.Join(dir, "context.json"))
@@ -341,7 +341,7 @@ func TestStageContext_includesRef(t *testing.T) {
 	dir := t.TempDir()
 	repo := &db.Repository{URL: "https://example.com/x", Name: "x"}
 	scan := &db.Scan{ID: 1, RepositoryID: 1, APIToken: "t", Ref: "2.4.x"}
-	if err := stageContext(dir, "http://127.0.0.1:8080/api", "", scan, repo); err != nil {
+	if err := stageContext(dir, "http://127.0.0.1:8080/api", "", "", scan, repo); err != nil {
 		t.Fatal(err)
 	}
 	b, err := os.ReadFile(filepath.Join(dir, "context.json"))
@@ -361,7 +361,7 @@ func TestStageContext_omitsRefWhenEmpty(t *testing.T) {
 	dir := t.TempDir()
 	repo := &db.Repository{URL: "https://example.com/x", Name: "x"}
 	scan := &db.Scan{ID: 1, RepositoryID: 1, APIToken: "t"}
-	if err := stageContext(dir, "http://127.0.0.1:8080/api", "", scan, repo); err != nil {
+	if err := stageContext(dir, "http://127.0.0.1:8080/api", "", "", scan, repo); err != nil {
 		t.Fatal(err)
 	}
 	b, err := os.ReadFile(filepath.Join(dir, "context.json"))
@@ -380,7 +380,7 @@ func TestStageContext_includesForkOrg(t *testing.T) {
 	dir := t.TempDir()
 	repo := &db.Repository{URL: "https://github.com/o/r", Name: "r"}
 	scan := &db.Scan{ID: 1, RepositoryID: 1, APIToken: "t"}
-	if err := stageContext(dir, "http://127.0.0.1:8080/api", "fork-central", scan, repo); err != nil {
+	if err := stageContext(dir, "http://127.0.0.1:8080/api", "fork-central", "", scan, repo); err != nil {
 		t.Fatal(err)
 	}
 	b, err := os.ReadFile(filepath.Join(dir, "context.json"))
@@ -393,6 +393,37 @@ func TestStageContext_includesForkOrg(t *testing.T) {
 	}
 	if got.Scrutineer.ForkOrg != "fork-central" {
 		t.Errorf("fork_org = %q, want fork-central", got.Scrutineer.ForkOrg)
+	}
+}
+
+func TestStageContext_includesMetadataDir(t *testing.T) {
+	dir := t.TempDir()
+	repo := &db.Repository{URL: "https://github.com/o/r", Name: "r"}
+	scan := &db.Scan{ID: 1, RepositoryID: 1, APIToken: "t"}
+	if err := stageContext(dir, "http://127.0.0.1:8080/api", "", ".ossprey/", scan, repo); err != nil {
+		t.Fatal(err)
+	}
+	b, err := os.ReadFile(filepath.Join(dir, "context.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got skillContext
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Scrutineer.MetadataDir != ".ossprey/" {
+		t.Errorf("metadata_dir = %q, want .ossprey/", got.Scrutineer.MetadataDir)
+	}
+}
+
+func TestWorker_metadataDir_defaultsWhenUnset(t *testing.T) {
+	w := &Worker{}
+	if got := w.metadataDir(); got != DefaultMetadataDir {
+		t.Errorf("default = %q, want %q", got, DefaultMetadataDir)
+	}
+	w.MetadataDir = ".custom/"
+	if got := w.metadataDir(); got != ".custom/" {
+		t.Errorf("override = %q, want .custom/", got)
 	}
 }
 

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -50,6 +50,10 @@ type Worker struct {
 	DataDir string // workspace root for clones
 	APIBase string // base URL for the scrutineer skill API (http://host:port/api)
 	ForkOrg string // github org the fork skill targets; empty disables it
+	// MetadataDir is the directory in a staging repo where scrutineer
+	// keeps per-project metadata. Empty means the worker substitutes
+	// the default, `.scrutineer/`, when staging the skill context.
+	MetadataDir string
 	Runner  SkillRunner
 	OnEvent func(scanID, repoID uint, name, data string) // optional SSE bridge
 	// OnFindingCreated, when non-nil, is called after a findings-emitting

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -54,8 +54,8 @@ type Worker struct {
 	// keeps per-project metadata. Empty means the worker substitutes
 	// the default, `.scrutineer/`, when staging the skill context.
 	MetadataDir string
-	Runner  SkillRunner
-	OnEvent func(scanID, repoID uint, name, data string) // optional SSE bridge
+	Runner      SkillRunner
+	OnEvent     func(scanID, repoID uint, name, data string) // optional SSE bridge
 	// OnFindingCreated, when non-nil, is called after a findings-emitting
 	// scan persists a fresh Finding row. The web layer wires it up to
 	// auto-enqueue a revalidate scan over High/Critical findings from

--- a/scrutineer.sample.yaml
+++ b/scrutineer.sample.yaml
@@ -99,3 +99,15 @@
 # (scrutineer.model in SKILL.md metadata); per-skill wins over this
 # default, and an explicit per-scan model wins over both.
 # default_model: claude-sonnet-4-6
+
+# GitHub organisation the fork skill stages scanned repositories into as
+# private repos. Empty disables the fork skill. Also exposed as
+# `-fork-org` on the command line; flag wins over this value.
+# fork_org: your-security-forks
+
+# Directory inside a staging repo where scrutineer keeps per-project
+# metadata (a repo-level metadata.yaml plus one folder per finding).
+# Default is `.scrutineer/`. Operators with a consortium-flavoured
+# convention can override it (e.g. `.ossprey/`); the scrutineer codebase
+# treats it as opaque.
+# metadata_dir: .scrutineer/

--- a/skills/fork/SKILL.md
+++ b/skills/fork/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: fork
-description: Stage a scanned repository into a private repo in the configured GitHub organisation. Creates the repo (no fork relationship), seeds it with the upstream tree, writes scrutineer metadata under `.ossprey/`, files one issue per open finding, and gives an org team push access. The staging repo is the per-project working surface for triage, fix development, and the disclosure paper trail.
+description: Stage a scanned repository into a private repo in the configured GitHub organisation. Creates the repo (no fork relationship), seeds it with the upstream tree, writes scrutineer metadata under the configured metadata directory, files one issue per open finding, and gives an org team push access. The staging repo is the per-project working surface for triage, fix development, and the disclosure paper trail.
 license: MIT
 compatibility: Needs the gh CLI authenticated with a token that can create private repos in `fork_org`, write to issues there, and manage team repo access. Needs network access to api.github.com and the scrutineer API. github.com upstreams only for now; other hosts will route through the same skill once `host__owner__repo` naming generalises.
 metadata:
@@ -12,12 +12,14 @@ metadata:
 
 # fork
 
-Stand up a private staging repo for one scanned upstream. The staging repo is a plain clone of the upstream tree (no GitHub fork relationship), lives in `fork_org`, and is the working surface for everything that follows: finding issues, PoC files, patch diffs, and validation reports all live here. Scrutineer's metadata sits in `.ossprey/` at the repo root. Run after a scan has produced findings; idempotent on re-runs.
+Stand up a private staging repo for one scanned upstream. The staging repo is a plain clone of the upstream tree (no GitHub fork relationship), lives in `fork_org`, and is the working surface for everything that follows: finding issues, PoC files, patch diffs, and validation reports all live here. Scrutineer's metadata sits at the repo root in the directory named by `scrutineer.metadata_dir` (default `.scrutineer/`). Run after a scan has produced findings; idempotent on re-runs.
+
+Below, the placeholder `{metadata_dir}` stands for the value of `scrutineer.metadata_dir` from `./context.json`. Substitute it verbatim before issuing any git or shell command.
 
 ## Workspace
 
 - `./src` — the upstream clone at the commit that was scanned
-- `./context.json` — has `repository.url`, `repository.full_name`, `repository.default_branch`, `scrutineer.api_base`, `scrutineer.token`, `scrutineer.repository_id`, `scrutineer.scan_id`, and `scrutineer.fork_org`
+- `./context.json` — has `repository.url`, `repository.full_name`, `repository.default_branch`, `scrutineer.api_base`, `scrutineer.token`, `scrutineer.repository_id`, `scrutineer.scan_id`, `scrutineer.fork_org`, and `scrutineer.metadata_dir`
 - `./report.json` — write what you did
 
 Use the `gh` CLI for every GitHub call. Do not use curl against api.github.com.
@@ -85,7 +87,7 @@ Authorization: Bearer {token}
 Build the per-repo metadata block:
 
 ```yaml
-# .ossprey/metadata.yaml
+# {metadata_dir}/metadata.yaml
 upstream:
   url: {repository.url}
   host: github.com
@@ -100,17 +102,17 @@ last_scan_commit: {same as seeded_commit on first run; refresh on re-runs}
 
 On re-runs only the `last_scan_*` fields change.
 
-The simplest write path is one commit per skill run carrying every file under `.ossprey/` that changed in this run. Clone the staging repo into a temp working tree, write the files, commit, push:
+The simplest write path is one commit per skill run carrying every file under `{metadata_dir}` that changed in this run. Clone the staging repo into a temp working tree, write the files, commit, push:
 
 ```
 TMP=$(mktemp -d)
 git clone --depth 1 https://github.com/{fork_org}/{host}__{owner}__{repo}.git "$TMP/staging"
 cd "$TMP/staging"
-mkdir -p .ossprey
-# write .ossprey/metadata.yaml and per-finding files (see step 4) here
-git add .ossprey
+mkdir -p {metadata_dir}
+# write {metadata_dir}/metadata.yaml and per-finding files (see step 4) here
+git add {metadata_dir}
 git -c user.email=scrutineer@local -c user.name=scrutineer \
-  commit -m "scrutineer: scan {scan_id} at {short-commit}" -m "Updated .ossprey/ from scrutineer run."
+  commit -m "scrutineer: scan {scan_id} at {short-commit}" -m "Updated {metadata_dir} from scrutineer run."
 git push origin {repository.default_branch}
 ```
 
@@ -122,7 +124,7 @@ Fetch the repository's findings: `GET {api_base}/repositories/{repository_id}/fi
 
 For each remaining finding fetch the full record (`GET {api_base}/findings/{id}`) so you have its prose, severity, status, CVSS, CWE, `disclosure_draft`, and `suggested_fix`.
 
-In the staging working tree, write the following files under `.ossprey/findings/{finding_id}/`:
+In the staging working tree, write the following files under `{metadata_dir}/findings/{finding_id}/`:
 
 - `metadata.yaml`:
   ```yaml
@@ -219,14 +221,14 @@ Colours: `severity:critical` `#8b0000`, `severity:high` `#dc3545`, `severity:med
 
 Status labels (`status:*`) are not applied by this skill yet; they belong with a future state-sync pass. Filing them prematurely would conflict with the future taxonomy.
 
-Capture the issue URL from the create response. Update `.ossprey/findings/{finding_id}/metadata.yaml` with `issue_url`. Then write the issue link back to scrutineer:
+Capture the issue URL from the create response. Update `{metadata_dir}/findings/{finding_id}/metadata.yaml` with `issue_url`. Then write the issue link back to scrutineer:
 
 - `POST {api_base}/findings/{id}/references` with `{"url": "<issue_url>", "tags": "staging-issue", "summary": "Issue on {fork_org} staging repo"}`
 - `POST {api_base}/findings/{id}/communications` with `{"channel": "github-issue", "direction": "outbound", "actor": "fork", "body": "Issue #{number} opened on {fork_org}/{host}__{owner}__{repo}"}`
 
 Do not change the finding's `status`. A staging issue is not a report upstream.
 
-After all writes, the working tree should contain one updated `.ossprey/metadata.yaml`, the per-finding directories with refreshed metadata and (where present) draft/patch files, and an unmodified upstream tree. Commit and push as described in step 3.
+After all writes, the working tree should contain one updated `{metadata_dir}/metadata.yaml`, the per-finding directories with refreshed metadata and (where present) draft/patch files, and an unmodified upstream tree. Commit and push as described in step 3.
 
 ## 6. Pick a team and give it push access
 

--- a/skills/fork/SKILL.md
+++ b/skills/fork/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: fork
-description: Fork the scanned repository into the configured GitHub organisation, enable private vulnerability reporting on the fork, record the scan as a git note, and file each finding as a draft security advisory on the fork with a relevant org team invited as collaborator. Run after a scan has produced findings; the fork is the staging area for disclosure work.
+description: Stage a scanned repository into a private repo in the configured GitHub organisation. Creates the repo (no fork relationship), seeds it with the upstream tree, writes scrutineer metadata under `.ossprey/`, files one issue per open finding, and gives an org team push access. The staging repo is the per-project working surface for triage, fix development, and the disclosure paper trail.
 license: MIT
-compatibility: Needs the gh CLI authenticated with a token that can create forks in the fork_org and manage repository settings and security advisories there. Needs network access to api.github.com and the scrutineer API. github.com upstreams only for now.
+compatibility: Needs the gh CLI authenticated with a token that can create private repos in `fork_org`, write to issues there, and manage team repo access. Needs network access to api.github.com and the scrutineer API. github.com upstreams only for now; other hosts will route through the same skill once `host__owner__repo` naming generalises.
 metadata:
   scrutineer.version: 1
   scrutineer.output_file: report.json
@@ -12,12 +12,12 @@ metadata:
 
 # fork
 
-Stage a scanned repository into the disclosure org. Forks the upstream into `fork_org`, turns on private vulnerability reporting on the fork, leaves a git note recording when scrutineer last scanned the upstream, and opens one draft advisory per finding on the fork so analysts and the relevant team can collaborate on the write-up before anything goes upstream.
+Stand up a private staging repo for one scanned upstream. The staging repo is a plain clone of the upstream tree (no GitHub fork relationship), lives in `fork_org`, and is the working surface for everything that follows: finding issues, PoC files, patch diffs, and validation reports all live here. Scrutineer's metadata sits in `.ossprey/` at the repo root. Run after a scan has produced findings; idempotent on re-runs.
 
 ## Workspace
 
 - `./src` — the upstream clone at the commit that was scanned
-- `./context.json` — has `repository.url`, `repository.full_name`, `scrutineer.api_base`, `scrutineer.token`, `scrutineer.repository_id`, `scrutineer.scan_id`, and `scrutineer.fork_org`
+- `./context.json` — has `repository.url`, `repository.full_name`, `repository.default_branch`, `scrutineer.api_base`, `scrutineer.token`, `scrutineer.repository_id`, `scrutineer.scan_id`, and `scrutineer.fork_org`
 - `./report.json` — write what you did
 
 Use the `gh` CLI for every GitHub call. Do not use curl against api.github.com.
@@ -27,126 +27,146 @@ Use the `gh` CLI for every GitHub call. Do not use curl against api.github.com.
 Read `./context.json`. Refuse to continue (write `{"error": "..."}` to `report.json` and exit 0) if:
 
 - `scrutineer.fork_org` is missing or empty — the operator has not configured `fork_org` in scrutineer.yaml
-- `repository.url` does not have host `github.com` — only GitHub upstreams are supported for now; non-GitHub hosts will get a create-in-org path later
+- `repository.url` does not have host `github.com` — other hosts get the same treatment but the host-prefix mapping (below) is hard-coded to `gh` for now
 - `gh auth status` fails — the runner has no GitHub credentials
 
 Derive `{owner}/{repo}` from `repository.full_name` (fall back to parsing the path of `repository.url`, stripping a trailing `.git`).
 
-## 1. Fork into the org
+## 1. Resolve the staging repo name
 
-First check whether scrutineer already knows the fork: `GET {api_base}/repositories/{repository_id}` returns a `fork` field. If it is non-empty and `gh repo view {fork}` succeeds with `.parent` pointing at `{owner}/{repo}`, use it as `{fork_org}/{fork_name}`, record `"forked": "exists"`, and skip to step 2.
+The staging repo lives at `{fork_org}/{host}__{owner}__{repo}`, lowercased:
 
-Otherwise the fork normally lives at `{fork_org}/{repo}`, but that slot may already be taken by an unrelated repository (e.g. forking `foo/redis` when `fork-central/redis` is already a fork of `bar/redis`). Resolve the fork name as follows.
+- `host` is `gh` for `github.com`
+- `owner` and `repo` come straight from the upstream URL
 
-For each candidate name, in order `{repo}` then `{owner}-{repo}`:
+So `https://github.com/madler/zlib` becomes `{fork_org}/gh__madler__zlib`. Deterministic and collision-free across hosts, so no probing for free slots.
 
-```
-gh repo view {fork_org}/{candidate} --json name,parent
-```
+If scrutineer already knows the staging repo (`GET {api_base}/repositories/{repository_id}` has a non-empty `fork`), use it as `{staging}` and skip to step 3. The field is named `fork` for legacy reasons; semantically it is the staging repo URL.
 
-- not found — the slot is free; remember this candidate as `{fork_name}` and stop
-- found and `.parent.owner.login == {owner}` and `.parent.name == {repo}` — this is already our fork; set `{fork_name}` to this candidate, record `"forked": "exists"`, and skip to step 2
-- found but the parent is something else (or null) — the name is taken by an unrelated repo; move to the next candidate
+## 2. Create and seed the staging repo
 
-If both candidates are taken by unrelated repositories, write `{"error": "no free fork name for {owner}/{repo} in {fork_org}"}` and exit 0.
-
-If you found a free slot, create the fork there:
+Check whether it already exists:
 
 ```
-gh repo fork {owner}/{repo} --org {fork_org} --fork-name {fork_name} --clone=false --default-branch-only
+gh repo view {fork_org}/{host}__{owner}__{repo}
 ```
 
-`gh repo fork` is asynchronous on GitHub's side. Poll `gh repo view {fork_org}/{fork_name}` until it returns 0 (a few seconds is normal; give up after a minute and report `{"error": "fork did not become available"}`). Record `"forked": "created"`.
+If `view` succeeds, record `"created": "exists"` and skip to step 3.
 
-Whichever path you took, persist the resolved name back to scrutineer so the next run and the UI can find it without re-probing:
+Otherwise create it:
+
+```
+gh repo create {fork_org}/{host}__{owner}__{repo} --private \
+  --description "scrutineer staging for {owner}/{repo}"
+```
+
+Then seed it from `./src`. The goal is a default branch on the staging repo that contains the upstream tree at its full history (so VIDs, fingerprints, locations, and patches all resolve the same way they do on the upstream):
+
+```
+cd ./src
+# Make sure history is complete enough to push. Shallow clones cannot be pushed.
+git fetch --unshallow origin || true
+git remote add scrutineer-staging https://github.com/{fork_org}/{host}__{owner}__{repo}.git
+git push scrutineer-staging HEAD:{repository.default_branch}
+```
+
+If `git fetch --unshallow` fails (the clone was already complete) ignore it. If the push fails because of unshallow, record `"error": "could not push full history"` and exit 0 — half-seeded repos cause more confusion than they fix.
+
+Record `"created": "created"` and persist the resolved name back to scrutineer so the next run skips the probe:
 
 ```
 PATCH {api_base}/repositories/{repository_id}
 Authorization: Bearer {token}
-{"fork": "{fork_org}/{fork_name}"}
+{"fork": "{fork_org}/{host}__{owner}__{repo}"}
 ```
 
-## 2. Enable private vulnerability reporting on the fork
+## 3. Write the repo-level metadata
 
-Use the dedicated endpoint; the `security_and_analysis` block on `PATCH /repos/...` accepts the field but does not actually flip it.
+Build the per-repo metadata block:
 
-```
-gh api -X PUT repos/{fork_org}/{fork_name}/private-vulnerability-reporting
-```
-
-A 204 means it is on. Confirm with `gh api repos/{fork_org}/{fork_name}/private-vulnerability-reporting` which returns `{"enabled": true|false}`. A 422 usually means the org has it forced on or off at the org level; record that in `notes` and carry on.
-
-## 3. Record the scan on the fork
-
-Record when scrutineer last looked at this repository, regardless of whether there were findings, as a git note on the scanned commit and push it to the fork. The note lives under `refs/notes/scrutineer` so it does not collide with anything upstream uses.
-
-```
-HEAD=$(git -C ./src rev-parse HEAD)
-NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-git -C ./src notes --ref=scrutineer add -f -m "scrutineer: scanned $NOW at $HEAD (scan {scan_id})" "$HEAD"
-git -C ./src push -f "https://github.com/{fork_org}/{fork_name}.git" refs/notes/scrutineer
+```yaml
+# .ossprey/metadata.yaml
+upstream:
+  url: {repository.url}
+  host: github.com
+  owner: {owner}
+  repo: {repo}
+seeded_at: {ISO-8601 timestamp, UTC}
+seeded_commit: {git -C ./src rev-parse HEAD}
+last_scan_at: {same timestamp, refreshed on every run}
+last_scan_id: {scan_id}
+last_scan_commit: {same as seeded_commit on first run; refresh on re-runs}
 ```
 
-If the workspace clone is shallow `git push` may need `git -C ./src fetch --unshallow` first; only do that if the push is rejected for shallow reasons. If the push fails for any other reason (branch protection on notes refs, auth), record the error in `notes` and carry on — the note is a convenience, not a hard requirement.
+On re-runs only the `last_scan_*` fields change.
 
-## 4. File draft advisories for findings
-
-Fetch the repository's findings: `GET {api_base}/repositories/{repository_id}/findings` with `Authorization: Bearer {token}`. File an advisory for every finding whose `status` is one of `new`, `enriched`, `triaged`, or `ready` — that is, anything that has not already been reported upstream or closed out. Skip `reported`, `acknowledged`, `fixed`, `published`, `rejected`, and `duplicate`; record those under `"skipped_advisories"` with the status as the reason. If nothing is left, record `"advisories": []` and skip to step 5.
-
-For each remaining finding fetch the full record (`GET {api_base}/findings/{id}`) so you have `disclosure_draft`, `cvss_vector`, `cwe`, `affected`, and `title`.
-
-Before filing, list the advisories already on the fork so re-runs do not duplicate:
+The simplest write path is one commit per skill run carrying every file under `.ossprey/` that changed in this run. Clone the staging repo into a temp working tree, write the files, commit, push:
 
 ```
-gh api repos/{fork_org}/{fork_name}/security-advisories --paginate --jq '.[].description'
+TMP=$(mktemp -d)
+git clone --depth 1 https://github.com/{fork_org}/{host}__{owner}__{repo}.git "$TMP/staging"
+cd "$TMP/staging"
+mkdir -p .ossprey
+# write .ossprey/metadata.yaml and per-finding files (see step 4) here
+git add .ossprey
+git -c user.email=scrutineer@local -c user.name=scrutineer \
+  commit -m "scrutineer: scan {scan_id} at {short-commit}" -m "Updated .ossprey/ from scrutineer run."
+git push origin {repository.default_branch}
 ```
 
-Every advisory this skill files carries a `[scrutineer-finding:{finding_id}]` marker on its last line (see below). Skip a finding whose marker already appears in any existing description; record it under `"skipped_advisories"` with reason `"already filed"`. Do not dedup on summary/title — distinct findings can share a title.
+The commit author is local; the push uses the gh CLI's credentials. One commit per run keeps the history readable.
 
-For each remaining finding, build the request body and create a draft repository security advisory on the fork. Use the admin create endpoint, not `/reports` — `/reports` is for external reporters and is rejected when the caller is a repo admin, which we are.
+## 4. Per-finding metadata files
 
-```
-gh api -X POST repos/{fork_org}/{fork_name}/security-advisories --input ./advisory-{finding_id}.json
-```
+Fetch the repository's findings: `GET {api_base}/repositories/{repository_id}/findings` with `Authorization: Bearer {token}`. Include findings whose `status` is one of `new`, `enriched`, `triaged`, `ready`, `reported`, `acknowledged`, `fixed`. Skip `rejected`, `duplicate`, and `published` — those do not have a staging-side life. Record skipped ones under `"skipped"` with the status as reason.
 
-The body shape is the GHSA create schema:
+For each remaining finding fetch the full record (`GET {api_base}/findings/{id}`) so you have its prose, severity, status, CVSS, CWE, `disclosure_draft`, and `suggested_fix`.
 
-```json
-{
-  "summary": "<finding.title>",
-  "description": "<finding.disclosure_draft>",
-  "severity": "<critical|high|medium|low, lowercased from finding.severity>",
-  "cvss_vector_string": "<finding.cvss_vector, omit severity if this is set>",
-  "cwe_ids": ["CWE-79"],
-  "vulnerabilities": [
-    {"package": {"ecosystem": "<ghsa enum>", "name": "<pkg>"}, "vulnerable_version_range": "<finding.affected>"}
-  ]
-}
-```
+In the staging working tree, write the following files under `.ossprey/findings/{finding_id}/`:
 
-Build `vulnerabilities` from `GET {api_base}/repositories/{repository_id}/packages` using the same ecosystem mapping the disclose skill uses (rubygems, npm, pip, maven, nuget, composer, go, rust, erlang, actions, pub, swift, other). If the repository has no packages, send `"vulnerabilities": [{"package": {"ecosystem": "other", "name": "{owner}/{repo}"}}]` — the endpoint requires at least one entry.
+- `metadata.yaml`:
+  ```yaml
+  finding_id: {id}
+  title: {title}
+  severity: {severity}
+  status: {status}
+  cwe: {cwe}
+  cvss_vector: {cvss_vector}
+  location: {location}
+  opened_at: {ISO-8601, set on first appearance; do not overwrite on re-runs}
+  last_updated_at: {ISO-8601, refreshed every run}
+  issue_url: {will be set in step 5 once the issue is filed; leave empty for now}
+  ```
+- `disclosure-draft.md`: contents of the finding's `disclosure_draft` field. Omit if empty.
+- `patch.diff`: contents of `suggested_fix`. Omit if empty.
 
-`vulnerable_version_range` must be a bare constraint string. `finding.affected` is analyst prose; normalise it before sending:
+If a finding directory already exists in the clone, preserve the `opened_at` field from the existing `metadata.yaml`; everything else is overwritten by the new run's values. Validation reports and PoC files written by other skills (`fix-validation`, future PoC writer) live in the same directory and are also preserved across re-runs.
 
-- drop anything in parentheses and any repeated package name
-- `all versions` / `every release` → `>= 0`
-- result must be comma-separated `OP VERSION` clauses where OP is one of `< <= > >= =` and VERSION is dotted-numeric (leading `v` is fine)
-- if you cannot reduce it to that shape, omit `vulnerable_version_range` and keep the original prose in the description's Affected versions section
+## 5. File one issue per finding
 
-Whatever description you send (the disclose draft, or the template below), append a final line `[scrutineer-finding:{finding_id}]` so re-runs can dedup on it.
-
-If `disclosure_draft` is empty the disclose skill has not run on this finding yet. Assemble the description yourself from the finding's six-step prose (the full `GET {api_base}/findings/{id}` response includes `trace`, `boundary`, `validation`, `prior_art`, `reach`, `rating` even for `new` findings). Use this template, dropping any section whose source field is empty:
+List existing issues on the staging repo once, capturing the marker line from each body:
 
 ```
-> Draft staged by scrutineer from finding {finding_id} (scan {scan_id}). Not yet reviewed by an analyst.
+gh api repos/{fork_org}/{host}__{owner}__{repo}/issues --paginate \
+  --jq '.[] | {number, body, state, labels: [.labels[].name]}'
+```
+
+Every issue this skill files carries a `[scrutineer-finding:{finding_id}]` marker on its last line. Skip a finding whose marker already appears in any existing issue body; back-fill its `issue_url` in `metadata.yaml` from the existing issue. Record it under `"skipped_issues"` with reason `"already filed"`.
+
+For each remaining finding, build the issue body. Use `disclosure_draft` when present; otherwise assemble from the finding's six-step prose. Drop any section whose source field is empty.
+
+```
+{title}
+
+> Staged by scrutineer from finding {finding_id} (scan {scan_id}).
 
 ## Summary
 
-{title}. {first sentence of rating, or "Severity: {severity}" if rating is empty}.
+{first sentence of rating, or "Severity: {severity}" if rating is empty}
 
 ## Location
 
-`{location}` on `{owner}/{repo}`.
+`{location}` on `{owner}/{repo}`
 
 ## Details
 
@@ -171,20 +191,44 @@ If `disclosure_draft` is empty the disclose skill has not run on this finding ye
 ## References
 
 - {repository.html_url}/blob/{default_branch}/{location path without :line}
-- https://cwe.mitre.org/data/definitions/{n}.html  (one per CWE in finding.cwe)
-- {each URL that appears verbatim in prior_art}
+- https://cwe.mitre.org/data/definitions/{n}.html  (one per CWE)
+- {each URL in prior_art}
+
+[scrutineer-finding:{finding_id}]
 ```
 
-Do not invent content for missing sections; the draft is allowed to be sparse. Note in `notes` that disclose has not run on that finding.
+The marker on the last line is the dedup contract — do not move it, do not change its shape.
 
-Capture the `ghsa_id` and `html_url` from the response. Then write them back to scrutineer so the finding page links to the draft:
+File the issue with severity labelled:
 
-- `POST {api_base}/findings/{id}/references` with `{"url": "<html_url>", "tags": "ghsa-draft", "summary": "Draft advisory on {fork_org} fork"}`
-- `POST {api_base}/findings/{id}/communications` with `{"channel": "ghsa", "direction": "outbound", "actor": "fork", "body": "Draft advisory <ghsa_id> opened on {fork_org}/{fork_name}"}`
+```
+gh issue create -R {fork_org}/{host}__{owner}__{repo} \
+  --title "{title}" \
+  --body-file ./issue-{finding_id}.md \
+  --label "severity:{severity-lowercase}"
+```
 
-Do not change the finding's `status`. `reported` means reported to the upstream maintainer; a draft on the staging fork is not that.
+Create the `severity:{level}` label first if it does not exist:
 
-## 5. Invite a team
+```
+gh label create "severity:{level}" -R {fork_org}/{host}__{owner}__{repo} \
+  --color "{matching colour}" --description "Finding severity" --force
+```
+
+Colours: `severity:critical` `#8b0000`, `severity:high` `#dc3545`, `severity:medium` `#ffc107`, `severity:low` `#6c757d`. `--force` makes label creation idempotent across runs.
+
+Status labels (`status:*`) are not applied by this skill yet; they belong with a future state-sync pass. Filing them prematurely would conflict with the future taxonomy.
+
+Capture the issue URL from the create response. Update `.ossprey/findings/{finding_id}/metadata.yaml` with `issue_url`. Then write the issue link back to scrutineer:
+
+- `POST {api_base}/findings/{id}/references` with `{"url": "<issue_url>", "tags": "staging-issue", "summary": "Issue on {fork_org} staging repo"}`
+- `POST {api_base}/findings/{id}/communications` with `{"channel": "github-issue", "direction": "outbound", "actor": "fork", "body": "Issue #{number} opened on {fork_org}/{host}__{owner}__{repo}"}`
+
+Do not change the finding's `status`. A staging issue is not a report upstream.
+
+After all writes, the working tree should contain one updated `.ossprey/metadata.yaml`, the per-finding directories with refreshed metadata and (where present) draft/patch files, and an unmodified upstream tree. Commit and push as described in step 3.
+
+## 6. Pick a team and give it push access
 
 List the org's teams once:
 
@@ -194,25 +238,20 @@ gh api orgs/{fork_org}/teams --paginate --jq '.[].slug'
 
 Pick at most one team whose slug matches the repository, trying these signals in order and stopping at the first hit:
 
-1. **Foundation / upstream org.** Lowercase the upstream `{owner}` and see if any team slug is a substring of it or vice versa. `eclipse-platform` or `eclipse-ee4j` matches an `eclipse` team, `apache` matches `apache`, a `kubernetes-sigs` repo matches `kubernetes` or `cncf`. Also check `GET {api_base}/repositories/{repository_id}/maintainers` — if a maintainer's affiliation or the repo's funding/SECURITY.md (already in `./src`) names a foundation that appears as a team slug, prefer that.
+1. **Foundation / upstream org.** Lowercase the upstream `{owner}` and check whether any team slug is a substring of it or vice versa. `eclipse-platform` or `eclipse-ee4j` matches an `eclipse` team, `apache` matches `apache`, a `kubernetes-sigs` repo matches `kubernetes` or `cncf`. Also check `GET {api_base}/repositories/{repository_id}/maintainers` — if a maintainer's affiliation or the repo's funding/SECURITY.md (already in `./src`) names a foundation that appears as a team slug, prefer that.
 2. **Ecosystem.** `package_managers[0].name` from `brief ./src`, mapped the same way as the GHSA ecosystem enum: Bundler→`ruby`/`rubygems`, npm/Yarn/pnpm→`npm`/`javascript`/`nodejs`, Cargo→`rust`, Go Modules→`go`/`golang`, pip/Poetry→`python`/`pypi`, Maven/Gradle→`java`/`maven`, Composer→`php`.
 3. **Primary language.** `languages[0].name` from `brief ./src`, lowercased.
 
 Match by normalising both the candidate and each team slug (lowercase, strip non-alphanumerics) and testing whether either contains the other. If nothing matches, leave `"team": null` and move on — do not invent a team.
 
-If a team matched and you filed at least one advisory, add the team as a collaborator on each new advisory:
+Give the team push access on the staging repo:
 
 ```
-gh api -X PATCH repos/{fork_org}/{fork_name}/security-advisories/{ghsa_id} --input - <<'JSON'
-{"collaborating_teams": ["<team-slug>"]}
-JSON
+gh api -X PUT orgs/{fork_org}/teams/{team-slug}/repos/{fork_org}/{host}__{owner}__{repo} \
+  -f permission=push
 ```
 
-Also give the team push access to the fork itself so they can see it and work on a patch later:
-
-```
-gh api -X PUT orgs/{fork_org}/teams/{team-slug}/repos/{fork_org}/{fork_name} -f permission=push
-```
+Idempotent — re-running with the same team produces the same access.
 
 ## Output
 
@@ -222,28 +261,28 @@ Write `./report.json`:
 {
   "fork_org": "fork-central",
   "upstream": "owner/repo",
-  "fork": "fork-central/repo",
-  "fork_name": "repo",
-  "forked": "created",
-  "private_reporting": "enabled",
+  "staging": "fork-central/gh__owner__repo",
+  "created": "created",
+  "seeded_commit": "abc123...",
   "scanned_at": "2026-05-04T12:00:00Z",
-  "scanned_commit": "abc123...",
-  "note_pushed": true,
-  "advisories": [
-    {"finding_id": 17, "ghsa_id": "GHSA-xxxx-xxxx-xxxx", "url": "https://github.com/fork-central/repo/security/advisories/GHSA-..."}
+  "issues": [
+    {"finding_id": 17, "number": 3, "url": "https://github.com/fork-central/gh__owner__repo/issues/3"}
   ],
-  "skipped_advisories": [{"finding_id": 18, "reason": "already filed"}],
+  "skipped_issues": [{"finding_id": 18, "reason": "already filed"}],
+  "skipped": [{"finding_id": 19, "reason": "duplicate"}],
   "team": "rust",
   "notes": "anything that did not go cleanly",
   "error": null
 }
 ```
 
-`forked` is one of `created`, `exists`. `private_reporting` is `enabled`, `already-enabled`, or `org-managed`. `team` is the slug you invited or `null`.
+`created` is one of `created`, `exists`. `team` is the slug you gave push access, or `null`.
 
 ## Constraints
 
-- Do not touch the upstream repository's settings or file anything against it. Everything in this skill targets the fork.
+- Do not touch the upstream repository's settings or file anything against it. Everything in this skill targets the staging repo.
 - Do not run if `fork_org` is unset; the operator must opt in.
-- Do not delete or overwrite an existing fork.
+- Do not delete or overwrite an existing staging repo.
 - Do not invent CVE IDs, CWEs, or package names that are not on the finding.
+- Do not file or modify draft GHSA advisories. Private staging repos have no PVR / no advisory surface; that path belongs to `report-upstream` against the github.com upstream.
+- Do not apply `status:*` labels — that taxonomy belongs to the future state-sync pass.

--- a/skills/report-upstream/SKILL.md
+++ b/skills/report-upstream/SKILL.md
@@ -12,7 +12,7 @@ metadata:
 
 # report-upstream
 
-Submit a finding to the upstream repository's maintainers through GitHub's private vulnerability reporting (PVR), and hand them the proposed fix. Unlike `fork`, which stages drafts on our own fork for internal review, this skill files against the upstream repo and is visible to its maintainers. Do not run it on a finding the analyst has not signed off on.
+Submit a finding to the upstream repository's maintainers through GitHub's private vulnerability reporting (PVR), and hand them the proposed fix. Unlike `fork`, which stands up a private staging repo in the org for internal review, this skill files against the upstream repo and is visible to its maintainers. Do not run it on a finding the analyst has not signed off on.
 
 ## Workspace
 
@@ -64,7 +64,7 @@ When `suggested_fix` is empty, append `## Proposed fix\n\nNo patch is attached. 
 
 GitHub caps `description` at 65535 characters. If the assembled description exceeds that, drop the diff block (keep the prose explaining a diff is available on request) and try again. If it still exceeds the cap, truncate `disclosure_draft` from the bottom and note `truncated: true` in `report.json`.
 
-End the description with a final line `[scrutineer-finding:{finding_id}]` so re-runs and the `fork` skill can recognise this advisory.
+End the description with a final line `[scrutineer-finding:{finding_id}]` so re-runs can recognise this advisory and the staging issue filed by `fork` carries the same marker.
 
 ## 2. File the report
 
@@ -72,7 +72,7 @@ End the description with a final line `[scrutineer-finding:{finding_id}]` so re-
 gh api -X POST repos/{owner}/{repo}/security-advisories/reports --input ./advisory.json
 ```
 
-This is the external-reporter endpoint; do not use the bare `/security-advisories` admin endpoint, which only works for repo admins and is what `fork` uses on our own staging fork. Capture `ghsa_id` and `html_url` from the response.
+This is the external-reporter endpoint; do not use the bare `/security-advisories` admin endpoint, which only works for repo admins. Capture `ghsa_id` and `html_url` from the response.
 
 A 422 with `Private vulnerability reporting is disabled` means PVR was turned off between the precondition check and the POST; treat as a refusal. A 422 mentioning a specific field (`vulnerabilities`, `cvss_vector_string`) means the body shape was rejected; fix the named field (drop `vulnerable_version_range`, drop `cvss_vector_string` in favour of `severity`) and retry once. Any other non-2xx is a refusal with the response body in `error`.
 


### PR DESCRIPTION
The fork skill used to do something that no longer fits the staging model: public `gh repo fork`, draft GHSA advisories on the fork, a git note for scan timestamp. Private staging repos have no PVR / no advisory surface, so the advisory path does not work; the new model wants a metadata directory committed to the repo instead of a git note.

## What changes

The fork skill now:

- creates a **private repo** in `fork_org` (no GitHub fork relationship), named `{host}__{owner}__{repo}` (e.g. `gh__madler__zlib`)
- **seeds it** by pushing `./src` to the staging repo's default branch — upstream tree at the root so paths, fingerprints, VIDs, and patches resolve the same way
- writes scrutineer's metadata under `{metadata_dir}` (default `.scrutineer/`):
  - `{metadata_dir}/metadata.yaml` at the repo root with upstream URL, seed/scan timestamps, scan id
  - `{metadata_dir}/findings/{id}/{metadata.yaml,disclosure-draft.md,patch.diff}` per open finding
- files one **issue per open finding** with the `[scrutineer-finding:{id}]` marker for dedup, plus a `severity:*` label (creates the label if missing). No `status:*` labels — that taxonomy belongs to a future state-sync pass.
- gives a matched team push access via the same foundation → ecosystem → language heuristic the old skill used

## Configurable metadata directory

The directory name is configurable: `metadata_dir` in `scrutineer.yaml`, default `.scrutineer/`. The scrutineer codebase treats it as opaque; operators with a different convention can override it without patching code. Plumbing follows `fork_org`: YAML only, default applied at the worker layer, always written to `context.json` so skills do not re-apply the default.

`DefaultMetadataDir` lives in the worker package as a constant.

## Companion edits

- `skills/report-upstream/SKILL.md`: three sentences updated to reflect the new staging shape; PVR-upstream behaviour is unchanged.
- `internal/config/config.go` and `internal/db/db.go`: comments on `ForkOrg` and `Repository.Fork` reworded; the `Fork` field name is kept for compatibility, with a note explaining the semantic is now "staging repo URL".
- `docs/skills.md` and `scrutineer.sample.yaml`: document both `fork_org` and `metadata_dir`.

## What is intentionally not done here

- No backfill or migration for existing public forks. `Repository.Fork` keeps its existing value if non-empty.
- No `status:*` labels on issues. That belongs to a bidirectional state-sync change which is its own scope.
- No empirical breaking-change / WG-fix flows. Those land in their own PRs.