### PR TITLE
test: cover scansResumePaused, sbomResolve/Delete, subprojects/repo_overview parsers

### DIFF
--- a/internal/web/sboms_test.go
+++ b/internal/web/sboms_test.go
@@ -99,6 +99,76 @@ func TestSBOMUpload_rejectsUnrecognized(t *testing.T) {
 	}
 }
 
+func TestSBOMResolveHandler(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	s.resolveSync = true
+	s.resolvePURL = func(_ context.Context, purl string) string {
+		if strings.Contains(purl, "lodash") {
+			return "https://github.com/lodash/lodash"
+		}
+		return ""
+	}
+	triage := db.Skill{Name: defaultSkillName, Body: "b", Active: true}
+	s.DB.Create(&triage)
+
+	up := db.SBOMUpload{Name: "demo", Packages: []db.SBOMPackage{
+		{Name: "lodash", PURL: "pkg:npm/lodash@4.17.21"},
+	}}
+	s.DB.Create(&up)
+
+	r := localReq("POST", fmt.Sprintf("/sboms/%d/resolve", up.ID))
+	r.Header.Set("Sec-Fetch-Site", "same-origin")
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, r)
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("status = %d, want 303; body=%s", w.Code, w.Body)
+	}
+	if loc := w.Header().Get("Location"); loc != fmt.Sprintf("/sboms/%d", up.ID) {
+		t.Errorf("Location = %q", loc)
+	}
+
+	var pkg db.SBOMPackage
+	s.DB.Where("sbom_upload_id = ?", up.ID).First(&pkg)
+	if pkg.RepositoryID == nil {
+		t.Errorf("package not linked after resolve handler: %+v", pkg)
+	}
+
+	r = localReq("POST", "/sboms/999999/resolve")
+	r.Header.Set("Sec-Fetch-Site", "same-origin")
+	w = httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, r)
+	if w.Code != http.StatusNotFound {
+		t.Errorf("missing upload: status = %d, want 404", w.Code)
+	}
+}
+
+func TestSBOMDelete(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	up := db.SBOMUpload{Name: "doomed", Packages: []db.SBOMPackage{
+		{Name: "lodash", PURL: "pkg:npm/lodash@4.17.21"},
+	}}
+	s.DB.Create(&up)
+
+	r := localReq("POST", fmt.Sprintf("/sboms/%d/delete", up.ID))
+	r.Header.Set("Sec-Fetch-Site", "same-origin")
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, r)
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("status = %d, want 303; body=%s", w.Code, w.Body)
+	}
+	if loc := w.Header().Get("Location"); loc != "/sboms" {
+		t.Errorf("Location = %q, want /sboms", loc)
+	}
+
+	var n int64
+	s.DB.Model(&db.SBOMUpload{}).Where("id = ?", up.ID).Count(&n)
+	if n != 0 {
+		t.Errorf("upload count = %d, want 0", n)
+	}
+}
+
 func TestSBOMResolve_linksRepoAndEnqueuesTriage(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()

--- a/internal/web/scans_test.go
+++ b/internal/web/scans_test.go
@@ -148,6 +148,55 @@ func TestScansCancelAll_cancelsRepoQueuedAndRunning(t *testing.T) {
 	}
 }
 
