### PR TITLE
python-ext profile: add ASan/UBSan CPython for native extensions

### DIFF
--- a/docker/profiles/python-ext/Dockerfile
+++ b/docker/profiles/python-ext/Dockerfile
@@ -1,0 +1,103 @@
+# Python-extension profile.
+#
+# Ships CPython built from source with --with-pydebug + ASan + UBSan, for
+# scanning Python packages that include compiled C/C++ extension modules.
+# C extensions installed against this interpreter (CFLAGS/LDFLAGS wire the
+# sanitizers in) are instrumented, so a reproducer that drives the
+# extension surfaces memory-safety and UB bugs the static scan can only
+# guess at. This mirrors the php-ext profile.
+#
+# Auto-selected for repos whose setup.py declares a C Extension (see
+# internal/worker/profile.go); also selectable by name via ?profile=. The
+# debug+sanitizer interpreter is much slower than the plain python
+# profile, so it is scoped to repos that actually ship native code.
+#
+# At runtime the worker builds this on demand (see internal/worker/profile.go:
+# EnsureImage), tagging the result scrutineer-profile-python-ext:<dockerfile-sha>
+# and passing the configured runner image via --build-arg RUNNER_IMAGE. The
+# build installs its toolchain with apt, so RUNNER_IMAGE must resolve to the
+# Debian runner built from ./Dockerfile.runner.
+#
+# To build it manually the way the project does, from the repo root:
+#
+#   # 1. Build the base runner image locally (Debian/glibc, ships brief etc.):
+#   docker build -t scrutineer-runner:local -f Dockerfile.runner .
+#
+#   # 2. Build this Python-extension profile on top of that local runner
+#   #    (compiles CPython from source with ASan/UBSan; takes several minutes):
+#   docker build -t scrutineer-profile-python-ext \
+#       -f docker/profiles/python-ext/Dockerfile \
+#       --build-arg RUNNER_IMAGE=scrutineer-runner:local \
+#       docker/profiles/python-ext
+#
+#   # 3. Smoke-test it (debug build, sanitizers wired in):
+#   docker run --rm --entrypoint sh scrutineer-profile-python-ext \
+#       -c 'python --version && python -c "import sys; print(sys._is_gil_enabled if hasattr(sys,\"_is_gil_enabled\") else 0)"'
+
+ARG RUNNER_IMAGE=ghcr.io/alpha-omega-security/scrutineer-runner:latest
+ARG PYTHON_GIT_URL=https://github.com/python/cpython.git
+ARG PYTHON_GIT_REF=v3.13.14
+
+FROM ${RUNNER_IMAGE}
+ARG PYTHON_GIT_URL
+ARG PYTHON_GIT_REF
+
+USER root
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    PATH=/usr/local/python-asan/bin:$PATH \
+    PYTHONMALLOC=malloc \
+    ASAN_OPTIONS="symbolize=1:detect_leaks=0:allocator_may_return_null=1:halt_on_error=0:print_summary=1" \
+    UBSAN_OPTIONS="print_stacktrace=1:print_summary=1"
+
+# gcc (build-essential) builds CPython: clang now defaults to
+# -Werror=implicit-function-declaration, which breaks several of
+# configure's feature probes (getaddrinfo among them). gdb for triage,
+# plus the headers the stdlib and most C extensions link against (ssl,
+# ffi, zlib, bz2, lzma, readline, sqlite, ncurses, gdbm, uuid).
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential \
+        gdb \
+        git ca-certificates \
+        pkg-config \
+        libssl-dev libffi-dev zlib1g-dev \
+        libbz2-dev liblzma-dev libreadline-dev \
+        libsqlite3-dev libncurses-dev libgdbm-dev uuid-dev \
+ && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /opt
+RUN git clone --depth 1 --branch "${PYTHON_GIT_REF}" "${PYTHON_GIT_URL}" cpython
+WORKDIR /opt/cpython
+# ac_cv_buggy_getaddrinfo=no: under ASan, configure's getaddrinfo runtime
+# probe can still misfire; this is the documented override for
+# sanitizer/cross builds.
+RUN ac_cv_buggy_getaddrinfo=no ./configure \
+        --prefix=/usr/local/python-asan \
+        --with-pydebug \
+        --with-address-sanitizer \
+        --with-undefined-behavior-sanitizer \
+        --without-pymalloc \
+ && make -j"$(nproc)" \
+ && make install \
+ && ln -s /usr/local/python-asan/bin/python3 /usr/local/bin/python \
+ && ln -s /usr/local/python-asan/bin/python3 /usr/local/bin/python3
+
+# Extensions built by pip against this interpreter must carry the same
+# sanitizers, built with the same compiler (gcc) so they share CPython's
+# gcc ASan runtime -- a clang-built .so dlopened into gcc-asan CPython
+# aborts with a runtime mismatch. -fno-sanitize-recover makes UB in an
+# extension abort rather than silently continue. Matches the php-ext
+# approach.
+ENV CFLAGS="-fsanitize=address -fsanitize=undefined -fno-sanitize-recover=undefined -fno-omit-frame-pointer -g -O1" \
+    CXXFLAGS="-fsanitize=address -fsanitize=undefined -fno-sanitize-recover=undefined -fno-omit-frame-pointer -g -O1" \
+    LDFLAGS="-fsanitize=address -fsanitize=undefined"
+
+# ASan/UBSan-built interpreter; the install dir must stay writable for the
+# host uid the scan runs as so pip can build extensions in place. Container
+# is ephemeral and --rm'd after the scan, so the blast radius is zero.
+RUN chmod -R a+rwX /usr/local/python-asan \
+ && python --version 2>&1 | grep -q "3.13" \
+ && python -c "import _testcapi; print('debug build ok')" \
+ && python -X dev -c "print('asan python runs')"
+
+USER runner

