### PR TITLE
Disable verify action while verify scan is active

### DIFF
--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -1123,26 +1123,26 @@ const patchSkillName = "patch"
 const mitigateSkillName = "mitigate"
 
 func (s *Server) findingVerify(w http.ResponseWriter, r *http.Request) {
-	s.runFindingSkill(w, r, verifySkillName)
+	s.runFindingSkill(w, r, verifySkillName, true)
 }
 
 func (s *Server) findingDisclose(w http.ResponseWriter, r *http.Request) {
-	s.runFindingSkill(w, r, discloseSkillName)
+	s.runFindingSkill(w, r, discloseSkillName, false)
 }
 
 func (s *Server) findingPublicIssue(w http.ResponseWriter, r *http.Request) {
-	s.runFindingSkill(w, r, publicIssueSkillName)
+	s.runFindingSkill(w, r, publicIssueSkillName, false)
 }
 
 func (s *Server) findingPatchRun(w http.ResponseWriter, r *http.Request) {
-	s.runFindingSkill(w, r, patchSkillName)
+	s.runFindingSkill(w, r, patchSkillName, false)
 }
 
 func (s *Server) findingMitigate(w http.ResponseWriter, r *http.Request) {
-	s.runFindingSkill(w, r, mitigateSkillName)
+	s.runFindingSkill(w, r, mitigateSkillName, false)
 }
 
