### PR TITLE
fix: Fix button class name so it actually works.

### DIFF
--- a/internal/web/templates/audit.html
+++ b/internal/web/templates/audit.html
@@ -4,7 +4,7 @@
   <h2 class="text-2xl font-semibold flex items-center gap-2">
     <i data-lucide="clipboard-check"></i> Audit
   </h2>
-  <a href="/api/v1/audit/queue" class="btn-outline-sm" title="Export the queue as JSON">
+  <a href="/api/v1/audit/queue" class="btn-sm-outline" title="Export the queue as JSON">
     <i data-lucide="download"></i> Export queue
   </a>
 </div>


### PR DESCRIPTION
Fix the button on the audits page.

Before:
<img width="175" height="76" alt="Screenshot 2026-06-13 at 8 23 50 PM" src="https://github.com/user-attachments/assets/ea51fc06-b076-4ce9-91d1-c6dbc21988b1" />
After:
<img width="201" height="85" alt="Screenshot 2026-06-13 at 8 24 00 PM" src="https://github.com/user-attachments/assets/6d73d713-4ac4-4c64-a682-98ce52c61b8e" />
