### PR TITLE
fix: Disable exposure button when a repo has no dependents

### DIFF
--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -1426,6 +1426,11 @@ func (s *Server) findingShow(w http.ResponseWriter, r *http.Request) {
 		"Exposures":        exposures,
 		"ShowExposure":     findingSupportsExposure(scan),
 	}
+	if data["ShowExposure"].(bool) {
+		var depCount int64
+		s.DB.Model(&db.Dependent{}).Where("repository_id = ?", scan.RepositoryID).Count(&depCount)
+		data["HasDependents"] = depCount > 0
+	}
 	if id, c, ok := LookupCWE(f.CWE); ok {
 		data["CWE"] = map[string]any{"ID": id, "Name": c.Name, "Description": c.Description}
 	}

--- a/internal/web/templates/finding_show.html
+++ b/internal/web/templates/finding_show.html
@@ -276,10 +276,12 @@
     </summary>
     <section class="pb-4 grid gap-3">
       <div class="flex items-center gap-2">
-        <form method="post" action="/findings/{{$f.ID}}/exposure" hx-post="/findings/{{$f.ID}}/exposure" hx-swap="none">
-          <button type="submit" class="btn-sm">Run exposure on top-10 dependents</button>
+        <form method="post" action="/findings/{{$f.ID}}/exposure" hx-post="/findings/{{$f.ID}}/exposure" hx-swap="none" hx-confirm="Run exposure on up to 10 dependents? This can enqueue up to 10 full scans.">
+          <button type="submit" class="btn-sm" {{if not .HasDependents}}disabled title="This repository has no recorded dependents."{{end}}>Run exposure on top-10 dependents</button>
         </form>
-        <span class="text-xs text-muted-foreground">Clones each dependent and audits whether this finding is reachable in its code.</span>
+        <span class="text-xs text-muted-foreground">
+          {{if .HasDependents}}Clones each dependent and audits whether this finding is reachable in its code.{{else}}No dependents recorded for this repository.{{end}}
+        </span>
       </div>
       {{if .Exposures}}
       <table class="w-full text-sm">


### PR DESCRIPTION
There's no point allowing the user to trigger an exposure run when the Finding's repository has no dependents. So we disable the button on repos like this.

Also, this adds a confirmation dialog to the "Run top 10 dependents" button so that the user is warned before we trigger 10 scans for them at once.

Generated with Claude Code, tested and reviewed by me.

<img width="1213" height="132" alt="Screenshot 2026-06-20 at 5 32 14 PM" src="https://github.com/user-attachments/assets/5f3fc7ef-6115-48f8-a45d-71e14bd8c699" />

<img width="397" height="164" alt="Screenshot 2026-06-20 at 5 32 23 PM" src="https://github.com/user-attachments/assets/79abeac3-872b-4e8e-afba-a22d2fbce65f" />
