### PR TITLE
test: cover analyst write path (api_finding_writes, finding_forms, db helpers)

### DIFF
--- a/internal/db/finding_helpers_test.go
+++ b/internal/db/finding_helpers_test.go
@@ -3,6 +3,7 @@ package db
 import (
 	"path/filepath"
 	"testing"
+	"time"
 
 	"gorm.io/gorm"
 )
@@ -249,6 +250,169 @@ func TestWriteFindingField_ghsaIDValidates(t *testing.T) {
 				t.Errorf("ghsa_id = %q, want %q", refreshed.GHSAID, tc.value)
 			}
 		}
+	}
+}
+
+// editableFindingFields lists every API field name findingFieldAccessor
+// accepts. Kept next to the round-trip test so a new accessor case that
+// isn't added here trips the unknown-field check below.
+var editableFindingFields = []string{
+	"title", "severity", "status", "cwe", "location", "affected",
+	"reachability", "quality_tier", "cve_id", "ghsa_id",
+	"cvss_vector", "cvss_v4_vector", "fix_version", "fix_commit",
+	"resolution", "disclosure_draft", "assignee",
+	"suggested_fix", "suggested_fix_commit",
+	"breaking_change", "breaking_change_rationale",
+	"exploited_in_wild", "exploited_in_wild_evidence",
+	"mitigation", "mitigation_semgrep",
+	"release_tag", "release_url", "last_revalidate_verdict",
+}
+
+// fieldTestValue returns a value WriteFindingField will accept for field.
+// Most fields are free text; a few have format constraints.
+func fieldTestValue(field string) string {
+	switch field {
+	case "ghsa_id":
+		return "GHSA-aaaa-bbbb-cccc"
+	case "cvss_vector":
+		return "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+	case "cvss_v4_vector":
+		return "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N"
+	default:
+		return "v-" + field
+	}
+}
+
+func TestWriteFindingField_allEditableFieldsRoundTrip(t *testing.T) {
+	gdb := newTestDB(t)
+	f := seedFinding(t, gdb)
+
+	for _, field := range editableFindingFields {
+		want := fieldTestValue(field)
+		if err := WriteFindingField(gdb, f.ID, field, want, SourceAnalyst, "tester"); err != nil {
+			t.Fatalf("WriteFindingField(%q): %v", field, err)
+		}
+		var refreshed Finding
+		gdb.First(&refreshed, f.ID)
+		got, col, err := findingFieldAccessor(&refreshed, field)
+		if err != nil {
+			t.Fatalf("findingFieldAccessor(%q): %v", field, err)
+		}
+		if got != want {
+			t.Errorf("field %q -> column %q = %q, want %q", field, col, got, want)
+		}
+	}
+
+	if _, _, err := findingFieldAccessor(&f, "not-a-field"); err == nil {
+		t.Error("findingFieldAccessor accepted an unknown field")
+	}
+}
+
+func TestWriteFindingTimeField(t *testing.T) {
+	gdb := newTestDB(t)
+	f := seedFinding(t, gdb)
+
+	at := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	if err := WriteFindingTimeField(gdb, f.ID, "released_at", at, SourceModel, "release-watch"); err != nil {
+		t.Fatalf("WriteFindingTimeField: %v", err)
+	}
+	var refreshed Finding
+	gdb.First(&refreshed, f.ID)
+	if refreshed.ReleasedAt == nil || !refreshed.ReleasedAt.Equal(at) {
+		t.Fatalf("ReleasedAt = %v, want %v", refreshed.ReleasedAt, at)
+	}
+	var hist []FindingHistory
+	gdb.Where("finding_id = ? AND field = ?", f.ID, "released_at").Find(&hist)
+	if len(hist) != 1 || hist[0].NewValue != at.Format(time.RFC3339) {
+		t.Fatalf("history = %+v, want one row with NewValue=%q", hist, at.Format(time.RFC3339))
+	}
+
+	// Same value is a no-op: no second history row.
+	if err := WriteFindingTimeField(gdb, f.ID, "released_at", at, SourceModel, "release-watch"); err != nil {
+		t.Fatalf("WriteFindingTimeField (noop): %v", err)
+	}
+	gdb.Where("finding_id = ? AND field = ?", f.ID, "released_at").Find(&hist)
+	if len(hist) != 1 {
+		t.Errorf("noop write logged a second history row: %+v", hist)
+	}
+
+	// A non-UTC value is normalised to UTC, so a re-run reporting the same
+	// instant in a different zone is still a no-op.
+	if err := WriteFindingTimeField(gdb, f.ID, "released_at", at.In(time.FixedZone("PST", -8*3600)), SourceModel, ""); err != nil {
+		t.Fatalf("WriteFindingTimeField (zone): %v", err)
+	}
+	gdb.Where("finding_id = ? AND field = ?", f.ID, "released_at").Find(&hist)
+	if len(hist) != 1 {
+		t.Errorf("same-instant different-zone write logged history: %+v", hist)
+	}
+
+	// Changing the value writes OldValue from the stored timestamp.
+	later := at.Add(24 * time.Hour)
+	if err := WriteFindingTimeField(gdb, f.ID, "released_at", later, SourceModel, ""); err != nil {
+		t.Fatalf("WriteFindingTimeField (update): %v", err)
+	}
+	gdb.Where("finding_id = ? AND field = ?", f.ID, "released_at").Order("id").Find(&hist)
+	if len(hist) != 2 || hist[1].OldValue != at.Format(time.RFC3339) {
+		t.Errorf("update history = %+v, want OldValue=%q on second row", hist, at.Format(time.RFC3339))
+	}
+
+	if err := WriteFindingTimeField(gdb, f.ID, "not_a_field", at, SourceModel, ""); err == nil {
+		t.Error("unknown timestamp field should error")
+	}
+	if err := WriteFindingTimeField(gdb, 999999, "released_at", at, SourceModel, ""); err == nil {
+		t.Error("missing finding should error")
+	}
+}
+
+func TestAddFindingCommunication(t *testing.T) {
+	gdb := newTestDB(t)
+	f := seedFinding(t, gdb)
+
+	at := time.Date(2026, 6, 1, 9, 0, 0, 0, time.UTC)
+	c, err := AddFindingCommunication(gdb, f.ID, "email", "outbound", "alice", "sent disclosure", "patch", at)
+	if err != nil {
+		t.Fatalf("AddFindingCommunication: %v", err)
+	}
+	if c.ID == 0 || c.Channel != "email" || c.Direction != "outbound" || !c.At.Equal(at) {
+		t.Errorf("communication = %+v", c)
+	}
+
+	// Zero At defaults to now.
+	c2, err := AddFindingCommunication(gdb, f.ID, "github", "inbound", "bot", "ack", "", time.Time{})
+	if err != nil {
+		t.Fatalf("AddFindingCommunication (zero at): %v", err)
+	}
+	if c2.At.IsZero() {
+		t.Error("zero At should default to now")
+	}
+
+	var n int64
+	gdb.Model(&FindingCommunication{}).Where("finding_id = ?", f.ID).Count(&n)
+	if n != 2 {
+		t.Errorf("communication count = %d, want 2", n)
+	}
+}
+
+func TestAddFindingReference(t *testing.T) {
+	gdb := newTestDB(t)
+	f := seedFinding(t, gdb)
+
+	ref, err := AddFindingReference(gdb, f.ID, "https://example.com/advisory", "advisory,upstream", "Upstream advisory")
+	if err != nil {
+		t.Fatalf("AddFindingReference: %v", err)
+	}
+	if ref.ID == 0 || ref.URL != "https://example.com/advisory" || ref.Tags != "advisory,upstream" {
+		t.Errorf("reference = %+v", ref)
+	}
+
+	if _, err := AddFindingReference(gdb, f.ID, "   ", "", ""); err == nil {
+		t.Error("empty URL should error")
+	}
+
+	var n int64
+	gdb.Model(&FindingReference{}).Where("finding_id = ?", f.ID).Count(&n)
+	if n != 1 {
+		t.Errorf("reference count = %d, want 1 (empty rejected)", n)
 	}
 }
 

