### PR TITLE
c-cpp profile: add C/C++ analysis runner and guide

### DIFF
--- a/docker/profiles/c-cpp/Dockerfile
+++ b/docker/profiles/c-cpp/Dockerfile
@@ -60,9 +60,11 @@ RUN apt-get update \
         cppcheck \
  # clang ships its sanitizer runtimes (libclang_rt.asan/ubsan/...) in a
  # separate, version-suffixed package; without it `clang -fsanitize=...`
- # fails to link. Derive the suffix from the installed clang so this keeps
- # working as the base distro moves clang forward.
- && clangver="$(clang --version | sed -n 's/.*version \([0-9][0-9]*\).*/\1/p' | head -n1)" \
+ # fails to link. Derive the major version with `clang -dumpversion` (a
+ # stable, machine-readable single value, vs parsing --version prose) so
+ # this keeps working as the base distro moves clang forward.
+ && clangver="$(clang -dumpversion | cut -d. -f1)" \
+ && test -n "$clangver" \
  && apt-get install -y --no-install-recommends "libclang-rt-${clangver}-dev" \
  && rm -rf /var/lib/apt/lists/* \
  && gcc --version \

--- a/docker/profiles/c-cpp/Dockerfile
+++ b/docker/profiles/c-cpp/Dockerfile
@@ -1,0 +1,80 @@
+# C/C++ profile. Extends the scrutineer runner with a C and C++ build and
+# analysis toolchain so scans of native projects can build, run, and
+# reproduce findings -- with AddressSanitizer/UndefinedBehaviorSanitizer,
+# valgrind, and gdb on hand to turn memory-safety bugs into evidence.
+#
+# Unlike the language profiles there is no single package manager to detect
+# (brief reports none for C/C++), so this profile is selected by build-file
+# marker (CMakeLists.txt, Makefile, configure.ac, meson.build) or by name
+# via ?profile=c-cpp. It serves both C and C++; the toolchains overlap
+# almost entirely, so one image covers both.
+#
+# The toolchain is installed from Debian's apt (unpinned, like the php
+# profile's apt packages): these are compilers and analysers, and tracking
+# the distro's current build keeps the profile building as the base moves
+# forward.
+#
+# At runtime the worker builds this on demand (see internal/worker/profile.go:
+# EnsureImage), tagging the result scrutineer-profile-c-cpp:<dockerfile-sha>
+# and passing the configured runner image via --build-arg RUNNER_IMAGE.
+#
+# To build it manually the way the project does, from the repo root:
+#
+#   # 1. Build the base runner image locally (Debian/glibc, ships brief etc.):
+#   docker build -t scrutineer-runner:local -f Dockerfile.runner .
+#
+#   # 2. Build this C/C++ profile on top of that local runner:
+#   docker build -t scrutineer-profile-c-cpp \
+#       -f docker/profiles/c-cpp/Dockerfile \
+#       --build-arg RUNNER_IMAGE=scrutineer-runner:local \
+#       docker/profiles/c-cpp
+#
+#   # 3. Smoke-test it:
+#   docker run --rm --entrypoint sh scrutineer-profile-c-cpp \
+#       -c 'gcc --version && clang --version && cmake --version && valgrind --version'
+
+ARG RUNNER_IMAGE=ghcr.io/alpha-omega-security/scrutineer-runner:latest
+
+FROM ${RUNNER_IMAGE}
+
+USER root
+
+# Sanitizer run-time defaults, so a reproducer built with -fsanitize=...
+# produces clean, useful output rather than aborting on benign noise.
+# Mirrors the php-ext profile.
+ENV ASAN_OPTIONS="symbolize=1:detect_leaks=0:allocator_may_return_null=1:halt_on_error=0:print_summary=1" \
+    UBSAN_OPTIONS="print_stacktrace=1:print_summary=1"
+
+# gcc/g++ and clang (clang adds -fsanitize=fuzzer, =memory, =thread that gcc
+# lacks); cmake/ninja/make/autotools for whatever build system the project
+# uses; gdb + valgrind to investigate crashes and leaks; clang-tidy and
+# cppcheck for static analysis. llvm supplies llvm-symbolizer for readable
+# sanitizer traces.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+        build-essential g++ \
+        clang lld llvm clang-tidy \
+        cmake ninja-build make \
+        autoconf automake libtool pkg-config m4 \
+        gdb valgrind \
+        cppcheck \
+ # clang ships its sanitizer runtimes (libclang_rt.asan/ubsan/...) in a
+ # separate, version-suffixed package; without it `clang -fsanitize=...`
+ # fails to link. Derive the suffix from the installed clang so this keeps
+ # working as the base distro moves clang forward.
+ && clangver="$(clang --version | sed -n 's/.*version \([0-9][0-9]*\).*/\1/p' | head -n1)" \
+ && apt-get install -y --no-install-recommends "libclang-rt-${clangver}-dev" \
+ && rm -rf /var/lib/apt/lists/* \
+ && gcc --version \
+ && g++ --version \
+ && clang --version \
+ && cmake --version \
+ && gdb --version \
+ && valgrind --version \
+ && cppcheck --version \
+ && printf 'int main(){return 0;}\n' > /tmp/t.c \
+ && clang -fsanitize=address,undefined /tmp/t.c -o /tmp/t && /tmp/t \
+ && gcc -fsanitize=address,undefined /tmp/t.c -o /tmp/tg && /tmp/tg \
+ && rm -f /tmp/t.c /tmp/t /tmp/tg
+
+USER runner

