### PR TITLE
ruby profile: ship PROFILE.md orientation guide

### DIFF
--- a/docker/profiles/ruby/PROFILE.md
+++ b/docker/profiles/ruby/PROFILE.md
@@ -1,0 +1,43 @@
+# Ruby scanning container
+
+The repository under `./src` is a Ruby project.
+
+## Runtime
+
+- **Ruby 3.4** — `ruby`
+- **`gem`** on PATH for installing individual gems.
+- **`bundle`** (Bundler ships with Ruby) for installing a project's locked dependency set. Use `--no-color`.
+- C toolchain (`gcc`, `make`, `autoconf`) plus the headers Ruby links against, so gems with native extensions compile when a scan reproduces a `Gemfile` in-place.
+
+## Operating procedure
+
+### Code scanning preparations
+
+If `./src/Gemfile.lock` exists, install dependencies first so requires resolve and native extensions build:
+
+```bash
+cd src && bundle install --no-color
+```
+
+If only `Gemfile` exists (no lock), call out the missing lock in the report but try anyway. If Bundler fails with
+`Could not resolve host` or a similar network error the scan is offline — proceed without installed gems and note
+which checks you had to skip.
+
+### Creating reproducers
+
+Every finding ships with a reproducer — a small piece of code that, when run in this container, actually triggers the
+issue. Paste the exact command you ran and the verbatim output (error message, return value, observable side effect)
+into the finding. Reasoning-only or "this would" reproducers do not count; if you couldn't run it here, say so
+explicitly instead of inventing one.
+
+- One-liner: `ruby -e '<code>'`
+- Multi-line: write to `/tmp/poc.rb`, run `ruby /tmp/poc.rb`
+- If the reproducer depends on the project's gems, run it through Bundler from `./src` after `bundle install`, e.g.
+  `bundle exec ruby /tmp/poc.rb`, so the locked versions load rather than whatever happens to be on the system
+- For framework- or HTTP-routed bugs, isolate the vulnerable method and invoke it directly with the malicious input
+  rather than booting a server — keeps the reproducer minimal and the evidence trivial to verify
+
+## Out of scope
+
+- Installed gems (Bundler's gem path, or `./src/vendor/bundle` if the project vendors there) — third-party code, not
+  the target of this scan unless a finding specifically pivots through it.

--- a/internal/worker/profile_test.go
+++ b/internal/worker/profile_test.go
@@ -295,15 +295,15 @@ func TestRepoShipsProfileDockerfiles(t *testing.T) {
 	}
 }
 
-// TestProfileGuidesShipForPHP keeps the php / php-ext profiles honest
-// about the per-container PROFILE.md they advertise. PROFILE.md is
-// optional in general (a profile without one simply gets no orientation
-// injected at scan time); the php profiles document specifics the
-// agent needs to behave correctly, so missing them is a real regression.
-func TestProfileGuidesShipForPHP(t *testing.T) {
+// TestProfileGuidesShip keeps the language profiles honest about the
+// per-container PROFILE.md they advertise. PROFILE.md is optional in
+// general (a profile without one simply gets no orientation injected at
+// scan time); these profiles document specifics the agent needs to
+// behave correctly, so missing them is a real regression.
+func TestProfileGuidesShip(t *testing.T) {
 	wd, _ := os.Getwd()
 	repoRoot := filepath.Join(wd, "..", "..")
-	for _, name := range []string{"php", "php-ext"} {
+	for _, name := range []string{"php", "php-ext", "ruby"} {
 		guide := filepath.Join(repoRoot, "docker", "profiles", name, "PROFILE.md")
 		if _, err := os.Stat(guide); err != nil {
 			t.Errorf("expected %s profile PROFILE.md to exist: %v", name, err)


### PR DESCRIPTION
The `ruby` profile builds a runner image but injects no per-container guidance at scan time, unlike `php`/`php-ext` which each ship a `PROFILE.md`. The scanning agent gets no Ruby-specific orientation as a result.

Add `docker/profiles/ruby/PROFILE.md`, modeled on the php guide:

- runtime summary (Ruby 3.4, `gem`, `bundle`, native-extension toolchain)
- install-from-lockfile step (`bundle install`) with an offline fallback note
- reproducer recipe (`ruby -e`, `bundle exec ruby /tmp/poc.rb`)
- out-of-scope note for installed gems

Extend the profile-guide test (renamed `TestProfileGuidesShipForPHP` -> `TestProfileGuidesShip`) to assert `ruby` ships a guide alongside `php`/`php-ext`.