### PR TITLE
feat(api): add validate-report endpoint for in-container schema checks

### DIFF
--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -11,6 +11,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -98,6 +99,7 @@ func (s *Server) apiHandler() http.Handler {
 	mux.HandleFunc("POST /repositories/{id}/skills/{name}/run", s.apiRunSkill)
 	mux.HandleFunc("POST /findings/{id}/skills/{name}/run", s.apiRunFindingSkill)
 	mux.HandleFunc("GET /scans/{id}", s.apiGetScan)
+	mux.HandleFunc("POST /scans/{id}/validate-report", s.apiValidateReport)
 	mux.HandleFunc("GET /findings/{id}", s.apiGetFinding)
 	mux.HandleFunc("PATCH /findings/{id}", s.apiPatchFinding)
 	mux.HandleFunc("GET /findings/{id}/notes", s.apiListFindingNotes)
@@ -210,6 +212,47 @@ func (s *Server) apiGetScan(w http.ResponseWriter, r *http.Request) {
 	summary["report"] = sc.Report
 	summary["log"] = sc.Log
 	writeJSON(w, http.StatusOK, summary)
+}
+
+// apiValidateReport lets a running skill check a candidate report.json against
+// its skill's schema without installing a JSON Schema library inside the runner
+// container. The request body is the candidate report; the response is
+// {"valid":true} or {"valid":false,"errors":"..."} using the exact same
+// validator (worker.ValidateReportSchema) the harness runs after the scan, so
+// an in-container pass guarantees the harness will not send a repair prompt.
+//
+// The body is already capped at apiMaxBody (1 MB) by apiAuth's MaxBytesReader;
+// an oversized report is rejected rather than silently truncated.
+func (s *Server) apiValidateReport(w http.ResponseWriter, r *http.Request) {
+	id, _ := strconv.Atoi(r.PathValue("id"))
+	scan := scanFromRequest(r)
+	if scan == nil || scan.ID != uint(id) {
+		writeAPIError(w, http.StatusForbidden, "scan may only validate its own report")
+		return
+	}
+	if scan.SkillID == nil {
+		writeAPIError(w, http.StatusBadRequest, "scan has no skill")
+		return
+	}
+	var skill db.Skill
+	if err := s.DB.First(&skill, *scan.SkillID).Error; err != nil {
+		writeAPIError(w, http.StatusNotFound, "skill not found")
+		return
+	}
+	if skill.SchemaJSON == "" {
+		writeJSON(w, http.StatusOK, map[string]any{"valid": true, "note": "skill has no schema"})
+		return
+	}
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		writeAPIError(w, http.StatusRequestEntityTooLarge, "could not read body (max 1 MB)")
+		return
+	}
+	if detail := worker.ValidateReportSchema(skill.SchemaJSON, string(body)); detail != "" {
+		writeJSON(w, http.StatusOK, map[string]any{"valid": false, "errors": detail})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"valid": true})
 }
 
 func (s *Server) apiRunSkill(w http.ResponseWriter, r *http.Request) {

--- a/internal/web/api_test.go
+++ b/internal/web/api_test.go
@@ -551,3 +551,140 @@ func TestAPIAuth_capsRequestBody(t *testing.T) {
 		t.Errorf("status %d, want 400 (decode fails on capped body)", w.Code)
 	}
 }
