### PR TITLE
fix: Sort markdown report severities by rank

### DIFF
--- a/internal/web/org_report.go
+++ b/internal/web/org_report.go
@@ -57,7 +57,7 @@ func renderOrgReport(gdb *gorm.DB, owner string, repos []db.Repository) string {
 	var findings []db.Finding
 	gdb.Where("repository_id IN ?", repoIDs).
 		Where("scan_id IN (?)", deepDiveScanIDs(gdb)).
-		Order("severity, id").Find(&findings)
+		Order(severityOrder).Order("id").Find(&findings)
 
 	bySeverity := map[string]int{}
 	byStatus := map[string]int{}

--- a/internal/web/scan_report.go
+++ b/internal/web/scan_report.go
@@ -149,7 +149,7 @@ func writeScanReportFindings(b *strings.Builder, gdb *gorm.DB, scan *db.Scan) {
 	// FK and undercounts the same way; worth a separate issue.
 	var findings []db.Finding
 	gdb.Where("last_seen_scan_id = ? OR scan_id = ?", scan.ID, scan.ID).
-		Order("severity, id").Find(&findings)
+		Order(severityOrder).Order("id").Find(&findings)
 	fmt.Fprintf(b, "## Findings\n\n")
 	if len(findings) == 0 {
 		fmt.Fprintf(b, "No findings recorded by this scan.\n\n")


### PR DESCRIPTION
`org_report.go` and `scan_report.go` used `Order("severity, id")`, which sorts the capitalized severity strings alphabetically (Critical, High, Low, Medium). This places Low above Medium. Use the `severityOrder CASE` expression like the rest of the app to rank Critical > High > Medium > Low.