### PR TITLE
repo list: cache clone-cache disk usage on the repository row

### DIFF
--- a/cmd/scrutineer/main.go
+++ b/cmd/scrutineer/main.go
@@ -321,6 +321,7 @@ func run(log *slog.Logger) error {
 	db.BackfillFindingRepository(gdb)
 	db.BackfillFindingFingerprints(gdb)
 	db.BackfillStatusPriority(gdb)
+	worker.BackfillRepoDiskUsage(gdb, f.dataDir)
 	if err := db.SeedDefaultLabels(gdb); err != nil {
 		return fmt.Errorf("seed labels: %w", err)
 	}

--- a/docs/database.md
+++ b/docs/database.md
@@ -32,6 +32,7 @@ The central entity. One row per git URL.
 | posture_summary | text | One-line explanation that goes with `posture`. |
 | fork | text | `owner/name` of the staging fork inside `-fork-org`. Written by the `fork` skill. |
 | clone_error | text | Last clone/fetch failure message; non-empty means the repo is currently unreachable. Cleared on next successful clone. |
+| disk_bytes | integer | Cached on-disk size of the persistent clone cache, so the repo list renders the disk badge from a column instead of walking each repo's cache per row. Refreshed by the worker after each scan and backfilled once at startup; 0 for local repos and remote repos not scanned since the column was added. |
 | threat_model | text | Operator's working-copy threat-model JSON. When set, the worker writes it to `./threat_model.json` in every skill workspace and `security-deep-dive` loads it instead of fetching the latest `threat-model` scan. Edited via the threat-model workbench tab. Empty = no override. |
 | created_at | datetime | |
 | updated_at | datetime | |

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -68,6 +68,14 @@ type Repository struct {
 	// currently unreachable. Cleared on next successful clone.
 	CloneError string
 
+	// DiskBytes caches the on-disk size of the persistent clone cache so
+	// the repo list can render the disk-usage badge from a column instead
+	// of walking each repo's cache directory per row on every render
+	// (#126). Refreshed by the worker when a scan finishes and backfilled
+	// once at startup; 0 for local repos (no managed clone) and for remote
+	// repos not scanned since the column was added.
+	DiskBytes int64
+
 	// ThreatModel is the operator's working-copy threat-model JSON for
 	// this repository. When non-empty the worker writes it to
 	// ./threat_model.json in every skill workspace, and security-deep-dive

--- a/internal/web/list_performance_test.go
+++ b/internal/web/list_performance_test.go
@@ -3,6 +3,7 @@ package web
 import (
 	"fmt"
 	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -87,6 +88,30 @@ func BenchmarkListPagesLargeDataset(b *testing.B) {
 				}
 			}
 		})
+	}
+}
+
+// The repo list renders the disk-usage badge from Repository.DiskBytes, not
+// by walking each repo's clone cache per row (#126). Seeding the column with
+// no cache directory on disk and seeing the size render proves the column is
+// the source: the old per-row filepath.Walk would have found nothing and
+// shown "-".
+func TestRepoList_diskBadgeReadsCachedColumn(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	repo := db.Repository{URL: "https://example.com/sized", Name: "sized", DiskBytes: 2048}
+	if err := s.DB.Create(&repo).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq("GET", "/"))
+	if w.Code != 200 {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+	row := requireRepoListRow(t, w.Body.String(), repo.ID)
+	if !strings.Contains(row, "2.0 KB") {
+		t.Errorf("repo row did not render cached disk size from the column: %s", row)
 	}
 }
 

--- a/internal/web/repo_delete_test.go
+++ b/internal/web/repo_delete_test.go
@@ -295,22 +295,12 @@ func TestRepoDiskSize_renderedInListAndSummary(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()
 
-	dataDir := t.TempDir()
-	s.Worker = &worker.Worker{DataDir: dataDir}
-
 	// No FetchedAt: disk size must render in the summary regardless of
 	// whether upstream metadata has been fetched (it renders unconditionally
-	// in the list, so the detail page must match).
-	repo := db.Repository{URL: "https://github.com/acme/sized", Name: "sized"}
+	// in the list, so the detail page must match). DiskBytes is the cached
+	// column the worker refreshes after each scan (#126); both pages read it.
+	repo := db.Repository{URL: "https://github.com/acme/sized", Name: "sized", DiskBytes: 2048}
 	s.DB.Create(&repo)
-
-	cacheDir := worker.RepoCacheRoot(dataDir, repo.URL)
-	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(cacheDir, "blob"), make([]byte, 2048), 0o644); err != nil {
-		t.Fatal(err)
-	}
 
 	w := httptest.NewRecorder()
 	s.Handler().ServeHTTP(w, localReq("GET", "/"))

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -656,8 +656,11 @@ func (s *Server) repoList(w http.ResponseWriter, r *http.Request) {
 			Repository:    repo,
 			LastScan:      lastScans[repo.ID],
 			FindingsTotal: findingCounts[repo.ID],
-			DiskBytes:     worker.RepoDiskUsage(s.Worker.DataDir, repo),
-			Branches:      branchesByRepo[repo.ID],
+			// Read the cached size from the row; the worker refreshes it on
+			// each scan and a startup backfill seeds it, so the list never
+			// walks the clone cache per row (#126).
+			DiskBytes: repo.DiskBytes,
+			Branches:  branchesByRepo[repo.ID],
 		})
 	}
 	languages := distinctLanguages(s.DB)
