### PR TITLE
db: apply per-connection pragmas via the DSN

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -976,17 +976,34 @@ func StatusPriorityFor(s ScanStatus) int {
 	}
 }
 
+// connectionPragmas are appended to the DSN so the modernc driver applies
+// them on every connection it opens, not just whichever pooled connection a
+// post-open gdb.Exec happens to land on (#457). foreign_keys and
+// busy_timeout are per-connection in SQLite; setting them once via Exec
+// left most of the pool running with the defaults (foreign_keys=OFF,
+// busy_timeout=0), which #453 observed as 3/8 connections without FK
+// enforcement. journal_mode is per-database and persistent, so it would
+// stick after one Exec, but setting it here keeps all three together.
+const connectionPragmas = "_pragma=foreign_keys(1)&_pragma=busy_timeout(5000)&_pragma=journal_mode(WAL)"
+
+// withPragmas appends connectionPragmas to dsn, joining with ? or &
+// depending on whether dsn already carries a query string (the in-memory
+// test DSNs do).
+func withPragmas(dsn string) string {
+	sep := "?"
+	if strings.Contains(dsn, "?") {
+		sep = "&"
+	}
+	return dsn + sep + connectionPragmas
+}
+
 func Open(dsn string) (*gorm.DB, error) {
 	cfg := &gorm.Config{
 		Logger: logger.Default.LogMode(logger.Warn),
 	}
-	gdb, err := gorm.Open(sqlite.Open(dsn), cfg)
+	gdb, err := gorm.Open(sqlite.Open(withPragmas(dsn)), cfg)
 	if err != nil {
 		return nil, fmt.Errorf("open sqlite: %w", err)
-	}
-	// WAL so the web server can read while the worker writes.
-	if err := gdb.Exec("PRAGMA journal_mode=WAL; PRAGMA busy_timeout=5000; PRAGMA foreign_keys=ON;").Error; err != nil {
-		return nil, fmt.Errorf("pragma: %w", err)
 	}
 	if err := gdb.AutoMigrate(
 		&Repository{}, &Scan{},

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -1,6 +1,8 @@
 package db
 
 import (
+	"context"
+	"database/sql"
 	"math"
 	"os"
 	"path/filepath"
@@ -202,6 +204,67 @@ func TestOpenAndMigrate(t *testing.T) {
 	}
 	if err := gdb.Create(&CNA{ShortName: "apache"}).Error; err == nil {
 		t.Errorf("expected unique-index violation on duplicate ShortName")
+	}
+}
+
+func TestWithPragmas_joinsOnExistingQuery(t *testing.T) {
+	cases := map[string]string{
+		"data/scrutineer.db":         "data/scrutineer.db?" + connectionPragmas,
+		":memory:":                   ":memory:?" + connectionPragmas,
+		"file::memory:?cache=shared": "file::memory:?cache=shared&" + connectionPragmas,
+	}
+	for in, want := range cases {
+		if got := withPragmas(in); got != want {
+			t.Errorf("withPragmas(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// foreign_keys and busy_timeout are per-connection in SQLite. Setting them
+// via a single gdb.Exec only configures whichever pooled connection that
+// Exec lands on, leaving the rest at the defaults (#457). Open now folds
+// the pragmas into the DSN so the driver applies them on every connection
+// it opens; this test pulls several distinct connections off the pool and
+// checks each one.
+func TestOpen_pragmasApplyToEveryConnection(t *testing.T) {
+	gdb, err := Open(filepath.Join(t.TempDir(), "p.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	sqldb, err := gdb.DB()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = sqldb.Close() }()
+
+	const n = 8
+	sqldb.SetMaxOpenConns(n)
+	ctx := context.Background()
+	conns := make([]*sql.Conn, 0, n)
+	for i := 0; i < n; i++ {
+		c, err := sqldb.Conn(ctx)
+		if err != nil {
+			t.Fatalf("conn %d: %v", i, err)
+		}
+		conns = append(conns, c)
+	}
+	// Holding all n at once forces n distinct connections out of the pool;
+	// release them after the loop so each iteration sees a fresh one.
+	for i, c := range conns {
+		var fk, bt int
+		if err := c.QueryRowContext(ctx, "PRAGMA foreign_keys").Scan(&fk); err != nil {
+			t.Fatalf("conn %d foreign_keys: %v", i, err)
+		}
+		if err := c.QueryRowContext(ctx, "PRAGMA busy_timeout").Scan(&bt); err != nil {
+			t.Fatalf("conn %d busy_timeout: %v", i, err)
+		}
+		if fk != 1 {
+			t.Errorf("conn %d: foreign_keys = %d, want 1", i, fk)
+		}
+		if bt != 5000 {
+			t.Errorf("conn %d: busy_timeout = %d, want 5000", i, bt)
+		}
+		_ = c.Close()
 	}
 }
 


### PR DESCRIPTION
`PRAGMA foreign_keys` and `PRAGMA busy_timeout` are per-connection in SQLite. `Open` ran them via a single `gdb.Exec`, which only configured whichever pooled connection that Exec landed on; #453 measured 3/8 connections with `foreign_keys=OFF` and worked around the cascade-delete symptom in `sbomDelete`.

Append the pragmas to the DSN as `_pragma=` params so the modernc driver applies them on every connection it opens, and drop the post-open `Exec`. `withPragmas` joins with `?` or `&` depending on whether the caller's DSN already carries a query string (the in-memory test DSNs do).

`TestOpen_pragmasApplyToEveryConnection` holds eight distinct connections off the pool at once and checks `PRAGMA foreign_keys` and `PRAGMA busy_timeout` on each.

Fixes #457.