+
+// seedScanWithSkill creates a repo + skill (with the given schema) + running
+// scan whose APIToken authenticates and whose SkillID points at the skill, so
+// validate-report calls resolve a schema to check against.
+func seedScanWithSkill(t *testing.T, s *Server, schema string) db.Scan {
+	t.Helper()
+	repo := db.Repository{URL: "https://example.com/vr", Name: "vr"}
+	s.DB.Create(&repo)
+	skill := db.Skill{Name: "threat-model", Description: "t", Body: "b", OutputFile: "report.json",
+		SchemaJSON: schema, Version: 1, Active: true, Source: "ui"}
+	s.DB.Create(&skill)
+	now := time.Now()
+	scan := db.Scan{
+		RepositoryID: repo.ID,
+		Kind:         worker.JobSkill,
+		Status:       db.ScanRunning,
+		SkillID:      &skill.ID,
+		SkillName:    skill.Name,
+		APIToken:     "tok-vr",
+		StartedAt:    &now,
+	}
+	s.DB.Create(&scan)
+	return scan
+}
+
+const validateTestSchema = `{
+  "type": "object",
+  "required": ["tier"],
+  "properties": {"tier": {"type": "string"}}
+}`
+
+func postValidate(t *testing.T, s *Server, scanID uint, token, body string) (int, map[string]any) {
+	t.Helper()
+	path := "/api/scans/" + strconv.FormatUint(uint64(scanID), 10) + "/validate-report"
+	r := httptest.NewRequest("POST", path, strings.NewReader(body))
+	r.Host = testHost
+	r.Header.Set("Authorization", "Bearer "+token)
+	r.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, r)
+	var out map[string]any
+	_ = json.NewDecoder(w.Body).Decode(&out)
+	return w.Code, out
+}
+
+func TestAPIValidateReport_valid(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	scan := seedScanWithSkill(t, s, validateTestSchema)
+
+	code, out := postValidate(t, s, scan.ID, scan.APIToken, `{"tier":"ready"}`)
+	if code != 200 {
+		t.Fatalf("status %d, want 200", code)
+	}
+	if out["valid"] != true {
+		t.Errorf("response = %+v, want valid:true", out)
+	}
+}
+
+func TestAPIValidateReport_invalidMatchesValidator(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	scan := seedScanWithSkill(t, s, validateTestSchema)
+
+	const report = `{"tier":42}`
+	code, out := postValidate(t, s, scan.ID, scan.APIToken, report)
+	if code != 200 {
+		t.Fatalf("status %d, want 200", code)
+	}
+	if out["valid"] != false {
+		t.Fatalf("response = %+v, want valid:false", out)
+	}
+	want := worker.ValidateReportSchema(validateTestSchema, report)
+	if want == "" {
+		t.Fatal("expected the validator to reject the report")
+	}
+	if got, _ := out["errors"].(string); got != want {
+		t.Errorf("errors = %q, want %q (must match the harness validator)", got, want)
+	}
+}
+
+func TestAPIValidateReport_crossScanForbidden(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	scan := seedScanWithSkill(t, s, validateTestSchema)
+
+	// A different running scan with its own token must not validate against
+	// scan's ID using its own credentials.
+	now := time.Now()
+	other := db.Scan{RepositoryID: scan.RepositoryID, Kind: worker.JobSkill, Status: db.ScanRunning,
+		SkillID: scan.SkillID, APIToken: "tok-other", StartedAt: &now}
+	s.DB.Create(&other)
+
+	code, out := postValidate(t, s, scan.ID, other.APIToken, `{"tier":"ready"}`)
+	if code != http.StatusForbidden {
+		t.Fatalf("status %d, want 403. body=%+v", code, out)
+	}
+}
+
+func TestAPIValidateReport_noSchema(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	scan := seedScanWithSkill(t, s, "")
+
+	code, out := postValidate(t, s, scan.ID, scan.APIToken, `{"anything":true}`)
+	if code != 200 {
+		t.Fatalf("status %d, want 200", code)
+	}
+	if out["valid"] != true || out["note"] != "skill has no schema" {
+		t.Errorf("response = %+v, want valid:true with no-schema note", out)
+	}
+}
+
+func TestAPIValidateReport_noSkill(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	_, scan := seedRunningScan(t, s) // SkillID is nil
+
+	code, out := postValidate(t, s, scan.ID, scan.APIToken, `{}`)
+	if code != http.StatusBadRequest {
+		t.Fatalf("status %d, want 400. body=%+v", code, out)
+	}
+}
+
+func TestAPIValidateReport_oversizedBodyRejected(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	scan := seedScanWithSkill(t, s, validateTestSchema)
+
+	// apiAuth caps every request body at apiMaxBody; a larger report is
+	// rejected rather than silently truncated.
+	body := `{"tier":"` + strings.Repeat("x", apiMaxBody) + `"}`
+	code, _ := postValidate(t, s, scan.ID, scan.APIToken, body)
+	if code != http.StatusRequestEntityTooLarge {
+		t.Errorf("status %d, want 413", code)
+	}
+}

