### PR TITLE
disclose: post a summary note on the finding

### DIFF
--- a/internal/skills/parse.go
+++ b/internal/skills/parse.go
@@ -94,6 +94,7 @@ var OutputKinds = map[string]bool{
 	"revalidate":      true,
 	"breaking_change": true,
 	"mitigation":      true,
+	"disclose":        true,
 	"release_watch":   true,
 	"subprojects":     true,
 	"repo_overview":   true,

--- a/internal/worker/skill.go
+++ b/internal/worker/skill.go
@@ -319,6 +319,8 @@ func (w *Worker) parseSkillOutput(skill *db.Skill, scan *db.Scan, report string,
 		return w.parseBreakingChangeOutput(scan, report, emit)
 	case "mitigation":
 		return w.parseMitigationOutput(scan, report, emit)
+	case "disclose":
+		return w.parseDiscloseOutput(scan, report, emit)
 	case "release_watch":
 		return w.parseReleaseWatchOutput(scan, report, emit)
 	case "subprojects":

--- a/internal/worker/skill_parsers.go
+++ b/internal/worker/skill_parsers.go
@@ -804,6 +804,63 @@ func (w *Worker) parseMitigationOutput(scan *db.Scan, report string, emit func(E
 	return nil
 }
 
+// parseDiscloseOutput posts a FindingNote summarising a disclose run so the
+// finding's Notes panel records that a draft was prepared, alongside the
+// verify/revalidate/patch entries (#482). The draft itself is on
+// Finding.DisclosureDraft (PATCHed by the skill via the API); this note is
+// the audit trail pointing at it: the GHSA summary, which fields were
+// patched/preserved, references added, and the report's notes prose. An
+// error-only report records why the skill refused to draft.
+func (w *Worker) parseDiscloseOutput(scan *db.Scan, report string, emit func(Event)) error {
+	if scan.FindingID == nil {
+		return fmt.Errorf("disclose scan has no finding_id")
+	}
+	var result struct {
+		GHSA struct {
+			Summary string `json:"summary"`
+		} `json:"ghsa"`
+		Patched           []string `json:"patched"`
+		Preserved         []string `json:"preserved"`
+		ReferencesAdded   int      `json:"references_added"`
+		ReferencesSkipped int      `json:"references_skipped"`
+		Notes             string   `json:"notes"`
+		Error             string   `json:"error"`
+	}
+	if err := json.Unmarshal([]byte(report), &result); err != nil {
+		return fmt.Errorf("parse disclose report: %w", err)
+	}
+
+	var b strings.Builder
+	if result.Error != "" {
+		fmt.Fprintf(&b, "disclose: refused\n\n%s\n", strings.TrimSpace(result.Error))
+	} else {
+		b.WriteString("disclose: drafted")
+		if result.GHSA.Summary != "" {
+			fmt.Fprintf(&b, " %q", result.GHSA.Summary)
+		}
+		b.WriteString("\n\n")
+		if len(result.Patched) > 0 {
+			fmt.Fprintf(&b, "Patched: %s\n", strings.Join(result.Patched, ", "))
+		}
+		if len(result.Preserved) > 0 {
+			fmt.Fprintf(&b, "Preserved: %s\n", strings.Join(result.Preserved, ", "))
+		}
+		if result.ReferencesAdded > 0 || result.ReferencesSkipped > 0 {
+			fmt.Fprintf(&b, "References: %d added, %d skipped\n",
+				result.ReferencesAdded, result.ReferencesSkipped)
+		}
+		if result.Notes != "" {
+			fmt.Fprintf(&b, "\n%s\n", strings.TrimSpace(result.Notes))
+		}
+	}
+	if _, err := db.AddFindingNote(w.DB, *scan.FindingID, b.String(), "disclose"); err != nil {
+		return fmt.Errorf("record disclose note: %w", err)
+	}
+
+	emit(Event{Kind: KindText, Text: fmt.Sprintf("finding %d disclosure draft note posted", *scan.FindingID)})
+	return nil
+}
+
 // parseReleaseWatchOutput records whether the upstream has cut a
 // release containing the fix. When released=true, the tag, URL, and
 // timestamp go to the finding's release_tag / release_url / released_at

--- a/internal/worker/skill_parsers_test.go
+++ b/internal/worker/skill_parsers_test.go
@@ -887,6 +887,60 @@ func TestParseReleaseWatch_rejectsMissingTimestamp(t *testing.T) {
 	}
 }
 
+func TestParseDisclose_postsSummaryNote(t *testing.T) {
+	report := `{
+		"ghsa": {"summary": "Command injection in run()"},
+		"patched": ["cvss_vector", "affected", "disclosure_draft"],
+		"preserved": ["title"],
+		"references_added": 2,
+		"references_skipped": 1,
+		"notes": "Source-only advisory; no published packages."
+	}`
+	f, gdb := runSkillWithFinding(t, "disclose", report, db.FindingTriaged)
+
+	var notes []db.FindingNote
+	gdb.Where("finding_id = ? AND `by` = ?", f.ID, "disclose").Find(&notes)
+	if len(notes) != 1 {
+		t.Fatalf("want one disclose note, got %d: %+v", len(notes), notes)
+	}
+	body := notes[0].Body
+	for _, want := range []string{
+		`disclose: drafted "Command injection in run()"`,
+		"Patched: cvss_vector, affected, disclosure_draft",
+		"Preserved: title",
+		"References: 2 added, 1 skipped",
+		"Source-only advisory; no published packages.",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("note body missing %q:\n%s", want, body)
+		}
+	}
+}
+
+func TestParseDisclose_errorReportRecordsRefusal(t *testing.T) {
+	report := `{"error": "finding has no Trace prose; cannot draft a description"}`
+	f, gdb := runSkillWithFinding(t, "disclose", report, db.FindingNew)
+
+	var notes []db.FindingNote
+	gdb.Where("finding_id = ? AND `by` = ?", f.ID, "disclose").Find(&notes)
+	if len(notes) != 1 {
+		t.Fatalf("want one disclose note, got %d", len(notes))
+	}
+	if !strings.Contains(notes[0].Body, "disclose: refused") {
+		t.Errorf("note body = %q, want refused header", notes[0].Body)
+	}
+	if !strings.Contains(notes[0].Body, "no Trace prose") {
+		t.Errorf("note body = %q, want error reason", notes[0].Body)
+	}
+}
+
+func TestParseDisclose_requiresFindingID(t *testing.T) {
+	w := &Worker{}
+	if err := w.parseDiscloseOutput(&db.Scan{}, `{}`, func(Event) {}); err == nil || !strings.Contains(err.Error(), "finding_id") {
+		t.Errorf("missing finding_id error = %v", err)
+	}
+}
+
 func TestParseFindingDedup_marksDuplicatesWithHistoryAndNote(t *testing.T) {
 	gdb, err := db.Open(filepath.Join(t.TempDir(), "dedup.db"))
 	if err != nil {

--- a/skills/disclose/SKILL.md
+++ b/skills/disclose/SKILL.md
@@ -6,7 +6,7 @@ compatibility: Needs network access to the scrutineer API (http://host:port/api)
 metadata:
   scrutineer.version: 1
   scrutineer.output_file: report.json
-  scrutineer.output_kind: freeform
+  scrutineer.output_kind: disclose
 ---
 
 # disclose


### PR DESCRIPTION
The disclose skill PATCHes the draft onto `Finding.DisclosureDraft` via the API, but unlike `verify`/`revalidate`/`patch`/`mitigate`/`release-watch` it had no parser writing a `FindingNote`, so the Notes panel showed nothing for the run and the model's "review it in the notes" closing message pointed at an empty list.

This adds a `disclose` `output_kind` whose parser posts a note summarising the run: the GHSA `summary`, which fields were patched and which were preserved, the reference counts, and the report's `notes` prose. An error-only report records `disclose: refused` with the reason.

Fixes #482.
