### PR TITLE
chore: surface unparseable skill timestamps and tidy two small spots

### DIFF
--- a/internal/web/theme.go
+++ b/internal/web/theme.go
@@ -71,8 +71,9 @@ func (s *Server) settingsShow(w http.ResponseWriter, r *http.Request) {
 	s.DB.Table("scans").Count(&stats.Scans)
 	// Split findings the same way the repo page does: deep-dive (curated
 	// audit) findings versus tool-scanner output (zizmor, semgrep, …).
-	s.DB.Model(&db.Finding{}).Where("scan_id IN (?)", deepDiveScanIDs(s.DB)).Count(&stats.Findings)
-	s.DB.Model(&db.Finding{}).Where("scan_id NOT IN (?)", deepDiveScanIDs(s.DB)).Count(&stats.ScannerFindings)
+	dd := deepDiveScanIDs(s.DB)
+	s.DB.Model(&db.Finding{}).Where("scan_id IN (?)", dd).Count(&stats.Findings)
+	s.DB.Model(&db.Finding{}).Where("scan_id NOT IN (?)", dd).Count(&stats.ScannerFindings)
 	s.DB.Table("packages").Count(&stats.Packages)
 	s.DB.Table("advisories").Count(&stats.Advisories)
 	s.DB.Table("maintainers").Count(&stats.Maintainers)

--- a/internal/worker/egress.go
+++ b/internal/worker/egress.go
@@ -273,6 +273,10 @@ func StartEgressProxy(p *EgressProxy) (int, error) {
 		return 0, err
 	}
 	srv := &http.Server{Handler: p, ReadHeaderTimeout: egressDialTimeout}
+	// The proxy lives for the process lifetime: it is started once from
+	// main.setupRunner and every container talks through it. There is no
+	// per-scan teardown, so no Shutdown wiring is needed; process exit
+	// closes the listener.
 	go func() { _ = srv.Serve(ln) }()
 	return ln.Addr().(*net.TCPAddr).Port, nil
 }

--- a/internal/worker/skill_parsers.go
+++ b/internal/worker/skill_parsers.go
@@ -66,7 +66,7 @@ func (w *Worker) parseRepoMetadataOutput(scan *db.Scan, report string, emit func
 	updates["stars"] = m.Stars
 	updates["forks"] = m.Forks
 	updates["archived"] = m.Archived
-	if t, ok := parseTime(m.PushedAt); ok {
+	if t, ok := parseTimeField(emit, "pushed_at", m.PushedAt); ok {
 		updates["pushed_at"] = t
 	}
 	if m.HTMLURL != "" {
@@ -126,7 +126,7 @@ func (w *Worker) parsePackagesOutput(scan *db.Scan, report string, emit func(Eve
 			RegistryURL:          p.RegistryURL,
 			DependentPackagesURL: p.DependentPackagesURL,
 		}
-		if t, ok := parseTime(p.LatestReleaseAt); ok {
+		if t, ok := parseTimeField(emit, "latest_release_at", p.LatestReleaseAt); ok {
 			row.LatestReleaseAt = &t
 		}
 		if p.Metadata != nil {
@@ -180,10 +180,10 @@ func (w *Worker) parseAdvisoriesOutput(scan *db.Scan, report string, emit func(E
 			Classification: a.Classification,
 			Packages:       a.Packages,
 		}
-		if t, ok := parseTime(a.PublishedAt); ok {
+		if t, ok := parseTimeField(emit, "published_at", a.PublishedAt); ok {
 			row.PublishedAt = &t
 		}
-		if t, ok := parseTime(a.WithdrawnAt); ok {
+		if t, ok := parseTimeField(emit, "withdrawn_at", a.WithdrawnAt); ok {
 			row.WithdrawnAt = &t
 		}
 		rows = append(rows, row)
@@ -1018,4 +1018,16 @@ func parseTime(s string) (time.Time, bool) {
 		}
 	}
 	return time.Time{}, false
+}
+
+// parseTimeField wraps parseTime and emits a transcript line when a non-empty
+// value matches none of the accepted layouts, so a model emitting timestamps
+// in an unexpected format is visible in the scan log instead of silently
+// dropping the field.
+func parseTimeField(emit func(Event), field, s string) (time.Time, bool) {
+	t, ok := parseTime(s)
+	if !ok && s != "" {
+		emit(Event{Kind: KindText, Text: fmt.Sprintf("ignoring unparseable %s value %q (want RFC3339 or YYYY-MM-DD)", field, s)})
+	}
+	return t, ok
 }

--- a/internal/worker/skill_parsers_test.go
+++ b/internal/worker/skill_parsers_test.go
@@ -373,6 +373,31 @@ func TestParseRevalidate_truePositiveMovesNewToEnriched(t *testing.T) {
 	}
 }
 
+func TestParseTimeField_emitsOnUnparseable(t *testing.T) {
+	var events []Event
+	emit := func(e Event) { events = append(events, e) }
+
+	if _, ok := parseTimeField(emit, "pushed_at", "2026-06-01T12:00:00Z"); !ok {
+		t.Error("RFC3339 should parse")
+	}
+	if _, ok := parseTimeField(emit, "pushed_at", "2026-06-01"); !ok {
+		t.Error("date-only should parse")
+	}
+	if _, ok := parseTimeField(emit, "pushed_at", ""); ok {
+		t.Error("empty should return ok=false")
+	}
+	if len(events) != 0 {
+		t.Errorf("valid/empty inputs should not emit: %+v", events)
+	}
+
+	if _, ok := parseTimeField(emit, "pushed_at", "yesterday"); ok {
+		t.Error("garbage should return ok=false")
+	}
+	if len(events) != 1 || !strings.Contains(events[0].Text, `pushed_at value "yesterday"`) {
+		t.Errorf("unparseable input should emit a transcript line: %+v", events)
+	}
+}
+
 func TestParseRevalidate_falsePositiveDoesNotAutoReject(t *testing.T) {
 	report := `{"verdict":"false_positive","reason":"the path lives under test/ fixtures; threat model disclaims it"}`
 	f, gdb := runSkillWithFinding(t, "revalidate", report, db.FindingNew)


### PR DESCRIPTION
Three small items from the older 2026-06-03 audit that don't conflict with anything in flight:

- `parseTimeField` wraps `parseTime` and emits a transcript line when a non-empty value matches none of the accepted layouts, so a model emitting timestamps in an unexpected format is visible in the scan log instead of silently dropping the field. The four callers (`pushed_at`, `latest_release_at`, `published_at`, `withdrawn_at`) switch to it. `TestParseTimeField_emitsOnUnparseable` covers valid/empty (no emit) and garbage (emits with field name and value).
- `settingsShow` binds `deepDiveScanIDs(s.DB)` once instead of building the subquery twice.
- `StartEgressProxy` gets a comment explaining the `srv.Serve` goroutine has no `Shutdown` wiring because the proxy lives for the process lifetime; process exit closes the listener.