--- a/internal/web/api_finding_writes_test.go
+++ b/internal/web/api_finding_writes_test.go
@@ -1,0 +1,266 @@
+package web
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"scrutineer/internal/db"
+)
+
+// seedFindingForAPI returns a finding plus the bearer token a skill running
+// against the same repo would present. A second repo+scan provides a token
+// that must NOT be allowed to act on the finding.
+func seedFindingForAPI(t *testing.T, s *Server) (db.Finding, string, string) {
+	t.Helper()
+	repo, scan := seedRunningScan(t, s)
+	skID := uint(1)
+	s.DB.Model(&scan).Update("skill_id", &skID)
+	scan.SkillID = &skID
+	f := db.Finding{ScanID: scan.ID, RepositoryID: repo.ID, Title: "t",
+		Severity: "High", Status: db.FindingNew}
+	s.DB.Create(&f)
+
+	other := db.Repository{URL: "https://example.com/other", Name: "other"}
+	s.DB.Create(&other)
+	otherScan := db.Scan{RepositoryID: other.ID, Kind: "skill", Status: db.ScanRunning,
+		APIToken: "tok-other"}
+	s.DB.Create(&otherScan)
+	return f, scan.APIToken, otherScan.APIToken
+}
+
+func apiReq(t *testing.T, s *Server, method, path, token, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	r := httptest.NewRequest(method, path, strings.NewReader(body))
+	r.Host = testHost
+	r.Header.Set("Authorization", "Bearer "+token)
+	if body != "" {
+		r.Header.Set("Content-Type", "application/json")
+	}
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, r)
+	return w
+}
+
+func TestAPIPatchFinding(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	f, tok, otherTok := seedFindingForAPI(t, s)
+	path := fmt.Sprintf("/api/findings/%d", f.ID)
+
+	w := apiReq(t, s, "PATCH", path, tok,
+		`{"fields":{"severity":"Critical","cve_id":"CVE-2026-12345"},"by":"disclose"}`)
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204; body=%s", w.Code, w.Body)
+	}
+	var got db.Finding
+	s.DB.First(&got, f.ID)
+	if got.Severity != "Critical" || got.CVEID != "CVE-2026-12345" {
+		t.Errorf("finding = severity=%q cve=%q after patch", got.Severity, got.CVEID)
+	}
+	var hist []db.FindingHistory
+	s.DB.Where("finding_id = ? AND source = ?", f.ID, db.SourceModel).Find(&hist)
+	if len(hist) != 2 {
+		t.Errorf("history rows = %d, want 2 with source=model_suggested", len(hist))
+	}
+
+	// validateFindingField surfaces as 422.
+	w = apiReq(t, s, "PATCH", path, tok, `{"fields":{"ghsa_id":"not-a-ghsa"}}`)
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Errorf("invalid ghsa_id: status = %d, want 422", w.Code)
+	}
+
+	// Unknown field rejected.
+	w = apiReq(t, s, "PATCH", path, tok, `{"fields":{"nope":"x"}}`)
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Errorf("unknown field: status = %d, want 422", w.Code)
+	}
+
+	// Bad JSON.
+	w = apiReq(t, s, "PATCH", path, tok, `not json`)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("bad json: status = %d, want 400", w.Code)
+	}
+
+	// A scan on a different repo cannot edit this finding.
+	w = apiReq(t, s, "PATCH", path, otherTok, `{"fields":{"severity":"Low"}}`)
+	if w.Code != http.StatusForbidden {
+		t.Errorf("cross-repo: status = %d, want 403", w.Code)
+	}
+
+	// Missing finding.
+	w = apiReq(t, s, "PATCH", "/api/findings/999999", tok, `{"fields":{"severity":"Low"}}`)
+	if w.Code != http.StatusNotFound {
+		t.Errorf("missing finding: status = %d, want 404", w.Code)
+	}
+}
+
+// TestAPIFindingChildCollections covers the POST-then-GET round trip for the
+// three sibling child collections (notes, communications, references). They
+// share findingScoped and the same JSON-body shape, so a table keeps the
+// per-collection differences (path, body, the field that proves the row
+// landed) in one place.
+func TestAPIFindingChildCollections(t *testing.T) {
+	cases := []struct {
+		name, suffix, createBody, listField, want string
+	}{
+		{
+			name:       "notes",
+			suffix:     "notes",
+			createBody: `{"body":"triaged: real bug","by":"disclose"}`,
+			listField:  "Body", want: "triaged: real bug",
+		},
+		{
+			name:       "communications",
+			suffix:     "communications",
+			createBody: `{"channel":"email","direction":"outbound","actor":"alice","body":"sent disclosure","at":"2026-06-01T09:00:00Z"}`,
+			listField:  "Channel", want: "email",
+		},
+		{
+			name:       "references",
+			suffix:     "references",
+			createBody: `{"url":"https://example.com/advisory","tags":"advisory","summary":"upstream advisory"}`,
+			listField:  "URL", want: "https://example.com/advisory",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s, done := newTestServer(t)
+			defer done()
+			f, tok, otherTok := seedFindingForAPI(t, s)
+			path := fmt.Sprintf("/api/findings/%d/%s", f.ID, tc.suffix)
+
+			w := apiReq(t, s, "POST", path, tok, tc.createBody)
+			if w.Code != http.StatusCreated {
+				t.Fatalf("create status = %d, want 201; body=%s", w.Code, w.Body)
+			}
+
+			if w := apiReq(t, s, "POST", path, tok, `not json`); w.Code != http.StatusBadRequest {
+				t.Errorf("bad json: status = %d, want 400", w.Code)
+			}
+
+			w = apiReq(t, s, "GET", path, tok, "")
+			if w.Code != http.StatusOK {
+				t.Fatalf("list status = %d", w.Code)
+			}
+			var rows []map[string]any
+			_ = json.NewDecoder(w.Body).Decode(&rows)
+			if len(rows) != 1 || rows[0][tc.listField] != tc.want {
+				t.Errorf("list = %+v, want 1 row with %s=%q", rows, tc.listField, tc.want)
+			}
+
+			if w := apiReq(t, s, "GET", path, otherTok, ""); w.Code != http.StatusForbidden {
+				t.Errorf("cross-repo list: status = %d, want 403", w.Code)
+			}
+			if w := apiReq(t, s, "GET", fmt.Sprintf("/api/findings/999999/%s", tc.suffix), tok, ""); w.Code != http.StatusNotFound {
+				t.Errorf("missing finding: status = %d, want 404", w.Code)
+			}
+		})
+	}
+}
+
+// The 422 paths differ per collection (notes reject empty body, references
+// reject empty url, communications accept anything), so they get their own
+// targeted checks.
+func TestAPIFindingChildCollections_validation(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	f, tok, _ := seedFindingForAPI(t, s)
+
+	if w := apiReq(t, s, "POST", fmt.Sprintf("/api/findings/%d/notes", f.ID), tok, `{"body":"  "}`); w.Code != http.StatusUnprocessableEntity {
+		t.Errorf("empty note body: status = %d, want 422", w.Code)
+	}
+	if w := apiReq(t, s, "POST", fmt.Sprintf("/api/findings/%d/references", f.ID), tok, `{"url":""}`); w.Code != http.StatusUnprocessableEntity {
+		t.Errorf("empty reference url: status = %d, want 422", w.Code)
+	}
+}
+
+func TestAPISetFindingLabels(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	f, tok, _ := seedFindingForAPI(t, s)
+	path := fmt.Sprintf("/api/findings/%d/labels", f.ID)
+
+	w := apiReq(t, s, "PUT", path, tok, `{"labels":["wontfix","needs-info"]}`)
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204; body=%s", w.Code, w.Body)
+	}
+	var got db.Finding
+	s.DB.Preload("Labels").First(&got, f.ID)
+	if len(got.Labels) != 2 {
+		t.Errorf("labels = %+v, want 2", got.Labels)
+	}
+
+	// Clearing.
+	w = apiReq(t, s, "PUT", path, tok, `{"labels":[]}`)
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("clear status = %d", w.Code)
+	}
+	s.DB.Preload("Labels").First(&got, f.ID)
+	if len(got.Labels) != 0 {
+		t.Errorf("labels after clear = %+v, want 0", got.Labels)
+	}
+
+	if w := apiReq(t, s, "PUT", path, tok, `not json`); w.Code != http.StatusBadRequest {
+		t.Errorf("bad json: status = %d, want 400", w.Code)
+	}
+}
+
+func TestAPIListFindingHistory(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	f, tok, _ := seedFindingForAPI(t, s)
+	_ = db.WriteFindingField(s.DB, f.ID, "severity", "Critical", db.SourceAnalyst, "")
+
+	w := apiReq(t, s, "GET", fmt.Sprintf("/api/findings/%d/history", f.ID), tok, "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d", w.Code)
+	}
+	var rows []map[string]any
+	_ = json.NewDecoder(w.Body).Decode(&rows)
+	if len(rows) != 1 || rows[0]["Field"] != "severity" {
+		t.Errorf("history = %+v, want 1 severity row", rows)
+	}
+}
+
+func TestSourceFromRequest(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	_, scan := seedRunningScan(t, s)
+
+	mk := func(tok string) *http.Request {
+		r := httptest.NewRequest("GET", "/api/findings/1", nil)
+		r.Host = testHost
+		r.Header.Set("Authorization", "Bearer "+tok)
+		// scanFromRequest reads the scan the auth middleware stashes on the
+		// request context, so route through Handler to populate it.
+		return r
+	}
+
+	// Scan without a SkillID -> analyst.
+	if got := sourceForToken(t, s, mk(scan.APIToken)); got != db.SourceAnalyst {
+		t.Errorf("no-skill scan source = %q, want analyst", got)
+	}
+
+	// With a SkillID -> model_suggested.
+	skID := uint(1)
+	s.DB.Model(&scan).Update("skill_id", &skID)
+	if got := sourceForToken(t, s, mk(scan.APIToken)); got != db.SourceModel {
+		t.Errorf("skill scan source = %q, want model_suggested", got)
+	}
+}
+
+// sourceForToken routes a request through the API auth middleware so the
+// scan context is populated, then reports what sourceFromRequest sees.
+func sourceForToken(t *testing.T, s *Server, r *http.Request) db.FindingSource {
+	t.Helper()
+	var got db.FindingSource
+	h := s.apiAuth(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		got = sourceFromRequest(r)
+	}))
+	h.ServeHTTP(httptest.NewRecorder(), r)
+	return got
+}

