### PR TITLE
dotnet profile: add .NET ecosystem runner and guide

### DIFF
--- a/docker/profiles/dotnet/Dockerfile
+++ b/docker/profiles/dotnet/Dockerfile
@@ -1,0 +1,84 @@
+# .NET profile. Extends the scrutineer runner with a pinned .NET SDK so
+# scans of NuGet/.NET projects can restore dependencies, build, test, and
+# reproduce findings in-place.
+#
+# The SDK is an official, sha512-verified release tarball (the hash
+# Microsoft publishes in releases.json), fetched the same way the runner
+# installs claude -- not from a moving apt feed. Bump DOTNET_VERSION and
+# both checksums together; the content-addressed image tag invalidates the
+# cache on any edit to this file.
+#
+# At runtime the worker builds this on demand (see internal/worker/profile.go:
+# EnsureImage), tagging the result scrutineer-profile-dotnet:<dockerfile-sha>
+# and passing the configured runner image via --build-arg RUNNER_IMAGE.
+#
+# To build it manually the way the project does, from the repo root:
+#
+#   # 1. Build the base runner image locally (Debian/glibc, ships brief etc.):
+#   docker build -t scrutineer-runner:local -f Dockerfile.runner .
+#
+#   # 2. Build this .NET profile on top of that local runner:
+#   docker build -t scrutineer-profile-dotnet \
+#       -f docker/profiles/dotnet/Dockerfile \
+#       --build-arg RUNNER_IMAGE=scrutineer-runner:local \
+#       docker/profiles/dotnet
+#
+#   # 3. Smoke-test it:
+#   docker run --rm --entrypoint sh scrutineer-profile-dotnet \
+#       -c 'dotnet --version && dotnet --list-sdks'
+
+ARG RUNNER_IMAGE=ghcr.io/alpha-omega-security/scrutineer-runner:latest
+
+FROM ${RUNNER_IMAGE}
+
+# .NET 10 LTS. Both arches are listed because the worker may build this on
+# an amd64 or arm64 host.
+ARG DOTNET_VERSION=10.0.301
+ARG DOTNET_SHA512_X64=cfbeec3a3a1d3ad3e168e37a77c4cc26c23125acd84a86d014047da3ecffce4c368a9acac4d7c950a047fa3d98989ce8aea69f8e5842cb6d330e8911e1c335a7
+ARG DOTNET_SHA512_ARM64=4ee438b363cb8468930d50b6bdc738a375e2f33b25bfd0c8dcb55853dda7f0fb187693e0f49dfc31556e68320b961a50dcf3b74c1f25abe3a5bd916db607db99
+
+USER root
+
+# Caches live under /opt (a real image dir) rather than $HOME=/tmp, which
+# the worker mounts noexec and caps at 256m -- too small for a restored
+# package set. Telemetry and the first-run banner are off so they don't
+# write to $HOME or muddy scan logs. Dirs are made 1777 below so the host
+# uid the scan runs as can write; the container is --rm'd after.
+ENV DOTNET_ROOT=/usr/share/dotnet \
+    PATH=/usr/share/dotnet:$PATH \
+    DOTNET_CLI_HOME=/opt/dotnet-home \
+    NUGET_PACKAGES=/opt/nuget \
+    DOTNET_CLI_TELEMETRY_OPTOUT=1 \
+    DOTNET_NOLOGO=1 \
+    DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
+
+# .NET's runtime depends on ICU (globalization), OpenSSL, zlib, libstdc++,
+# and the kerberos lib. libicu-dev carries a stable package name across
+# Debian releases and pulls in whichever libicuNN the distro ships, so the
+# profile keeps building as the runner base moves between releases.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+        libicu-dev \
+        libssl3 \
+        zlib1g \
+        libstdc++6 \
+        libgcc-s1 \
+        libgssapi-krb5-2 \
+ && rm -rf /var/lib/apt/lists/* \
+ && case "$(dpkg --print-architecture)" in \
+        amd64) arch=x64;   sha="${DOTNET_SHA512_X64}" ;; \
+        arm64) arch=arm64; sha="${DOTNET_SHA512_ARM64}" ;; \
+        *) echo "unsupported architecture: $(dpkg --print-architecture)" >&2; exit 1 ;; \
+    esac \
+ && curl -fsSL -o /tmp/dotnet.tar.gz \
+        "https://builds.dotnet.microsoft.com/dotnet/Sdk/${DOTNET_VERSION}/dotnet-sdk-${DOTNET_VERSION}-linux-${arch}.tar.gz" \
+ && echo "${sha}  /tmp/dotnet.tar.gz" | sha512sum -c - \
+ && mkdir -p /usr/share/dotnet \
+ && tar -xzf /tmp/dotnet.tar.gz -C /usr/share/dotnet \
+ && rm /tmp/dotnet.tar.gz \
+ && ln -s /usr/share/dotnet/dotnet /usr/local/bin/dotnet \
+ && install -d -m 1777 /opt/dotnet-home /opt/nuget \
+ && dotnet --version \
+ && dotnet --list-sdks
+
+USER runner

--- a/docker/profiles/dotnet/PROFILE.md
+++ b/docker/profiles/dotnet/PROFILE.md
@@ -1,0 +1,44 @@
+# .NET scanning container
+
+The repository under `./src` is a .NET project (C#, F#, or VB), built with NuGet.
+
+## Runtime
+
+- **.NET SDK 10** — `dotnet`. Covers restore, build, test, and run.
+- The NuGet package cache (`/opt/nuget`) and CLI home (`/opt/dotnet-home`) live on an exec-capable path rather than under `HOME`, which is a small noexec mount. Telemetry and the first-run banner are off.
+
+## Operating procedure
+
+### Code scanning preparations
+
+Restore dependencies and build the solution or project:
+
+```bash
+cd src
+dotnet restore   # or let build/test restore implicitly
+dotnet build --no-restore
+```
+
+`dotnet` discovers the `.sln` or `.csproj` in the current directory; point it at a specific one if there are several.
+If restore fails with a network error the scan is offline — work from the source already present and note which checks
+you had to skip.
+
+### Creating reproducers
+
+Every finding ships with a reproducer — a small piece of code that, when run in this container, actually triggers the
+issue. Paste the exact command you ran and the verbatim output (error message, return value, observable side effect)
+into the finding. Reasoning-only or "this would" reproducers do not count; if you couldn't run it here, say so
+explicitly instead of inventing one.
+
+- A focused test: add an xUnit/NUnit/MSTest case to the project's test assembly and run
+  `dotnet test --filter 'FullyQualifiedName~Namespace.ClassName.Method'`. The test output is the evidence.
+- A standalone program: `dotnet new console -o /tmp/poc`, add a `ProjectReference` or `PackageReference` to the code
+  under test, and `dotnet run --project /tmp/poc`.
+- Drive the vulnerable method directly with the malicious input (a crafted string, a hostile serialized payload, an XML
+  document for an XXE sink) rather than booting the whole application — keeps the reproducer minimal and the evidence
+  trivial to verify.
+
+## Out of scope
+
+- Restored packages under the NuGet cache — third-party code, not the target of this scan unless a finding
+  specifically pivots through one.

--- a/internal/worker/profile.go
+++ b/internal/worker/profile.go
@@ -88,6 +88,7 @@ var builtinProfiles = []Profile{
 	{Name: "python", Ecosystems: []string{"pip", "Pipenv", "Poetry", "uv", "PDM"}},
 	{Name: "go", Ecosystem: "Go Modules"},
 	{Name: "java", Ecosystems: []string{"Maven", "Gradle"}},
+	{Name: "dotnet", Ecosystem: "NuGet"},
 }
 
 // ProfileByName returns the registered profile, or the default profile

--- a/internal/worker/profile_test.go
+++ b/internal/worker/profile_test.go
@@ -216,6 +216,16 @@ func TestMatchProfile(t *testing.T) {
 			want: "java",
 		},
 		{
+			name: "nuget matches dotnet",
+			json: `{"package_managers":[{"name":"NuGet"}]}`,
+			want: "dotnet",
+		},
+		{
+			name: "nuget case-insensitive",
+			json: `{"package_managers":[{"name":"nuget"}]}`,
+			want: "dotnet",
+		},
+		{
 			name: "truly unknown manager falls back",
 			json: `{"package_managers":[{"name":"Cargo"}]}`,
 			want: "",


### PR DESCRIPTION
Adds a `dotnet` profile so scans of NuGet/.NET projects can restore dependencies, build, test, and reproduce findings in-place, matching the other language profiles.

`docker/profiles/dotnet/Dockerfile` extends the runner with a pinned .NET 10 LTS SDK from a sha512-verified release tarball (the hash Microsoft publishes in `releases.json`), fetched the same way the runner installs `claude`. It installs the runtime's native dependencies (ICU via the stable `libicu-dev` name so it survives a base-distro bump, plus OpenSSL, zlib, libstdc++, kerberos). The NuGet package cache (`/opt/nuget`) and CLI home (`/opt/dotnet-home`) live under `/opt` because `HOME=/tmp` is a small noexec mount; telemetry and the first-run banner are disabled.

`PROFILE.md` covers restore/build, the reproducer recipe (`dotnet test --filter`, standalone `dotnet run`), and marks restored packages out of scope.

Registers `dotnet` (ecosystem `NuGet`) and covers detection, naming, and the shipped guide in the worker tests. Built locally on the runner image and verified under the worker sandbox (`--user`, `HOME=/tmp`, noexec `/tmp`): a project with NuGet test dependencies restores into `/opt/nuget` and `dotnet test` runs an xUnit test to green.