--- a/internal/worker/claude.go
+++ b/internal/worker/claude.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"syscall"
 
 	"scrutineer/internal/db"
@@ -315,8 +316,23 @@ func buildSkillPrompt(name, outputFile string) string {
 	p := fmt.Sprintf("Use the %q skill on the repository cloned at ./src.", name)
 	if outputFile != "" {
 		p += fmt.Sprintf(" Write your structured output to ./%s as the skill specifies.", outputFile)
+		p += schemaValidationHint(outputFile)
 	}
 	return p
+}
+
+// schemaValidationHint tells claude to validate its JSON output against the
+// skill's schema via scrutineer's API instead of installing a JSON Schema
+// library inside the runner container. The package-install route wastes turns
+// (the container has no pip/gem) and is unreliable (Ruby's json_schemer chokes
+// on contentMediaType annotations); the endpoint reuses the harness's own
+// validator, so a pass here means the post-scan check will also pass. Only
+// emitted for JSON outputs, since the endpoint validates against schema.json.
+func schemaValidationHint(outputFile string) string {
+	if !strings.HasSuffix(outputFile, ".json") {
+		return ""
+	}
+	return fmt.Sprintf(" To check ./%s against ./schema.json, POST it to {scrutineer.api_base}/scans/{scrutineer.scan_id}/validate-report (header \"Authorization: Bearer {scrutineer.token}\", values in ./context.json); {\"valid\":true} means it conforms. Don't install a schema validator.", outputFile)
 }
 
 // buildLoggedPrompt is what scrutineer records on scan.Prompt for the UI. It

--- a/internal/worker/dependencies_script_test.go
+++ b/internal/worker/dependencies_script_test.go
@@ -31,7 +31,7 @@ func TestDependenciesScriptNormalizesEmptyGitPkgsOutput(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if got := validateReportSchema(string(schema), out); got != "" {
+			if got := ValidateReportSchema(string(schema), out); got != "" {
 				t.Fatalf("script output failed schema validation: %s\n%s", got, out)
 			}
 		})

