### PR TITLE
java profile: add JVM ecosystem runner and guide

### DIFF
--- a/docker/profiles/java/Dockerfile
+++ b/docker/profiles/java/Dockerfile
@@ -98,17 +98,23 @@ RUN apt-get update \
  # extract libnative-platform.so to the noexec $HOME=/tmp and fail. A
  # gradle.properties in GRADLE_USER_HOME fixes the daemon's java.io.tmpdir
  # and disables the daemon (scans are one-shot, so a daemon only adds risk).
+ # It is left root-owned and read-only (0644) so a scanned project cannot
+ # rewrite the noexec workaround or re-enable the daemon; GRADLE_USER_HOME
+ # itself is sticky-writable (1777) so the scan uid can still create the
+ # native/ cache and its lock files beside it.
  && printf 'org.gradle.daemon=false\norg.gradle.jvmargs=-Djava.io.tmpdir=/opt/java-tmp\n' \
         > /opt/gradle-home/gradle.properties \
- && chmod 0666 /opt/gradle-home/gradle.properties \
+ && chmod 0644 /opt/gradle-home/gradle.properties \
+ # Smoke-test the toolchain with throwaway home/tmp dirs so the build does
+ # not seed /opt/{gradle-home,m2/repo,java-tmp} with root-owned files the
+ # scan uid (the host uid, not the image user) could not then write beside.
+ # The scan populates those dirs itself, fresh, as that uid.
+ && BOOT=/tmp/jvm-bootstrap \
+ && mkdir -p "$BOOT/gradle" "$BOOT/jtmp" \
  && java -version \
  && javac -version \
- && mvn -version \
- && gradle --version \
- # `gradle --version` (run as root here) extracts its native libraries
- # into GRADLE_USER_HOME/native owned by root; the scan runs as the host
- # uid and must be able to write the .lock files beside them, so open up
- # the pre-populated caches. Ephemeral container, --rm'd after the scan.
- && chmod -R a+rwX /opt/gradle-home /opt/m2/repo
+ && MAVEN_OPTS="-Djava.io.tmpdir=$BOOT/jtmp" mvn -version \
+ && GRADLE_USER_HOME="$BOOT/gradle" GRADLE_OPTS="-Djava.io.tmpdir=$BOOT/jtmp" gradle --version \
+ && rm -rf "$BOOT"
 
 USER runner

