### PR TITLE
refactor(web): unify api_reads.go projections on typed structs

### DIFF
--- a/internal/web/api_reads.go
+++ b/internal/web/api_reads.go
@@ -3,6 +3,7 @@ package web
 import (
 	"net/http"
 	"strconv"
+	"time"
 
 	"scrutineer/internal/db"
 )
@@ -12,126 +13,179 @@ import (
 // (verify/patch/disclose, security-deep-dive's reach and prior-art steps)
 // call these instead of re-parsing the original scan reports.
 
-func (s *Server) apiListMaintainers(w http.ResponseWriter, r *http.Request) {
+// repoScopedID parses the path id and enforces the scan-owns-repo auth
+// rule for the apiList* handlers. Returns false when the response has
+// already been written with a 403.
+func (s *Server) repoScopedID(w http.ResponseWriter, r *http.Request) (uint, bool) {
 	id, _ := strconv.Atoi(r.PathValue("id"))
 	if !s.scanOwnsRepo(r, uint(id)) {
 		writeAPIError(w, http.StatusForbidden, "scan may only read its own repository")
+		return 0, false
+	}
+	return uint(id), true
+}
+
+type maintainerResponse struct {
+	ID     uint   `json:"id"`
+	Login  string `json:"login"`
+	Name   string `json:"name"`
+	Email  string `json:"email"`
+	Status string `json:"status"`
+	Notes  string `json:"notes"`
+}
+
+func (s *Server) apiListMaintainers(w http.ResponseWriter, r *http.Request) {
+	id, ok := s.repoScopedID(w, r)
+	if !ok {
 		return
 	}
 	var rows []db.Maintainer
 	s.DB.Joins("JOIN repository_maintainers rm ON rm.maintainer_id = maintainers.id").
 		Where("rm.repository_id = ?", id).
 		Order("maintainers.login").Find(&rows)
-	out := make([]map[string]any, 0, len(rows))
+	out := make([]maintainerResponse, 0, len(rows))
 	for _, m := range rows {
-		out = append(out, map[string]any{
-			"id":      m.ID,
-			"login":   m.Login,
-			"name":    m.Name,
-			"email":   m.Email,
-			statusKey: string(m.Status),
-			"notes":   m.Notes,
+		out = append(out, maintainerResponse{
+			ID:     m.ID,
+			Login:  m.Login,
+			Name:   m.Name,
+			Email:  m.Email,
+			Status: string(m.Status),
+			Notes:  m.Notes,
 		})
 	}
 	writeJSON(w, http.StatusOK, out)
 }
 
-//nolint:dupl // Field projections differ per row type; sharing boilerplate would hide that.
+type packageResponse struct {
+	ID                uint       `json:"id"`
+	Name              string     `json:"name"`
+	Ecosystem         string     `json:"ecosystem"`
+	PURL              string     `json:"purl"`
+	LatestVersion     string     `json:"latest_version"`
+	Downloads         int64      `json:"downloads"`
+	DependentPackages int        `json:"dependent_packages"`
+	DependentRepos    int        `json:"dependent_repos"`
+	RegistryURL       string     `json:"registry_url"`
+	LatestReleaseAt   *time.Time `json:"latest_release_at"`
+}
+
 func (s *Server) apiListPackages(w http.ResponseWriter, r *http.Request) {
-	id, _ := strconv.Atoi(r.PathValue("id"))
-	if !s.scanOwnsRepo(r, uint(id)) {
-		writeAPIError(w, http.StatusForbidden, "scan may only read its own repository")
+	id, ok := s.repoScopedID(w, r)
+	if !ok {
 		return
 	}
 	var rows []db.Package
 	s.DB.Where("repository_id = ?", id).Order("dependent_repos desc, downloads desc").Find(&rows)
-	out := make([]map[string]any, 0, len(rows))
+	out := make([]packageResponse, 0, len(rows))
 	for _, p := range rows {
-		out = append(out, map[string]any{
-			"id":                 p.ID,
-			"name":               p.Name,
-			"ecosystem":          p.Ecosystem,
-			"purl":               p.PURL,
-			"latest_version":     p.LatestVersion,
-			"downloads":          p.Downloads,
-			"dependent_packages": p.DependentPackages,
-			"dependent_repos":    p.DependentRepos,
-			"registry_url":       p.RegistryURL,
-			"latest_release_at":  p.LatestReleaseAt,
+		out = append(out, packageResponse{
+			ID:                p.ID,
+			Name:              p.Name,
+			Ecosystem:         p.Ecosystem,
+			PURL:              p.PURL,
+			LatestVersion:     p.LatestVersion,
+			Downloads:         p.Downloads,
+			DependentPackages: p.DependentPackages,
+			DependentRepos:    p.DependentRepos,
+			RegistryURL:       p.RegistryURL,
+			LatestReleaseAt:   p.LatestReleaseAt,
 		})
 	}
 	writeJSON(w, http.StatusOK, out)
 }
 
-//nolint:dupl // Field projections differ per row type; sharing boilerplate would hide that.
+type advisoryResponse struct {
+	ID             uint       `json:"id"`
+	UUID           string     `json:"uuid"`
+	URL            string     `json:"url"`
+	Title          string     `json:"title"`
+	Severity       string     `json:"severity"`
+	CVSSScore      float64    `json:"cvss_score"`
+	Classification string     `json:"classification"`
+	Packages       string     `json:"packages"`
+	PublishedAt    *time.Time `json:"published_at"`
+	WithdrawnAt    *time.Time `json:"withdrawn_at"`
+}
+
 func (s *Server) apiListAdvisories(w http.ResponseWriter, r *http.Request) {
-	id, _ := strconv.Atoi(r.PathValue("id"))
-	if !s.scanOwnsRepo(r, uint(id)) {
-		writeAPIError(w, http.StatusForbidden, "scan may only read its own repository")
+	id, ok := s.repoScopedID(w, r)
+	if !ok {
 		return
 	}
 	var rows []db.Advisory
 	s.DB.Where("repository_id = ?", id).Order("cvss_score desc").Find(&rows)
-	out := make([]map[string]any, 0, len(rows))
+	out := make([]advisoryResponse, 0, len(rows))
 	for _, a := range rows {
-		out = append(out, map[string]any{
-			"id":             a.ID,
-			"uuid":           a.UUID,
-			"url":            a.URL,
-			"title":          a.Title,
-			"severity":       a.Severity,
-			"cvss_score":     a.CVSSScore,
-			"classification": a.Classification,
-			"packages":       a.Packages,
-			"published_at":   a.PublishedAt,
-			"withdrawn_at":   a.WithdrawnAt,
+		out = append(out, advisoryResponse{
+			ID:             a.ID,
+			UUID:           a.UUID,
+			URL:            a.URL,
+			Title:          a.Title,
+			Severity:       a.Severity,
+			CVSSScore:      a.CVSSScore,
+			Classification: a.Classification,
+			Packages:       a.Packages,
+			PublishedAt:    a.PublishedAt,
+			WithdrawnAt:    a.WithdrawnAt,
 		})
 	}
 	writeJSON(w, http.StatusOK, out)
 }
 
+type dependentResponse struct {
+	ID             uint   `json:"id"`
+	Name           string `json:"name"`
+	Ecosystem      string `json:"ecosystem"`
+	PURL           string `json:"purl"`
+	RepositoryURL  string `json:"repository_url"`
+	Downloads      int64  `json:"downloads"`
+	DependentRepos int    `json:"dependent_repos"`
+	RegistryURL    string `json:"registry_url"`
+	LatestVersion  string `json:"latest_version"`
+}
+
 func (s *Server) apiListDependents(w http.ResponseWriter, r *http.Request) {
-	id, _ := strconv.Atoi(r.PathValue("id"))
-	if !s.scanOwnsRepo(r, uint(id)) {
-		writeAPIError(w, http.StatusForbidden, "scan may only read its own repository")
+	id, ok := s.repoScopedID(w, r)
+	if !ok {
 		return
 	}
 	var rows []db.Dependent
 	s.DB.Where("repository_id = ?", id).Order("dependent_repos desc").Find(&rows)
-	out := make([]map[string]any, 0, len(rows))
+	out := make([]dependentResponse, 0, len(rows))
 	for _, d := range rows {
-		out = append(out, map[string]any{
-			"id":              d.ID,
-			"name":            d.Name,
-			"ecosystem":       d.Ecosystem,
-			"purl":            d.PURL,
-			"repository_url":  d.RepositoryURL,
-			"downloads":       d.Downloads,
-			"dependent_repos": d.DependentRepos,
-			"registry_url":    d.RegistryURL,
-			"latest_version":  d.LatestVersion,
+		out = append(out, dependentResponse{
+			ID:             d.ID,
+			Name:           d.Name,
+			Ecosystem:      d.Ecosystem,
+			PURL:           d.PURL,
+			RepositoryURL:  d.RepositoryURL,
+			Downloads:      d.Downloads,
+			DependentRepos: d.DependentRepos,
+			RegistryURL:    d.RegistryURL,
+			LatestVersion:  d.LatestVersion,
 		})
 	}
 	writeJSON(w, http.StatusOK, out)
 }
 
+type dependencyResponse struct {
+	ID                    uint   `json:"id"`
+	Name                  string `json:"name"`
+	Ecosystem             string `json:"ecosystem"`
+	PURL                  string `json:"purl"`
+	Requirement           string `json:"requirement"`
+	RequirementUnresolved bool   `json:"requirement_unresolved"`
+	RequirementResolution string `json:"requirement_resolution"`
+	DependencyType        string `json:"dependency_type"`
+	ManifestPath          string `json:"manifest_path"`
+	ManifestKind          string `json:"manifest_kind"`
+}
+
 func (s *Server) apiListDependencies(w http.ResponseWriter, r *http.Request) {
-	id, _ := strconv.Atoi(r.PathValue("id"))
-	if !s.scanOwnsRepo(r, uint(id)) {
-		writeAPIError(w, http.StatusForbidden, "scan may only read its own repository")
+	id, ok := s.repoScopedID(w, r)
+	if !ok {
 		return
-	}
-	type dependencyResponse struct {
-		ID                    uint   `json:"id"`
-		Name                  string `json:"name"`
-		Ecosystem             string `json:"ecosystem"`
-		PURL                  string `json:"purl"`
-		Requirement           string `json:"requirement"`
-		RequirementUnresolved bool   `json:"requirement_unresolved"`
-		RequirementResolution string `json:"requirement_resolution"`
-		DependencyType        string `json:"dependency_type"`
-		ManifestPath          string `json:"manifest_path"`
-		ManifestKind          string `json:"manifest_kind"`
 	}
 	var rows []db.Dependency
 	s.DB.Where("repository_id = ?", id).Order("ecosystem, name").Find(&rows)
@@ -158,12 +212,11 @@ func (s *Server) apiListDependencies(w http.ResponseWriter, r *http.Request) {
 // token still only authorises the caller's own repo; the cross-repo read is
 // derived from that repo's dependencies, not chosen by the caller.
 func (s *Server) apiListDependencyFindings(w http.ResponseWriter, r *http.Request) {
-	id, _ := strconv.Atoi(r.PathValue("id"))
-	if !s.scanOwnsRepo(r, uint(id)) {
-		writeAPIError(w, http.StatusForbidden, "scan may only read its own repository")
+	id, ok := s.repoScopedID(w, r)
+	if !ok {
 		return
 	}
-	rows, err := db.DependencyFindings(s.DB, uint(id))
+	rows, err := db.DependencyFindings(s.DB, id)
 	if err != nil {
 		writeAPIError(w, http.StatusInternalServerError, err.Error())
 		return
@@ -183,9 +236,8 @@ func (s *Server) apiListDependencyFindings(w http.ResponseWriter, r *http.Reques
 // apiListFindings returns the findings for a repository across every scan.
 // Scoped to the authenticated scan's repository; severity filter optional.
 func (s *Server) apiListFindings(w http.ResponseWriter, r *http.Request) {
-	id, _ := strconv.Atoi(r.PathValue("id"))
-	if !s.scanOwnsRepo(r, uint(id)) {
-		writeAPIError(w, http.StatusForbidden, "scan may only read its own repository")
+	id, ok := s.repoScopedID(w, r)
+	if !ok {
 		return
 	}
 	// Direct subquery; GORM's Joins("Scan") aliasing doesn't round-trip on


### PR DESCRIPTION
After #353 the file mixed three patterns: `map[string]any` (most handlers), `map[string]any` with `//nolint:dupl` (`apiListPackages`, `apiListAdvisories`), and a typed response struct (`apiListDependencies`). Convert the four remaining projection handlers to typed structs so the file has one pattern and the two suppressions can go; `dupl` no longer fires because each struct definition has a distinct field set.

A `repoScopedID` helper extracts the path-id atoi + `scanOwnsRepo` check that opened every handler in the file.

JSON output is unchanged (same field tags). All five handlers were at 66-80% before this change; existing API tests pass with no test changes.

`apiListFindings` / `findingSummary` stay as `map[string]any` because `apiGetFinding` extends the same map with extra prose fields; that restructure belongs with the `findingShow` extraction in the `server.go` split.