### PR TITLE
fix: compare AuditQueue since-filter as instants, not text

### DIFF
--- a/internal/db/audit.go
+++ b/internal/db/audit.go
@@ -87,7 +87,10 @@ func AuditQueue(gdb *gorm.DB, opts AuditQueueOptions) ([]Finding, error) {
 		).
 		Where("id NOT IN (SELECT finding_id FROM finding_reviews)")
 	if !opts.Since.IsZero() {
-		q = q.Where("created_at >= ?", opts.Since)
+		// SQLite stores timestamps as text with whatever TZ offset the
+		// driver serialised, so a bare >= compares strings, not instants.
+		// datetime() normalises both sides to UTC YYYY-MM-DD HH:MM:SS.
+		q = q.Where("datetime(created_at) >= datetime(?)", opts.Since)
 	}
 	var out []Finding
 	err := q.Order("updated_at desc").Limit(limit).Find(&out).Error

--- a/internal/db/audit_test.go
+++ b/internal/db/audit_test.go
@@ -114,6 +114,45 @@ func TestAuditQueue_excludesReviewedFindings(t *testing.T) {
 	}
 }
 
+// TestAuditQueue_sinceFilterComparesInstants pins the fix for SQLite's
+// text-based timestamp comparison: a created_at stored with a +02:00 offset
+// must compare against a UTC Since by instant, not by lexical string order.
+func TestAuditQueue_sinceFilterComparesInstants(t *testing.T) {
+	gdb, err := Open(filepath.Join(t.TempDir(), "since.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo := Repository{URL: "https://example.com/x", Name: "x"}
+	gdb.Create(&repo)
+	scan := Scan{RepositoryID: repo.ID, Status: ScanDone}
+	gdb.Create(&scan)
+	f := Finding{ScanID: scan.ID, RepositoryID: repo.ID, Title: "low", Severity: "Low", Status: FindingNew}
+	gdb.Create(&f)
+
+	// 2026-01-01 12:00 +02:00 == 2026-01-01 10:00 UTC. As text it sorts after
+	// "2026-01-01 11:00...+00:00", so a naive >= comparison includes it even
+	// though Since is an hour later.
+	zone := time.FixedZone("E2", 2*3600)
+	created := time.Date(2026, 1, 1, 12, 0, 0, 0, zone)
+	gdb.Model(&Finding{}).Where("id = ?", f.ID).Update("created_at", created)
+
+	count := func(since time.Time) int {
+		rows, err := AuditQueue(gdb, AuditQueueOptions{Since: since})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return len(rows)
+	}
+	after := time.Date(2026, 1, 1, 11, 0, 0, 0, time.UTC)
+	if n := count(after); n != 0 {
+		t.Errorf("Since one hour after creation returned %d rows, want 0", n)
+	}
+	before := time.Date(2026, 1, 1, 9, 0, 0, 0, time.UTC)
+	if n := count(before); n != 1 {
+		t.Errorf("Since one hour before creation returned %d rows, want 1", n)
+	}
+}
+
 func TestComputeAuditMetrics_agreementOnlyCountsKnownAutomatedOutcomes(t *testing.T) {
 	gdb, err := Open(filepath.Join(t.TempDir(), "metrics.db"))
 	if err != nil {


### PR DESCRIPTION
Found while writing the handler tests in #400.

`db.AuditQueue` filters with `created_at >= ?` against `opts.Since`. SQLite stores timestamps as text with whatever TZ offset the driver serialised (e.g. `2026-06-15 10:53:14.517+01:00` on a BST machine), and the bound `Since` arrives in UTC, so the `>=` runs as a string comparison: a row created at `12:00+02:00` (10:00 UTC) sorts lexically after an `11:00+00:00` cutoff and is wrongly included. Sub-day cutoffs are unreliable on any non-UTC host.

Wrap both sides in `datetime()` so SQLite normalises to `YYYY-MM-DD HH:MM:SS` UTC before comparing. `TestAuditQueue_sinceFilterComparesInstants` pins the behaviour: a finding stored at `12:00+02:00` is excluded by `Since=11:00Z` (one hour after) and included by `Since=09:00Z` (one hour before).

Once this lands, the date-level workaround comment in #400's `TestApiAuditQueue` can be tightened to a real sub-day cutoff if wanted.