### PR TITLE
perf(web): cap detail-page collections and paginate the SBOM index

### DIFF
--- a/internal/web/cwe.go
+++ b/internal/web/cwe.go
@@ -120,21 +120,6 @@ func CWEsInCategory(category string) []string {
 	return cweByCategory[category]
 }
 
-// findingMatchesCategory reports whether a finding's CWE belongs to the given
-// View-1400 category. Mirrors applyCWECategoryFilter for callers that need to
-// filter an already-loaded slice instead of narrowing a query.
-func findingMatchesCategory(cwe, category string) bool {
-	if category == UncategorizedCWE {
-		if cwe == "" {
-			return true
-		}
-		_, ok := cweIndex[cwe]
-		return !ok || cweIndex[cwe].Category == ""
-	}
-	c, ok := cweIndex[cwe]
-	return ok && c.Category == category
-}
-
 // applyCWECategoryFilter restricts a findings query to the CWE-IDs in the
 // given View-1400 category. UncategorizedCWE matches findings whose cwe is
 // empty or absent from the catalogue. An unknown category matches nothing.

--- a/internal/web/sboms.go
+++ b/internal/web/sboms.go
@@ -28,9 +28,12 @@ func (s *Server) registerSBOMRoutes(mux *http.ServeMux) {
 }
 
 func (s *Server) sbomList(w http.ResponseWriter, r *http.Request) {
+	var total int64
+	s.DB.Model(&db.SBOMUpload{}).Count(&total)
+	page := paginate(r, total)
 	var rows []db.SBOMUpload
-	s.DB.Order("id desc").Find(&rows)
-	s.render(w, r, "sboms.html", map[string]any{"SBOMs": rows})
+	s.DB.Order("id desc").Limit(perPage).Offset((page.N - 1) * perPage).Find(&rows)
+	s.render(w, r, "sboms.html", map[string]any{"SBOMs": rows, "Page": page})
 }
 
 func (s *Server) sbomNew(w http.ResponseWriter, r *http.Request) {
@@ -131,7 +134,9 @@ func (s *Server) sbomShow(w http.ResponseWriter, r *http.Request) {
 
 	sort := r.URL.Query().Get("sort")
 	var findings []db.Finding
+	var findingsTotal int64
 	var advisories []db.Advisory
+	var advisoriesTotal int64
 	if len(repoIDs) > 0 {
 		// Deep-dive findings only — the SBOM "Findings" tab is a
 		// downstream-impact view, where lint output from per-repo scanners
@@ -154,10 +159,12 @@ func (s *Server) sbomShow(w http.ResponseWriter, r *http.Request) {
 			sort = defaultSort
 			q = q.Order("id desc")
 		}
-		q.Find(&findings)
+		q.Model(&db.Finding{}).Count(&findingsTotal)
+		q.Limit(tabRowCap).Find(&findings)
 
-		s.DB.Where("repository_id IN ? AND withdrawn_at IS NULL", repoIDs).
-			Order("cvss_score desc, published_at desc").Find(&advisories)
+		advQ := s.DB.Where("repository_id IN ? AND withdrawn_at IS NULL", repoIDs)
+		advQ.Model(&db.Advisory{}).Count(&advisoriesTotal)
+		advQ.Order("cvss_score desc, published_at desc").Limit(tabRowCap).Find(&advisories)
 	}
 
 	resolved, withRepo := 0, 0
@@ -172,7 +179,9 @@ func (s *Server) sbomShow(w http.ResponseWriter, r *http.Request) {
 
 	s.render(w, r, "sbom_show.html", map[string]any{
 		"SBOM": up, "Packages": pkgs,
-		"Findings": findings, "Advisories": advisories, "Repos": reposByID,
+		"Findings": findings, "FindingsTotal": findingsTotal,
+		"Advisories": advisories, "AdvisoriesTotal": advisoriesTotal,
+		"Repos":    reposByID,
 		"Resolved": resolved, "WithRepo": withRepo,
 		"Severity": r.URL.Query().Get("severity"), "Sort": sort,
 		"Category":   r.URL.Query().Get("category"),

--- a/internal/web/sboms_test.go
+++ b/internal/web/sboms_test.go
@@ -169,6 +169,31 @@ func TestSBOMDelete(t *testing.T) {
 	}
 }
 
+func TestSBOMList_paginates(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	for i := range perPage + 5 {
+		s.DB.Create(&db.SBOMUpload{Name: fmt.Sprintf("sbom%d", i), Format: "cyclonedx"})
+	}
+
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq("GET", "/sboms"))
+	body := w.Body.String()
+	if n := strings.Count(body, `<tr id="sbom-`); n != perPage {
+		t.Errorf("page 1 rendered %d rows, want %d", n, perPage)
+	}
+	if !strings.Contains(body, "of 2") {
+		t.Errorf("page 1 missing pagination 'of 2'")
+	}
+
+	w = httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq("GET", "/sboms?page=2"))
+	body = w.Body.String()
+	if n := strings.Count(body, `<tr id="sbom-`); n != 5 {
+		t.Errorf("page 2 rendered %d rows, want 5", n)
+	}
+}
+
 func TestSBOMResolve_linksRepoAndEnqueuesTriage(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -147,7 +147,7 @@ func New(gdb *gorm.DB, q *queue.Queue, log *slog.Logger, broker *Broker, w *work
 			return m
 		},
 		"list":  func(xs ...string) []string { return xs },
-		"len64": func(v any) int64 { return int64(reflect.ValueOf(v).Len()) },
+		"len64": tmplLen64,
 		"cwename": func(id string) string {
 			if _, c, ok := LookupCWE(id); ok {
 				return c.Name
@@ -438,6 +438,19 @@ const (
 	sortRepository = "repository"
 	sortSeverity   = "severity"
 )
+
+// tmplLen64 is the len64 template func: returns len(v) as an int64 for
+// comparison against COUNT(*)-typed totals. Non-len-able or nil values
+// return 0 instead of panicking so a stray template arg renders as
+// "not capped" rather than 500ing the page.
+func tmplLen64(v any) int64 {
+	rv := reflect.ValueOf(v)
+	switch rv.Kind() {
+	case reflect.Slice, reflect.Array, reflect.Map, reflect.String, reflect.Chan:
+		return int64(rv.Len())
+	}
+	return 0
+}
 
 type Page struct {
 	N     int
@@ -1671,14 +1684,25 @@ func (s *Server) repoShow(w http.ResponseWriter, r *http.Request) {
 	s.DB.Joins("JOIN repository_maintainers ON repository_maintainers.maintainer_id = maintainers.id").
 		Where("repository_maintainers.repository_id = ?", repo.ID).Find(&maintainers)
 
+	// Apply the runtime-only filter in SQL before capping, so the first N
+	// rows on the default tab are runtime deps, not whatever sorts first
+	// by name. hiddenDeps and depsTotal both describe the same set the tab
+	// is rendering.
 	showAllDeps := r.URL.Query().Get("deps") == "all"
-	var rawDeps []db.Dependency
+	hiddenTypes := []string{db.DependencyDev, db.DependencyTest, db.DependencyBuild}
+	var hiddenDeps int64
+	s.DB.Model(&db.Dependency{}).
+		Where("repository_id = ? AND dependency_type IN ?", repo.ID, hiddenTypes).
+		Count(&hiddenDeps)
+	depQ := s.DB.Model(&db.Dependency{}).Where("repository_id = ?", repo.ID)
+	if !showAllDeps {
+		depQ = depQ.Where("dependency_type NOT IN ?", hiddenTypes)
+	}
 	var depsTotal int64
-	s.DB.Model(&db.Dependency{}).Where("repository_id = ?", repo.ID).Count(&depsTotal)
-	s.DB.Where("repository_id = ?", repo.ID).Order("ecosystem, name, manifest_kind desc").
-		Limit(tabRowCap).Find(&rawDeps)
-	visibleDeps, hiddenDeps := filterRepoDeps(rawDeps, showAllDeps)
-	deps := groupDeps(visibleDeps)
+	depQ.Count(&depsTotal)
+	var rawDeps []db.Dependency
+	depQ.Order("ecosystem, name, manifest_kind desc").Limit(tabRowCap).Find(&rawDeps)
+	deps := groupDeps(rawDeps)
 
 	var depsCommit string
 	if len(deps) > 0 {
@@ -2155,22 +2179,6 @@ func groupDeps(deps []db.Dependency) []DepGroup {
 		out = append(out, *m[k])
 	}
 	return out
-}
-
-func filterRepoDeps(deps []db.Dependency, includeNonRuntime bool) ([]db.Dependency, int) {
-	if includeNonRuntime {
-		return deps, 0
-	}
-	out := make([]db.Dependency, 0, len(deps))
-	hidden := 0
-	for _, d := range deps {
-		if db.DependencyVisibleByDefault(d.DependencyType) {
-			out = append(out, d)
-		} else {
-			hidden++
-		}
-	}
-	return out, hidden
 }
 
 func preferDependencyForGroup(a, b db.Dependency) bool {

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -14,6 +14,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"reflect"
 	"sort"
 	"strconv"
 	"strings"
@@ -145,7 +146,8 @@ func New(gdb *gorm.DB, q *queue.Queue, log *slog.Logger, broker *Broker, w *work
 			}
 			return m
 		},
-		"list": func(xs ...string) []string { return xs },
+		"list":  func(xs ...string) []string { return xs },
+		"len64": func(v any) int64 { return int64(reflect.ValueOf(v).Len()) },
 		"cwename": func(id string) string {
 			if _, c, ok := LookupCWE(id); ok {
 				return c.Name
@@ -415,8 +417,17 @@ func (s *Server) index(w http.ResponseWriter, r *http.Request) {
 }
 
 const (
-	perPage        = 20
-	defaultSort    = "newest"
+	perPage     = 20
+	defaultSort = "newest"
+	// tabRowCap bounds per-tab collections on detail pages (repo Findings,
+	// Dependencies, Dependents, Advisories; SBOM Findings/Advisories). The
+	// tabs are summary views: when a repo has more rows than this, the page
+	// shows the first N with a count and a link to the full filtered index.
+	tabRowCap = 200
+	// historyRowCap bounds the FindingHistory list on a finding page. A
+	// finding observed across hundreds of rescans accumulates one row each;
+	// only the most recent are useful inline.
+	historyRowCap  = 100
 	statusKey      = "status"
 	allStatusValue = "all"
 	errorKey       = "error"
@@ -696,39 +707,60 @@ func firstNonEmpty(vals ...string) string {
 // When category is non-empty, only the deep-dive slice is narrowed to the
 // View-1400 bucket; scanner findings are returned unfiltered so the Scanners
 // tab stays reachable.
-func loadRepoFindings(gdb *gorm.DB, repoID uint, category string) ([]db.Finding, []db.Finding, map[uint]string, map[uint]string) {
-	var all []db.Finding
-	gdb.Where("repository_id = ? AND status NOT IN ?", repoID, db.ClosedFindingLifecycles).
-		Order(severityOrder).Order("id desc").Find(&all)
+func loadRepoFindings(gdb *gorm.DB, repoID uint, category string) repoFindings {
+	base := func() *gorm.DB {
+		return gdb.Model(&db.Finding{}).
+			Where("repository_id = ? AND status NOT IN ?", repoID, db.ClosedFindingLifecycles)
+	}
 
-	scanSkill := map[uint]string{}
-	scanCommit := map[uint]string{}
-	if len(all) == 0 {
-		return nil, nil, scanSkill, scanCommit
+	ddQ := base().Where("scan_id IN (?)", deepDiveScanIDs(gdb))
+	if category != "" {
+		ddQ = applyCWECategoryFilter(ddQ, category)
+	}
+	var rf repoFindings
+	ddQ.Count(&rf.DeepDiveTotal)
+	ddQ.Order(severityOrder).Order("id desc").Limit(tabRowCap).Find(&rf.DeepDive)
+
+	scQ := base().Where("scan_id NOT IN (?)", deepDiveScanIDs(gdb))
+	scQ.Count(&rf.ScannersTotal)
+	scQ.Order(severityOrder).Order("id desc").Limit(tabRowCap).Find(&rf.Scanners)
+
+	rf.ScanSkill = map[uint]string{}
+	rf.ScanCommit = map[uint]string{}
+	if len(rf.DeepDive)+len(rf.Scanners) == 0 {
+		return rf
+	}
+	scanIDs := make([]uint, 0, len(rf.DeepDive)+len(rf.Scanners))
+	seen := map[uint]bool{}
+	for _, f := range append(rf.DeepDive, rf.Scanners...) {
+		if !seen[f.ScanID] {
+			seen[f.ScanID] = true
+			scanIDs = append(scanIDs, f.ScanID)
+		}
 	}
 	var rows []struct {
 		ID        uint
 		SkillName string
 		Commit    string
 	}
-	gdb.Raw("SELECT id, COALESCE(skill_name, '') AS skill_name, COALESCE(`commit`, '') AS `commit` FROM scans WHERE repository_id = ?", repoID).Scan(&rows)
+	gdb.Raw("SELECT id, COALESCE(skill_name, '') AS skill_name, COALESCE(`commit`, '') AS `commit` FROM scans WHERE id IN ?", scanIDs).Scan(&rows)
 	for _, row := range rows {
-		scanSkill[row.ID] = row.SkillName
-		scanCommit[row.ID] = row.Commit
+		rf.ScanSkill[row.ID] = row.SkillName
+		rf.ScanCommit[row.ID] = row.Commit
 	}
-	var deepDive, scanners []db.Finding
-	for _, f := range all {
-		name := scanSkill[f.ScanID]
-		if name == "" || name == deepDiveSkillName {
-			if category != "" && !findingMatchesCategory(f.CWE, category) {
-				continue
-			}
-			deepDive = append(deepDive, f)
-		} else {
-			scanners = append(scanners, f)
-		}
-	}
-	return deepDive, scanners, scanSkill, scanCommit
+	return rf
+}
+
+// repoFindings carries the two capped finding sets for a repo's tabs plus
+// the per-scan lookup maps the template needs to render the producing skill
+// name and the location-link commit.
+type repoFindings struct {
+	DeepDive      []db.Finding
+	DeepDiveTotal int64
+	Scanners      []db.Finding
+	ScannersTotal int64
+	ScanSkill     map[uint]string
+	ScanCommit    map[uint]string
 }
 
 func (s *Server) findings(w http.ResponseWriter, r *http.Request) {
@@ -1297,7 +1329,10 @@ func (s *Server) findingShow(w http.ResponseWriter, r *http.Request) {
 	var refs []db.FindingReference
 	s.DB.Where("finding_id = ?", f.ID).Order("id desc").Find(&refs)
 	var history []db.FindingHistory
-	s.DB.Where("finding_id = ?", f.ID).Order("created_at desc").Find(&history)
+	var historyTotal int64
+	s.DB.Model(&db.FindingHistory{}).Where("finding_id = ?", f.ID).Count(&historyTotal)
+	s.DB.Where("finding_id = ?", f.ID).Order("created_at desc").
+		Limit(historyRowCap).Find(&history)
 	reviews, _ := db.ListFindingReviews(s.DB, f.ID)
 	latestRevalidate := db.LatestRevalidateVerdict(s.DB, f.ID)
 	var labels []db.FindingLabel
@@ -1347,6 +1382,7 @@ func (s *Server) findingShow(w http.ResponseWriter, r *http.Request) {
 		"Communications":   comms,
 		"References":       refs,
 		"History":          history,
+		"HistoryTotal":     historyTotal,
 		"Reviews":          reviews,
 		"LatestRevalidate": latestRevalidate,
 		"AllLabels":        labels,
@@ -1617,7 +1653,7 @@ func (s *Server) repoShow(w http.ResponseWriter, r *http.Request) {
 		Select("COALESCE(SUM(cost_usd), 0)").Scan(&totalCost)
 
 	category := r.URL.Query().Get("category")
-	findings, scannerFindings, scanSkill, scanCommit := loadRepoFindings(s.DB, repo.ID, category)
+	rf := loadRepoFindings(s.DB, repo.ID, category)
 
 	// Count deep-dive findings still awaiting verification, scoped to the
 	// same category filter as the visible list. Drives the "Verify all new"
@@ -1637,7 +1673,10 @@ func (s *Server) repoShow(w http.ResponseWriter, r *http.Request) {
 
 	showAllDeps := r.URL.Query().Get("deps") == "all"
 	var rawDeps []db.Dependency
-	s.DB.Where("repository_id = ?", repo.ID).Order("ecosystem, name, manifest_kind desc").Find(&rawDeps)
+	var depsTotal int64
+	s.DB.Model(&db.Dependency{}).Where("repository_id = ?", repo.ID).Count(&depsTotal)
+	s.DB.Where("repository_id = ?", repo.ID).Order("ecosystem, name, manifest_kind desc").
+		Limit(tabRowCap).Find(&rawDeps)
 	visibleDeps, hiddenDeps := filterRepoDeps(rawDeps, showAllDeps)
 	deps := groupDeps(visibleDeps)
 
@@ -1650,10 +1689,16 @@ func (s *Server) repoShow(w http.ResponseWriter, r *http.Request) {
 	s.DB.Where("repository_id = ?", repo.ID).Order("dependent_repos desc, downloads desc").Find(&pkgs)
 
 	var dependents []db.Dependent
-	s.DB.Where("repository_id = ?", repo.ID).Order("dependent_repos desc").Find(&dependents)
+	var dependentsTotal int64
+	s.DB.Model(&db.Dependent{}).Where("repository_id = ?", repo.ID).Count(&dependentsTotal)
+	s.DB.Where("repository_id = ?", repo.ID).Order("dependent_repos desc").
+		Limit(tabRowCap).Find(&dependents)
 
 	var advisories []db.Advisory
-	s.DB.Where("repository_id = ?", repo.ID).Order("cvss_score desc").Find(&advisories)
+	var advisoriesTotal int64
+	s.DB.Model(&db.Advisory{}).Where("repository_id = ?", repo.ID).Count(&advisoriesTotal)
+	s.DB.Where("repository_id = ?", repo.ID).Order("cvss_score desc").
+		Limit(tabRowCap).Find(&advisories)
 
 	knownPURLs := s.lookupKnownPURLs(deps)
 	knownURLs := s.lookupKnownURLs(dependents)
@@ -1703,18 +1748,24 @@ func (s *Server) repoShow(w http.ResponseWriter, r *http.Request) {
 
 	data := map[string]any{
 		"Repo": repo, "Scans": scans, "Latest": latest,
-		"Findings":        findings,
-		"ScannerFindings": scannerFindings,
-		"ScanSkill":       scanSkill,
-		"ScanCommit":      scanCommit,
-		"NewFindingCount": int(newFindings),
-		"FailedScans":     failedScans,
-		"ActiveScans":     int(activeScans),
-		"TotalCost":       totalCost,
-		"DiskBytes":       worker.RepoDiskUsage(s.Worker.DataDir, repo),
-		"TMCommit":        tmCommit,
-		"DepsCommit":      depsCommit,
-		"Deps":            deps, "Pkgs": pkgs, "Dependents": dependents, "Advisories": advisories, "Maintainers": maintainers, "ThreatModel": threatModel,
+		"Findings":             rf.DeepDive,
+		"FindingsTotal":        rf.DeepDiveTotal,
+		"ScannerFindings":      rf.Scanners,
+		"ScannerFindingsTotal": rf.ScannersTotal,
+		"ScanSkill":            rf.ScanSkill,
+		"ScanCommit":           rf.ScanCommit,
+		"NewFindingCount":      int(newFindings),
+		"FailedScans":          failedScans,
+		"ActiveScans":          int(activeScans),
+		"TotalCost":            totalCost,
+		"DiskBytes":            worker.RepoDiskUsage(s.Worker.DataDir, repo),
+		"TMCommit":             tmCommit,
+		"DepsCommit":           depsCommit,
+		"Deps":                 deps, "DepsTotal": depsTotal,
+		"Pkgs":       pkgs,
+		"Dependents": dependents, "DependentsTotal": dependentsTotal,
+		"Advisories": advisories, "AdvisoriesTotal": advisoriesTotal,
+		"Maintainers": maintainers, "ThreatModel": threatModel,
 		"KnownURLs": knownURLs, "KnownPURLs": knownPURLs,
 		"ShowAllDeps": showAllDeps, "HiddenDeps": hiddenDeps,
 		"Skills":        activeSkills,
@@ -1723,6 +1774,7 @@ func (s *Server) repoShow(w http.ResponseWriter, r *http.Request) {
 		"Category":      category,
 		"Categories":    CWECategories(),
 		"Uncategorized": UncategorizedCWE,
+		"TabRowCap":     int64(tabRowCap),
 	}
 	s.render(w, r, "repo_show.html", data)
 }

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -2402,6 +2402,80 @@ func TestRepoShow_findingsTabAggregatesAcrossScans(t *testing.T) {
 	}
 }
 
+func TestRepoShow_tabRowCapAppliesAndShowsNotice(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	repo := db.Repository{URL: "https://example.com/cap", Name: "cap", Owner: "capowner"}
+	s.DB.Create(&repo)
+	scan := db.Scan{RepositoryID: repo.ID, Kind: "skill", SkillName: deepDiveSkillName, Status: db.ScanDone}
+	s.DB.Create(&scan)
+
+	// Seed past the cap on findings, dependents, and advisories so each tab
+	// renders exactly tabRowCap rows plus the "Showing N of M" notice. Batched
+	// inserts keep the test under a second.
+	over := tabRowCap + 5
+	fs := make([]db.Finding, over)
+	deps := make([]db.Dependent, over)
+	advs := make([]db.Advisory, over)
+	for i := range over {
+		fs[i] = db.Finding{ScanID: scan.ID, RepositoryID: repo.ID,
+			Title: fmt.Sprintf("f%d", i), Severity: "High", Status: db.FindingNew}
+		deps[i] = db.Dependent{RepositoryID: repo.ID, Name: fmt.Sprintf("dep%d", i), Ecosystem: "npm"}
+		advs[i] = db.Advisory{RepositoryID: repo.ID, Title: fmt.Sprintf("a%d", i), Severity: "High"}
+	}
+	s.DB.CreateInBatches(&fs, 100)
+	s.DB.CreateInBatches(&deps, 100)
+	s.DB.CreateInBatches(&advs, 100)
+
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq("GET", fmt.Sprintf("/repositories/%d", repo.ID)))
+	if w.Code != 200 {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+	body := w.Body.String()
+	// Each capped tab shows exactly tabRowCap rows.
+	if n := strings.Count(body, `id="finding-card-`); n != tabRowCap {
+		t.Errorf("rendered %d finding cards, want %d", n, tabRowCap)
+	}
+	notice := fmt.Sprintf("Showing %d of %d.", tabRowCap, over)
+	if got := strings.Count(body, notice); got != 3 {
+		t.Errorf("found %d %q notices, want 3 (findings, dependents, advisories)", got, notice)
+	}
+	if !strings.Contains(body, "/findings?owner=capowner") {
+		t.Error("findings cap notice should link to the owner-filtered findings index")
+	}
+}
+
+func TestFindingShow_historyCapAppliesAndShowsNotice(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	repo := db.Repository{URL: "https://example.com/hist", Name: "hist"}
+	s.DB.Create(&repo)
+	scan := db.Scan{RepositoryID: repo.ID, Kind: "skill", Status: db.ScanDone}
+	s.DB.Create(&scan)
+	f := db.Finding{ScanID: scan.ID, RepositoryID: repo.ID, Title: "t", Severity: "High"}
+	s.DB.Create(&f)
+
+	over := historyRowCap + 5
+	rows := make([]db.FindingHistory, over)
+	for i := range over {
+		rows[i] = db.FindingHistory{FindingID: f.ID, Field: "observed",
+			NewValue: fmt.Sprintf("scan %d", i), Source: db.SourceTool}
+	}
+	s.DB.CreateInBatches(&rows, 100)
+
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq("GET", fmt.Sprintf("/findings/%d", f.ID)))
+	if w.Code != 200 {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+	body := w.Body.String()
+	notice := fmt.Sprintf("Showing %d of %d.", historyRowCap, over)
+	if !strings.Contains(body, notice) {
+		t.Errorf("missing history cap notice %q", notice)
+	}
+}
+
 func TestRepoShow_categoryFilterKeepsScannerTab(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -2441,8 +2441,56 @@ func TestRepoShow_tabRowCapAppliesAndShowsNotice(t *testing.T) {
 	if got := strings.Count(body, notice); got != 3 {
 		t.Errorf("found %d %q notices, want 3 (findings, dependents, advisories)", got, notice)
 	}
-	if !strings.Contains(body, "/findings?owner=capowner") {
-		t.Error("findings cap notice should link to the owner-filtered findings index")
+	if !strings.Contains(body, "/findings?owner=capowner&amp;category=") {
+		t.Error("findings cap notice should link to the owner+category-filtered findings index")
+	}
+}
+
+func TestRepoShow_depsCapAppliesAfterRuntimeFilter(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	repo := db.Repository{URL: "https://example.com/deps", Name: "deps"}
+	s.DB.Create(&repo)
+
+	// Seed tabRowCap+5 dev deps (sort early by ecosystem) and 3 runtime deps
+	// (sort later). Before the fix, the cap fired on the dev deps and the
+	// runtime-only default view came up empty.
+	devDeps := make([]db.Dependency, tabRowCap+5)
+	for i := range devDeps {
+		devDeps[i] = db.Dependency{RepositoryID: repo.ID, Name: fmt.Sprintf("dev%03d", i),
+			Ecosystem: "aaa", DependencyType: db.DependencyDev, ManifestPath: "package.json"}
+	}
+	s.DB.CreateInBatches(&devDeps, 100)
+	for i := range 3 {
+		s.DB.Create(&db.Dependency{RepositoryID: repo.ID, Name: fmt.Sprintf("rt%d", i),
+			Ecosystem: "zzz", DependencyType: db.DependencyRuntime, ManifestPath: "package.json"})
+	}
+
+	// Default (runtime-only) view shows the 3 runtime deps and no cap notice.
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq("GET", fmt.Sprintf("/repositories/%d", repo.ID)))
+	if w.Code != 200 {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+	body := w.Body.String()
+	for _, want := range []string{"rt0", "rt1", "rt2"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("runtime-only view missing %q (cap fired before filter)", want)
+		}
+	}
+	if strings.Contains(body, "Dependency list capped") {
+		t.Error("runtime-only view should not show cap notice (only 3 runtime deps)")
+	}
+	if !strings.Contains(body, fmt.Sprintf("%d test/build/dev row(s) hidden", tabRowCap+5)) {
+		t.Error("hidden-deps count should be the SQL total, not capped")
+	}
+
+	// deps=all view caps at tabRowCap and shows the notice with the all-deps total.
+	w = httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq("GET", fmt.Sprintf("/repositories/%d?deps=all", repo.ID)))
+	body = w.Body.String()
+	if !strings.Contains(body, fmt.Sprintf("first %d of %d rows", tabRowCap, tabRowCap+5+3)) {
+		t.Errorf("deps=all view missing cap notice with total=%d", tabRowCap+5+3)
 	}
 }
 

--- a/internal/web/templates/finding_show.html
+++ b/internal/web/templates/finding_show.html
@@ -645,7 +645,7 @@ git commit -m "fix: {{$f.Title}}"</pre>
   <details class="group border-b">
     <summary class="w-full outline-none rounded-md focus-visible:ring-ring/50 focus-visible:ring-[3px]">
       <h3 class="flex flex-1 items-center justify-between gap-4 py-4 text-sm font-medium hover:underline">
-        History <span class="text-muted-foreground ml-auto mr-2 text-xs">{{len .History}}</span>
+        History <span class="text-muted-foreground ml-auto mr-2 text-xs">{{.HistoryTotal}}</span>
         <i data-lucide="chevron-down" class="text-muted-foreground size-4 shrink-0 transition-transform duration-200 group-open:rotate-180"></i>
       </h3>
     </summary>
@@ -661,6 +661,7 @@ git commit -m "fix: {{$f.Title}}"</pre>
         <li>No recorded changes.</li>
       {{end}}
       </ul>
+      {{template "row-cap" (dict "Shown" .History "Total" .HistoryTotal)}}
     </section>
   </details>
 

--- a/internal/web/templates/partials.html
+++ b/internal/web/templates/partials.html
@@ -29,6 +29,12 @@
 {{end}}
 {{end}}
 
+{{define "row-cap"}}{{- if gt .Total (len64 .Shown) -}}
+<p class="text-sm text-muted-foreground mt-3">
+  Showing {{len .Shown}} of {{.Total}}.{{if .Href}} <a class="hover:underline" href="{{.Href}}">View all</a>.{{end}}
+</p>
+{{- end -}}{{end}}
+
 {{define "loc-link"}}
   {{$u := locurl .RepoID .Commit .Location}}
   {{if $u}}

--- a/internal/web/templates/repo_show.html
+++ b/internal/web/templates/repo_show.html
@@ -279,6 +279,7 @@
         </div>
       {{end}}
     </div>
+    {{- template "row-cap" (dict "Shown" .Findings "Total" .FindingsTotal "Href" (printf "/findings?owner=%s" .Repo.Owner))}}
   </div>
   {{end}}
 
@@ -312,6 +313,7 @@
         </div>
       {{end}}
     </div>
+    {{- template "row-cap" (dict "Shown" .ScannerFindings "Total" .ScannerFindingsTotal "Href" (printf "/findings?owner=%s&scanners=1" .Repo.Owner))}}
   </div>
   {{end}}
 
@@ -372,6 +374,11 @@
         {{end}}
         </tbody>
       </table>
+      {{if gt .DepsTotal .TabRowCap}}
+      <p class="text-sm text-muted-foreground mt-3">
+        Dependency list capped at the first {{.TabRowCap}} of {{.DepsTotal}} rows.
+      </p>
+      {{end}}
     {{else if .HiddenDeps}}
       <p class="text-muted-foreground text-sm p-4">No runtime dependencies in the default view.</p>
     {{else}}
@@ -408,6 +415,7 @@
       {{end}}
       </tbody>
     </table>
+    {{- template "row-cap" (dict "Shown" .Advisories "Total" .AdvisoriesTotal)}}
   </div>
   {{end}}
 
@@ -431,6 +439,7 @@
       {{end}}
       </tbody>
     </table>
+    {{- template "row-cap" (dict "Shown" .Dependents "Total" .DependentsTotal)}}
   </div>
   {{end}}
 

--- a/internal/web/templates/repo_show.html
+++ b/internal/web/templates/repo_show.html
@@ -279,7 +279,7 @@
         </div>
       {{end}}
     </div>
-    {{- template "row-cap" (dict "Shown" .Findings "Total" .FindingsTotal "Href" (printf "/findings?owner=%s" .Repo.Owner))}}
+    {{- template "row-cap" (dict "Shown" .Findings "Total" .FindingsTotal "Href" (printf "/findings?owner=%s&category=%s" .Repo.Owner .Category))}}
   </div>
   {{end}}
 

--- a/internal/web/templates/sbom_show.html
+++ b/internal/web/templates/sbom_show.html
@@ -181,6 +181,7 @@
       {{end}}
       </tbody>
     </table>
+    {{template "row-cap" (dict "Shown" .Findings "Total" .FindingsTotal)}}
   </div>
   {{end}}
 
@@ -210,6 +211,7 @@
       {{end}}
       </tbody>
     </table>
+    {{template "row-cap" (dict "Shown" .Advisories "Total" .AdvisoriesTotal)}}
   </div>
   {{end}}
 </div>

--- a/internal/web/templates/sboms.html
+++ b/internal/web/templates/sboms.html
@@ -43,6 +43,7 @@
     {{end}}
     </tbody>
   </table>
+  {{template "pagination" .Page}}
 {{else}}
   {{template "empty" (dict "Icon" "file-box" "Title" "No SBOMs yet" "Body" "Upload a CycloneDX or SPDX JSON document to scan every package it lists.")}}
 {{end}}


### PR DESCRIPTION
Last PR from the post-merge sweep.

#358 bounded the index pages but several detail/aggregate views still loaded full tables: `repoShow` loaded every non-closed finding (then partitioned in Go) plus every dependency/dependent/advisory row for the repo; `findingShow` loaded every `FindingHistory` row (one per re-observation); `sbomShow` loaded every finding and advisory across every linked repo; `sbomList` loaded every upload with no pagination.

Cap each tab at `tabRowCap=200` (history at `historyRowCap=100`), count the total separately, and render a "Showing N of M" notice via a new `row-cap` template partial when the cap applies. The findings tabs link to the owner-filtered global findings index. `sbomList` gets the same `paginate()` treatment as the other index pages.

`loadRepoFindings` is restructured into two separate capped queries (deep-dive vs scanners via the existing `deepDiveScanIDs` subquery) instead of load-all-then-partition, returning a `repoFindings` struct with totals. The per-scan lookup map is now keyed on just the loaded scan IDs rather than every scan on the repo. The Go-side `findingMatchesCategory` helper is removed since its only caller now uses the SQL `applyCWECategoryFilter`.

Dependencies get a bespoke notice ("capped at the first N of M rows") rather than the generic partial because `groupDeps` merges duplicate name+ecosystem rows across manifests, so `len(.Deps)` differs from the raw load count even when nothing was capped.

`TestRepoShow_tabRowCapAppliesAndShowsNotice` seeds 205 findings/dependents/advisories and asserts 200 cards rendered + 3 notices + the view-all link. `TestFindingShow_historyCapAppliesAndShowsNotice` and `TestSBOMList_paginates` cover the other two paths. The existing `TestRepoShow_findingsTabAggregatesAcrossScans` and `TestRepoShow_categoryFilterKeepsScannerTab` still pass, confirming the deep-dive/scanner partition is preserved.