### PR TITLE
Add reference-harness inspired vuln-scan skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ When a repo is added, the `triage` skill is enqueued. Its SKILL.md lists the ski
 | `subprojects` | Enumerates monorepo packages/workspaces so deep-dives can be scoped to a sub-path |
 | `threat-model` | Derives the project's security contract (components, entry-point trust table, claimed and disclaimed properties) for the deep-dive to load |
 | `semgrep` | Static analysis mapped into findings shape |
+| `vuln-scan` | High-recall model-backed static candidate scan adapted from Anthropic's defending-code reference harness |
 | `zizmor` | GitHub Actions workflow audit mapped into findings shape |
 | `ingest` | Normalizes external reports in arbitrary formats into findings when `/v1/import` cannot recognise the payload |
 | `security-deep-dive` | The model-backed audit producing structured findings |

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -23,6 +23,7 @@ These ship in `skills/` and are loaded with `-skills ./skills`. The `triage` ski
 | `posture` | Scores readiness to receive a vulnerability report: SECURITY.md, private vulnerability reporting, prior advisories, scanning workflows. |
 | `cna-match` | Matches the repository to its CVE Numbering Authority so disclosures route to the right contact. |
 | `semgrep` | Runs semgrep with the `p/security-audit` and `p/secrets` rulesets and maps hits into the findings shape. |
+| `vuln-scan` | High-recall model-backed static source-code candidate scan adapted from Anthropic's defending-code reference harness. |
 | `zizmor` | Audits GitHub Actions workflows and maps hits into the findings shape. |
 | `ingest` | Normalizes an externally-produced security report in an arbitrary format into findings. Runs when `/v1/import` cannot recognise the payload; the raw report is staged at `import/report`. |
 | `threat-model` | Derives the project's security contract from source and docs: components, entry-point trust table, claimed and disclaimed properties, and disposition labels. Loaded by `security-deep-dive` so it does not re-derive boundaries per run. |