--- a/internal/web/api_finding_writes_test.go
+++ b/internal/web/api_finding_writes_test.go
@@ -213,7 +213,9 @@ func TestAPIListFindingHistory(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()
 	f, tok, _ := seedFindingForAPI(t, s)
-	_ = db.WriteFindingField(s.DB, f.ID, "severity", "Critical", db.SourceAnalyst, "")
+	if err := db.WriteFindingField(s.DB, f.ID, "severity", "Critical", db.SourceAnalyst, ""); err != nil {
+		t.Fatalf("seed history: %v", err)
+	}
 
 	w := apiReq(t, s, "GET", fmt.Sprintf("/api/findings/%d/history", f.ID), tok, "")
 	if w.Code != http.StatusOK {
@@ -235,8 +237,6 @@ func TestSourceFromRequest(t *testing.T) {
 		r := httptest.NewRequest("GET", "/api/findings/1", nil)
 		r.Host = testHost
 		r.Header.Set("Authorization", "Bearer "+tok)
-		// scanFromRequest reads the scan the auth middleware stashes on the
-		// request context, so route through Handler to populate it.
 		return r
 	}
 

--- a/internal/web/finding_forms_test.go
+++ b/internal/web/finding_forms_test.go
@@ -1,0 +1,171 @@
+package web
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"scrutineer/internal/db"
+)
+
+func seedFindingForForm(t *testing.T, s *Server) db.Finding {
+	t.Helper()
+	repo := db.Repository{URL: "https://example.com/forms", Name: "forms"}
+	s.DB.Create(&repo)
+	scan := db.Scan{RepositoryID: repo.ID, Kind: "skill", Status: db.ScanDone}
+	s.DB.Create(&scan)
+	f := db.Finding{ScanID: scan.ID, RepositoryID: repo.ID, Title: "t",
+		Severity: "High", Status: db.FindingNew}
+	s.DB.Create(&f)
+	return f
+}
+
+func TestFindingFields(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	f := seedFindingForForm(t, s)
+	path := fmt.Sprintf("/findings/%d/fields", f.ID)
+
+	w := postForm(t, s, path, url.Values{
+		"severity":   {"Critical"},
+		"cve_id":     {" CVE-2026-12345 "},
+		"affected":   {">=1.0.0 <2.0.0"},
+		"ignored":    {"x"}, // not in analystFields, dropped
+		"resolution": {""},  // present but unchanged, no-op
+	})
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("status = %d, want 303; body=%s", w.Code, w.Body)
+	}
+	if loc := w.Header().Get("Location"); loc != fmt.Sprintf("/findings/%d", f.ID) {
+		t.Errorf("Location = %q", loc)
+	}
+
+	var got db.Finding
+	s.DB.First(&got, f.ID)
+	if got.Severity != "Critical" || got.CVEID != "CVE-2026-12345" || got.Affected != ">=1.0.0 <2.0.0" {
+		t.Errorf("after edit: severity=%q cve=%q affected=%q", got.Severity, got.CVEID, got.Affected)
+	}
+	var hist []db.FindingHistory
+	s.DB.Where("finding_id = ?", f.ID).Find(&hist)
+	if len(hist) != 3 {
+		t.Errorf("history rows = %d, want 3 (severity, cve_id, affected)", len(hist))
+	}
+	for _, h := range hist {
+		if h.Source != db.SourceAnalyst {
+			t.Errorf("history source = %q, want analyst", h.Source)
+		}
+	}
+
+	// validateFindingField surfaces as 422 and no further fields are written.
+	w = postForm(t, s, path, url.Values{"ghsa_id": {"not-a-ghsa"}})
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Errorf("invalid ghsa_id: status = %d, want 422", w.Code)
+	}
+
+	if w := postForm(t, s, "/findings/999999/fields", url.Values{"severity": {"Low"}}); w.Code != http.StatusNotFound {
+		t.Errorf("missing finding: status = %d, want 404", w.Code)
+	}
+}
+
+func TestFindingCommunications(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	f := seedFindingForForm(t, s)
+	path := fmt.Sprintf("/findings/%d/communications", f.ID)
+
+	w := postForm(t, s, path, url.Values{
+		"channel":   {"email"},
+		"direction": {"outbound"},
+		"actor":     {"alice"},
+		"body":      {"sent disclosure"},
+		"at":        {"2026-06-01"},
+	})
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("status = %d, want 303; body=%s", w.Code, w.Body)
+	}
+	var rows []db.FindingCommunication
+	s.DB.Where("finding_id = ?", f.ID).Find(&rows)
+	if len(rows) != 1 || rows[0].Channel != "email" || rows[0].At.Format("2006-01-02") != "2026-06-01" {
+		t.Errorf("communications = %+v", rows)
+	}
+
+	// Empty/unparseable at defaults to now.
+	w = postForm(t, s, path, url.Values{"channel": {"github"}, "at": {"not-a-date"}})
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("status = %d, want 303", w.Code)
+	}
+	s.DB.Where("finding_id = ?", f.ID).Order("id").Find(&rows)
+	if len(rows) != 2 || rows[1].At.IsZero() {
+		t.Errorf("second communication = %+v, want non-zero At", rows)
+	}
+}
+
+func TestFindingReferences(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	f := seedFindingForForm(t, s)
+	path := fmt.Sprintf("/findings/%d/references", f.ID)
+
+	w := postForm(t, s, path, url.Values{
+		"url":     {"https://example.com/advisory"},
+		"tags":    {"advisory"},
+		"summary": {"upstream advisory"},
+	})
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("status = %d, want 303; body=%s", w.Code, w.Body)
+	}
+	var rows []db.FindingReference
+	s.DB.Where("finding_id = ?", f.ID).Find(&rows)
+	if len(rows) != 1 || rows[0].URL != "https://example.com/advisory" {
+		t.Errorf("references = %+v", rows)
+	}
+
+	if w := postForm(t, s, path, url.Values{"url": {"   "}}); w.Code != http.StatusUnprocessableEntity {
+		t.Errorf("empty url: status = %d, want 422", w.Code)
+	}
+}
+
+func TestFindingLabels(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	f := seedFindingForForm(t, s)
+	path := fmt.Sprintf("/findings/%d/labels", f.ID)
+
+	labelsOf := func() []string {
+		var got db.Finding
+		s.DB.Preload("Labels").First(&got, f.ID)
+		names := make([]string, len(got.Labels))
+		for i, l := range got.Labels {
+			names[i] = l.Name
+		}
+		return names
+	}
+
+	// Checkbox-style: multiple labels= form values.
+	w := postForm(t, s, path, url.Values{"labels": {"wontfix", "needs-info", " ", ""}})
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("status = %d, want 303; body=%s", w.Code, w.Body)
+	}
+	if got := labelsOf(); len(got) != 2 {
+		t.Errorf("labels = %v, want [wontfix needs-info]", got)
+	}
+
+	// Comma-style: one labels= value with commas.
+	w = postForm(t, s, path, url.Values{"labels": {"regression, duplicate ,"}})
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("comma status = %d", w.Code)
+	}
+	if got := labelsOf(); len(got) != 2 {
+		t.Errorf("labels after comma input = %v, want [regression duplicate]", got)
+	}
+
+	// Clearing.
+	w = postForm(t, s, path, url.Values{"labels": {""}})
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("clear status = %d", w.Code)
+	}
+	if got := labelsOf(); len(got) != 0 {
+		t.Errorf("labels after clear = %v, want []", got)
+	}
+}

