### PR TITLE
worker: pull runner base image before profile build

### DIFF
--- a/internal/worker/profile.go
+++ b/internal/worker/profile.go
@@ -353,12 +353,9 @@ func (p Profile) EnsureImage(ctx context.Context, profilesDir, runnerImage strin
 		return tag, nil
 	}
 	emit(Event{Kind: KindText, Text: "profile: building " + tag + " (first build can take several minutes)"})
+	pullRunnerImage(ctx, runnerImage, emit)
 	start := time.Now()
-	buildArgs := []string{"build", "-t", tag, "-f", dockerfile}
-	if runnerImage != "" {
-		buildArgs = append(buildArgs, "--build-arg", "RUNNER_IMAGE="+runnerImage)
-	}
-	buildArgs = append(buildArgs, filepath.Join(profilesDir, p.Name))
+	buildArgs := profileBuildArgs(tag, dockerfile, filepath.Join(profilesDir, p.Name), runnerImage)
 	cmd := exec.CommandContext(ctx, "docker", buildArgs...)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return "", fmt.Errorf("docker build %s: %w\n%s", tag, err, out)
@@ -369,4 +366,32 @@ func (p Profile) EnsureImage(ctx context.Context, profilesDir, runnerImage strin
 
 func imageExistsLocally(ctx context.Context, tag string) bool {
 	return exec.CommandContext(ctx, "docker", "image", "inspect", tag).Run() == nil
+}
+
+// profileBuildArgs returns the `docker build` argument vector for a
+// profile image. Split out so the assembly can be unit-tested without
+// shelling out.
+func profileBuildArgs(tag, dockerfile, contextDir, runnerImage string) []string {
+	args := []string{"build", "-t", tag, "-f", dockerfile}
+	if runnerImage != "" {
+		args = append(args, "--build-arg", "RUNNER_IMAGE="+runnerImage)
+	}
+	return append(args, contextDir)
+}
+
+// pullRunnerImage refreshes the runner image from its registry before a
+// profile build so the FROM resolves to the current upstream rather than
+// a stale locally cached :latest. Best-effort: a pull failure (offline,
+// or runnerImage points at a locally built tag with no registry behind
+// it) is logged via emit and the build proceeds with whatever is cached.
+// See https://github.com/alpha-omega-security/scrutineer/issues/477.
+func pullRunnerImage(ctx context.Context, runnerImage string, emit func(Event)) {
+	if runnerImage == "" {
+		return
+	}
+	emit(Event{Kind: KindText, Text: "profile: pulling base " + runnerImage})
+	out, err := exec.CommandContext(ctx, "docker", "pull", "--", runnerImage).CombinedOutput()
+	if err != nil {
+		emit(Event{Kind: KindText, Text: "profile: pull " + runnerImage + " failed (using local cache): " + firstLine(string(out))})
+	}
 }

--- a/internal/worker/profile_test.go
+++ b/internal/worker/profile_test.go
@@ -377,6 +377,27 @@ func TestImageTag_contentAddressed(t *testing.T) {
 	}
 }
 
+func TestProfileBuildArgs(t *testing.T) {
+	got := profileBuildArgs("scrutineer-profile-python:abc", "/p/python/Dockerfile", "/p/python", "ghcr.io/x/runner:latest")
+	want := []string{
+		"build", "-t", "scrutineer-profile-python:abc",
+		"-f", "/p/python/Dockerfile",
+		"--build-arg", "RUNNER_IMAGE=ghcr.io/x/runner:latest",
+		"/p/python",
+	}
+	if strings.Join(got, " ") != strings.Join(want, " ") {
+		t.Errorf("profileBuildArgs\n got: %v\nwant: %v", got, want)
+	}
+
+	noRunner := profileBuildArgs("t:x", "/p/Dockerfile", "/p", "")
+	for _, a := range noRunner {
+		if strings.HasPrefix(a, "RUNNER_IMAGE=") || a == "--build-arg" {
+			t.Errorf("empty runnerImage should not add build-arg, got %v", noRunner)
+			break
+		}
+	}
+}
+
 func TestLockForTag_sameTagSameMutex(t *testing.T) {
 	a := lockForTag("scrutineer-profile-test:abc")
 	b := lockForTag("scrutineer-profile-test:abc")


### PR DESCRIPTION
`EnsureImage` ran `docker build` without refreshing the `FROM` base, so a stale locally cached `scrutineer-runner:latest` was reused. In #477 that stale image was the pre-#271 Alpine / pre-#304 amd64-only build, which on an arm64 host produced `apt-get: not found` plus an `InvalidBaseImagePlatform` warning.

This adds a best-effort `docker pull` of the configured runner image before the profile build. A failed pull (offline, or `--runner-image` pointing at a local-only tag like `scrutineer-runner:local`) is logged and the build carries on with whatever is cached, so the documented local-dev flow in the profile Dockerfile headers keeps working. `docker build --pull` was the obvious alternative but it hard-fails when the base only exists locally.

The pull only fires on a profile-image cache miss, which is already the slow first-build path.

Also lifts the build-arg assembly into `profileBuildArgs` so it can be unit tested without shelling out.

Not addressed here: `imageTag()` hashes the runner image ref string rather than its resolved digest, so a moved `:latest` won't invalidate an already-built `scrutineer-profile-*` image. Will file separately.

Fixes #477
