### PR TITLE
worker: auto-enqueue finding-dedup after deep-dive

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"slices"
 	"strings"
 	"time"
 
@@ -303,6 +304,14 @@ var FindingLifecycles = []FindingLifecycle{
 // ClosedFindingLifecycles are terminal or hidden-by-default findings.
 var ClosedFindingLifecycles = []FindingLifecycle{
 	FindingFixed, FindingPublished, FindingRejected, FindingDuplicate,
+}
+
+// Closed reports whether the lifecycle is terminal or hidden-by-default
+// (fixed, published, rejected, duplicate) — a finding no longer in the
+// active triage funnel. The in-memory counterpart to the "status NOT IN
+// ClosedFindingLifecycles" filter used in queries.
+func (s FindingLifecycle) Closed() bool {
+	return slices.Contains(ClosedFindingLifecycles, s)
 }
 
 func ClosedFindingLifecycleSQLValues() string {

--- a/internal/web/finding_dedup_enqueue.go
+++ b/internal/web/finding_dedup_enqueue.go
@@ -11,8 +11,8 @@ import (
 // See skills/finding-dedup/SKILL.md.
 const findingDedupSkillName = "finding-dedup"
 
-// autoEnqueueFindingDedupAfterDeepDive is wired onto Worker.OnScanDone. The
-// worker calls it once after a scan completes and its findings are
+// autoEnqueueFindingDedupAfterDeepDive is wired onto Worker.OnScanFinalized.
+// The worker calls it once after a scan completes and its findings are
 // committed. We enqueue a repository-scoped finding-dedup run only when both
 // conditions the dedup pass needs to be worth its model spend hold:
 //
@@ -20,10 +20,11 @@ const findingDedupSkillName = "finding-dedup"
 //     finding. Re-observed findings keep the scan_id of the run that first
 //     created them, so counting findings with scan_id == this scan counts
 //     exactly the new rows. Nothing new means nothing fresh to dedup.
-//  2. The repository already held other non-scanner findings before this
-//     scan — open deep-dive/legacy/manual rows from a prior scan, an import
-//     of that kind, or a manual entry. Without something else to compare
-//     the new findings against, dedup has no pairs to consider.
+//  2. The repository now holds at least two open non-scanner findings in
+//     total (the new rows count toward this). Dedup needs a pair to compare,
+//     but the pair need not predate this scan: a first-ever deep-dive that
+//     emits several findings describing the same bug from different subagent
+//     angles is exactly what dedup exists to collapse.
 //
 // "Non-scanner" matches the Findings-tab toggle exactly (nonScannerScanFilter):
 // the cheap tool scanners (semgrep, zizmor) and tool imports (CodeQL, Snyk)
@@ -50,17 +51,17 @@ func (s *Server) autoEnqueueFindingDedupAfterDeepDive(scan *db.Scan) {
 		return
 	}
 
-	var otherNonScanner int64
+	var openNonScanner int64
 	if err := s.DB.Model(&db.Finding{}).
-		Where("repository_id = ? AND scan_id <> ?", scan.RepositoryID, scan.ID).
+		Where("repository_id = ?", scan.RepositoryID).
 		Where(nonScannerScanFilter, deepDiveSkillName).
 		Where("status NOT IN (" + db.ClosedFindingLifecycleSQLValues() + ")").
-		Count(&otherNonScanner).Error; err != nil {
-		s.Log.Warn("auto-enqueue finding-dedup: count existing findings",
+		Count(&openNonScanner).Error; err != nil {
+		s.Log.Warn("auto-enqueue finding-dedup: count open findings",
 			"scan", scan.ID, "repo", scan.RepositoryID, "err", err)
 		return
 	}
-	if otherNonScanner == 0 {
+	if openNonScanner < 2 {
 		return
 	}
 

--- a/internal/web/finding_dedup_enqueue.go
+++ b/internal/web/finding_dedup_enqueue.go
@@ -1,0 +1,95 @@
+package web
+
+import (
+	"context"
+
+	"scrutineer/internal/db"
+)
+
+// findingDedupSkillName is the repository-scoped pass that compares open
+// findings and marks ones describing the same vulnerability as duplicates.
+// See skills/finding-dedup/SKILL.md.
+const findingDedupSkillName = "finding-dedup"
+
+// autoEnqueueFindingDedupAfterDeepDive is wired onto Worker.OnScanDone. The
+// worker calls it once after a scan completes and its findings are
+// committed. We enqueue a repository-scoped finding-dedup run only when both
+// conditions the dedup pass needs to be worth its model spend hold:
+//
+//  1. The scan is a security-deep-dive that produced at least one *new*
+//     finding. Re-observed findings keep the scan_id of the run that first
+//     created them, so counting findings with scan_id == this scan counts
+//     exactly the new rows. Nothing new means nothing fresh to dedup.
+//  2. The repository already held other non-scanner findings before this
+//     scan — open deep-dive/legacy/manual rows from a prior scan, an import
+//     of that kind, or a manual entry. Without something else to compare
+//     the new findings against, dedup has no pairs to consider.
+//
+// "Non-scanner" matches the Findings-tab toggle exactly (nonScannerScanFilter):
+// the cheap tool scanners (semgrep, zizmor) and tool imports (CodeQL, Snyk)
+// do not count. Both counts read committed state rather than threading a
+// tally through the callback, so the decision is independent of parse-time
+// races.
+//
+// Errors are logged and swallowed: failing to enqueue the dedup pass must
+// never fail the upstream scan.
+func (s *Server) autoEnqueueFindingDedupAfterDeepDive(scan *db.Scan) {
+	if scan == nil || scan.SkillName != deepDiveSkillName {
+		return
+	}
+
+	var newFromScan int64
+	if err := s.DB.Model(&db.Finding{}).
+		Where("scan_id = ?", scan.ID).
+		Count(&newFromScan).Error; err != nil {
+		s.Log.Warn("auto-enqueue finding-dedup: count new findings",
+			"scan", scan.ID, "repo", scan.RepositoryID, "err", err)
+		return
+	}
+	if newFromScan == 0 {
+		return
+	}
+
+	var otherNonScanner int64
+	if err := s.DB.Model(&db.Finding{}).
+		Where("repository_id = ? AND scan_id <> ?", scan.RepositoryID, scan.ID).
+		Where(nonScannerScanFilter, deepDiveSkillName).
+		Where("status NOT IN (" + db.ClosedFindingLifecycleSQLValues() + ")").
+		Count(&otherNonScanner).Error; err != nil {
+		s.Log.Warn("auto-enqueue finding-dedup: count existing findings",
+			"scan", scan.ID, "repo", scan.RepositoryID, "err", err)
+		return
+	}
+	if otherNonScanner == 0 {
+		return
+	}
+
+	s.enqueueFindingDedupForRepo(context.Background(), scan.RepositoryID)
+}
+
+// enqueueFindingDedupForRepo looks up the active finding-dedup skill and
+// enqueues a repository-scoped run. No dedup skill registered means no
+// auto-dedup, which is fine; the workflow degrades to leaving duplicates for
+// a human rather than failing the upstream scan. A dedup run already queued
+// or in flight for this repo is a no-op so concurrent deep-dives do not pile
+// up redundant passes.
+func (s *Server) enqueueFindingDedupForRepo(ctx context.Context, repoID uint) {
+	var skill db.Skill
+	if err := s.DB.Where("name = ? AND active = ?", findingDedupSkillName, true).First(&skill).Error; err != nil {
+		return
+	}
+	if s.hasOpenRepoScopedScan(repoID, skill.ID) {
+		return
+	}
+	if _, err := s.enqueueSkillWith(ctx, repoID, skill.ID, ScanOpts{}); err != nil {
+		s.Log.Warn("auto-enqueue finding-dedup",
+			"repo", repoID, "skill", findingDedupSkillName, "err", err)
+	}
+}
+
+// hasOpenRepoScopedScan returns true when a queued or running repository-scoped
+// scan (no finding attached) of the given skill already exists for the repo.
+// Mirrors hasOpenFindingScopedScan for repo-wide passes like finding-dedup.
+func (s *Server) hasOpenRepoScopedScan(repoID, skillID uint) bool {
+	return s.hasOpenScan("repository_id = ? AND skill_id = ? AND finding_id IS NULL", repoID, skillID)
+}

--- a/internal/web/finding_dedup_enqueue.go
+++ b/internal/web/finding_dedup_enqueue.go
@@ -11,6 +11,11 @@ import (
 // See skills/finding-dedup/SKILL.md.
 const findingDedupSkillName = "finding-dedup"
 
+// dedupMinFindings is the fewest open non-scanner findings a repository must
+// hold for a dedup pass to be worth running: dedup compares findings pairwise,
+// so it needs at least a pair.
+const dedupMinFindings = 2
+
 // autoEnqueueFindingDedupAfterDeepDive is wired onto Worker.OnScanFinalized.
 // The worker calls it once after a scan completes and its findings are
 // committed. We enqueue a repository-scoped finding-dedup run only when both
@@ -61,7 +66,7 @@ func (s *Server) autoEnqueueFindingDedupAfterDeepDive(scan *db.Scan) {
 			"scan", scan.ID, "repo", scan.RepositoryID, "err", err)
 		return
 	}
-	if openNonScanner < 2 {
+	if openNonScanner < dedupMinFindings {
 		return
 	}
 

--- a/internal/web/finding_dedup_enqueue_test.go
+++ b/internal/web/finding_dedup_enqueue_test.go
@@ -1,0 +1,170 @@
+package web
+
+import (
+	"testing"
+
+	"scrutineer/internal/db"
+)
+
+// dedupTestSetup creates a repo and an active finding-dedup skill, and
+// returns helpers for creating scans and findings the callback tests act on.
+func dedupTestSetup(t *testing.T) (s *Server, done func(), repoID uint, dedupID uint) {
+	t.Helper()
+	s, done = newTestServer(t)
+	repo := db.Repository{URL: "https://example.com/r", Name: "r"}
+	s.DB.Create(&repo)
+	dedup := db.Skill{Name: "finding-dedup", OutputFile: "report.json", OutputKind: "finding_dedup", Version: 1, Active: true}
+	s.DB.Create(&dedup)
+	return s, done, repo.ID, dedup.ID
+}
+
+func newScan(t *testing.T, s *Server, repoID uint, skillName string) *db.Scan {
+	t.Helper()
+	scan := db.Scan{RepositoryID: repoID, Status: db.ScanDone, SkillName: skillName}
+	s.DB.Create(&scan)
+	return &scan
+}
+
+func newFindingUnder(t *testing.T, s *Server, repoID, scanID uint, status db.FindingLifecycle) {
+	t.Helper()
+	f := db.Finding{ScanID: scanID, RepositoryID: repoID, Title: "t", Severity: "High", Status: status}
+	s.DB.Create(&f)
+}
+
+func dedupQueued(s *Server, repoID, dedupID uint) int64 {
+	var n int64
+	s.DB.Model(&db.Scan{}).
+		Where("repository_id = ? AND skill_id = ? AND status = ?", repoID, dedupID, db.ScanQueued).
+		Count(&n)
+	return n
+}
+
+// TestAutoEnqueueFindingDedup_conditions covers the two gating conditions:
+// the deep dive must produce at least one new finding, and the repo must
+// already hold another open non-scanner finding to compare against.
+func TestAutoEnqueueFindingDedup_conditions(t *testing.T) {
+	cases := []struct {
+		name string
+		// scanSkill is the skill the just-completed scan ran.
+		scanSkill string
+		// newFinding controls whether a fresh finding is attached to the
+		// completed scan (condition 1).
+		newFinding bool
+		// hasPrior, when set, creates a pre-existing finding from an earlier
+		// scan described by priorSkill/priorStatus (condition 2).
+		hasPrior    bool
+		priorSkill  string
+		priorStatus db.FindingLifecycle
+		wantQueued  bool
+	}{
+		{
+			name:       "deep-dive new finding with prior open non-scanner finding",
+			scanSkill:  "security-deep-dive",
+			newFinding: true, hasPrior: true, priorSkill: "security-deep-dive", priorStatus: db.FindingNew,
+			wantQueued: true,
+		},
+		{
+			name:       "prior legacy (empty skill) finding also counts",
+			scanSkill:  "security-deep-dive",
+			newFinding: true, hasPrior: true, priorSkill: "", priorStatus: db.FindingNew,
+			wantQueued: true,
+		},
+		{
+			name:       "no new finding does not enqueue",
+			scanSkill:  "security-deep-dive",
+			newFinding: false, hasPrior: true, priorSkill: "security-deep-dive", priorStatus: db.FindingNew,
+			wantQueued: false,
+		},
+		{
+			name:       "no prior non-scanner finding does not enqueue",
+			scanSkill:  "security-deep-dive",
+			newFinding: true, hasPrior: false,
+			wantQueued: false,
+		},
+		{
+			name:       "prior scanner finding does not count",
+			scanSkill:  "security-deep-dive",
+			newFinding: true, hasPrior: true, priorSkill: "semgrep", priorStatus: db.FindingNew,
+			wantQueued: false,
+		},
+		{
+			name:       "prior import finding does not count",
+			scanSkill:  "security-deep-dive",
+			newFinding: true, hasPrior: true, priorSkill: "CodeQL", priorStatus: db.FindingNew,
+			wantQueued: false,
+		},
+		{
+			name:       "prior closed non-scanner finding does not count",
+			scanSkill:  "security-deep-dive",
+			newFinding: true, hasPrior: true, priorSkill: "security-deep-dive", priorStatus: db.FindingDuplicate,
+			wantQueued: false,
+		},
+		{
+			name:       "non-deep-dive scan does not enqueue",
+			scanSkill:  "semgrep",
+			newFinding: true, hasPrior: true, priorSkill: "security-deep-dive", priorStatus: db.FindingNew,
+			wantQueued: false,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			s, done, repoID, dedupID := dedupTestSetup(t)
+			defer done()
+
+			if c.hasPrior {
+				prior := newScan(t, s, repoID, c.priorSkill)
+				newFindingUnder(t, s, repoID, prior.ID, c.priorStatus)
+			}
+
+			scan := newScan(t, s, repoID, c.scanSkill)
+			if c.newFinding {
+				newFindingUnder(t, s, repoID, scan.ID, db.FindingNew)
+			}
+
+			s.autoEnqueueFindingDedupAfterDeepDive(scan)
+
+			got := dedupQueued(s, repoID, dedupID) > 0
+			if got != c.wantQueued {
+				t.Errorf("queued=%v, want %v", got, c.wantQueued)
+			}
+		})
+	}
+}
+
+func TestAutoEnqueueFindingDedup_doesNotDoubleQueue(t *testing.T) {
+	s, done, repoID, dedupID := dedupTestSetup(t)
+	defer done()
+
+	prior := newScan(t, s, repoID, "security-deep-dive")
+	newFindingUnder(t, s, repoID, prior.ID, db.FindingNew)
+	scan := newScan(t, s, repoID, "security-deep-dive")
+	newFindingUnder(t, s, repoID, scan.ID, db.FindingNew)
+
+	s.autoEnqueueFindingDedupAfterDeepDive(scan)
+	s.autoEnqueueFindingDedupAfterDeepDive(scan)
+
+	if n := dedupQueued(s, repoID, dedupID); n != 1 {
+		t.Errorf("queued = %d, want 1 (re-queue guard)", n)
+	}
+}
+
+func TestAutoEnqueueFindingDedup_gracefulWhenSkillAbsent(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	repo := db.Repository{URL: "https://example.com/r", Name: "r"}
+	s.DB.Create(&repo)
+	// No finding-dedup skill registered: must not panic.
+	prior := newScan(t, s, repo.ID, "security-deep-dive")
+	newFindingUnder(t, s, repo.ID, prior.ID, db.FindingNew)
+	scan := newScan(t, s, repo.ID, "security-deep-dive")
+	newFindingUnder(t, s, repo.ID, scan.ID, db.FindingNew)
+
+	s.autoEnqueueFindingDedupAfterDeepDive(scan)
+}
+
+func TestAutoEnqueueFindingDedup_nilScan(t *testing.T) {
+	s, done, _, _ := dedupTestSetup(t)
+	defer done()
+	s.autoEnqueueFindingDedupAfterDeepDive(nil) // must not panic
+}

--- a/internal/web/finding_dedup_enqueue_test.go
+++ b/internal/web/finding_dedup_enqueue_test.go
@@ -40,69 +40,76 @@ func dedupQueued(s *Server, repoID, dedupID uint) int64 {
 }
 
 // TestAutoEnqueueFindingDedup_conditions covers the two gating conditions:
-// the deep dive must produce at least one new finding, and the repo must
-// already hold another open non-scanner finding to compare against.
+// the deep dive must produce at least one new finding, and the repo must end
+// up with at least two open non-scanner findings to compare against (the new
+// rows count, so a first-ever deep-dive emitting several findings qualifies).
 func TestAutoEnqueueFindingDedup_conditions(t *testing.T) {
 	cases := []struct {
 		name string
 		// scanSkill is the skill the just-completed scan ran.
 		scanSkill string
-		// newFinding controls whether a fresh finding is attached to the
-		// completed scan (condition 1).
-		newFinding bool
+		// newFindings is how many fresh findings are attached to the
+		// completed scan (condition 1 needs at least one).
+		newFindings int
 		// hasPrior, when set, creates a pre-existing finding from an earlier
-		// scan described by priorSkill/priorStatus (condition 2).
+		// scan described by priorSkill/priorStatus (counts toward condition 2).
 		hasPrior    bool
 		priorSkill  string
 		priorStatus db.FindingLifecycle
 		wantQueued  bool
 	}{
 		{
-			name:       "deep-dive new finding with prior open non-scanner finding",
-			scanSkill:  "security-deep-dive",
-			newFinding: true, hasPrior: true, priorSkill: "security-deep-dive", priorStatus: db.FindingNew,
+			name:        "deep-dive new finding with prior open non-scanner finding",
+			scanSkill:   "security-deep-dive",
+			newFindings: 1, hasPrior: true, priorSkill: "security-deep-dive", priorStatus: db.FindingNew,
 			wantQueued: true,
 		},
 		{
-			name:       "prior legacy (empty skill) finding also counts",
-			scanSkill:  "security-deep-dive",
-			newFinding: true, hasPrior: true, priorSkill: "", priorStatus: db.FindingNew,
+			name:        "first-ever deep-dive emitting two new findings",
+			scanSkill:   "security-deep-dive",
+			newFindings: 2, hasPrior: false,
 			wantQueued: true,
 		},
 		{
-			name:       "no new finding does not enqueue",
-			scanSkill:  "security-deep-dive",
-			newFinding: false, hasPrior: true, priorSkill: "security-deep-dive", priorStatus: db.FindingNew,
+			name:        "prior legacy (empty skill) finding also counts",
+			scanSkill:   "security-deep-dive",
+			newFindings: 1, hasPrior: true, priorSkill: "", priorStatus: db.FindingNew,
+			wantQueued: true,
+		},
+		{
+			name:        "no new finding does not enqueue",
+			scanSkill:   "security-deep-dive",
+			newFindings: 0, hasPrior: true, priorSkill: "security-deep-dive", priorStatus: db.FindingNew,
 			wantQueued: false,
 		},
 		{
-			name:       "no prior non-scanner finding does not enqueue",
-			scanSkill:  "security-deep-dive",
-			newFinding: true, hasPrior: false,
+			name:        "single new finding with no other does not enqueue",
+			scanSkill:   "security-deep-dive",
+			newFindings: 1, hasPrior: false,
 			wantQueued: false,
 		},
 		{
-			name:       "prior scanner finding does not count",
-			scanSkill:  "security-deep-dive",
-			newFinding: true, hasPrior: true, priorSkill: "semgrep", priorStatus: db.FindingNew,
+			name:        "prior scanner finding does not count",
+			scanSkill:   "security-deep-dive",
+			newFindings: 1, hasPrior: true, priorSkill: "semgrep", priorStatus: db.FindingNew,
 			wantQueued: false,
 		},
 		{
-			name:       "prior import finding does not count",
-			scanSkill:  "security-deep-dive",
-			newFinding: true, hasPrior: true, priorSkill: "CodeQL", priorStatus: db.FindingNew,
+			name:        "prior import finding does not count",
+			scanSkill:   "security-deep-dive",
+			newFindings: 1, hasPrior: true, priorSkill: "CodeQL", priorStatus: db.FindingNew,
 			wantQueued: false,
 		},
 		{
-			name:       "prior closed non-scanner finding does not count",
-			scanSkill:  "security-deep-dive",
-			newFinding: true, hasPrior: true, priorSkill: "security-deep-dive", priorStatus: db.FindingDuplicate,
+			name:        "prior closed non-scanner finding does not count",
+			scanSkill:   "security-deep-dive",
+			newFindings: 1, hasPrior: true, priorSkill: "security-deep-dive", priorStatus: db.FindingDuplicate,
 			wantQueued: false,
 		},
 		{
-			name:       "non-deep-dive scan does not enqueue",
-			scanSkill:  "semgrep",
-			newFinding: true, hasPrior: true, priorSkill: "security-deep-dive", priorStatus: db.FindingNew,
+			name:        "non-deep-dive scan does not enqueue",
+			scanSkill:   "semgrep",
+			newFindings: 1, hasPrior: true, priorSkill: "security-deep-dive", priorStatus: db.FindingNew,
 			wantQueued: false,
 		},
 	}
@@ -118,7 +125,7 @@ func TestAutoEnqueueFindingDedup_conditions(t *testing.T) {
 			}
 
 			scan := newScan(t, s, repoID, c.scanSkill)
-			if c.newFinding {
+			for i := 0; i < c.newFindings; i++ {
 				newFindingUnder(t, s, repoID, scan.ID, db.FindingNew)
 			}
 

--- a/internal/web/revalidate_enqueue.go
+++ b/internal/web/revalidate_enqueue.go
@@ -3,8 +3,6 @@ package web
 import (
 	"context"
 
-	"gorm.io/gorm"
-
 	"scrutineer/internal/db"
 )
 
@@ -71,11 +69,19 @@ func (s *Server) hasOpenRevalidate(findingID, skillID uint) bool {
 }
 
 func (s *Server) hasOpenFindingScopedScan(findingID, skillID uint) bool {
+	return s.hasOpenScan("finding_id = ? AND skill_id = ?", findingID, skillID)
+}
+
+// hasOpenScan reports whether a queued or running scan matching the given
+// scope predicate already exists. Shared by the finding-scoped and
+// repo-scoped open-scan guards so the "open" definition (queued or running)
+// lives in one place.
+func (s *Server) hasOpenScan(scope string, args ...any) bool {
 	var n int64
 	if err := s.DB.Model(&db.Scan{}).
-		Where("finding_id = ? AND skill_id = ? AND status IN ?",
-			findingID, skillID, []db.ScanStatus{db.ScanQueued, db.ScanRunning}).
-		Count(&n).Error; err != nil && err != gorm.ErrRecordNotFound {
+		Where("status IN ?", []db.ScanStatus{db.ScanQueued, db.ScanRunning}).
+		Where(scope, args...).
+		Count(&n).Error; err != nil {
 		return false
 	}
 	return n > 0

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -249,6 +249,7 @@ func New(gdb *gorm.DB, q *queue.Queue, log *slog.Logger, broker *Broker, w *work
 	if w != nil {
 		w.OnFindingCreated = s.autoEnqueueRevalidate
 		w.OnRevalidateVerdict = s.autoChainVerifyAfterRevalidate
+		w.OnScanFinalized = s.autoEnqueueFindingDedupAfterDeepDive
 	}
 	return s, nil
 }
@@ -876,7 +877,7 @@ func (s *Server) findingToggleCounts(r *http.Request, scanners bool) (int64, int
 	missedWhere = append(missedWhere, "missed_count > 0")
 
 	scannerWhere, scannerArgs := findingIndexWhereSQL(r, true, true)
-	scannerWhere = append(scannerWhere, "scan_id NOT IN (SELECT id FROM scans WHERE skill_name = ? OR skill_name = '' OR skill_name IS NULL)")
+	scannerWhere = append(scannerWhere, scannerScanFilter)
 	scannerArgs = append(scannerArgs, deepDiveSkillName)
 
 	var counts struct {
@@ -899,7 +900,7 @@ func findingIndexWhereSQL(r *http.Request, includeScanners, includeMissed bool) 
 	where := []string{"1 = 1"}
 	var args []any
 	if !includeScanners {
-		where = append(where, "scan_id IN (SELECT id FROM scans WHERE skill_name = ? OR skill_name = '' OR skill_name IS NULL)")
+		where = append(where, nonScannerScanFilter)
 		args = append(args, deepDiveSkillName)
 	}
 	if sev := r.URL.Query().Get("severity"); sev != "" {
@@ -1011,6 +1012,17 @@ const (
 	// deepDiveSkillName is the skill whose reports feed the Summary, Findings
 	// and Threat Model tabs on the repository page.
 	deepDiveSkillName = "security-deep-dive"
+	// nonScannerScanFilter selects findings whose parent scan is the
+	// security-deep-dive scanner, the legacy claude job (empty skill name),
+	// or has no recorded source — everything the UI groups under
+	// "non-scanner". scannerScanFilter is its structural inverse: the cheap
+	// tool scanners (semgrep, zizmor) and imported reports (CodeQL, Snyk,
+	// which carry the tool name as skill_name). Both take deepDiveSkillName
+	// as the single bound parameter; deriving one from the other keeps the
+	// Findings toggle and the dedup auto-enqueue agreeing on what "scanner"
+	// means without a second copy of the subquery to keep in sync.
+	nonScannerScanFilter = "scan_id IN (SELECT id FROM scans WHERE skill_name = ? OR skill_name = '' OR skill_name IS NULL)"
+	scannerScanFilter    = "NOT (" + nonScannerScanFilter + ")"
 	// threatModelSkillName is the skill whose report feeds the Threat Model
 	// tab when present; repos that predate it fall back to the boundaries
 	// section of the deep-dive report so older scans keep rendering.

--- a/internal/worker/skill_parsers.go
+++ b/internal/worker/skill_parsers.go
@@ -875,6 +875,17 @@ func (w *Worker) parseRevalidateOutput(scan *db.Scan, report string, emit func(E
 		return fmt.Errorf("load finding %d: %w", *scan.FindingID, err)
 	}
 
+	// Skip findings that have left the active funnel. A concurrent
+	// finding-dedup pass (or an analyst) may have closed this finding
+	// between enqueue and run; revalidating it would promote new->enriched,
+	// cache a verdict, and chain a verify run on a finding nobody will look
+	// at — wasted spend, and the promotion would clobber a just-applied
+	// duplicate status back to enriched.
+	if f.Status.Closed() {
+		emit(Event{Kind: KindText, Text: fmt.Sprintf("finding %d is %s; skipping revalidate", f.ID, f.Status)})
+		return nil
+	}
+
 	// Cache the verdict on the finding so the audit queue can filter
 	// without scanning finding_notes (#362). Written before the status
 	// transition so a true_positive promotion sits on top of the verdict
@@ -998,13 +1009,11 @@ func (w *Worker) dedupFinding(repoID, findingID uint) (db.Finding, bool) {
 	return f, true
 }
 
+// dedupCandidateOpen reports whether a finding is still in the active funnel
+// and so eligible to be marked (or kept as) a duplicate. The complement of
+// db.FindingLifecycle.Closed.
 func dedupCandidateOpen(status db.FindingLifecycle) bool {
-	switch status {
-	case db.FindingNew, db.FindingEnriched, db.FindingTriaged, db.FindingReady, db.FindingReported, db.FindingAcknowledged:
-		return true
-	default:
-		return false
-	}
+	return !status.Closed()
 }
 
 func (w *Worker) addDedupNote(duplicateID, canonicalID uint, reason string) error {

--- a/internal/worker/skill_parsers_test.go
+++ b/internal/worker/skill_parsers_test.go
@@ -556,6 +556,23 @@ func TestParseTimeField_emitsOnUnparseable(t *testing.T) {
 	}
 }
 
+func TestParseRevalidate_skipsClosedFinding(t *testing.T) {
+	// A concurrent finding-dedup pass may close the finding between enqueue
+	// and run. Revalidate must not promote it, cache a verdict, or chain a
+	// verify on it.
+	report := `{"verdict":"true_positive","reason":"sink still reachable"}`
+	f, gdb := runSkillWithFinding(t, "revalidate", report, db.FindingDuplicate)
+	if f.Status != db.FindingDuplicate {
+		t.Errorf("status = %s, want duplicate (unchanged)", f.Status)
+	}
+	if f.LastRevalidateVerdict != "" {
+		t.Errorf("last_revalidate_verdict = %q, want empty (no write on closed finding)", f.LastRevalidateVerdict)
+	}
+	if notes := findingNotes(gdb, f.ID); len(notes) != 0 {
+		t.Errorf("want no notes on a skipped finding, got %+v", notes)
+	}
+}
+
 func TestParseRevalidate_falsePositiveDoesNotAutoReject(t *testing.T) {
 	report := `{"verdict":"false_positive","reason":"the path lives under test/ fixtures; threat model disclaims it"}`
 	f, gdb := runSkillWithFinding(t, "revalidate", report, db.FindingNew)

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -85,7 +85,18 @@ type Worker struct {
 	// lower than the original claim, and the chain to verify uses the
 	// revised value.
 	OnRevalidateVerdict func(scan *db.Scan, finding *db.Finding, verdict, severity string)
-	ScanTimeout         time.Duration
+	// OnScanFinalized, when non-nil, is called once after a scan finishes its
+	// analysis with findings committed and the worker has no further writes
+	// to make for the scan — that is, ScanDone or a fail_on-threshold
+	// failure (which still persists findings). Named "finalized" rather than
+	// "done" precisely because it also fires on that failure path. The web
+	// layer wires it up to auto-enqueue a repository-scoped finding-dedup
+	// pass after a security-deep-dive run adds new findings to a repo that
+	// already holds other non-scanner findings. Firing post-commit means the
+	// dedup run sees the full finding set, and the worker has no queue access
+	// of its own so this callback is the seam.
+	OnScanFinalized func(scan *db.Scan)
+	ScanTimeout     time.Duration
 
 	// Queue is the queue this worker is registered on. Required for the
 	// prereq gate to re-enqueue a scan whose upstream skills have not yet
@@ -361,6 +372,17 @@ func (w *Worker) wrap(h handler) func(context.Context, []byte) error {
 		scan.StatusPriority = db.StatusPriorityFor(scan.Status)
 		if saveErr := w.DB.Save(&scan).Error; saveErr != nil {
 			return saveErr
+		}
+		if w.OnScanFinalized != nil {
+			// Fire after a scan finishes its analysis with findings
+			// committed. A fail_on threshold leaves Status=ScanFailed but the
+			// findings are already persisted (see finishErroredScan), so a
+			// deep-dive that trips fail_on must still trigger downstream
+			// dedup — exactly the high-severity case we most want deduped.
+			_, failOnThreshold := errors.AsType[*FailOnThresholdError](err)
+			if scan.Status == db.ScanDone || failOnThreshold {
+				w.OnScanFinalized(&scan)
+			}
 		}
 		if scan.Status.Terminal() {
 			if rmErr := os.RemoveAll(w.scanWorkRoot(&scan)); rmErr != nil {

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -364,34 +364,45 @@ func (w *Worker) wrap(h handler) func(context.Context, []byte) error {
 		emit := w.scanEmitter(&scan)
 
 		report, err := h(ctx, &scan, emit)
+		return w.finalizeScan(ctx, &scan, report, err, timeout, emit)
+	}
+}
 
-		finishScan(ctx, &scan, report, err, timeout, emit)
-		if scan.Status == db.ScanDone && !scan.MaxTurnsHit {
-			w.clearSessionStore(&scan)
+// finalizeScan persists the terminal scan state, fires post-completion
+// hooks, cleans up the workspace, and publishes the status. It returns an
+// error only when the terminal save fails, which wrap propagates to goqite.
+func (w *Worker) finalizeScan(ctx context.Context, scan *db.Scan, report string, err error, timeout time.Duration, emit func(Event)) error {
+	finishScan(ctx, scan, report, err, timeout, emit)
+	if scan.Status == db.ScanDone && !scan.MaxTurnsHit {
+		w.clearSessionStore(scan)
+	}
+	scan.StatusPriority = db.StatusPriorityFor(scan.Status)
+	if saveErr := w.DB.Save(scan).Error; saveErr != nil {
+		return saveErr
+	}
+	w.maybeFireScanFinalized(scan, err)
+	if scan.Status.Terminal() {
+		if rmErr := os.RemoveAll(w.scanWorkRoot(scan)); rmErr != nil {
+			w.Log.Warn("workspace cleanup failed", "scan", scan.ID, "err", rmErr)
 		}
-		scan.StatusPriority = db.StatusPriorityFor(scan.Status)
-		if saveErr := w.DB.Save(&scan).Error; saveErr != nil {
-			return saveErr
-		}
-		if w.OnScanFinalized != nil {
-			// Fire after a scan finishes its analysis with findings
-			// committed. A fail_on threshold leaves Status=ScanFailed but the
-			// findings are already persisted (see finishErroredScan), so a
-			// deep-dive that trips fail_on must still trigger downstream
-			// dedup — exactly the high-severity case we most want deduped.
-			_, failOnThreshold := errors.AsType[*FailOnThresholdError](err)
-			if scan.Status == db.ScanDone || failOnThreshold {
-				w.OnScanFinalized(&scan)
-			}
-		}
-		if scan.Status.Terminal() {
-			if rmErr := os.RemoveAll(w.scanWorkRoot(&scan)); rmErr != nil {
-				w.Log.Warn("workspace cleanup failed", "scan", scan.ID, "err", rmErr)
-			}
-		}
-		w.publish(scan.ID, scan.RepositoryID, "scan-status", string(scan.Status))
-		w.Log.Info("job finished", "scan", scan.ID, "kind", scan.Kind, "status", scan.Status)
-		return nil
+	}
+	w.publish(scan.ID, scan.RepositoryID, "scan-status", string(scan.Status))
+	w.Log.Info("job finished", "scan", scan.ID, "kind", scan.Kind, "status", scan.Status)
+	return nil
+}
+
+// maybeFireScanFinalized invokes the OnScanFinalized hook once a scan has
+// finished its analysis with findings committed. A fail_on threshold leaves
+// Status=ScanFailed but the findings are already persisted (see
+// finishErroredScan), so a deep-dive that trips fail_on must still trigger
+// downstream dedup — exactly the high-severity case we most want deduped.
+func (w *Worker) maybeFireScanFinalized(scan *db.Scan, runErr error) {
+	if w.OnScanFinalized == nil {
+		return
+	}
+	_, failOnThreshold := errors.AsType[*FailOnThresholdError](runErr)
+	if scan.Status == db.ScanDone || failOnThreshold {
+		w.OnScanFinalized(scan)
 	}
 }
 


### PR DESCRIPTION
Generated with Claude Code, reviewed and tested by me.

## What

Auto-runs the `finding-dedup` skill after a `security-deep-dive` scan completes, and hardens the concurrent revalidate/dedup interaction.

### Commit 1 — auto-enqueue finding-dedup after deep-dive
Wires `autoEnqueueFindingDedupAfterDeepDive` onto `Worker.OnScanFinalized`. After a deep-dive scan finalizes (and its findings are committed), enqueue a repo-scoped dedup run **only when both** hold:

1. The deep-dive produced at least one *new* finding (re-observed findings keep their original `scan_id`, so `scan_id == this scan` counts exactly the new rows).
2. The repo already held another *open non-scanner* finding to compare against — matching the Findings-tab toggle exactly (`nonScannerScanFilter`): deep-dive/legacy/manual only; the cheap scanners (semgrep, zizmor) and tool imports (CodeQL, Snyk) do **not** count.

Both counts read committed DB state rather than threading a tally through the callback, so the decision is independent of parse-time races. A dedup run already queued/in-flight for the repo is a no-op. Enqueue errors are logged and swallowed so they never fail the upstream scan.

`OnScanFinalized` fires on `ScanDone` **or** a `FailOnThresholdError` (fail_on still commits findings).

### Commit 2 — skip revalidate on findings that have left the active funnel
A finding-scoped revalidate and the repo-scoped dedup can run concurrently (worker concurrency = 4). If dedup marks a finding `duplicate` first, a later revalidate would promote it `new->enriched`, cache a verdict, and chain a verify run on a finding nobody will look at — clobbering the duplicate status and wasting spend.

`parseRevalidateOutput` now bails when the loaded finding is closed. Adds `db.FindingLifecycle.Closed()` (the in-memory counterpart to the `status NOT IN ClosedFindingLifecycles` SQL filter) and refactors the dedup-side `dedupCandidateOpen` to its complement, so both skills share one definition of "open".

## Race notes
No data-corruption risk: SQLite (WAL + `busy_timeout`) serializes writers, and both skills write through `WriteFindingField` (targeted single-column `UPDATE`, not whole-row `Save`). Commit 2 closes the more damaging half of the lost-update window on the shared `status` column. The symmetric ordering (revalidate's `enriched` landing after dedup's `duplicate`) remains last-writer-wins; fully closing it would need a status-guarded CAS in `WriteFindingField`, left as a follow-up since it touches shared infrastructure.

## Tests
- `internal/web`: table test covering both gating conditions, scanner/import/closed exclusion, non-deep-dive skip, double-queue guard, absent-skill graceful, nil scan.
- `internal/worker`: `TestParseRevalidate_skipsClosedFinding`.
- Full `db` / `worker` / `web` suites, `go build`, and `go vet` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)