### PR TITLE
worker: scheme-validate html_url and icon_url before storing (T7)

### DIFF
--- a/internal/worker/skill_parsers.go
+++ b/internal/worker/skill_parsers.go
@@ -69,17 +69,30 @@ func (w *Worker) parseRepoMetadataOutput(scan *db.Scan, report string, emit func
 	if t, ok := parseTimeField(emit, "pushed_at", m.PushedAt); ok {
 		updates["pushed_at"] = t
 	}
-	if m.HTMLURL != "" {
-		updates["html_url"] = m.HTMLURL
+	if u := safeURL(m.HTMLURL); u != "" {
+		updates["html_url"] = u
 	}
-	if m.IconURL != "" {
-		updates["icon_url"] = m.IconURL
+	if u := safeURL(m.IconURL); u != "" {
+		updates["icon_url"] = u
 	}
 	if err := w.DB.Model(&db.Repository{}).Where("id = ?", scan.RepositoryID).Updates(updates).Error; err != nil {
 		return fmt.Errorf("update repository: %w", err)
 	}
 	emit(Event{Kind: KindText, Text: "updated repository metadata"})
 	return nil
+}
+
+// safeURL returns u trimmed when it carries an http or https scheme, else
+// empty. Applied to model-emitted URLs (html_url, icon_url) before they
+// reach the database so a hostile metadata response cannot land a
+// javascript: or data: URI that the templates then render as a clickable
+// link (T7 in threatmodel.md).
+func safeURL(u string) string {
+	u = strings.TrimSpace(u)
+	if strings.HasPrefix(u, "http://") || strings.HasPrefix(u, "https://") {
+		return u
+	}
+	return ""
 }
 
 // parsePackagesOutput replaces Package rows for the scan's repository. We

--- a/internal/worker/skill_parsers_test.go
+++ b/internal/worker/skill_parsers_test.go
@@ -206,6 +206,49 @@ func TestParseRepoMetadata_updatesRepository(t *testing.T) {
 	}
 }
 
+func TestSafeURL(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"https://github.com/x/y", "https://github.com/x/y"},
+		{"http://example.com", "http://example.com"},
+		{"  https://example.com  ", "https://example.com"},
+		{"javascript:alert(1)", ""},
+		{"data:text/html,<script>alert(1)</script>", ""},
+		{"vbscript:msgbox(1)", ""},
+		{"//evil.com/x", ""},
+		{"file:///etc/passwd", ""},
+		{"HTTPS://example.com", ""},
+		{"", ""},
+		{"   ", ""},
+	}
+	for _, tc := range cases {
+		if got := safeURL(tc.in); got != tc.want {
+			t.Errorf("safeURL(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestParseRepoMetadata_dropsUnsafeURLs(t *testing.T) {
+	report := `{
+		"full_name": "example/x",
+		"html_url": "javascript:alert(1)",
+		"icon_url": "data:text/html,<script>alert(1)</script>"
+	}`
+	repo, gdb := runSkillWithReport(t, "repo_metadata", report)
+	var got db.Repository
+	gdb.First(&got, repo.ID)
+	if got.HTMLURL != "" {
+		t.Errorf("HTMLURL = %q, want empty (javascript: scheme rejected)", got.HTMLURL)
+	}
+	if got.IconURL != "" {
+		t.Errorf("IconURL = %q, want empty (data: scheme rejected)", got.IconURL)
+	}
+	if got.FullName != "example/x" {
+		t.Errorf("safe fields should still be written, got FullName=%q", got.FullName)
+	}
+}
+
 func TestParsePackages_replacesPackageRows(t *testing.T) {
 	report := `{"packages":[
 		{"name":"foo","ecosystem":"rubygems","purl":"pkg:gem/foo","latest_version":"1.0.0","downloads":1000000,"dependent_repos":50,"dependent_packages_url":"https://packages.ecosyste.ms/api/v1/registries/rubygems/packages/foo/dependent_packages","metadata":{"foo":"bar"}},

--- a/threatmodel.md
+++ b/threatmodel.md
@@ -92,13 +92,13 @@ Mitigation remaining: tag finding rows with their source job; render claude-sour
 
 ### T6: Stored XSS via finding fields (mitigated by stdlib + toolchain upgrade)
 
-Go's `html/template` auto-escapes all finding fields. `internal/web/jsontree.go` returns `template.HTML` but escapes every leaf through `html.EscapeString`. `internal/web/location.go` builds hrefs from `HTMLURL`, which is not yet scheme-validated (see T7).
+Go's `html/template` auto-escapes all finding fields. `internal/web/jsontree.go` returns `template.HTML` but escapes every leaf through `html.EscapeString`. `internal/web/location.go` builds hrefs from `HTMLURL`, which is scheme-validated at the write site by `safeURL` (see T7).
 
 The two `html/template` XSS vulnerabilities (`GO-2026-4865`, `GO-2026-4603`) are fixed by `toolchain go1.26.2` in go.mod.
 
-### T7: Untrusted upstream metadata (partially mitigated)
+### T7: Untrusted upstream metadata (mitigated)
 
-All five `io.ReadAll` calls in `metadata.go` are wrapped with `io.LimitReader(resp.Body, 10MB)` to prevent OOM from hostile endpoints. `HTMLURL` and `IconURL` are stored as-is without scheme validation; `safeURL()` is planned but not yet landed (#236).
+All five `io.ReadAll` calls in `metadata.go` are wrapped with `io.LimitReader(resp.Body, 10MB)` to prevent OOM from hostile endpoints. `HTMLURL` and `IconURL` are scheme-validated by `safeURL()` in `parseRepoMetadataOutput` before storage, so only http/https values reach the database and the templates that render them.
 
 Residual: no certificate pinning for ecosyste.ms. A MITM'd response could still return a hostile `repository_url` that passes the `https://` check, leading to cloning an attacker repo. Accepted risk given HTTPS + public CA is the standard trust model.
 
@@ -175,7 +175,7 @@ GORM usage is consistently parameterised; no `Raw`, no string-built `Where`, and
 - [x] `--` separator before URL in `git clone` (T2).
 - [x] `GIT_PROTOCOL_FROM_USER=0` in clone environment (T2).
 - [x] `io.LimitReader` (10 MB cap) on all ecosyste.ms response bodies (T7).
-- [ ] `safeURL` validation on HTMLURL and IconURL before storing (T7).
+- [x] `safeURL` validation on HTMLURL and IconURL before storing (T7).
 - [x] `0700` on the data directory at startup (T8).
 - [x] `toolchain go1.26.2` in go.mod so host builds match the image (T10).
 - [x] Pin tool versions in Dockerfile: claude-code, semgrep, git-pkgs, brief, zizmor (T11).


### PR DESCRIPTION
threatmodel.md claimed `safeURL()` gated these but the helper was never landed; the metadata skill's `html_url` and `icon_url` were stored verbatim, so a hostile or steered response could plant a `javascript:` or `data:` URI that the templates then render as a clickable link.

Adds `safeURL` in `skill_parsers.go` (returns the trimmed input only when it carries an `http://` or `https://` prefix) and applies it at the two write sites in `parseRepoMetadataOutput`. `TestSafeURL` is a table over http/https/javascript/data/vbscript/file/protocol-relative/uppercase/empty/whitespace; `TestParseRepoMetadata_dropsUnsafeURLs` confirms a hostile metadata report leaves the URL columns empty while other fields still write. T7 marked mitigated in threatmodel.md.

Supersedes #236 — same `safeURL` and call-site changes @N0tre3l proposed there, without the T4 SSRF hunks that overlapped the closed #233.