### PR TITLE
feat: Add "by day" usage view to Usage page.

### DIFF
--- a/internal/web/templates/usage.html
+++ b/internal/web/templates/usage.html
@@ -9,46 +9,79 @@
     <span class="badge-outline">{{usd .TotalCost}} total</span>
   </div>
 </div>
-<p class="text-sm text-muted-foreground mb-6">
-  Cost and turn-count distribution per skill across every completed or failed scan.
-  Queued, running and cancelled scans are excluded.
-</p>
+<div class="flex items-center justify-between mb-6">
+  <p class="text-sm text-muted-foreground">
+    Cost and turn-count distribution per skill across every completed or failed scan.
+    Queued, running and cancelled scans are excluded.
+  </p>
+  <div class="flex items-center gap-1 shrink-0 ml-4">
+    <a href="/usage?view=skill" class="{{if eq .View "skill"}}btn-outline{{else}}btn-sm-ghost{{end}}">By skill</a>
+    <a href="/usage?view=day" class="{{if eq .View "day"}}btn-outline{{else}}btn-sm-ghost{{end}}">By day</a>
+  </div>
+</div>
 
-{{if .Rows}}
-  <table class="table w-full">
-    <thead><tr>
-      <th>Skill</th>
-      <th class="text-right">Runs</th>
-      <th class="text-right">Min</th>
-      <th class="text-right">Median</th>
-      <th class="text-right">p90</th>
-      <th class="text-right">Max</th>
-      <th class="text-right">Total</th>
-      <th class="text-right">Tokens in</th>
-      <th class="text-right">Tokens out</th>
-      <th class="text-right">Median turns</th>
-      <th class="text-right">p90 turns</th>
-    </tr></thead>
-    <tbody>
-    {{range .Rows}}
-      <tr>
-        <td class="font-medium">{{.Skill}}</td>
-        <td class="text-right text-muted-foreground">{{.Runs}}</td>
-        <td class="text-right">{{usd .Cost.Min}}</td>
-        <td class="text-right">{{usd .Cost.Median}}</td>
-        <td class="text-right">{{usd .Cost.P90}}</td>
-        <td class="text-right">{{usd .Cost.Max}}</td>
-        <td class="text-right font-medium">{{usd .Cost.Sum}}</td>
-        <td class="text-right text-muted-foreground">{{bignum .TokensIn}}</td>
-        <td class="text-right text-muted-foreground">{{bignum .TokensOut}}</td>
-        <td class="text-right text-muted-foreground">{{printf "%.0f" .Turns.Median}}</td>
-        <td class="text-right text-muted-foreground">{{printf "%.0f" .Turns.P90}}</td>
-      </tr>
-    {{end}}
-    </tbody>
-  </table>
+{{if eq .View "day"}}
+  {{if .DayRows}}
+    <table class="table w-full">
+      <thead><tr>
+        <th>Date</th>
+        <th class="text-right">Runs</th>
+        <th class="text-right">Total cost</th>
+        <th class="text-right">Tokens in</th>
+        <th class="text-right">Tokens out</th>
+      </tr></thead>
+      <tbody>
+      {{range .DayRows}}
+        <tr>
+          <td class="font-medium">{{.Date}}</td>
+          <td class="text-right text-muted-foreground">{{.Runs}}</td>
+          <td class="text-right font-medium">{{usd .TotalCost}}</td>
+          <td class="text-right text-muted-foreground">{{bignum .TokensIn}}</td>
+          <td class="text-right text-muted-foreground">{{bignum .TokensOut}}</td>
+        </tr>
+      {{end}}
+      </tbody>
+    </table>
+  {{else}}
+    {{template "empty" (dict "Icon" "coins" "Title" "No usage yet" "Body" "Cost data appears here once scans have completed.")}}
+  {{end}}
 {{else}}
