### PR TITLE
fix(worker): mirror context.json into skill dir so ./context.json resolves

### DIFF
--- a/internal/worker/exposure.go
+++ b/internal/worker/exposure.go
@@ -163,11 +163,11 @@ func (w *Worker) doExposure(ctx context.Context, scan *db.Scan, emit func(Event)
 	}
 
 	skillDir := filepath.Join(workRoot, ".claude", "skills", skill.Name)
-	if err := stageSkill(&skill, workRoot, skillDir); err != nil {
-		return "", fmt.Errorf("stage skill: %w", err)
-	}
 	if err := stageContext(workRoot, w.APIBase, w.ForkOrg, w.metadataDir(), scan, &scan.Repository); err != nil {
 		return "", fmt.Errorf("stage context: %w", err)
+	}
+	if err := stageSkill(&skill, workRoot, skillDir); err != nil {
+		return "", fmt.Errorf("stage skill: %w", err)
 	}
 
 	depRepo := db.Repository{URL: dep.RepositoryURL, Name: dep.Name}

--- a/internal/worker/skill.go
+++ b/internal/worker/skill.go
@@ -754,14 +754,15 @@ func validateSkillPaths(name, outputFile string) error {
 }
 
 // stageSkill writes the skill's files into dst so claude-code discovers them
-// at ./.claude/skills/{name}. Only SKILL.md and schema.json are reconstructed
-// from the DB; supplementary files (scripts/, references/, assets/) are
-// copied from SourcePath when the skill was loaded from disk.
+// at ./.claude/skills/{name}. SKILL.md and schema.json are reconstructed from
+// the DB; supplementary files (scripts/, references/, assets/) are copied
+// from SourcePath when the skill was loaded from disk.
 //
 // schema.json is also written to workRoot so the `./schema.json` path every
 // SKILL.md references resolves without the model having to glob for it (#221).
 // context.json is mirrored from workRoot into dst so `./context.json` resolves
-// from the skill directory as well as the workspace root.
+// from the skill directory as well as the workspace root; that read means
+// stageSkill must run after stageContext, which is what produces the file.
 func stageSkill(skill *db.Skill, workRoot, dst string) error {
 	if err := os.RemoveAll(dst); err != nil {
 		return err
@@ -781,7 +782,12 @@ func stageSkill(skill *db.Skill, workRoot, dst string) error {
 			return err
 		}
 	}
-	if data, err := os.ReadFile(filepath.Join(workRoot, "context.json")); err == nil {
+	switch data, err := os.ReadFile(filepath.Join(workRoot, "context.json")); {
+	case errors.Is(err, os.ErrNotExist):
+		// stageContext hasn't run (or this caller doesn't use one); no mirror.
+	case err != nil:
+		return fmt.Errorf("read context.json: %w", err)
+	default:
 		if werr := os.WriteFile(filepath.Join(dst, "context.json"), data, filePerm); werr != nil {
 			return werr
 		}

--- a/internal/worker/skill.go
+++ b/internal/worker/skill.go
@@ -760,6 +760,8 @@ func validateSkillPaths(name, outputFile string) error {
 //
 // schema.json is also written to workRoot so the `./schema.json` path every
 // SKILL.md references resolves without the model having to glob for it (#221).
+// context.json is mirrored from workRoot into dst so `./context.json` resolves
+// from the skill directory as well as the workspace root.
 func stageSkill(skill *db.Skill, workRoot, dst string) error {
 	if err := os.RemoveAll(dst); err != nil {
 		return err
@@ -777,6 +779,11 @@ func stageSkill(skill *db.Skill, workRoot, dst string) error {
 		}
 		if err := os.WriteFile(filepath.Join(workRoot, "schema.json"), []byte(skill.SchemaJSON), filePerm); err != nil {
 			return err
+		}
+	}
+	if data, err := os.ReadFile(filepath.Join(workRoot, "context.json")); err == nil {
+		if werr := os.WriteFile(filepath.Join(dst, "context.json"), data, filePerm); werr != nil {
+			return werr
 		}
 	}
 	if skill.SourcePath != "" && skill.Source != "ui" {

--- a/internal/worker/skill_test.go
+++ b/internal/worker/skill_test.go
@@ -474,6 +474,28 @@ func TestStageSkill_noScriptsDirIsNoop(t *testing.T) {
 	}
 }
 
+func TestStageSkill_mirrorsContextJSONToSkillDir(t *testing.T) {
+	// stageContext writes context.json to workRoot; stageSkill must copy it
+	// into the skill directory so ./context.json resolves from the skill dir.
+	work := t.TempDir()
+	ctx := `{"repository":{"url":"https://example.com/r"}}`
+	if err := os.WriteFile(filepath.Join(work, "context.json"), []byte(ctx), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	skill := &db.Skill{Name: "s", Description: "d", Body: "body", Source: "ui"}
+	dst := filepath.Join(work, ".claude", "skills", "s")
+	if err := stageSkill(skill, work, dst); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(filepath.Join(dst, "context.json"))
+	if err != nil {
+		t.Fatalf("context.json not mirrored into skill dir: %v", err)
+	}
+	if string(got) != ctx {
+		t.Errorf("mirrored context.json = %q, want %q", string(got), ctx)
+	}
+}
+
 func TestStageContext_includesRef(t *testing.T) {
 	dir := t.TempDir()
 	repo := &db.Repository{URL: "https://example.com/x", Name: "x"}


### PR DESCRIPTION
## Summary

- `stageContext` writes `context.json` to `workRoot` (`/work/context.json`), but skill agents sometimes try to read it relative to the skill directory (`.claude/skills/{name}/context.json`) — the same failure mode that hit `schema.json` (#221) and `scripts/` (#305).
- Fix: `stageSkill` now reads `context.json` from `workRoot` and copies it into the skill directory (`dst`) alongside `SKILL.md` and `schema.json`.
- Added `TestStageSkill_mirrorsContextJSONToSkillDir` to cover the new behaviour.

## Test plan

- [ ] `go test ./internal/worker/ -run TestStageSkill` — all pass including new test
- [ ] `go test ./internal/worker/` — full suite passes
- [ ] `golangci-lint run ./internal/worker/...` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)