### PR TITLE
feat: exclude test/spec dirs and files from semgrep scans

### DIFF
--- a/skills/semgrep/SKILL.md
+++ b/skills/semgrep/SKILL.md
@@ -23,7 +23,7 @@ Run semgrep against `./src` using the `p/security-audit` and `p/secrets` ruleset
 
 ## Available scripts
 
-- `scripts/scan.py` — runs semgrep, maps results into findings with the fields we actually populate (`id`, `title`, `severity`, `cwe`, `location`, `trace`, `rating`). Severity maps: `ERROR` → High, `WARNING` → Medium, `INFO`/`INVENTORY`/`EXPERIMENT` → Low.
+- `scripts/scan.py` — runs semgrep, maps results into findings with the fields we actually populate (`id`, `title`, `severity`, `cwe`, `location`, `trace`, `rating`). Severity maps: `ERROR` → High, `WARNING` → Medium, `INFO`/`INVENTORY`/`EXPERIMENT` → Low. Test/spec directories and files (e.g. `test/`, `spec/`, `*_test.go`, `*.spec.ts`) are skipped via semgrep `--exclude` since findings there aren't shipped to production.
 
 ## What to do
 

--- a/skills/semgrep/scripts/scan.py
+++ b/skills/semgrep/scripts/scan.py
@@ -27,23 +27,51 @@ SEVERITY_MAP = {
     "EXPERIMENT": "Low",
 }
 
+# Test/spec code is not shipped to production, so findings there are noise.
+# semgrep's --exclude takes a glob (matched against the path) and is
+# repeatable; these cover the common directory and filename conventions.
+EXCLUDES = [
+    "test",
+    "tests",
+    "spec",
+    "specs",
+    "__tests__",
+    "*_test.go",
+    "*_test.py",
+    "test_*.py",
+    "*.test.js",
+    "*.test.ts",
+    "*.test.jsx",
+    "*.test.tsx",
+    "*.spec.js",
+    "*.spec.ts",
+    "*.spec.jsx",
+    "*.spec.tsx",
+    "*_spec.rb",
+    "*_test.rb",
+]
+
 
 def main():
     if shutil.which("semgrep") is None:
         print(json.dumps({"findings": [], "error": "semgrep not on PATH"}))
         sys.exit(0)
 
+    cmd = [
+        "semgrep",
+        "--config",
+        "p/security-audit",
+        "--config",
+        "p/secrets",
+        "--json",
+        "--quiet",
+    ]
+    for pattern in EXCLUDES:
+        cmd += ["--exclude", pattern]
+    cmd.append(".")
+
     proc = subprocess.run(
-        [
-            "semgrep",
-            "--config",
-            "p/security-audit",
-            "--config",
-            "p/secrets",
-            "--json",
-            "--quiet",
-            ".",
-        ],
+        cmd,
         cwd="./src",
         capture_output=True,
         text=True,


### PR DESCRIPTION
Test and spec code is not shipped to production, so semgrep findings there are noise. Pass semgrep's repeatable --exclude glob flag for the common test/spec directory names and filename conventions across Go, Python, JS/TS, and Ruby.

Nearly all of the semgrep findings I've seen across a hundred different projects have been false-positives due to files in the test directory.