### PR TITLE
chore: Bump zizmor to v1.26.1.

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
-      - run: pipx install zizmor==1.24.1
+      - run: pipx install zizmor==1.26.1
       - run: zizmor --pedantic .github/
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN GOBIN=/out CGO_ENABLED=1 go install github.com/andrew/VID/cmd/vid@v0.1.0
 
 FROM rust:1.96-alpine@sha256:f87aa870663e2b57ec8c69de82c7eedf7383bee987eef7612c0359635eaadb41 AS zizmor-build
 RUN apk add --no-cache build-base linux-headers
-RUN cargo install --locked --root /out zizmor@1.24.1
+RUN cargo install --locked --root /out zizmor@1.26.1
 
 FROM python:3.15.0b2-alpine@sha256:05458e2cf3a3b7a158d3c2e11940de557c626c064f41311f874a2c08ede01074
 RUN apk add --no-cache git ca-certificates bash nodejs coreutils && \

--- a/Dockerfile.runner
+++ b/Dockerfile.runner
@@ -10,7 +10,7 @@ RUN GOBIN=/out go install github.com/git-pkgs/git-pkgs@v0.15.3 && \
     GOBIN=/out go install github.com/git-pkgs/brief/cmd/brief@v0.6.0
 
 FROM rust:1.96-trixie@sha256:c6811167278337db5f3b0234964ced5f538f154a2a20f09ec03721d7411c933d AS zizmor-build
-RUN cargo install --locked --root /out zizmor@1.24.1
+RUN cargo install --locked --root /out zizmor@1.26.1
 
 FROM debian:trixie-slim@sha256:4e401d95de7083948053197a9c3913343cd06b706bf15eb6a0c3ccd26f436a0e
 ARG CLAUDE_VERSION

--- a/internal/worker/versions.go
+++ b/internal/worker/versions.go
@@ -66,7 +66,7 @@ func QueryRunnerToolVersions(ctx context.Context, image string) RunnerToolVersio
 }
 
 // versionRe matches the first dotted-numeric version token in a string, so
-// "zizmor 1.24.1" and "2.1.123 (Claude Code)" both reduce to the bare number.
+// "zizmor 1.26.1" and "2.1.123 (Claude Code)" both reduce to the bare number.
 var versionRe = regexp.MustCompile(`\d+\.\d+[\w.\-+]*`)
 
 func parseToolVersions(out string) RunnerToolVersions {

--- a/internal/worker/versions_test.go
+++ b/internal/worker/versions_test.go
@@ -3,12 +3,12 @@ package worker
 import "testing"
 
 func TestParseToolVersions(t *testing.T) {
-	out := "zizmor=zizmor 1.24.1\n" +
+	out := "zizmor=zizmor 1.26.1\n" +
 		"semgrep=1.167.0\n" +
 		"claude=2.1.123 (Claude Code)\n"
 	got := parseToolVersions(out)
-	if got.Zizmor != "1.24.1" {
-		t.Errorf("Zizmor = %q, want 1.24.1", got.Zizmor)
+	if got.Zizmor != "1.26.1" {
+		t.Errorf("Zizmor = %q, want 1.26.1", got.Zizmor)
 	}
 	if got.Semgrep != "1.167.0" {
 		t.Errorf("Semgrep = %q, want 1.167.0", got.Semgrep)

--- a/threatmodel.md
+++ b/threatmodel.md
@@ -118,7 +118,7 @@ No rate limiting on `POST /repositories`, no cap on clone size, no timeout on th
 
 ### T11: Image supply chain (partially mitigated)
 
-Tool versions are pinned: `claude-code@2.1.173`, `semgrep==1.167.0`, `git-pkgs@v0.15.3`, `brief@v0.6.0`, `zizmor@1.24.1`. The final stage is `debian:trixie-slim`; the `golang:1.26-trixie` and `rust:1.96-trixie` builder stages are pinned by sha256 digest. The container runs as non-root user `runner`. The runner image is built in CI, smoke-tested, and published to GHCR; users pull a known-good artifact rather than rebuilding against live registries.
+Tool versions are pinned: `claude-code@2.1.173`, `semgrep==1.167.0`, `git-pkgs@v0.15.3`, `brief@v0.6.0`, `zizmor@1.26.1`. The final stage is `debian:trixie-slim`; the `golang:1.26-trixie` and `rust:1.96-trixie` builder stages are pinned by sha256 digest. The container runs as non-root user `runner`. The runner image is built in CI, smoke-tested, and published to GHCR; users pull a known-good artifact rather than rebuilding against live registries.
 
 Supply-chain surface in the final stage:
 - `apt` pulls from Debian's official mirrors plus the GitHub CLI repo at `cli.github.com/packages` (signed-by keyring under `/etc/apt/keyrings/`). `gh` is used at scan time by the `fork` and `report-upstream` skills.


### PR DESCRIPTION
To get some new rules and bug fixes.

See https://docs.zizmor.sh/release-notes/#1260 and https://docs.zizmor.sh/release-notes/#1250