### PR TITLE
go profile: add Go ecosystem runner and guide

### DIFF
--- a/docker/profiles/go/Dockerfile
+++ b/docker/profiles/go/Dockerfile
@@ -49,9 +49,11 @@ USER root
 # image dir, exec-capable) rather than $HOME=/tmp, which the worker mounts
 # noexec -- `go run`/`go test` exec the binaries they build, so GOTMPDIR
 # must sit on an exec-capable path. 1777 so any host uid can write; the
-# container is --rm'd after the scan. (Hardened mode mounts the rootfs
-# read-only, leaving only /work and /tmp writable, so in that mode point
-# these at a /work subdir instead.)
+# container is --rm'd after the scan. Known limitation: hardened mode
+# mounts the rootfs read-only (only /work and /tmp stay writable), so
+# these /opt cache paths are not writable there and a build would fail --
+# same constraint as the php pie-home dir. Default (non-hardened) scans,
+# which is what these profiles target, are unaffected.
 ENV PATH=/usr/local/go/bin:$PATH \
     GOTOOLCHAIN=local \
     GOPATH=/opt/go/path \

--- a/docker/profiles/go/Dockerfile
+++ b/docker/profiles/go/Dockerfile
@@ -1,0 +1,95 @@
+# Go profile. Extends the scrutineer runner with a pinned Go toolchain,
+# govulncheck, and a C toolchain (cgo) so scans of Go-module projects can
+# build, test, and reproduce findings in-place.
+#
+# Go ships official, sha256-verifiable release archives, so the toolchain
+# is fetched and checksummed the same way the runner installs claude --
+# not from a moving apt repo. Bump GO_VERSION and the matching checksums
+# together; both arches are listed because the worker may build this on an
+# amd64 or arm64 host.
+#
+# At runtime the worker builds this on demand (see internal/worker/profile.go:
+# EnsureImage), tagging the result scrutineer-profile-go:<dockerfile-sha>
+# and passing the configured runner image via --build-arg RUNNER_IMAGE.
+#
+# To build it manually the way the project does, from the repo root:
+#
+#   # 1. Build the base runner image locally (Debian/glibc, ships brief etc.):
+#   docker build -t scrutineer-runner:local -f Dockerfile.runner .
+#
+#   # 2. Build this Go profile on top of that local runner:
+#   docker build -t scrutineer-profile-go \
+#       -f docker/profiles/go/Dockerfile \
+#       --build-arg RUNNER_IMAGE=scrutineer-runner:local \
+#       docker/profiles/go
+#
+#   # 3. Smoke-test it:
+#   docker run --rm --entrypoint sh scrutineer-profile-go \
+#       -c 'go version && govulncheck -version'
+
+ARG RUNNER_IMAGE=ghcr.io/alpha-omega-security/scrutineer-runner:latest
+
+FROM ${RUNNER_IMAGE}
+
+# Explicit, sha256-verifiable Go version. Bump GO_VERSION and both
+# checksums together; the content-addressed image tag invalidates the
+# cache on any edit to this file.
+ARG GO_VERSION=1.26.4
+ARG GO_SHA256_AMD64=1153d3d50e0ac764b447adfe05c2bcf08e889d42a02e0fe0259bd47f6733ad7f
+ARG GO_SHA256_ARM64=ef758ae7c6cf9267c9c0ef080b8965f453d89ab2d25d9eb22de4405925238768
+# govulncheck reports known vulns in the project's module graph and (with
+# source) which are actually reachable. Pinned; built from source below.
+ARG GOVULNCHECK_VERSION=v1.4.0
+
+USER root
+
+# GOTOOLCHAIN=local pins the installed toolchain: a project go.mod that
+# requires a newer Go would otherwise make `go` download another toolchain
+# mid-scan (network + unpinned). The cache/tmp dirs live under /opt (a real
+# image dir, exec-capable) rather than $HOME=/tmp, which the worker mounts
+# noexec -- `go run`/`go test` exec the binaries they build, so GOTMPDIR
+# must sit on an exec-capable path. 1777 so any host uid can write; the
+# container is --rm'd after the scan. (Hardened mode mounts the rootfs
+# read-only, leaving only /work and /tmp writable, so in that mode point
+# these at a /work subdir instead.)
+ENV PATH=/usr/local/go/bin:$PATH \
+    GOTOOLCHAIN=local \
+    GOPATH=/opt/go/path \
+    GOMODCACHE=/opt/go/path/pkg/mod \
+    GOCACHE=/opt/go/cache \
+    GOTMPDIR=/opt/go/tmp
+
+# build-essential for cgo (a project with import "C" needs a C compiler to
+# build and test). Kept in the final image because the in-place reproduce
+# step compiles.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends build-essential \
+ && rm -rf /var/lib/apt/lists/* \
+ && case "$(dpkg --print-architecture)" in \
+        amd64) arch=amd64; sha="${GO_SHA256_AMD64}" ;; \
+        arm64) arch=arm64; sha="${GO_SHA256_ARM64}" ;; \
+        *) echo "unsupported architecture: $(dpkg --print-architecture)" >&2; exit 1 ;; \
+    esac \
+ && curl -fsSL -o /tmp/go.tar.gz \
+        "https://go.dev/dl/go${GO_VERSION}.linux-${arch}.tar.gz" \
+ && echo "${sha}  /tmp/go.tar.gz" | sha256sum -c - \
+ && tar -C /usr/local -xzf /tmp/go.tar.gz \
+ && rm /tmp/go.tar.gz \
+ && install -d -m 1777 /opt/go/path /opt/go/cache /opt/go/tmp \
+ && go install "golang.org/x/vuln/cmd/govulncheck@${GOVULNCHECK_VERSION}" \
+ && install -m 0755 /opt/go/path/bin/govulncheck /usr/local/bin/govulncheck \
+ && go version \
+ && govulncheck -version \
+ && printf 'package main\nimport "fmt"\nfunc main(){fmt.Println("go run ok")}\n' > /tmp/smoke.go \
+ && go run /tmp/smoke.go \
+ && rm /tmp/smoke.go \
+ # A GOCACHE populated during docker build is committed into the image
+ # layer and then poisons std-package resolution at scan time (`go list
+ # std` reports every std package as "not in std", and `go test` fails to
+ # build its testmain). govulncheck is already on PATH, so the build cache
+ # is no longer needed: empty it and recreate the dir 1777 so the scan
+ # starts from a clean, writable cache.
+ && go clean -cache \
+ && install -d -m 1777 /opt/go/cache
+
+USER runner

--- a/docker/profiles/go/PROFILE.md
+++ b/docker/profiles/go/PROFILE.md
@@ -1,0 +1,52 @@
+# Go scanning container
+
+The repository under `./src` is a Go module.
+
+## Runtime
+
+- **Go 1.26** — `go`. `GOTOOLCHAIN=local`, so the installed toolchain is used as-is rather than downloading another one mid-scan.
+- **`govulncheck`** on PATH — reports known vulnerabilities in the module graph and, with source, which are actually reachable.
+- C toolchain (`build-essential`) for cgo, so a project that imports `"C"` builds, tests, and reproduces.
+
+The Go module cache, build cache, and tmp dir live under `/opt/go` (an exec-capable path), because `HOME` is a noexec
+mount and `go run`/`go test` execute the binaries they build.
+
+## Operating procedure
+
+### Code scanning preparations
+
+Modules resolve from `go.mod`/`go.sum`; there is no separate install step. Warm the build and verify it compiles:
+
+```bash
+cd src
+go build ./...
+```
+
+If a build needs modules not yet cached, `go` fetches them on first use. If that fails with a network error the scan
+is offline — work from the source already present and note which checks (including `govulncheck`, which needs its
+vulnerability database) you had to skip.
+
+### Reachability
+
+`govulncheck ./...` from the module root reports known-vulnerable symbols the code actually calls, which is stronger
+evidence than a version-only advisory match. Quote its output when a finding rests on it.
+
+### Creating reproducers
+
+Every finding ships with a reproducer — a small piece of code that, when run in this container, actually triggers the
+issue. Paste the exact command you ran and the verbatim output (error message, return value, observable side effect)
+into the finding. Reasoning-only or "this would" reproducers do not count; if you couldn't run it here, say so
+explicitly instead of inventing one.
+
+- A focused test: write `xxx_test.go` next to the code and run `go test -run TestXxx ./path/...`. The test output is
+  the evidence.
+- A standalone program: write to `/tmp/poc/` with its own `go.mod`, or add a `main` package under the module, and
+  `go run` it.
+- Drive the vulnerable function directly with the malicious input rather than booting the whole service — keeps the
+  reproducer minimal and the evidence trivial to verify.
+- For a panic or data race, `go test -race` turns a latent race into a loud, pinpointed report; quote it.
+
+## Out of scope
+
+- Dependencies under the module cache (`$GOMODCACHE`) — third-party code, not the target of this scan unless a finding
+  specifically pivots through one.

--- a/internal/worker/profile.go
+++ b/internal/worker/profile.go
@@ -85,6 +85,7 @@ var builtinProfiles = []Profile{
 		},
 	},
 	{Name: "python", Ecosystems: []string{"pip", "Pipenv", "Poetry", "uv", "PDM"}},
+	{Name: "go", Ecosystem: "Go Modules"},
 }
 
 // ProfileByName returns the registered profile, or the default profile

--- a/internal/worker/profile_test.go
+++ b/internal/worker/profile_test.go
@@ -17,13 +17,18 @@ func TestProfileByName(t *testing.T) {
 	}{
 		{"", "", true, false},
 		{"default", "", true, false},
-		{"php", "php", true, true},
-		{"php-ext", "php-ext", true, true},
-		{"ruby", "ruby", true, true},
-		{"node", "node", true, true},
-		{"python", "python", true, true},
-		{"python-ext", "python-ext", true, true},
 		{"unknown", "", false, false},
+	}
+	// Every registered profile resolves to itself and is known/named.
+	// Deriving these from builtinProfiles keeps this table out of the
+	// conflict path when a profile is added.
+	for _, p := range builtinProfiles {
+		tests = append(tests, struct {
+			name    string
+			want    string
+			isKnown bool
+			isNamed bool
+		}{p.Name, p.Name, true, true})
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -184,6 +189,16 @@ func TestMatchProfile(t *testing.T) {
 				writeSetupPy(t, dir, setupPyPurePython)
 			},
 			want: "python",
+		},
+		{
+			name: "go modules matches go",
+			json: `{"package_managers":[{"name":"Go Modules"}]}`,
+			want: "go",
+		},
+		{
+			name: "go modules case-insensitive",
+			json: `{"package_managers":[{"name":"go modules"}]}`,
+			want: "go",
 		},
 		{
 			name: "truly unknown manager falls back",


### PR DESCRIPTION
Adds a `go` profile so scans of Go-module projects can build, run `govulncheck`, and reproduce findings in-place, matching the other language profiles.

`docker/profiles/go/Dockerfile`:

- a sha256-verified Go toolchain (fetched the same way the runner installs `claude`, both arches listed), pinned to the 1.26.4 the runner's build stage already uses
- `govulncheck` built from a pinned source version, copied onto PATH
- `build-essential` for cgo, so a project that imports `"C"` builds and tests
- `GOTOOLCHAIN=local` so a project `go.mod` requiring a newer Go can't trigger an unpinned toolchain download mid-scan
- module/build caches and `GOTMPDIR` under `/opt` (exec-capable), because the worker mounts `HOME=/tmp` noexec and `go run`/`go test` exec the binaries they build

One subtlety worth calling out: the build cache is cleared at the end of the image build. A `GOCACHE` populated during `docker build` is committed into the image layer and then poisons std-package resolution at scan time (`go list std` reports every package as "not in std" and `go test` fails to build its testmain). Clearing it makes the scan start from a clean, writable cache. This took a while to track down, so the Dockerfile has a comment explaining it.

`PROFILE.md` covers building, `govulncheck` reachability, and the reproducer recipe (focused `_test.go`, standalone `go run`, `go test -race`).

Registers `go` (ecosystem `Go Modules`) and covers detection, naming, and the shipped guide in the worker tests. Built locally on the runner image and verified under the worker's exact sandbox (`--user`, `HOME=/tmp`, noexec `/tmp` tmpfs): `go list std`, `go build`, `go run`, `go test`, and `cgo` all work, and `govulncheck` runs.