### PR TITLE
Upgrade Semgrep to 1.167.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ FROM node:26-alpine@sha256:3ad34ca6292aec4a91d8ddeb9229e29d9c2f689efd0dd24286088
 RUN npm install -g @anthropic-ai/claude-code@2.1.173
 
 FROM python:3.15.0b2-alpine@sha256:7b994e30eec677e35f9b57882dda3da2077dfb3936908f320397c5442e2654bb AS python-tools
-RUN pip install --no-cache-dir semgrep==1.116.0 "setuptools<81"
+RUN pip install --no-cache-dir semgrep==1.167.0 "setuptools<81"
 
 FROM golang:1.26.4-alpine@sha256:7a3e50096189ad57c9f9f865e7e4aa8585ed1585248513dc5cda498e2f41812c AS go-tools
 RUN apk add --no-cache git

--- a/Dockerfile.runner
+++ b/Dockerfile.runner
@@ -3,7 +3,7 @@
 #   docker build -t scrutineer-runner -f Dockerfile.runner .
 
 ARG CLAUDE_VERSION=2.1.173
-ARG SEMGREP_VERSION=1.116.0
+ARG SEMGREP_VERSION=1.167.0
 
 FROM golang:1.26.4-trixie@sha256:bbf22ddccb3205344f2755ea8fa4fe39f7a8b2b77b9f7b764ec2aad31406f6fc AS go-tools
 RUN GOBIN=/out go install github.com/git-pkgs/git-pkgs@v0.15.3 && \

--- a/internal/worker/versions_test.go
+++ b/internal/worker/versions_test.go
@@ -4,14 +4,14 @@ import "testing"
 
 func TestParseToolVersions(t *testing.T) {
 	out := "zizmor=zizmor 1.24.1\n" +
-		"semgrep=1.116.0\n" +
+		"semgrep=1.167.0\n" +
 		"claude=2.1.123 (Claude Code)\n"
 	got := parseToolVersions(out)
 	if got.Zizmor != "1.24.1" {
 		t.Errorf("Zizmor = %q, want 1.24.1", got.Zizmor)
 	}
-	if got.Semgrep != "1.116.0" {
-		t.Errorf("Semgrep = %q, want 1.116.0", got.Semgrep)
+	if got.Semgrep != "1.167.0" {
+		t.Errorf("Semgrep = %q, want 1.167.0", got.Semgrep)
 	}
 	if got.Claude != "2.1.123" {
 		t.Errorf("Claude = %q, want 2.1.123", got.Claude)

--- a/threatmodel.md
+++ b/threatmodel.md
@@ -118,7 +118,7 @@ No rate limiting on `POST /repositories`, no cap on clone size, no timeout on th
 
 ### T11: Image supply chain (partially mitigated)
 
-Tool versions are pinned: `claude-code@2.1.173`, `semgrep==1.116.0`, `git-pkgs@v0.15.3`, `brief@v0.6.0`, `zizmor@1.24.1`. The final stage is `debian:trixie-slim`; the `golang:1.26-trixie` and `rust:1.96-trixie` builder stages are pinned by sha256 digest. The container runs as non-root user `runner`. The runner image is built in CI, smoke-tested, and published to GHCR; users pull a known-good artifact rather than rebuilding against live registries.
+Tool versions are pinned: `claude-code@2.1.173`, `semgrep==1.167.0`, `git-pkgs@v0.15.3`, `brief@v0.6.0`, `zizmor@1.24.1`. The final stage is `debian:trixie-slim`; the `golang:1.26-trixie` and `rust:1.96-trixie` builder stages are pinned by sha256 digest. The container runs as non-root user `runner`. The runner image is built in CI, smoke-tested, and published to GHCR; users pull a known-good artifact rather than rebuilding against live registries.
 
 Supply-chain surface in the final stage:
 - `apt` pulls from Debian's official mirrors plus the GitHub CLI repo at `cli.github.com/packages` (signed-by keyring under `/etc/apt/keyrings/`). `gh` is used at scan time by the `fork` and `report-upstream` skills.


### PR DESCRIPTION
Closes #419

## Summary

Updates the Semgrep version used by Scrutineer's Docker images from `1.116.0` to `1.167.0`.

## Changes

- Bump `semgrep` in the main Dockerfile
- Bump `SEMGREP_VERSION` in `Dockerfile.runner`
- Update the runner tool-version test fixture
- Update the threat model's pinned tool version list

## Testing

- `go test ./internal/worker -run 'TestParseToolVersions|TestRunnerImageName' -count=1`
- `go test ./...`
- `git diff --check`
- Verified `semgrep==1.167.0` installs from PyPI and reports `1.167.0`