### PR TITLE
worker: pause scans on Claude token limit instead of failing them

### DIFF
--- a/internal/web/list_performance_test.go
+++ b/internal/web/list_performance_test.go
@@ -47,11 +47,14 @@ func TestScanListStatsAggregatesCounts(t *testing.T) {
 	for _, status := range []db.ScanStatus{db.ScanQueued, db.ScanQueued, db.ScanPaused, db.ScanRunning} {
 		s.DB.Create(&db.Scan{RepositoryID: repo.ID, Kind: "skill", Status: status})
 	}
+	// A scan paused because the account hit the Claude token/credit limit
+	// (auto-paused by the worker), plus an unrelated failure that must not
+	// be counted.
 	s.DB.Create(&db.Scan{
 		RepositoryID: repo.ID,
 		Kind:         "skill",
-		Status:       db.ScanFailed,
-		Error:        "Claude plan limit reached. Pause queued scans and retry after your limit resets.",
+		Status:       db.ScanPaused,
+		Error:        "Claude plan limit reached. Queued scan paused automatically; resume after the limit resets.",
 	})
 	s.DB.Create(&db.Scan{
 		RepositoryID: repo.ID,
@@ -60,9 +63,11 @@ func TestScanListStatsAggregatesCounts(t *testing.T) {
 		Error:        "different failure",
 	})
 
+	// PausedCount counts both the bare paused scan and the plan-limit one;
+	// PlanLimitPausedCount counts only the latter.
 	stats := s.scanListStats()
-	if stats.QueuedCount != 2 || stats.PausedCount != 1 || stats.PlanLimitFailedCount != 1 {
-		t.Fatalf("scanListStats = %+v, want queued=2 paused=1 plan-limit=1", stats)
+	if stats.QueuedCount != 2 || stats.PausedCount != 2 || stats.PlanLimitPausedCount != 1 {
+		t.Fatalf("scanListStats = %+v, want queued=2 paused=2 plan-limit-paused=1", stats)
 	}
 }
 

--- a/internal/web/scans.go
+++ b/internal/web/scans.go
@@ -59,14 +59,14 @@ func (s *Server) jobs(w http.ResponseWriter, r *http.Request) {
 		"Scans": scans, "Page": page,
 		"Skill": skillName, "Status": status, "Sort": sort, "Skills": skillNames,
 		"AnySubPath": anySubPath, "QueuedCount": stats.QueuedCount, "PausedCount": stats.PausedCount,
-		"PlanLimitFailedCount": stats.PlanLimitFailedCount,
+		"PlanLimitPausedCount": stats.PlanLimitPausedCount,
 	})
 }
 
 type scanListStats struct {
 	QueuedCount          int64
 	PausedCount          int64
-	PlanLimitFailedCount int64
+	PlanLimitPausedCount int64
 }
 
 func (s *Server) scanListStats() scanListStats {
@@ -75,10 +75,10 @@ func (s *Server) scanListStats() scanListStats {
 		Select(
 			"COUNT(CASE WHEN status = ? THEN 1 END) AS queued_count, "+
 				"COUNT(CASE WHEN status = ? THEN 1 END) AS paused_count, "+
-				"COUNT(CASE WHEN status = ? AND error LIKE ? THEN 1 END) AS plan_limit_failed_count",
+				"COUNT(CASE WHEN status = ? AND error LIKE ? THEN 1 END) AS plan_limit_paused_count",
 			db.ScanQueued,
 			db.ScanPaused,
-			db.ScanFailed,
+			db.ScanPaused,
 			"Claude plan limit reached.%",
 		).
 		Scan(&stats)

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -3943,17 +3943,18 @@ func TestScanResumePaused(t *testing.T) {
 	}
 }
 
-func TestJobs_showsPlanLimitPauseActions(t *testing.T) {
+func TestJobs_showsPlanLimitResumeActions(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()
 
 	repo := db.Repository{URL: "https://example.com/x.git", Name: "x"}
 	s.DB.Create(&repo)
-	s.DB.Create(&db.Scan{RepositoryID: repo.ID, Kind: "skill", Status: db.ScanQueued, StatusPriority: db.StatusPriorityFor(db.ScanQueued)})
+	// A scan auto-paused because the account hit the Claude token limit. The
+	// banner should surface it and the Resume-paused action should be offered.
 	s.DB.Create(&db.Scan{
-		RepositoryID: repo.ID, Kind: "skill", Status: db.ScanFailed,
-		StatusPriority: db.StatusPriorityFor(db.ScanFailed),
-		Error:          "Claude plan limit reached. Pause queued scans and retry after your limit resets.",
+		RepositoryID: repo.ID, Kind: "skill", Status: db.ScanPaused,
+		StatusPriority: db.StatusPriorityFor(db.ScanPaused),
+		Error:          "Claude plan limit reached. Queued scan paused automatically; resume after the limit resets.",
 	})
 
 	w := httptest.NewRecorder()
@@ -3962,7 +3963,7 @@ func TestJobs_showsPlanLimitPauseActions(t *testing.T) {
 		t.Fatalf("status %d: %s", w.Code, w.Body)
 	}
 	body := w.Body.String()
-	for _, want := range []string{"Claude plan limit reached", "/scans/pause-queued"} {
+	for _, want := range []string{"Claude plan limit reached", "/scans/resume-paused"} {
 		if !strings.Contains(body, want) {
 			t.Errorf("missing %q in jobs body", want)
 		}

--- a/internal/web/templates/jobs.html
+++ b/internal/web/templates/jobs.html
@@ -76,12 +76,12 @@
   </div>
 </div>
 
-{{if and .PlanLimitFailedCount .QueuedCount}}
+{{if .PlanLimitPausedCount}}
   <div class="alert-destructive mb-6">
     <i data-lucide="triangle-alert"></i>
     <section>
       <strong>Claude plan limit reached.</strong>
-      Pause queued scans so they do not keep starting, then resume them after the limit resets.
+      Queued scans were paused automatically. Resume them after the limit resets.
     </section>
   </div>
 {{end}}

--- a/internal/worker/claude_limit.go
+++ b/internal/worker/claude_limit.go
@@ -3,17 +3,18 @@ package worker
 import "strings"
 
 // ClaudePlanLimitError is returned when claude-code reports an account or plan
-// limit rather than a skill failure. The scan still fails, but the UI can show
-// a clear operator action instead of a generic process-exit error.
+// limit rather than a skill failure. The worker pauses the scan (and the rest
+// of the queue) instead of failing it, so the operator resumes the batch once
+// the limit resets rather than retrying each scan.
 type ClaudePlanLimitError struct {
 	Detail string
 }
 
 func (e *ClaudePlanLimitError) Error() string {
 	if e.Detail == "" {
-		return "Claude plan limit reached. Pause queued scans and retry after your limit resets."
+		return "Claude plan limit reached. Queued scans were paused; resume after your limit resets."
 	}
-	return "Claude plan limit reached. Pause queued scans and retry after your limit resets. " + e.Detail
+	return "Claude plan limit reached. Queued scans were paused; resume after your limit resets. " + e.Detail
 }
 
 func claudePlanLimitText(s string) string {

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -368,9 +368,11 @@ func (w *Worker) wrap(h handler) func(context.Context, []byte) error {
 	}
 }
 
-// finalizeScan persists the terminal scan state, fires post-completion
-// hooks, cleans up the workspace, and publishes the status. It returns an
-// error only when the terminal save fails, which wrap propagates to goqite.
+// finalizeScan persists the terminal/paused scan state, fires
+// post-completion hooks, bulk-pauses the rest of the queue when this scan
+// hit a Claude token limit, cleans up the workspace, and publishes the
+// status. It returns an error only when the terminal save fails, which
+// wrap propagates to goqite.
 func (w *Worker) finalizeScan(ctx context.Context, scan *db.Scan, report string, err error, timeout time.Duration, emit func(Event)) error {
 	finishScan(ctx, scan, report, err, timeout, emit)
 	if scan.Status == db.ScanDone && !scan.MaxTurnsHit {
@@ -381,6 +383,9 @@ func (w *Worker) finalizeScan(ctx context.Context, scan *db.Scan, report string,
 		return saveErr
 	}
 	w.maybeFireScanFinalized(scan, err)
+	if _, isLimit := errors.AsType[*ClaudePlanLimitError](err); isLimit && scan.Status == db.ScanPaused {
+		w.pauseQueuedOnTokenLimit(scan.ID)
+	}
 	if scan.Status.Terminal() {
 		if rmErr := os.RemoveAll(w.scanWorkRoot(scan)); rmErr != nil {
 			w.Log.Warn("workspace cleanup failed", "scan", scan.ID, "err", rmErr)
@@ -446,8 +451,44 @@ func finishErroredScan(scan *db.Scan, report string, err error, emit func(Event)
 	case schemaValidation:
 		scan.Report = report
 	case planLimit:
+		// A token/credit limit is not this scan's fault and is recoverable
+		// once the limit resets, so pause rather than fail: the operator
+		// resumes the batch instead of retrying each scan. The remaining
+		// queued scans are paused by the worker loop (pauseQueuedOnTokenLimit).
+		scan.Status = db.ScanPaused
 		emit(Event{Kind: KindError, Text: scan.Error})
 	default:
 		emit(Event{Kind: KindError, Text: scan.Error})
+	}
+}
+
+// tokenLimitPauseReason is recorded on scans auto-paused because another
+// scan hit the account's Claude token/credit limit. It keeps the "Claude
+// plan limit reached." prefix the scans page matches on, so these paused
+// scans surface in the limit banner alongside the one that triggered it.
+const tokenLimitPauseReason = "Claude plan limit reached. Queued scan paused automatically; resume after the limit resets."
+
+// pauseQueuedOnTokenLimit pauses every still-queued scan after one scan
+// hit a Claude token/credit limit. The limit is account-wide, so the rest
+// of the queue would only run into the same wall; pausing keeps the batch
+// intact for a later resume instead of failing it scan by scan. The worker
+// loop drops the now-stale queue jobs when they fire (see wrap), exactly as
+// a manual "pause queued" does, so updating the rows here is enough.
+func (w *Worker) pauseQueuedOnTokenLimit(triggerID uint) {
+	now := time.Now()
+	res := w.DB.Model(&db.Scan{}).
+		Where("status = ?", db.ScanQueued).
+		Updates(map[string]any{
+			"status":          db.ScanPaused,
+			"status_priority": db.StatusPriorityFor(db.ScanPaused),
+			"error":           tokenLimitPauseReason,
+			"finished_at":     &now,
+		})
+	if res.Error != nil {
+		w.Log.Warn("pause-on-token-limit failed", "trigger", triggerID, "err", res.Error)
+		return
+	}
+	if res.RowsAffected > 0 {
+		w.Log.Info("paused queued scans after Claude token limit", "count", res.RowsAffected, "trigger", triggerID)
 	}
 }

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -156,7 +156,7 @@ func TestWorker_maxTurnsReachedCompletesNotFails(t *testing.T) {
 	}
 }
 
-func TestWorker_claudePlanLimitUsesHelpfulError(t *testing.T) {
+func TestWorker_claudePlanLimitPausesScanAndQueue(t *testing.T) {
 	gdb, err := db.Open(filepath.Join(t.TempDir(), "limit.db"))
 	if err != nil {
 		t.Fatal(err)
@@ -167,6 +167,10 @@ func TestWorker_claudePlanLimitUsesHelpfulError(t *testing.T) {
 	gdb.Create(&skill)
 	scan := db.Scan{RepositoryID: repo.ID, Kind: JobSkill, Status: db.ScanQueued, SkillID: &skill.ID}
 	gdb.Create(&scan)
+	// A second queued scan (e.g. from a "scan all subprojects" batch) that
+	// has not started yet; it must be paused, not left to hit the same wall.
+	other := db.Scan{RepositoryID: repo.ID, Kind: JobSkill, Status: db.ScanQueued, SkillID: &skill.ID}
+	gdb.Create(&other)
 
 	w := &Worker{
 		DB:             gdb,
@@ -182,11 +186,20 @@ func TestWorker_claudePlanLimitUsesHelpfulError(t *testing.T) {
 
 	var got db.Scan
 	gdb.First(&got, scan.ID)
-	if got.Status != db.ScanFailed {
-		t.Errorf("status = %s, want failed", got.Status)
+	if got.Status != db.ScanPaused {
+		t.Errorf("triggering scan status = %s, want paused", got.Status)
 	}
 	if !strings.Contains(got.Error, "Claude plan limit reached") {
 		t.Errorf("error = %q", got.Error)
+	}
+
+	var gotOther db.Scan
+	gdb.First(&gotOther, other.ID)
+	if gotOther.Status != db.ScanPaused {
+		t.Errorf("other queued scan status = %s, want paused", gotOther.Status)
+	}
+	if !strings.Contains(gotOther.Error, "Claude plan limit reached") {
+		t.Errorf("other scan error = %q, want plan-limit prefix", gotOther.Error)
 	}
 }
 


### PR DESCRIPTION
Addresses the core of #436: in a bulk run (e.g. Scan all Subprojects), running out of tokens should not fail every scan — they should be kept and resumable.

When a scan hits an account-wide Claude token/credit limit (already detected as `ClaudePlanLimitError` via the stderr/stdout phrase matching in `claude_limit.go`), it is now marked **paused** rather than **failed**, and every other still-queued scan is paused too. Otherwise the rest of the batch would each run straight into the same wall and fail one by one. Pausing keeps the batch intact so the operator hits the existing **Resume paused** action once the limit resets.

Most of the machinery already existed — the `ScanPaused` status, the pause/resume handlers (`scansResumePaused`/`resumeScan`), and the limit detection. This change wires the limit error to a pause:

- `finishErroredScan` sets `ScanPaused` (was leaving it failed)
- the worker loop bulk-pauses the rest of the queue via `pauseQueuedOnTokenLimit`; `wrap()` already drops stale queue jobs whose scan is no longer `queued`, so updating the rows is enough (same mechanism as a manual "Pause queued")
- paused scans keep the `Claude plan limit reached.` error prefix, so the scans page surfaces them: the stat and banner now key on paused-with-limit rather than failed-with-limit and point at Resume
- extracted `persistFinishedScan` from `wrap` to stay under the gocognit cap

Tests: a worker test confirms the triggering scan and a second queued scan both end paused with the limit prefix; the scans-stats and jobs-banner tests are updated for the paused semantics.

Deliberately **not** included, and worth a separate issue/PR: the proactive half of #436 — monitoring the account's credit balance and auto-resuming when tokens return. Anthropic doesn't expose a simple per-account credit-balance API for all plan types, so 'know when credits are back' realistically means a timed retry (plan-limit windows) or operator action; I'd scope that on its own rather than bolt it on here.