### PR TITLE
python-ext profile: add ASan/UBSan CPython for native extensions

### DIFF
--- a/docker/profiles/python-ext/Dockerfile
+++ b/docker/profiles/python-ext/Dockerfile
@@ -1,0 +1,103 @@
+# Python-extension profile.
+#
+# Ships CPython built from source with --with-pydebug + ASan + UBSan, for
+# scanning Python packages that include compiled C/C++ extension modules.
+# C extensions installed against this interpreter (CFLAGS/LDFLAGS wire the
+# sanitizers in) are instrumented, so a reproducer that drives the
+# extension surfaces memory-safety and UB bugs the static scan can only
+# guess at. This mirrors the php-ext profile.
+#
+# Auto-selected for repos whose setup.py declares a C Extension (see
+# internal/worker/profile.go); also selectable by name via ?profile=. The
+# debug+sanitizer interpreter is much slower than the plain python
+# profile, so it is scoped to repos that actually ship native code.
+#
+# At runtime the worker builds this on demand (see internal/worker/profile.go:
+# EnsureImage), tagging the result scrutineer-profile-python-ext:<dockerfile-sha>
+# and passing the configured runner image via --build-arg RUNNER_IMAGE. The
+# build installs its toolchain with apt, so RUNNER_IMAGE must resolve to the
+# Debian runner built from ./Dockerfile.runner.
+#
+# To build it manually the way the project does, from the repo root:
+#
+#   # 1. Build the base runner image locally (Debian/glibc, ships brief etc.):
+#   docker build -t scrutineer-runner:local -f Dockerfile.runner .
+#
+#   # 2. Build this Python-extension profile on top of that local runner
+#   #    (compiles CPython from source with ASan/UBSan; takes several minutes):
+#   docker build -t scrutineer-profile-python-ext \
+#       -f docker/profiles/python-ext/Dockerfile \
+#       --build-arg RUNNER_IMAGE=scrutineer-runner:local \
+#       docker/profiles/python-ext
+#
+#   # 3. Smoke-test it (debug build, sanitizers wired in):
+#   docker run --rm --entrypoint sh scrutineer-profile-python-ext \
+#       -c 'python --version && python -c "import sys; print(sys._is_gil_enabled if hasattr(sys,\"_is_gil_enabled\") else 0)"'
+
+ARG RUNNER_IMAGE=ghcr.io/alpha-omega-security/scrutineer-runner:latest
+ARG PYTHON_GIT_URL=https://github.com/python/cpython.git
+ARG PYTHON_GIT_REF=v3.13.14
+
+FROM ${RUNNER_IMAGE}
+ARG PYTHON_GIT_URL
+ARG PYTHON_GIT_REF
+
+USER root
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    PATH=/usr/local/python-asan/bin:$PATH \
+    PYTHONMALLOC=malloc \
+    ASAN_OPTIONS="symbolize=1:detect_leaks=0:allocator_may_return_null=1:halt_on_error=0:print_summary=1" \
+    UBSAN_OPTIONS="print_stacktrace=1:print_summary=1"
+
+# gcc (build-essential) builds CPython: clang now defaults to
+# -Werror=implicit-function-declaration, which breaks several of
+# configure's feature probes (getaddrinfo among them). gdb for triage,
+# plus the headers the stdlib and most C extensions link against (ssl,
+# ffi, zlib, bz2, lzma, readline, sqlite, ncurses, gdbm, uuid).
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential \
+        gdb \
+        git ca-certificates \
+        pkg-config \
+        libssl-dev libffi-dev zlib1g-dev \
+        libbz2-dev liblzma-dev libreadline-dev \
+        libsqlite3-dev libncurses-dev libgdbm-dev uuid-dev \
+ && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /opt
+RUN git clone --depth 1 --branch "${PYTHON_GIT_REF}" "${PYTHON_GIT_URL}" cpython
+WORKDIR /opt/cpython
+# ac_cv_buggy_getaddrinfo=no: under ASan, configure's getaddrinfo runtime
+# probe can still misfire; this is the documented override for
+# sanitizer/cross builds.
+RUN ac_cv_buggy_getaddrinfo=no ./configure \
+        --prefix=/usr/local/python-asan \
+        --with-pydebug \
+        --with-address-sanitizer \
+        --with-undefined-behavior-sanitizer \
+        --without-pymalloc \
+ && make -j"$(nproc)" \
+ && make install \
+ && ln -s /usr/local/python-asan/bin/python3 /usr/local/bin/python \
+ && ln -s /usr/local/python-asan/bin/python3 /usr/local/bin/python3
+
+# Extensions built by pip against this interpreter must carry the same
+# sanitizers, built with the same compiler (gcc) so they share CPython's
+# gcc ASan runtime -- a clang-built .so dlopened into gcc-asan CPython
+# aborts with a runtime mismatch. -fno-sanitize-recover makes UB in an
+# extension abort rather than silently continue. Matches the php-ext
+# approach.
+ENV CFLAGS="-fsanitize=address -fsanitize=undefined -fno-sanitize-recover=undefined -fno-omit-frame-pointer -g -O1" \
+    CXXFLAGS="-fsanitize=address -fsanitize=undefined -fno-sanitize-recover=undefined -fno-omit-frame-pointer -g -O1" \
+    LDFLAGS="-fsanitize=address -fsanitize=undefined"
+
+# ASan/UBSan-built interpreter; the install dir must stay writable for the
+# host uid the scan runs as so pip can build extensions in place. Container
+# is ephemeral and --rm'd after the scan, so the blast radius is zero.
+RUN chmod -R a+rwX /usr/local/python-asan \
+ && python --version 2>&1 | grep -q "3.13" \
+ && python -c "import _testcapi; print('debug build ok')" \
+ && python -X dev -c "print('asan python runs')"
+
+USER runner