--- a/internal/worker/schema_bundled_test.go
+++ b/internal/worker/schema_bundled_test.go
@@ -93,6 +93,20 @@ func TestBundledSchemas_compileAndAcceptSamples(t *testing.T) {
 			    "known_non_finding","model_gap"],
 			  "open_questions":[{"claim":"path is trusted","field":"entry_points","proposed":"yes"}]}`,
 		},
+		{
+			"../../skills/vuln-scan/schema.json",
+			`{"findings":[{"id":"F001","title":"Archive extraction writes outside the target directory",
+			  "severity":"High","confidence":"medium","cwe":"CWE-22","location":"pkg/archive/extract.go:88",
+			  "locations":["pkg/archive/extract.go:71"],"reachability":"reachable","quality_tier":"high",
+			  "trace":"Archive entry names flow from ParseArchive to filepath.Join before Create.",
+			  "boundary":"The public extraction API accepts caller-provided archives and does not document trusted entry names.",
+			  "validation":"Static-only review checked for Clean, EvalSymlinks, and containment checks before file creation.",
+			  "rating":"High impact because traversal can overwrite files outside the extraction root; medium confidence because no PoC was executed."}]}`,
+		},
+		{
+			"../../skills/vuln-scan/schema.json",
+			`{"findings":[]}`,
+		},
 	}
 	for _, tc := range cases {
 		schema, err := os.ReadFile(tc.schema)
@@ -119,6 +133,16 @@ func TestBundledSchemas_rejectBadShapes(t *testing.T) {
 		{"../../skills/sbom/schema.json", `{}`, "oneOf"},
 		{"../../skills/dependencies/schema.json", `{"dependencies":null}`, "/dependencies"},
 		{"../../skills/threat-model/schema.json", `{"spec_version":2}`, "/spec_version"},
+		{"../../skills/vuln-scan/schema.json",
+			`{"findings":[{"id":"F001","title":"Bad confidence","severity":"High",
+			  "confidence":"maybe","cwe":"CWE-22","location":"pkg/archive/extract.go:88","reachability":"reachable",
+			  "quality_tier":"high","trace":"x","boundary":"x","validation":"x","rating":"x"}]}`,
+			"/findings/0/confidence"},
+		{"../../skills/vuln-scan/schema.json",
+			`{"findings":[{"id":"F001","title":"Bad location","severity":"High","confidence":"high",
+			  "cwe":"CWE-22","location":"pkg/archive/extract.go","reachability":"reachable",
+			  "quality_tier":"high","trace":"x","boundary":"x","validation":"x","rating":"x"}]}`,
+			"/findings/0/location"},
 		{"../../skills/threat-model/schema.json",
 			`{"spec_version":1,"repository":"https://x","commit":"abc1234","date":"2026-01-01",
 			  "description":"x","components":[{"name":"c","entry_points":[],"touches":[],

--- a/skills/vuln-scan/SKILL.md
+++ b/skills/vuln-scan/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: vuln-scan
+description: High-recall static source-code vulnerability scan adapted from Anthropic's defending-code reference harness. Fans out by focus area, ranks candidates by confidence, and emits Scrutineer findings for later verification.
+license: MIT
+compatibility: Static and read-only. Needs source in ./src and may use Claude subagents. Does not build, run, install dependencies, or use network.
+metadata:
+  scrutineer.version: 1
+  scrutineer.output_file: report.json
+  scrutineer.output_kind: findings
+  scrutineer.max_turns: 90
+  scrutineer.model: max
+---
+
+# vuln-scan
+
+Run a broad static source-code vulnerability scan. This skill is adapted from Anthropic's defending-code reference harness: it uses a quick recon pass, splits the repository into security focus areas, and then consolidates high-signal candidate findings into Scrutineer's findings shape.
+
+The target is first-party source code. Do not report vulnerabilities that exist only in dependencies, generated files, fixtures, examples, tests, docs, or unchanged vendored code.
+
+## Workspace
+
+- `./src` - cloned repository
+- `./context.json` - repository identity plus a `scrutineer` block with `api_base`, `token`, `repository_id`, and optional `scan_subpath`
+- `./report.json` - write the findings report here
+- `./schema.json` - output schema
+
+If `scrutineer.scan_subpath` is set, scope every read and report location to `./src/{scan_subpath}`. Do not inspect code outside that subtree except to understand workspace layout. Report locations relative to the scoped project root.
+
+## Safety
+
+This scan is read-only:
+
+- Do not build or run target code.
+- Do not install dependencies.
+- Do not start services, containers, package managers, or test suites.
+- Do not use the network for source analysis. If Scrutineer's local API is reachable through `context.json`, you may read prior Scrutineer scan reports; otherwise reason from `./src`.
+
+## Orientation
+
+First, build a compact map of the target:
+
+1. Read `context.json` and determine the scoped source root.
+2. List files with `rg --files` or equivalent.
+3. Identify languages, package layout, public entry points, handlers, parsers, CLIs, unsafe/FFI areas, deserializers, archive/file/network operations, authz boundaries, and agent/model/tool integrations.
+4. If available, fetch prior local reports from Scrutineer's API and use them as context:
+   - `GET {api_base}/repositories/{repository_id}/scans?skill=threat-model&status=done`, then `GET {api_base}/scans/{id}` for trust boundaries
+   - `GET {api_base}/repositories/{repository_id}/scans?skill=repo-overview&status=done`, then `GET {api_base}/scans/{id}` for project shape
+   - `GET {api_base}/repositories/{repository_id}/findings?skill=semgrep` for static-analysis anchors
+
+If any API request fails or returns no data, continue with source-only review.
+
+## Focus Areas
+
+Create three to ten focus areas. Prefer focus areas from the threat model if one exists; otherwise derive them from recon. Useful focus areas include:
+
+- Memory safety: C/C++, unsafe Rust, raw pointers, unchecked indexes, allocation sizes, integer arithmetic that feeds buffers, FFI, lifetime hazards.
+- Injection and execution: eval, shell/process execution, dynamic imports, templates, SQL/NoSQL/query construction, regex construction, format strings.
+- Filesystem and archives: path traversal, symlink races, archive extraction, permissions, temporary files, canonicalization before access decisions.
+- Deserialization and parsing: unsafe object construction, parser differentials, round-trip integrity, validation bypasses.
+- Authn/authz and tenant isolation: object lookup by attacker-controlled ID, missing ownership checks, privilege transitions.
+- Network and SSRF: attacker-controlled URLs, redirects, proxy handling, DNS rebinding, TLS verification changes.
+- Crypto and secrets: weak primitives, IV/nonce reuse, missing MAC verification, hardcoded or logged secrets.
+- Agentic integrations: untrusted content entering prompts, tool definitions, tool arguments, model-visible fetched content, unconstrained loops or cost triggers.
+- Shared state and concurrency: global mutable state, cache poisoning, check-then-act races, request cross-talk.
+
+For small repositories, a single pass is fine. For larger repositories, use one subagent per focus area, capped at ten. If subagents are unavailable, review the focus areas sequentially.
+
+## Review Rules
+
+Report only candidate vulnerabilities with a concrete source path, sink, trust boundary, and plausible exploit scenario.
+
+Do not report:
+
+- Best-practice gaps without an exploit path.
+- Volumetric denial-of-service issues unless the project explicitly provides a bounded-resource security property.
+- Memory-safety concerns in memory-safe code unless unsafe/FFI/native extensions are involved.
+- XSS in frameworks that auto-escape by default unless the code uses a raw HTML/script escape hatch.
+- Regex injection, log spoofing, open redirect, missing audit logs, old dependencies, or weak configuration defaults without a stronger project-specific impact.
+- CLI arguments, environment variables, local config files, or developer-supplied paths as attacker-controlled unless the project documents a privilege boundary where an untrusted actor controls them.
+
+For each candidate, record:
+
+- `id` - stable `F001`, `F002`, ...
+- `title` - concise vulnerability statement
+- `severity` - `Critical`, `High`, `Medium`, or `Low`
+- `confidence` - `high`, `medium`, or `low`
+- `cwe` - best matching `CWE-N`; use an empty string only when no mapping fits
+- `location` - primary `path:line`
+- `locations` - optional supporting `path:line` entries
+- `reachability` - `reachable`, `harness_only`, or `unclear`
+- `quality_tier` - `high` for concrete exploit paths; `low` for speculative or incomplete paths that still deserve analyst attention
+- `trace` - how attacker-controlled input reaches the sink
+- `boundary` - why the input crosses a real trust boundary in this project's model
+- `validation` - static checks performed, including existing mitigations you looked for; note that no code was executed
+- `prior_art` - optional related fixes, advisories, or issues found in local context
+- `reach` - optional downstream or deployment reachability notes
+- `rating` - severity/confidence rationale, exploit scenario, and recommendation
+
+Use these common CWE mappings when they fit: command injection `CWE-78`, path traversal `CWE-22`, SQL injection `CWE-89`, XSS `CWE-79`, SSRF `CWE-918`, unsafe deserialization `CWE-502`, authz bypass `CWE-862` or `CWE-863`, hardcoded secret `CWE-798`, weak crypto `CWE-327`, buffer overflow `CWE-120`, use-after-free `CWE-416`, integer overflow `CWE-190`, race condition `CWE-367`.
+
+## Consolidation
+
+Before writing the report:
+
+1. Drop candidates that lack a concrete code location.
+2. Drop candidates whose exploit depends only on a trusted developer/operator choosing unsafe local configuration.
+3. Deduplicate candidates with the same root cause; keep the clearest location and list supporting locations.
+4. Convert numeric confidence notes, if any, to Scrutineer's labels: `high` for strong evidence, `medium` for plausible but not fully proven, `low` for weak or incomplete paths.
+5. Ensure every finding has the required narrative fields and that locations are relative to the scan scope.
+
+Write `./report.json` as:
+
+```json
+{
+  "findings": [
+    {
+      "id": "F001",
+      "title": "Archive extraction writes outside the target directory",
+      "severity": "High",
+      "confidence": "medium",
+      "cwe": "CWE-22",
+      "location": "pkg/archive/extract.go:88",
+      "locations": ["pkg/archive/extract.go:71"],
+      "reachability": "reachable",
+      "quality_tier": "high",
+      "trace": "User-supplied archive entry names flow from ParseArchive to filepath.Join before the file is created.",
+      "boundary": "The documented API accepts archives from callers and does not state that entry names are trusted.",
+      "validation": "Static-only review. Checked for filepath.Clean, EvalSymlinks, and containment checks around the write path; none guard the joined path before Create.",
+      "rating": "High because a crafted archive can overwrite files outside the extraction root. Medium confidence because the scan did not execute a PoC. Reject absolute paths and require the real output path to stay under the destination root."
+    }
+  ]
+}
+```
+
+If you find nothing worth reporting, write `{"findings":[]}`.
+
+## Provenance
+
+This skill adapts the focus-area scanning workflow from Anthropic's defending-code reference harness while using Scrutineer's workspace, schema, and finding lifecycle conventions.

--- a/skills/vuln-scan/schema.json
+++ b/skills/vuln-scan/schema.json
@@ -1,0 +1,91 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "vuln-scan findings report",
+  "type": "object",
+  "required": ["findings"],
+  "additionalProperties": false,
+  "properties": {
+    "findings": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/finding" }
+    }
+  },
+  "$defs": {
+    "severity": {
+      "type": "string",
+      "enum": ["Critical", "High", "Medium", "Low"]
+    },
+    "confidence": {
+      "type": "string",
+      "enum": ["high", "medium", "low"]
+    },
+    "cwe": {
+      "type": "string",
+      "pattern": "^(CWE-[0-9]+)?$"
+    },
+    "reachability": {
+      "type": "string",
+      "enum": ["reachable", "harness_only", "unclear"]
+    },
+    "quality_tier": {
+      "type": "string",
+      "enum": ["high", "low"]
+    },
+    "location": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^[^:]+:[0-9]+$"
+    },
+    "markdown": {
+      "type": "string",
+      "minLength": 1,
+      "contentMediaType": "text/markdown"
+    },
+    "finding": {
+      "type": "object",
+      "required": [
+        "id",
+        "title",
+        "severity",
+        "confidence",
+        "cwe",
+        "location",
+        "reachability",
+        "quality_tier",
+        "trace",
+        "boundary",
+        "validation",
+        "rating"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "type": "string", "pattern": "^F[0-9]+$" },
+        "sinks": { "type": "array", "items": { "type": "string" } },
+        "title": { "type": "string", "minLength": 1 },
+        "severity": { "$ref": "#/$defs/severity" },
+        "confidence": { "$ref": "#/$defs/confidence" },
+        "cwe": { "$ref": "#/$defs/cwe" },
+        "location": { "$ref": "#/$defs/location" },
+        "locations": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/location" }
+        },
+        "affected": { "type": "string" },
+        "reachability": { "$ref": "#/$defs/reachability" },
+        "quality_tier": { "$ref": "#/$defs/quality_tier" },
+        "reach_checked": { "type": "integer", "minimum": 0 },
+        "reach_exposed": { "type": "integer", "minimum": 0 },
+        "references": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "trace": { "$ref": "#/$defs/markdown" },
+        "boundary": { "$ref": "#/$defs/markdown" },
+        "validation": { "$ref": "#/$defs/markdown" },
+        "prior_art": { "$ref": "#/$defs/markdown" },
+        "reach": { "$ref": "#/$defs/markdown" },
+        "rating": { "$ref": "#/$defs/markdown" }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Ref #315
## Summary

Adds a bundled `vuln-scan` skill adapted from Anthropic's defending-code reference harness. The skill performs a broad, read-only static source-code vulnerability scan, splits review by focus area and emits normal Scrutineer findings for later verification.

## Changes

- Add new `skills/vuln-scan` bundled skill with Scrutineer metadata
- Add a strict findings schema for `vuln-scan` reports
- Wire `vuln-scan` into the default `triage` code-scan path
- Document the new skill in README and skills docs
- Add bundled schema tests for valid and invalid `vuln-scan` output

## Testing

- `go test ./internal/worker -run TestBundledSchemas -count=1`
- `go test ./internal/skills -run TestLoadDirectory_bundledSkillsAreValid -count=1`
- `git diff --check`
- `go test ./...`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run`

