### PR TITLE
fix: Improve design of exploitation status row, move editing to a modal

### DIFF
--- a/internal/web/templates/finding_workflow.html
+++ b/internal/web/templates/finding_workflow.html
@@ -119,14 +119,17 @@
     </form>
   </section>
 
-  <footer class="border-t mt-4 flex items-center gap-2 text-sm text-muted-foreground">
-    <i data-lucide="bug" class="size-4"></i>
-    <span>Exploitation status</span>
-    {{if eq .ExploitedInWild "yes"}}<span class="badge-destructive">yes</span>{{else if eq .ExploitedInWild "no"}}<span class="badge-outline">no</span>{{else}}<span>unknown</span>{{end}}
-    <button type="button" data-dialog="exploitation-{{$id}}" class="btn-sm btn-outline ml-auto">
-      <i data-lucide="pencil"></i> Edit
-    </button>
-  </footer>
+  <section class="border-t mt-4 grid gap-1 text-sm text-muted-foreground">
+    <div class="flex items-center gap-2">
+      <i data-lucide="bug" class="size-4"></i>
+      <span>Exploitation status</span>
+      {{if eq .ExploitedInWild "yes"}}<span class="badge-destructive">yes</span>{{else if eq .ExploitedInWild "no"}}<span class="badge-outline">no</span>{{else}}<span>unknown</span>{{end}}
+      <button type="button" data-dialog="exploitation-{{$id}}" class="btn-sm btn-outline ml-auto">
+        <i data-lucide="pencil"></i> Edit
+      </button>
+    </div>
+    {{if .ExploitedInWildEvidence}}<p class="text-xs pl-6">{{.ExploitedInWildEvidence}}</p>{{end}}
+  </section>
 </div>
 
 <dialog id="exploitation-{{$id}}" class="dialog">

--- a/internal/web/templates/finding_workflow.html
+++ b/internal/web/templates/finding_workflow.html
@@ -119,7 +119,7 @@
     </form>
   </section>
 
-  <section class="border-t mt-4 grid gap-1 text-sm text-muted-foreground">
+  <section class="border-t pt-6 grid gap-1 text-sm text-muted-foreground">
     <div class="flex items-center gap-2">
       <i data-lucide="bug" class="size-4"></i>
       <span>Exploitation status</span>

--- a/internal/web/templates/finding_workflow.html
+++ b/internal/web/templates/finding_workflow.html
@@ -119,7 +119,7 @@
     </form>
   </section>
 
-  <details class="mt-4 border-t pt-3" {{if eq .ExploitedInWild "yes"}}open{{end}}>
+  <details class="mt-4 border-t pt-3 px-6" {{if eq .ExploitedInWild "yes"}}open{{end}}>
     <summary class="text-xs text-muted-foreground cursor-pointer hover:underline flex items-center gap-2">
       <i data-lucide="bug"></i>
       Exploitation status

--- a/internal/web/templates/finding_workflow.html
+++ b/internal/web/templates/finding_workflow.html
@@ -119,30 +119,41 @@
     </form>
   </section>
 
-  <details class="mt-4 border-t pt-3 px-6" {{if eq .ExploitedInWild "yes"}}open{{end}}>
-    <summary class="text-xs text-muted-foreground cursor-pointer hover:underline flex items-center gap-2">
-      <i data-lucide="bug"></i>
-      Exploitation status
-      {{if eq .ExploitedInWild "yes"}}<span class="badge-destructive ml-auto">yes</span>{{else if eq .ExploitedInWild "no"}}<span class="badge-outline ml-auto">no</span>{{else}}<span class="text-muted-foreground ml-auto">unknown</span>{{end}}
-    </summary>
-    <form method="post" action="/findings/{{$id}}/exploited-in-wild" class="grid gap-2 mt-3 text-sm">
-      <div class="flex items-center gap-2">
-        <label class="text-xs text-muted-foreground w-24">Exploited?</label>
-        <select class="input" name="exploited_in_wild">
+  <footer class="border-t mt-4 flex items-center gap-2 text-sm text-muted-foreground">
+    <i data-lucide="bug" class="size-4"></i>
+    <span>Exploitation status</span>
+    {{if eq .ExploitedInWild "yes"}}<span class="badge-destructive">yes</span>{{else if eq .ExploitedInWild "no"}}<span class="badge-outline">no</span>{{else}}<span>unknown</span>{{end}}
+    <button type="button" data-dialog="exploitation-{{$id}}" class="btn-sm btn-outline ml-auto">
+      <i data-lucide="pencil"></i> Edit
+    </button>
+  </footer>
+</div>
+
+<dialog id="exploitation-{{$id}}" class="dialog">
+  <article>
+    <header>
+      <h2>Exploitation status</h2>
+      <p class="text-sm text-muted-foreground">Has this finding been exploited in the wild?</p>
+    </header>
+    <form method="post" action="/findings/{{$id}}/exploited-in-wild" class="form grid gap-4">
+      <div class="grid gap-2">
+        <label class="label" for="exploited-{{$id}}">Exploited?</label>
+        <select class="input" id="exploited-{{$id}}" name="exploited_in_wild">
           <option value=""{{if eq .ExploitedInWild ""}} selected{{end}}>unknown</option>
           <option value="yes"{{if eq .ExploitedInWild "yes"}} selected{{end}}>yes</option>
           <option value="no"{{if eq .ExploitedInWild "no"}} selected{{end}}>no</option>
         </select>
       </div>
