### PR TITLE
Make max-turns scans resumable

### DIFF
--- a/docs/database.md
+++ b/docs/database.md
@@ -67,6 +67,7 @@ One row per skill execution or external import. `skill_name` / `skill_version` p
 | output_tokens | integer | Output tokens billed. |
 | cache_read_tokens | integer | `cache_read_input_tokens` from the result event. |
 | cache_write_tokens | integer | `cache_creation_input_tokens` from the result event. |
+| max_turns_hit | boolean | True when the scan is `done` with partial output because Claude hit the configured max-turns cap. Such scans keep their session id so Retry can resume. |
 | prompt | text | Activation prompt sent to claude. The skill body lives in the Skill row, not here. |
 | report | text | The skill's primary output. JSON for parsed kinds, freeform for everything else. |
 | log | text | Line-by-line transcript of the scan. Streamed to the UI via SSE. |

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -170,12 +170,16 @@ type Scan struct {
 	// SessionID is the claude-code session this scan's run belongs to,
 	// captured from the stream-json init/result events. It is written as
 	// soon as the init event arrives (before the run finishes) so it
-	// survives a crash, and cleared once the scan reaches "done" so a
-	// deliberate re-run from the UI starts a fresh conversation. A retry
-	// of a failed scan carries this value forward so the runner can pass
-	// `claude -p --resume <id>` and continue from where it left off
-	// instead of restarting from turn 0.
+	// survives a crash, and cleared once the scan reaches ordinary "done"
+	// so a deliberate re-run from the UI starts a fresh conversation. A
+	// retry of a failed or max-turns-hit scan carries this value forward
+	// so the runner can pass `claude -p --resume <id>` and continue from
+	// where it left off instead of restarting from turn 0.
 	SessionID string
+	// MaxTurnsHit marks scans that completed with partial output because
+	// claude-code hit --max-turns. They stay status=done because the
+	// partial report is real output, but keep SessionID so Retry can resume.
+	MaxTurnsHit bool `gorm:"not null;default:false"`
 	// ResumedFromScanID points at the lineage-root scan whose claude session
 	// and workspace a retry reuses. Nil on a fresh scan. claude keys its
 	// session store by working directory, so a resuming run must execute

--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -378,6 +378,7 @@ func scanSummary(sc db.Scan) map[string]any {
 		"skill_version": sc.SkillVersion,
 		"started_at":    sc.StartedAt,
 		"finished_at":   sc.FinishedAt,
+		"max_turns_hit": sc.MaxTurnsHit,
 		errorKey:        sc.Error,
 	}
 	if sc.Ref != "" {

--- a/internal/web/api_export.go
+++ b/internal/web/api_export.go
@@ -311,6 +311,7 @@ func scanExport(sc db.Scan) map[string]any {
 		"output_tokens":      sc.OutputTokens,
 		"cache_read_tokens":  sc.CacheReadTokens,
 		"cache_write_tokens": sc.CacheWriteTokens,
+		"max_turns_hit":      sc.MaxTurnsHit,
 		"prompt":             sc.Prompt,
 		"report":             sc.Report,
 		"log":                sc.Log,

--- a/internal/web/scans.go
+++ b/internal/web/scans.go
@@ -142,12 +142,14 @@ func (s *Server) scanRetry(w http.ResponseWriter, r *http.Request) {
 }
 
 // resumeOpts decides whether a retry of scan should resume its claude
-// session. Only a failed scan that captured a session is resumable; a done
-// or cancelled scan, or one that never reached the model, retries fresh.
-// ResumedFromScanID is pinned to the lineage root so a chain of retries all
-// reuse one workspace and session rather than forking a new one each time.
+// session. Failed scans and soft-success scans that hit max turns are
+// resumable when they captured a session; ordinary done/cancelled scans, or
+// scans that never reached the model, retry fresh. ResumedFromScanID is pinned
+// to the lineage root so a chain of retries all reuse one workspace and
+// session rather than forking a new one each time.
 func resumeOpts(scan db.Scan) (sessionID string, resumeOf *uint) {
-	if scan.Status != db.ScanFailed || scan.SessionID == "" {
+	resumableStatus := scan.Status == db.ScanFailed || (scan.Status == db.ScanDone && scan.MaxTurnsHit)
+	if !resumableStatus || scan.SessionID == "" {
 		return "", nil
 	}
 	root := scan.ID

--- a/internal/web/scans_test.go
+++ b/internal/web/scans_test.go
@@ -29,6 +29,16 @@ func TestResumeOpts(t *testing.T) {
 			wantSID: "s1", wantResume: uintPtr(7),
 		},
 		{
+			name:    "max-turns done scan resumes from its own id",
+			scan:    db.Scan{ID: 7, Status: db.ScanDone, MaxTurnsHit: true, SessionID: "s1"},
+			wantSID: "s1", wantResume: uintPtr(7),
+		},
+		{
+			name:    "max-turns retry keeps the lineage root",
+			scan:    db.Scan{ID: 9, Status: db.ScanDone, MaxTurnsHit: true, SessionID: "s1", ResumedFromScanID: uintPtr(7)},
+			wantSID: "s1", wantResume: uintPtr(7),
+		},
+		{
 			name: "done scan retries fresh",
 			scan: db.Scan{ID: 7, Status: db.ScanDone, SessionID: ""},
 		},

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -3069,6 +3069,34 @@ func TestScansIndex_noBranchTagForDefaultBranch(t *testing.T) {
 	}
 }
 
+func TestScansIndex_maxTurnsScanShowsBadgeAndRetry(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	repo := db.Repository{URL: "https://github.com/spf13/cobra", Name: "cobra"}
+	s.DB.Create(&repo)
+	skill := db.Skill{Name: "security-deep-dive", Description: "x", Body: "b", Active: true, Source: "ui", Version: 1}
+	s.DB.Create(&skill)
+	scan := db.Scan{
+		RepositoryID: repo.ID, Kind: "skill", SkillName: "security-deep-dive",
+		SkillID: &skill.ID, Status: db.ScanDone, StatusPriority: db.StatusPriorityFor(db.ScanDone),
+		MaxTurnsHit: true, SessionID: "sess-1",
+	}
+	s.DB.Create(&scan)
+
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq("GET", "/scans"))
+	body := w.Body.String()
+	if w.Code != http.StatusOK {
+		t.Fatalf("status %d: %s", w.Code, body)
+	}
+	if !strings.Contains(body, "max turns") {
+		t.Error("max-turns scan should render a badge")
+	}
+	if !strings.Contains(body, fmt.Sprintf(`/scans/%d/retry`, scan.ID)) {
+		t.Error("max-turns scan should render retry action")
+	}
+}
+
 func TestRetry_preservesSubPath(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()
@@ -3097,6 +3125,43 @@ func TestRetry_preservesSubPath(t *testing.T) {
 	s.DB.Where("id != ?", orig.ID).First(&fresh)
 	if fresh.SubPath != "airflow-core" {
 		t.Errorf("retry lost sub-path: got %q, want airflow-core", fresh.SubPath)
+	}
+}
+
+func TestRetry_maxTurnsDoneScanResumesSession(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	repo := db.Repository{URL: "https://github.com/apache/airflow.git", Name: "airflow"}
+	s.DB.Create(&repo)
+	skill := db.Skill{Name: "security-deep-dive", Description: "x", Body: "b", Active: true, Source: "ui", Version: 1}
+	s.DB.Create(&skill)
+	orig := db.Scan{
+		RepositoryID: repo.ID, Kind: "skill", Status: db.ScanDone,
+		SkillID: &skill.ID, SkillName: "security-deep-dive",
+		SessionID: "sess-1", MaxTurnsHit: true, FinishedAt: new(time.Now()),
+	}
+	s.DB.Create(&orig)
+
+	req := httptest.NewRequest("POST", fmt.Sprintf("/scans/%d/retry", orig.ID), nil)
+	req.Host = testHost
+	req.Header.Set("Sec-Fetch-Site", "same-origin")
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("retry status %d: %s", w.Code, w.Body)
+	}
+
+	var fresh db.Scan
+	s.DB.Where("id != ?", orig.ID).First(&fresh)
+	if fresh.SessionID != "sess-1" {
+		t.Errorf("retry session id = %q, want sess-1", fresh.SessionID)
+	}
+	if fresh.ResumedFromScanID == nil || *fresh.ResumedFromScanID != orig.ID {
+		t.Errorf("retry resumed_from_scan_id = %v, want %d", fresh.ResumedFromScanID, orig.ID)
+	}
+	if fresh.MaxTurnsHit {
+		t.Error("fresh retry should not inherit MaxTurnsHit before it runs")
 	}
 }
 

--- a/internal/web/templates/jobs.html
+++ b/internal/web/templates/jobs.html
@@ -105,7 +105,7 @@
           <td class="text-xs text-muted-foreground">{{if .SubPath}}<code>{{.SubPath}}</code>{{else}}<span>root</span>{{end}}</td>
         {{end}}
         <td>{{if .SkillName}}{{.SkillName}}{{else}}{{.Kind}}{{end}} {{template "branch-tag" .Ref}}</td>
-        <td>{{template "status-badge" (status .Status)}}</td>
+        <td>{{template "status-badge" (status .Status)}} {{if .MaxTurnsHit}}<span class="badge-outline"><i data-lucide="timer-off"></i> max turns</span>{{end}}</td>
         <td>{{if gt .FindingsCount 0}}{{template "findings-badge" .FindingsCount}}{{end}}</td>
         <td class="text-muted-foreground">{{if .Model}}{{.Model}}{{else}}-{{end}}</td>
         <td class="text-muted-foreground">{{if gt .CostUSD 0.0}}{{usd .CostUSD}}{{else}}-{{end}}</td>

--- a/internal/web/templates/layout.html
+++ b/internal/web/templates/layout.html
@@ -230,7 +230,7 @@
           hx-swap="none">
       <button type="submit" class="btn-sm-ghost" aria-label="Resume scan" data-tooltip="Resume"><i data-lucide="play"></i></button>
     </form>
-  {{else if and (or (eq (status .Status) "failed") (eq (status .Status) "cancelled")) .SkillID}}
+  {{else if and (or (eq (status .Status) "failed") (eq (status .Status) "cancelled") .MaxTurnsHit) .SkillID}}
     <form method="post" action="/scans/{{.ID}}/retry" hx-post="/scans/{{.ID}}/retry"
           hx-swap="none">
       <button type="submit" class="btn-sm-ghost" aria-label="Retry scan" data-tooltip="Retry"><i data-lucide="refresh-cw"></i></button>

--- a/internal/web/templates/repo_show.html
+++ b/internal/web/templates/repo_show.html
@@ -522,7 +522,7 @@
   <tr id="scan-{{.ID}}"{{if $.OOB}} hx-swap-oob="true"{{end}}>
     <td><a href="/scans/{{.ID}}">{{.ID}}</a></td>
     <td>{{if .SkillName}}{{.SkillName}}{{else}}{{.Kind}}{{end}} {{template "branch-tag" .Ref}}</td>
-    <td>{{template "status-badge" (status .Status)}}</td>
+    <td>{{template "status-badge" (status .Status)}} {{if .MaxTurnsHit}}<span class="badge-outline"><i data-lucide="timer-off"></i> max turns</span>{{end}}</td>
     <td>{{if gt .FindingsCount 0}}{{template "findings-badge" .FindingsCount}}{{end}}</td>
     <td class="text-muted-foreground">{{if .Model}}{{.Model}}{{else}}-{{end}}</td>
     <td class="text-muted-foreground">{{if gt .CostUSD 0.0}}{{usd .CostUSD}}{{else}}-{{end}}</td>

--- a/internal/web/templates/scan_show.html
+++ b/internal/web/templates/scan_show.html
@@ -9,6 +9,7 @@
   <h2 class="text-2xl font-semibold flex items-center gap-3">
     {{if .SkillName}}{{if .SkillID}}<a href="/skills/{{.SkillID}}">{{.SkillName}}</a>{{else}}{{.SkillName}}{{end}}{{else}}{{.Kind}}{{end}} / scan #{{.ID}}
     {{template "status-badge" (status .Status)}}
+    {{if .MaxTurnsHit}}<span class="badge-outline"><i data-lucide="timer-off"></i> max turns</span>{{end}}
   </h2>
   {{if and (eq .Kind "skill") .SkillID}}
     <div class="flex items-center gap-2">
@@ -103,6 +104,13 @@
   <div class="alert-destructive mb-6">
     <i data-lucide="triangle-alert"></i>
     <section>{{.Error}}</section>
+  </div>
+{{end}}
+
+{{if .MaxTurnsHit}}
+  <div class="alert mb-6">
+    <i data-lucide="timer-off"></i>
+    <section>This scan hit the max turns cap after producing partial output. Retry will resume the saved Claude session.</section>
   </div>
 {{end}}
 

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -180,14 +180,13 @@ func (w *Worker) claudeConfigDirID(scanID uint) string {
 }
 
 // RemoveScanArtifacts deletes the on-disk per-scan workspace and claude
-// session store for scanID. A terminal scan removes its own workspace and a
-// done scan its session store, so this reclaims space left by scans still
-// holding a workspace (queued/running, or crashed before cleanup) and by
-// failed scans whose session store is kept for --resume. It is a no-op when
-// the directories are already gone. Passing every scan id of a repository
-// covers resume lineages too: a retry reuses its root's workspace id, and the
-// root scan is itself in the repo, while the retry's own id maps to a
-// directory that was never created.
+// session store for scanID. Normal terminal cleanup removes workspaces, while
+// resumable scans (failed or max-turns-hit) keep their session store for
+// --resume; this explicit removal path reclaims both. It is a no-op when the
+// directories are already gone. Passing every scan id of a repository covers
+// resume lineages too: a retry reuses its root's workspace id, and the root
+// scan is itself in the repo, while the retry's own id maps to a directory
+// that was never created.
 func (w *Worker) RemoveScanArtifacts(scanID uint) error {
 	return errors.Join(
 		os.RemoveAll(w.workRoot(scanID)),
@@ -197,9 +196,9 @@ func (w *Worker) RemoveScanArtifacts(scanID uint) error {
 
 // applyResume fills a SkillJob's session-resume inputs from the scan: the
 // claude session id to --resume (set on a retry that carries one forward
-// from a failed run) and the persistent config dir the docker runner mounts
-// so the session store survives a container exit. A fresh scan has an empty
-// SessionID, so the runner just starts a new conversation.
+// from a failed or max-turns-hit run) and the persistent config dir the docker
+// runner mounts so the session store survives a container exit. A fresh scan
+// has an empty SessionID, so the runner just starts a new conversation.
 func (w *Worker) applyResume(scan *db.Scan, sj *SkillJob, emit func(Event)) {
 	sj.ClaudeConfigDir = w.claudeConfigDir(scan)
 	if scan.SessionID != "" {
@@ -248,8 +247,9 @@ func (w *Worker) scanEmitter(scan *db.Scan) func(Event) {
 
 // clearSessionStore wipes a finished scan's resume state so its next
 // deliberate re-run starts fresh: it drops the session id and tears down the
-// persisted claude session store. Only called on "done" — a failed scan
-// keeps both so a UI retry can --resume instead of restarting from turn 0.
+// persisted claude session store. Only called on ordinary "done" — failed and
+// max-turns-hit scans keep both so a UI retry can --resume instead of
+// restarting from turn 0.
 func (w *Worker) clearSessionStore(scan *db.Scan) {
 	scan.SessionID = ""
 	if rmErr := os.RemoveAll(w.claudeConfigDir(scan)); rmErr != nil {
@@ -318,7 +318,7 @@ func (w *Worker) wrap(h handler) func(context.Context, []byte) error {
 		report, err := h(ctx, &scan, emit)
 
 		finishScan(ctx, &scan, report, err, timeout, emit)
-		if scan.Status == db.ScanDone {
+		if scan.Status == db.ScanDone && !scan.MaxTurnsHit {
 			w.clearSessionStore(&scan)
 		}
 		scan.StatusPriority = db.StatusPriorityFor(scan.Status)
@@ -338,6 +338,7 @@ func (w *Worker) wrap(h handler) func(context.Context, []byte) error {
 
 func finishScan(ctx context.Context, scan *db.Scan, report string, err error, timeout time.Duration, emit func(Event)) {
 	scan.FinishedAt = new(time.Now())
+	scan.MaxTurnsHit = false
 	switch {
 	case errors.Is(ctx.Err(), context.DeadlineExceeded):
 		scan.Status = db.ScanFailed
@@ -367,6 +368,7 @@ func finishErroredScan(scan *db.Scan, report string, err error, emit func(Event)
 		scan.Status = db.ScanDone
 		scan.Report = report
 		scan.Error = ""
+		scan.MaxTurnsHit = true
 		emit(Event{Kind: KindText, Text: "scan completed (hit max turns cap)"})
 	case failOnThreshold:
 		scan.Report = report

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -30,10 +30,14 @@ func stubPrepareRepoSrc(_ context.Context, _, _, workRoot string, _ func(Event))
 type fakeRunner struct {
 	skillRes SkillResult
 	skillErr error
+	session  string
 }
 
 func (f fakeRunner) RunSkill(_ context.Context, sj SkillJob, emit func(Event)) (SkillResult, error) {
 	emit(Event{Kind: "text", Text: "running skill " + sj.Name})
+	if f.session != "" {
+		emit(Event{Kind: KindSession, SessionID: f.session})
+	}
 	return f.skillRes, f.skillErr
 }
 
@@ -128,7 +132,7 @@ func TestWorker_maxTurnsReachedCompletesNotFails(t *testing.T) {
 		DB:             gdb,
 		Log:            slog.New(slog.NewTextHandler(io.Discard, nil)),
 		DataDir:        t.TempDir(),
-		Runner:         fakeRunner{skillRes: SkillResult{Report: `{"partial":true}`}, skillErr: &MaxTurnsReachedError{}},
+		Runner:         fakeRunner{skillRes: SkillResult{Report: `{"partial":true}`}, skillErr: &MaxTurnsReachedError{}, session: "sess-1"},
 		PrepareRepoSrc: stubPrepareRepoSrc,
 	}
 	body, _ := json.Marshal(queue.Payload{ScanID: scan.ID})
@@ -143,6 +147,12 @@ func TestWorker_maxTurnsReachedCompletesNotFails(t *testing.T) {
 	}
 	if got.Report != `{"partial":true}` {
 		t.Errorf("report = %q, want partial report preserved", got.Report)
+	}
+	if !got.MaxTurnsHit {
+		t.Error("MaxTurnsHit = false, want true")
+	}
+	if got.SessionID != "sess-1" {
+		t.Errorf("session id = %q, want preserved max-turns session", got.SessionID)
 	}
 }
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -945,13 +945,14 @@ components:
         id:            { type: integer, format: int64 }
         repository_id: { type: integer, format: int64 }
         kind:          { type: string }
-        status:        { type: string, enum: [queued, running, done, failed] }
+        status:        { type: string, enum: [queued, running, paused, done, failed, cancelled] }
         model:         { type: string }
         commit:        { type: string }
         skill_name:    { type: string }
         skill_version: { type: integer }
         started_at:    { type: string, format: date-time, nullable: true }
         finished_at:   { type: string, format: date-time, nullable: true }
+        max_turns_hit: { type: boolean, description: True when the scan completed with partial output after hitting the Claude max-turns cap; retry resumes the saved session when available. }
         error:         { type: string }
 
     ScanDetail:


### PR DESCRIPTION
Closes #331

## Summary

Keeps scans that hit the Claude max-turns cap resumable without changing them from soft-success `done` scans into failures.

## Changes

- Add a `max_turns_hit` flag to scan rows
- Set `max_turns_hit` when Claude returns `MaxTurnsReachedError`
- Preserve the Claude session ID and session store for max-turns-hit scans
- Let Retry resume max-turns-hit scans from the saved Claude session
- Keep retry lineage pinned so repeated max-turns retries remain resumable
- Show a `max turns` badge and retry affordance in scan views
- Expose `max_turns_hit` in scan API/export responses
- Document the new scan column and OpenAPI field

## Testing

- `go test ./internal/worker -run 'TestWorker_maxTurnsReachedCompletesNotFails|TestWorker_Session|TestWorker_ResumeReusesLineageWorkspace|TestWorker_maxTurnsParseFailureLogged' -count=1`
- `go test ./internal/web -run 'TestResumeOpts|TestRetry_maxTurnsDoneScanResumesSession|TestScansIndex_maxTurnsScanShowsBadgeAndRetry|TestRetry_preservesSubPath|TestRetry_preservesImportPayload' -count=1`
- `go test ./internal/db -run 'TestOpenAndMigrate' -count=1`
- `go test ./...`
- `go vet ./...`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run ./...`