--- a/docker/profiles/c-cpp/PROFILE.md
+++ b/docker/profiles/c-cpp/PROFILE.md
@@ -1,0 +1,55 @@
+# C/C++ scanning container
+
+The repository under `./src` is a C or C++ project. The job is to find **security vulnerabilities** in it.
+
+## Runtime
+
+- **gcc / g++** and **clang / clang++** (the default `cc`/`c++` is gcc). clang additionally offers `-fsanitize=fuzzer`, `=memory`, and `=thread`.
+- Build systems: **cmake** (with **ninja**), **make**, and **autotools** (`autoconf`/`automake`/`libtool`/`pkg-config`).
+- Analysis tools: **AddressSanitizer / UndefinedBehaviorSanitizer** (via the compiler flags below), **valgrind**, **gdb**, **clang-tidy**, and **cppcheck**.
+
+## Why the sanitizers
+
+ASan/UBSan turn silent memory corruption and undefined behaviour into loud, pinpointed reports, so you can find bugs in
+C/C++ instead of guessing from static reading. They are detection tooling, not the deliverable. The deliverable is a
+security finding: what the bug is, what an attacker controls, the impact (info disclosure, memory corruption to RCE,
+DoS, type confusion), and a reproducer that shows it.
+
+`ASAN_OPTIONS` and `UBSAN_OPTIONS` are pre-exported with sensible defaults (`detect_leaks=0`, non-fatal so exploration
+continues, readable traces).
+
+## Operating procedure
+
+### Building
+
+Use the project's own build system, adding the sanitizers through the standard flag variables:
+
+```bash
+cd src
+# CMake
+cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug \
+      -DCMAKE_C_FLAGS="-fsanitize=address,undefined -g" \
+      -DCMAKE_CXX_FLAGS="-fsanitize=address,undefined -g" && cmake --build build
+# Make / autotools
+./configure 2>/dev/null; make CFLAGS="-fsanitize=address,undefined -g" CXXFLAGS="-fsanitize=address,undefined -g"
+```
+
+Build with gcc or clang, but link the same compiler you compiled with so the sanitizer runtime matches. If a build
+needs a dependency, install it with `apt-get` without asking. If a fetch fails with a network error the scan is offline
+-- work from the source present and note what you skipped.
+
+### Investigating and reproducing
+
+- Run the built binary (or a focused harness) against attacker-controlled input; quote the ASan/UBSan `SUMMARY:` line
+  plus the relevant top of the stack as evidence, then describe the bug in one line.
+- `valgrind -q ./binary` catches leaks and uninitialised reads the sanitizers may miss; `gdb` for interactive triage.
+- For a standalone case, compile a minimal harness that calls the vulnerable function directly with the malicious input
+  rather than driving the whole program -- minimal is the evidence. With clang you can also build a libFuzzer target
+  (`-fsanitize=fuzzer,address`).
+- `cppcheck` and `clang-tidy` are useful for a quick static pass to surface candidates, but a real finding is one you
+  reproduced by running it here. "Potential RCE" with no demonstrated primitive is a hypothesis -- say so honestly.
+
+## Out of scope
+
+- Vendored or system third-party libraries -- not the target of this scan unless a finding specifically pivots through
+  one.