+func TestScansResumePaused(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	repo := db.Repository{URL: "https://example.com/r", Name: "r"}
+	s.DB.Create(&repo)
+
+	mk := func(st db.ScanStatus) db.Scan {
+		sc := db.Scan{RepositoryID: repo.ID, Kind: "skill", Status: st,
+			StatusPriority: db.StatusPriorityFor(st)}
+		s.DB.Create(&sc)
+		return sc
+	}
+	p1 := mk(db.ScanPaused)
+	p2 := mk(db.ScanPaused)
+	queued := mk(db.ScanQueued)
+	finished := mk(db.ScanDone)
+
+	r := localReq("POST", "/scans/resume-paused")
+	r.Header.Set("Sec-Fetch-Site", "same-origin")
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, r)
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("status = %d, want 303; body=%s", w.Code, w.Body)
+	}
+	if loc := w.Header().Get("Location"); loc != "/scans?status=queued" {
+		t.Errorf("Location = %q, want /scans?status=queued", loc)
+	}
+
+	statusOf := func(id uint) db.ScanStatus {
+		var sc db.Scan
+		s.DB.First(&sc, id)
+		return sc.Status
+	}
+	if statusOf(p1.ID) != db.ScanQueued || statusOf(p2.ID) != db.ScanQueued {
+		t.Errorf("paused scans should be queued: p1=%s p2=%s", statusOf(p1.ID), statusOf(p2.ID))
+	}
+	if statusOf(queued.ID) != db.ScanQueued {
+		t.Errorf("already-queued scan touched: %s", statusOf(queued.ID))
+	}
+	if statusOf(finished.ID) != db.ScanDone {
+		t.Errorf("done scan touched: %s", statusOf(finished.ID))
+	}
+	var p1got db.Scan
+	s.DB.First(&p1got, p1.ID)
+	if p1got.StatusPriority != db.StatusPriorityFor(db.ScanQueued) {
+		t.Errorf("status_priority = %d, want queued priority", p1got.StatusPriority)
+	}
+}
+
 func TestScansCancelAll_requiresRepository(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()

--- a/internal/worker/skill_parsers_test.go
+++ b/internal/worker/skill_parsers_test.go
@@ -37,11 +37,17 @@ func TestParseSubprojectsOutput(t *testing.T) {
 		t.Errorf("row[1] = %+v", rows[1])
 	}
 
-	// A second run replaces the previous set rather than appending.
-	repo2, gdb2 := runSkillWithReport(t, "subprojects", `{"subprojects":[{"path":"only","name":"only"}]}`)
-	gdb2.Where("repository_id = ?", repo2.ID).Find(&rows)
+	// A second run replaces the previous set rather than appending. Reuse the
+	// same DB and repo so the prior two rows are present to be replaced.
+	scan := db.Scan{RepositoryID: repo.ID}
+	gdb.Create(&scan)
+	w := &Worker{DB: gdb, Log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	if err := w.parseSubprojectsOutput(&scan, `{"subprojects":[{"path":"only","name":"only"}]}`, func(Event) {}); err != nil {
+		t.Fatal(err)
+	}
+	gdb.Where("repository_id = ?", repo.ID).Find(&rows)
 	if len(rows) != 1 || rows[0].Path != "only" {
-		t.Errorf("second run rows = %+v, want [only]", rows)
+		t.Errorf("second run rows = %+v, want [only] (prior set replaced, not appended)", rows)
 	}
 }
 

--- a/internal/worker/skill_parsers_test.go
+++ b/internal/worker/skill_parsers_test.go
@@ -17,6 +17,115 @@ import (
 	"scrutineer/internal/queue"
 )
 
+func TestParseSubprojectsOutput(t *testing.T) {
+	report := `{"subprojects":[
+		{"path":"packages/core","name":"core","kind":"library","description":"shared core"},
+		{"path":" /packages/cli/ ","name":"cli","kind":"binary"},
+		{"path":"","name":"ignored"},
+		{"path":"   ","name":"also ignored"}
+	]}`
+	repo, gdb := runSkillWithReport(t, "subprojects", report)
+	var rows []db.Subproject
+	gdb.Where("repository_id = ?", repo.ID).Order("path").Find(&rows)
+	if len(rows) != 2 {
+		t.Fatalf("rows = %d, want 2 (empty paths dropped)", len(rows))
+	}
+	if rows[0].Path != "packages/cli" || rows[0].Name != "cli" {
+		t.Errorf("row[0] = %+v, want trimmed cli", rows[0])
+	}
+	if rows[1].Path != "packages/core" || rows[1].Kind != "library" || rows[1].Description != "shared core" {
+		t.Errorf("row[1] = %+v", rows[1])
+	}
+
+	// A second run replaces the previous set rather than appending.
+	repo2, gdb2 := runSkillWithReport(t, "subprojects", `{"subprojects":[{"path":"only","name":"only"}]}`)
+	gdb2.Where("repository_id = ?", repo2.ID).Find(&rows)
+	if len(rows) != 1 || rows[0].Path != "only" {
+		t.Errorf("second run rows = %+v, want [only]", rows)
+	}
+}
+
+func TestParseSubprojectsOutput_invalidJSON(t *testing.T) {
+	gdb, err := db.Open(filepath.Join(t.TempDir(), "p.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo := db.Repository{URL: "https://example.com/x", Name: "x"}
+	gdb.Create(&repo)
+	scan := db.Scan{RepositoryID: repo.ID}
+	gdb.Create(&scan)
+	w := &Worker{DB: gdb, Log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	if err := w.parseSubprojectsOutput(&scan, "not json", func(Event) {}); err == nil {
+		t.Error("expected error on invalid JSON")
+	}
+}
+
+func TestParseRepoOverviewOutput(t *testing.T) {
+	report := `{
+		"git": {"default_branch": "develop"},
+		"languages": [
+			{"name":"Go","category":"language"},
+			{"name":"Ruby","category":""},
+			{"name":"Docker","category":"container"},
+			{"name":"","category":"language"}
+		],
+		"resources": {"license_type": "MIT"}
+	}`
+	repo, gdb := runSkillWithReport(t, "repo_overview", report)
+	var got db.Repository
+	gdb.First(&got, repo.ID)
+	if got.DefaultBranch != "develop" {
+		t.Errorf("DefaultBranch = %q, want develop", got.DefaultBranch)
+	}
+	if got.Languages != "Go, Ruby" {
+		t.Errorf("Languages = %q, want 'Go, Ruby' (non-language category and empty name dropped)", got.Languages)
+	}
+	if got.License != "MIT" {
+		t.Errorf("License = %q, want MIT", got.License)
+	}
+}
+
+func TestParseRepoOverviewOutput_partialAndEmpty(t *testing.T) {
+	gdb, err := db.Open(filepath.Join(t.TempDir(), "p.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo := db.Repository{URL: "https://example.com/x", Name: "x",
+		DefaultBranch: "main", Languages: "Python", License: "Apache-2.0"}
+	gdb.Create(&repo)
+	scan := db.Scan{RepositoryID: repo.ID}
+	gdb.Create(&scan)
+	w := &Worker{DB: gdb, Log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+
+	// Unparseable JSON is skipped, no error.
+	if err := w.parseRepoOverviewOutput(&scan, "not json", func(Event) {}); err != nil {
+		t.Errorf("unparseable: %v", err)
+	}
+	var got db.Repository
+	gdb.First(&got, repo.ID)
+	if got.Languages != "Python" {
+		t.Errorf("unparseable input should not touch repo: %+v", got)
+	}
+
+	// Empty document writes nothing (existing fields preserved).
+	if err := w.parseRepoOverviewOutput(&scan, `{}`, func(Event) {}); err != nil {
+		t.Errorf("empty: %v", err)
+	}
+	gdb.First(&got, repo.ID)
+	if got.DefaultBranch != "main" || got.Languages != "Python" || got.License != "Apache-2.0" {
+		t.Errorf("empty document overwrote repo: %+v", got)
+	}
+
+	// Partial document only writes the present fields.
+	if err := w.parseRepoOverviewOutput(&scan, `{"git":{"default_branch":"trunk"}}`, func(Event) {}); err != nil {
+		t.Errorf("partial: %v", err)
+	}
+	gdb.First(&got, repo.ID)
+	if got.DefaultBranch != "trunk" || got.Languages != "Python" {
+		t.Errorf("partial = %+v, want default_branch=trunk, languages preserved", got)
+	}
+}
+
 // runSkillWithReport wires a fakeRunner that returns the given report, runs
 // one skill scan against a fresh DB, and returns the scanned Repository and
 // the *gorm.DB for further assertions.


### PR DESCRIPTION
Fourth PR from the post-merge sweep. Test-only.

Five functions whose siblings already had tests:

- `scansResumePaused` (0% -> 66.7%): bulk resume mirrors the existing `TestScansPauseQueued`; verifies paused -> queued, status_priority updated, queued/done untouched, redirect target.
- `sbomResolve` (0% -> 100%) and `sbomDelete` (0% -> 50%): drive the HTTP routes. The underlying `resolveSBOMPackages` was already tested directly; this covers the handler wiring (`goResolve` sync path, redirect, 404 on missing upload, row gone after delete).
- `parseSubprojectsOutput` (0% -> 87.5%): path trim, empty-path drop, full replace on second run, invalid-JSON error.
- `parseRepoOverviewOutput` (0% -> 96.2%): language category filter, default_branch and license backfill, unparseable-JSON skip, empty document leaves existing fields, partial document only writes present fields.

`internal/worker` 68.3% -> 70.4%, `internal/web` 76.8% -> 77.2%. Remaining uncovered lines are db-error branches and the async `go` path in `goResolve`.