### PR TITLE
feat(web): add "Resume all" button to repo Scans tab

### DIFF
--- a/internal/web/scans.go
+++ b/internal/web/scans.go
@@ -249,8 +249,13 @@ func (s *Server) scansPauseQueued(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) scansResumePaused(w http.ResponseWriter, r *http.Request) {
+	repoID, _ := strconv.Atoi(r.URL.Query().Get("repository"))
+	q := s.DB.Where("status = ?", db.ScanPaused)
+	if repoID > 0 {
+		q = q.Where("repository_id = ?", repoID)
+	}
 	var scans []db.Scan
-	if err := s.DB.Where("status = ?", db.ScanPaused).Find(&scans).Error; err != nil {
+	if err := q.Find(&scans).Error; err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -267,6 +272,12 @@ func (s *Server) scansResumePaused(w http.ResponseWriter, r *http.Request) {
 		cat = errorKey
 	}
 	setFlash(w, Flash{Category: cat, Title: fmt.Sprintf("%d paused scans resumed", resumed)})
+	// Repo-scoped resumes return to that repo's Scans tab so the operator stays
+	// in context; otherwise we send them to the global queued list.
+	if repoID > 0 {
+		s.redirect(w, r, fmt.Sprintf("/repositories/%d#rt3", repoID))
+		return
+	}
 	s.redirect(w, r, "/scans?status=queued")
 }
 

--- a/internal/web/scans_test.go
+++ b/internal/web/scans_test.go
@@ -260,6 +260,51 @@ func TestScansResumePaused(t *testing.T) {
 	}
 }
 
