### PR TITLE
fix: Fix invisible "Edit" button text in light mode

### DIFF
--- a/internal/web/templates/finding_workflow.html
+++ b/internal/web/templates/finding_workflow.html
@@ -130,7 +130,7 @@
       <i data-lucide="bug" class="size-3.5"></i>
       <span>Exploitation status</span>
       {{if eq .ExploitedInWild "yes"}}<span class="badge-destructive">yes</span>{{else if eq .ExploitedInWild "no"}}<span class="badge-outline">no</span>{{else}}<span>unknown</span>{{end}}
-      <button type="button" data-dialog="exploitation-{{$id}}" class="btn-sm btn-outline ml-auto">
+      <button type="button" data-dialog="exploitation-{{$id}}" class="btn-sm-outline ml-auto">
         <i data-lucide="pencil"></i> Edit
       </button>
     </div>


### PR DESCRIPTION
I didn't test the change I made yesterday in light mode, so I broke this without realizing it 😅 

Before:

<img width="1183" height="85" alt="Screenshot 2026-06-18 at 5 06 13 PM" src="https://github.com/user-attachments/assets/d76cc48a-e082-4f97-bfe1-77517a261020" />

After:

<img width="1183" height="91" alt="Screenshot 2026-06-18 at 5 07 35 PM" src="https://github.com/user-attachments/assets/1954a895-51e6-4a1b-a34b-2fe786d0d515" />
