### PR TITLE
Move runner images to `trixie`

### DIFF
--- a/Dockerfile.runner
+++ b/Dockerfile.runner
@@ -5,14 +5,14 @@
 ARG CLAUDE_VERSION=2.1.173
 ARG SEMGREP_VERSION=1.116.0
 
-FROM golang:1.26.4-bookworm@sha256:5f68ec6805843bd3981a951ffada82a26a0bd2631045c8f7dba483fa868f5ec5 AS go-tools
+FROM golang:1.26.4-trixie@sha256:bbf22ddccb3205344f2755ea8fa4fe39f7a8b2b77b9f7b764ec2aad31406f6fc AS go-tools
 RUN GOBIN=/out go install github.com/git-pkgs/git-pkgs@v0.15.3 && \
     GOBIN=/out go install github.com/git-pkgs/brief/cmd/brief@v0.6.0
 
-FROM rust:1.96-bookworm@sha256:19817ead3289c8c631c73df281e18b59b172f6a31f4f563290f69cddd06c30e9 AS zizmor-build
+FROM rust:1.96-trixie@sha256:4fd8406017c992f7b8ab55a2f99a1d56aeb1d7ecd255850dfa04239a88601f73 AS zizmor-build
 RUN cargo install --locked --root /out zizmor@1.24.1
 
-FROM debian:bookworm-slim@sha256:96e378d7e6531ac9a15ad505478fcc2e69f371b10f5cdf87857c4b8188404716
+FROM debian:trixie-slim@sha256:4e401d95de7083948053197a9c3913343cd06b706bf15eb6a0c3ccd26f436a0e
 ARG CLAUDE_VERSION
 ARG SEMGREP_VERSION
 

--- a/docker/profiles/ruby/Dockerfile
+++ b/docker/profiles/ruby/Dockerfile
@@ -2,7 +2,7 @@
 # interpreter and Bundler so scans of Bundler/RubyGems projects can audit
 # or reproduce in-place.
 #
-# The runner's Debian release (bookworm-slim, inherited via FROM) only
+# The runner's Debian release (trixie-slim, inherited via FROM) only
 # supplies the build toolchain here -- Ruby itself is compiled from source
 # by ruby-build at an explicit pinned version, so the interpreter is
 # current regardless of what the distro packages.

--- a/threatmodel.md
+++ b/threatmodel.md
@@ -118,7 +118,7 @@ No rate limiting on `POST /repositories`, no cap on clone size, no timeout on th
 
 ### T11: Image supply chain (partially mitigated)
 
-Tool versions are pinned: `claude-code@2.1.173`, `semgrep==1.116.0`, `git-pkgs@v0.15.3`, `brief@v0.6.0`, `zizmor@1.24.1`. The final stage is `debian:bookworm-slim`; the `golang:1.26-bookworm` and `rust:1.88-bookworm` builder stages are pinned by sha256 digest. The container runs as non-root user `runner`. The runner image is built in CI, smoke-tested, and published to GHCR; users pull a known-good artifact rather than rebuilding against live registries.
+Tool versions are pinned: `claude-code@2.1.173`, `semgrep==1.116.0`, `git-pkgs@v0.15.3`, `brief@v0.6.0`, `zizmor@1.24.1`. The final stage is `debian:trixie-slim`; the `golang:1.26-trixie` and `rust:1.96-trixie` builder stages are pinned by sha256 digest. The container runs as non-root user `runner`. The runner image is built in CI, smoke-tested, and published to GHCR; users pull a known-good artifact rather than rebuilding against live registries.
 
 Supply-chain surface in the final stage:
 - `apt` pulls from Debian's official mirrors plus the GitHub CLI repo at `cli.github.com/packages` (signed-by keyring under `/etc/apt/keyrings/`). `gh` is used at scan time by the `fork` and `report-upstream` skills.


### PR DESCRIPTION
A couple of weeks ago @connorshea raised the point about the Debian release version.

This moves everything to Trixie

| Language | Versions |
| -- | -- | 
| php | PHP 8.4.22, Composer 2.10.1, PIE, 77 extensions | 
| ruby | Ruby 3.4.9 (source build), gem 3.6.9, Bundler 2.6.9 |
| php-ext | PHP 8.5.6 DEBUG; |

Didn't update any version for the move, happy to follow up with a bump of everything generic (gh, claude, zizmor)