@@ -1884,10 +1887,11 @@ func (s *Server) repoShow(w http.ResponseWriter, r *http.Request) {
 		"ActiveScans":          int(activeScans),
 		"PausedScans":          int(pausedScans),
 		"TotalCost":            totalCost,
-		"DiskBytes":            worker.RepoDiskUsage(s.Worker.DataDir, repo),
-		"TMCommit":             tmCommit,
-		"DepsCommit":           depsCommit,
-		"Deps":                 deps, "DepsTotal": depsTotal,
+		// Cached on the row, refreshed by the worker after each scan (#126).
+		"DiskBytes":  repo.DiskBytes,
+		"TMCommit":   tmCommit,
+		"DepsCommit": depsCommit,
+		"Deps":       deps, "DepsTotal": depsTotal,
 		"Pkgs":       pkgs,
 		"Dependents": dependents, "DependentsTotal": dependentsTotal,
 		"Advisories": advisories, "AdvisoriesTotal": advisoriesTotal,

--- a/internal/worker/repo_cache.go
+++ b/internal/worker/repo_cache.go
@@ -10,6 +10,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"gorm.io/gorm"
+
 	"scrutineer/internal/db"
 )
 
@@ -32,6 +34,45 @@ func RepoDiskUsage(dataDir string, repo db.Repository) int64 {
 	}
 	n, _ := dirSize(RepoCacheRoot(dataDir, repo.URL))
 	return n
+}
+
+// refreshRepoDiskUsage recomputes the clone-cache size for one repository
+// and stores it on the row, so the repo list can read the badge from a
+// column instead of walking the filesystem per row (#126). Best-effort:
+// called after a scan finishes, when the cache has just changed; a load or
+// walk failure is logged and the stored value is left as-is.
+func (w *Worker) refreshRepoDiskUsage(repoID uint) {
+	var repo db.Repository
+	if err := w.DB.First(&repo, repoID).Error; err != nil {
+		w.Log.Warn("disk usage refresh: load repo", "repo", repoID, "err", err)
+		return
+	}
+	usage := RepoDiskUsage(w.DataDir, repo)
+	if err := w.DB.Model(&db.Repository{}).Where("id = ?", repoID).
+		Update("disk_bytes", usage).Error; err != nil {
+		w.Log.Warn("disk usage refresh: store", "repo", repoID, "err", err)
+	}
+}
+
+// BackfillRepoDiskUsage fills Repository.DiskBytes for remote repos that
+// have no cached value yet, so the disk-usage badge shows immediately on
+// upgrade instead of waiting for each repo's next scan. Runs once at
+// startup. Only repos with disk_bytes = 0 are walked, so a second boot
+// re-walks just the genuinely-empty ones (a single failed stat each);
+// local repos are skipped entirely.
+func BackfillRepoDiskUsage(gdb *gorm.DB, dataDir string) {
+	var repos []db.Repository
+	gdb.Where("disk_bytes = 0").Find(&repos)
+	for _, repo := range repos {
+		if repo.IsLocal() {
+			continue
+		}
+		usage := RepoDiskUsage(dataDir, repo)
+		if usage == 0 {
+			continue
+		}
+		gdb.Model(&db.Repository{}).Where("id = ?", repo.ID).Update("disk_bytes", usage)
+	}
 }
 
 // prepareRepoSrc updates the per-URL cache under a lock, copies the

--- a/internal/worker/repo_cache_test.go
+++ b/internal/worker/repo_cache_test.go
@@ -2,12 +2,104 @@ package worker
 
 import (
 	"context"
+	"io"
+	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"scrutineer/internal/db"
 )
