### PR TITLE
feat: add GHSA ID disclosure field for findings

### DIFF
--- a/docs/database.md
+++ b/docs/database.md
@@ -135,6 +135,7 @@ One row per vulnerability. Lifecycle columns are mutated through `db.WriteFindin
 | imported_from | text | Originating tool name when the finding came in via `POST /api/v1/import`; empty for native scans. |
 | affected | text | Version range, e.g. `>=0.2.0, <=4.0.5`. |
 | cve_id | text | e.g. `CVE-2026-12345`. |
+| ghsa_id | text | GitHub Security Advisory id, e.g. `GHSA-xxxx-xxxx-xxxx`; set once the advisory is published on GitHub. |
 | cvss_vector | text | CVSS v3.x base vector, e.g. `CVSS:3.1/AV:N/AC:L/...`. |
 | cvss_score | real | Derived from `cvss_vector` on write. Cleared when the vector is empty or unparseable. |
 | cvss_v4_vector | text | CVSS v4.0 base vector, e.g. `CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N`. Stored independently of `cvss_vector` because the v4 metric set and scoring formula differ. |

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -455,6 +455,10 @@ type Finding struct {
 	// Disclosure / triage fields. Any of these may be set by a tool, a
 	// model-backed skill, or the analyst; see FindingHistory for the trail.
 	CVEID string
+	// GHSAID is the GitHub Security Advisory identifier (GHSA-xxxx-xxxx-xxxx),
+	// populated once the advisory has been published on GitHub. It sits
+	// alongside CVEID; a finding may carry both.
+	GHSAID string `gorm:"column:ghsa_id"`
 	// CVSSVector is the canonical CVSS v3.x base vector (3.0 or 3.1).
 	// CVSSv4Vector is the v4.0 base vector. Both may be populated when
 	// the analyst (or the disclose skill) carries both forward, which

--- a/internal/db/finding_helpers.go
+++ b/internal/db/finding_helpers.go
@@ -2,12 +2,36 @@ package db
 
 import (
 	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
 
 	"gorm.io/gorm"
 )
+
+// ghsaIDRE matches a GitHub Security Advisory id: the GHSA prefix
+// followed by three 4-character base32 groups, e.g. GHSA-jfh8-c2jp-5v3q.
+// Case-insensitive; callers gate it on a non-empty value so clearing the
+// field stays allowed.
+var ghsaIDRE = regexp.MustCompile(`^(?i)GHSA(-[0-9a-z]{4}){3}$`)
+
+// validateFindingField rejects values that must follow a fixed format
+// before they reach the column. Most fields are free text and pass
+// through untouched; an empty value is always allowed so a field can be
+// cleared. Errors surface to the analyst (422 in the web/API layer).
+func validateFindingField(field, value string) error {
+	if value == "" {
+		return nil
+	}
+	switch field {
+	case "ghsa_id":
+		if !ghsaIDRE.MatchString(value) {
+			return fmt.Errorf("ghsa_id %q is not a valid GHSA id (expected GHSA-xxxx-xxxx-xxxx)", value)
+		}
+	}
+	return nil
+}
 
 // WriteFindingField updates a Finding column and records the change in
 // FindingHistory. Callers pass the JSON-style field name (severity,
@@ -27,6 +51,9 @@ func WriteFindingField(gdb *gorm.DB, findingID uint, field, newValue string, sou
 	}
 	if old == newValue {
 		return nil
+	}
+	if err := validateFindingField(field, newValue); err != nil {
+		return err
 	}
 	if err := gdb.Model(&Finding{}).Where("id = ?", f.ID).Update(colName, newValue).Error; err != nil {
 		return fmt.Errorf("update %s: %w", colName, err)
@@ -211,6 +238,8 @@ func findingFieldAccessor(f *Finding, field string) (current, column string, err
 		return f.QualityTier, "quality_tier", nil
 	case "cve_id":
 		return f.CVEID, "cve_id", nil
+	case "ghsa_id":
+		return f.GHSAID, "ghsa_id", nil
 	case "cvss_vector":
 		return f.CVSSVector, "cvss_vector", nil
 	case "cvss_v4_vector":

--- a/internal/db/finding_helpers.go
+++ b/internal/db/finding_helpers.go
@@ -24,11 +24,8 @@ func validateFindingField(field, value string) error {
 	if value == "" {
 		return nil
 	}
-	switch field {
-	case "ghsa_id":
-		if !ghsaIDRE.MatchString(value) {
-			return fmt.Errorf("ghsa_id %q is not a valid GHSA id (expected GHSA-xxxx-xxxx-xxxx)", value)
-		}
+	if field == "ghsa_id" && !ghsaIDRE.MatchString(value) {
+		return fmt.Errorf("ghsa_id %q is not a valid GHSA id (expected GHSA-xxxx-xxxx-xxxx)", value)
 	}
 	return nil
 }

--- a/internal/db/finding_helpers_test.go
+++ b/internal/db/finding_helpers_test.go
@@ -219,6 +219,39 @@ func TestWriteFindingField_cvssVectorEmptyClearsScore(t *testing.T) {
 	}
 }
 
+func TestWriteFindingField_ghsaIDValidates(t *testing.T) {
+	cases := []struct {
+		value   string
+		wantErr bool
+	}{
+		{"GHSA-jfh8-c2jp-5v3q", false},
+		{"ghsa-jfh8-c2jp-5v3q", false}, // case-insensitive
+		{"", false},                    // clearing is allowed
+		{"GHSA-jfh8-c2jp", true},       // too few groups
+		{"CVE-2026-12345", true},       // wrong prefix
+		{"GHSA-jfh8-c2jp-5v3q-extra", true},
+		{"not an id", true},
+	}
+	for _, tc := range cases {
+		gdb := newTestDB(t)
+		f := seedFinding(t, gdb)
+		err := WriteFindingField(gdb, f.ID, "ghsa_id", tc.value, SourceAnalyst, "")
+		if tc.wantErr && err == nil {
+			t.Errorf("ghsa_id %q: expected error, got nil", tc.value)
+		}
+		if !tc.wantErr && err != nil {
+			t.Errorf("ghsa_id %q: unexpected error: %v", tc.value, err)
+		}
+		if !tc.wantErr {
+			var refreshed Finding
+			gdb.First(&refreshed, f.ID)
+			if refreshed.GHSAID != tc.value {
+				t.Errorf("ghsa_id = %q, want %q", refreshed.GHSAID, tc.value)
+			}
+		}
+	}
+}
+
 func TestAddFindingNote_rejectsEmpty(t *testing.T) {
 	gdb := newTestDB(t)
 	f := seedFinding(t, gdb)

--- a/internal/web/api_export.go
+++ b/internal/web/api_export.go
@@ -132,6 +132,7 @@ func findingExport(f db.Finding) map[string]any {
 		"reachability":        f.Reachability,
 		"quality_tier":        f.QualityTier,
 		"cve_id":              f.CVEID,
+		"ghsa_id":             f.GHSAID,
 		"cvss_vector":         f.CVSSVector,
 		"cvss_score":          f.CVSSScore,
 		"fix_version":         f.FixVersion,

--- a/internal/web/api_reads.go
+++ b/internal/web/api_reads.go
@@ -239,6 +239,7 @@ func findingSummary(f db.Finding) map[string]any {
 		"reachability":  f.Reachability,
 		"quality_tier":  f.QualityTier,
 		"cve_id":        f.CVEID,
+		"ghsa_id":       f.GHSAID,
 		"cvss_vector":   f.CVSSVector,
 		"cvss_score":    f.CVSSScore,
 		"fix_version":   f.FixVersion,

--- a/internal/web/finding_forms.go
+++ b/internal/web/finding_forms.go
@@ -18,7 +18,7 @@ import (
 // reject it anyway.
 var analystFields = []string{
 	"title", "severity", "cwe", "location", "affected",
-	"cve_id", "cvss_vector", "cvss_v4_vector", "fix_version", "fix_commit",
+	"cve_id", "ghsa_id", "cvss_vector", "cvss_v4_vector", "fix_version", "fix_commit",
 	"resolution", "disclosure_draft", "assignee",
 }
 

--- a/internal/web/finding_osv.go
+++ b/internal/web/finding_osv.go
@@ -264,8 +264,8 @@ var ghsaRE = regexp.MustCompile(`(?i)GHSA(-[0-9a-z]{4}){3}`)
 // export; it still surfaces in the references and database_specific.
 var gitSHARE = regexp.MustCompile(`^([a-f0-9]{40}|[a-f0-9]{64})$`)
 
-// osvAliases collects upstream identifiers: the finding's CVE plus any GHSA id
-// found in a reference URL or summary. De-duplicated, CVE first.
+// osvAliases collects upstream identifiers: the finding's CVE and GHSA id plus
+// any GHSA id found in a reference URL or summary. De-duplicated, CVE first.
 func osvAliases(f db.Finding, refs []db.FindingReference) []string {
 	seen := map[string]bool{}
 	var out []string
@@ -277,6 +277,7 @@ func osvAliases(f db.Finding, refs []db.FindingReference) []string {
 		out = append(out, id)
 	}
 	add(f.CVEID)
+	add(f.GHSAID)
 	for _, r := range refs {
 		add(ghsaRE.FindString(r.URL))
 		add(ghsaRE.FindString(r.Summary))

--- a/internal/web/finding_osv_test.go
+++ b/internal/web/finding_osv_test.go
@@ -412,6 +412,24 @@ func TestFindingOSV_aliasesIncludeGHSAFromReferences(t *testing.T) {
 	}
 }
 
+func TestFindingOSV_aliasesIncludeGHSAID(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	f := seedCSAFFinding(t, s, func(f *db.Finding) {
+		f.GHSAID = "GHSA-jfh8-c2jp-5v3q"
+	})
+
+	w := getOSV(t, s, f.ID)
+	if w.Code != 200 {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+	doc := decodeCSAF(t, w.Body.Bytes())
+	if !slices.Contains(toStringSlice(doc["aliases"]), "GHSA-jfh8-c2jp-5v3q") {
+		t.Errorf("aliases should include the finding's GHSA id: %v", doc["aliases"])
+	}
+}
+
 func TestFindingOSV_duplicateReturns410(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()

--- a/internal/web/repo_report.go
+++ b/internal/web/repo_report.go
@@ -217,6 +217,7 @@ func writeReportFinding(b *strings.Builder, gdb *gorm.DB, f db.Finding, latest *
 		{"Affected", f.Affected},
 		{"Exploited in wild", f.ExploitedInWild},
 		{"CVE", f.CVEID},
+		{"GHSA", f.GHSAID},
 		{"CVSS", f.CVSSVector},
 		{"Fix version", f.FixVersion},
 		{"Fix commit", f.FixCommit},

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -763,8 +763,8 @@ func (s *Server) findings(w http.ResponseWriter, r *http.Request) {
 	search := strings.TrimSpace(r.URL.Query().Get("q"))
 	if search != "" {
 		like := "%" + search + "%"
-		q = q.Where("title LIKE ? OR location LIKE ? OR cwe LIKE ? OR cve_id LIKE ? OR affected LIKE ?",
-			like, like, like, like, like)
+		q = q.Where("title LIKE ? OR location LIKE ? OR cwe LIKE ? OR cve_id LIKE ? OR ghsa_id LIKE ? OR affected LIKE ?",
+			like, like, like, like, like, like)
 	}
 
 	sort := r.URL.Query().Get("sort")

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -1232,6 +1232,56 @@ func TestFindingShow_rendersMissedCount(t *testing.T) {
 	}
 }
 
+func TestFindingShow_ghsaLinksToRepoAdvisory(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	repo := db.Repository{URL: "https://github.com/savonrb/savon", Name: "savon",
+		HTMLURL: "https://github.com/savonrb/savon"}
+	s.DB.Create(&repo)
+	scan := db.Scan{RepositoryID: repo.ID, Kind: "skill", Status: db.ScanDone, SkillName: "x"}
+	s.DB.Create(&scan)
+	f := db.Finding{ScanID: scan.ID, RepositoryID: repo.ID, Title: "xxe", Severity: "High",
+		GHSAID: "GHSA-mx5j-mp4f-g8jg"}
+	s.DB.Create(&f)
+
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq("GET", fmt.Sprintf("/findings/%d", f.ID)))
+	body := w.Body.String()
+	if w.Code != 200 {
+		t.Fatalf("status %d: %s", w.Code, body)
+	}
+	want := "https://github.com/savonrb/savon/security/advisories/GHSA-mx5j-mp4f-g8jg"
+	if !strings.Contains(body, want) {
+		t.Errorf("expected repo-nested GHSA advisory link %q on finding page", want)
+	}
+}
+
+func TestFindingShow_ghsaFallsBackToGlobalAdvisory(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	// Local/non-GitHub repos have no HTMLURL; the link falls back to the
+	// global advisories page rather than emitting a broken relative URL.
+	repo := db.Repository{URL: "file:///tmp/r", Name: "r"}
+	s.DB.Create(&repo)
+	scan := db.Scan{RepositoryID: repo.ID, Kind: "skill", Status: db.ScanDone, SkillName: "x"}
+	s.DB.Create(&scan)
+	f := db.Finding{ScanID: scan.ID, RepositoryID: repo.ID, Title: "xxe", Severity: "High",
+		GHSAID: "GHSA-mx5j-mp4f-g8jg"}
+	s.DB.Create(&f)
+
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq("GET", fmt.Sprintf("/findings/%d", f.ID)))
+	body := w.Body.String()
+	if w.Code != 200 {
+		t.Fatalf("status %d: %s", w.Code, body)
+	}
+	if !strings.Contains(body, "https://github.com/advisories/GHSA-mx5j-mp4f-g8jg") {
+		t.Error("expected global GHSA advisory link when repo has no HTMLURL")
+	}
+}
+
 func TestFindingShow_hidesExposureForZizmorFindings(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()

--- a/internal/web/templates/finding_show.html
+++ b/internal/web/templates/finding_show.html
@@ -127,6 +127,13 @@
     <dd><code>{{$f.CVEID}}</code></dd>
   </div>
   {{end}}
+  {{if $f.GHSAID}}
+  <div>
+    <dt class="text-muted-foreground">GHSA</dt>
+    <dd><a class="hover:underline" href="https://github.com/advisories/{{$f.GHSAID}}"
+      rel="noopener" target="_blank"><code>{{$f.GHSAID}}</code></a></dd>
+  </div>
+  {{end}}
   {{if $f.CVSSVector}}
   <div class="col-span-2">
     <dt class="text-muted-foreground">CVSS v3</dt>
@@ -403,6 +410,11 @@ git commit -m "fix: {{$f.Title}}"</pre>
         <div class="grid gap-1">
           <label class="text-xs text-muted-foreground">CVE ID</label>
           <input class="input" name="cve_id" value="{{$f.CVEID}}" placeholder="CVE-2026-12345">
+        </div>
+        <div class="grid gap-1">
+          <label class="text-xs text-muted-foreground">GHSA ID</label>
+          <input class="input" name="ghsa_id" value="{{$f.GHSAID}}" placeholder="GHSA-xxxx-xxxx-xxxx"
+            pattern="[Gg][Hh][Ss][Aa](-[0-9A-Za-z]{4}){3}" title="GHSA-xxxx-xxxx-xxxx">
         </div>
         <div class="grid gap-1 col-span-2">
           <label class="text-xs text-muted-foreground">CVSS v3 vector</label>

--- a/internal/web/templates/finding_show.html
+++ b/internal/web/templates/finding_show.html
@@ -130,7 +130,7 @@
   {{if $f.GHSAID}}
   <div>
     <dt class="text-muted-foreground">GHSA</dt>
-    <dd><a class="hover:underline" href="https://github.com/advisories/{{$f.GHSAID}}"
+    <dd><a class="hover:underline" href="{{if $repo.HTMLURL}}{{$repo.HTMLURL}}/security/advisories/{{$f.GHSAID}}{{else}}https://github.com/advisories/{{$f.GHSAID}}{{end}}"
       rel="noopener" target="_blank"><code>{{$f.GHSAID}}</code></a></dd>
   </div>
   {{end}}

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -279,7 +279,7 @@ paths:
                   description: |
                     Map of field name to new value. Allowed fields:
                     title, severity, status, cwe, location, affected,
-                    cve_id, cvss_vector, cvss_v4_vector, fix_version, fix_commit,
+                    cve_id, ghsa_id, cvss_vector, cvss_v4_vector, fix_version, fix_commit,
                     resolution, disclosure_draft, assignee.
       responses:
         '204': { description: Updated }
@@ -1036,6 +1036,7 @@ components:
         reachability:  { type: string, enum: [reachable, harness_only, unclear] }
         quality_tier:  { type: string, enum: [high, low] }
         cve_id:        { type: string }
+        ghsa_id:       { type: string, description: "GitHub Security Advisory id (GHSA-xxxx-xxxx-xxxx), set once the advisory is published." }
         cvss_vector:    { type: string, description: "CVSS v3.x base vector (3.0 or 3.1)." }
         cvss_score:     { type: number, description: "Base score derived from cvss_vector." }
         cvss_v4_vector: { type: string, description: "CVSS v4.0 base vector. Independent of cvss_vector; both may be populated." }


### PR DESCRIPTION
Generated with Claude Code, reviewed and tested by me.

Add a GHSA ID field alongside CVE ID so an analyst can record the GitHub Security Advisory identifier after a finding is published via GitHub. Wired through the data model, edit form, API (PATCH + reads + export), full-text search, OSV aliases, and the markdown report.

The finding page renders the GHSA ID as a link to its GitHub advisory page (https://github.com/owner/repo/advisories/GHSA-...). Values are format- validated server-side in WriteFindingField (rejected with 422 on the form and API) and client-side via an input pattern; empty stays allowed so the field can be cleared.

For example:

<img width="1203" height="461" alt="Screenshot 2026-06-13 at 8 10 44 PM" src="https://github.com/user-attachments/assets/a033f005-9d0d-4bd1-85d8-76e06022265e" />

<img width="1215" height="389" alt="Screenshot 2026-06-13 at 8 13 06 PM" src="https://github.com/user-attachments/assets/153632ed-ea22-4113-978c-13dca6abfbf7" />
