### PR TITLE
feat: Skip `dependents` job when `packages` comes back with no published packages

### DIFF
--- a/internal/worker/preflight.go
+++ b/internal/worker/preflight.go
@@ -19,6 +19,14 @@
 // reached a terminal failed/cancelled state the dependent fails
 // immediately rather than burning the retry budget waiting on
 // something that will not recover on its own.
+//
+// One content-aware special case sits on top of the generic rule: the
+// dependents skill is meaningful only when the repository publishes a
+// package. Once its packages prereq is satisfied, if packages ran but
+// produced no Package rows the dependents scan is marked a no-op done
+// rather than dispatched, sparing an agent run that could only emit an
+// empty result. dependents is the sole skill that requires packages, so
+// this stays a name-keyed check here instead of generic machinery.
 
 package worker
 
@@ -31,11 +39,15 @@ import (
 	"scrutineer/internal/skills"
 )
 
-// preflightSkill checks the skill's declared prereqs and decides whether
-// to dispatch now, re-enqueue with a delay, or fail the scan. Returns
-// (deferred, err): deferred=true means the caller should return without
-// running the handler; the scan stays at status queued and a delayed
-// copy of the job is back on the queue.
+// preflightSkill checks the skill's declared prereqs and decides what to
+// do with the scan. Returns (deferred, err): deferred=true means the
+// caller should return without running the handler. There are four
+// outcomes: dispatch now (false, nil); re-enqueue with a delay while a
+// prereq is still in flight (true, nil + a delayed copy back on the
+// queue); fail the scan when a prereq has irrecoverably failed
+// (true, nil); and skip the scan as a no-op done when the dependents
+// skill's `packages` prereq completed but found no published packages
+// (true, nil) — see skipScanNoPackages.
 func (w *Worker) preflightSkill(ctx context.Context, scan *db.Scan, attempt int) (bool, error) {
 	if scan.SkillID == nil {
 		return false, nil
@@ -55,6 +67,15 @@ func (w *Worker) preflightSkill(ctx context.Context, scan *db.Scan, attempt int)
 		return true, nil
 	}
 	if len(pending) == 0 {
+		// Prereqs satisfied. The dependents skill still has nothing to do
+		// when its packages prereq ran and found no published package —
+		// skip it as a no-op rather than burning an agent run. dependents
+		// is the only skill that requires packages, so keying on the name
+		// keeps this content-aware gate out of the generic path.
+		if skill.Name == "dependents" && w.packagesRanButEmpty(scan.RepositoryID) {
+			w.skipScanNoPackages(scan, skill.Name)
+			return true, nil
+		}
 		return false, nil
 	}
 
@@ -154,6 +175,72 @@ func (w *Worker) unsatisfiedPrereqs(repoID uint, names []string) (pending, dead 
 		}
 	}
 	return pending, dead
