### PR TITLE
feat: Add "Cancel all" button to repository Scans tab

### DIFF
--- a/internal/web/scans.go
+++ b/internal/web/scans.go
@@ -334,16 +334,74 @@ func (s *Server) scanCancel(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "scan is paused", http.StatusBadRequest)
 		return
 	}
-	if !s.Worker.Cancel(scan.ID) {
-		// Not in flight: mark the row so the queue handler drops it on pickup.
-		now := time.Now()
-		s.DB.Model(&scan).Updates(map[string]any{
-			statusKey:     db.ScanCancelled,
-			errorKey:      "cancelled by user",
-			"finished_at": &now,
-		})
+	if s.cancelScan(&scan) {
+		// A queued scan isn't in flight, so the worker never publishes a
+		// scan-status event for it; push one ourselves so the repo Scans tab
+		// and the scan page reflect the cancellation live.
+		s.Broker.Publish(Event{Name: "scan-status", ScanID: scan.ID, RepoID: scan.RepositoryID})
 	}
-	s.redirect(w, r, fmt.Sprintf("/scans/%d", scan.ID))
+	// Deliberately no redirect: cancelling from a list (repo Scans tab, jobs)
+	// should leave the operator on that list so they can cancel the next one,
+	// rather than bouncing to the scan page on every click. htmx clients get a
+	// live row update over SSE; the plain-form fallback reloads the referrer.
+	if isHX(r) {
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+	if ref := r.Header.Get("Referer"); ref != "" {
+		http.Redirect(w, r, ref, http.StatusSeeOther)
+		return
+	}
+	http.Redirect(w, r, fmt.Sprintf("/scans/%d", scan.ID), http.StatusSeeOther)
+}
+
+// cancelScan aborts one non-terminal scan. A running scan is signalled through
+// the worker, which flips its row and publishes scan-status as it unwinds; a
+// queued scan isn't in flight, so we flip the row here (the queue handler drops
+// a cancelled row on pickup) and return true so the caller can publish a
+// scan-status event itself. Returns false when there was nothing to do.
+func (s *Server) cancelScan(scan *db.Scan) (flippedQueued bool) {
+	if s.Worker.Cancel(scan.ID) {
+		return false
+	}
+	now := time.Now()
+	// Gate on the live status so a scan the worker picks up between the caller's
+	// read and this write doesn't get a "cancelled" row while it keeps running.
+	res := s.DB.Model(&db.Scan{}).
+		Where("id = ? AND status IN ?", scan.ID, []db.ScanStatus{db.ScanQueued, db.ScanRunning}).
+		Updates(map[string]any{
+			statusKey:         db.ScanCancelled,
+			"status_priority": db.StatusPriorityFor(db.ScanCancelled),
+			errorKey:          "cancelled by user",
+			"finished_at":     &now,
+		})
+	return res.RowsAffected > 0
+}
+
+// scansCancelAll cancels every queued or running scan on a repository — the
+// bulk companion to the per-row Cancel button, so an operator who fired off a
+// batch can stop them all in one click instead of cancelling each in turn.
+func (s *Server) scansCancelAll(w http.ResponseWriter, r *http.Request) {
+	repoID, _ := strconv.Atoi(r.URL.Query().Get("repository"))
+	if repoID <= 0 {
+		http.Error(w, "missing repository", http.StatusBadRequest)
+		return
+	}
+	var scans []db.Scan
+	if err := s.DB.Where("repository_id = ? AND status IN ?",
+		repoID, []db.ScanStatus{db.ScanQueued, db.ScanRunning}).Find(&scans).Error; err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	var cancelled int
+	for i := range scans {
+		s.cancelScan(&scans[i])
+		cancelled++
+	}
+	setFlash(w, Flash{Category: successKey, Title: fmt.Sprintf("%d scan(s) cancelled", cancelled)})
+	// Back to the Scans tab: the redirect re-renders the table with fresh DB
+	// state, so every flipped row shows "cancelled" without per-scan SSE pushes.
+	s.redirect(w, r, fmt.Sprintf("/repositories/%d#rt3", repoID))
 }
 
 // scanLog returns just the <pre> log block. The scan page polls this with

--- a/internal/web/scans_test.go
+++ b/internal/web/scans_test.go
@@ -1,6 +1,9 @@
 package web
 
 import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"scrutineer/internal/db"
@@ -54,5 +57,103 @@ func TestResumeOpts(t *testing.T) {
 				t.Errorf("resumeOf = %d, want %d", *resume, *tc.wantResume)
 			}
 		})
