### PR TITLE
Increase patch skill max turns

### DIFF
--- a/internal/skills/parse_test.go
+++ b/internal/skills/parse_test.go
@@ -581,6 +581,13 @@ func TestLoadDirectory_bundledSkillsAreValid(t *testing.T) {
 	if n == 0 {
 		t.Fatal("no skills loaded from ../../skills")
 	}
+	var patch db.Skill
+	if err := gdb.Where("name = ?", "patch").First(&patch).Error; err != nil {
+		t.Fatalf("patch skill not loaded: %v", err)
+	}
+	if patch.MaxTurns != 50 {
+		t.Errorf("patch max_turns = %d, want 50", patch.MaxTurns)
+	}
 }
 
 func TestLoadDirectory_failsOnInvalidSkill(t *testing.T) {

--- a/skills/patch/SKILL.md
+++ b/skills/patch/SKILL.md
@@ -7,6 +7,7 @@ metadata:
   scrutineer.version: 1
   scrutineer.output_file: report.json
   scrutineer.output_kind: patch
+  scrutineer.max_turns: 50
 ---
 
 # patch


### PR DESCRIPTION
closes #448

## Summary

Increases the bundled `patch` skill's per-skill max turns from the global default to 50, so patch generation has more room before hitting the turn cap.

## Changes

- Add `scrutineer.max_turns: 50` to `skills/patch/SKILL.md`
- Add regression coverage that the bundled `patch` skill loads with `MaxTurns == 50`

## Testing

- `go test ./internal/skills -run TestLoadDirectory_bundledSkillsAreValid -count=1`
- `go test ./...`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run`
- `git diff --check`