### PR TITLE
fix(config): validate effort at startup

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -135,6 +135,21 @@ func ValidateTheme(s string) error {
 	return fmt.Errorf("theme: unknown %q", s)
 }
 
+// Efforts lists every valid effort level, fastest first. These are the only
+// values `claude --effort` accepts. Mirror of web.Efforts (which owns the
+// display labels); a cross-check test in the web package guards against drift.
+var Efforts = []string{"low", "medium", "high", "xhigh", "max"}
+
+// ValidateEffort returns an error when s is not a known effort level. Empty
+// is valid (caller keeps the default). Exposed so the CLI flag can use the
+// same rule as the YAML field.
+func ValidateEffort(s string) error {
+	if s == "" || slices.Contains(Efforts, s) {
+		return nil
+	}
+	return fmt.Errorf("effort: unknown %q", s)
+}
+
 // Load reads a YAML config from path. Returns (nil, nil) when the file
 // does not exist and the caller passed "" or DefaultPath — making config
 // fully opt-in. Explicit paths that don't exist are an error.
@@ -161,6 +176,9 @@ func Load(path string) (*Config, error) {
 		return nil, fmt.Errorf("parse config %s: %w", path, err)
 	}
 	if err := ValidateTheme(c.Theme); err != nil {
+		return nil, fmt.Errorf("parse config %s: %w", path, err)
+	}
+	if err := ValidateEffort(c.Effort); err != nil {
 		return nil, fmt.Errorf("parse config %s: %w", path, err)
 	}
 	return &c, nil

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -182,3 +182,32 @@ func TestLoad_parsesTheme(t *testing.T) {
 		t.Errorf("theme=%q, want catppuccin", c.Theme)
 	}
 }
+
+func TestValidateEffort(t *testing.T) {
+	for _, name := range []string{"", "low", "medium", "high", "xhigh", "max"} {
+		if err := ValidateEffort(name); err != nil {
+			t.Errorf("ValidateEffort(%q) = %v, want nil", name, err)
+		}
+	}
+	if err := ValidateEffort("superhigh"); err == nil {
+		t.Error("expected error for unknown effort")
+	}
+}
+
+func TestLoad_rejectsInvalidEffort(t *testing.T) {
+	path := write(t, "effort: superhigh\n")
+	if _, err := Load(path); err == nil {
+		t.Error("expected error for invalid effort value")
+	}
+}
+
+func TestLoad_parsesEffort(t *testing.T) {
+	path := write(t, "effort: max\n")
+	c, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c.Effort != "max" {
+		t.Errorf("effort=%q, want max", c.Effort)
+	}
+}

--- a/internal/web/efforts.go
+++ b/internal/web/efforts.go
@@ -10,7 +10,9 @@ type Effort struct {
 }
 
 // Efforts is the ordered effort scale, fastest first. The Values are the
-// only levels `claude --effort` accepts.
+// only levels `claude --effort` accepts. This is the source of truth for the
+// effort levels; config.Efforts mirrors the Values for startup validation, and
+// TestEffortsMatchConfig guards the two against drift.
 var Efforts = []Effort{
 	{"low", "Low"},
 	{"medium", "Medium"},

--- a/internal/web/efforts_test.go
+++ b/internal/web/efforts_test.go
@@ -1,6 +1,28 @@
 package web
 
-import "testing"
+import (
+	"testing"
+
+	"scrutineer/internal/config"
+)
+
+// TestEffortsMatchConfig guards against drift between web.Efforts (the source
+// of truth, coupled to display labels) and config.Efforts (the independent
+// list config.Load validates against at startup). Add a level to one and this
+// fails until the other catches up.
+func TestEffortsMatchConfig(t *testing.T) {
+	if len(Efforts) != len(config.Efforts) {
+		t.Fatalf("len(web.Efforts)=%d, len(config.Efforts)=%d", len(Efforts), len(config.Efforts))
+	}
+	for i, e := range Efforts {
+		if e.Value != config.Efforts[i] {
+			t.Errorf("Efforts[%d]=%q, config.Efforts[%d]=%q", i, e.Value, i, config.Efforts[i])
+		}
+		if err := config.ValidateEffort(e.Value); err != nil {
+			t.Errorf("config.ValidateEffort(%q) = %v, want nil", e.Value, err)
+		}
+	}
+}
 
 func TestValidEffort(t *testing.T) {
 	for _, e := range []string{"low", "medium", "high", "xhigh", "max"} {


### PR DESCRIPTION
## Summary

Unlike the sibling `clone`, `theme`, and `scan_timeout` config keys, `effort` was passed straight through to `web.SetDefaultEffort` / claude `--effort` with no `config.Load` validation. An invalid value (e.g. `effort: superhigh`) silently no-ops at startup and only surfaces later at scan time, rather than failing fast when the config is loaded.

This closes that consistency gap by adding `config.ValidateEffort`, mirroring `ValidateClone`/`ValidateTheme`, and calling it in `config.Load`.

## Changes

- **`internal/config/config.go`** — add `Efforts` (`low`/`medium`/`high`/`xhigh`/`max`) and `ValidateEffort`; wire it into `config.Load` with the same `parse config %s` error wrap as the other validators.
- **`internal/config/config_test.go`** — add `TestValidateEffort`, `TestLoad_rejectsInvalidEffort`, `TestLoad_parsesEffort`.
- **Drift guard** — `config` cannot import `web` (web → config already, so importing back would cycle), so the level list is necessarily duplicated. `web.Efforts` remains the source of truth (it owns the display labels); `config.Efforts` is a deliberate mirror. `TestEffortsMatchConfig` (in the web package) asserts the two lists stay in sync, and both lists carry a comment pointing at the other.

## Out of scope

- The CLI `--effort superhigh` flag path still silently no-ops via `SetDefaultEffort` (invalid → falls back to default, no error). This issue is scoped to `config.Load`, so the flag-level gap is left as-is.

## Testing

- `go build ./...` passes
- `go test ./internal/config/ ./internal/web/` — all green, including the new tests
- `golangci-lint run ./internal/config/... ./internal/web/...` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)