--- a/internal/worker/profile.go
+++ b/internal/worker/profile.go
@@ -35,9 +35,12 @@ type Profile struct {
 	// "use the default runner image, no per-profile build".
 	Name string
 	// Ecosystem is a `brief` package_managers[].name, matched
-	// case-insensitively. When Ecosystem and Ecosystems are both empty the
-	// profile matches on Markers/AnyMarkers alone — useful for ecosystems
-	// brief cannot see (e.g. a PECL C extension repo without composer.json).
+	// case-insensitively, for runtimes brief can see. A profile needs at
+	// least one of Ecosystem/Ecosystems, Markers, or AnyMarkers: each
+	// matcher treats an empty constraint as "no constraint", so an entry
+	// with all of them empty would match every repo. The registry sanity
+	// test rejects that. Markers/AnyMarkers cover ecosystems brief cannot
+	// see (e.g. a PECL C extension repo without composer.json).
 	Ecosystem string
 	// Ecosystems lists additional `brief` package_managers[].name values
 	// the profile also matches, for ecosystems one runtime serves under

--- a/internal/worker/profile.go
+++ b/internal/worker/profile.go
@@ -36,8 +36,8 @@ type Profile struct {
 	Name string
 	// Ecosystem is a `brief` package_managers[].name, matched
 	// case-insensitively. When Ecosystem and Ecosystems are both empty the
-	// profile matches on Markers alone — useful for ecosystems that brief
-	// cannot see (e.g. a PECL C extension repo without composer.json).
+	// profile matches on Markers/AnyMarkers alone — useful for ecosystems
+	// brief cannot see (e.g. a PECL C extension repo without composer.json).
 	Ecosystem string
 	// Ecosystems lists additional `brief` package_managers[].name values
 	// the profile also matches, for ecosystems one runtime serves under
@@ -45,7 +45,14 @@ type Profile struct {
 	// JVM's Maven and Gradle). The profile matches if any of Ecosystem or
 	// Ecosystems matches.
 	Ecosystems []string
-	Markers    []ProfileMarker
+	// Markers must ALL be present (AND) for the profile to match. Use for a
+	// precise signal, e.g. a config.m4 that contains PHP_ARG_.
+	Markers []ProfileMarker
+	// AnyMarkers match if at least ONE is present (OR). Use when a single
+	// ecosystem has several equally-valid build-file signals and brief
+	// reports no package manager for it — e.g. C/C++ projects built with
+	// CMake, Make, autotools, or meson.
+	AnyMarkers []ProfileMarker
 }
 
 // IsDefault reports whether p falls back to the configured runner image
@@ -90,6 +97,22 @@ var builtinProfiles = []Profile{
 	{Name: "java", Ecosystems: []string{"Maven", "Gradle"}},
 	{Name: "dotnet", Ecosystem: "NuGet"},
 	{Name: "beam", Ecosystems: []string{"Mix", "rebar3"}},
+	{
+		// Last: brief reports no package manager for C/C++, so this is a
+		// fallback for repos that match no language ecosystem above but
+		// carry a native build file. Language repos (which also often have
+		// a Makefile) match their ecosystem first, so this only catches
+		// repos that are actually native.
+		Name: "c-cpp",
+		AnyMarkers: []ProfileMarker{
+			{Path: "CMakeLists.txt"},
+			{Path: "Makefile"},
+			{Path: "GNUmakefile"},
+			{Path: "configure.ac"},
+			{Path: "configure.in"},
+			{Path: "meson.build"},
+		},
+	},
 }
 
 // ProfileByName returns the registered profile, or the default profile
@@ -148,6 +171,9 @@ func matchProfile(briefOut []byte, srcDir string) Profile {
 		if !markersMatch(p.Markers, srcDir) {
 			continue
 		}
+		if !anyMarkersMatch(p.AnyMarkers, srcDir) {
+			continue
+		}
 		return p
 	}
 	return Profile{}
@@ -187,6 +213,31 @@ func markersMatch(markers []ProfileMarker, srcDir string) bool {
 		}
 	}
 	return true
+}
+
+// anyMarkersMatch reports whether at least one marker is present (OR). An
+// empty list matches (the profile imposes no AnyMarkers constraint); a
+// non-empty list with no srcDir cannot match.
+func anyMarkersMatch(markers []ProfileMarker, srcDir string) bool {
+	if len(markers) == 0 {
+		return true
+	}
+	if srcDir == "" {
+		return false
+	}
+	for _, m := range markers {
+		full := filepath.Join(srcDir, m.Path)
+		if m.Contains == "" {
+			if _, err := os.Stat(full); err == nil {
+				return true
+			}
+			continue
+		}
+		if fileContains(full, m.Contains) {
+			return true
+		}
+	}
+	return false
 }
 
 // markerReadCap bounds Contains-substring scans so a hostile or