--- a/internal/worker/exposure.go
+++ b/internal/worker/exposure.go
@@ -229,7 +229,7 @@ func (w *Worker) doExposure(ctx context.Context, scan *db.Scan, emit func(Event)
 // back to under_investigation; invalid justification labels are dropped.
 func (w *Worker) parseExposureOutput(skill *db.Skill, scan *db.Scan, depID uint, report string, emit func(Event)) error {
 	if skill.SchemaJSON != "" {
-		if detail := validateReportSchema(skill.SchemaJSON, report); detail != "" {
+		if detail := ValidateReportSchema(skill.SchemaJSON, report); detail != "" {
 			emit(Event{Kind: KindError, Text: "schema: report.json does not validate against schema.json:\n" + detail})
 			if w.SchemaStrict {
 				return &SchemaValidationError{Skill: skill.Name, Detail: detail}

--- a/internal/worker/schema_bundled_test.go
+++ b/internal/worker/schema_bundled_test.go
@@ -122,7 +122,7 @@ func TestBundledSchemas_compileAndAcceptSamples(t *testing.T) {
 		if err != nil {
 			t.Fatalf("read %s: %v", tc.schema, err)
 		}
-		if got := validateReportSchema(string(schema), tc.report); got != "" {
+		if got := ValidateReportSchema(string(schema), tc.report); got != "" {
 			t.Errorf("%s rejected sample: %s\nreport: %s", tc.schema, got, tc.report)
 		}
 	}
@@ -174,7 +174,7 @@ func TestBundledSchemas_rejectBadShapes(t *testing.T) {
 		if err != nil {
 			t.Fatalf("read %s: %v", tc.schema, err)
 		}
-		got := validateReportSchema(string(schema), tc.report)
+		got := ValidateReportSchema(string(schema), tc.report)
 		if got == "" {
 			t.Errorf("%s accepted bad report %s", tc.schema, tc.report)
 			continue

--- a/internal/worker/schema_validate.go
+++ b/internal/worker/schema_validate.go
@@ -22,13 +22,17 @@ func (e *SchemaValidationError) Error() string {
 
 const maxSchemaErrors = 8
 
-// validateReportSchema compiles schemaJSON and validates report against it.
+// ValidateReportSchema compiles schemaJSON and validates report against it.
 // Returns "" when valid, otherwise a one-line-per-failure summary capped at
 // maxSchemaErrors. A schema that does not compile, or a report that is not
 // JSON, returns a single line saying so; both are treated as validation
 // failures rather than scan errors so a malformed schema cannot fail every
 // scan in strict mode.
-func validateReportSchema(schemaJSON, report string) string {
+//
+// It is exported so the web API can offer skills a server-side validation
+// endpoint that uses the exact same validator as the harness, sparing them
+// from installing a JSON Schema library inside the runner container.
+func ValidateReportSchema(schemaJSON, report string) string {
 	c := jsonschema.NewCompiler()
 	doc, err := jsonschema.UnmarshalJSON(strings.NewReader(schemaJSON))
 	if err != nil {

--- a/internal/worker/schema_validate_test.go
+++ b/internal/worker/schema_validate_test.go
@@ -26,7 +26,7 @@ const testSchema = `{
 }`
 
 func TestValidateReportSchema_valid(t *testing.T) {
-	got := validateReportSchema(testSchema, `{"tier":"ready","summary":"ok"}`)
+	got := ValidateReportSchema(testSchema, `{"tier":"ready","summary":"ok"}`)
 	if got != "" {
 		t.Errorf("expected no validation error, got %q", got)
 	}
@@ -46,7 +46,7 @@ func TestValidateReportSchema_failures(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := validateReportSchema(testSchema, tc.report)
+			got := ValidateReportSchema(testSchema, tc.report)
 			if got == "" {
 				t.Fatalf("expected validation failure, got none")
 			}
@@ -58,10 +58,10 @@ func TestValidateReportSchema_failures(t *testing.T) {
 }
 
 func TestValidateReportSchema_malformedSchema(t *testing.T) {
-	if got := validateReportSchema(`not json`, `{}`); !strings.Contains(got, "schema.json is not valid JSON") {
+	if got := ValidateReportSchema(`not json`, `{}`); !strings.Contains(got, "schema.json is not valid JSON") {
 		t.Errorf("got %q", got)
 	}
-	if got := validateReportSchema(`{"type":42}`, `{}`); !strings.Contains(got, "schema.json could not be compiled") {
+	if got := ValidateReportSchema(`{"type":42}`, `{}`); !strings.Contains(got, "schema.json could not be compiled") {
 		t.Errorf("got %q", got)
 	}
 }
@@ -73,7 +73,7 @@ func TestValidateReportSchema_capsErrorCount(t *testing.T) {
 		"g":{"type":"string"},"h":{"type":"string"},"i":{"type":"string"},
 		"j":{"type":"string"}}}`
 	report := `{"a":1,"b":1,"c":1,"d":1,"e":1,"f":1,"g":1,"h":1,"i":1,"j":1}`
-	got := validateReportSchema(schema, report)
+	got := ValidateReportSchema(schema, report)
 	lines := strings.Count(got, "\n") + 1
 	if lines > maxSchemaErrors+1 {
 		t.Errorf("output has %d lines, want at most %d (cap + ellipsis): %q", lines, maxSchemaErrors+1, got)

--- a/internal/worker/skill.go
+++ b/internal/worker/skill.go
@@ -203,7 +203,7 @@ func (w *Worker) parsePartialSkillReport(skill *db.Skill, scan *db.Scan, report 
 
 func (w *Worker) repairAndParseSkillOutput(ctx context.Context, skill *db.Skill, scan *db.Scan, sj SkillJob, report string, emit func(Event)) (string, error) {
 	if skill.SchemaJSON != "" {
-		if detail := validateReportSchema(skill.SchemaJSON, report); detail != "" {
+		if detail := ValidateReportSchema(skill.SchemaJSON, report); detail != "" {
 			if repairedReport, ok := w.repairSchemaReport(ctx, skill, scan, sj, report, detail, emit); ok {
 				report = repairedReport
 			}
@@ -245,7 +245,7 @@ func (w *Worker) repairSchemaReport(ctx context.Context, skill *db.Skill, scan *
 		emit(Event{Kind: KindError, Text: fmt.Sprintf("schema: repair attempt did not produce %s; parsing original output", outputFile)})
 		return "", false
 	}
-	if detail = validateReportSchema(skill.SchemaJSON, res.Report); detail == "" {
+	if detail = ValidateReportSchema(skill.SchemaJSON, res.Report); detail == "" {
 		emit(Event{Kind: KindText, Text: fmt.Sprintf("schema: repaired %s validates", outputFile)})
 		return res.Report, true
 	}
@@ -287,7 +287,7 @@ func truncateSchemaRepairReport(report string) string {
 
 func (w *Worker) parseSkillOutput(skill *db.Skill, scan *db.Scan, report string, emit func(Event)) error {
 	if skill.SchemaJSON != "" {
-		if detail := validateReportSchema(skill.SchemaJSON, report); detail != "" {
+		if detail := ValidateReportSchema(skill.SchemaJSON, report); detail != "" {
 			emit(schemaValidationEvent(skill, detail))
 			if w.SchemaStrict {
 				return &SchemaValidationError{Skill: skill.Name, Detail: detail}

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -617,6 +617,53 @@ paths:
         '403': { $ref: '#/components/responses/Forbidden' }
         '404': { $ref: '#/components/responses/NotFound' }
 
+  /scans/{id}/validate-report:
+    post:
+      summary: Validate a candidate report.json against the skill's schema
+      description: >
+        Lets a running skill check its report against its skill's schema using
+        scrutineer's own validator, instead of installing a JSON Schema library
+        inside the runner container. The request body is the candidate report
+        JSON; a 200 response carries {"valid": true} when it conforms, or
+        {"valid": false, "errors": "..."} listing the failures. A skill with no
+        schema returns {"valid": true, "note": "skill has no schema"}. The token
+        may only validate the scan it was issued for. Body is capped at 1 MB.
+      operationId: validateReport
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: { type: integer, format: int64 }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { type: object, additionalProperties: true }
+      responses:
+        '200':
+          description: Validation result (valid true or false; never a schema error)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  valid: { type: boolean }
+                  errors: { type: string }
+                  note: { type: string }
+                required: [valid]
+        '400':
+          description: Scan has no associated skill
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/NotFound' }
+        '413':
+          description: Report body exceeds the 1 MB limit
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+
   /findings/{id}:
     get:
       summary: Fetch one finding with its six-step prose


### PR DESCRIPTION
Add `POST /api/scans/{id}/validate-report` so a skill running in the runner container can validate its `report.json` against the skill's schema via curl, reusing the harness's own validator (ValidateReportSchema). 

This should improve the token usage and unnecessary additional turns required for Claude to install a schema validation package, write the validator, run the validator, and then get back a loud validation response. 

Changes:
- Export `worker.ValidateReportSchema` for reuse by the web package.
- Inject a concise schema-validation hint into the centralized skill activation prompt (`buildSkillPrompt`) for all JSON-output skills.
- Document the endpoint in `openapi.yaml`.

This was generated with Claude Code, fixes #471. 

I've tested this myself locally on two full repo scans and a few minor retries, I'm pretty confident in the change now.

Example logs after this change:

```
All 10 skills enqueued successfully (201). No 404s. Now let me write the report.
[write] /work/report.json
Now let me validate the report against the schema.
[bash] curl -s -X POST -H "Authorization: Bearer token" -H "Content-Type: application/json" -d @/work/report.json "http://host.docker.internal:8080/api/scans/3025/validate-report"
The schema doesn't allow `release_watch` as a field. Let me remove it.
[edit] /work/report.json
[bash] curl -s -X POST -H "Authorization: Bearer token" -H "Content-Type: application/json" -d @/work/report.json "http://host.docker.internal:8080/api/scans/3025/validate-report"
Report validated successfully. Here's what happened:
```

This should also reduce the likelihood of needing a re-run of the job due to schema errors.