+func TestScansResumePaused_scopedToRepo(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	repo := db.Repository{URL: "https://example.com/a", Name: "a"}
+	other := db.Repository{URL: "https://example.com/b", Name: "b"}
+	s.DB.Create(&repo)
+	s.DB.Create(&other)
+
+	mk := func(repoID uint, st db.ScanStatus) db.Scan {
+		sc := db.Scan{RepositoryID: repoID, Kind: "skill", Status: st,
+			StatusPriority: db.StatusPriorityFor(st)}
+		s.DB.Create(&sc)
+		return sc
+	}
+	paused := mk(repo.ID, db.ScanPaused)
+	otherPaused := mk(other.ID, db.ScanPaused)
+	finished := mk(repo.ID, db.ScanDone)
+
+	r := localReq("POST", fmt.Sprintf("/scans/resume-paused?repository=%d", repo.ID))
+	r.Header.Set("HX-Request", "true")
+	w := httptest.NewRecorder()
+	s.scansResumePaused(w, r)
+
+	if loc := w.Header().Get("HX-Redirect"); loc != fmt.Sprintf("/repositories/%d#rt3", repo.ID) {
+		t.Errorf("HX-Redirect = %q, want repo Scans tab", loc)
+	}
+
+	statusOf := func(id uint) db.ScanStatus {
+		var sc db.Scan
+		s.DB.First(&sc, id)
+		return sc.Status
+	}
+	// Only this repo's paused scan is resumed; the other repo's paused scan and
+	// terminal scans are untouched.
+	if got := statusOf(paused.ID); got != db.ScanQueued {
+		t.Errorf("paused -> %q, want queued", got)
+	}
+	if got := statusOf(otherPaused.ID); got != db.ScanPaused {
+		t.Errorf("other repo paused -> %q, want paused (untouched)", got)
+	}
+	if got := statusOf(finished.ID); got != db.ScanDone {
+		t.Errorf("done -> %q, want done", got)
+	}
+}
+
 func TestScansCancelAll_requiresRepository(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -1698,6 +1698,17 @@ func bulkToastDescription(invalid []string) string {
 	return fmt.Sprintf("Rejected: %s, and %d more", strings.Join(invalid[:maxShow], ", "), len(invalid)-maxShow)
 }
 
+// repoScanActionCounts returns the number of cancellable (running/queued) and
+// resumable (paused) scans on a repo, driving the "Cancel all" and "Resume all"
+// bulk buttons on the Scans tab.
+func (s *Server) repoScanActionCounts(repoID uint) (active, paused int64) {
+	s.DB.Model(&db.Scan{}).Where("repository_id = ? AND status IN ?",
+		repoID, []db.ScanStatus{db.ScanRunning, db.ScanQueued}).Count(&active)
+	s.DB.Model(&db.Scan{}).Where("repository_id = ? AND status = ?",
+		repoID, db.ScanPaused).Count(&paused)
+	return active, paused
+}
+
 func (s *Server) repoShow(w http.ResponseWriter, r *http.Request) {
 	repo, ok := loadByID[db.Repository](s, w, r)
 	if !ok {
@@ -1854,13 +1865,11 @@ func (s *Server) repoShow(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Drives the delete-confirm warning: a running scan keeps writing into the
-	// repo's clone/workspace until it returns, so the operator should cancel
-	// before deleting. Counted over every scan, not the latest-per-skill set,
-	// and over the cancellable non-terminal states (paused can't be cancelled).
-	var activeScans int64
-	s.DB.Model(&db.Scan{}).Where("repository_id = ? AND status IN ?",
-		repo.ID, []db.ScanStatus{db.ScanRunning, db.ScanQueued}).Count(&activeScans)
+	// activeScans drives both the delete-confirm warning (a running scan keeps
+	// writing into the repo's clone/workspace until it returns) and the "Cancel
+	// all" button; pausedScans drives "Resume all". Both are counted over every
+	// scan, not the latest-per-skill set.
+	activeScans, pausedScans := s.repoScanActionCounts(repo.ID)
 
 	data := map[string]any{
 		"Repo": repo, "Scans": scans, "Latest": latest,
@@ -1873,6 +1882,7 @@ func (s *Server) repoShow(w http.ResponseWriter, r *http.Request) {
 		"NewFindingCount":      int(newFindings),
 		"FailedScans":          failedScans,
 		"ActiveScans":          int(activeScans),
+		"PausedScans":          int(pausedScans),
 		"TotalCost":            totalCost,
 		"DiskBytes":            worker.RepoDiskUsage(s.Worker.DataDir, repo),
 		"TMCommit":             tmCommit,

--- a/internal/web/templates/repo_show.html
+++ b/internal/web/templates/repo_show.html
@@ -484,7 +484,7 @@
   </div>
 
   <div role="tabpanel" id="rp3" aria-labelledby="rt3" hidden>
-    {{if or (gt .ActiveScans 0) (gt .FailedScans 0)}}
+    {{if or (gt .ActiveScans 0) (gt .PausedScans 0) (gt .FailedScans 0)}}
       <div class="flex justify-end gap-2 mb-2">
         {{if gt .ActiveScans 0}}
         <form method="post" action="/scans/cancel-all?repository={{.Repo.ID}}"
@@ -492,6 +492,15 @@
               hx-confirm="Cancel all {{.ActiveScans}} running or queued scan(s) on {{.Repo.Name}}? Any work in progress is discarded.">
           <button type="submit" class="btn-outline">
             <i data-lucide="x"></i> Cancel all ({{.ActiveScans}})
+          </button>
+        </form>
+        {{end}}
+        {{if gt .PausedScans 0}}
+        <form method="post" action="/scans/resume-paused?repository={{.Repo.ID}}"
+              hx-post="/scans/resume-paused?repository={{.Repo.ID}}" hx-swap="none"
+              hx-confirm="Resume all {{.PausedScans}} paused scan(s) on {{.Repo.Name}}?">
+          <button type="submit" class="btn-outline">
+            <i data-lucide="play"></i> Resume all ({{.PausedScans}})
           </button>
         </form>
         {{end}}


### PR DESCRIPTION
## What

Adds a bulk **"Resume all"** button next to "Cancel all" on a repository's Scans tab. It only appears when the repo has paused scans that can be resumed.

<img width="1203" height="256" alt="Screenshot 2026-06-21 at 5 01 22 PM" src="https://github.com/user-attachments/assets/b62a2d54-d178-4fd0-bda0-9447e847c050" />


## How

- `scansResumePaused` now accepts an optional `repository` query param (mirroring the existing `scansRetryFailed` handler). When scoped to a repo it resumes only that repo's paused scans and redirects back to the repo's Scans tab (`/repositories/{id}#rt3`); the global behavior is unchanged.
- `repoShow` exposes a `PausedScans` count, extracted with the existing active-scan count into a small `repoScanActionCounts` helper.
- The template gates the new button on `PausedScans > 0` and widens the toolbar's outer condition so it renders when only paused scans exist.

Note: paused is itself the resumability condition — `resumeScan` gates only on `Status == ScanPaused` (no skill/kind restriction, unlike retry).

## Testing

- New `TestScansResumePaused_scopedToRepo` verifies only the target repo's paused scans are re-enqueued and the redirect lands on the repo Scans tab.
- `go test ./internal/web/...` passes; `golangci-lint run` reports 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)