--- a/internal/worker/profile_test.go
+++ b/internal/worker/profile_test.go
@@ -83,6 +83,15 @@ func writeSetupPy(t *testing.T, dir, contents string) {
 	}
 }
 
+func writeMarkerFile(t *testing.T, dir, name string) {
+	t.Helper()
+	const markerFileMode = 0o644
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte("x\n"), markerFileMode); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
 func TestMatchProfile(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -239,6 +248,38 @@ func TestMatchProfile(t *testing.T) {
 			name: "mix case-insensitive",
 			json: `{"package_managers":[{"name":"mix"}]}`,
 			want: "beam",
+		},
+		{
+			name: "CMakeLists.txt selects c-cpp (no package manager)",
+			json: `{"package_managers":[]}`,
+			setup: func(t *testing.T, dir string) {
+				writeMarkerFile(t, dir, "CMakeLists.txt")
+			},
+			want: "c-cpp",
+		},
+		{
+			name: "Makefile selects c-cpp",
+			json: `{"package_managers":[]}`,
+			setup: func(t *testing.T, dir string) {
+				writeMarkerFile(t, dir, "Makefile")
+			},
+			want: "c-cpp",
+		},
+		{
+			name: "meson.build selects c-cpp",
+			json: `{"package_managers":[]}`,
+			setup: func(t *testing.T, dir string) {
+				writeMarkerFile(t, dir, "meson.build")
+			},
+			want: "c-cpp",
+		},
+		{
+			name: "language ecosystem wins over a c-cpp build file",
+			json: `{"package_managers":[{"name":"Composer"}]}`,
+			setup: func(t *testing.T, dir string) {
+				writeMarkerFile(t, dir, "Makefile")
+			},
+			want: "php",
 		},
 		{
 			name: "truly unknown manager falls back",
@@ -403,8 +444,8 @@ func TestBuiltinProfiles_registrySanity(t *testing.T) {
 			t.Error("profile with empty Name")
 		}
 		ecos := p.allEcosystems()
-		if len(ecos) == 0 && len(p.Markers) == 0 {
-			t.Errorf("profile %q has neither Ecosystem nor Markers", p.Name)
+		if len(ecos) == 0 && len(p.Markers) == 0 && len(p.AnyMarkers) == 0 {
+			t.Errorf("profile %q has no Ecosystem, Markers, or AnyMarkers", p.Name)
 		}
 		if names[p.Name] {
 			t.Errorf("duplicate profile Name %q", p.Name)


### PR DESCRIPTION
Adds a combined C/C++ profile with a build and security-analysis toolchain so scans of native projects can build, run, and reproduce findings with sanitizers on hand.

`docker/profiles/c-cpp/Dockerfile` installs gcc and g++, clang/clang++ with their sanitizer runtimes (`libclang-rt-<ver>-dev`, version derived from the installed clang so it survives a base-distro bump), cmake + ninja, make, autotools, plus valgrind, gdb, clang-tidy, and cppcheck. One image serves both C and C++ since the toolchains overlap almost entirely. `ASAN_OPTIONS`/`UBSAN_OPTIONS` are pre-exported like php-ext.

Detection is the interesting part: `brief` reports no package manager for C/C++. So `Profile` gains an `AnyMarkers` field (OR semantics: match if any one marker is present, vs `Markers` which is AND), and `c-cpp` is registered **last** keyed on `CMakeLists.txt`/`Makefile`/`GNUmakefile`/`configure.ac`/`configure.in`/`meson.build`. Being last, it only catches repos that match no language ecosystem above, so a Go or Python repo that also ships a Makefile still routes to its language profile (there's a test for exactly that). Also selectable by name via `?profile=c-cpp`.

`PROFILE.md` is analysis-oriented like php-ext: why the sanitizers, how to build with ASan/UBSan through the project's own build system (CMake/Make/autotools), and how to turn a sanitizer hit into a reproduced security finding.

Registers `c-cpp` and covers AnyMarkers detection (including that a language ecosystem still wins over a stray Makefile), naming, and the shipped guide in the worker tests. Built locally on the runner image and verified under the worker sandbox (`--user`, `HOME=/tmp`, noexec `/tmp`): gcc and clang ASan both fire on a heap-buffer-overflow, clang UBSan reports a signed-overflow, a CMake+Ninja build runs, and valgrind and cppcheck work.