-  {{template "empty" (dict "Icon" "coins" "Title" "No usage yet" "Body" "Cost data appears here once scans have completed.")}}
+  {{if .Rows}}
+    <table class="table w-full">
+      <thead><tr>
+        <th>Skill</th>
+        <th class="text-right">Runs</th>
+        <th class="text-right">Min</th>
+        <th class="text-right">Median</th>
+        <th class="text-right">p90</th>
+        <th class="text-right">Max</th>
+        <th class="text-right">Total</th>
+        <th class="text-right">Tokens in</th>
+        <th class="text-right">Tokens out</th>
+        <th class="text-right">Median turns</th>
+        <th class="text-right">p90 turns</th>
+      </tr></thead>
+      <tbody>
+      {{range .Rows}}
+        <tr>
+          <td class="font-medium">{{.Skill}}</td>
+          <td class="text-right text-muted-foreground">{{.Runs}}</td>
+          <td class="text-right">{{usd .Cost.Min}}</td>
+          <td class="text-right">{{usd .Cost.Median}}</td>
+          <td class="text-right">{{usd .Cost.P90}}</td>
+          <td class="text-right">{{usd .Cost.Max}}</td>
+          <td class="text-right font-medium">{{usd .Cost.Sum}}</td>
+          <td class="text-right text-muted-foreground">{{bignum .TokensIn}}</td>
+          <td class="text-right text-muted-foreground">{{bignum .TokensOut}}</td>
+          <td class="text-right text-muted-foreground">{{printf "%.0f" .Turns.Median}}</td>
+          <td class="text-right text-muted-foreground">{{printf "%.0f" .Turns.P90}}</td>
+        </tr>
+      {{end}}
+      </tbody>
+    </table>
+  {{else}}
+    {{template "empty" (dict "Icon" "coins" "Title" "No usage yet" "Body" "Cost data appears here once scans have completed.")}}
+  {{end}}
 {{end}}
 
 {{template "foot" .}}

--- a/internal/web/usage.go
+++ b/internal/web/usage.go
@@ -20,6 +20,16 @@ type SkillUsage struct {
 	TokensOut int
 }
 
+// DayUsage is one row of the /usage?view=day table: total cost and
+// token spend for all skill scans that finished on a given calendar day.
+type DayUsage struct {
+	Date      string
+	Runs      int
+	TotalCost float64
+	TokensIn  int
+	TokensOut int
+}
+
 type Stats struct {
 	Min    float64
 	Median float64
@@ -29,12 +39,18 @@ type Stats struct {
 }
 
 func (s *Server) usage(w http.ResponseWriter, r *http.Request) {
+	view := r.URL.Query().Get("view")
+	if view != "day" {
+		view = "skill"
+	}
+
 	// Only completed runs contribute to the distribution; queued/running
 	// rows have zero cost and would drag the floor down, and failed runs
 	// did still spend tokens so they stay in.
 	var scans []db.Scan
 	s.DB.Select("skill_name", "cost_usd", "turns",
-		"input_tokens", "output_tokens", "cache_read_tokens", "cache_write_tokens").
+		"input_tokens", "output_tokens", "cache_read_tokens", "cache_write_tokens",
+		"finished_at", "created_at").
 		Where("status IN ?", []db.ScanStatus{db.ScanDone, db.ScanFailed}).
 		Where("skill_name != ''").
 		Find(&scans)
@@ -43,11 +59,26 @@ func (s *Server) usage(w http.ResponseWriter, r *http.Request) {
 	turnsBy := map[string][]float64{}
 	inBy := map[string]int{}
 	outBy := map[string]int{}
+	costByDay := map[string]float64{}
+	runsByDay := map[string]int{}
+	inByDay := map[string]int{}
+	outByDay := map[string]int{}
 	for _, sc := range scans {
 		costBy[sc.SkillName] = append(costBy[sc.SkillName], sc.CostUSD)
 		turnsBy[sc.SkillName] = append(turnsBy[sc.SkillName], float64(sc.Turns))
 		inBy[sc.SkillName] += sc.TotalInputTokens()
 		outBy[sc.SkillName] += sc.OutputTokens
+
+		var day string
+		if sc.FinishedAt != nil {
+			day = sc.FinishedAt.UTC().Format("2006-01-02")
+		} else {
+			day = sc.CreatedAt.UTC().Format("2006-01-02")
+		}
+		costByDay[day] += sc.CostUSD
+		runsByDay[day]++
+		inByDay[day] += sc.TotalInputTokens()
+		outByDay[day] += sc.OutputTokens
 	}
 
 	rows := make([]SkillUsage, 0, len(costBy))
@@ -68,10 +99,24 @@ func (s *Server) usage(w http.ResponseWriter, r *http.Request) {
 	}
 	sort.Slice(rows, func(i, j int) bool { return rows[i].Cost.Sum > rows[j].Cost.Sum })
 
+	dayRows := make([]DayUsage, 0, len(costByDay))
+	for day, cost := range costByDay {
+		dayRows = append(dayRows, DayUsage{
+			Date:      day,
+			Runs:      runsByDay[day],
+			TotalCost: cost,
+			TokensIn:  inByDay[day],
+			TokensOut: outByDay[day],
+		})
+	}
+	sort.Slice(dayRows, func(i, j int) bool { return dayRows[i].Date > dayRows[j].Date })
+
 	s.render(w, r, "usage.html", map[string]any{
 		"Rows":      rows,
+		"DayRows":   dayRows,
 		"TotalCost": totalCost,
 		"TotalRuns": totalRuns,
+		"View":      view,
 	})
 }
 

--- a/internal/web/usage_test.go
+++ b/internal/web/usage_test.go
@@ -114,6 +114,58 @@ func TestUsage_perSkillStatsAndOrdering(t *testing.T) {
 	}
 }
 
