### PR TITLE
fix(web): exclude closed findings from org page counts/list

### DIFF
--- a/internal/web/orgs.go
+++ b/internal/web/orgs.go
@@ -166,6 +166,7 @@ func (s *Server) orgShow(w http.ResponseWriter, r *http.Request) {
 	s.DB.Model(&db.Finding{}).
 		Select("repository_id, COUNT(*) AS n").
 		Where("repository_id IN ?", repoIDs).
+		Where("status NOT IN ?", db.ClosedFindingLifecycles).
 		Where("scan_id IN (?)", deepDiveScanIDs(s.DB)).
 		Group("repository_id").Scan(&counts)
 	for _, c := range counts {
@@ -178,6 +179,7 @@ func (s *Server) orgShow(w http.ResponseWriter, r *http.Request) {
 	// before Medium, which misreads for a stakeholder scanning the tab.
 	category := r.URL.Query().Get("category")
 	findingsQ := s.DB.Where("repository_id IN ?", repoIDs).
+		Where("status NOT IN ?", db.ClosedFindingLifecycles).
 		Where("scan_id IN (?)", deepDiveScanIDs(s.DB))
 	if category != "" {
 		findingsQ = applyCWECategoryFilter(findingsQ, category)


### PR DESCRIPTION
## Summary

`orgShow`'s per-repo `findingCounts` and Findings-tab list (`internal/web/orgs.go`) filtered only by `deepDiveScanIDs`, omitting the `status NOT IN ClosedFindingLifecycles` filter that the repo's own page (`loadRepoFindings`, `server.go:742`) and SBOM view (`sboms.go:144`) apply.

As a result, closed/rejected/duplicate findings were counted and listed at the org level but hidden at the repo level, so the org count exceeded the repo count for the same repo.

## Fix

Add `.Where("status NOT IN ?", db.ClosedFindingLifecycles)` to both queries so org-level counts and the Findings tab agree with the repo page.

## Testing

- `go build ./internal/web/` passes
- `golangci-lint run ./internal/web/` reports 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)