### PR TITLE
refactor: rename deepDiveScanIDs/autoEnqueueFindingDedup helpers

### DIFF
--- a/internal/web/finding_dedup_enqueue.go
+++ b/internal/web/finding_dedup_enqueue.go
@@ -16,7 +16,7 @@ const findingDedupSkillName = "finding-dedup"
 // so it needs at least a pair.
 const dedupMinFindings = 2
 
-// autoEnqueueFindingDedupAfterDeepDive is wired onto Worker.OnScanFinalized.
+// autoEnqueueFindingDedup is wired onto Worker.OnScanFinalized.
 // The worker calls it once after a scan completes and its findings are
 // committed. We enqueue a repository-scoped finding-dedup run only when both
 // conditions the dedup pass needs to be worth its model spend hold:
@@ -39,7 +39,7 @@ const dedupMinFindings = 2
 //
 // Errors are logged and swallowed: failing to enqueue the dedup pass must
 // never fail the upstream scan.
-func (s *Server) autoEnqueueFindingDedupAfterDeepDive(scan *db.Scan) {
+func (s *Server) autoEnqueueFindingDedup(scan *db.Scan) {
 	if scan == nil || scan.SkillName != deepDiveSkillName {
 		return
 	}

--- a/internal/web/finding_dedup_enqueue_test.go
+++ b/internal/web/finding_dedup_enqueue_test.go
@@ -129,7 +129,7 @@ func TestAutoEnqueueFindingDedup_conditions(t *testing.T) {
 				newFindingUnder(t, s, repoID, scan.ID, db.FindingNew)
 			}
 
-			s.autoEnqueueFindingDedupAfterDeepDive(scan)
+			s.autoEnqueueFindingDedup(scan)
 
 			got := dedupQueued(s, repoID, dedupID) > 0
 			if got != c.wantQueued {
@@ -148,8 +148,8 @@ func TestAutoEnqueueFindingDedup_doesNotDoubleQueue(t *testing.T) {
 	scan := newScan(t, s, repoID, "security-deep-dive")
 	newFindingUnder(t, s, repoID, scan.ID, db.FindingNew)
 
-	s.autoEnqueueFindingDedupAfterDeepDive(scan)
-	s.autoEnqueueFindingDedupAfterDeepDive(scan)
+	s.autoEnqueueFindingDedup(scan)
+	s.autoEnqueueFindingDedup(scan)
 
 	if n := dedupQueued(s, repoID, dedupID); n != 1 {
 		t.Errorf("queued = %d, want 1 (re-queue guard)", n)
@@ -167,11 +167,11 @@ func TestAutoEnqueueFindingDedup_gracefulWhenSkillAbsent(t *testing.T) {
 	scan := newScan(t, s, repo.ID, "security-deep-dive")
 	newFindingUnder(t, s, repo.ID, scan.ID, db.FindingNew)
 
-	s.autoEnqueueFindingDedupAfterDeepDive(scan)
+	s.autoEnqueueFindingDedup(scan)
 }
 
 func TestAutoEnqueueFindingDedup_nilScan(t *testing.T) {
 	s, done, _, _ := dedupTestSetup(t)
 	defer done()
-	s.autoEnqueueFindingDedupAfterDeepDive(nil) // must not panic
+	s.autoEnqueueFindingDedup(nil) // must not panic
 }

--- a/internal/web/maintainers.go
+++ b/internal/web/maintainers.go
@@ -120,7 +120,7 @@ func (s *Server) maintainerShow(w http.ResponseWriter, r *http.Request) {
 		// keeping scanner noise off the maintainer view used for disclosure
 		// routing.
 		s.DB.Where("repository_id IN ?", repoIDs).
-			Where("scan_id IN (?)", deepDiveScanIDs(s.DB)).
+			Where("scan_id IN (?)", findingsScanIDs(s.DB)).
 			Order("id desc").Find(&findings)
 	}
 	reposByID := loadRepoMap(s.DB, findings, findingRepoID)

--- a/internal/web/org_report.go
+++ b/internal/web/org_report.go
@@ -56,7 +56,7 @@ func renderOrgReport(gdb *gorm.DB, owner string, repos []db.Repository) string {
 	// and would dominate the totals if rolled in here.
 	var findings []db.Finding
 	gdb.Where("repository_id IN ?", repoIDs).
-		Where("scan_id IN (?)", deepDiveScanIDs(gdb)).
+		Where("scan_id IN (?)", findingsScanIDs(gdb)).
 		Order(severityOrder).Order("id").Find(&findings)
 
 	bySeverity := map[string]int{}

--- a/internal/web/orgs.go
+++ b/internal/web/orgs.go
@@ -167,7 +167,7 @@ func (s *Server) orgShow(w http.ResponseWriter, r *http.Request) {
 		Select("repository_id, COUNT(*) AS n").
 		Where("repository_id IN ?", repoIDs).
 		Where("status NOT IN ?", db.ClosedFindingLifecycles).
-		Where("scan_id IN (?)", deepDiveScanIDs(s.DB)).
+		Where("scan_id IN (?)", findingsScanIDs(s.DB)).
 		Group("repository_id").Scan(&counts)
 	for _, c := range counts {
 		findingCounts[c.RepositoryID] = c.N
@@ -180,7 +180,7 @@ func (s *Server) orgShow(w http.ResponseWriter, r *http.Request) {
 	category := r.URL.Query().Get("category")
 	findingsQ := s.DB.Where("repository_id IN ?", repoIDs).
 		Where("status NOT IN ?", db.ClosedFindingLifecycles).
-		Where("scan_id IN (?)", deepDiveScanIDs(s.DB))
+		Where("scan_id IN (?)", findingsScanIDs(s.DB))
 	if category != "" {
 		findingsQ = applyCWECategoryFilter(findingsQ, category)
 	}

--- a/internal/web/repo_report.go
+++ b/internal/web/repo_report.go
@@ -119,7 +119,7 @@ func loadReportFindings(gdb *gorm.DB, repoID uint) []db.Finding {
 	var findings []db.Finding
 	gdb.Where("repository_id = ?", repoID).
 		Where("status NOT IN ?", db.ClosedFindingLifecycles).
-		Where("scan_id IN (?)", deepDiveScanIDs(gdb)).
+		Where("scan_id IN (?)", findingsScanIDs(gdb)).
 		Order(severityOrder).Order("id desc").Find(&findings)
 	return findings
 }

--- a/internal/web/sboms.go
+++ b/internal/web/sboms.go
@@ -144,7 +144,7 @@ func (s *Server) sbomShow(w http.ResponseWriter, r *http.Request) {
 		// downstream-impact view, where lint output from per-repo scanners
 		// (zizmor, semgrep) would be misleading at this level.
 		q := s.DB.Where("repository_id IN ? AND status NOT IN ?", repoIDs, db.ClosedFindingLifecycles).
-			Where("scan_id IN (?)", deepDiveScanIDs(s.DB))
+			Where("scan_id IN (?)", findingsScanIDs(s.DB))
 		if sev := r.URL.Query().Get("severity"); sev != "" {
 			q = q.Where("severity = ?", sev)
 		}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -259,7 +259,7 @@ func New(gdb *gorm.DB, q *queue.Queue, log *slog.Logger, broker *Broker, w *work
 	if w != nil {
 		w.OnFindingCreated = s.autoEnqueueRevalidate
 		w.OnRevalidateVerdict = s.autoChainVerifyAfterRevalidate
-		w.OnScanFinalized = s.autoEnqueueFindingDedupAfterDeepDive
+		w.OnScanFinalized = s.autoEnqueueFindingDedup
 	}
 	return s, nil
 }
@@ -607,7 +607,7 @@ func (s *Server) repoList(w http.ResponseWriter, r *http.Request) {
 		s.DB.Model(&db.Finding{}).
 			Select("repository_id, COUNT(*) AS n").
 			Where("repository_id IN ?", repoIDs).
-			Where("scan_id IN (?)", deepDiveScanIDs(s.DB)).
+			Where("scan_id IN (?)", findingsScanIDs(s.DB)).
 			Where("status NOT IN ?", db.ClosedFindingLifecycles).
 			Group("repository_id").
 			Scan(&counts)
@@ -756,7 +756,7 @@ func loadRepoFindings(gdb *gorm.DB, repoID uint, category string) repoFindings {
 			Where("repository_id = ? AND status NOT IN ?", repoID, db.ClosedFindingLifecycles)
 	}
 
-	ddQ := base().Where("scan_id IN (?)", deepDiveScanIDs(gdb))
+	ddQ := base().Where("scan_id IN (?)", findingsScanIDs(gdb))
 	if category != "" {
 		ddQ = applyCWECategoryFilter(ddQ, category)
 	}
@@ -764,7 +764,7 @@ func loadRepoFindings(gdb *gorm.DB, repoID uint, category string) repoFindings {
 	ddQ.Count(&rf.DeepDiveTotal)
 	ddQ.Order(severityOrder).Order("id desc").Limit(tabRowCap).Find(&rf.DeepDive)
 
-	scQ := base().Where("scan_id NOT IN (?)", deepDiveScanIDs(gdb))
+	scQ := base().Where("scan_id NOT IN (?)", findingsScanIDs(gdb))
 	scQ.Count(&rf.ScannersTotal)
 	scQ.Order(severityOrder).Order("id desc").Limit(tabRowCap).Find(&rf.Scanners)
 
@@ -861,7 +861,7 @@ func (s *Server) findings(w http.ResponseWriter, r *http.Request) {
 func (s *Server) findingsIndexQuery(r *http.Request, includeScanners, includeMissed bool) *gorm.DB {
 	q := s.DB.Model(&db.Finding{})
 	if !includeScanners {
-		q = q.Where("scan_id IN (?)", deepDiveScanIDs(s.DB))
+		q = q.Where("scan_id IN (?)", findingsScanIDs(s.DB))
 	}
 	if sev := r.URL.Query().Get("severity"); sev != "" {
 		q = q.Where("severity = ?", sev)
@@ -1053,11 +1053,11 @@ var deepDiveFindingsCountSQL = `SELECT COUNT(*) FROM findings f
 	      AND f.scan_id IN (SELECT id FROM scans
 	        WHERE skill_name = '` + deepDiveSkillName + `' OR skill_name = '' OR skill_name IS NULL)`
 
-// deepDiveScanIDs returns a GORM subquery selecting scan IDs that belong to
+// findingsScanIDs returns a GORM subquery selecting scan IDs that belong to
 // the curated audit (security-deep-dive) or to legacy/empty skill_name rows.
 // Use it as a `scan_id IN (?)` filter to keep listings consistent with the
 // repo Findings tab.
-func deepDiveScanIDs(gdb *gorm.DB) *gorm.DB {
+func findingsScanIDs(gdb *gorm.DB) *gorm.DB {
 	return gdb.Model(&db.Scan{}).Select("id").
 		Where("skill_name = ? OR skill_name = '' OR skill_name IS NULL", deepDiveSkillName)
 }
@@ -1230,7 +1230,7 @@ func (s *Server) repoVerifyAll(w http.ResponseWriter, r *http.Request) {
 
 	q := s.DB.Model(&db.Finding{}).
 		Where("repository_id = ? AND status = ? AND scan_id IN (?)",
-			repo.ID, db.FindingNew, deepDiveScanIDs(s.DB))
+			repo.ID, db.FindingNew, findingsScanIDs(s.DB))
 	if category := r.URL.Query().Get("category"); category != "" {
 		q = applyCWECategoryFilter(q, category)
 	}
@@ -1765,7 +1765,7 @@ func (s *Server) repoShow(w http.ResponseWriter, r *http.Request) {
 	// button on the Findings tab; the bulk handler acts on this exact set.
 	newFindingsQuery := s.DB.Model(&db.Finding{}).
 		Where("repository_id = ? AND status = ? AND scan_id IN (?)",
-			repo.ID, db.FindingNew, deepDiveScanIDs(s.DB))
+			repo.ID, db.FindingNew, findingsScanIDs(s.DB))
 	if category != "" {
 		newFindingsQuery = applyCWECategoryFilter(newFindingsQuery, category)
 	}

--- a/internal/web/theme.go
+++ b/internal/web/theme.go
@@ -71,7 +71,7 @@ func (s *Server) settingsShow(w http.ResponseWriter, r *http.Request) {
 	s.DB.Table("scans").Count(&stats.Scans)
 	// Split findings the same way the repo page does: deep-dive (curated
 	// audit) findings versus tool-scanner output (zizmor, semgrep, …).
-	dd := deepDiveScanIDs(s.DB)
+	dd := findingsScanIDs(s.DB)
 	s.DB.Model(&db.Finding{}).Where("scan_id IN (?)", dd).Count(&stats.Findings)
 	s.DB.Model(&db.Finding{}).Where("scan_id NOT IN (?)", dd).Count(&stats.ScannerFindings)
 	s.DB.Table("packages").Count(&stats.Packages)


### PR DESCRIPTION
## Summary

Pure identifier renames in `internal/web`, with no behavior change:

- `deepDiveScanIDs` → `findingsScanIDs` (the GORM subquery helper + all call sites)
- `autoEnqueueFindingDedupAfterDeepDive` → `autoEnqueueFindingDedup` (the `OnScanFinalized` worker hook + tests)

The function bodies are untouched — `findingsScanIDs` still filters on the security-deep-dive skill name.

## Why

I wanted to land the various method renames as the first PR so it's easier to understand what's happening. I'll update the code in a subsequent PR to start including vuln-scan results as proper Findings instead of Scanner results.

## Test plan

- `go build ./internal/web/` passes
- `go vet ./internal/web/` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)