--- a/docker/profiles/python-ext/Dockerfile
+++ b/docker/profiles/python-ext/Dockerfile
@@ -8,7 +8,8 @@
 # guess at. This mirrors the php-ext profile.
 #
 # Auto-selected for repos whose setup.py declares a C Extension (see
-# internal/worker/profile.go); also selectable by name via ?profile=. The
+# internal/worker/profile.go); also selectable by name via
+# ?profile=python-ext. The
 # debug+sanitizer interpreter is much slower than the plain python
 # profile, so it is scoped to repos that actually ship native code.
 #

--- a/docker/profiles/python-ext/PROFILE.md
+++ b/docker/profiles/python-ext/PROFILE.md
@@ -1,0 +1,98 @@
+# Python-extension scanning container
+
+The repository under `./src` is a Python package with a compiled C/C++ extension. The job is to find **security
+vulnerabilities** in the native code.
+
+## Why this container
+
+CPython here is built **--with-pydebug + AddressSanitizer + UndefinedBehaviorSanitizer**. ASan/UBSan are detection
+tooling: they turn silent memory corruption into loud, pinpointable hits so you can find bugs in C code instead of
+guessing from static reading. They are not the deliverable.
+
+The deliverable is a security finding: what the bug is, what an attacker controls from the Python side, what the impact
+is (info disclosure, memory corruption to RCE, DoS, type confusion bypassing a check), and a reproducer that shows it.
+A sanitizer hit is a starting point, not a report.
+
+## Layout
+
+- `./src` — package source, including the C/C++ extension (start here).
+- `/usr/local/python-asan` — debug+ASan+UBSan CPython. `python`/`python3` on PATH; the build reports a debug build and
+  loads `_testcapi`.
+- `/opt/cpython` — CPython source tree. Cross-reference C-API internals (`Include/*.h`, `Objects/`) when triaging.
+- `gdb`, `gh`, `claude` — on PATH.
+
+## Building the extension
+
+Extensions are compiled with **gcc** (the default `cc`, matching how CPython itself was built) and the pre-exported
+sanitizer `CFLAGS`/`CXXFLAGS`/`LDFLAGS`, so anything pip builds against this interpreter is instrumented and shares the
+interpreter's ASan runtime. A clang-built `.so` dlopened into this gcc-ASan CPython aborts with a runtime mismatch, so
+build standalone fuzz harnesses with clang if you want libFuzzer, but build loadable extensions with gcc. Build in
+place:
+
+```bash
+cd src
+python -m pip install -e . -v        # or: python setup.py build_ext --inplace
+```
+
+`pip` is available here (the interpreter is one we built, not an externally-managed install). If a build needs a
+dependency, install it the same way; it gets instrumented too. If the build fails with `Could not resolve host` the
+scan is offline — note which steps you had to skip.
+
+## Sanitizer config (pre-exported)
+
+```
+PYTHONMALLOC=malloc
+  Routes Python allocations through libc malloc so ASan sees every allocation, not just the arenas pymalloc
+  requests from libc. The interpreter is built --without-pymalloc to match.
+
+ASAN_OPTIONS=
+  symbolize=1                  readable stack traces
+  detect_leaks=0               CPython has known interpreter-shutdown leaks; flip to 1 only when chasing a suspect
+  allocator_may_return_null=1  a huge allocation returns NULL instead of aborting, so you reach the code under test
+  halt_on_error=0              keep going after the first report while exploring
+  print_summary=1              one-line summary at the end
+
+UBSAN_OPTIONS=
+  print_stacktrace=1
+  print_summary=1
+```
+
+Extensions are built with `-fno-sanitize-recover=undefined`, so a UB hit in the extension aborts rather than silently
+continuing — the abort is the evidence.
+
+## Investigating a sanitizer hit
+
+A hit means a memory-safety bug in C code. Work the bug, don't just file the trace.
+
+1. **What is the primitive?** Read the ASan/UBSan output — heap-buffer-overflow (read or write?), use-after-free,
+   double-free, integer overflow into an allocation, type confusion. Each has a different exploitability ceiling.
+2. **What does an attacker control?** Walk back from the crash to the Python-level entry point — the method or function
+   the extension exposes, its argument parsing (`PyArg_ParseTuple`, the buffer protocol). Which argument's length,
+   contents, or type reaches the bad code, and could a caller realistically pass it?
+3. **What is the impact?** OOB read to info disclosure; OOB write / UAF / double-free to memory corruption (often
+   RCE-able in native code); integer overflow into an allocation to an undersized buffer then overflow; missing type
+   or bounds check to a pivot. UBSan-only hits may be benign — chase the consequence, not the label.
+4. **Reduce to the smallest reproducer that still triggers it.** Minimal Python, only what's needed. The minimal form
+   is the evidence.
+5. Cross-reference `/opt/cpython` for C-API contracts (reference counting, buffer protocol, `PyObject` layout) when the
+   surrounding C relies on semantics that aren't local.
+
+## Creating reproducers
+
+A reproducer demonstrates the security bug, not just that something crashed. It must be something you actually ran in
+this container. If you couldn't run it here, say so explicitly — never invent one.
+
+- Small case: a script run with `python /tmp/poc.py` after building the extension in place.
+- The reproducer should show the **attacker-controlled input** reaching the bug — what call, what argument, what value.
+  A bug that only triggers under values nobody could supply is a weak finding; find the real attack surface or
+  downgrade the report.
+- Quote the sanitizer output as **evidence** (the `SUMMARY:` line plus the relevant top of the stack), then describe
+  the bug in one line — e.g. "1-byte heap-buffer-overflow write in `parse_header`, byte sourced from the
+  attacker-supplied `data` argument".
+- "Potential RCE" with no demonstrated primitive is a hypothesis — say so honestly rather than overclaiming.
+
+## Rules
+
+- Back every claim with a command you ran in the container. Prefer running things over static reasoning.
+- Build the extension before analyzing.
+- Install missing build deps via `pip` or `apt-get` without asking.

