### PR TITLE
fix: wrap delete-then-insert and update-then-insert in transactions

### DIFF
--- a/internal/db/finding_helpers.go
+++ b/internal/db/finding_helpers.go
@@ -55,27 +55,33 @@ func WriteFindingField(gdb *gorm.DB, findingID uint, field, newValue string, sou
 	if err := validateFindingField(field, newValue); err != nil {
 		return err
 	}
-	if err := gdb.Model(&Finding{}).Where("id = ?", f.ID).Update(colName, newValue).Error; err != nil {
-		return fmt.Errorf("update %s: %w", colName, err)
-	}
-	if err := gdb.Create(&FindingHistory{
-		FindingID: f.ID,
-		Field:     field,
-		OldValue:  old,
-		NewValue:  newValue,
-		Source:    source,
-		By:        by,
-		CreatedAt: time.Now(),
-	}).Error; err != nil {
-		return err
-	}
-	if field == "cvss_vector" {
-		return syncCVSSScore(gdb, &f, newValue, source, by)
-	}
-	if field == "cvss_v4_vector" {
-		return syncCVSSv4Score(gdb, &f, newValue, source, by)
-	}
-	return nil
+	// The column update, its history row, and any dependent CVSS-score
+	// sync must commit together: a failure between them would change the
+	// stored value with no matching history row (breaking the audit
+	// trail) or leave cvss_score inconsistent with cvss_vector.
+	return gdb.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Model(&Finding{}).Where("id = ?", f.ID).Update(colName, newValue).Error; err != nil {
+			return fmt.Errorf("update %s: %w", colName, err)
+		}
+		if err := tx.Create(&FindingHistory{
+			FindingID: f.ID,
+			Field:     field,
+			OldValue:  old,
+			NewValue:  newValue,
+			Source:    source,
+			By:        by,
+			CreatedAt: time.Now(),
+		}).Error; err != nil {
+			return err
+		}
+		if field == "cvss_vector" {
+			return syncCVSSScore(tx, &f, newValue, source, by)
+		}
+		if field == "cvss_v4_vector" {
+			return syncCVSSv4Score(tx, &f, newValue, source, by)
+		}
+		return nil
+	})
 }
 
 // WriteFindingTimeField is the time.Time twin of WriteFindingField for
@@ -102,22 +108,26 @@ func WriteFindingTimeField(gdb *gorm.DB, findingID uint, field string, newValue 
 	if old != nil && old.Equal(newUTC) {
 		return nil
 	}
-	if err := gdb.Model(&Finding{}).Where("id = ?", f.ID).Update(colName, newUTC).Error; err != nil {
-		return fmt.Errorf("update %s: %w", colName, err)
-	}
 	oldStr := ""
 	if old != nil {
 		oldStr = old.UTC().Format(time.RFC3339)
 	}
-	return gdb.Create(&FindingHistory{
-		FindingID: f.ID,
-		Field:     field,
-		OldValue:  oldStr,
-		NewValue:  newUTC.Format(time.RFC3339),
-		Source:    source,
-		By:        by,
-		CreatedAt: time.Now(),
-	}).Error
+	// Column update and history row must commit together so the audit
+	// trail can't lose a row on a mid-write failure.
+	return gdb.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Model(&Finding{}).Where("id = ?", f.ID).Update(colName, newUTC).Error; err != nil {
+			return fmt.Errorf("update %s: %w", colName, err)
+		}
+		return tx.Create(&FindingHistory{
+			FindingID: f.ID,
+			Field:     field,
+			OldValue:  oldStr,
+			NewValue:  newUTC.Format(time.RFC3339),
+			Source:    source,
+			By:        by,
+			CreatedAt: time.Now(),
+		}).Error
+	})
 }
 
 // findingTimeFieldAccessor mirrors findingFieldAccessor for timestamp

--- a/internal/db/finding_helpers_test.go
+++ b/internal/db/finding_helpers_test.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"errors"
 	"path/filepath"
 	"testing"
 	"time"
