### PR TITLE
repo_report: add summary block and sink-disposition column

### DIFF
--- a/internal/web/repo_report.go
+++ b/internal/web/repo_report.go
@@ -36,14 +36,19 @@ func (s *Server) repoReport(w http.ResponseWriter, r *http.Request) {
 }
 
 func renderRepoReport(gdb *gorm.DB, repo *db.Repository) string {
+	// Findings and sink dispositions are computed once up front so the
+	// summary, threat-model inventory, and findings sections all render
+	// from the same data without re-querying.
+	latest, threatModel := latestDeepDive(gdb, repo.ID)
+	findings := loadReportFindings(gdb, repo.ID)
+	disp := buildSinkDispositions(threatModel, findings)
+
 	var b strings.Builder
 	writeReportHeader(&b, repo)
+	writeReportSummary(&b, latest, findings, disp)
 	writeReportMetadata(&b, repo)
-
-	latest, threatModel := latestDeepDive(gdb, repo.ID)
-	writeReportThreatModel(&b, latest, threatModel)
-
-	writeReportFindings(&b, gdb, repo.ID, latest)
+	writeReportThreatModel(&b, latest, threatModel, disp)
+	writeReportFindings(&b, gdb, findings, latest)
 	writeReportPackages(&b, gdb, repo.ID)
 	writeReportAdvisories(&b, gdb, repo.ID)
 	writeReportDependents(&b, gdb, repo.ID)
@@ -106,7 +111,149 @@ func latestDeepDive(gdb *gorm.DB, repoID uint) (*db.Scan, map[string]any) {
 	return &scan, tm
 }
 
-func writeReportThreatModel(b *strings.Builder, scan *db.Scan, tm map[string]any) {
+// loadReportFindings mirrors the repo page Findings tab: deep-dive output
+// only, ordered Critical-first so the summary's top-N and the findings
+// section share one ordering.
+func loadReportFindings(gdb *gorm.DB, repoID uint) []db.Finding {
+	var findings []db.Finding
+	gdb.Where("repository_id = ?", repoID).
+		Where("scan_id IN (?)", deepDiveScanIDs(gdb)).
+		Order(severityOrder).Order("id").Find(&findings)
+	return findings
+}
+
+// sinkDisposition records where one inventory sink id ended up so the
+// inventory table can show outcome alongside catalogue and the summary
+// can report coverage without the reader cross-referencing the
+// inventory and ruled-out sections.
+type sinkDisposition struct {
+	findingID uint
+	ruled     bool
+	step      int
+	reason    string
+}
+
+func (d sinkDisposition) cell() string {
+	switch {
+	case d.findingID != 0:
+		return fmt.Sprintf("→ Finding #%d", d.findingID)
+	case d.ruled:
+		r := firstClause(d.reason)
+		if r == "" {
+			return fmt.Sprintf("ruled out, step %d", d.step)
+		}
+		return fmt.Sprintf("ruled out, step %d — %s", d.step, r)
+	default:
+		return "unresolved"
+	}
+}
+
+// buildSinkDispositions maps each inventory sink id to its outcome. The
+// deep-dive skill guarantees every inventory entry lands in either a
+// finding's Sinks or a ruled_out entry, so anything left over is a
+// coverage gap worth surfacing as "unresolved". A sink claimed by both
+// keeps the finding outcome since that is the actionable one.
+func buildSinkDispositions(tm map[string]any, findings []db.Finding) map[string]sinkDisposition {
+	inv := listSlice(tm, "inventory")
+	if len(inv) == 0 {
+		return nil
+	}
+	disp := make(map[string]sinkDisposition, len(inv))
+	for _, x := range inv {
+		if m, ok := x.(map[string]any); ok {
+			if id, _ := m["id"].(string); id != "" {
+				disp[id] = sinkDisposition{}
+			}
+		}
+	}
+	for _, x := range listSlice(tm, "ruled_out") {
+		m, ok := x.(map[string]any)
+		if !ok {
+			continue
+		}
+		step := intVal(m["step"])
+		reason, _ := m["reason"].(string)
+		for _, id := range stringSlice(m["sinks"]) {
+			if _, ok := disp[id]; ok {
+				disp[id] = sinkDisposition{ruled: true, step: step, reason: reason}
+			}
+		}
+	}
+	for _, f := range findings {
+		for _, id := range splitSinks(f.Sinks) {
+			if _, ok := disp[id]; ok {
+				disp[id] = sinkDisposition{findingID: f.ID}
+			}
+		}
+	}
+	return disp
+}
+
+// dispositionCounts returns (ruled out, became findings, unresolved). The
+// catalogued count is len(disp).
+func dispositionCounts(disp map[string]sinkDisposition) (ruled, found, unresolved int) {
+	for _, d := range disp {
+		switch {
+		case d.findingID != 0:
+			found++
+		case d.ruled:
+			ruled++
+		default:
+			unresolved++
+		}
+	}
+	return ruled, found, unresolved
+}
+
+const summaryTopN = 3
+
+// writeReportSummary emits a five-line block a maintainer can read in
+// thirty seconds: severity counts, top findings, sink coverage, where
+// to start, and which tree it applies to. Upstream feedback was that
+// the full report takes hours to digest before it is actionable; this
+// gives them the headline first.
+func writeReportSummary(b *strings.Builder, scan *db.Scan, findings []db.Finding, disp map[string]sinkDisposition) {
+	if scan == nil && len(findings) == 0 {
+		return
+	}
+	fmt.Fprintf(b, "## Summary\n\n")
+
+	by := severityCounts(findings)
+	fmt.Fprintf(b, "- %d findings: %d critical, %d high, %d medium, %d low\n",
+		len(findings), by["Critical"], by["High"], by["Medium"], by["Low"])
+
+	for i, f := range findings {
+		if i >= summaryTopN {
+			break
+		}
+		fmt.Fprintf(b, "- **%s** — Finding #%d, %s\n", escapeMD(f.Title), f.ID, f.Severity)
+	}
+
+	if len(disp) > 0 {
+		ruled, found, unresolved := dispositionCounts(disp)
+		fmt.Fprintf(b, "- Sink coverage: %d catalogued, %d ruled out, %d became findings, %d unresolved\n",
+			len(disp), ruled, found, unresolved)
+	}
+
+	if len(findings) > 0 {
+		fmt.Fprintf(b, "- Start with Finding #%d\n", findings[0].ID)
+	}
+
+	if scan != nil {
+		fmt.Fprintf(b, "- Scan at commit `%s` (%s)\n", shortCommit(scan.Commit), formatScanDate(scan))
+	}
+	b.WriteString("\n")
+}
+
+func severityCounts(findings []db.Finding) map[string]int {
+	by := make(map[string]int, len(db.SeverityLevels))
+	for _, f := range findings {
+		by[f.Severity]++
+	}
+	return by
+}
+
+func writeReportThreatModel(b *strings.Builder, scan *db.Scan, tm map[string]any, disp map[string]sinkDisposition) {
 	fmt.Fprintf(b, "## Threat model\n\n")
 	if scan == nil {
 		fmt.Fprintf(b, "No completed %s scan yet.\n\n", deepDiveSkillName)
@@ -144,12 +291,14 @@ func writeReportThreatModel(b *strings.Builder, scan *db.Scan, tm map[string]any
 
 	if inventory := listSlice(tm, "inventory"); len(inventory) > 0 {
 		fmt.Fprintf(b, "### Sink inventory\n\n")
-		fmt.Fprintf(b, "| # | Class | Primitive | Location | Consumes |\n|---|---|---|---|---|\n")
+		fmt.Fprintf(b, "| # | Class | Primitive | Location | Consumes | Disposition |\n|---|---|---|---|---|---|\n")
 		for _, x := range inventory {
 			if m, ok := x.(map[string]any); ok {
-				fmt.Fprintf(b, "| %s | %s | %s | `%s` | %s |\n",
-					mdCell(m, "id"), mdCell(m, "class"), mdCell(m, "primitive"),
-					mdCell(m, "location"), mdCell(m, "consumes"))
+				id, _ := m["id"].(string)
+				fmt.Fprintf(b, "| %s | %s | %s | `%s` | %s | %s |\n",
+					escapeMD(id), mdCell(m, "class"), mdCell(m, "primitive"),
+					mdCell(m, "location"), mdCell(m, "consumes"),
+					escapeMD(disp[id].cell()))
 			}
 		}
 		b.WriteString("\n")
@@ -178,15 +327,8 @@ func writeReportThreatModel(b *strings.Builder, scan *db.Scan, tm map[string]any
 	}
 }
 
-func writeReportFindings(b *strings.Builder, gdb *gorm.DB, repoID uint, latest *db.Scan) {
+func writeReportFindings(b *strings.Builder, gdb *gorm.DB, findings []db.Finding, latest *db.Scan) {
 	fmt.Fprintf(b, "## Findings\n\n")
-	// Mirrors the repo page Findings tab: deep-dive output only. Scanner
-	// findings (zizmor, semgrep) belong to the Scanners tab and stay out of
-	// the curated report so download recipients don't drown in lint noise.
-	var findings []db.Finding
-	gdb.Where("repository_id = ?", repoID).
-		Where("scan_id IN (?)", deepDiveScanIDs(gdb)).
-		Order("severity, id").Find(&findings)
 	if len(findings) == 0 {
 		fmt.Fprintf(b, "No findings recorded for this repository.\n\n")
 		return
@@ -477,6 +619,48 @@ func stringSlice(v any) []string {
 func mdCell(m map[string]any, key string) string {
 	v, _ := m[key].(string)
 	return escapeMD(v)
+}
+
+// intVal extracts an int from an untyped JSON value. encoding/json
+// decodes numbers as float64 by default; ruled_out.step is documented
+// as an integer so the truncation is exact in practice.
+func intVal(v any) int {
+	switch n := v.(type) {
+	case float64:
+		return int(n)
+	case int:
+		return n
+	}
+	return 0
+}
+
+// splitSinks tokenises a Finding.Sinks column ("S1, S2") into ids.
+// findings.go writes them comma-joined with a trailing space; older
+// rows might lack the space, so trim each token.
+func splitSinks(s string) []string {
+	if s == "" {
+		return nil
+	}
+	parts := strings.Split(s, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// firstClause returns the text up to the first sentence or clause
+// terminator, trimmed. Used to fit a ruled-out reason into one
+// inventory-table cell while the full prose stays in the Ruled out
+// section below.
+func firstClause(s string) string {
+	s = strings.TrimSpace(s)
+	if i := strings.IndexAny(s, ".;\n"); i >= 0 {
+		s = s[:i]
+	}
+	return strings.TrimSpace(s)
 }
 
 func escapeMD(s string) string {

--- a/internal/web/repo_report.go
+++ b/internal/web/repo_report.go
@@ -41,7 +41,7 @@ func renderRepoReport(gdb *gorm.DB, repo *db.Repository) string {
 	// from the same data without re-querying.
 	latest, threatModel := latestDeepDive(gdb, repo.ID)
 	findings := loadReportFindings(gdb, repo.ID)
-	disp := buildSinkDispositions(threatModel, findings)
+	disp := buildSinkDispositions(threatModel, latestScanFindings(gdb, latest))
 
 	var b strings.Builder
 	writeReportHeader(&b, repo)
@@ -111,14 +111,32 @@ func latestDeepDive(gdb *gorm.DB, repoID uint) (*db.Scan, map[string]any) {
 	return &scan, tm
 }
 
-// loadReportFindings mirrors the repo page Findings tab: deep-dive output
-// only, ordered Critical-first so the summary's top-N and the findings
-// section share one ordering.
+// loadReportFindings mirrors the repo page Findings tab: open deep-dive
+// findings (closed lifecycles excluded, as the tab does), ordered
+// Critical-first then most-recent id, so the summary's top-N and the
+// findings section share the same ordering the UI shows.
 func loadReportFindings(gdb *gorm.DB, repoID uint) []db.Finding {
 	var findings []db.Finding
 	gdb.Where("repository_id = ?", repoID).
+		Where("status NOT IN ?", db.ClosedFindingLifecycles).
 		Where("scan_id IN (?)", deepDiveScanIDs(gdb)).
-		Order(severityOrder).Order("id").Find(&findings)
+		Order(severityOrder).Order("id desc").Find(&findings)
+	return findings
+}
+
+// latestScanFindings loads the findings produced by one scan, for
+// resolving sink dispositions. Inventory sink ids (S1, S2, …) are only
+// unique within a single deep-dive report, so dispositions must be built
+// from the findings of the same scan that produced the inventory; mixing
+// in an older scan's findings would let its "S1" claim this scan's
+// inventory "S1". All lifecycles are kept on purpose — a sink that became
+// a finding is covered even if that finding was later triaged closed.
+func latestScanFindings(gdb *gorm.DB, scan *db.Scan) []db.Finding {
+	if scan == nil {
+		return nil
+	}
+	var findings []db.Finding
+	gdb.Where("scan_id = ?", scan.ID).Find(&findings)
 	return findings
 }
 

--- a/internal/web/repo_report_test.go
+++ b/internal/web/repo_report_test.go
@@ -46,7 +46,7 @@ func seedRepoWithReport(t *testing.T, s *Server) db.Repository {
 		ScanID: scan.ID, RepositoryID: repo.ID, Commit: scan.Commit,
 		FindingID: "F1", Title: "OS command injection via arg",
 		Severity: "High", Status: db.FindingEnriched, CWE: "CWE-78",
-		Location: "main.go:12", Affected: ">=1.0,<1.4",
+		Location: "main.go:12", Sinks: "S1", Affected: ">=1.0,<1.4",
 		Trace: "arg comes in, hits os.Exec", Boundary: "crosses caller boundary",
 		Validation: "`echo $(cat repro.sh)` triggers", Rating: "High because X",
 		CVEID: "CVE-2026-00042", CVSSVector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
@@ -112,6 +112,8 @@ func TestRepoReport_includesEverySection(t *testing.T) {
 	wants := []string{
 		"# acme/thing",
 		"https://github.com/acme/thing",
+		"## Summary",
+		"1 findings: 0 critical, 1 high, 0 medium, 0 low",
 		"## Repository metadata",
 		"| Languages | Go |",
 		"| License | MIT |",
@@ -119,7 +121,9 @@ func TestRepoReport_includesEverySection(t *testing.T) {
 		"### Trust boundaries",
 		"| caller | yes | arg | README |",
 		"### Sink inventory",
+		"Disposition",
 		"Command execution",
+		"→ Finding #",
 		"### Ruled out",
 		"internal path, no caller provides",
 		"## Findings",
@@ -198,6 +202,103 @@ func TestRepoReport_omitsSkillsRepoSHAWhenUnset(t *testing.T) {
 	body := w.Body.String()
 	if strings.Contains(body, "skills repo") {
 		t.Errorf("expected no skills-repo mention, got:\n%s", body)
+	}
+}
+
+func TestRepoReport_summaryAndSinkDisposition(t *testing.T) {
+	// A repository with three sinks: S1 becomes a Critical finding, S2
+	// is ruled out at step 3, S3 appears in neither. The report must
+	// open with a summary (severity counts, top finding pointer, sink
+	// coverage) and the inventory table must carry a Disposition column
+	// joining each sink to its outcome.
+	s, done := newTestServer(t)
+	defer done()
+
+	repo := db.Repository{URL: "https://github.com/acme/three", Name: "three"}
+	s.DB.Create(&repo)
+
+	now := time.Now()
+	report := `{
+		"repository":"https://github.com/acme/three","commit":"feedfacecafe",
+		"spec_version":10,"model":"t","date":"2026-06-01","languages":["Go"],
+		"boundaries":[{"actor":"user","trusted":"no","controls":"input","source":"docs"}],
+		"inventory":[
+			{"id":"S1","class":"Command execution","location":"a.go:10","consumes":"arg","primitive":"os.Exec"},
+			{"id":"S2","class":"Filesystem write","location":"b.go:20","consumes":"path","primitive":"os.Create"},
+			{"id":"S3","class":"Network egress","location":"c.go:30","consumes":"url","primitive":"http.Get"}
+		],
+		"ruled_out":[{"sinks":["S2"],"step":3,"reason":"path is a compile-time constant. No caller controls it."}],
+		"findings":[]
+	}`
+	scan := db.Scan{
+		RepositoryID: repo.ID, Kind: worker.JobSkill, Status: db.ScanDone,
+		SkillName: "security-deep-dive", Commit: "feedfacecafebeef", Report: report,
+		FinishedAt: &now, CreatedAt: now,
+	}
+	s.DB.Create(&scan)
+
+	crit := db.Finding{
+		ScanID: scan.ID, RepositoryID: repo.ID, Commit: scan.Commit,
+		FindingID: "F1", Title: "Argument injection into os.Exec",
+		Severity: "Critical", Status: db.FindingReady, Sinks: "S1",
+		Location: "a.go:10", Trace: "user input reaches exec",
+	}
+	s.DB.Create(&crit)
+	med := db.Finding{
+		ScanID: scan.ID, RepositoryID: repo.ID, Commit: scan.Commit,
+		FindingID: "F2", Title: "Verbose error leaks path",
+		Severity: "Medium", Status: db.FindingEnriched,
+		Location: "d.go:5",
+	}
+	s.DB.Create(&med)
+
+	body := renderRepoReport(s.DB, &repo)
+
+	// Summary block precedes the metadata table.
+	if i, j := strings.Index(body, "## Summary"), strings.Index(body, "## Repository metadata"); i < 0 || i > j {
+		t.Errorf("summary missing or after metadata; idx summary=%d metadata=%d", i, j)
+	}
+	wants := []string{
+		"## Summary",
+		"2 findings: 1 critical, 0 high, 1 medium, 0 low",
+		"Argument injection into os.Exec",
+		"Sink coverage: 3 catalogued, 1 ruled out, 1 became findings, 1 unresolved",
+		"Start with Finding #" + strconv.FormatUint(uint64(crit.ID), 10),
+		"`feedfacecaf",
+	}
+	for _, want := range wants {
+		if !strings.Contains(body, want) {
+			t.Errorf("summary missing %q", want)
+		}
+	}
+
+	// Disposition column on the inventory table.
+	if !strings.Contains(body, "| # | Class | Primitive | Location | Consumes | Disposition |") {
+		t.Error("inventory header missing Disposition column")
+	}
+	for _, want := range []string{
+		"| S1 |", "→ Finding #" + strconv.FormatUint(uint64(crit.ID), 10),
+		"| S2 |", "ruled out, step 3 — path is a compile-time constant",
+		"| S3 |", "unresolved",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("inventory row missing %q", want)
+		}
+	}
+}
+
+func TestFirstClause(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"single sentence", "single sentence"},
+		{"first. second.", "first"},
+		{"first; second", "first"},
+		{"  spaced  ", "spaced"},
+		{"", ""},
+	}
+	for _, tc := range cases {
+		if got := firstClause(tc.in); got != tc.want {
+			t.Errorf("firstClause(%q) = %q, want %q", tc.in, got, tc.want)
+		}
 	}
 }
 

--- a/internal/web/repo_report_test.go
+++ b/internal/web/repo_report_test.go
@@ -287,6 +287,61 @@ func TestRepoReport_summaryAndSinkDisposition(t *testing.T) {
 	}
 }
 
+func TestRepoReport_sinkDispositionScopedToLatestScan(t *testing.T) {
+	// Sink ids are only unique within one report. An older deep-dive scan
+	// produced a finding for its "S1"; the latest scan's inventory also has
+	// an "S1" but no finding for it. The disposition must read "unresolved"
+	// for the latest S1, not point at the older scan's finding.
+	s, done := newTestServer(t)
+	defer done()
+
+	repo := db.Repository{URL: "https://github.com/acme/two-scans", Name: "two-scans"}
+	s.DB.Create(&repo)
+
+	now := time.Now()
+	old := now.Add(-time.Hour)
+	oldReport := `{"repository":"r","commit":"old","spec_version":10,"model":"t","date":"2026-05-01","languages":["Go"],
+		"inventory":[{"id":"S1","class":"Command execution","location":"old.go:1","consumes":"a","primitive":"exec"}],
+		"ruled_out":[],"findings":[]}`
+	oldScan := db.Scan{
+		RepositoryID: repo.ID, Kind: worker.JobSkill, Status: db.ScanDone,
+		SkillName: "security-deep-dive", Commit: "oldcommit", Report: oldReport,
+		FinishedAt: &old, CreatedAt: old,
+	}
+	s.DB.Create(&oldScan)
+	// The older scan's finding claims its own S1.
+	oldFinding := db.Finding{
+		ScanID: oldScan.ID, RepositoryID: repo.ID, Commit: oldScan.Commit,
+		FindingID: "OLD1", Title: "Old scan command injection",
+		Severity: "Critical", Status: db.FindingReady, Sinks: "S1", Location: "old.go:1",
+	}
+	s.DB.Create(&oldFinding)
+
+	latestReport := `{"repository":"r","commit":"new","spec_version":10,"model":"t","date":"2026-06-01","languages":["Go"],
+		"inventory":[{"id":"S1","class":"Network egress","location":"new.go:9","consumes":"url","primitive":"http.Get"}],
+		"ruled_out":[],"findings":[]}`
+	latestScan := db.Scan{
+		RepositoryID: repo.ID, Kind: worker.JobSkill, Status: db.ScanDone,
+		SkillName: "security-deep-dive", Commit: "newcommit", Report: latestReport,
+		FinishedAt: &now, CreatedAt: now,
+	}
+	s.DB.Create(&latestScan)
+
+	body := renderRepoReport(s.DB, &repo)
+
+	// The latest S1 row must be unresolved; its disposition must not point
+	// at the older scan's finding. (The older finding is still open, so it
+	// legitimately appears in the findings list — what must not happen is
+	// its id showing up as a disposition pointer.)
+	if !strings.Contains(body, "| S1 |") || !strings.Contains(body, "unresolved") {
+		t.Errorf("latest S1 should be unresolved; body:\n%s", body)
+	}
+	oldPointer := "→ Finding #" + strconv.FormatUint(uint64(oldFinding.ID), 10)
+	if strings.Contains(body, oldPointer) {
+		t.Errorf("older scan's finding %q leaked into a disposition cell", oldPointer)
+	}
+}
+
 func TestFirstClause(t *testing.T) {
 	cases := []struct{ in, want string }{
 		{"single sentence", "single sentence"},


### PR DESCRIPTION
Upstream feedback on a shared markdown report: the sink inventory and ruled-out sections require cross-referencing by id, and the document takes hours to digest before it is actionable.

`renderRepoReport` now loads findings once up front (ordered via `severityOrder`, which also fixes the alphabetic Low-before-Medium sort) and builds a sink-id → disposition map from the deep-dive report's `inventory`, `ruled_out`, and the finding rows' `Sinks` column.

`writeReportSummary` emits a five-bullet block right after the header: severity counts, top three findings, sink coverage (catalogued / ruled out / became findings / unresolved), a start-with pointer to the highest-severity finding, and the scan commit + date. Skipped when the repo has no deep-dive scan and no findings.

The sink inventory table gains a Disposition column rendering `→ Finding #N`, `ruled out, step N — <first clause>`, or `unresolved`. The long-form Ruled out section stays for the full reasons.

Related: #425, #426, #427 cover the remaining items from the same feedback (parsing sink class, code snippets, upstream-audience mode).