--- a/internal/web/finding_forms_test.go
+++ b/internal/web/finding_forms_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"slices"
 	"testing"
 
 	"scrutineer/internal/db"
@@ -57,10 +58,18 @@ func TestFindingFields(t *testing.T) {
 		}
 	}
 
-	// validateFindingField surfaces as 422 and no further fields are written.
+	// validateFindingField surfaces as 422 and the bad value is not stored.
 	w = postForm(t, s, path, url.Values{"ghsa_id": {"not-a-ghsa"}})
 	if w.Code != http.StatusUnprocessableEntity {
 		t.Errorf("invalid ghsa_id: status = %d, want 422", w.Code)
+	}
+	s.DB.First(&got, f.ID)
+	if got.GHSAID != "" {
+		t.Errorf("GHSAID = %q, want empty (rejected value should not be stored)", got.GHSAID)
+	}
+	s.DB.Where("finding_id = ?", f.ID).Find(&hist)
+	if len(hist) != 3 {
+		t.Errorf("history rows after rejected write = %d, want still 3", len(hist))
 	}
 
 	if w := postForm(t, s, "/findings/999999/fields", url.Values{"severity": {"Low"}}); w.Code != http.StatusNotFound {
@@ -139,6 +148,7 @@ func TestFindingLabels(t *testing.T) {
 		for i, l := range got.Labels {
 			names[i] = l.Name
 		}
+		slices.Sort(names)
 		return names
 	}
 
@@ -147,8 +157,8 @@ func TestFindingLabels(t *testing.T) {
 	if w.Code != http.StatusSeeOther {
 		t.Fatalf("status = %d, want 303; body=%s", w.Code, w.Body)
 	}
-	if got := labelsOf(); len(got) != 2 {
-		t.Errorf("labels = %v, want [wontfix needs-info]", got)
+	if got := labelsOf(); !slices.Equal(got, []string{"needs-info", "wontfix"}) {
+		t.Errorf("labels = %v, want [needs-info wontfix]", got)
 	}
 
 	// Comma-style: one labels= value with commas.
@@ -156,8 +166,8 @@ func TestFindingLabels(t *testing.T) {
 	if w.Code != http.StatusSeeOther {
 		t.Fatalf("comma status = %d", w.Code)
 	}
-	if got := labelsOf(); len(got) != 2 {
-		t.Errorf("labels after comma input = %v, want [regression duplicate]", got)
+	if got := labelsOf(); !slices.Equal(got, []string{"duplicate", "regression"}) {
+		t.Errorf("labels after comma input = %v, want [duplicate regression]", got)
 	}
 
 	// Clearing.


### PR DESCRIPTION
Second PR from the post-merge sweep. Test-only.

The analyst CRUD spine shipped without handler tests: every function in `api_finding_writes.go` and `finding_forms.go` was at 0%, and the db helpers behind them (`WriteFindingTimeField`, `AddFindingCommunication`, `AddFindingReference`, most of `findingFieldAccessor`) likewise. This pins current behaviour before the unbounded-query and GHSA-regex work that touches the same files.

- `internal/db/finding_helpers_test.go`: round-trip every field name `findingFieldAccessor` accepts through `WriteFindingField`; `WriteFindingTimeField` set/noop/timezone-noop/update/unknown-field/missing-finding; `AddFindingCommunication` and `AddFindingReference` happy path and validation.
- `internal/web/api_finding_writes_test.go`: `PATCH /api/findings/{id}` (multi-field write, history source, ghsa_id 422, unknown-field 422, bad json, cross-repo 403, 404), table-driven POST+GET round-trip for notes/communications/references with cross-repo and 404 checks, per-collection 422 cases, `PUT labels` set+clear, `GET history`, `sourceFromRequest` skill vs analyst.
- `internal/web/finding_forms_test.go`: `findingFields` (multi-field, trim, ignored fields, ghsa_id 422, 404), `findingCommunications` (date parse + default-now), `findingReferences` (empty url 422), `findingLabels` (checkbox-style, comma-style, clear).

Coverage: `internal/db` 69.7% -> 81.5%, `internal/web` 76.8% -> 79.9%, total 73.5% -> 75.9%.