### PR TITLE
python profile: add Python ecosystem runner and guide

### DIFF
--- a/docker/profiles/python/Dockerfile
+++ b/docker/profiles/python/Dockerfile
@@ -1,0 +1,92 @@
+# Python profile. Extends the scrutineer runner with a pinned CPython,
+# uv, and pip so scans of pip/Poetry/Pipenv/PDM/uv projects can install
+# their dependency set and reproduce findings in-place.
+#
+# CPython is installed by uv from a sha-verified standalone build at an
+# explicit pinned version, so the interpreter is current and identical
+# regardless of what the base image's distro packages (the runner has
+# drifted between Debian releases, shipping 3.11 on bookworm and 3.13 on
+# trixie -- pinning here keeps the scan interpreter stable across that).
+#
+# uv itself is a pinned, sha256-verified release tarball, fetched the same
+# way the runner installs claude rather than from a moving installer.
+#
+# At runtime the worker builds this on demand (see internal/worker/profile.go:
+# EnsureImage), tagging the result scrutineer-profile-python:<dockerfile-sha>
+# and passing the configured runner image via --build-arg RUNNER_IMAGE.
+#
+# To build it manually the way the project does, from the repo root:
+#
+#   # 1. Build the base runner image locally (Debian/glibc, ships brief etc.):
+#   docker build -t scrutineer-runner:local -f Dockerfile.runner .
+#
+#   # 2. Build this Python profile on top of that local runner:
+#   docker build -t scrutineer-profile-python \
+#       -f docker/profiles/python/Dockerfile \
+#       --build-arg RUNNER_IMAGE=scrutineer-runner:local \
+#       docker/profiles/python
+#
+#   # 3. Smoke-test it:
+#   docker run --rm --entrypoint sh scrutineer-profile-python \
+#       -c 'python --version && uv --version && uv pip --version'
+
+ARG RUNNER_IMAGE=ghcr.io/alpha-omega-security/scrutineer-runner:latest
+
+FROM ${RUNNER_IMAGE}
+
+# Explicit pinned versions. uv resolves PYTHON_VERSION to a sha-verified
+# python-build-standalone release; bump either and the content-addressed
+# image tag invalidates the cache.
+ARG UV_VERSION=0.11.21
+ARG UV_SHA256_X64=8c88519b0ef0af9801fcdee419bbb12116bd9e6b18e162ae093c932d8b264050
+ARG UV_SHA256_ARM64=88e800834007cc5efd4675f166eb2a51e7e3ad19876d85fa8805a6fb5c922397
+ARG PYTHON_VERSION=3.13.14
+
+USER root
+
+# uv-managed CPython lives here; the install below symlinks its python /
+# python3 onto PATH so reproducers and venvs use the pinned interpreter by
+# default. UV_TOOL_BIN_DIR puts any `uv tool install` shims on PATH too.
+ENV UV_PYTHON_INSTALL_DIR=/opt/uv/python \
+    UV_TOOL_BIN_DIR=/usr/local/bin
+
+# build-essential plus the headers C-extension wheels most commonly link
+# against (ffi, openssl, zlib). The standalone CPython brings its own
+# Python headers; these cover the third-party libs wheels build against.
+# Toolchain stays in the final image because the in-place reproduce step
+# compiles wheels.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+        build-essential \
+        pkg-config \
+        libffi-dev \
+        libssl-dev \
+        zlib1g-dev \
+ && rm -rf /var/lib/apt/lists/* \
+ && case "$(dpkg --print-architecture)" in \
+        amd64) arch=x86_64;  sha="${UV_SHA256_X64}" ;; \
+        arm64) arch=aarch64; sha="${UV_SHA256_ARM64}" ;; \
+        *) echo "unsupported architecture: $(dpkg --print-architecture)" >&2; exit 1 ;; \
+    esac \
+ && curl -fsSL -o /tmp/uv.tar.gz \
+        "https://github.com/astral-sh/uv/releases/download/${UV_VERSION}/uv-${arch}-unknown-linux-gnu.tar.gz" \
+ && echo "${sha}  /tmp/uv.tar.gz" | sha256sum -c - \
+ && tar -xzf /tmp/uv.tar.gz -C /tmp \
+ && install -m 0755 "/tmp/uv-${arch}-unknown-linux-gnu/uv" /usr/local/bin/uv \
+ && install -m 0755 "/tmp/uv-${arch}-unknown-linux-gnu/uvx" /usr/local/bin/uvx \
+ && rm -rf /tmp/uv.tar.gz "/tmp/uv-${arch}-unknown-linux-gnu" \
+ && uv python install "${PYTHON_VERSION}" \
+ && ln -s "$(uv python find "${PYTHON_VERSION}")" /usr/local/bin/python3 \
+ && ln -s /usr/local/bin/python3 /usr/local/bin/python \
+ && python --version \
+ && python3 --version \
+ && uv --version
+
+# The pinned interpreter and its install dir must stay readable, and pip
+# must be able to write a per-user cache, when the container runs as the
+# host's uid (docker --user $(id -u):$(id -g)) rather than the image user.
+# Container is ephemeral and --rm'd after the scan, so the blast radius of
+# a write here is zero.
+RUN chmod -R a+rX /opt/uv
+
+USER runner

--- a/docker/profiles/python/Dockerfile
+++ b/docker/profiles/python/Dockerfile
@@ -1,6 +1,8 @@
-# Python profile. Extends the scrutineer runner with a pinned CPython,
-# uv, and pip so scans of pip/Poetry/Pipenv/PDM/uv projects can install
-# their dependency set and reproduce findings in-place.
+# Python profile. Extends the scrutineer runner with a pinned CPython and
+# uv so scans of pip/Poetry/Pipenv/PDM/uv projects can install their
+# dependency set and reproduce findings in-place. There is no global pip;
+# the interpreter is externally managed and uv handles installs (uv pip,
+# uv venv, uv sync).
 #
 # CPython is installed by uv from a sha-verified standalone build at an
 # explicit pinned version, so the interpreter is current and identical
@@ -76,17 +78,16 @@ RUN apt-get update \
  && install -m 0755 "/tmp/uv-${arch}-unknown-linux-gnu/uvx" /usr/local/bin/uvx \
  && rm -rf /tmp/uv.tar.gz "/tmp/uv-${arch}-unknown-linux-gnu" \
  && uv python install "${PYTHON_VERSION}" \
- && ln -s "$(uv python find "${PYTHON_VERSION}")" /usr/local/bin/python3 \
- && ln -s /usr/local/bin/python3 /usr/local/bin/python \
+ && ln -sf "$(uv python find "${PYTHON_VERSION}")" /usr/local/bin/python3 \
+ && ln -sf /usr/local/bin/python3 /usr/local/bin/python \
  && python --version \
  && python3 --version \
  && uv --version
 
-# The pinned interpreter and its install dir must stay readable, and pip
-# must be able to write a per-user cache, when the container runs as the
-# host's uid (docker --user $(id -u):$(id -g)) rather than the image user.
-# Container is ephemeral and --rm'd after the scan, so the blast radius of
-# a write here is zero.
+# The pinned interpreter and its install dir must stay readable when the
+# container runs as the host's uid (docker --user $(id -u):$(id -g))
+# rather than the image user. uv writes its own caches under HOME at scan
+# time, so only read/execute access is needed here.
 RUN chmod -R a+rX /opt/uv
 
 USER runner

--- a/docker/profiles/python/PROFILE.md
+++ b/docker/profiles/python/PROFILE.md
@@ -1,0 +1,51 @@
+# Python scanning container
+
+The repository under `./src` is a Python project.
+
+## Runtime
+
+- **CPython 3.13** — `python` / `python3` (a pinned uv-managed interpreter).
+- **`uv`** on PATH for environment and dependency management. Use it for installs (`uv venv`, `uv pip`, `uv sync`, `uv run`).
+- C toolchain (`build-essential`, `pkg-config`) plus the `ffi`/`openssl`/`zlib` dev headers, so C-extension wheels compile when a scan reproduces a project that ships them.
+
+There is no global `pip`; the interpreter is externally managed. Install into a venv with `uv pip`, or use `uv run`.
+
+## Operating procedure
+
+### Code scanning preparations
+
+Create an environment and install the dependency set with the manager that matches the project, so imports resolve and
+any C extensions build:
+
+```bash
+cd src
+uv venv && . .venv/bin/activate
+
+uv pip install -r requirements.txt   # requirements*.txt
+uv sync                              # uv.lock, or a PEP 621 pyproject.toml
+```
+
+For Poetry, Pipenv, or PDM projects, `uv pip install -r <exported-requirements>` works once you have a requirements
+file, or install the lock's pinned set directly if the tool is available. If only `pyproject.toml` exists with no lock,
+call out the missing lock in the report and install the declared dependencies anyway. If install fails with `Could not
+resolve host` or a similar network error the scan is offline — proceed without installed packages and note which checks
+you had to skip.
+
+### Creating reproducers
+
+Every finding ships with a reproducer — a small piece of code that, when run in this container, actually triggers the
+issue. Paste the exact command you ran and the verbatim output (error message, return value, observable side effect)
+into the finding. Reasoning-only or "this would" reproducers do not count; if you couldn't run it here, say so
+explicitly instead of inventing one.
+
+- One-liner: `python -c '<code>'`
+- Multi-line: write to `/tmp/poc.py`, run `python /tmp/poc.py`
+- If the reproducer imports the project's own modules, run it from `./src` inside the activated venv so the package and
+  its dependencies resolve. `uv run python /tmp/poc.py` also works and provisions the environment on demand
+- For framework- or HTTP-routed bugs, isolate the vulnerable function and call it directly with the malicious input
+  rather than booting a server — keeps the reproducer minimal and the evidence trivial to verify
+
+## Out of scope
+
+- Installed third-party packages (under the venv's `site-packages`) — not the target of this scan unless a finding
+  specifically pivots through one.

--- a/internal/worker/profile.go
+++ b/internal/worker/profile.go
@@ -35,9 +35,9 @@ type Profile struct {
 	// "use the default runner image, no per-profile build".
 	Name string
 	// Ecosystem is a `brief` package_managers[].name, matched
-	// case-insensitively. Empty falls back to Markers — useful for
-	// ecosystems brief cannot see (e.g. a PECL C extension repo without
-	// composer.json).
+	// case-insensitively. When Ecosystem and Ecosystems are both empty the
+	// profile matches on Markers alone — useful for ecosystems brief
+	// cannot see (e.g. a PECL C extension repo without composer.json).
 	Ecosystem string
 	// Ecosystems lists additional `brief` package_managers[].name values
 	// the profile also matches, for ecosystems one runtime serves under

--- a/internal/worker/profile.go
+++ b/internal/worker/profile.go
@@ -39,12 +39,28 @@ type Profile struct {
 	// ecosystems brief cannot see (e.g. a PECL C extension repo without
 	// composer.json).
 	Ecosystem string
-	Markers   []ProfileMarker
+	// Ecosystems lists additional `brief` package_managers[].name values
+	// the profile also matches, for ecosystems one runtime serves under
+	// several names (e.g. Python's pip / Poetry / Pipenv / uv / PDM). The
+	// profile matches if any of Ecosystem or Ecosystems matches.
+	Ecosystems []string
+	Markers    []ProfileMarker
 }
 
 // IsDefault reports whether p falls back to the configured runner image
 // instead of a profile-specific built one.
 func (p Profile) IsDefault() bool { return p.Name == "" }
+
+// allEcosystems returns every brief package-manager name the profile
+// matches: the singular Ecosystem (if set) plus any in Ecosystems.
+func (p Profile) allEcosystems() []string {
+	out := make([]string, 0, len(p.Ecosystems)+1)
+	if p.Ecosystem != "" {
+		out = append(out, p.Ecosystem)
+	}
+	out = append(out, p.Ecosystems...)
+	return out
+}
 
 // builtinProfiles is the v1 registry. Order matters: first match wins,
 // so more specific profiles (php-ext) come before their general
@@ -60,6 +76,7 @@ var builtinProfiles = []Profile{
 	{Name: "php", Ecosystem: "Composer"},
 	{Name: "ruby", Ecosystem: "Bundler"},
 	{Name: "node", Ecosystem: "npm"},
+	{Name: "python", Ecosystems: []string{"pip", "Pipenv", "Poetry", "uv", "PDM"}},
 }
 
 // ProfileByName returns the registered profile, or the default profile
@@ -112,7 +129,7 @@ func matchProfile(briefOut []byte, srcDir string) Profile {
 		pms = append(pms, pm.Name)
 	}
 	for _, p := range builtinProfiles {
-		if !ecosystemMatch(p.Ecosystem, pms) {
+		if !ecosystemMatch(p.allEcosystems(), pms) {
 			continue
 		}
 		if !markersMatch(p.Markers, srcDir) {
@@ -123,13 +140,15 @@ func matchProfile(briefOut []byte, srcDir string) Profile {
 	return Profile{}
 }
 
-func ecosystemMatch(ecosystem string, pms []string) bool {
-	if ecosystem == "" {
+func ecosystemMatch(ecosystems, pms []string) bool {
+	if len(ecosystems) == 0 {
 		return true
 	}
-	for _, pm := range pms {
-		if strings.EqualFold(pm, ecosystem) {
-			return true
+	for _, e := range ecosystems {
+		for _, pm := range pms {
+			if strings.EqualFold(pm, e) {
+				return true
+			}
 		}
 	}
 	return false

--- a/internal/worker/profile_test.go
+++ b/internal/worker/profile_test.go
@@ -21,6 +21,7 @@ func TestProfileByName(t *testing.T) {
 		{"php-ext", "php-ext", true, true},
 		{"ruby", "ruby", true, true},
 		{"node", "node", true, true},
+		{"python", "python", true, true},
 		{"unknown", "", false, false},
 	}
 	for _, tt := range tests {
@@ -121,6 +122,26 @@ func TestMatchProfile(t *testing.T) {
 			name: "composer before node when both present (registry order)",
 			json: `{"package_managers":[{"name":"npm"},{"name":"Composer"}]}`,
 			want: "php",
+		},
+		{
+			name: "pip matches python",
+			json: `{"package_managers":[{"name":"pip"}]}`,
+			want: "python",
+		},
+		{
+			name: "poetry matches python (secondary ecosystem)",
+			json: `{"package_managers":[{"name":"Poetry"}]}`,
+			want: "python",
+		},
+		{
+			name: "uv matches python case-insensitive",
+			json: `{"package_managers":[{"name":"UV"}]}`,
+			want: "python",
+		},
+		{
+			name: "pdm matches python",
+			json: `{"package_managers":[{"name":"PDM"}]}`,
+			want: "python",
 		},
 		{
 			name: "truly unknown manager falls back",
@@ -273,8 +294,10 @@ func TestEnsureImage_missingDockerfile(t *testing.T) {
 // Ecosystem or at least one Marker, names must be unique, and ecosystems
 // must be unique case-insensitively (a duplicate would silently make
 // auto-detection resolve the wrong profile, with no other test failing).
-// Marker-only profiles legitimately have an empty Ecosystem and are
-// excluded from the ecosystem-uniqueness check.
+// Marker-only profiles legitimately have no Ecosystem and are excluded
+// from the ecosystem-uniqueness check. A profile that matches several
+// ecosystems (e.g. python) lists them via Ecosystems; every one is
+// checked for uniqueness against every other profile's.
 func TestBuiltinProfiles_registrySanity(t *testing.T) {
 	names := map[string]bool{}
 	ecosystems := map[string]bool{}
@@ -282,21 +305,21 @@ func TestBuiltinProfiles_registrySanity(t *testing.T) {
 		if p.Name == "" {
 			t.Error("profile with empty Name")
 		}
-		if p.Ecosystem == "" && len(p.Markers) == 0 {
+		ecos := p.allEcosystems()
+		if len(ecos) == 0 && len(p.Markers) == 0 {
 			t.Errorf("profile %q has neither Ecosystem nor Markers", p.Name)
 		}
 		if names[p.Name] {
 			t.Errorf("duplicate profile Name %q", p.Name)
 		}
 		names[p.Name] = true
-		if p.Ecosystem == "" {
-			continue
+		for _, e := range ecos {
+			eco := strings.ToLower(e)
+			if ecosystems[eco] {
+				t.Errorf("duplicate profile Ecosystem %q (case-insensitive)", e)
+			}
+			ecosystems[eco] = true
 		}
-		eco := strings.ToLower(p.Ecosystem)
-		if ecosystems[eco] {
-			t.Errorf("duplicate profile Ecosystem %q (case-insensitive)", p.Ecosystem)
-		}
-		ecosystems[eco] = true
 	}
 }
 
@@ -319,7 +342,7 @@ func TestRepoShipsProfileDockerfiles(t *testing.T) {
 func TestProfileGuidesShip(t *testing.T) {
 	wd, _ := os.Getwd()
 	repoRoot := filepath.Join(wd, "..", "..")
-	for _, name := range []string{"php", "php-ext", "ruby", "node"} {
+	for _, name := range []string{"php", "php-ext", "ruby", "node", "python"} {
 		guide := filepath.Join(repoRoot, "docker", "profiles", name, "PROFILE.md")
 		if _, err := os.Stat(guide); err != nil {
 			t.Errorf("expected %s profile PROFILE.md to exist: %v", name, err)


### PR DESCRIPTION
Adds a `python` profile so scans of pip/Poetry/Pipenv/PDM/uv projects can install their dependency set and reproduce findings in-place, matching `php`/`ruby`/`node`.

`docker/profiles/python/Dockerfile`:

- installs `uv` from a sha256-verified release tarball (fetched the same way the runner installs `claude`, both arches listed)
- uses uv to install a pinned CPython 3.13 from a sha-verified standalone build, symlinked onto PATH as `python`/`python3`. Pinning through uv keeps the scan interpreter stable and current regardless of the base distro, which has shipped different Python versions across Debian releases (the runner image currently drifts between 3.11 on bookworm and 3.13 on trixie)
- adds `build-essential`, `pkg-config`, and `ffi`/`openssl`/`zlib` dev headers so C-extension wheels compile during in-place reproduction

There is no global `pip` (uv's interpreter is externally managed); `PROFILE.md` steers the agent to `uv venv` / `uv pip` / `uv run`, gives the reproducer recipe (`python -c`, `/tmp/poc.py`), and marks installed packages out of scope.

`brief` reports Python projects under several package-manager names (`pip`, `Poetry`, `Pipenv`, `uv`, `PDM`), so `Profile` gains an `Ecosystems` list and the profile matches any of them. Registers `python` and covers detection, naming, multi-ecosystem registry sanity, and the shipped guide in the worker tests.

Built locally on top of the runner image and smoke-tested as the `runner` uid with `HOME=/tmp`: `python` 3.13.14 and `uv` resolve, `uv venv` + `uv pip install` works, and a C extension (`cffi`, `--no-binary`) compiles against the installed headers and imports.