### PR TITLE
stream: read unbounded lines and surface read errors

### DIFF
--- a/internal/worker/stream.go
+++ b/internal/worker/stream.go
@@ -67,49 +67,66 @@ type contentBlock struct {
 // ParseStream reads claude --output-format stream-json lines from r and
 // calls emit for each event. Lines that fail to decode are passed through
 // as text so nothing is silently dropped.
+//
+// Lines are read with bufio.Reader rather than bufio.Scanner so a single
+// oversized line (a large thinking block, or a tool_use/tool_result echoing
+// a big file) does not truncate the rest of the stream — which would lose
+// the terminal result event carrying cost/turns/usage and the max-turns
+// signal (#467). A read error other than EOF is surfaced as an error event.
 func ParseStream(r io.Reader, emit func(Event)) {
-	const bufSize = 1024 * 1024
-	sc := bufio.NewScanner(r)
-	sc.Buffer(make([]byte, 0, bufSize), bufSize)
+	br := bufio.NewReader(r)
+	for {
+		raw, readErr := br.ReadBytes('\n')
+		if len(raw) > 0 {
+			parseStreamLine(raw, emit)
+		}
+		if readErr == io.EOF {
+			return
+		}
+		if readErr != nil {
+			emit(Event{Kind: KindError, Text: "stream read: " + readErr.Error()})
+			return
+		}
+	}
+}
 
-	for sc.Scan() {
-		line := strings.TrimSpace(sc.Text())
-		if line == "" {
-			continue
+func parseStreamLine(raw []byte, emit func(Event)) {
+	line := strings.TrimSpace(string(raw))
+	if line == "" {
+		return
+	}
+	var msg streamMessage
+	if err := json.Unmarshal([]byte(line), &msg); err != nil {
+		emit(Event{Kind: KindText, Text: line})
+		return
+	}
+	switch msg.Type {
+	case "system":
+		// The init system message is the first line of a run and is the
+		// only reliable place to read the session id. Capturing it here
+		// lets the worker persist it before the run finishes, so a crash
+		// mid-run is resumable. It is also the signal a `--resume`
+		// actually loaded the conversation: a resume that fails to find
+		// the session emits no init at all (just an error and a result
+		// carrying a brand-new throwaway session id), so the runner must
+		// not treat the result's session id as "resume succeeded" — only
+		// this init event counts.
+		if msg.Subtype == "init" && msg.SessionID != "" {
+			emit(Event{Kind: KindSession, SessionID: msg.SessionID})
 		}
-		var msg streamMessage
-		if err := json.Unmarshal([]byte(line), &msg); err != nil {
-			emit(Event{Kind: KindText, Text: line})
-			continue
+	case "assistant":
+		emitAssistant(msg.Message, emit)
+	case "result":
+		emit(resultEvent(msg))
+		if msg.Subtype == "error_max_turns" {
+			emit(Event{Kind: KindError, Text: "hit max turns"})
 		}
-		switch msg.Type {
-		case "system":
-			// The init system message is the first line of a run and is the
-			// only reliable place to read the session id. Capturing it here
-			// lets the worker persist it before the run finishes, so a crash
-			// mid-run is resumable. It is also the signal a `--resume`
-			// actually loaded the conversation: a resume that fails to find
-			// the session emits no init at all (just an error and a result
-			// carrying a brand-new throwaway session id), so the runner must
-			// not treat the result's session id as "resume succeeded" — only
-			// this init event counts.
-			if msg.Subtype == "init" && msg.SessionID != "" {
-				emit(Event{Kind: KindSession, SessionID: msg.SessionID})
-			}
-		case "assistant":
-			emitAssistant(msg.Message, emit)
-		case "result":
-			emit(resultEvent(msg))
-			if msg.Subtype == "error_max_turns" {
-				emit(Event{Kind: KindError, Text: "hit max turns"})
-			}
-		case "error":
-			var s string
-			if json.Unmarshal(msg.Error, &s) != nil {
-				s = string(msg.Error)
-			}
-			emit(Event{Kind: KindError, Text: s})
+	case "error":
+		var s string
+		if json.Unmarshal(msg.Error, &s) != nil {
+			s = string(msg.Error)
 		}
+		emit(Event{Kind: KindError, Text: s})
 	}
 }
 

--- a/internal/worker/stream_test.go
+++ b/internal/worker/stream_test.go
@@ -1,8 +1,11 @@
 package worker
 
 import (
+	"errors"
+	"io"
 	"strings"
 	"testing"
+	"testing/iotest"
 )
 
 func TestParseStream(t *testing.T) {
@@ -83,6 +86,77 @@ func collectEvents(in string) []Event {
 	var got []Event
 	ParseStream(strings.NewReader(in), func(e Event) { got = append(got, e) })
 	return got
+}
+
+// A single >1 MiB stream-json line (a large thinking block, or a
+// tool_use/tool_result echoing a big file) must not truncate the rest of the
+// stream: the terminal result event carries cost/turns/usage and the
+// max-turns signal, so dropping it silently mis-records the scan (#467).
+func TestParseStream_oversizedLineDoesNotTruncate(t *testing.T) {
+	huge := `{"type":"assistant","message":{"content":[{"type":"thinking","thinking":"` +
+		strings.Repeat("x", 2*1024*1024) + `"}]}}`
+	in := huge + "\n" +
+		`{"type":"assistant","message":{"content":[{"type":"text","text":"after"}]}}` + "\n" +
+		`{"type":"result","subtype":"error_max_turns","total_cost_usd":1.5,"num_turns":40}` + "\n"
+
+	got := collectEvents(in)
+
+	var sawAfter, sawResult, sawMaxTurns bool
+	for _, e := range got {
+		switch {
+		case e.Kind == KindText && e.Text == "after":
+			sawAfter = true
+		case e.Kind == KindResult:
+			sawResult = true
+			if e.CostUSD != 1.5 || e.Turns != 40 {
+				t.Errorf("result event = %+v, want cost=1.5 turns=40", e)
+			}
+		case e.Kind == KindError && e.Text == "hit max turns":
+			sawMaxTurns = true
+		}
+	}
+	if !sawAfter {
+		t.Error("event after the oversized line was dropped")
+	}
+	if !sawResult {
+		t.Error("terminal result event was dropped")
+	}
+	if !sawMaxTurns {
+		t.Error("max-turns error event was dropped")
+	}
+	// The oversized line itself must still parse, not be dropped.
+	if got[0].Kind != KindThinking || len(got[0].Text) != 2*1024*1024 {
+		t.Errorf("oversized thinking event: kind=%q len=%d", got[0].Kind, len(got[0].Text))
+	}
+}
+
+// A final line with no trailing newline (the process closed stdout without
+// flushing one) must still be parsed, not silently lost on EOF.
+func TestParseStream_finalLineWithoutNewline(t *testing.T) {
+	in := `{"type":"assistant","message":{"content":[{"type":"text","text":"hi"}]}}` + "\n" +
+		`{"type":"result","total_cost_usd":0.1,"num_turns":3}`
+	got := collectEvents(in)
+	if len(got) != 2 || got[1].Kind != KindResult || got[1].Turns != 3 {
+		t.Errorf("events = %+v, want text + result", got)
+	}
+}
+
+// A read error other than EOF is surfaced as an error event so a broken pipe
+// or short read is visible in the scan log rather than swallowed.
+func TestParseStream_readErrorIsEmitted(t *testing.T) {
+	r := io.MultiReader(
+		strings.NewReader(`{"type":"assistant","message":{"content":[{"type":"text","text":"hi"}]}}`+"\n"),
+		iotest.ErrReader(errors.New("pipe broke")),
+	)
+	var got []Event
+	ParseStream(r, func(e Event) { got = append(got, e) })
+
+	if len(got) != 2 {
+		t.Fatalf("events = %+v, want text + error", got)
+	}
+	if got[1].Kind != KindError || !strings.Contains(got[1].Text, "pipe broke") {
+		t.Errorf("last event = %+v, want error carrying the read error", got[1])
+	}
 }
 
 func TestFormatEvent(t *testing.T) {


### PR DESCRIPTION
`ParseStream` used a `bufio.Scanner` capped at 1 MiB and never checked `sc.Err()`, so a single oversized stream-json line (a large thinking block, or a `tool_use`/`tool_result` echoing a big file) silently ended the loop and dropped everything after it — including the terminal `result` event carrying cost/turns/usage and the `error_max_turns` subtype that drives `hitMaxTurns` at `claude.go` / `docker.go`.

Switch to `bufio.Reader.ReadBytes('\n')` so lines have no fixed cap, move the per-line parsing into `parseStreamLine`, and emit a `KindError` event for any non-EOF read error so a broken stream is visible in the scan log.

New tests cover a 2 MiB thinking line followed by text and a max-turns result (all events arrive), a final line with no trailing newline, and a mid-stream read error.

Fixes #467.