@@ -217,6 +218,83 @@ func TestWriteFindingField_cvssVectorEmptyClearsScore(t *testing.T) {
 	gdb.First(&refreshed, f.ID)
 	if refreshed.CVSSScore != 0 {
 		t.Errorf("score = %v, want 0", refreshed.CVSSScore)
+	}
+}
+
+// failCreate registers a before-create callback that fails any insert for
+// which pred returns true, simulating a mid-write database error. The
+// returned func removes the injection.
+func failCreate(t *testing.T, gdb *gorm.DB, pred func(*gorm.DB) bool) func() {
+	t.Helper()
+	const name = "test:fail_create"
+	if err := gdb.Callback().Create().Before("gorm:create").Register(name, func(d *gorm.DB) {
+		if pred(d) {
+			_ = d.AddError(errors.New("injected insert failure"))
+		}
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return func() {
+		if err := gdb.Callback().Create().Remove(name); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+// If the history insert fails, the column update must roll back with it:
+// the stored value is unchanged and no audit row is left behind.
+func TestWriteFindingField_rollsBackOnHistoryFailure(t *testing.T) {
+	gdb := newTestDB(t)
+	f := seedFinding(t, gdb)
+
+	remove := failCreate(t, gdb, func(d *gorm.DB) bool {
+		return d.Statement.Table == "finding_histories"
+	})
+	if err := WriteFindingField(gdb, f.ID, severityField, "Critical", SourceAnalyst, "me"); err == nil {
+		t.Fatal("expected error when the history insert fails")
+	}
+	remove()
+
+	var refreshed Finding
+	gdb.First(&refreshed, f.ID)
+	if refreshed.Severity != "High" {
+		t.Errorf("severity = %q, want High (column update must roll back with the failed history row)", refreshed.Severity)
+	}
+	var count int64
+	gdb.Model(&FindingHistory{}).Where("finding_id = ?", f.ID).Count(&count)
+	if count != 0 {
+		t.Errorf("history rows = %d, want 0", count)
+	}
+}
+
+// A cvss_vector write fans out to three database writes (the vector column +
+// its history row, then the synced score column + its history row). Failing
+// the score history insert — which happens last — must roll back the whole
+// chain, so the vector never lands without a matching score.
+func TestWriteFindingField_cvssSyncRollsBackAtomically(t *testing.T) {
+	gdb := newTestDB(t)
+	f := seedFinding(t, gdb)
+
+	remove := failCreate(t, gdb, func(d *gorm.DB) bool {
+		fh, ok := d.Statement.Dest.(*FindingHistory)
+		return ok && fh.Field == "cvss_score"
+	})
+	const vec = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+	if err := WriteFindingField(gdb, f.ID, "cvss_vector", vec, SourceAnalyst, "me"); err == nil {
+		t.Fatal("expected error when the cvss_score history insert fails")
+	}
+	remove()
+
+	var refreshed Finding
+	gdb.First(&refreshed, f.ID)
+	if refreshed.CVSSVector != "" || refreshed.CVSSScore != 0 {
+		t.Errorf("vector=%q score=%v, want both cleared (vector column, vector history, and score must roll back together)",
+			refreshed.CVSSVector, refreshed.CVSSScore)
+	}
+	var count int64
+	gdb.Model(&FindingHistory{}).Where("finding_id = ?", f.ID).Count(&count)
+	if count != 0 {
+		t.Errorf("history rows = %d, want 0 (vector history must roll back with the failed score history)", count)
 	}
 }
 

--- a/internal/worker/skill_parsers.go
+++ b/internal/worker/skill_parsers.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	mavenpom "github.com/git-pkgs/pom"
+	"gorm.io/gorm"
 
 	"scrutineer/internal/db"
 )
@@ -120,9 +121,6 @@ func (w *Worker) parsePackagesOutput(scan *db.Scan, report string, emit func(Eve
 	if err := json.Unmarshal([]byte(report), &result); err != nil {
 		return fmt.Errorf("parse packages: %w", err)
 	}
-	if err := w.DB.Where("repository_id = ?", scan.RepositoryID).Delete(&db.Package{}).Error; err != nil {
-		return fmt.Errorf("delete old packages: %w", err)
-	}
 	rows := make([]db.Package, 0, len(result.Packages))
 	for _, p := range result.Packages {
 		row := db.Package{
@@ -149,10 +147,21 @@ func (w *Worker) parsePackagesOutput(scan *db.Scan, report string, emit func(Eve
 		}
 		rows = append(rows, row)
 	}
-	if len(rows) > 0 {
-		if err := w.DB.CreateInBatches(&rows, insertBatchSize).Error; err != nil {
-			return fmt.Errorf("save packages: %w", err)
+	// Replace the prior row set atomically: a failed insert after the
+	// delete would otherwise leave the repository with zero packages
+	// until the next successful scan.
+	if err := w.DB.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Where("repository_id = ?", scan.RepositoryID).Delete(&db.Package{}).Error; err != nil {
+			return fmt.Errorf("delete old packages: %w", err)
 		}
+		if len(rows) > 0 {
+			if err := tx.CreateInBatches(&rows, insertBatchSize).Error; err != nil {
+				return fmt.Errorf("save packages: %w", err)
+			}
+		}
+		return nil
+	}); err != nil {
+		return err
 	}
 	emit(Event{Kind: KindText, Text: fmt.Sprintf("saved %d package(s)", len(rows))})
 	return nil
@@ -177,9 +186,6 @@ func (w *Worker) parseAdvisoriesOutput(scan *db.Scan, report string, emit func(E
 	if err := json.Unmarshal([]byte(report), &result); err != nil {
 		return fmt.Errorf("parse advisories: %w", err)
 	}
-	if err := w.DB.Where("repository_id = ?", scan.RepositoryID).Delete(&db.Advisory{}).Error; err != nil {
-		return fmt.Errorf("delete old advisories: %w", err)
-	}
 	rows := make([]db.Advisory, 0, len(result.Advisories))
 	for _, a := range result.Advisories {
 		row := db.Advisory{
@@ -201,10 +207,20 @@ func (w *Worker) parseAdvisoriesOutput(scan *db.Scan, report string, emit func(E
 		}
 		rows = append(rows, row)
 	}
-	if len(rows) > 0 {
-		if err := w.DB.CreateInBatches(&rows, insertBatchSize).Error; err != nil {
-			return fmt.Errorf("save advisories: %w", err)
+	// Replace the prior row set atomically so a failed insert can't leave
+	// the repository with zero advisories.
+	if err := w.DB.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Where("repository_id = ?", scan.RepositoryID).Delete(&db.Advisory{}).Error; err != nil {
+			return fmt.Errorf("delete old advisories: %w", err)
 		}
+		if len(rows) > 0 {
+			if err := tx.CreateInBatches(&rows, insertBatchSize).Error; err != nil {
+				return fmt.Errorf("save advisories: %w", err)
+			}
+		}
+		return nil
+	}); err != nil {
+		return err
 	}
 	emit(Event{Kind: KindText, Text: fmt.Sprintf("saved %d advisor(ies)", len(rows))})
 	return nil
@@ -227,9 +243,6 @@ func (w *Worker) parseDependentsOutput(scan *db.Scan, report string, emit func(E
 	if err := json.Unmarshal([]byte(report), &result); err != nil {
 		return fmt.Errorf("parse dependents: %w", err)
 	}
-	if err := w.DB.Where("repository_id = ?", scan.RepositoryID).Delete(&db.Dependent{}).Error; err != nil {
-		return fmt.Errorf("delete old dependents: %w", err)
-	}
 	rows := make([]db.Dependent, 0, len(result.Dependents))
 	for _, d := range result.Dependents {
 		rows = append(rows, db.Dependent{
@@ -244,10 +257,20 @@ func (w *Worker) parseDependentsOutput(scan *db.Scan, report string, emit func(E
 			LatestVersion:  d.LatestVersion,
 		})
 	}
-	if len(rows) > 0 {
-		if err := w.DB.CreateInBatches(&rows, insertBatchSize).Error; err != nil {
-			return fmt.Errorf("save dependents: %w", err)
+	// Replace the prior row set atomically so a failed insert can't leave
+	// the repository with zero dependents.
+	if err := w.DB.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Where("repository_id = ?", scan.RepositoryID).Delete(&db.Dependent{}).Error; err != nil {
+			return fmt.Errorf("delete old dependents: %w", err)
 		}
+		if len(rows) > 0 {
+			if err := tx.CreateInBatches(&rows, insertBatchSize).Error; err != nil {
+				return fmt.Errorf("save dependents: %w", err)
+			}
+		}
+		return nil
+	}); err != nil {
+		return err
 	}
 	emit(Event{Kind: KindText, Text: fmt.Sprintf("saved %d dependent(s)", len(rows))})
 	return nil
@@ -264,9 +287,6 @@ func (w *Worker) parseDependenciesOutput(scan *db.Scan, report string, emit func
 		return fmt.Errorf("parse dependencies: %w", err)
 	}
 	w.resolveMavenDependencyRequirements(scan, result.Dependencies, emit)
-	if err := w.DB.Where("repository_id = ?", scan.RepositoryID).Delete(&db.Dependency{}).Error; err != nil {
-		return fmt.Errorf("delete old dependencies: %w", err)
-	}
 	rows := make([]db.Dependency, 0, len(result.Dependencies))
 	for _, d := range result.Dependencies {
 		depType := d.Type
@@ -287,10 +307,20 @@ func (w *Worker) parseDependenciesOutput(scan *db.Scan, report string, emit func
 			ManifestKind:          d.ManifestKind,
 		})
 	}
-	if len(rows) > 0 {
-		if err := w.DB.CreateInBatches(&rows, insertBatchSize).Error; err != nil {
-			return fmt.Errorf("save dependencies: %w", err)
+	// Replace the prior row set atomically so a failed insert can't leave
+	// the repository with zero dependencies.
+	if err := w.DB.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Where("repository_id = ?", scan.RepositoryID).Delete(&db.Dependency{}).Error; err != nil {
+			return fmt.Errorf("delete old dependencies: %w", err)
 		}
+		if len(rows) > 0 {
+			if err := tx.CreateInBatches(&rows, insertBatchSize).Error; err != nil {
+				return fmt.Errorf("save dependencies: %w", err)
+			}
+		}
+		return nil
+	}); err != nil {
+		return err
 	}
 	emit(Event{Kind: KindText, Text: fmt.Sprintf("saved %d dependenc(ies)", len(rows))})
 	return nil
@@ -486,9 +516,6 @@ func (w *Worker) parseSubprojectsOutput(scan *db.Scan, report string, emit func(
 	if err := json.Unmarshal([]byte(report), &result); err != nil {
 		return fmt.Errorf("parse subprojects: %w", err)
 	}
-	if err := w.DB.Where("repository_id = ?", scan.RepositoryID).Delete(&db.Subproject{}).Error; err != nil {
-		return fmt.Errorf("delete old subprojects: %w", err)
-	}
 	rows := make([]db.Subproject, 0, len(result.Subprojects))
 	for _, sp := range result.Subprojects {
 		path := strings.Trim(sp.Path, "/ \t\n")
@@ -503,10 +530,20 @@ func (w *Worker) parseSubprojectsOutput(scan *db.Scan, report string, emit func(
 			Description:  sp.Description,
 		})
 	}
-	if len(rows) > 0 {
-		if err := w.DB.CreateInBatches(&rows, insertBatchSize).Error; err != nil {
-			return fmt.Errorf("save subprojects: %w", err)
+	// Replace the prior row set atomically so a failed insert can't leave
+	// the repository with zero subprojects.
+	if err := w.DB.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Where("repository_id = ?", scan.RepositoryID).Delete(&db.Subproject{}).Error; err != nil {
+			return fmt.Errorf("delete old subprojects: %w", err)
 		}
+		if len(rows) > 0 {
+			if err := tx.CreateInBatches(&rows, insertBatchSize).Error; err != nil {
+				return fmt.Errorf("save subprojects: %w", err)
+			}
+		}
+		return nil
+	}); err != nil {
+		return err
 	}
 	emit(Event{Kind: KindText, Text: fmt.Sprintf("saved %d subproject(s)", len(rows))})
 	return nil

--- a/internal/worker/skill_parsers_test.go
+++ b/internal/worker/skill_parsers_test.go
@@ -3,6 +3,7 @@ package worker
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"log/slog"
 	"os"
@@ -265,6 +266,46 @@ func TestParsePackages_replacesPackageRows(t *testing.T) {
 	}
 	if rows[0].Metadata == "" {
 		t.Error("package metadata blob not stored")
+	}
+}
+
+// A failed insert must not destroy the existing rows: the delete and the
+// re-insert run in one transaction, so a mid-write failure rolls the delete
+// back and the repository keeps the packages from its last good scan.
+func TestParsePackagesOutput_rollsBackOnInsertFailure(t *testing.T) {
+	repo, gdb := runSkillWithReport(t, "packages",
+		`{"packages":[{"name":"old","ecosystem":"npm","purl":"pkg:npm/old"}]}`)
+	var before int64
+	gdb.Model(&db.Package{}).Where("repository_id = ?", repo.ID).Count(&before)
+	if before != 1 {
+		t.Fatalf("seed rows = %d, want 1", before)
+	}
+
+	scan := db.Scan{RepositoryID: repo.ID}
+	gdb.Create(&scan)
+
+	const name = "test:fail_packages_insert"
+	if err := gdb.Callback().Create().Before("gorm:create").Register(name, func(d *gorm.DB) {
+		if d.Statement.Table == "packages" {
+			_ = d.AddError(errors.New("injected insert failure"))
+		}
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	w := &Worker{DB: gdb, Log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	err := w.parsePackagesOutput(&scan, `{"packages":[{"name":"new","ecosystem":"npm","purl":"pkg:npm/new"}]}`, func(Event) {})
+	if err == nil {
+		t.Fatal("expected error from the injected insert failure")
+	}
+	if err := gdb.Callback().Create().Remove(name); err != nil {
+		t.Fatal(err)
+	}
+
+	var after []db.Package
+	gdb.Where("repository_id = ?", repo.ID).Find(&after)
+	if len(after) != 1 || after[0].Name != "old" {
+		t.Errorf("rows after failed insert = %+v, want [old] (delete must roll back)", after)
 	}
 }
 


### PR DESCRIPTION
## Problem

Two write paths mutated the database in separate, non-atomic steps, so a failure between steps left data in a broken state:

- **`worker/skill_parsers.go`** — the skill parsers (packages, advisories, dependents, dependencies, subprojects) deleted all rows for a repository (committing immediately) then inserted the new set separately. A failed insert left the repository with **zero rows** until the next successful scan.
- **`db/finding_helpers.go`** — `WriteFindingField` / `WriteFindingTimeField` updated a column then created a `FindingHistory` row unwrapped. A failure between them changed the stored value with **no audit row**, and for CVSS could leave `cvss_score` / `cvss_vector` mutually inconsistent.

## Fix

Wrap each delete+insert and update+insert pair in `Transaction(...)` so the steps commit together or not at all. `syncCVSSScore` / `syncCVSSv4Score` now run within the parent transaction (they receive `tx`), making the vector column, its history, and the synced score atomic.

## Tests

Failure-injection tests register a GORM before-create callback that errors on a target insert, proving rollback:

- `WriteFindingField`: a failed `finding_histories` insert leaves the column unchanged with no audit row; a failed `cvss_score` history insert rolls back the vector column, vector history, and synced score together.
- `parsePackagesOutput`: a failed re-insert rolls back the delete, so the repository keeps the packages from its last good scan.

Verified the tests have teeth by temporarily removing a transaction wrapper (test went red, then restored). Full `./internal/db` + `./internal/worker` suites pass and golangci-lint is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)