-      <div class="grid gap-1">
-        <label class="text-xs text-muted-foreground">Evidence / source</label>
-        <textarea class="input text-xs" name="exploited_in_wild_evidence" rows="2"
+      <div class="grid gap-2">
+        <label class="label" for="evidence-{{$id}}">Evidence / source</label>
+        <textarea class="input" id="evidence-{{$id}}" name="exploited_in_wild_evidence" rows="3"
                   placeholder="Where this came from — researcher report, CERT advisory, in-the-wild traffic, etc.">{{.ExploitedInWildEvidence}}</textarea>
       </div>
-      <div class="flex justify-end">
-        <button type="submit" class="btn-sm">Save exploitation status</button>
-      </div>
+      <footer class="flex justify-end gap-2">
+        <button type="submit" class="btn-outline" formmethod="dialog" formnovalidate>Cancel</button>
+        <button type="submit" class="btn">Save</button>
+      </footer>
     </form>
-  </details>
-</div>
+  </article>
+</dialog>
 {{end}}

--- a/internal/web/templates/finding_workflow.html
+++ b/internal/web/templates/finding_workflow.html
@@ -119,16 +119,16 @@
     </form>
   </section>
 
-  <section class="border-t pt-6 grid gap-1 text-sm text-muted-foreground">
+  <section class="border-t pt-3 grid gap-1 text-xs text-muted-foreground">
     <div class="flex items-center gap-2">
-      <i data-lucide="bug" class="size-4"></i>
+      <i data-lucide="bug" class="size-3.5"></i>
       <span>Exploitation status</span>
       {{if eq .ExploitedInWild "yes"}}<span class="badge-destructive">yes</span>{{else if eq .ExploitedInWild "no"}}<span class="badge-outline">no</span>{{else}}<span>unknown</span>{{end}}
       <button type="button" data-dialog="exploitation-{{$id}}" class="btn-sm btn-outline ml-auto">
         <i data-lucide="pencil"></i> Edit
       </button>
     </div>
-    {{if .ExploitedInWildEvidence}}<p class="text-xs pl-6">{{.ExploitedInWildEvidence}}</p>{{end}}
+    {{if .ExploitedInWildEvidence}}<p class="pl-6">{{.ExploitedInWildEvidence}}</p>{{end}}
   </section>
 </div>
 


### PR DESCRIPTION
Generated w/ Claude Code, reviewed and tested by me.

Before:

<img width="1200" height="204" alt="Screenshot 2026-06-16 at 5 20 47 PM" src="https://github.com/user-attachments/assets/c85b8cdb-98f4-4a58-9182-532507288fee" />

After:

<img width="1190" height="203" alt="Screenshot 2026-06-16 at 5 34 56 PM" src="https://github.com/user-attachments/assets/2decd181-a725-48a2-87a5-43a593693738" />

<img width="1185" height="182" alt="Screenshot 2026-06-16 at 5 35 07 PM" src="https://github.com/user-attachments/assets/7e9c2c53-11d0-4baa-b0fb-62e32d9f62a6" />

<img width="516" height="348" alt="Screenshot 2026-06-16 at 5 36 54 PM" src="https://github.com/user-attachments/assets/3d54a3a1-fdc3-4042-9147-2379ab80e8ab" />

I found the inline edit to be difficult to understand due to the lack of contrast, and it isn't going to be edited very often anyway, so putting it in a modal seems fine to me. I think we should consider moving the exploitation status out of the main findings header area entirely as it seems like it'd be rare to use, but for now this at least fixes up the design.