+func TestUsage_perDay(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	repo := db.Repository{URL: "https://x/day", Name: "day"}
+	s.DB.Create(&repo)
+
+	day1 := time.Date(2025, 1, 10, 12, 0, 0, 0, time.UTC)
+	day2 := time.Date(2025, 1, 11, 12, 0, 0, 0, time.UTC)
+	mk := func(skill string, status db.ScanStatus, cost float64, finished *time.Time) {
+		s.DB.Create(&db.Scan{RepositoryID: repo.ID, Kind: "skill", SkillName: skill,
+			Status: status, CostUSD: cost, FinishedAt: finished})
+	}
+	mk("audit", db.ScanDone, 1.00, &day1)
+	mk("audit", db.ScanDone, 2.00, &day1)
+	mk("metadata", db.ScanFailed, 0.50, &day2)
+	// queued/running excluded.
+	mk("audit", db.ScanQueued, 0, nil)
+
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq("GET", "/usage?view=day"))
+	if w.Code != 200 {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+	body := w.Body.String()
+
+	// Both dates present; newest (day2) should appear before day1.
+	if !strings.Contains(body, "2025-01-10") {
+		t.Errorf("missing 2025-01-10 row")
+	}
+	if !strings.Contains(body, "2025-01-11") {
+		t.Errorf("missing 2025-01-11 row")
+	}
+	if strings.Index(body, "2025-01-11") > strings.Index(body, "2025-01-10") {
+		t.Errorf("expected newer date before older date")
+	}
+	// Day1 total = $3.00; day2 total = $0.50.
+	if !strings.Contains(body, "$3.00") {
+		t.Errorf("missing day1 total $3.00")
+	}
+	if !strings.Contains(body, "$0.50") {
+		t.Errorf("missing day2 total $0.50")
+	}
+	// Header totals still cover all days.
+	if !strings.Contains(body, "$3.50") {
+		t.Errorf("missing grand total $3.50")
+	}
+	if !strings.Contains(body, "3 runs") {
+		t.Errorf("missing 3 runs count")
+	}
+}
+
 func TestRepoShow_totalCostBadge(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()


### PR DESCRIPTION
Add the ability to display usage information on a per-day basis instead of per-skill:

<img width="1225" height="510" alt="Screenshot 2026-06-21 at 12 53 54 PM" src="https://github.com/user-attachments/assets/d84d97a9-5087-4e4b-a39e-4cfdeb38f823" />

Generated with Claude Code, reviewed and tested by me.

Note that the table will skip days wherein you never ran Scrutineer and thus have no scans. We could make this display every day, even ones without scans, but I didn't really feel strongly either way.

These are displayed based on UTC datetime ranges. We could render with the user's timezone but I wasn't sure if that was worth the trouble.