--- a/docker/profiles/python-ext/Dockerfile
+++ b/docker/profiles/python-ext/Dockerfile
@@ -8,7 +8,8 @@
 # guess at. This mirrors the php-ext profile.
 #
 # Auto-selected for repos whose setup.py declares a C Extension (see
-# internal/worker/profile.go); also selectable by name via ?profile=. The
+# internal/worker/profile.go); also selectable by name via
+# ?profile=python-ext. The
 # debug+sanitizer interpreter is much slower than the plain python
 # profile, so it is scoped to repos that actually ship native code.
 #

--- a/docker/profiles/python-ext/PROFILE.md
+++ b/docker/profiles/python-ext/PROFILE.md
@@ -1,0 +1,98 @@
+# Python-extension scanning container
+
+The repository under `./src` is a Python package with a compiled C/C++ extension. The job is to find **security
+vulnerabilities** in the native code.
+
+## Why this container
+
+CPython here is built **--with-pydebug + AddressSanitizer + UndefinedBehaviorSanitizer**. ASan/UBSan are detection
+tooling: they turn silent memory corruption into loud, pinpointable hits so you can find bugs in C code instead of
+guessing from static reading. They are not the deliverable.
+
+The deliverable is a security finding: what the bug is, what an attacker controls from the Python side, what the impact
+is (info disclosure, memory corruption to RCE, DoS, type confusion bypassing a check), and a reproducer that shows it.
+A sanitizer hit is a starting point, not a report.
+
+## Layout
+
+- `./src` — package source, including the C/C++ extension (start here).
+- `/usr/local/python-asan` — debug+ASan+UBSan CPython. `python`/`python3` on PATH; the build reports a debug build and
+  loads `_testcapi`.
+- `/opt/cpython` — CPython source tree. Cross-reference C-API internals (`Include/*.h`, `Objects/`) when triaging.
+- `gdb`, `gh`, `claude` — on PATH.
+
+## Building the extension
+
+Extensions are compiled with **gcc** (the default `cc`, matching how CPython itself was built) and the pre-exported
+sanitizer `CFLAGS`/`CXXFLAGS`/`LDFLAGS`, so anything pip builds against this interpreter is instrumented and shares the
+interpreter's ASan runtime. A clang-built `.so` dlopened into this gcc-ASan CPython aborts with a runtime mismatch, so
+build standalone fuzz harnesses with clang if you want libFuzzer, but build loadable extensions with gcc. Build in
+place:
+
+```bash
+cd src
+python -m pip install -e . -v        # or: python setup.py build_ext --inplace
+```
+
+`pip` is available here (the interpreter is one we built, not an externally-managed install). If a build needs a
+dependency, install it the same way; it gets instrumented too. If the build fails with `Could not resolve host` the
+scan is offline — note which steps you had to skip.
+
+## Sanitizer config (pre-exported)
+
+```
+PYTHONMALLOC=malloc
+  Routes Python allocations through libc malloc so ASan sees every allocation, not just the arenas pymalloc
+  requests from libc. The interpreter is built --without-pymalloc to match.
+
+ASAN_OPTIONS=
+  symbolize=1                  readable stack traces
+  detect_leaks=0               CPython has known interpreter-shutdown leaks; flip to 1 only when chasing a suspect
+  allocator_may_return_null=1  a huge allocation returns NULL instead of aborting, so you reach the code under test
+  halt_on_error=0              keep going after the first report while exploring
+  print_summary=1              one-line summary at the end
+
+UBSAN_OPTIONS=
+  print_stacktrace=1
+  print_summary=1
+```
+
+Extensions are built with `-fno-sanitize-recover=undefined`, so a UB hit in the extension aborts rather than silently
+continuing — the abort is the evidence.
+
+## Investigating a sanitizer hit
+
+A hit means a memory-safety bug in C code. Work the bug, don't just file the trace.
+
+1. **What is the primitive?** Read the ASan/UBSan output — heap-buffer-overflow (read or write?), use-after-free,
+   double-free, integer overflow into an allocation, type confusion. Each has a different exploitability ceiling.
+2. **What does an attacker control?** Walk back from the crash to the Python-level entry point — the method or function
+   the extension exposes, its argument parsing (`PyArg_ParseTuple`, the buffer protocol). Which argument's length,
+   contents, or type reaches the bad code, and could a caller realistically pass it?
+3. **What is the impact?** OOB read to info disclosure; OOB write / UAF / double-free to memory corruption (often
+   RCE-able in native code); integer overflow into an allocation to an undersized buffer then overflow; missing type
+   or bounds check to a pivot. UBSan-only hits may be benign — chase the consequence, not the label.
+4. **Reduce to the smallest reproducer that still triggers it.** Minimal Python, only what's needed. The minimal form
+   is the evidence.
+5. Cross-reference `/opt/cpython` for C-API contracts (reference counting, buffer protocol, `PyObject` layout) when the
+   surrounding C relies on semantics that aren't local.
+
+## Creating reproducers
+
+A reproducer demonstrates the security bug, not just that something crashed. It must be something you actually ran in
+this container. If you couldn't run it here, say so explicitly — never invent one.
+
+- Small case: a script run with `python /tmp/poc.py` after building the extension in place.
+- The reproducer should show the **attacker-controlled input** reaching the bug — what call, what argument, what value.
+  A bug that only triggers under values nobody could supply is a weak finding; find the real attack surface or
+  downgrade the report.
+- Quote the sanitizer output as **evidence** (the `SUMMARY:` line plus the relevant top of the stack), then describe
+  the bug in one line — e.g. "1-byte heap-buffer-overflow write in `parse_header`, byte sourced from the
+  attacker-supplied `data` argument".
+- "Potential RCE" with no demonstrated primitive is a hypothesis — say so honestly rather than overclaiming.
+
+## Rules
+
+- Back every claim with a command you ran in the container. Prefer running things over static reasoning.
+- Build the extension before analyzing.
+- Install missing build deps via `pip` or `apt-get` without asking.

