### PR TITLE
feat(web): syntax-highlight SKILL.md body and schema.json on skill page

### DIFF
--- a/internal/web/static/theme.css
+++ b/internal/web/static/theme.css
@@ -399,6 +399,15 @@ pre.log { background: var(--muted); padding: 1rem; border-radius: var(--radius);
 .prose th { background: var(--muted); font-weight: 600; }
 .prose hr { border: none; border-top: 1px solid var(--border); margin: 1.5em 0; }
 
+/* ── skill source blocks (highlighted SKILL.md body / schema.json) ── */
+/* Sit on the standard muted inset like pre.log and .prose pre, and neutralise
+   highlight.js's own near-black panel background so only its token colours show.
+   Without this the .hljs background clashes with the card behind it. The
+   pre.skill-src code selector outranks hljs's .hljs rule on specificity. */
+pre.skill-src { background: var(--muted); padding: 0.75rem; border-radius: var(--radius);
+                overflow-x: auto; }
+pre.skill-src code { background: none; padding: 0; }
+
 /* ── code browser ── */
 #blob { display: block; padding: 0.5rem 0; tab-size: 4; }
 .hl-line { padding-left: 3.5rem; position: relative; }

--- a/internal/web/templates/skill_show.html
+++ b/internal/web/templates/skill_show.html
@@ -28,13 +28,13 @@
 
 <section class="card p-4 mb-6">
   <h3 class="font-medium mb-3">SKILL.md body</h3>
-  <pre class="text-xs whitespace-pre-wrap font-mono bg-muted p-3 rounded">{{.Body}}</pre>
+  <pre class="text-xs whitespace-pre-wrap font-mono skill-src"><code class="language-markdown">{{.Body}}</code></pre>
 </section>
 
 {{if .SchemaJSON}}
 <section class="card p-4 mb-6">
   <h3 class="font-medium mb-3">schema.json</h3>
-  <pre class="text-xs whitespace-pre-wrap font-mono bg-muted p-3 rounded">{{prettyjson .SchemaJSON}}</pre>
+  <pre class="text-xs whitespace-pre-wrap font-mono skill-src"><code class="language-json">{{prettyjson .SchemaJSON}}</code></pre>
 </section>
 {{end}}
 {{end}}


### PR DESCRIPTION
Wrap both blocks on the skill detail page in `<code class="language-...">` so the globally-loaded highlight.js auto-highlight pass in app.js picks them up: markdown for the SKILL.md body, json for schema.json.

Before:

<img width="1195" height="747" alt="Screenshot 2026-06-16 at 9 38 24 PM" src="https://github.com/user-attachments/assets/f93ce0ab-1d8e-4d50-b9ea-e40a381a4a0a" />

After:

<img width="1211" height="766" alt="Screenshot 2026-06-16 at 9 37 47 PM" src="https://github.com/user-attachments/assets/03eac91e-5199-44cb-9da1-8851e2dd3ad1" />