--- a/docker/profiles/java/Dockerfile
+++ b/docker/profiles/java/Dockerfile
@@ -1,0 +1,114 @@
+# Java/JVM profile. Extends the scrutineer runner with a pinned Temurin
+# JDK plus Maven and Gradle so scans of Maven or Gradle projects can
+# resolve dependencies, build, test, and reproduce findings in-place.
+#
+# The JDK, Maven, and Gradle are all fetched as official, checksum-verified
+# archives (JDK + Gradle by sha256, Maven by sha512 as Apache publishes),
+# the same way the runner installs claude -- not from a moving apt repo.
+# Bump a version and its checksum together; the content-addressed image
+# tag invalidates the cache on any edit to this file.
+#
+# At runtime the worker builds this on demand (see internal/worker/profile.go:
+# EnsureImage), tagging the result scrutineer-profile-java:<dockerfile-sha>
+# and passing the configured runner image via --build-arg RUNNER_IMAGE.
+#
+# To build it manually the way the project does, from the repo root:
+#
+#   # 1. Build the base runner image locally (Debian/glibc, ships brief etc.):
+#   docker build -t scrutineer-runner:local -f Dockerfile.runner .
+#
+#   # 2. Build this Java profile on top of that local runner:
+#   docker build -t scrutineer-profile-java \
+#       -f docker/profiles/java/Dockerfile \
+#       --build-arg RUNNER_IMAGE=scrutineer-runner:local \
+#       docker/profiles/java
+#
+#   # 3. Smoke-test it:
+#   docker run --rm --entrypoint sh scrutineer-profile-java \
+#       -c 'java -version && mvn -version && gradle --version'
+
+ARG RUNNER_IMAGE=ghcr.io/alpha-omega-security/scrutineer-runner:latest
+
+FROM ${RUNNER_IMAGE}
+
+# Temurin 21 LTS, the current long-term-support JDK. Both arches are listed
+# because the worker may build this on an amd64 or arm64 host.
+ARG JDK_VERSION=21.0.11_10
+ARG JDK_PATH_VERSION=jdk-21.0.11%2B10
+ARG JDK_SHA256_X64=4b2220e232a97997b436ca6ab15cbf70171ecff52958a46159dfa5a8c44ca4de
+ARG JDK_SHA256_ARM64=8d498ec88e1c1989fab95c6784240ab92d011e29c54d20a3f9c324b13476f9ad
+# Maven publishes a sha512 alongside each binary; Gradle a sha256.
+ARG MAVEN_VERSION=3.9.16
+ARG MAVEN_SHA512=831a8591fe20c8243b1dbe7d71e3244f31d1665b0804b2e825e38cbbe5ce0cafb8338851f90780735568773e0a6cd07bbec107cda0b896b008b861075358b6f6
+ARG GRADLE_VERSION=9.5.1
+ARG GRADLE_SHA256=bafc141b619ad6350fd975fc903156dd5c151998cc8b058e8c1044ab5f7b031f
+
+USER root
+
+# Build caches live under /opt (a real image dir) rather than $HOME=/tmp,
+# which the worker mounts noexec and caps at 256m -- too small for a
+# resolved dependency set. 1777 so the host uid the scan runs as can write;
+# the container is --rm'd after. (Hardened mode mounts the rootfs
+# read-only, leaving only /work and /tmp writable, so in that mode the
+# 256m cap applies and a large build may not fit.)
+# java.io.tmpdir is redirected off $HOME=/tmp (noexec): Maven's jansi and
+# other JVM libs extract native .so files to the JVM temp dir and dlopen
+# them, which fails on a noexec mount. Pointing it at an exec-capable /opt
+# dir fixes mvn and gradle; a standalone `java` reproducer that loads a
+# native lib should pass -Djava.io.tmpdir=/opt/java-tmp too.
+ENV JAVA_HOME=/opt/java \
+    GRADLE_USER_HOME=/opt/gradle-home \
+    MAVEN_OPTS=-Djava.io.tmpdir=/opt/java-tmp \
+    GRADLE_OPTS=-Djava.io.tmpdir=/opt/java-tmp \
+    PATH=/opt/java/bin:/opt/maven/bin:/opt/gradle/bin:$PATH
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends unzip \
+ && rm -rf /var/lib/apt/lists/* \
+ && case "$(dpkg --print-architecture)" in \
+        amd64) jdkarch=x64;     jdksha="${JDK_SHA256_X64}" ;; \
+        arm64) jdkarch=aarch64; jdksha="${JDK_SHA256_ARM64}" ;; \
+        *) echo "unsupported architecture: $(dpkg --print-architecture)" >&2; exit 1 ;; \
+    esac \
+ # JDK
+ && curl -fsSL -o /tmp/jdk.tar.gz \
+        "https://github.com/adoptium/temurin21-binaries/releases/download/${JDK_PATH_VERSION}/OpenJDK21U-jdk_${jdkarch}_linux_hotspot_${JDK_VERSION}.tar.gz" \
+ && echo "${jdksha}  /tmp/jdk.tar.gz" | sha256sum -c - \
+ && mkdir -p /opt/java \
+ && tar -xzf /tmp/jdk.tar.gz -C /opt/java --strip-components=1 \
+ && rm /tmp/jdk.tar.gz \
+ # Maven
+ && curl -fsSL -o /tmp/maven.tar.gz \
+        "https://dlcdn.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz" \
+ && echo "${MAVEN_SHA512}  /tmp/maven.tar.gz" | sha512sum -c - \
+ && mkdir -p /opt/maven \
+ && tar -xzf /tmp/maven.tar.gz -C /opt/maven --strip-components=1 \
+ && rm /tmp/maven.tar.gz \
+ # Gradle
+ && curl -fsSL -o /tmp/gradle.zip \
+        "https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip" \
+ && echo "${GRADLE_SHA256}  /tmp/gradle.zip" | sha256sum -c - \
+ && unzip -q /tmp/gradle.zip -d /opt \
+ && mv "/opt/gradle-${GRADLE_VERSION}" /opt/gradle \
+ && rm /tmp/gradle.zip \
+ # Maven local repo and Gradle home, writable by the scan uid
+ && sed -i 's#</settings>#  <localRepository>/opt/m2/repo</localRepository>\n</settings>#' /opt/maven/conf/settings.xml \
+ && install -d -m 1777 /opt/m2/repo /opt/gradle-home /opt/java-tmp \
+ # Gradle forks a daemon JVM that does not inherit GRADLE_OPTS, so it would
+ # extract libnative-platform.so to the noexec $HOME=/tmp and fail. A
+ # gradle.properties in GRADLE_USER_HOME fixes the daemon's java.io.tmpdir
+ # and disables the daemon (scans are one-shot, so a daemon only adds risk).
+ && printf 'org.gradle.daemon=false\norg.gradle.jvmargs=-Djava.io.tmpdir=/opt/java-tmp\n' \
+        > /opt/gradle-home/gradle.properties \
+ && chmod 0666 /opt/gradle-home/gradle.properties \
+ && java -version \
+ && javac -version \
+ && mvn -version \
+ && gradle --version \
+ # `gradle --version` (run as root here) extracts its native libraries
+ # into GRADLE_USER_HOME/native owned by root; the scan runs as the host
+ # uid and must be able to write the .lock files beside them, so open up
+ # the pre-populated caches. Ephemeral container, --rm'd after the scan.
+ && chmod -R a+rwX /opt/gradle-home /opt/m2/repo
+
+USER runner

--- a/docker/profiles/java/PROFILE.md
+++ b/docker/profiles/java/PROFILE.md
@@ -1,0 +1,53 @@
+# Java/JVM scanning container
+
+The repository under `./src` is a JVM project, built with Maven or Gradle.
+
+## Runtime
+
+- **Temurin JDK 21** — `java`, `javac`. `JAVA_HOME=/opt/java`.
+- **`mvn`** (Maven 3.9) on PATH for `pom.xml` projects.
+- **`gradle`** (Gradle 9) on PATH for `build.gradle` / `build.gradle.kts` projects.
+
+The Maven local repository (`/opt/m2/repo`) and Gradle home (`/opt/gradle-home`) live on an exec-capable path rather
+than under `HOME`, which is a small noexec mount. `mvn` and `gradle` already run with `java.io.tmpdir=/opt/java-tmp` so
+JVM libraries that unpack native `.so` files can load them; a standalone `java` reproducer that loads a native library
+should pass `-Djava.io.tmpdir=/opt/java-tmp` too.
+
+## Operating procedure
+
+### Code scanning preparations
+
+Resolve dependencies and compile with the tool that matches the project.
+
+For Gradle projects, prefer the project's own wrapper when present, so the build uses the version it pins:
+
+```bash
+cd src
+./gradlew assemble --offline 2>/dev/null || ./gradlew assemble || gradle assemble   # build.gradle(.kts)
+mvn -B -o compile 2>/dev/null || mvn -B compile                                     # pom.xml
+```
+
+`-B` runs Maven in batch (non-interactive) mode. Try an offline pass first; if it fails because dependencies aren't
+cached yet, run online. If that fails with a network error the scan is offline — work from the source already present
+and note which checks you had to skip. A Gradle wrapper download (`gradlew`) also needs the network on first use; fall
+back to the image's `gradle` when it can't fetch.
+
+### Creating reproducers
+
+Every finding ships with a reproducer — a small piece of code that, when run in this container, actually triggers the
+issue. Paste the exact command you ran and the verbatim output (error message, return value, observable side effect)
+into the finding. Reasoning-only or "this would" reproducers do not count; if you couldn't run it here, say so
+explicitly instead of inventing one.
+
+- A focused test: add a JUnit test under the project's `src/test/java` and run it with `mvn -B -Dtest=ClassName#method test`
+  or `gradle test --tests 'ClassName.method'`. The test output is the evidence.
+- A standalone program: drop a small `Main.java` with a `main` method, compile it against the project's classpath, and
+  run it — e.g. `javac -cp "$(mvn -q dependency:build-classpath -Dmdep.outputFile=/dev/stdout)" Main.java`.
+- Drive the vulnerable method directly with the malicious input (a crafted string, a hostile serialized blob, an XML
+  payload for an XXE sink) rather than booting the whole application — keeps the reproducer minimal and the evidence
+  trivial to verify.
+
+## Out of scope
+
+- Dependencies in the Maven/Gradle caches — third-party code, not the target of this scan unless a finding
+  specifically pivots through one.

--- a/internal/worker/profile.go
+++ b/internal/worker/profile.go
@@ -41,8 +41,9 @@ type Profile struct {
 	Ecosystem string
 	// Ecosystems lists additional `brief` package_managers[].name values
 	// the profile also matches, for ecosystems one runtime serves under
-	// several names (e.g. Python's pip / Poetry / Pipenv / uv / PDM). The
-	// profile matches if any of Ecosystem or Ecosystems matches.
+	// several names (e.g. Python's pip / Poetry / Pipenv / uv / PDM, or the
+	// JVM's Maven and Gradle). The profile matches if any of Ecosystem or
+	// Ecosystems matches.
 	Ecosystems []string
 	Markers    []ProfileMarker
 }
@@ -86,6 +87,7 @@ var builtinProfiles = []Profile{
 	},
 	{Name: "python", Ecosystems: []string{"pip", "Pipenv", "Poetry", "uv", "PDM"}},
 	{Name: "go", Ecosystem: "Go Modules"},
+	{Name: "java", Ecosystems: []string{"Maven", "Gradle"}},
 }
 
 // ProfileByName returns the registered profile, or the default profile

--- a/internal/worker/profile_test.go
+++ b/internal/worker/profile_test.go
@@ -201,6 +201,21 @@ func TestMatchProfile(t *testing.T) {
 			want: "go",
 		},
 		{
+			name: "maven matches java",
+			json: `{"package_managers":[{"name":"Maven"}]}`,
+			want: "java",
+		},
+		{
+			name: "gradle matches java (secondary ecosystem)",
+			json: `{"package_managers":[{"name":"Gradle"}]}`,
+			want: "java",
+		},
+		{
+			name: "gradle case-insensitive",
+			json: `{"package_managers":[{"name":"gradle"}]}`,
+			want: "java",
+		},
+		{
 			name: "truly unknown manager falls back",
 			json: `{"package_managers":[{"name":"Cargo"}]}`,
 			want: "",
@@ -353,7 +368,7 @@ func TestEnsureImage_missingDockerfile(t *testing.T) {
 // auto-detection resolve the wrong profile, with no other test failing).
 // Marker-only profiles legitimately have no Ecosystem and are excluded
 // from the ecosystem-uniqueness check. A profile that matches several
-// ecosystems (e.g. python) lists them via Ecosystems; every one is
+// ecosystems (e.g. python, java) lists them via Ecosystems; every one is
 // checked for uniqueness against every other profile's.
 func TestBuiltinProfiles_registrySanity(t *testing.T) {
 	names := map[string]bool{}


### PR DESCRIPTION
Adds a `java` profile so scans of Maven or Gradle projects can resolve dependencies, build, test, and reproduce findings in-place, matching the other language profiles.

`docker/profiles/java/Dockerfile` extends the runner with a pinned Temurin 21 LTS JDK plus Maven and Gradle, each a checksum-verified official archive (JDK and Gradle by sha256, Maven by sha512 as Apache publishes), fetched like the runner's `claude` binary. Build caches (Maven local repo, Gradle home) live under `/opt` because `HOME=/tmp` is a small noexec mount.

Two fixes the noexec `/tmp` forced, both verified under the worker's sandbox:

- `java.io.tmpdir` is redirected to an exec-capable `/opt` dir for `mvn` and `gradle`, so JVM libraries that unpack native `.so` files (Maven's jansi) can dlopen them.
- Gradle runs daemonless with its daemon-JVM tmpdir set via `gradle.properties`, and the native libraries it extracts at build time are made world-writable so the scan uid can write their `.lock` files (otherwise gradle fails at "Could not initialize native services").

`brief` reports JVM projects as either `Maven` or `Gradle`, so `Profile` gains an `Ecosystems` list and the profile matches either. `PROFILE.md` covers building with each tool (preferring the project's gradle wrapper), the reproducer recipe (JUnit test, standalone `Main.java` against the project classpath), and the `java.io.tmpdir` note.

Registers `java` and covers detection, naming, multi-ecosystem registry sanity, and the shipped guide in the worker tests. Built locally on the runner image and verified under the worker sandbox (`--user`, `HOME=/tmp`, noexec `/tmp`): a Maven project (`mvn -B test`) and a Gradle project (`gradle test`) each compile, download deps into the `/opt` caches, and run a JUnit test to green.

Note: the `Ecosystems` struct field added here is the same enhancement as in the python profile PR (#431); whichever merges second will need a trivial conflict resolution on that field.