### PR TITLE
node profile: add Node.js ecosystem runner and guide

### DIFF
--- a/docker/profiles/node/Dockerfile
+++ b/docker/profiles/node/Dockerfile
@@ -1,0 +1,80 @@
+# Node.js profile. Extends the scrutineer runner with a pinned Node.js
+# interpreter plus npm, pnpm, and yarn so scans of npm/pnpm/yarn projects
+# can install their locked dependency set and reproduce in-place.
+#
+# Node ships official, sha256-verifiable prebuilt binaries (glibc), so the
+# interpreter is fetched and checksummed the same way the runner installs
+# claude -- not from a moving apt repo. Bump NODE_VERSION and the matching
+# checksums together; both arches are listed because the worker may build
+# this on amd64 or arm64 hosts.
+#
+# At runtime the worker builds this on demand (see internal/worker/profile.go:
+# EnsureImage), tagging the result scrutineer-profile-node:<dockerfile-sha>
+# and passing the configured runner image via --build-arg RUNNER_IMAGE.
+#
+# To build it manually the way the project does, from the repo root:
+#
+#   # 1. Build the base runner image locally (Debian/glibc, ships brief etc.):
+#   docker build -t scrutineer-runner:local -f Dockerfile.runner .
+#
+#   # 2. Build this Node profile on top of that local runner:
+#   docker build -t scrutineer-profile-node \
+#       -f docker/profiles/node/Dockerfile \
+#       --build-arg RUNNER_IMAGE=scrutineer-runner:local \
+#       docker/profiles/node
+#
+#   # 3. Smoke-test it:
+#   docker run --rm --entrypoint sh scrutineer-profile-node \
+#       -c 'node --version && npm --version && pnpm --version && yarn --version'
+
+ARG RUNNER_IMAGE=ghcr.io/alpha-omega-security/scrutineer-runner:latest
+
+FROM ${RUNNER_IMAGE}
+
+# Explicit, sha256-verifiable Node version (current 22.x LTS "Jod"). Bump
+# NODE_VERSION and both checksums together; the content-addressed image
+# tag invalidates the cache on any edit to this file.
+ARG NODE_VERSION=22.23.0
+ARG NODE_SHA256_X64=14d7de44f235534799f8b171a4050d9a6a4bc99c87e053a25d3d54afa580aa20
+ARG NODE_SHA256_ARM64=4018815ac1bed4f18208901bbde524fee881253b591ee7bc952660e69bd057af
+
+# pnpm and yarn pinned to exact versions. Unlike sury's apt repo, the npm
+# registry keeps every published version forever, so an exact pin never
+# 404s. yarn stays on the 1.x (classic) line, which reads the yarn.lock v1
+# format most projects still ship. corepack is intentionally left disabled
+# so these globals -- present offline -- are what `pnpm`/`yarn` resolve to,
+# rather than corepack reaching out to the network mid-scan.
+ARG PNPM_VERSION=11.8.0
+ARG YARN_VERSION=1.22.22
+
+USER root
+
+ENV PATH=/usr/local/node/bin:$PATH
+
+# xz-utils to unpack the .tar.xz; build-essential so node-gyp can compile
+# native addons when a scan reproduces a project that ships them (python3
+# is already in the runner). Toolchain kept in the final image because the
+# in-place reproduce step needs it.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+        xz-utils \
+        build-essential \
+ && rm -rf /var/lib/apt/lists/* \
+ && case "$(dpkg --print-architecture)" in \
+        amd64) arch=x64;   sha="${NODE_SHA256_X64}" ;; \
+        arm64) arch=arm64; sha="${NODE_SHA256_ARM64}" ;; \
+        *) echo "unsupported architecture: $(dpkg --print-architecture)" >&2; exit 1 ;; \
+    esac \
+ && curl -fsSL -o /tmp/node.tar.xz \
+        "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${arch}.tar.xz" \
+ && echo "${sha}  /tmp/node.tar.xz" | sha256sum -c - \
+ && mkdir -p /usr/local/node \
+ && tar -xJf /tmp/node.tar.xz -C /usr/local/node --strip-components=1 \
+ && rm /tmp/node.tar.xz \
+ && npm install -g "pnpm@${PNPM_VERSION}" "yarn@${YARN_VERSION}" \
+ && node --version \
+ && npm --version \
+ && pnpm --version \
+ && yarn --version
+
+USER runner

--- a/docker/profiles/node/PROFILE.md
+++ b/docker/profiles/node/PROFILE.md
@@ -1,0 +1,53 @@
+# Node.js scanning container
+
+The repository under `./src` is a JavaScript or TypeScript project.
+
+## Runtime
+
+- **Node.js 22** — `node`
+- **`npm`** on PATH (bundled with Node).
+- **`pnpm`** and **`yarn`** (classic 1.x) on PATH, for projects whose lockfile is `pnpm-lock.yaml` or `yarn.lock`.
+- C toolchain (`build-essential`) plus `python3`, so packages with native addons build via `node-gyp` when a scan reproduces them in-place.
+
+## Operating procedure
+
+### Code scanning preparations
+
+Install dependencies with the manager that matches the lockfile present, so requires resolve and any native addons build:
+
+```bash
+cd src
+npm ci                          # package-lock.json
+pnpm install --frozen-lockfile  # pnpm-lock.yaml
+yarn install --frozen-lockfile  # yarn.lock
+```
+
+Pick one based on which lockfile exists; do not run more than one. If only `package.json` exists (no lock), call out the
+missing lock in the report and fall back to `npm install`. If install fails with `Could not resolve host` or a similar
+network error the scan is offline — proceed without installed packages and note which checks you had to skip.
+
+`corepack` is disabled, so the `pnpm`/`yarn` above are the image's pinned globals. If a project pins a different exact
+manager version via the `packageManager` field, just use the global one and note the version difference rather than
+trying to fetch the pinned version.
+
+### Creating reproducers
+
+Every finding ships with a reproducer — a small piece of code that, when run in this container, actually triggers the
+issue. Paste the exact command you ran and the verbatim output (error message, return value, observable side effect)
+into the finding. Reasoning-only or "this would" reproducers do not count; if you couldn't run it here, say so
+explicitly instead of inventing one.
+
+- One-liner: `node -e '<code>'`
+- Multi-line: write to `/tmp/poc.js`, run `node /tmp/poc.js`
+- If the reproducer imports the project's own modules, run it from `./src` after installing dependencies so
+  `node_modules` and the package's entry points resolve. Use `node --input-type=module` or a `.mjs` file for ESM
+  packages
+- For TypeScript sources, prefer requiring the published/compiled entry point; if you must run a `.ts` file directly,
+  compile the minimal slice rather than pulling in a full build
+- For framework- or HTTP-routed bugs, isolate the vulnerable function and call it directly with the malicious input
+  rather than booting a server — keeps the reproducer minimal and the evidence trivial to verify
+
+## Out of scope
+
+- `./src/node_modules/` after install — third-party code, not the target of this scan unless a finding specifically
+  pivots through it.

--- a/docker/profiles/node/PROFILE.md
+++ b/docker/profiles/node/PROFILE.md
@@ -13,7 +13,7 @@ The repository under `./src` is a JavaScript or TypeScript project.
 
 ### Code scanning preparations
 
-Install dependencies with the manager that matches the lockfile present, so requires resolve and any native addons build:
+Install dependencies with the manager that matches the lockfile present, so imports resolve and any native addons build:
 
 ```bash
 cd src

--- a/internal/worker/profile.go
+++ b/internal/worker/profile.go
@@ -59,6 +59,7 @@ var builtinProfiles = []Profile{
 	},
 	{Name: "php", Ecosystem: "Composer"},
 	{Name: "ruby", Ecosystem: "Bundler"},
+	{Name: "node", Ecosystem: "npm"},
 }
 
 // ProfileByName returns the registered profile, or the default profile

--- a/internal/worker/profile_test.go
+++ b/internal/worker/profile_test.go
@@ -20,6 +20,7 @@ func TestProfileByName(t *testing.T) {
 		{"php", "php", true, true},
 		{"php-ext", "php-ext", true, true},
 		{"ruby", "ruby", true, true},
+		{"node", "node", true, true},
 		{"unknown", "", false, false},
 	}
 	for _, tt := range tests {
@@ -107,8 +108,23 @@ func TestMatchProfile(t *testing.T) {
 			want: "php",
 		},
 		{
-			name: "unknown manager falls back",
+			name: "npm matches node",
 			json: `{"package_managers":[{"name":"npm"}]}`,
+			want: "node",
+		},
+		{
+			name: "npm case-insensitive",
+			json: `{"package_managers":[{"name":"NPM"}]}`,
+			want: "node",
+		},
+		{
+			name: "composer before node when both present (registry order)",
+			json: `{"package_managers":[{"name":"npm"},{"name":"Composer"}]}`,
+			want: "php",
+		},
+		{
+			name: "truly unknown manager falls back",
+			json: `{"package_managers":[{"name":"Cargo"}]}`,
 			want: "",
 		},
 		{
@@ -303,7 +319,7 @@ func TestRepoShipsProfileDockerfiles(t *testing.T) {
 func TestProfileGuidesShip(t *testing.T) {
 	wd, _ := os.Getwd()
 	repoRoot := filepath.Join(wd, "..", "..")
-	for _, name := range []string{"php", "php-ext", "ruby"} {
+	for _, name := range []string{"php", "php-ext", "ruby", "node"} {
 		guide := filepath.Join(repoRoot, "docker", "profiles", name, "PROFILE.md")
 		if _, err := os.Stat(guide); err != nil {
 			t.Errorf("expected %s profile PROFILE.md to exist: %v", name, err)


### PR DESCRIPTION
Adds a `node` profile so scans of npm/pnpm/yarn projects can install their locked dependency set and reproduce findings in-place, matching `php`/`ruby`.

`docker/profiles/node/Dockerfile` extends the runner with:

- a sha256-verified Node 22 LTS tarball, fetched and checksummed the same way the runner installs `claude` (both arches listed), rather than from a moving apt repo
- `pnpm` and `yarn` (classic 1.x) pinned to exact versions; the npm registry keeps exact versions forever so the pin never 404s
- `build-essential` so `node-gyp` can compile native addons (`python3` is already in the runner)
- `corepack` left disabled so the pinned globals are what `pnpm`/`yarn` resolve to, instead of corepack reaching the network mid-scan

`docker/profiles/node/PROFILE.md` gives the scanning agent the per-manager install command (`npm ci` / `pnpm install --frozen-lockfile` / `yarn install --frozen-lockfile`), the reproducer recipe (`node -e`, `/tmp/poc.js`, ESM notes), and an out-of-scope note for `node_modules`.

Registers `node` (ecosystem `npm`) in `builtinProfiles` and covers detection, naming, and the shipped guide in the worker tests. Built locally on top of the runner image and smoke-tested: `node`, `npm`, `pnpm`, `yarn` and the node-gyp toolchain (`python3`/`make`/`cc`/`g++`) all resolve as the `runner` user.