### PR TITLE
web: move default-model/effort overrides onto Server

### DIFF
--- a/cmd/scrutineer/main.go
+++ b/cmd/scrutineer/main.go
@@ -91,6 +91,7 @@ type flags struct {
 	addr             string
 	dataDir          string
 	effort           string
+	defaultModel     string
 	noDocker         bool
 	hardened         bool
 	runnerImage      string
@@ -142,8 +143,9 @@ func parseFlags() *flags {
 }
 
 // merge layers cfg underneath f: a config value applies only when the
-// matching CLI flag was not set explicitly. Also pushes model overrides
-// into the web package.
+// matching CLI flag was not set explicitly. Also pushes the model pick
+// list and theme into the web package; runtime defaults (model, effort)
+// are stored on flags here and applied to the Server after construction.
 //
 //nolint:gocognit,gocyclo // flat: one guarded assignment per config key
 func (f *flags) merge(cfg *config.Config) {
@@ -213,9 +215,8 @@ func (f *flags) merge(cfg *config.Config) {
 		web.SetModels(models)
 	}
 	if cfg.DefaultModel != "" {
-		web.SetDefaultModel(cfg.DefaultModel)
+		f.defaultModel = cfg.DefaultModel
 	}
-	web.SetDefaultEffort(f.effort)
 	if cfg.Theme != "" {
 		web.SetTheme(cfg.Theme)
 	}
@@ -389,6 +390,8 @@ func run(log *slog.Logger) error {
 	}
 	srv.SkillsRepoSHA = skillsRepoSHA
 	srv.Commit = buildCommit()
+	srv.SetDefaultModel(f.defaultModel)
+	srv.SetDefaultEffort(f.effort)
 
 	if f.recipientsFile != "" {
 		recs, err := loadRecipients(f.recipientsFile)

--- a/internal/web/efforts.go
+++ b/internal/web/efforts.go
@@ -23,26 +23,26 @@ var Efforts = []Effort{
 
 const builtinDefaultEffort = "high"
 
-// defaultEffortOverride, when non-empty, is the runtime-selected effort
-// applied to new scans. Set at startup from config and mutable via
-// /settings/effort; empty leaves the built-in default. Mirrors the model
-// override: in-memory only, so it resets to the configured default on
-// restart.
-var defaultEffortOverride string
-
 // SetDefaultEffort pins the effort applied to new scans. No-op for an empty
 // or unknown value so a bad config or form post leaves the current default.
-func SetDefaultEffort(value string) {
-	if ValidEffort(value) {
-		defaultEffortOverride = value
+// Set at startup from config and mutable via /settings/effort; in-memory
+// only, so restart resets it to the configured default.
+func (s *Server) SetDefaultEffort(value string) {
+	if !ValidEffort(value) {
+		return
 	}
+	s.defaultsMu.Lock()
+	s.defaultEffort = value
+	s.defaultsMu.Unlock()
 }
 
 // DefaultEffort is the effort a new scan inherits when the caller pins none.
 // The runtime override wins; otherwise the built-in default.
-func DefaultEffort() string {
-	if defaultEffortOverride != "" {
-		return defaultEffortOverride
+func (s *Server) DefaultEffort() string {
+	s.defaultsMu.RLock()
+	defer s.defaultsMu.RUnlock()
+	if s.defaultEffort != "" {
+		return s.defaultEffort
 	}
 	return builtinDefaultEffort
 }

--- a/internal/web/efforts_test.go
+++ b/internal/web/efforts_test.go
@@ -1,6 +1,7 @@
 package web
 
 import (
+	"sync"
 	"testing"
 
 	"scrutineer/internal/config"
@@ -37,33 +38,53 @@ func TestValidEffort(t *testing.T) {
 	}
 }
 
-func TestDefaultEffort(t *testing.T) {
-	defer restoreEffort(defaultEffortOverride)
-
-	defaultEffortOverride = ""
-	if got := DefaultEffort(); got != builtinDefaultEffort {
+func TestServerDefaultEffort(t *testing.T) {
+	var s Server
+	if got := s.DefaultEffort(); got != builtinDefaultEffort {
 		t.Errorf("DefaultEffort() with no override = %q, want %q", got, builtinDefaultEffort)
 	}
-	defaultEffortOverride = "max"
-	if got := DefaultEffort(); got != "max" {
+	s.SetDefaultEffort("max")
+	if got := s.DefaultEffort(); got != "max" {
 		t.Errorf("DefaultEffort() with override = %q, want max", got)
 	}
 }
 
-func TestSetDefaultEffort(t *testing.T) {
-	defer restoreEffort(defaultEffortOverride)
-
-	defaultEffortOverride = "high"
-	SetDefaultEffort("xhigh")
-	if defaultEffortOverride != "xhigh" {
-		t.Errorf("SetDefaultEffort(xhigh) = %q, want xhigh", defaultEffortOverride)
+func TestServerSetDefaultEffort_rejectsInvalid(t *testing.T) {
+	var s Server
+	s.SetDefaultEffort("xhigh")
+	if got := s.DefaultEffort(); got != "xhigh" {
+		t.Fatalf("SetDefaultEffort(xhigh) = %q, want xhigh", got)
 	}
 	// An empty or unknown value must not clobber the current setting.
-	SetDefaultEffort("")
-	SetDefaultEffort("garbage")
-	if defaultEffortOverride != "xhigh" {
-		t.Errorf("invalid SetDefaultEffort changed it to %q, want xhigh", defaultEffortOverride)
+	s.SetDefaultEffort("")
+	s.SetDefaultEffort("garbage")
+	if got := s.DefaultEffort(); got != "xhigh" {
+		t.Errorf("invalid SetDefaultEffort changed it to %q, want xhigh", got)
 	}
 }
 
-func restoreEffort(v string) { defaultEffortOverride = v }
+func TestServerDefaults_concurrentReadWrite(t *testing.T) {
+	// Exercises the defaultsMu guard so `go test -race` flags any
+	// regression to unguarded package-level state. Both default-model
+	// and default-effort share the mutex.
+	var s Server
+	var wg sync.WaitGroup
+	for range 8 {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			for range 100 {
+				s.SetDefaultEffort("max")
+				s.SetDefaultModel("claude-opus-4-8")
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			for range 100 {
+				_ = s.DefaultEffort()
+				_ = s.DefaultModel()
+			}
+		}()
+	}
+	wg.Wait()
+}

--- a/internal/web/models.go
+++ b/internal/web/models.go
@@ -57,9 +57,13 @@ func SetModels(models []Model) {
 // SetDefaultModel pins the default model id, overriding "first entry in
 // the pick list". Set at startup from config and mutable via
 // /settings/model; in-memory only, so restart resets it to the
-// configured default.
+// configured default. The empty string and any id not in the pick list
+// are no-ops, so a bad default_model in config can't silently install an
+// invalid runtime default that resolveModelPreference would then
+// propagate into scans. Mirrors SetDefaultEffort. Call SetModels first so
+// a configured pick list is in place to validate against.
 func (s *Server) SetDefaultModel(id string) {
-	if id == "" {
+	if id == "" || !ValidModel(id) {
 		return
 	}
 	s.defaultsMu.Lock()

--- a/internal/web/models.go
+++ b/internal/web/models.go
@@ -34,8 +34,8 @@ var ModelTiers = []ModelTier{
 	{Name: "Max", Value: ModelTierMax, Description: "Best available model for deep security review."},
 }
 
-// Models is the pick list. The first entry is the default unless
-// defaultModelOverride is set by the config loader.
+// Models is the pick list. The first entry is the default unless the
+// server's runtime override is set; see Server.DefaultModel.
 var Models = []Model{
 	{"Opus 4.6", "claude-opus-4-6"},
 	{"Opus 4.7", "claude-opus-4-7"},
@@ -43,10 +43,6 @@ var Models = []Model{
 	{"Sonnet", "claude-sonnet-4-6"},
 	{"Fable 5", "claude-fable-5[1m]"},
 }
-
-// defaultModelOverride, when non-empty, replaces the first-entry-wins
-// rule. Set at startup from config; empty leaves Models[0] as default.
-var defaultModelOverride string
 
 // SetModels replaces the pick list. Called at startup from config; no-op
 // for an empty list so a config with only default_model set keeps the
@@ -58,15 +54,27 @@ func SetModels(models []Model) {
 	Models = models
 }
 
-// SetDefaultModel pins the default model id, overriding "first entry".
-// Called at startup from config.
-func SetDefaultModel(id string) {
-	defaultModelOverride = id
+// SetDefaultModel pins the default model id, overriding "first entry in
+// the pick list". Set at startup from config and mutable via
+// /settings/model; in-memory only, so restart resets it to the
+// configured default.
+func (s *Server) SetDefaultModel(id string) {
+	if id == "" {
+		return
+	}
+	s.defaultsMu.Lock()
+	s.defaultModel = id
+	s.defaultsMu.Unlock()
 }
 
-func DefaultModel() string {
-	if defaultModelOverride != "" {
-		return defaultModelOverride
+// DefaultModel is the model id a tier falls back to when no
+// tier-specific setting is configured. The runtime override wins;
+// otherwise the first entry in the pick list.
+func (s *Server) DefaultModel() string {
+	s.defaultsMu.RLock()
+	defer s.defaultsMu.RUnlock()
+	if s.defaultModel != "" {
+		return s.defaultModel
 	}
 	return Models[0].ID
 }
@@ -106,7 +114,12 @@ func modelTierSettingKey(tier string) string {
 	}
 }
 
-func ModelForTier(gdb *gorm.DB, tier string) string {
+// ModelForTier resolves a tier name to a concrete model id: a
+// per-tier setting in the DB wins, then a built-in heuristic over the
+// pick list, then the caller-supplied fallback (the server's default
+// model). The fallback is threaded in rather than read from a global
+// so the runtime default lives on Server behind a mutex.
+func ModelForTier(gdb *gorm.DB, tier, fallback string) string {
 	if !ValidModelTier(tier) {
 		tier = ModelTierHigh
 	}
@@ -117,18 +130,18 @@ func ModelForTier(gdb *gorm.DB, tier string) string {
 			}
 		}
 	}
-	return builtinModelForTier(tier)
+	return builtinModelForTier(tier, fallback)
 }
 
-func ModelTierValues(gdb *gorm.DB) map[string]string {
+func ModelTierValues(gdb *gorm.DB, fallback string) map[string]string {
 	values := make(map[string]string, len(ModelTiers))
 	for _, tier := range ModelTiers {
-		values[tier.Value] = ModelForTier(gdb, tier.Value)
+		values[tier.Value] = ModelForTier(gdb, tier.Value, fallback)
 	}
 	return values
 }
 
-func builtinModelForTier(tier string) string {
+func builtinModelForTier(tier, fallback string) string {
 	// Built-in tiers assume the built-in Anthropic-flavoured model ids and
 	// ordering. If operators replace Models with a multi-vendor list that
 	// lacks "sonnet" or "opus", the tier intentionally falls back to
@@ -143,7 +156,7 @@ func builtinModelForTier(tier string) string {
 			return id
 		}
 	}
-	return DefaultModel()
+	return fallback
 }
 
 func firstModelContaining(needle string) string {
@@ -164,12 +177,12 @@ func lastModelContaining(needle string) string {
 	return ""
 }
 
-func resolveModelPreference(gdb *gorm.DB, preference string) string {
+func resolveModelPreference(gdb *gorm.DB, preference, fallback string) string {
 	if ValidModel(preference) {
 		return preference
 	}
 	if ValidModelTier(preference) {
-		return ModelForTier(gdb, preference)
+		return ModelForTier(gdb, preference, fallback)
 	}
-	return ModelForTier(gdb, ModelTierHigh)
+	return ModelForTier(gdb, ModelTierHigh, fallback)
 }

--- a/internal/web/models_test.go
+++ b/internal/web/models_test.go
@@ -5,13 +5,29 @@ import "testing"
 func withTestModels(t *testing.T, models []Model) {
 	t.Helper()
 	oldModels := Models
-	oldDefault := defaultModelOverride
 	Models = models
-	defaultModelOverride = ""
-	t.Cleanup(func() {
-		Models = oldModels
-		defaultModelOverride = oldDefault
+	t.Cleanup(func() { Models = oldModels })
+}
+
+func TestServerDefaultModel(t *testing.T) {
+	withTestModels(t, []Model{
+		{Name: "First", ID: "first-entry"},
+		{Name: "Second", ID: "second-entry"},
 	})
+	var s Server
+	if got := s.DefaultModel(); got != "first-entry" {
+		t.Errorf("DefaultModel() with no override = %q, want first pick-list entry", got)
+	}
+	s.SetDefaultModel("second-entry")
+	if got := s.DefaultModel(); got != "second-entry" {
+		t.Errorf("DefaultModel() with override = %q, want second-entry", got)
+	}
+	// Empty must not clobber an existing override; main.go calls
+	// SetDefaultModel unconditionally with whatever the config held.
+	s.SetDefaultModel("")
+	if got := s.DefaultModel(); got != "second-entry" {
+		t.Errorf("SetDefaultModel(\"\") cleared override to %q", got)
+	}
 }
 
 func TestModelTiers(t *testing.T) {
@@ -28,13 +44,14 @@ func TestModelTiers(t *testing.T) {
 	if ValidModelTier("ultra") {
 		t.Fatal("unknown tier should not be valid")
 	}
-	if got := builtinModelForTier(ModelTierMid); got != "test-sonnet" {
+	const fallback = "test-high"
+	if got := builtinModelForTier(ModelTierMid, fallback); got != "test-sonnet" {
 		t.Errorf("mid tier default = %q, want sonnet", got)
 	}
-	if got := builtinModelForTier(ModelTierHigh); got != DefaultModel() {
-		t.Errorf("high tier default = %q, want DefaultModel()", got)
+	if got := builtinModelForTier(ModelTierHigh, fallback); got != fallback {
+		t.Errorf("high tier default = %q, want fallback", got)
 	}
-	if got := builtinModelForTier(ModelTierMax); got != "test-opus-b" {
+	if got := builtinModelForTier(ModelTierMax, fallback); got != "test-opus-b" {
 		t.Errorf("max tier default = %q, want latest opus", got)
 	}
 }
@@ -46,7 +63,7 @@ func TestModelTiersFallbackToDefaultModelWithCustomModelList(t *testing.T) {
 	})
 
 	for _, tier := range []string{ModelTierMid, ModelTierHigh, ModelTierMax} {
-		if got := builtinModelForTier(tier); got != "vendor-default" {
+		if got := builtinModelForTier(tier, "vendor-default"); got != "vendor-default" {
 			t.Errorf("builtinModelForTier(%q) = %q, want vendor-default", tier, got)
 		}
 	}
@@ -59,13 +76,14 @@ func TestResolveModelPreference(t *testing.T) {
 		{Name: "Opus", ID: "test-opus"},
 	})
 
-	if got := resolveModelPreference(nil, "test-opus"); got != "test-opus" {
+	const fallback = "test-high"
+	if got := resolveModelPreference(nil, "test-opus", fallback); got != "test-opus" {
 		t.Errorf("exact model = %q, want test-opus", got)
 	}
-	if got := resolveModelPreference(nil, ModelTierMid); got != "test-sonnet" {
+	if got := resolveModelPreference(nil, ModelTierMid, fallback); got != "test-sonnet" {
 		t.Errorf("tier model = %q, want test-sonnet", got)
 	}
-	if got := resolveModelPreference(nil, "not-configured"); got != "test-high" {
+	if got := resolveModelPreference(nil, "not-configured", fallback); got != "test-high" {
 		t.Errorf("invalid preference fallback = %q, want high tier default", got)
 	}
 }

--- a/internal/web/models_test.go
+++ b/internal/web/models_test.go
@@ -28,6 +28,12 @@ func TestServerDefaultModel(t *testing.T) {
 	if got := s.DefaultModel(); got != "second-entry" {
 		t.Errorf("SetDefaultModel(\"\") cleared override to %q", got)
 	}
+	// An id outside the pick list (e.g. a typo in config's default_model)
+	// must be rejected rather than installed as the runtime default.
+	s.SetDefaultModel("not-in-pick-list")
+	if got := s.DefaultModel(); got != "second-entry" {
+		t.Errorf("SetDefaultModel(invalid) changed override to %q, want second-entry", got)
+	}
 }
 
 func TestModelTiers(t *testing.T) {

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -96,6 +96,16 @@ type Server struct {
 	// the network lookup, mirroring resolvePURL and listBranches.
 	fetchOrgRepos func(ctx context.Context, org string) ([]OrgRepo, error)
 
+	// Runtime defaults a new scan inherits when the caller pins none.
+	// Both are seeded at startup from config/flags and mutable via the
+	// settings page, so a request can write while another reads. One
+	// mutex covers both; the default-model getter falls back to
+	// Models[0] and the default-effort getter to builtinDefaultEffort
+	// when unset.
+	defaultsMu    sync.RWMutex
+	defaultModel  string
+	defaultEffort string
+
 	skillNamesMu    sync.Mutex
 	skillNamesCache []string
 	skillNamesTTL   time.Time
@@ -2158,9 +2168,9 @@ func (s *Server) enqueueSkillWith(ctx context.Context, repoID, skillID uint, opt
 	if !ValidModelPreference(opts.Model) && hasSkill {
 		opts.Model = sk.Model
 	}
-	opts.Model = resolveModelPreference(s.DB, opts.Model)
+	opts.Model = resolveModelPreference(s.DB, opts.Model, s.DefaultModel())
 	if !ValidEffort(opts.Effort) {
-		opts.Effort = DefaultEffort()
+		opts.Effort = s.DefaultEffort()
 	}
 	kind := worker.JobSkill
 	if opts.DependentID != nil {

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -2045,8 +2045,7 @@ func TestEnqueueSkillWith_modelPrecedence(t *testing.T) {
 func TestEnqueueSkillWith_effort(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()
-	defer restoreEffort(defaultEffortOverride)
-	defaultEffortOverride = "high"
+	s.SetDefaultEffort("high")
 
 	repo := db.Repository{URL: "https://github.com/foo/bar", Name: "bar"}
 	s.DB.Create(&repo)
@@ -3457,10 +3456,9 @@ func TestScansRetryFailed(t *testing.T) {
 func TestScansRetryFailed_preservesEffort(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()
-	defer restoreEffort(defaultEffortOverride)
 	// Force the runtime default away from the scan's effort so a dropped
 	// `effort` column in the retry Select would surface as "low", not "max".
-	defaultEffortOverride = "low"
+	s.SetDefaultEffort("low")
 
 	repo := db.Repository{URL: "https://example.com/x.git", Name: "x"}
 	s.DB.Create(&repo)
@@ -4104,7 +4102,6 @@ func TestSettingsUpdateTheme_rejectsInvalid(t *testing.T) {
 func TestSettingsUpdateEffort_setsDefault(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()
-	defer restoreEffort(defaultEffortOverride)
 
 	form := url.Values{"effort": {"max"}}
 	req := httptest.NewRequest("POST", "/settings/effort", strings.NewReader(form.Encode()))
@@ -4115,7 +4112,7 @@ func TestSettingsUpdateEffort_setsDefault(t *testing.T) {
 	if w.Code != http.StatusSeeOther {
 		t.Fatalf("status %d: %s", w.Code, w.Body)
 	}
-	if got := DefaultEffort(); got != "max" {
+	if got := s.DefaultEffort(); got != "max" {
 		t.Errorf("DefaultEffort() = %q, want max", got)
 	}
 }
@@ -4123,7 +4120,6 @@ func TestSettingsUpdateEffort_setsDefault(t *testing.T) {
 func TestSettingsUpdateEffort_rejectsInvalid(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()
-	defer restoreEffort(defaultEffortOverride)
 
 	form := url.Values{"effort": {"extreme"}}
 	req := httptest.NewRequest("POST", "/settings/effort", strings.NewReader(form.Encode()))

--- a/internal/web/settings_handlers_test.go
+++ b/internal/web/settings_handlers_test.go
@@ -54,7 +54,7 @@ func TestSettingsUpdateModelTier(t *testing.T) {
 	if w.Code != http.StatusSeeOther {
 		t.Fatalf("status %d: %s", w.Code, w.Body)
 	}
-	if got := ModelForTier(s.DB, ModelTierMid); got != "claude-sonnet-4-6" {
+	if got := ModelForTier(s.DB, ModelTierMid, s.DefaultModel()); got != "claude-sonnet-4-6" {
 		t.Errorf("mid tier model = %q, want claude-sonnet-4-6", got)
 	}
 
@@ -67,7 +67,7 @@ func TestSettingsUpdateModelTier(t *testing.T) {
 			t.Errorf("form=%v: status %d, want 422", form, w.Code)
 		}
 	}
-	if got := ModelForTier(s.DB, ModelTierMid); got != "claude-sonnet-4-6" {
+	if got := ModelForTier(s.DB, ModelTierMid, s.DefaultModel()); got != "claude-sonnet-4-6" {
 		t.Errorf("invalid update clobbered mid tier = %q", got)
 	}
 }

--- a/internal/web/theme.go
+++ b/internal/web/theme.go
@@ -100,9 +100,9 @@ func (s *Server) settingsShow(w http.ResponseWriter, r *http.Request) {
 		"Themes":           config.Themes,
 		"Models":           Models,
 		"ModelTiers":       ModelTiers,
-		"TierModels":       ModelTierValues(s.DB),
+		"TierModels":       ModelTierValues(s.DB, s.DefaultModel()),
 		"Efforts":          Efforts,
-		"DefaultEffort":    DefaultEffort(),
+		"DefaultEffort":    s.DefaultEffort(),
 		"ColorScheme":      resolveColorScheme(r),
 		"Concurrency":      s.Queue.Concurrency(),
 		"ConcurrencyInput": concurrencyInput,
@@ -192,7 +192,7 @@ func (s *Server) settingsUpdateModel(w http.ResponseWriter, r *http.Request) {
 		s.redirect(w, r, "/settings")
 		return
 	}
-	SetDefaultModel(model)
+	s.SetDefaultModel(model)
 	setFlash(w, Flash{Category: successKey, Title: "Default model updated"})
 	s.redirect(w, r, "/settings")
 }
@@ -203,7 +203,7 @@ func (s *Server) settingsUpdateEffort(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "unknown effort", http.StatusUnprocessableEntity)
 		return
 	}
-	SetDefaultEffort(effort)
+	s.SetDefaultEffort(effort)
 	setFlash(w, Flash{Category: successKey, Title: "Default effort updated"})
 	s.redirect(w, r, "/settings")
 }


### PR DESCRIPTION
`defaultModelOverride` and `defaultEffortOverride` were package globals written by the `/settings/model` and `/settings/effort` handlers and read by the enqueue path with no synchronisation. Move both onto `Server` behind one `sync.RWMutex`.

`ModelForTier` / `builtinModelForTier` / `ModelTierValues` / `resolveModelPreference` now take the fallback model id explicitly instead of reading the global, so the per-server default threads through cleanly. `main.go` seeds the defaults on `srv` after construction rather than via package functions in `merge()`. Config keys (`default_model`, `effort`) are unchanged.

Tests no longer share state through the global: the `restoreEffort` dance is gone and each test server carries its own defaults. `TestServerDefaults_concurrentReadWrite` hammers both setters and getters from eight goroutines so `go test -race` flags any regression.