### PR TITLE
api: move audit endpoints to the host-only /api/v1 mux

### DIFF
--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -104,8 +104,10 @@ func (s *Server) apiHandler() http.Handler {
 	mux.HandleFunc("POST /findings/{id}/notes", s.apiAddFindingNote)
 	mux.HandleFunc("GET /findings/{id}/reviews", s.apiListFindingReviews)
 	mux.HandleFunc("POST /findings/{id}/reviews", s.apiAddFindingReview)
-	mux.HandleFunc("GET /audit/queue", s.apiAuditQueue)
-	mux.HandleFunc("GET /audit/metrics", s.apiAuditMetrics)
+	// /audit/queue and /audit/metrics are intentionally on the host-only
+	// /api/v1 export mux, not here: they return findings across every
+	// repository on the instance, so a scan token issued for one repo
+	// must not be able to read them (#454).
 	mux.HandleFunc("GET /findings/{id}/communications", s.apiListFindingCommunications)
 	mux.HandleFunc("POST /findings/{id}/communications", s.apiAddFindingCommunication)
 	mux.HandleFunc("GET /findings/{id}/references", s.apiListFindingReferences)

--- a/internal/web/api_export.go
+++ b/internal/web/api_export.go
@@ -22,6 +22,11 @@ func (s *Server) exportHandler() http.Handler {
 	mux.HandleFunc("GET /findings", s.apiExportFindings)
 	mux.HandleFunc("GET /scans", s.apiExportScans)
 	mux.HandleFunc("POST /import", s.handleImport)
+	// Audit endpoints return instance-wide findings and review aggregates,
+	// so they live behind the host-only boundary with the other operator
+	// exports rather than under per-scan bearer auth (#454).
+	mux.HandleFunc("GET /audit/queue", s.apiAuditQueue)
+	mux.HandleFunc("GET /audit/metrics", s.apiAuditMetrics)
 	return mux
 }
 

--- a/internal/web/audit.go
+++ b/internal/web/audit.go
@@ -63,7 +63,11 @@ func (s *Server) apiListFindingReviews(w http.ResponseWriter, r *http.Request) {
 }
 
 // apiAuditQueue returns the queue payload as JSON, so a TOC export can
-// pull it into a spreadsheet without scraping the HTML page.
+// pull it into a spreadsheet without scraping the HTML page. The query
+// covers findings across every repository on the instance, so it is
+// served from the host-only /api/v1 mux, not the per-scan bearer API: a
+// scan token issued for one repo must not be able to read other repos'
+// undisclosed findings (#454).
 func (s *Server) apiAuditQueue(w http.ResponseWriter, r *http.Request) {
 	rows, err := db.AuditQueue(s.DB, auditQueueOptionsFromQuery(r))
 	if err != nil {

--- a/internal/web/audit_test.go
+++ b/internal/web/audit_test.go
@@ -128,8 +128,6 @@ func TestApiAuditMetrics_returnsAggregate(t *testing.T) {
 	defer done()
 	repo := db.Repository{URL: "https://example.com/r", Name: "r"}
 	s.DB.Create(&repo)
-	authScan := db.Scan{RepositoryID: repo.ID, Status: db.ScanRunning, APIToken: "T2"}
-	s.DB.Create(&authScan)
 	scan := db.Scan{RepositoryID: repo.ID, Status: db.ScanDone}
 	s.DB.Create(&scan)
 	mk := func(id string) db.Finding {
@@ -141,9 +139,8 @@ func TestApiAuditMetrics_returnsAggregate(t *testing.T) {
 	_, _ = db.AddFindingReview(s.DB, a.ID, "false_positive", "", "false_positive", "andrew")
 	_, _ = db.AddFindingReview(s.DB, b.ID, "true_positive", "", "false_positive", "andrew")
 
-	r := httptest.NewRequest(http.MethodGet, "/api/audit/metrics", nil)
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/audit/metrics", nil)
 	r.Host = "127.0.0.1:8080"
-	r.Header.Set("Authorization", "Bearer T2")
 	w := httptest.NewRecorder()
 	s.Handler().ServeHTTP(w, r)
 	if w.Code != http.StatusOK {
@@ -205,6 +202,40 @@ func TestApiListFindingReviews(t *testing.T) {
 	}
 }
 
+// The audit endpoints return findings across every repository on the
+// instance, so a per-repo scan token must not reach them (#454). They are
+// on the host-only /api/v1 mux, which rejects non-localhost Host headers,
+// and the per-scan /api mux no longer routes them at all.
+func TestApiAudit_notReachableFromScanContainer(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	_, tok := seedAuditFixture(t, s)
+
+	// The host-only mux rejects the Host header a runner container uses.
+	for _, path := range []string{"/api/v1/audit/queue", "/api/v1/audit/metrics"} {
+		r := httptest.NewRequest("GET", path, nil)
+		r.Host = "host.docker.internal:8080"
+		w := httptest.NewRecorder()
+		s.Handler().ServeHTTP(w, r)
+		if w.Code != http.StatusForbidden {
+			t.Errorf("%s with non-localhost Host: status = %d, want 403", path, w.Code)
+		}
+	}
+
+	// The per-scan bearer API no longer routes these at all, so a valid
+	// scan token gets a 404 rather than instance-wide findings.
+	for _, path := range []string{"/api/audit/queue", "/api/audit/metrics"} {
+		r := httptest.NewRequest("GET", path, nil)
+		r.Host = testHost
+		r.Header.Set("Authorization", "Bearer "+tok)
+		w := httptest.NewRecorder()
+		s.Handler().ServeHTTP(w, r)
+		if w.Code != http.StatusNotFound {
+			t.Errorf("%s on scan-token mux: status = %d, want 404", path, w.Code)
+		}
+	}
+}
+
 func TestApiAuditQueue(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()
@@ -224,7 +255,7 @@ func TestApiAuditQueue(t *testing.T) {
 		t.Fatalf("seed review: %v", err)
 	}
 
-	w := auditAPIReq(t, s, "GET", "/api/audit/queue", tok, "")
+	w := auditAPIReq(t, s, "GET", "/api/v1/audit/queue", tok, "")
 	if w.Code != http.StatusOK {
 		t.Fatalf("status = %d; body=%s", w.Code, w.Body)
 	}
@@ -245,7 +276,7 @@ func TestApiAuditQueue(t *testing.T) {
 	}
 
 	// limit applies.
-	w = auditAPIReq(t, s, "GET", "/api/audit/queue?limit=1", tok, "")
+	w = auditAPIReq(t, s, "GET", "/api/v1/audit/queue?limit=1", tok, "")
 	if w.Code != http.StatusOK {
 		t.Fatalf("limit=1 status = %d; body=%s", w.Code, w.Body)
 	}
@@ -260,7 +291,7 @@ func TestApiAuditQueue(t *testing.T) {
 	// sub-day cutoffs across timezones are unreliable; use date-level
 	// boundaries here so the comparison holds regardless of encoding.
 	countAt := func(since string) int {
-		w := auditAPIReq(t, s, "GET", "/api/audit/queue?since="+url.QueryEscape(since), tok, "")
+		w := auditAPIReq(t, s, "GET", "/api/v1/audit/queue?since="+url.QueryEscape(since), tok, "")
 		if w.Code != http.StatusOK {
 			t.Fatalf("since=%s status = %d; body=%s", since, w.Code, w.Body)
 		}
@@ -341,7 +372,7 @@ func TestAuditQueueOptionsFromQuery(t *testing.T) {
 		{"?limit=3&since=" + at.Format(time.RFC3339), 3, at},
 	}
 	for _, tc := range cases {
-		r := httptest.NewRequest("GET", "/api/audit/queue"+tc.query, nil)
+		r := httptest.NewRequest("GET", "/api/v1/audit/queue"+tc.query, nil)
 		got := auditQueueOptionsFromQuery(r)
 		if got.Limit != tc.wantLimit {
 			t.Errorf("%q: Limit = %d, want %d", tc.query, got.Limit, tc.wantLimit)

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -400,7 +400,7 @@ paths:
             application/json:
               schema: { $ref: '#/components/schemas/FindingReview' }
 
-  /audit/queue:
+  /v1/audit/queue:
     get:
       summary: Sample of recently auto-bucketed findings without a recorded review
       description: |
@@ -409,6 +409,10 @@ paths:
         already fixed, or uncertain) and that do not yet have a
         FindingReview row. Spot-check the queue to keep automated triage
         calibrated.
+
+        Instance-wide and unauthenticated; relies on the host-only
+        boundary like the other `/v1/*` exports. Not reachable with a
+        per-scan bearer token.
       operationId: getAuditQueue
       parameters:
         - name: limit
@@ -427,13 +431,16 @@ paths:
                 type: array
                 items: { $ref: '#/components/schemas/Finding' }
 
-  /audit/metrics:
+  /v1/audit/metrics:
     get:
       summary: Aggregate audit metrics
       description: |
         Total reviews, those comparable to an automation outcome,
         agreements between human verdict and automation, and the
         agreement rate (0..1). The audit page renders the same numbers.
+
+        Instance-wide and unauthenticated; relies on the host-only
+        boundary like the other `/v1/*` exports.
       operationId: getAuditMetrics
       responses:
         '200':


### PR DESCRIPTION
`/api/audit/queue` and `/api/audit/metrics` returned findings across every repository on the instance with no scope check, but were mounted under the per-scan bearer-token API. A scan running on attacker-controlled repo content holds a valid token in `context.json` and could `GET /api/audit/queue?limit=500` to read other repos' undisclosed findings (title, severity, CWE, location, status).

The endpoints are operator/TOC tooling ("so a TOC export can pull it into a spreadsheet"), not skill tooling. Move them to the host-only `/api/v1` export mux, where `securityHeaders` rejects any request whose Host is not `127.0.0.1`/`localhost`/`[::1]`; a runner container calling via `host.docker.internal` cannot satisfy that. The per-scan `/api` mux now 404s the old paths.

Path change: `/api/audit/queue` → `/api/v1/audit/queue`, `/api/audit/metrics` → `/api/v1/audit/metrics`. Any operator scripts hitting the old paths need updating.

Fixes #454.