-func (s *Server) runFindingSkill(w http.ResponseWriter, r *http.Request, name string) {
+func (s *Server) runFindingSkill(w http.ResponseWriter, r *http.Request, name string, skipOpen bool) {
 	f, ok := loadByID[db.Finding](s, w, r)
 	if !ok {
 		return
@@ -1157,12 +1157,32 @@ func (s *Server) runFindingSkill(w http.ResponseWriter, r *http.Request, name st
 		http.Error(w, name+" skill is not installed", http.StatusPreconditionFailed)
 		return
 	}
+	if skipOpen {
+		if openScan, ok := s.openFindingSkillScan(f.ID, name); ok {
+			setFlash(w, Flash{Category: warningKey, Title: name + " already queued or running"})
+			s.redirect(w, r, fmt.Sprintf("/scans/%d", openScan.ID))
+			return
+		}
+	}
 	scanID, err := s.enqueueSkillScoped(r.Context(), scan.RepositoryID, skill.ID, new(f.ID), r.FormValue("model"))
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 	s.redirect(w, r, fmt.Sprintf("/scans/%d", scanID))
+}
+
+func (s *Server) openFindingSkillScan(findingID uint, skillName string) (db.Scan, bool) {
+	var scan db.Scan
+	err := s.DB.
+		Where("finding_id = ? AND skill_name = ? AND status IN ?",
+			findingID, skillName, []db.ScanStatus{db.ScanQueued, db.ScanRunning}).
+		Order("status_priority asc, id desc").
+		First(&scan).Error
+	if err != nil {
+		return db.Scan{}, false
+	}
+	return scan, true
 }
 
 // repoVerifyAll is the bulk equivalent of the per-finding Verify button: it
@@ -1348,6 +1368,11 @@ func (s *Server) advisoriesList(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+type findingWorkflowData struct {
+	db.Finding
+	VerifyInFlight bool
+}
+
 func (s *Server) findingShow(w http.ResponseWriter, r *http.Request) {
 	var f db.Finding
 	if err := s.DB.Preload("Labels").First(&f, r.PathValue("id")).Error; err != nil {
@@ -1377,6 +1402,7 @@ func (s *Server) findingShow(w http.ResponseWriter, r *http.Request) {
 	for _, l := range f.Labels {
 		selected[l.Name] = true
 	}
+	_, verifyInFlight := s.openFindingSkillScan(f.ID, verifySkillName)
 
 	type exposureRow struct {
 		Dep    db.Dependent
@@ -1423,6 +1449,7 @@ func (s *Server) findingShow(w http.ResponseWriter, r *http.Request) {
 		"LatestRevalidate": latestRevalidate,
 		"AllLabels":        labels,
 		"Selected":         selected,
+		"Workflow":         findingWorkflowData{Finding: f, VerifyInFlight: verifyInFlight},
 		"Exposures":        exposures,
 		"ShowExposure":     findingSupportsExposure(scan),
 	}

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -1292,6 +1292,33 @@ func TestFindingShow_rendersMissedCount(t *testing.T) {
 	}
 }
 
+func TestFindingShow_disablesVerifyActionWhenVerifyInFlight(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	repo := db.Repository{URL: "https://example.com/r", Name: "r"}
+	s.DB.Create(&repo)
+	scan := db.Scan{RepositoryID: repo.ID, Kind: "skill", Status: db.ScanDone, SkillName: "security-deep-dive"}
+	s.DB.Create(&scan)
+	f := db.Finding{ScanID: scan.ID, RepositoryID: repo.ID, Title: "awaiting verify", Severity: "High", Status: db.FindingNew}
+	s.DB.Create(&f)
+	s.DB.Create(&db.Scan{RepositoryID: repo.ID, Kind: "skill", Status: db.ScanRunning,
+		StatusPriority: db.StatusPriorityFor(db.ScanRunning), SkillName: verifySkillName, FindingID: new(f.ID)})
+
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq("GET", fmt.Sprintf("/findings/%d", f.ID)))
+	body := w.Body.String()
+	if w.Code != http.StatusOK {
+		t.Fatalf("status %d: %s", w.Code, body)
+	}
+	if strings.Contains(body, fmt.Sprintf(`hx-post="/findings/%d/verify"`, f.ID)) {
+		t.Error("finding page should not render an active verify action while verify is in flight")
+	}
+	if !strings.Contains(body, `button type="button" class="btn" disabled`) || !strings.Contains(body, "Verify in progress") {
+		t.Errorf("finding page should render disabled verify state, body=%s", body)
+	}
+}
+
 func TestFindingShow_ghsaLinksToRepoAdvisory(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()
@@ -1879,6 +1906,42 @@ func TestFindingPublicIssueEnqueuesPublicIssueSkill(t *testing.T) {
 	}
 	if row.APIToken == "" {
 		t.Error("scan missing api token")
+	}
+}
+
+func TestFindingVerifySkipsOpenVerifyScan(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	repo := db.Repository{URL: "https://github.com/foo/bar", Name: "bar"}
+	s.DB.Create(&repo)
+	parent := db.Scan{RepositoryID: repo.ID, Kind: "skill", Status: db.ScanDone, SkillName: "security-deep-dive"}
+	s.DB.Create(&parent)
+	finding := db.Finding{ScanID: parent.ID, RepositoryID: repo.ID, FindingID: "F1", Title: "x", Severity: "High", Status: db.FindingNew}
+	s.DB.Create(&finding)
+	verify := db.Skill{Name: verifySkillName, Description: "v", Body: "b", OutputFile: "report.json", OutputKind: "verify", Version: 1, Active: true, Source: "ui"}
+	s.DB.Create(&verify)
+	openScan := db.Scan{RepositoryID: repo.ID, Kind: "skill", Status: db.ScanQueued,
+		StatusPriority: db.StatusPriorityFor(db.ScanQueued), SkillName: verifySkillName, SkillID: new(verify.ID), FindingID: new(finding.ID)}
+	s.DB.Create(&openScan)
+
+	req := httptest.NewRequest("POST", fmt.Sprintf("/findings/%d/verify", finding.ID), nil)
+	req.Host = testHost
+	req.Header.Set("Sec-Fetch-Site", "same-origin")
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+	if got, want := w.Header().Get("Location"), fmt.Sprintf("/scans/%d", openScan.ID); got != want {
+		t.Errorf("redirect = %q, want existing scan %q", got, want)
+	}
+	var count int64
+	s.DB.Model(&db.Scan{}).
+		Where("finding_id = ? AND skill_name = ?", finding.ID, verifySkillName).
+		Count(&count)
+	if count != 1 {
+		t.Errorf("verify scans = %d, want 1", count)
 	}
 }
 

--- a/internal/web/templates/finding_show.html
+++ b/internal/web/templates/finding_show.html
@@ -34,7 +34,7 @@
 </div>
 {{end}}
 
-{{template "finding_workflow" $f}}
+{{template "finding_workflow" .Workflow}}
 
 <dl class="grid grid-cols-2 sm:grid-cols-6 gap-4 mb-6 text-sm">
   <div>

--- a/internal/web/templates/finding_workflow.html
+++ b/internal/web/templates/finding_workflow.html
@@ -41,10 +41,16 @@
     <form method="post" action="/findings/{{$id}}/status" hx-swap="none"
           class="flex items-center gap-2 shrink-0">
       {{if eq $s "new"}}
-        <button type="submit" class="btn" formaction="/findings/{{$id}}/verify"
-                hx-post="/findings/{{$id}}/verify">
-          <i data-lucide="shield-check"></i> Verify
-        </button>
+        {{if .VerifyInFlight}}
+          <button type="button" class="btn" disabled title="A verify scan is already queued or running for this finding">
+            <i data-lucide="loader-circle" class="animate-spin"></i> Verify in progress
+          </button>
+        {{else}}
+          <button type="submit" class="btn" formaction="/findings/{{$id}}/verify"
+                  hx-post="/findings/{{$id}}/verify">
+            <i data-lucide="shield-check"></i> Verify
+          </button>
+        {{end}}
         <button type="submit" name="status" value="triaged" class="btn-outline"
                 hx-post="/findings/{{$id}}/status">
           Skip to triage


### PR DESCRIPTION
Closes #444
## Summary

Disables the per-finding `Verify` action when that finding already has a queued or running verify scan.

## Changes

- Detect queued/running `verify` scans for the finding page
- Render a disabled `Verify in progress` button instead of an active `Verify` submit button
- Guard direct POSTs to `/findings/{id}/verify` so duplicate submits redirect to the existing scan instead of enqueueing another one
- Add regression coverage for the UI and POST behavior

## Testing

- `go test ./internal/web -run 'TestFindingShow_(disablesVerifyActionWhenVerifyInFlight|rendersMissedCount)|TestFindingVerifySkipsOpenVerifyScan|TestRepoVerifyAll' -count=1`
- `go test ./...`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run`
- `git diff --check`