+	}
+}
+
+// The test worker has an empty running map, so worker.Cancel always reports
+// "not in flight" — only the queued-flip path is exercisable here.
+func TestScanCancel_flipsQueuedWithoutRedirect(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	repo := db.Repository{URL: "https://example.com/c", Name: "c"}
+	s.DB.Create(&repo)
+	scan := db.Scan{RepositoryID: repo.ID, Kind: "skill", Status: db.ScanQueued,
+		StatusPriority: db.StatusPriorityFor(db.ScanQueued)}
+	s.DB.Create(&scan)
+
+	r := localReq("POST", fmt.Sprintf("/scans/%d/cancel", scan.ID))
+	r.Header.Set("HX-Request", "true")
+	r.SetPathValue("id", fmt.Sprint(scan.ID))
+	w := httptest.NewRecorder()
+	s.scanCancel(w, r)
+
+	// No redirect for htmx — just a 204 so the operator stays on the list.
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204; body=%s", w.Code, w.Body)
+	}
+	if loc := w.Header().Get("HX-Redirect"); loc != "" {
+		t.Errorf("HX-Redirect = %q, want none", loc)
+	}
+
+	var got db.Scan
+	s.DB.First(&got, scan.ID)
+	if got.Status != db.ScanCancelled {
+		t.Errorf("status = %q, want cancelled", got.Status)
+	}
+	if got.StatusPriority != db.StatusPriorityFor(db.ScanCancelled) {
+		t.Errorf("status_priority = %d, want %d", got.StatusPriority, db.StatusPriorityFor(db.ScanCancelled))
+	}
+}
+
+func TestScansCancelAll_cancelsRepoQueuedAndRunning(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	repo := db.Repository{URL: "https://example.com/a", Name: "a"}
+	other := db.Repository{URL: "https://example.com/b", Name: "b"}
+	s.DB.Create(&repo)
+	s.DB.Create(&other)
+
+	mk := func(repoID uint, st db.ScanStatus) db.Scan {
+		sc := db.Scan{RepositoryID: repoID, Kind: "skill", Status: st,
+			StatusPriority: db.StatusPriorityFor(st)}
+		s.DB.Create(&sc)
+		return sc
+	}
+	queued := mk(repo.ID, db.ScanQueued)
+	running := mk(repo.ID, db.ScanRunning)
+	finished := mk(repo.ID, db.ScanDone)
+	paused := mk(repo.ID, db.ScanPaused)
+	otherQueued := mk(other.ID, db.ScanQueued)
+
+	r := localReq("POST", fmt.Sprintf("/scans/cancel-all?repository=%d", repo.ID))
+	r.Header.Set("HX-Request", "true")
+	w := httptest.NewRecorder()
+	s.scansCancelAll(w, r)
+
+	if loc := w.Header().Get("HX-Redirect"); loc != fmt.Sprintf("/repositories/%d#rt3", repo.ID) {
+		t.Errorf("HX-Redirect = %q, want repo Scans tab", loc)
+	}
+
+	statusOf := func(id uint) db.ScanStatus {
+		var sc db.Scan
+		s.DB.First(&sc, id)
+		return sc.Status
+	}
+	// Queued and running on this repo are cancelled; terminal, paused, and the
+	// other repo's queued scan are untouched.
+	if got := statusOf(queued.ID); got != db.ScanCancelled {
+		t.Errorf("queued -> %q, want cancelled", got)
+	}
+	if got := statusOf(running.ID); got != db.ScanCancelled {
+		t.Errorf("running -> %q, want cancelled", got)
+	}
+	if got := statusOf(finished.ID); got != db.ScanDone {
+		t.Errorf("done -> %q, want done", got)
+	}
+	if got := statusOf(paused.ID); got != db.ScanPaused {
+		t.Errorf("paused -> %q, want paused", got)
+	}
+	if got := statusOf(otherQueued.ID); got != db.ScanQueued {
+		t.Errorf("other repo queued -> %q, want queued (untouched)", got)
+	}
+}
+
+func TestScansCancelAll_requiresRepository(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	w := httptest.NewRecorder()
+	s.scansCancelAll(w, localReq("POST", "/scans/cancel-all"))
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", w.Code)
 	}
 }

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -296,6 +296,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("POST /scans/pause-queued", s.scansPauseQueued)
 	mux.HandleFunc("POST /scans/resume-paused", s.scansResumePaused)
 	mux.HandleFunc("POST /scans/retry-failed", s.scansRetryFailed)
+	mux.HandleFunc("POST /scans/cancel-all", s.scansCancelAll)
 	mux.HandleFunc("POST /scans/{id}/cancel", s.scanCancel)
 	mux.HandleFunc("GET /scans/{id}/log", s.scanLog)
 	mux.HandleFunc("GET /usage", s.usage)

--- a/internal/web/templates/repo_show.html
+++ b/internal/web/templates/repo_show.html
@@ -467,8 +467,18 @@
   </div>
 
   <div role="tabpanel" id="rp3" aria-labelledby="rt3" hidden>
-    {{if gt .FailedScans 0}}
-      <div class="flex justify-end mb-2">
+    {{if or (gt .ActiveScans 0) (gt .FailedScans 0)}}
+      <div class="flex justify-end gap-2 mb-2">
+        {{if gt .ActiveScans 0}}
+        <form method="post" action="/scans/cancel-all?repository={{.Repo.ID}}"
+              hx-post="/scans/cancel-all?repository={{.Repo.ID}}" hx-swap="none"
+              hx-confirm="Cancel all {{.ActiveScans}} running or queued scan(s) on {{.Repo.Name}}? Any work in progress is discarded.">
+          <button type="submit" class="btn-outline">
+            <i data-lucide="x"></i> Cancel all ({{.ActiveScans}})
+          </button>
+        </form>
+        {{end}}
+        {{if gt .FailedScans 0}}
         <form method="post" action="/scans/retry-failed?repository={{.Repo.ID}}"
               hx-post="/scans/retry-failed?repository={{.Repo.ID}}" hx-swap="none"
               hx-confirm="Re-enqueue every failed scan on this repository?">
@@ -476,6 +486,7 @@
             <i data-lucide="refresh-cw"></i> Retry failed ({{.FailedScans}})
           </button>
         </form>
+        {{end}}
       </div>
     {{end}}
     <table class="table">


### PR DESCRIPTION
Adds a bulk "Cancel all (N)" button on a repository's Scans tab that cancels every queued or running scan in one click, alongside the existing "Retry failed" button. Closes #395.

Also stops single-scan Cancel from redirecting to the scan page: cancelling from a list (repo Scans tab or jobs index) now leaves the operator on that list, so mass-cancelling row by row no longer bounces them away on every click. htmx clients get a live row update over SSE (a scan-status event is now published for the queued-flip path, which the worker never emits); the plain-form fallback reloads the referrer.