--- a/internal/worker/profile.go
+++ b/internal/worker/profile.go
@@ -76,6 +76,14 @@ var builtinProfiles = []Profile{
 	{Name: "php", Ecosystem: "Composer"},
 	{Name: "ruby", Ecosystem: "Bundler"},
 	{Name: "node", Ecosystem: "npm"},
+	{
+		// Before python: a repo whose setup.py declares a C Extension is
+		// shipping native code, so route it to the ASan/UBSan interpreter.
+		Name: "python-ext",
+		Markers: []ProfileMarker{
+			{Path: "setup.py", Contains: "Extension("},
+		},
+	},
 	{Name: "python", Ecosystems: []string{"pip", "Pipenv", "Poetry", "uv", "PDM"}},
 }
 

--- a/internal/worker/profile_test.go
+++ b/internal/worker/profile_test.go
@@ -22,6 +22,7 @@ func TestProfileByName(t *testing.T) {
 		{"ruby", "ruby", true, true},
 		{"node", "node", true, true},
 		{"python", "python", true, true},
+		{"python-ext", "python-ext", true, true},
 		{"unknown", "", false, false},
 	}
 	for _, tt := range tests {
@@ -56,6 +57,23 @@ func writeConfigM4(t *testing.T, dir, contents string) {
 	const configM4FileMode = 0o644
 	path := filepath.Join(dir, "config.m4")
 	if err := os.WriteFile(path, []byte(contents), configM4FileMode); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+const setupPyWithExtension = `from setuptools import setup, Extension
+setup(ext_modules=[Extension("pkg._speedups", ["src/speedups.c"])])
+`
+
+const setupPyPurePython = `from setuptools import setup
+setup(name="pkg", version="1.0", packages=["pkg"])
+`
+
+func writeSetupPy(t *testing.T, dir, contents string) {
+	t.Helper()
+	const setupPyFileMode = 0o644
+	path := filepath.Join(dir, "setup.py")
+	if err := os.WriteFile(path, []byte(contents), setupPyFileMode); err != nil {
 		t.Fatalf("write %s: %v", path, err)
 	}
 }
@@ -141,6 +159,30 @@ func TestMatchProfile(t *testing.T) {
 		{
 			name: "pdm matches python",
 			json: `{"package_managers":[{"name":"PDM"}]}`,
+			want: "python",
+		},
+		{
+			name: "setup.py with Extension selects python-ext",
+			json: `{"package_managers":[{"name":"pip"}]}`,
+			setup: func(t *testing.T, dir string) {
+				writeSetupPy(t, dir, setupPyWithExtension)
+			},
+			want: "python-ext",
+		},
+		{
+			name: "setup.py with Extension matches python-ext even without a manager",
+			json: `{"package_managers":[]}`,
+			setup: func(t *testing.T, dir string) {
+				writeSetupPy(t, dir, setupPyWithExtension)
+			},
+			want: "python-ext",
+		},
+		{
+			name: "pure-python setup.py does not match python-ext, pip picks python",
+			json: `{"package_managers":[{"name":"pip"}]}`,
+			setup: func(t *testing.T, dir string) {
+				writeSetupPy(t, dir, setupPyPurePython)
+			},
 			want: "python",
 		},
 		{
@@ -342,7 +384,7 @@ func TestRepoShipsProfileDockerfiles(t *testing.T) {
 func TestProfileGuidesShip(t *testing.T) {
 	wd, _ := os.Getwd()
 	repoRoot := filepath.Join(wd, "..", "..")
-	for _, name := range []string{"php", "php-ext", "ruby", "node", "python"} {
+	for _, name := range []string{"php", "php-ext", "ruby", "node", "python", "python-ext"} {
 		guide := filepath.Join(repoRoot, "docker", "profiles", name, "PROFILE.md")
 		if _, err := os.Stat(guide); err != nil {
 			t.Errorf("expected %s profile PROFILE.md to exist: %v", name, err)

--- a/internal/worker/profile_test.go
+++ b/internal/worker/profile_test.go
@@ -377,17 +377,19 @@ func TestRepoShipsProfileDockerfiles(t *testing.T) {
 }
 
 // TestProfileGuidesShip keeps the language profiles honest about the
-// per-container PROFILE.md they advertise. PROFILE.md is optional in
-// general (a profile without one simply gets no orientation injected at
-// scan time); these profiles document specifics the agent needs to
-// behave correctly, so missing them is a real regression.
+// per-container PROFILE.md they advertise. The runtime treats PROFILE.md
+// as optional (a profile without one simply gets no orientation injected
+// at scan time), but every shipped profile documents specifics the agent
+// needs to behave correctly, so the test requires one per registered
+// profile. Iterating builtinProfiles rather than a hand-kept list keeps
+// this test out of the conflict path when a profile is added.
 func TestProfileGuidesShip(t *testing.T) {
 	wd, _ := os.Getwd()
 	repoRoot := filepath.Join(wd, "..", "..")
-	for _, name := range []string{"php", "php-ext", "ruby", "node", "python", "python-ext"} {
-		guide := filepath.Join(repoRoot, "docker", "profiles", name, "PROFILE.md")
+	for _, p := range builtinProfiles {
+		guide := filepath.Join(repoRoot, "docker", "profiles", p.Name, "PROFILE.md")
 		if _, err := os.Stat(guide); err != nil {
-			t.Errorf("expected %s profile PROFILE.md to exist: %v", name, err)
+			t.Errorf("expected %s profile PROFILE.md to exist: %v", p.Name, err)
 		}
 	}
 }


### PR DESCRIPTION
Stacked on #431 (python profile) — review/merge that first; this branch's base will need retargeting to main after #431 merges.

Adds a `python-ext` profile, the native-code twin of `python` and the Python analogue of `php-ext`. It ships CPython built from source with `--with-pydebug` + AddressSanitizer + UndefinedBehaviorSanitizer, so C/C++ extension modules installed against it are instrumented and a reproducer that drives the extension surfaces memory-safety and UB bugs the static scan can only guess at.

Build notes:

- CPython is built with **gcc**. clang now defaults to `-Werror=implicit-function-declaration`, which breaks configure's `getaddrinfo` probe (`checking for getaddrinfo... no` then a hard error). `ac_cv_buggy_getaddrinfo=no` is kept as belt-and-suspenders for the ASan runtime probe.
- Extensions are built with the same gcc plus the exported sanitizer `CFLAGS`/`CXXFLAGS`/`LDFLAGS`, so they share CPython's gcc ASan runtime (a clang-built `.so` dlopened into gcc-ASan CPython aborts on a runtime mismatch). `-fno-sanitize-recover=undefined` makes UB in an extension abort rather than silently continue.
- `PROFILE.md` mirrors php-ext: why the container exists, the pre-exported sanitizer config, how to build the extension in place, how to work a sanitizer hit into a security finding, and reproducer rules.

Routing: auto-selected (ordered before `python`) for repos whose `setup.py` declares a C `Extension(`, and selectable by name via `?profile=python-ext`. The debug+sanitizer interpreter is far slower than the plain `python` profile, so it is scoped to repos that actually ship native code. One thing worth a sanity check in review: whether `setup.py` containing `Extension(` is the right auto-detect signal, or whether python-ext should be selection-only.

Covers marker detection, naming, and the shipped guide in the worker tests. Built locally on the runner image: CPython 3.13.14 debug+ASan compiles and runs, and a deliberately buggy C extension built in place (`build_ext --inplace`) trips ASan with a heap-buffer-overflow when called from Python.


Reopened from #432 (auto-closed when its base branch was deleted by the #431 merge).
