### PR TITLE
refactor: share GHSA id pattern between db and web; document commitRE

### DIFF
--- a/internal/db/finding_helpers.go
+++ b/internal/db/finding_helpers.go
@@ -10,11 +10,14 @@ import (
 	"gorm.io/gorm"
 )
 
-// ghsaIDRE matches a GitHub Security Advisory id: the GHSA prefix
+// GHSAIDPattern matches a GitHub Security Advisory id: the GHSA prefix
 // followed by three 4-character base32 groups, e.g. GHSA-jfh8-c2jp-5v3q.
-// Case-insensitive; callers gate it on a non-empty value so clearing the
-// field stays allowed.
-var ghsaIDRE = regexp.MustCompile(`^(?i)GHSA(-[0-9a-z]{4}){3}$`)
+// Case-insensitive. Exported as the unanchored body so the web layer can
+// reuse it for FindString scanning of free text without the format
+// drifting between packages; this package anchors it for input validation.
+const GHSAIDPattern = `(?i)GHSA(-[0-9a-z]{4}){3}`
+
+var ghsaIDRE = regexp.MustCompile("^" + GHSAIDPattern + "$")
 
 // validateFindingField rejects values that must follow a fixed format
 // before they reach the column. Most fields are free text and pass

--- a/internal/web/code_browser.go
+++ b/internal/web/code_browser.go
@@ -24,10 +24,10 @@ import (
 const maxBrowserBytes = 2 << 20
 
 // commitRE accepts abbreviated SHAs (down to 4 hex chars) because the code
-// browser is fed user-clicked links that often carry the short form. Contrast
-// gitSHARE in finding_osv.go, which requires a full 40/64-char hash because
-// the OSV GIT range schema does.
-var commitRE = regexp.MustCompile(`^[0-9a-f]{4,40}$`)
+// browser is fed user-clicked links that often carry the short form, and up
+// to 64 for SHA-256 object-format repos. Contrast gitSHARE in finding_osv.go,
+// which requires a full 40/64-char hash because the OSV GIT range schema does.
+var commitRE = regexp.MustCompile(`^[0-9a-f]{4,64}$`)
 
 // repoBlob reads one file via `git show <commit>:<path>` from the worker's
 // repo-cache, so historical commits resolve even after rescans move HEAD.

--- a/internal/web/code_browser.go
+++ b/internal/web/code_browser.go
@@ -23,6 +23,10 @@ import (
 // browser; larger files render as a "too large" notice.
 const maxBrowserBytes = 2 << 20
 
+// commitRE accepts abbreviated SHAs (down to 4 hex chars) because the code
+// browser is fed user-clicked links that often carry the short form. Contrast
+// gitSHARE in finding_osv.go, which requires a full 40/64-char hash because
+// the OSV GIT range schema does.
 var commitRE = regexp.MustCompile(`^[0-9a-f]{4,40}$`)
 
 // repoBlob reads one file via `git show <commit>:<path>` from the worker's

--- a/internal/web/code_browser_test.go
+++ b/internal/web/code_browser_test.go
@@ -15,6 +15,27 @@ import (
 	"scrutineer/internal/worker"
 )
 
+func TestCommitRE(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"abcd", true},
+		{strings.Repeat("a", 40), true},
+		{strings.Repeat("a", 64), true},
+		{"abc", false},
+		{strings.Repeat("a", 65), false},
+		{"abcg", false},
+		{"ABCDEF12", false},
+		{"", false},
+	}
+	for _, tc := range cases {
+		if got := commitRE.MatchString(tc.in); got != tc.want {
+			t.Errorf("commitRE(%q) = %v, want %v", tc.in, got, tc.want)
+		}
+	}
+}
+
 func TestSanitizeBlobPath(t *testing.T) {
 	cases := []struct {
 		in   string

--- a/internal/web/finding_osv.go
+++ b/internal/web/finding_osv.go
@@ -256,7 +256,7 @@ func osvCredits(f db.Finding) []osvCredit {
 	return out
 }
 
-var ghsaRE = regexp.MustCompile(`(?i)GHSA(-[0-9a-z]{4}){3}`)
+var ghsaRE = regexp.MustCompile(db.GHSAIDPattern)
 
 // gitSHARE matches the full commit hashes a GIT range event accepts (the
 // schema constrains introduced/fixed to ^(0|[a-f0-9]{40}|[a-f0-9]{64})$). A


### PR DESCRIPTION
Fifth PR from the post-merge sweep.

#392 added `ghsaIDRE` in `internal/db/finding_helpers.go` with the same pattern body as the existing `ghsaRE` in `internal/web/finding_osv.go` (one anchored for input validation, one unanchored for text scanning). Export the body as `db.GHSAIDPattern` and derive both from it so the format can't drift between packages. No behaviour change; `TestWriteFindingField_ghsaIDValidates` and both `TestFindingOSV_aliasesIncludeGHSA*` tests pass unchanged.

Also adds a comment on `commitRE` in `code_browser.go` explaining why it accepts 4-40 hex chars while `gitSHARE` in `finding_osv.go` requires full 40/64: the browser is fed user-clicked links that often carry abbreviated SHAs, the OSV GIT range schema requires full hashes.