### PR TITLE
feat(triage): skip zizmor when repo has no .github/workflows

### DIFF
--- a/skills/triage/SKILL.md
+++ b/skills/triage/SKILL.md
@@ -32,13 +32,19 @@ From those, set two flags:
 
 A docs repo (markdown only) has neither. Anything with detected source gets the code scans, whether it is an application, a library, infra scripts, or a flat-layout package. The cost of running semgrep on a stray shell script is far lower than missing a real library because brief failed to populate `layout.source_dirs`. Do not gate on `layout.source_dirs`; it is a heuristic and routinely empty for legitimate codebases. If `brief` is not on PATH or exits non-zero, set both flags true and carry on.
 
+`brief` does not report CI configuration, so set a third flag from a direct filesystem check:
+
+- `has_workflows` = `./src/.github/workflows` exists and is a directory
+
+This gates `zizmor`, which only audits GitHub Actions workflows; with no workflows directory its scan immediately no-ops, so skipping it at triage avoids enqueueing a scan that can do nothing. Unlike the code/package flags this is a definitive check, not a heuristic, so do not default it true on error — if the directory is absent, `has_workflows` is false.
+
 ## The scan set
 
 Before enqueueing anything, check what already ran so a re-trigger does not double-enqueue work that is already current.
 
 Get the commit you are running at: `git -C ./src rev-parse HEAD`. Then fetch `GET {api_base}/repositories/{repository_id}/scans`, which returns every scan on this repository with `skill_name`, `status`, and `commit`. If that fetch fails, treat the skip set as empty and carry on. Otherwise build a set of skill names to skip: a skill goes in the skip set if it has a scan with `status` in {`queued`, `running`}, or a scan with `status="done"` whose `commit` equals the current HEAD. A `done` scan at any other commit does not count; the repository has moved since then and the skill should run again. `failed` scans are re-enqueued.
 
-Classify each skill in the list below into exactly one bucket, checking in this order and stopping at the first match: `gated` (its `has_code`/`has_packages` flag is false), `already_done` (it is in the skip set), `triggered` (enqueue it). Enqueue with `POST {api_base}/repositories/{id}/skills/{name}/run` and an `Authorization: Bearer {token}` header. Order does not matter; the scrutineer worker runs them as they come in. A 404 response moves the skill from `triggered` to `skipped`.
+Classify each skill in the list below into exactly one bucket, checking in this order and stopping at the first match: `gated` (its `has_code`/`has_packages`/`has_workflows` flag is false), `already_done` (it is in the skip set), `triggered` (enqueue it). Enqueue with `POST {api_base}/repositories/{id}/skills/{name}/run` and an `Authorization: Bearer {token}` header. Order does not matter; the scrutineer worker runs them as they come in. A 404 response moves the skill from `triggered` to `skipped`.
 
 If `scrutineer.scan_ref` is set in `context.json`, include it in the POST body as `{"ref": "<value>"}` so child scans clone the same branch. If it is empty, send an empty JSON body or omit the body. Verify runs (below) always send `{}`; they are finding-scoped and do not take a ref.
 
@@ -47,9 +53,12 @@ Always:
 - `metadata`
 - `maintainers`
 - `repo-overview`
-- `zizmor`
 - `packages`
 - `advisories`
+
+Only when `has_workflows`:
+
+- `zizmor`
 
 Only when `has_packages`:
 
@@ -86,10 +95,11 @@ Write `./report.json` as:
 {
   "has_code": true,
   "has_packages": true,
+  "has_workflows": false,
   "brief": {"languages": ["Ruby"], "package_managers": ["Bundler"]},
   "triggered": ["packages", "advisories", ...],
   "skipped":   ["semgrep"],
-  "gated":     [],
+  "gated":     ["zizmor"],
   "already_done": ["metadata"],
   "verify":        [12, 34],
   "release_watch": [55, 56],
@@ -97,7 +107,7 @@ Write `./report.json` as:
 }
 ```
 
-`gated` lists skills that were not enqueued because `has_code` or `has_packages` was false. `already_done` holds skills that were skipped because a scan is currently running or already completed at this commit. `skipped` is for skills that came back `404 skill not found or inactive`. `brief` is the subset of brief's output the gates were derived from, so an operator can see why a repo got the short treatment and re-run triage manually if the classification was wrong.
+`gated` lists skills that were not enqueued because `has_code`, `has_packages`, or `has_workflows` was false. `already_done` holds skills that were skipped because a scan is currently running or already completed at this commit. `skipped` is for skills that came back `404 skill not found or inactive`. `brief` is the subset of brief's output the gates were derived from, so an operator can see why a repo got the short treatment and re-run triage manually if the classification was wrong.
 
 Do not wait for any of the scans to finish. The API returns a scan id immediately; your job is to fire them off and exit.
 

--- a/skills/triage/schema.json
+++ b/skills/triage/schema.json
@@ -5,8 +5,9 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
-    "has_code":     { "type": "boolean" },
-    "has_packages": { "type": "boolean" },
+    "has_code":      { "type": "boolean" },
+    "has_packages":  { "type": "boolean" },
+    "has_workflows": { "type": "boolean" },
     "brief": {
       "type": "object",
       "description": "Subset of brief --json the gates were derived from.",


### PR DESCRIPTION
zizmor only audits GitHub Actions workflows; with no workflows dir its scan immediately no-ops. Add a `has_workflows` flag (from a direct filesystem check, since brief does not report CI config) and gate zizmor on it so triage stops enqueueing a scan that does nothing.