+}
+
+// packagesRanButEmpty reports whether the `packages` skill has a done
+// scan for the repository yet produced zero Package rows — i.e. the repo
+// publishes nothing. parsePackagesOutput commits Package rows before the
+// packages scan is marked done, so done+zero-rows reliably means "ran and
+// found nothing" with no read race. Returns false when packages has no
+// done scan: zero rows there means "not yet known", not "no packages", and
+// must not trigger a skip — the gated skill dispatches as it does today and
+// self-gates if packages later turns up empty.
+//
+// An in-flight packages scan (queued/running/paused) also returns false even
+// though an earlier done scan exists. On a re-scan the satisfied prereq is the
+// previous commit's done scan, while the current commit's packages run is
+// mid-flight: parsePackagesOutput deletes then re-creates Package rows in two
+// non-transactional calls, so the row count is momentarily zero while the new
+// run parses. Skipping in that window would wrongly drop a publishing library's
+// dependents. Deferring instead lets the fresh packages run finish; dependents
+// then re-checks against a stable count.
+func (w *Worker) packagesRanButEmpty(repoID uint) bool {
+	var done int64
+	w.DB.Model(&db.Scan{}).
+		Where("repository_id = ? AND skill_name = ? AND status = ?", repoID, "packages", db.ScanDone).
+		Count(&done)
+	if done == 0 {
+		return false
+	}
+	var live int64
+	w.DB.Model(&db.Scan{}).
+		Where("repository_id = ? AND skill_name = ? AND status IN ?",
+			repoID, "packages", []db.ScanStatus{db.ScanQueued, db.ScanRunning, db.ScanPaused}).
+		Count(&live)
+	if live > 0 {
+		return false
+	}
+	var pkgs int64
+	w.DB.Model(&db.Package{}).Where("repository_id = ?", repoID).Count(&pkgs)
+	return pkgs == 0
+}
+
+// skipScanNoPackages marks a gated scan as a no-op done: its packages
+// prereq completed but the repository publishes no packages, so the skill
+// (dependents) has nothing to do. Terminal and not requeued — the same
+// shape as failScanPrereqs but a success status, so anything that
+// `requires` this skill downstream stays satisfied rather than blocked.
+//
+// Deliberately leaves Error empty. This is a successful no-op, not a
+// failure, and Error renders as a destructive alert (scan_show.html) and an
+// "### Error" section (scan_report.go) — both of which would misrepresent
+// the skip as a failure. The outcome is identical to dependents running and
+// finding nothing: a done scan with no findings. The reason is recorded in
+// the log line below for operators who need it.
+func (w *Worker) skipScanNoPackages(scan *db.Scan, skillName string) {
+	now := time.Now()
+	scan.Status = db.ScanDone
+	scan.StatusPriority = db.StatusPriorityFor(db.ScanDone)
+	scan.StartedAt = &now
+	scan.FinishedAt = &now
+	if err := w.DB.Save(scan).Error; err != nil {
+		w.Log.Error("save skipped-no-packages scan",
+			"scan", scan.ID, "skill", skillName, "err", err)
+		return
+	}
+	w.publish(scan.ID, scan.RepositoryID, "scan-status", string(scan.Status))
+	w.Log.Info("scan skipped: repository publishes no packages",
+		"scan", scan.ID, "skill", skillName)
 }
 
 func (w *Worker) failScanPrereqs(scan *db.Scan, skillName, msg string, missing []string) {

--- a/internal/worker/preflight.go
+++ b/internal/worker/preflight.go
@@ -20,13 +20,19 @@
 // immediately rather than burning the retry budget waiting on
 // something that will not recover on its own.
 //
-// One content-aware special case sits on top of the generic rule: the
-// dependents skill is meaningful only when the repository publishes a
-// package. Once its packages prereq is satisfied, if packages ran but
-// produced no Package rows the dependents scan is marked a no-op done
-// rather than dispatched, sparing an agent run that could only emit an
-// empty result. dependents is the sole skill that requires packages, so
-// this stays a name-keyed check here instead of generic machinery.
+// Two content-aware special cases sit on top of the generic rule for the
+// dependents skill, which is meaningful only when the repository publishes
+// a package:
+//  1. A packages re-scan is in progress (done scan + live scan): Package
+//     rows are mid delete-recreate, so a zero count is "parsing" not
+//     "empty". Treat packages as pending so dependents defers until the
+//     re-scan settles.
+//  2. packages ran and produced no Package rows: skip dependents as a
+//     no-op done, sparing an agent run that could only emit an empty
+//     result.
+//
+// dependents is the sole skill that requires packages, so both checks
+// stay name-keyed here instead of in generic machinery.
 
 package worker
 
@@ -67,16 +73,23 @@ func (w *Worker) preflightSkill(ctx context.Context, scan *db.Scan, attempt int)
 		return true, nil
 	}
 	if len(pending) == 0 {
-		// Prereqs satisfied. The dependents skill still has nothing to do
-		// when its packages prereq ran and found no published package —
-		// skip it as a no-op rather than burning an agent run. dependents
-		// is the only skill that requires packages, so keying on the name
-		// keeps this content-aware gate out of the generic path.
-		if skill.Name == "dependents" && w.packagesRanButEmpty(scan.RepositoryID) {
-			w.skipScanNoPackages(scan, skill.Name)
-			return true, nil
+		// Prereqs satisfied. Apply the two content-aware dependents checks
+		// (see file header). The rescan check must come first: during a
+		// re-scan Package rows are momentarily zero (mid delete-recreate),
+		// so packagesRanButEmpty would fire falsely if called in that
+		// window. Appending "packages" to pending lets the defer machinery
+		// below re-enqueue dependents until the re-scan settles.
+		if skill.Name == "dependents" {
+			if w.packagesRescanInFlight(scan.RepositoryID) {
+				pending = append(pending, "packages")
+			} else if w.packagesRanButEmpty(scan.RepositoryID) {
+				w.skipScanNoPackages(scan, skill.Name)
+				return true, nil
+			}
 		}
-		return false, nil
+		if len(pending) == 0 {
+			return false, nil
+		}
 	}
 
 	maxAttempts := w.MaxPrereqAttempts
@@ -177,24 +190,13 @@ func (w *Worker) unsatisfiedPrereqs(repoID uint, names []string) (pending, dead 
 	return pending, dead
 }
 
-// packagesRanButEmpty reports whether the `packages` skill has a done
-// scan for the repository yet produced zero Package rows — i.e. the repo
-// publishes nothing. parsePackagesOutput commits Package rows before the
-// packages scan is marked done, so done+zero-rows reliably means "ran and
-// found nothing" with no read race. Returns false when packages has no
-// done scan: zero rows there means "not yet known", not "no packages", and
-// must not trigger a skip — the gated skill dispatches as it does today and
-// self-gates if packages later turns up empty.
-//
-// An in-flight packages scan (queued/running/paused) also returns false even
-// though an earlier done scan exists. On a re-scan the satisfied prereq is the
-// previous commit's done scan, while the current commit's packages run is
-// mid-flight: parsePackagesOutput deletes then re-creates Package rows in two
-// non-transactional calls, so the row count is momentarily zero while the new
-// run parses. Skipping in that window would wrongly drop a publishing library's
-// dependents. Deferring instead lets the fresh packages run finish; dependents
-// then re-checks against a stable count.
-func (w *Worker) packagesRanButEmpty(repoID uint) bool {
+// packagesRescanInFlight reports whether a packages re-scan is in progress:
+// a prior done scan satisfies the prereq while a new run is still live
+// (queued/running/paused). During this window parsePackagesOutput has deleted
+// the old Package rows and not yet committed the new ones, so the row count is
+// momentarily zero even for a repo that publishes packages. Callers must check
+// this before packagesRanButEmpty; see preflightSkill.
+func (w *Worker) packagesRescanInFlight(repoID uint) bool {
 	var done int64
 	w.DB.Model(&db.Scan{}).
 		Where("repository_id = ? AND skill_name = ? AND status = ?", repoID, "packages", db.ScanDone).
@@ -207,7 +209,25 @@ func (w *Worker) packagesRanButEmpty(repoID uint) bool {
 		Where("repository_id = ? AND skill_name = ? AND status IN ?",
 			repoID, "packages", []db.ScanStatus{db.ScanQueued, db.ScanRunning, db.ScanPaused}).
 		Count(&live)
-	if live > 0 {
+	return live > 0
+}
+
+// packagesRanButEmpty reports whether the `packages` skill has a done scan for
+// the repository yet produced zero Package rows — i.e. the repo publishes
+// nothing. parsePackagesOutput commits Package rows before the packages scan is
+// marked done, so done+zero-rows reliably means "ran and found nothing" with no
+// read race. Returns false when packages has no done scan: zero rows there means
+// "not yet known", not "no packages".
+//
+// Callers must check packagesRescanInFlight first. During a re-scan Package rows
+// are momentarily zero (mid delete-recreate), so this function would incorrectly
+// return true in that window.
+func (w *Worker) packagesRanButEmpty(repoID uint) bool {
+	var done int64
+	w.DB.Model(&db.Scan{}).
+		Where("repository_id = ? AND skill_name = ? AND status = ?", repoID, "packages", db.ScanDone).
+		Count(&done)
+	if done == 0 {
 		return false
 	}
 	var pkgs int64

--- a/internal/worker/preflight_test.go
+++ b/internal/worker/preflight_test.go
@@ -407,12 +407,12 @@ func TestPreflightSkill_dependentsDispatchesWhenPackagesFound(t *testing.T) {
 	}
 }
 
-func TestPreflightSkill_dependentsDispatchesWhenPackagesRescanInFlight(t *testing.T) {
+func TestPreflightSkill_dependentsDeferredWhenPackagesRescanInFlight(t *testing.T) {
 	// Re-scan window: an earlier commit's packages scan is done (satisfying
 	// the prereq) while the current commit's packages run is in flight. The
 	// parser deletes-then-recreates Package rows non-transactionally, so a
 	// zero row count here is "mid-parse", not "no packages". The gate must
-	// NOT skip — dispatch and let the fresh packages run settle.
+	// defer — not skip and not dispatch — until the re-scan settles.
 	w := newPreflightWorker(t)
 	scan := seedDependentsScan(t, w)
 	pkgSkill := seedPrereqSkill(t, w, "packages", true)
@@ -425,8 +425,8 @@ func TestPreflightSkill_dependentsDispatchesWhenPackagesRescanInFlight(t *testin
 	if err != nil {
 		t.Fatal(err)
 	}
-	if deferred {
-		t.Fatal("dependents must dispatch (not skip) while a packages re-scan is in flight")
+	if !deferred {
+		t.Fatal("dependents must defer (not dispatch or skip) while a packages re-scan is in flight")
 	}
 
 	var loaded db.Scan
@@ -434,7 +434,7 @@ func TestPreflightSkill_dependentsDispatchesWhenPackagesRescanInFlight(t *testin
 		t.Fatal(err)
 	}
 	if loaded.Status != db.ScanQueued {
-		t.Errorf("scan status = %q, want queued (dispatch leaves it for the handler), not skipped to done", loaded.Status)
+		t.Errorf("scan status = %q, want queued (deferred, not skipped to done)", loaded.Status)
 	}
 }
 

--- a/internal/worker/preflight_test.go
+++ b/internal/worker/preflight_test.go
@@ -322,3 +322,143 @@ func TestPreflightSkill_failedPrereqWithRetryInFlightDefers(t *testing.T) {
 		t.Errorf("scan status = %q, want queued (defer while retry is in flight)", loaded.Status)
 	}
 }
+
+// seedDependentsScan seeds a queued scan for a skill literally named
+// "dependents" that requires "packages" — the name-keyed content gate in
+// preflightSkill only fires for this skill.
+func seedDependentsScan(t *testing.T, w *Worker) *db.Scan {
+	t.Helper()
+	repo := db.Repository{URL: "https://example.com/repo", Name: "repo"}
+	if err := w.DB.Create(&repo).Error; err != nil {
+		t.Fatal(err)
+	}
+	skill := db.Skill{Name: "dependents", Body: "x", Requires: "packages"}
+	if err := w.DB.Create(&skill).Error; err != nil {
+		t.Fatal(err)
+	}
+	scan := db.Scan{
+		RepositoryID: repo.ID,
+		Kind:         JobSkill,
+		Status:       db.ScanQueued,
+		SkillName:    skill.Name,
+	}
+	scan.SkillID = &skill.ID
+	if err := w.DB.Create(&scan).Error; err != nil {
+		t.Fatal(err)
+	}
+	return &scan
+}
+
+func TestPreflightSkill_dependentsSkippedWhenPackagesEmpty(t *testing.T) {
+	// packages ran (done) but found no published package, so dependents
+	// has nothing to do: mark it a no-op done rather than dispatch.
+	w := newPreflightWorker(t)
+	scan := seedDependentsScan(t, w)
+	seedPrereqSkillAndDoneScan(t, w, scan.RepositoryID, "packages")
+
+	deferred, err := w.preflightSkill(context.Background(), scan, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !deferred {
+		t.Fatal("dependents on a no-packages repo should be skipped, not dispatched")
+	}
+
+	var loaded db.Scan
+	if err := w.DB.First(&loaded, scan.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if loaded.Status != db.ScanDone {
+		t.Errorf("scan status = %q, want done (no-op skip)", loaded.Status)
+	}
+	// A skip is a successful no-op, not a failure. Error must stay empty so
+	// the UI does not render the done scan as a destructive alert; the reason
+	// lives in the worker log instead.
+	if loaded.Error != "" {
+		t.Errorf("skipped scan should leave Error empty, got %q", loaded.Error)
+	}
+}
+
+func TestPreflightSkill_dependentsDispatchesWhenPackagesFound(t *testing.T) {
+	// packages ran and found a published package, so dependents has work
+	// to do and must dispatch as before.
+	w := newPreflightWorker(t)
+	scan := seedDependentsScan(t, w)
+	seedPrereqSkillAndDoneScan(t, w, scan.RepositoryID, "packages")
+	pkg := db.Package{RepositoryID: scan.RepositoryID, Name: "lib", Ecosystem: "rubygems"}
+	if err := w.DB.Create(&pkg).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	deferred, err := w.preflightSkill(context.Background(), scan, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if deferred {
+		t.Fatal("dependents must dispatch when the repo publishes packages")
+	}
+
+	var loaded db.Scan
+	if err := w.DB.First(&loaded, scan.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if loaded.Status != db.ScanQueued {
+		t.Errorf("scan status = %q, want queued (dispatch leaves it for the handler)", loaded.Status)
+	}
+}
+
+func TestPreflightSkill_dependentsDispatchesWhenPackagesRescanInFlight(t *testing.T) {
+	// Re-scan window: an earlier commit's packages scan is done (satisfying
+	// the prereq) while the current commit's packages run is in flight. The
+	// parser deletes-then-recreates Package rows non-transactionally, so a
+	// zero row count here is "mid-parse", not "no packages". The gate must
+	// NOT skip — dispatch and let the fresh packages run settle.
+	w := newPreflightWorker(t)
+	scan := seedDependentsScan(t, w)
+	pkgSkill := seedPrereqSkill(t, w, "packages", true)
+	seedPrereqScan(t, w, pkgSkill, scan.RepositoryID, db.ScanDone)    // prior commit
+	seedPrereqScan(t, w, pkgSkill, scan.RepositoryID, db.ScanRunning) // current commit, mid-flight
+	// Zero Package rows: the running re-scan has deleted the old rows and not
+	// yet committed the new ones.
+
+	deferred, err := w.preflightSkill(context.Background(), scan, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if deferred {
+		t.Fatal("dependents must dispatch (not skip) while a packages re-scan is in flight")
+	}
+
+	var loaded db.Scan
+	if err := w.DB.First(&loaded, scan.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if loaded.Status != db.ScanQueued {
+		t.Errorf("scan status = %q, want queued (dispatch leaves it for the handler), not skipped to done", loaded.Status)
+	}
+}
+
+func TestPreflightSkill_dependentsDispatchesWhenPackagesNeverRan(t *testing.T) {
+	// packages was never enqueued for this repo. Zero Package rows here
+	// means "not yet known", not "no packages", so the gate must NOT skip:
+	// dispatch and let dependents self-gate as it does today.
+	w := newPreflightWorker(t)
+	scan := seedDependentsScan(t, w)
+	seedPrereqSkill(t, w, "packages", true) // registered, but no scan rows
+
+	deferred, err := w.preflightSkill(context.Background(), scan, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if deferred {
+		t.Fatal("dependents must dispatch when packages has not run (no false skip)")
+	}
+
+	var loaded db.Scan
+	if err := w.DB.First(&loaded, scan.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if loaded.Status != db.ScanQueued {
+		t.Errorf("scan status = %q, want queued", loaded.Status)
+	}
+}


### PR DESCRIPTION
Generated with Claude Code, reviewed and tested by me.

The `dependents` skill only has work when the repository actually publishes a package. Today `triage`'s `has_packages` gate is true for any repo with a package manager (e.g. a `Gemfile` counts), so it cannot tell "publishes" from "consumes": a Rails app gets `dependents` enqueued, runs a full agent, queries `ecosyste.ms`, finds nothing, and exits. This adds a content-aware gate in the worker prereq layer, where `dependents` already waits on `packages`, to skip that wasted agent run.

This should eliminate unnecessary token spend when scanning something like a Rails app.

This may not be the right place to put this guard, I can try other options if preferred, but the initial attempt by Claude required an additional database column on skills, which seemed quite excessive for this change.