### PR TITLE
Fix small repository UI paper cuts

### DIFF
--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -1629,7 +1629,7 @@ func TestMaintainersSortOptions(t *testing.T) {
 	logins := func(body string) []string {
 		idx := map[string]int{}
 		for _, want := range []string{alpha, charlie, zeta} {
-			if i := strings.Index(body, want); i >= 0 {
+			if i := strings.Index(body, ">"+want+"</td>"); i >= 0 {
 				idx[want] = i
 			}
 		}
@@ -2976,6 +2976,55 @@ func TestRepoList_showsBranchTags(t *testing.T) {
 	// Exactly one tag: the default-only repo (empty Ref) must not get one.
 	if n := strings.Count(body, `data-lucide="git-branch"`); n != 1 {
 		t.Errorf("want exactly 1 branch tag, got %d", n)
+	}
+}
+
+func TestRepoList_showsLastScanDate(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	repo := db.Repository{URL: "https://github.com/example/repo", Name: "repo"}
+	s.DB.Create(&repo)
+	created := time.Date(2026, time.June, 16, 19, 15, 8, 0, time.UTC)
+	s.DB.Create(&db.Scan{
+		RepositoryID: repo.ID,
+		Kind:         "skill",
+		SkillName:    "triage",
+		Status:       db.ScanDone,
+		CreatedAt:    created,
+	})
+
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq("GET", "/"))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+	row := requireRepoListRow(t, w.Body.String(), repo.ID)
+	if !strings.Contains(row, "2026-06-16 19:15") {
+		t.Errorf("repo row missing date-bearing last scan timestamp: %s", row)
+	}
+	if !strings.Contains(row, `title="2026-06-16 19:15:08 UTC"`) {
+		t.Errorf("repo row missing full last scan tooltip: %s", row)
+	}
+}
+
+func TestLayout_linksToProjectResources(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq("GET", "/"))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+	body := w.Body.String()
+	for _, want := range []string{
+		`href="https://github.com/alpha-omega-security/scrutineer"`,
+		`href="https://github.com/alpha-omega-security/scrutineer#readme"`,
+		`href="https://github.com/alpha-omega-security/scrutineer/issues/new"`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("layout missing project link %s", want)
+		}
 	}
 }
 

--- a/internal/web/templates/layout.html
+++ b/internal/web/templates/layout.html
@@ -60,6 +60,17 @@
       </div>
     </section>
     <footer>
+      <div class="grid gap-1 mb-2">
+        <a href="https://github.com/alpha-omega-security/scrutineer" target="_blank" rel="noopener noreferrer" class="btn-sm-ghost justify-start">
+          <i data-lucide="github"></i> GitHub
+        </a>
+        <a href="https://github.com/alpha-omega-security/scrutineer#readme" target="_blank" rel="noopener noreferrer" class="btn-sm-ghost justify-start">
+          <i data-lucide="book-open"></i> Documentation
+        </a>
+        <a href="https://github.com/alpha-omega-security/scrutineer/issues/new" target="_blank" rel="noopener noreferrer" class="btn-sm-ghost justify-start">
+          <i data-lucide="circle-alert"></i> Report issue
+        </a>
+      </div>
       <a href="/repositories/new" data-dialog="add-repo" class="btn w-full">
         <i data-lucide="plus"></i> Add repository
       </a>

--- a/internal/web/templates/repo_list.html
+++ b/internal/web/templates/repo_list.html
@@ -52,7 +52,7 @@
           {{range .Branches}}{{template "branch-tag" .}}{{end}}
         </td>
         <td class="text-muted-foreground">{{if .Languages}}{{.Languages}}{{else}}-{{end}}</td>
-        <td>{{if .LastScan}}{{.LastScan.CreatedAt.Format "15:04:05"}}{{else}}never{{end}}</td>
+        <td>{{if .LastScan}}<span title="{{.LastScan.CreatedAt.Format "2006-01-02 15:04:05 MST"}}">{{.LastScan.CreatedAt.Format "2006-01-02 15:04"}}</span>{{else}}never{{end}}</td>
         <td>{{if .LastScan}}{{template "status-badge" (status .LastScan.Status)}}{{end}}</td>
         <td>{{template "findings-badge" .FindingsTotal}}</td>
         <td class="text-muted-foreground">{{if .DiskBytes}}{{bytes .DiskBytes}}{{else}}-{{end}}</td>


### PR DESCRIPTION
## Summary

Fixes #408.

- Show repository last-scan timestamps with the date and time instead of only the time of day
- Add sidebar links back to the Scrutineer GitHub repo, documentation and issue reporting
- Add regression coverage for the last-scan timestamp and project links
- Tighten a maintainer sort test so it checks maintainer rows instead of incidental layout text

## Testing

- `go test ./internal/web -run 'TestMaintainersSortOptions|TestRepoList_showsLastScanDate|TestLayout_linksToProjectResources|TestRepoList_showsBranchTags' -count=1`
- `env GOTOOLCHAIN=local /Users/gautam/go/bin/golangci-lint run ./...`
- `go test ./...`
- `go vet ./...`