+
+// seedCacheFile writes a file of n bytes into the clone cache for url under
+// dataDir, so RepoDiskUsage reports a known non-zero size.
+func seedCacheFile(t *testing.T, dataDir, url string, n int) {
+	t.Helper()
+	dir := RepoCacheRoot(dataDir, url)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "blob"), make([]byte, n), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRefreshRepoDiskUsage_storesComputedSize(t *testing.T) {
+	dataDir := t.TempDir()
+	gdb, err := db.Open(filepath.Join(t.TempDir(), "r.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo := db.Repository{URL: "https://example.com/a", Name: "a"}
+	gdb.Create(&repo)
+	seedCacheFile(t, dataDir, repo.URL, 2048)
+
+	w := &Worker{DB: gdb, DataDir: dataDir, Log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	w.refreshRepoDiskUsage(repo.ID)
+
+	var got db.Repository
+	gdb.First(&got, repo.ID)
+	if got.DiskBytes != 2048 {
+		t.Errorf("DiskBytes = %d, want 2048", got.DiskBytes)
+	}
+}
+
+func TestBackfillRepoDiskUsage_fillsZeroRowsSkipsLocal(t *testing.T) {
+	dataDir := t.TempDir()
+	gdb, err := db.Open(filepath.Join(t.TempDir(), "b.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	remote := db.Repository{URL: "https://example.com/remote", Name: "remote"}
+	local := db.Repository{URL: "file:///tmp/local", Name: "local"}
+	uncached := db.Repository{URL: "https://example.com/uncached", Name: "uncached"}
+	gdb.Create(&remote)
+	gdb.Create(&local)
+	gdb.Create(&uncached)
+	seedCacheFile(t, dataDir, remote.URL, 4096)
+	// A local repo with a stray cache dir must still be skipped on IsLocal.
+	seedCacheFile(t, dataDir, local.URL, 9999)
+
+	BackfillRepoDiskUsage(gdb, dataDir)
+
+	sizeOf := func(id uint) int64 {
+		var r db.Repository
+		gdb.First(&r, id)
+		return r.DiskBytes
+	}
+	if got := sizeOf(remote.ID); got != 4096 {
+		t.Errorf("remote DiskBytes = %d, want 4096", got)
+	}
+	if got := sizeOf(local.ID); got != 0 {
+		t.Errorf("local DiskBytes = %d, want 0 (local repos skipped)", got)
+	}
+	if got := sizeOf(uncached.ID); got != 0 {
+		t.Errorf("uncached DiskBytes = %d, want 0 (no cache dir)", got)
+	}
+}
+
+func TestBackfillRepoDiskUsage_leavesNonZeroAlone(t *testing.T) {
+	dataDir := t.TempDir()
+	gdb, err := db.Open(filepath.Join(t.TempDir(), "n.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo := db.Repository{URL: "https://example.com/keep", Name: "keep", DiskBytes: 123}
+	gdb.Create(&repo)
+	// Cache on disk says 4096, but the row already carries a value; the
+	// backfill only touches rows at 0, so the stored value must be kept.
+	seedCacheFile(t, dataDir, repo.URL, 4096)
+
+	BackfillRepoDiskUsage(gdb, dataDir)
+
+	var got db.Repository
+	gdb.First(&got, repo.ID)
+	if got.DiskBytes != 123 {
+		t.Errorf("DiskBytes = %d, want 123 (non-zero rows are not re-walked)", got.DiskBytes)
+	}
+}
 
 func TestRepoCacheRoot(t *testing.T) {
 	a := RepoCacheRoot("/data", "https://github.com/a/b")

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -386,6 +386,12 @@ func (w *Worker) finalizeScan(ctx context.Context, scan *db.Scan, report string,
 	if _, isLimit := errors.AsType[*ClaudePlanLimitError](err); isLimit && scan.Status == db.ScanPaused {
 		w.pauseQueuedOnTokenLimit(scan.ID)
 	}
+	// The clone cache may have grown (clone/fetch/unshallow); refresh the
+	// cached size so the repo list reads it from the row instead of walking
+	// the filesystem per render (#126).
+	if !scan.Repository.IsLocal() {
+		w.refreshRepoDiskUsage(scan.RepositoryID)
+	}
 	if scan.Status.Terminal() {
 		if rmErr := os.RemoveAll(w.scanWorkRoot(scan)); rmErr != nil {
 			w.Log.Warn("workspace cleanup failed", "scan", scan.ID, "err", rmErr)


### PR DESCRIPTION
The repo list called `worker.RepoDiskUsage` per row, which does a full `filepath.Walk` over each repo's clone cache on every render. With a page of repos that is one recursive filesystem walk per row, invisible to the query-count regression tests because it is filesystem I/O, not a DB query.

This caches the size in `Repository.DiskBytes`: the worker refreshes it when a scan finishes (the cache has just changed via clone/fetch/unshallow), and a one-time startup backfill seeds it for repos scanned before the column existed (only rows at 0 are walked, so subsequent boots re-walk just the genuinely-empty ones; local repos are skipped). The repo list and detail pages read the column instead of walking the tree.

`TestRepoList_diskBadgeReadsCachedColumn` proves the source: it seeds `DiskBytes` with no cache directory on disk and the size still renders, where the old per-row walk would have shown `-`.

The second cost named in the issue, the findings-sort correlated subquery, is left as is: it only runs under `?sort=findings`, is bounded by repo count, and denormalising the per-repo finding count would add several drift-prone write paths (status changes, dedup, revalidate verdicts).

Fixes #126.