--- a/docker/profiles/python/Dockerfile
+++ b/docker/profiles/python/Dockerfile
@@ -1,0 +1,92 @@
+# Python profile. Extends the scrutineer runner with a pinned CPython,
+# uv, and pip so scans of pip/Poetry/Pipenv/PDM/uv projects can install
+# their dependency set and reproduce findings in-place.
+#
+# CPython is installed by uv from a sha-verified standalone build at an
+# explicit pinned version, so the interpreter is current and identical
+# regardless of what the base image's distro packages (the runner has
+# drifted between Debian releases, shipping 3.11 on bookworm and 3.13 on
+# trixie -- pinning here keeps the scan interpreter stable across that).
+#
+# uv itself is a pinned, sha256-verified release tarball, fetched the same
+# way the runner installs claude rather than from a moving installer.
+#
+# At runtime the worker builds this on demand (see internal/worker/profile.go:
+# EnsureImage), tagging the result scrutineer-profile-python:<dockerfile-sha>
+# and passing the configured runner image via --build-arg RUNNER_IMAGE.
+#
+# To build it manually the way the project does, from the repo root:
+#
+#   # 1. Build the base runner image locally (Debian/glibc, ships brief etc.):
+#   docker build -t scrutineer-runner:local -f Dockerfile.runner .
+#
+#   # 2. Build this Python profile on top of that local runner:
+#   docker build -t scrutineer-profile-python \
+#       -f docker/profiles/python/Dockerfile \
+#       --build-arg RUNNER_IMAGE=scrutineer-runner:local \
+#       docker/profiles/python
+#
+#   # 3. Smoke-test it:
+#   docker run --rm --entrypoint sh scrutineer-profile-python \
+#       -c 'python --version && uv --version && uv pip --version'
+
+ARG RUNNER_IMAGE=ghcr.io/alpha-omega-security/scrutineer-runner:latest
+
+FROM ${RUNNER_IMAGE}
+
+# Explicit pinned versions. uv resolves PYTHON_VERSION to a sha-verified
+# python-build-standalone release; bump either and the content-addressed
+# image tag invalidates the cache.
+ARG UV_VERSION=0.11.21
+ARG UV_SHA256_X64=8c88519b0ef0af9801fcdee419bbb12116bd9e6b18e162ae093c932d8b264050
+ARG UV_SHA256_ARM64=88e800834007cc5efd4675f166eb2a51e7e3ad19876d85fa8805a6fb5c922397
+ARG PYTHON_VERSION=3.13.14
+
+USER root
+
+# uv-managed CPython lives here; the install below symlinks its python /
+# python3 onto PATH so reproducers and venvs use the pinned interpreter by
+# default. UV_TOOL_BIN_DIR puts any `uv tool install` shims on PATH too.
+ENV UV_PYTHON_INSTALL_DIR=/opt/uv/python \
+    UV_TOOL_BIN_DIR=/usr/local/bin
+
+# build-essential plus the headers C-extension wheels most commonly link
+# against (ffi, openssl, zlib). The standalone CPython brings its own
+# Python headers; these cover the third-party libs wheels build against.
+# Toolchain stays in the final image because the in-place reproduce step
+# compiles wheels.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+        build-essential \
+        pkg-config \
+        libffi-dev \
+        libssl-dev \
+        zlib1g-dev \
+ && rm -rf /var/lib/apt/lists/* \
+ && case "$(dpkg --print-architecture)" in \
+        amd64) arch=x86_64;  sha="${UV_SHA256_X64}" ;; \
+        arm64) arch=aarch64; sha="${UV_SHA256_ARM64}" ;; \
+        *) echo "unsupported architecture: $(dpkg --print-architecture)" >&2; exit 1 ;; \
+    esac \
+ && curl -fsSL -o /tmp/uv.tar.gz \
+        "https://github.com/astral-sh/uv/releases/download/${UV_VERSION}/uv-${arch}-unknown-linux-gnu.tar.gz" \
+ && echo "${sha}  /tmp/uv.tar.gz" | sha256sum -c - \
+ && tar -xzf /tmp/uv.tar.gz -C /tmp \
+ && install -m 0755 "/tmp/uv-${arch}-unknown-linux-gnu/uv" /usr/local/bin/uv \
+ && install -m 0755 "/tmp/uv-${arch}-unknown-linux-gnu/uvx" /usr/local/bin/uvx \
+ && rm -rf /tmp/uv.tar.gz "/tmp/uv-${arch}-unknown-linux-gnu" \
+ && uv python install "${PYTHON_VERSION}" \
+ && ln -s "$(uv python find "${PYTHON_VERSION}")" /usr/local/bin/python3 \
+ && ln -s /usr/local/bin/python3 /usr/local/bin/python \
+ && python --version \
+ && python3 --version \
+ && uv --version
+
+# The pinned interpreter and its install dir must stay readable, and pip
+# must be able to write a per-user cache, when the container runs as the
+# host's uid (docker --user $(id -u):$(id -g)) rather than the image user.
+# Container is ephemeral and --rm'd after the scan, so the blast radius of
+# a write here is zero.
+RUN chmod -R a+rX /opt/uv
+
+USER runner

--- a/docker/profiles/python/Dockerfile
+++ b/docker/profiles/python/Dockerfile
@@ -1,6 +1,8 @@
-# Python profile. Extends the scrutineer runner with a pinned CPython,
-# uv, and pip so scans of pip/Poetry/Pipenv/PDM/uv projects can install
-# their dependency set and reproduce findings in-place.
+# Python profile. Extends the scrutineer runner with a pinned CPython and
+# uv so scans of pip/Poetry/Pipenv/PDM/uv projects can install their
+# dependency set and reproduce findings in-place. There is no global pip;
+# the interpreter is externally managed and uv handles installs (uv pip,
+# uv venv, uv sync).
 #
 # CPython is installed by uv from a sha-verified standalone build at an
 # explicit pinned version, so the interpreter is current and identical
@@ -76,17 +78,16 @@ RUN apt-get update \
  && install -m 0755 "/tmp/uv-${arch}-unknown-linux-gnu/uvx" /usr/local/bin/uvx \
  && rm -rf /tmp/uv.tar.gz "/tmp/uv-${arch}-unknown-linux-gnu" \
  && uv python install "${PYTHON_VERSION}" \
- && ln -s "$(uv python find "${PYTHON_VERSION}")" /usr/local/bin/python3 \
- && ln -s /usr/local/bin/python3 /usr/local/bin/python \
+ && ln -sf "$(uv python find "${PYTHON_VERSION}")" /usr/local/bin/python3 \
+ && ln -sf /usr/local/bin/python3 /usr/local/bin/python \
  && python --version \
  && python3 --version \
  && uv --version
 
-# The pinned interpreter and its install dir must stay readable, and pip
-# must be able to write a per-user cache, when the container runs as the
-# host's uid (docker --user $(id -u):$(id -g)) rather than the image user.
-# Container is ephemeral and --rm'd after the scan, so the blast radius of
-# a write here is zero.
+# The pinned interpreter and its install dir must stay readable when the
+# container runs as the host's uid (docker --user $(id -u):$(id -g))
+# rather than the image user. uv writes its own caches under HOME at scan
+# time, so only read/execute access is needed here.
 RUN chmod -R a+rX /opt/uv
 
 USER runner

--- a/docker/profiles/python/PROFILE.md
+++ b/docker/profiles/python/PROFILE.md
@@ -1,0 +1,51 @@
+# Python scanning container
+
+The repository under `./src` is a Python project.
+
+## Runtime
+
+- **CPython 3.13** — `python` / `python3` (a pinned uv-managed interpreter).
+- **`uv`** on PATH for environment and dependency management. Use it for installs (`uv venv`, `uv pip`, `uv sync`, `uv run`).
+- C toolchain (`build-essential`, `pkg-config`) plus the `ffi`/`openssl`/`zlib` dev headers, so C-extension wheels compile when a scan reproduces a project that ships them.
+
+There is no global `pip`; the interpreter is externally managed. Install into a venv with `uv pip`, or use `uv run`.
+
+## Operating procedure
+
+### Code scanning preparations
+
+Create an environment and install the dependency set with the manager that matches the project, so imports resolve and
+any C extensions build:
+
+```bash
+cd src
+uv venv && . .venv/bin/activate
+
+uv pip install -r requirements.txt   # requirements*.txt
+uv sync                              # uv.lock, or a PEP 621 pyproject.toml
+```
+
+For Poetry, Pipenv, or PDM projects, `uv pip install -r <exported-requirements>` works once you have a requirements
+file, or install the lock's pinned set directly if the tool is available. If only `pyproject.toml` exists with no lock,
+call out the missing lock in the report and install the declared dependencies anyway. If install fails with `Could not
+resolve host` or a similar network error the scan is offline — proceed without installed packages and note which checks
+you had to skip.
+
+### Creating reproducers
+
+Every finding ships with a reproducer — a small piece of code that, when run in this container, actually triggers the
+issue. Paste the exact command you ran and the verbatim output (error message, return value, observable side effect)
+into the finding. Reasoning-only or "this would" reproducers do not count; if you couldn't run it here, say so
+explicitly instead of inventing one.
+
+- One-liner: `python -c '<code>'`
+- Multi-line: write to `/tmp/poc.py`, run `python /tmp/poc.py`
+- If the reproducer imports the project's own modules, run it from `./src` inside the activated venv so the package and
+  its dependencies resolve. `uv run python /tmp/poc.py` also works and provisions the environment on demand
+- For framework- or HTTP-routed bugs, isolate the vulnerable function and call it directly with the malicious input
+  rather than booting a server — keeps the reproducer minimal and the evidence trivial to verify
+
+## Out of scope
+
+- Installed third-party packages (under the venv's `site-packages`) — not the target of this scan unless a finding
+  specifically pivots through one.

--- a/internal/worker/profile.go
+++ b/internal/worker/profile.go
@@ -35,9 +35,9 @@ type Profile struct {
 	// "use the default runner image, no per-profile build".
 	Name string
 	// Ecosystem is a `brief` package_managers[].name, matched
-	// case-insensitively. Empty falls back to Markers — useful for
-	// ecosystems brief cannot see (e.g. a PECL C extension repo without
-	// composer.json).
+	// case-insensitively. When Ecosystem and Ecosystems are both empty the
+	// profile matches on Markers alone — useful for ecosystems brief
+	// cannot see (e.g. a PECL C extension repo without composer.json).
 	Ecosystem string
 	// Ecosystems lists additional `brief` package_managers[].name values
 	// the profile also matches, for ecosystems one runtime serves under

--- a/internal/worker/profile.go
+++ b/internal/worker/profile.go
@@ -39,12 +39,28 @@ type Profile struct {
 	// ecosystems brief cannot see (e.g. a PECL C extension repo without
 	// composer.json).
 	Ecosystem string
-	Markers   []ProfileMarker
+	// Ecosystems lists additional `brief` package_managers[].name values
+	// the profile also matches, for ecosystems one runtime serves under
+	// several names (e.g. Python's pip / Poetry / Pipenv / uv / PDM). The
+	// profile matches if any of Ecosystem or Ecosystems matches.
+	Ecosystems []string
+	Markers    []ProfileMarker
 }
 
 // IsDefault reports whether p falls back to the configured runner image
 // instead of a profile-specific built one.
 func (p Profile) IsDefault() bool { return p.Name == "" }
+
+// allEcosystems returns every brief package-manager name the profile
+// matches: the singular Ecosystem (if set) plus any in Ecosystems.
+func (p Profile) allEcosystems() []string {
+	out := make([]string, 0, len(p.Ecosystems)+1)
+	if p.Ecosystem != "" {
+		out = append(out, p.Ecosystem)
+	}
+	out = append(out, p.Ecosystems...)
+	return out
+}
 
 // builtinProfiles is the v1 registry. Order matters: first match wins,
 // so more specific profiles (php-ext) come before their general
@@ -59,6 +75,7 @@ var builtinProfiles = []Profile{
 	},
 	{Name: "php", Ecosystem: "Composer"},
 	{Name: "ruby", Ecosystem: "Bundler"},
+	{Name: "python", Ecosystems: []string{"pip", "Pipenv", "Poetry", "uv", "PDM"}},
 }
 
 // ProfileByName returns the registered profile, or the default profile
@@ -111,7 +128,7 @@ func matchProfile(briefOut []byte, srcDir string) Profile {
 		pms = append(pms, pm.Name)
 	}
 	for _, p := range builtinProfiles {
-		if !ecosystemMatch(p.Ecosystem, pms) {
+		if !ecosystemMatch(p.allEcosystems(), pms) {
 			continue
 		}
 		if !markersMatch(p.Markers, srcDir) {
@@ -122,13 +139,15 @@ func matchProfile(briefOut []byte, srcDir string) Profile {
 	return Profile{}
 }
 
-func ecosystemMatch(ecosystem string, pms []string) bool {
-	if ecosystem == "" {
+func ecosystemMatch(ecosystems, pms []string) bool {
+	if len(ecosystems) == 0 {
 		return true
 	}
-	for _, pm := range pms {
-		if strings.EqualFold(pm, ecosystem) {
-			return true
+	for _, e := range ecosystems {
+		for _, pm := range pms {
+			if strings.EqualFold(pm, e) {
+				return true
+			}
 		}
 	}
 	return false

--- a/internal/worker/profile.go
+++ b/internal/worker/profile.go
@@ -75,6 +75,14 @@ var builtinProfiles = []Profile{
 	},
 	{Name: "php", Ecosystem: "Composer"},
 	{Name: "ruby", Ecosystem: "Bundler"},
+	{
+		// Before python: a repo whose setup.py declares a C Extension is
+		// shipping native code, so route it to the ASan/UBSan interpreter.
+		Name: "python-ext",
+		Markers: []ProfileMarker{
+			{Path: "setup.py", Contains: "Extension("},
+		},
+	},
 	{Name: "python", Ecosystems: []string{"pip", "Pipenv", "Poetry", "uv", "PDM"}},
 }
 

--- a/internal/worker/profile_test.go
+++ b/internal/worker/profile_test.go
@@ -20,6 +20,7 @@ func TestProfileByName(t *testing.T) {
 		{"php", "php", true, true},
 		{"php-ext", "php-ext", true, true},
 		{"ruby", "ruby", true, true},
+		{"python", "python", true, true},
 		{"unknown", "", false, false},
 	}
 	for _, tt := range tests {
@@ -105,6 +106,26 @@ func TestMatchProfile(t *testing.T) {
 			name: "bundler + composer still picks php (registry order, not brief order)",
 			json: `{"package_managers":[{"name":"Bundler"},{"name":"Composer"}]}`,
 			want: "php",
+		},
+		{
+			name: "pip matches python",
+			json: `{"package_managers":[{"name":"pip"}]}`,
+			want: "python",
+		},
+		{
+			name: "poetry matches python (secondary ecosystem)",
+			json: `{"package_managers":[{"name":"Poetry"}]}`,
+			want: "python",
+		},
+		{
+			name: "uv matches python case-insensitive",
+			json: `{"package_managers":[{"name":"UV"}]}`,
+			want: "python",
+		},
+		{
+			name: "pdm matches python",
+			json: `{"package_managers":[{"name":"PDM"}]}`,
+			want: "python",
 		},
 		{
 			name: "unknown manager falls back",
@@ -257,8 +278,10 @@ func TestEnsureImage_missingDockerfile(t *testing.T) {
 // Ecosystem or at least one Marker, names must be unique, and ecosystems
 // must be unique case-insensitively (a duplicate would silently make
 // auto-detection resolve the wrong profile, with no other test failing).
-// Marker-only profiles legitimately have an empty Ecosystem and are
-// excluded from the ecosystem-uniqueness check.
+// Marker-only profiles legitimately have no Ecosystem and are excluded
+// from the ecosystem-uniqueness check. A profile that matches several
+// ecosystems (e.g. python) lists them via Ecosystems; every one is
+// checked for uniqueness against every other profile's.
 func TestBuiltinProfiles_registrySanity(t *testing.T) {
 	names := map[string]bool{}
 	ecosystems := map[string]bool{}
@@ -266,21 +289,21 @@ func TestBuiltinProfiles_registrySanity(t *testing.T) {
 		if p.Name == "" {
 			t.Error("profile with empty Name")
 		}
-		if p.Ecosystem == "" && len(p.Markers) == 0 {
+		ecos := p.allEcosystems()
+		if len(ecos) == 0 && len(p.Markers) == 0 {
 			t.Errorf("profile %q has neither Ecosystem nor Markers", p.Name)
 		}
 		if names[p.Name] {
 			t.Errorf("duplicate profile Name %q", p.Name)
 		}
 		names[p.Name] = true
-		if p.Ecosystem == "" {
-			continue
+		for _, e := range ecos {
+			eco := strings.ToLower(e)
+			if ecosystems[eco] {
+				t.Errorf("duplicate profile Ecosystem %q (case-insensitive)", e)
+			}
+			ecosystems[eco] = true
 		}
-		eco := strings.ToLower(p.Ecosystem)
-		if ecosystems[eco] {
-			t.Errorf("duplicate profile Ecosystem %q (case-insensitive)", p.Ecosystem)
-		}
-		ecosystems[eco] = true
 	}
 }
 
@@ -303,7 +326,7 @@ func TestRepoShipsProfileDockerfiles(t *testing.T) {
 func TestProfileGuidesShipForPHP(t *testing.T) {
 	wd, _ := os.Getwd()
 	repoRoot := filepath.Join(wd, "..", "..")
-	for _, name := range []string{"php", "php-ext"} {
+	for _, name := range []string{"php", "php-ext", "python"} {
 		guide := filepath.Join(repoRoot, "docker", "profiles", name, "PROFILE.md")
 		if _, err := os.Stat(guide); err != nil {
 			t.Errorf("expected %s profile PROFILE.md to exist: %v", name, err)

--- a/internal/worker/profile_test.go
+++ b/internal/worker/profile_test.go
@@ -21,6 +21,7 @@ func TestProfileByName(t *testing.T) {
 		{"php-ext", "php-ext", true, true},
 		{"ruby", "ruby", true, true},
 		{"python", "python", true, true},
+		{"python-ext", "python-ext", true, true},
 		{"unknown", "", false, false},
 	}
 	for _, tt := range tests {
@@ -55,6 +56,23 @@ func writeConfigM4(t *testing.T, dir, contents string) {
 	const configM4FileMode = 0o644
 	path := filepath.Join(dir, "config.m4")
 	if err := os.WriteFile(path, []byte(contents), configM4FileMode); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+const setupPyWithExtension = `from setuptools import setup, Extension
+setup(ext_modules=[Extension("pkg._speedups", ["src/speedups.c"])])
+`
+
+const setupPyPurePython = `from setuptools import setup
+setup(name="pkg", version="1.0", packages=["pkg"])
+`
+
+func writeSetupPy(t *testing.T, dir, contents string) {
+	t.Helper()
+	const setupPyFileMode = 0o644
+	path := filepath.Join(dir, "setup.py")
+	if err := os.WriteFile(path, []byte(contents), setupPyFileMode); err != nil {
 		t.Fatalf("write %s: %v", path, err)
 	}
 }
@@ -125,6 +143,30 @@ func TestMatchProfile(t *testing.T) {
 		{
 			name: "pdm matches python",
 			json: `{"package_managers":[{"name":"PDM"}]}`,
+			want: "python",
+		},
+		{
+			name: "setup.py with Extension selects python-ext",
+			json: `{"package_managers":[{"name":"pip"}]}`,
+			setup: func(t *testing.T, dir string) {
+				writeSetupPy(t, dir, setupPyWithExtension)
+			},
+			want: "python-ext",
+		},
+		{
+			name: "setup.py with Extension matches python-ext even without a manager",
+			json: `{"package_managers":[]}`,
+			setup: func(t *testing.T, dir string) {
+				writeSetupPy(t, dir, setupPyWithExtension)
+			},
+			want: "python-ext",
+		},
+		{
+			name: "pure-python setup.py does not match python-ext, pip picks python",
+			json: `{"package_managers":[{"name":"pip"}]}`,
+			setup: func(t *testing.T, dir string) {
+				writeSetupPy(t, dir, setupPyPurePython)
+			},
 			want: "python",
 		},
 		{
@@ -326,7 +368,7 @@ func TestRepoShipsProfileDockerfiles(t *testing.T) {
 func TestProfileGuidesShip(t *testing.T) {
 	wd, _ := os.Getwd()
 	repoRoot := filepath.Join(wd, "..", "..")
-	for _, name := range []string{"php", "php-ext", "python"} {
+	for _, name := range []string{"php", "php-ext", "python", "python-ext"} {
 		guide := filepath.Join(repoRoot, "docker", "profiles", name, "PROFILE.md")
 		if _, err := os.Stat(guide); err != nil {
 			t.Errorf("expected %s profile PROFILE.md to exist: %v", name, err)

--- a/internal/worker/profile_test.go
+++ b/internal/worker/profile_test.go
@@ -318,12 +318,12 @@ func TestRepoShipsProfileDockerfiles(t *testing.T) {
 	}
 }
 
-// TestProfileGuidesShipForPHP keeps the php / php-ext profiles honest
-// about the per-container PROFILE.md they advertise. PROFILE.md is
-// optional in general (a profile without one simply gets no orientation
-// injected at scan time); the php profiles document specifics the
-// agent needs to behave correctly, so missing them is a real regression.
-func TestProfileGuidesShipForPHP(t *testing.T) {
+// TestProfileGuidesShip keeps the language profiles honest about the
+// per-container PROFILE.md they advertise. PROFILE.md is optional in
+// general (a profile without one simply gets no orientation injected at
+// scan time); these profiles document specifics the agent needs to
+// behave correctly, so missing them is a real regression.
+func TestProfileGuidesShip(t *testing.T) {
 	wd, _ := os.Getwd()
 	repoRoot := filepath.Join(wd, "..", "..")
 	for _, name := range []string{"php", "php-ext", "python"} {


### PR DESCRIPTION
Stacked on #431 (python profile) — review/merge that first; this branch's base will need retargeting to main after #431 merges.

Adds a `python-ext` profile, the native-code twin of `python` and the Python analogue of `php-ext`. It ships CPython built from source with `--with-pydebug` + AddressSanitizer + UndefinedBehaviorSanitizer, so C/C++ extension modules installed against it are instrumented and a reproducer that drives the extension surfaces memory-safety and UB bugs the static scan can only guess at.

Build notes:

- CPython is built with **gcc**. clang now defaults to `-Werror=implicit-function-declaration`, which breaks configure's `getaddrinfo` probe (`checking for getaddrinfo... no` then a hard error). `ac_cv_buggy_getaddrinfo=no` is kept as belt-and-suspenders for the ASan runtime probe.
- Extensions are built with the same gcc plus the exported sanitizer `CFLAGS`/`CXXFLAGS`/`LDFLAGS`, so they share CPython's gcc ASan runtime (a clang-built `.so` dlopened into gcc-ASan CPython aborts on a runtime mismatch). `-fno-sanitize-recover=undefined` makes UB in an extension abort rather than silently continue.
- `PROFILE.md` mirrors php-ext: why the container exists, the pre-exported sanitizer config, how to build the extension in place, how to work a sanitizer hit into a security finding, and reproducer rules.

Routing: auto-selected (ordered before `python`) for repos whose `setup.py` declares a C `Extension(`, and selectable by name via `?profile=python-ext`. The debug+sanitizer interpreter is far slower than the plain `python` profile, so it is scoped to repos that actually ship native code. One thing worth a sanity check in review: whether `setup.py` containing `Extension(` is the right auto-detect signal, or whether python-ext should be selection-only.

Covers marker detection, naming, and the shipped guide in the worker tests. Built locally on the runner image: CPython 3.13.14 debug+ASan compiles and runs, and a deliberately buggy C extension built in place (`build_ext --inplace`) trips ASan with a heap-buffer-overflow when called from Python.