### PR TITLE
feat(web): add fix-validation pipeline

### DIFF
--- a/docs/database.md
+++ b/docs/database.md
@@ -55,6 +55,7 @@ One row per skill execution or external import. `skill_name` / `skill_version` p
 | skill_name | text | Denormalised skill name for UI display. |
 | finding_id | integer FK | Set when the scan is finding-scoped (verify/patch/disclose/exposure). References `findings.id`. |
 | dependent_id | integer FK | Set on `exposure` scans only. References `dependents.id`; identifies which downstream consumer the skill is auditing for reachability of the upstream finding. |
+| baseline_scan_id | integer FK | Set on a fix-validation scan (`POST /repositories/{id}/validate-fix`). References the baseline `scans.id` the fix ref is diffed against. Marks the scan as a validation anchor (the auto triage funnel skips it) and, when it finalises, drives the fingerprint diff written back to `report`. Null on ordinary scans. |
 | api_token | text | Per-scan bearer token that the skill presents when calling `/api`. Only valid while the scan is running. |
 | ref | text | Git ref to checkout after cloning. Empty means the default branch. |
 | skills_repo_sha | text | Commit of `-skills-repo` resolved at startup and stamped on every skill scan. Empty when `-skills-repo` is unset or for `import` scans. |
@@ -71,7 +72,7 @@ One row per skill execution or external import. `skill_name` / `skill_version` p
 | cache_write_tokens | integer | `cache_creation_input_tokens` from the result event. |
 | max_turns_hit | boolean | True when the scan is `done` with partial output because Claude hit the configured max-turns cap. Such scans keep their session id so Retry can resume. |
 | prompt | text | Activation prompt sent to claude. The skill body lives in the Skill row, not here. |
-| report | text | The skill's primary output. JSON for parsed kinds, freeform for everything else. |
+| report | text | The skill's primary output. JSON for parsed kinds, freeform for everything else. On a fix-validation anchor (`baseline_scan_id` set) it is replaced, once the scan finalises, by the JSON validation report: the resolved/surviving/new fingerprint diff against the baseline plus the finding-scoped verify verdicts. |
 | log | text | Line-by-line transcript of the scan. Streamed to the UI via SSE. |
 | error | text | Error message if the scan failed. |
 | findings_count | integer | Denormalised count of findings parsed from the report. |

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -152,8 +152,16 @@ type Scan struct {
 	// auditing for reachability of the upstream finding. The scan's
 	// Repository remains the library; ./src is staged from the
 	// dependent's repo URL via the dependent-clone cache.
-	DependentID *uint  `gorm:"index"`
-	APIToken    string `gorm:"index"`
+	DependentID *uint `gorm:"index"`
+	// BaselineScanID is set on a fix-validation scan (see validate_fix.go):
+	// it re-runs a finding's producing skill against a candidate fix ref,
+	// then records in its Report how the baseline scan's findings fared
+	// (resolved/surviving/new) alongside the finding-scoped verify verdicts.
+	// The pointer both marks the scan as a validation anchor — so the auto
+	// triage funnel skips it — and pins the baseline scan it diffs against.
+	// Nil on every ordinary scan.
+	BaselineScanID *uint  `gorm:"index"`
+	APIToken       string `gorm:"index"`
 
 	// StatusPriority is a denormalised sort key so the scans index can use
 	// an index instead of evaluating a CASE on every row. 0 = running,

--- a/internal/web/finding_dedup_enqueue.go
+++ b/internal/web/finding_dedup_enqueue.go
@@ -40,7 +40,10 @@ const dedupMinFindings = 2
 // Errors are logged and swallowed: failing to enqueue the dedup pass must
 // never fail the upstream scan.
 func (s *Server) autoEnqueueFindingDedup(scan *db.Scan) {
-	if scan == nil || scan.SkillName != deepDiveSkillName {
+	// A fix-validation anchor (validate_fix.go) re-runs deep-dive on a fix ref
+	// purely to diff fingerprints; its findings are validation scratch, not a
+	// repo's working set, so they must not trigger a dedup pass.
+	if scan == nil || scan.SkillName != deepDiveSkillName || scan.BaselineScanID != nil {
 		return
 	}
 

--- a/internal/web/revalidate_enqueue.go
+++ b/internal/web/revalidate_enqueue.go
@@ -30,7 +30,11 @@ func (s *Server) autoEnqueueRevalidate(scan *db.Scan, f *db.Finding) {
 	if scan == nil || f == nil {
 		return
 	}
-	if scan.SkillName != deepDiveSkillName {
+	// A fix-validation anchor (validate_fix.go) re-runs deep-dive on a fix
+	// ref only to diff fingerprints; feeding its findings back into the
+	// revalidate -> verify funnel would double the spend and race the
+	// finding-scoped verify the pipeline already enqueued against that ref.
+	if scan.SkillName != deepDiveSkillName || scan.BaselineScanID != nil {
 		return
 	}
 	if !db.SeverityAtLeast(f.Severity, "High") {

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -259,7 +259,7 @@ func New(gdb *gorm.DB, q *queue.Queue, log *slog.Logger, broker *Broker, w *work
 	if w != nil {
 		w.OnFindingCreated = s.autoEnqueueRevalidate
 		w.OnRevalidateVerdict = s.autoChainVerifyAfterRevalidate
-		w.OnScanFinalized = s.autoEnqueueFindingDedup
+		w.OnScanFinalized = s.onScanFinalized
 	}
 	return s, nil
 }
@@ -280,6 +280,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("GET /repositories/{id}/report.md", s.repoReport)
 	mux.HandleFunc("POST /repositories/{id}/scan", s.repoScan)
 	mux.HandleFunc("POST /repositories/{id}/scan-all", s.repoScanAll)
+	mux.HandleFunc("POST /repositories/{id}/validate-fix", s.validateFix)
 	mux.HandleFunc("POST /repositories/{id}/delete", s.repoDelete)
 	mux.HandleFunc("POST /repositories/{id}/disclosure-channel", s.repoDisclosureChannel)
 	mux.HandleFunc("POST /repositories/{id}/threat-model", s.repoThreatModelSave)
@@ -2137,9 +2138,12 @@ type ScanOpts struct {
 	Effort      string
 	FindingID   *uint
 	DependentID *uint
-	SubPath     string
-	Ref         string
-	Profile     string
+	// BaselineScanID marks a fix-validation anchor scan and pins the baseline
+	// scan it diffs against. See validate_fix.go.
+	BaselineScanID *uint
+	SubPath        string
+	Ref            string
+	Profile        string
 	// SessionID and ResumedFromScanID carry a failed scan's claude session
 	// into its retry so the new run continues the conversation with
 	// `claude -p --resume` instead of restarting from turn 0. Both empty
@@ -2206,6 +2210,7 @@ func (s *Server) enqueueSkillWith(ctx context.Context, repoID, skillID uint, opt
 		SkillName:         sk.Name,
 		FindingID:         opts.FindingID,
 		DependentID:       opts.DependentID,
+		BaselineScanID:    opts.BaselineScanID,
 		SubPath:           opts.SubPath,
 		Ref:               opts.Ref,
 		Profile:           opts.Profile,

--- a/internal/web/validate_fix.go
+++ b/internal/web/validate_fix.go
@@ -1,0 +1,145 @@
+package web
+
+import (
+	"encoding/json"
+	"sort"
+
+	"scrutineer/internal/db"
+)
+
+// fixValidationReport is the single artefact a fix-validation scan emits into
+// its Report column. It composes the three signals fix-validation needs:
+// the fingerprint diff of the baseline scan against the fix-ref
+// re-scan (resolved/surviving/new) and the finding-scoped verify verdicts run
+// against the fix ref. Stored as JSON so the existing scan_show report view
+// (prettyjson) renders it without new UI.
+type fixValidationReport struct {
+	FixRef         string                 `json:"fix_ref"`
+	Skill          string                 `json:"skill"`
+	BaselineScanID uint                   `json:"baseline_scan_id"`
+	FixScanID      uint                   `json:"fix_scan_id"`
+	FixCommit      string                 `json:"fix_commit,omitempty"`
+	Counts         fixValidationCounts    `json:"counts"`
+	Resolved       []fixValidationFinding `json:"resolved"`
+	Surviving      []fixValidationFinding `json:"surviving"`
+	New            []fixValidationFinding `json:"new"`
+	Verify         []fixValidationVerify  `json:"verify"`
+}
+
+type fixValidationCounts struct {
+	Resolved  int `json:"resolved"`
+	Surviving int `json:"surviving"`
+	New       int `json:"new"`
+}
+
+type fixValidationFinding struct {
+	FindingID   uint   `json:"finding_id"`
+	Fingerprint string `json:"fingerprint"`
+	Title       string `json:"title"`
+	Severity    string `json:"severity"`
+	CWE         string `json:"cwe,omitempty"`
+	Location    string `json:"location,omitempty"`
+}
+
+// fixValidationVerify is one targeted finding's reproduction-level verdict
+// against the fix ref. Status mirrors the verify skill enum (fixed,
+// confirmed, inconclusive); "pending" means the verify scan had not finished
+// when the report was assembled.
+type fixValidationVerify struct {
+	FindingID uint   `json:"finding_id"`
+	Title     string `json:"title"`
+	Status    string `json:"status"`
+}
+
+const verifyStatusPending = "pending"
+
+// classifyFixValidation splits the baseline scan's findings into the ones the
+// fix-ref re-scan no longer reports (resolved) and the ones it still reports
+// (surviving), and passes through the re-scan's brand-new findings (new). It
+// keys off the re-observation bookkeeping the findings parser already
+// maintains rather than diffing two raw sets: re-observing a finding merges
+// into its existing row and bumps LastSeenScanID to the observing scan, so a
+// baseline finding whose LastSeenScanID is the fix scan survived, and one with
+// any other value was missed (resolved). New findings are the rows the fix
+// scan created in its own right — a fresh fingerprint for the repository.
+// Pure so the classification is unit-testable without a worker run.
+func classifyFixValidation(baseline, fixNew []db.Finding, fixScanID uint) (resolved, surviving, newFindings []db.Finding) {
+	for _, f := range baseline {
+		if f.LastSeenScanID == fixScanID {
+			surviving = append(surviving, f)
+		} else {
+			resolved = append(resolved, f)
+		}
+	}
+	return resolved, surviving, fixNew
+}
+
+// buildFixValidationReport assembles the report struct from the already-loaded
+// inputs. Kept pure (no DB access) so the composition and ordering are
+// testable; the callback in validate_fix_enqueue.go does the loading.
+func buildFixValidationReport(fixScan db.Scan, baselineScanID uint, baseline, fixNew []db.Finding, verify []fixValidationVerify) fixValidationReport {
+	resolved, surviving, newFindings := classifyFixValidation(baseline, fixNew, fixScan.ID)
+	if verify == nil {
+		verify = []fixValidationVerify{}
+	}
+	sortVerify(verify)
+	return fixValidationReport{
+		FixRef:         fixScan.Ref,
+		Skill:          fixScan.SkillName,
+		BaselineScanID: baselineScanID,
+		FixScanID:      fixScan.ID,
+		FixCommit:      fixScan.Commit,
+		Counts: fixValidationCounts{
+			Resolved:  len(resolved),
+			Surviving: len(surviving),
+			New:       len(newFindings),
+		},
+		Resolved:  toValidationFindings(resolved),
+		Surviving: toValidationFindings(surviving),
+		New:       toValidationFindings(newFindings),
+		Verify:    verify,
+	}
+}
+
+// toValidationFindings projects findings onto the report shape and sorts them
+// deterministically (severity high to low, then fingerprint) so the emitted
+// JSON is reproducible regardless of DB row order (project rule: sort before
+// emitting anything reproducible). Returns a non-nil slice so empty buckets
+// marshal as [] rather than null.
+func toValidationFindings(fs []db.Finding) []fixValidationFinding {
+	out := make([]fixValidationFinding, 0, len(fs))
+	for _, f := range fs {
+		out = append(out, fixValidationFinding{
+			FindingID:   f.ID,
+			Fingerprint: f.Fingerprint,
+			Title:       f.Title,
+			Severity:    f.Severity,
+			CWE:         f.CWE,
+			Location:    f.Location,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if ri, rj := severityRank(out[i].Severity), severityRank(out[j].Severity); ri != rj {
+			return ri > rj
+		}
+		return out[i].Fingerprint < out[j].Fingerprint
+	})
+	return out
+}
+
+func sortVerify(v []fixValidationVerify) {
+	sort.Slice(v, func(i, j int) bool { return v[i].FindingID < v[j].FindingID })
+}
+
+// parseVerifyStatus pulls the verify skill's status enum out of a verify
+// scan's report.json. Empty when the report is absent or unparseable, which
+// the caller maps to a pending verdict.
+func parseVerifyStatus(report string) string {
+	var v struct {
+		Status string `json:"status"`
+	}
+	if json.Unmarshal([]byte(report), &v) != nil {
+		return ""
+	}
+	return v.Status
+}

--- a/internal/web/validate_fix_enqueue.go
+++ b/internal/web/validate_fix_enqueue.go
@@ -212,10 +212,13 @@ func (s *Server) fixValidationVerdicts(baseline []db.Finding, ref string) []fixV
 	}
 
 	var scans []db.Scan
-	s.DB.Select("finding_id, status, report").
+	if err := s.DB.Select("finding_id, status, report").
 		Where("finding_id IN ? AND skill_name = ? AND ref = ?", ids, verifySkillName, ref).
 		Order("id desc").
-		Find(&scans)
+		Find(&scans).Error; err != nil {
+		s.Log.Warn("fix-validation: load verify verdicts", "ref", ref, "err", err)
+		return nil
+	}
 
 	seen := map[uint]bool{}
 	var out []fixValidationVerify

--- a/internal/web/validate_fix_enqueue.go
+++ b/internal/web/validate_fix_enqueue.go
@@ -1,0 +1,236 @@
+package web
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"scrutineer/internal/db"
+	"scrutineer/internal/worker"
+)
+
+// validateFix composes the fix-validation pipeline into one operation.
+// Given a repository, a candidate fix ref, and one or more finding
+// ids that must share a baseline (producing) scan, it:
+//
+//  1. enqueues a finding-scoped verify against the fix ref for each finding,
+//     so the reproduction is re-run where the fix lives; and
+//  2. re-runs the baseline scan's skill against the fix ref as the anchor
+//     scan, marked with BaselineScanID so onScanFinalized computes the
+//     fingerprint diff (resolved/surviving/new) and writes the single
+//     validation report once the re-scan finalizes.
+//
+// The findings must come from one baseline scan so the re-scan uses one skill
+// and the fingerprint diff is apples-to-apples (same skill is part of the
+// fingerprint). Verify scans carry PrioFinding, so they run ahead of the
+// PrioScan anchor and their verdicts are usually ready when the report is
+// assembled.
+func (s *Server) validateFix(w http.ResponseWriter, r *http.Request) {
+	repo, ok := loadByID[db.Repository](s, w, r)
+	if !ok {
+		return
+	}
+
+	ref := strings.TrimSpace(r.FormValue("ref"))
+	if ref == "" {
+		s.validateFixReject(w, r, repo.ID, "a fix ref is required")
+		return
+	}
+	if err := worker.ValidateGitRef(ref); err != nil {
+		s.validateFixReject(w, r, repo.ID, fmt.Sprintf("invalid fix ref: %v", err))
+		return
+	}
+
+	findingIDs, err := parseFindingIDs(r)
+	if err != nil {
+		s.validateFixReject(w, r, repo.ID, err.Error())
+		return
+	}
+
+	var findings []db.Finding
+	if err := s.DB.Where("id IN ? AND repository_id = ?", findingIDs, repo.ID).Find(&findings).Error; err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if len(findings) != len(findingIDs) {
+		s.validateFixReject(w, r, repo.ID, "some findings were not found on this repository")
+		return
+	}
+	baselineScanID := findings[0].ScanID
+	for _, f := range findings {
+		if f.ScanID != baselineScanID {
+			s.validateFixReject(w, r, repo.ID, "all findings must come from the same baseline scan")
+			return
+		}
+	}
+
+	var baseline db.Scan
+	if err := s.DB.First(&baseline, baselineScanID).Error; err != nil {
+		http.Error(w, "baseline scan not found", http.StatusInternalServerError)
+		return
+	}
+	if baseline.SkillID == nil {
+		s.validateFixReject(w, r, repo.ID, "baseline scan has no skill to re-run against the fix ref")
+		return
+	}
+
+	model := r.FormValue("model")
+	s.enqueueValidateFixVerify(r, repo.ID, findings, ref, model)
+
+	anchorID, err := s.enqueueSkillWith(r.Context(), repo.ID, *baseline.SkillID, ScanOpts{
+		Model:          model,
+		Ref:            ref,
+		SubPath:        baseline.SubPath,
+		BaselineScanID: &baselineScanID,
+	})
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	s.redirect(w, r, fmt.Sprintf("/scans/%d", anchorID))
+}
+
+// enqueueValidateFixVerify runs the verify skill finding-scoped against the
+// fix ref for each targeted finding. A missing verify skill degrades to "no
+// reproduction-level check" rather than failing the operation; a verify for
+// the same finding against the same ref already in flight is skipped so a
+// re-submit does not pile up duplicates.
+func (s *Server) enqueueValidateFixVerify(r *http.Request, repoID uint, findings []db.Finding, ref, model string) {
+	var verifySkill db.Skill
+	if err := s.DB.Where("name = ? AND active = ?", verifySkillName, true).First(&verifySkill).Error; err != nil {
+		return
+	}
+	for _, f := range findings {
+		fid := f.ID
+		if s.hasOpenScan("finding_id = ? AND skill_id = ? AND ref = ?", fid, verifySkill.ID, ref) {
+			continue
+		}
+		if _, err := s.enqueueSkillWith(r.Context(), repoID, verifySkill.ID, ScanOpts{
+			Model:     model,
+			FindingID: &fid,
+			Ref:       ref,
+		}); err != nil {
+			s.Log.Warn("validate-fix: enqueue verify", "finding", fid, "ref", ref, "err", err)
+		}
+	}
+}
+
+func (s *Server) validateFixReject(w http.ResponseWriter, r *http.Request, repoID uint, msg string) {
+	setFlash(w, Flash{Category: errorKey, Title: msg})
+	s.redirect(w, r, fmt.Sprintf("/repositories/%d", repoID))
+}
+
+// parseFindingIDs reads the finding_ids form values, which may arrive as
+// repeated fields and/or comma-separated lists, into a de-duplicated slice.
+// An empty or malformed set is an error so the caller can flash it.
+func parseFindingIDs(r *http.Request) ([]uint, error) {
+	if err := r.ParseForm(); err != nil {
+		return nil, fmt.Errorf("could not parse form: %w", err)
+	}
+	seen := map[uint]bool{}
+	var ids []uint
+	for _, field := range r.Form["finding_ids"] {
+		for raw := range strings.SplitSeq(field, ",") {
+			raw = strings.TrimSpace(raw)
+			if raw == "" {
+				continue
+			}
+			n, err := strconv.ParseUint(raw, 10, 64)
+			if err != nil {
+				return nil, fmt.Errorf("invalid finding id %q", raw)
+			}
+			if id := uint(n); !seen[id] {
+				seen[id] = true
+				ids = append(ids, id)
+			}
+		}
+	}
+	if len(ids) == 0 {
+		return nil, fmt.Errorf("at least one finding id is required")
+	}
+	return ids, nil
+}
+
+// onScanFinalized is the single OnScanFinalized hook: it computes the
+// fix-validation report for anchor scans and runs the existing post-deep-dive
+// dedup pass for everything else. Both inspect committed state, so order does
+// not matter; autoEnqueueFindingDedup already skips anchor scans.
+func (s *Server) onScanFinalized(scan *db.Scan) {
+	s.autoComputeFixValidation(scan)
+	s.autoEnqueueFindingDedup(scan)
+}
+
+// autoComputeFixValidation is the anchor half of onScanFinalized. For a scan
+// marked with BaselineScanID it diffs the baseline scan's findings against the
+// re-scan by fingerprint, folds in the verify verdicts, and stores the JSON
+// report on the scan so the existing report view renders it. Errors are logged
+// and swallowed: a failed report must not fail the re-scan itself.
+func (s *Server) autoComputeFixValidation(scan *db.Scan) {
+	if scan == nil || scan.BaselineScanID == nil {
+		return
+	}
+	baselineID := *scan.BaselineScanID
+
+	var baseline []db.Finding
+	if err := s.DB.Where("scan_id = ?", baselineID).Find(&baseline).Error; err != nil {
+		s.Log.Warn("fix-validation: load baseline findings", "scan", scan.ID, "baseline", baselineID, "err", err)
+		return
+	}
+	var fixNew []db.Finding
+	if err := s.DB.Where("scan_id = ?", scan.ID).Find(&fixNew).Error; err != nil {
+		s.Log.Warn("fix-validation: load fix findings", "scan", scan.ID, "err", err)
+		return
+	}
+
+	report := buildFixValidationReport(*scan, baselineID, baseline, fixNew, s.fixValidationVerdicts(baseline, scan.Ref))
+	payload, err := json.Marshal(report)
+	if err != nil {
+		s.Log.Warn("fix-validation: marshal report", "scan", scan.ID, "err", err)
+		return
+	}
+	if err := s.DB.Model(&db.Scan{}).Where("id = ?", scan.ID).Update("report", string(payload)).Error; err != nil {
+		s.Log.Warn("fix-validation: store report", "scan", scan.ID, "err", err)
+	}
+}
+
+// fixValidationVerdicts collects, for each baseline finding that had a verify
+// run against the fix ref, that verify's reproduction-level verdict. Findings
+// with no verify-against-ref scan are omitted; one whose verify has not yet
+// finished is reported pending. One query (not one per finding) keeps the
+// not-found case quiet and cheap; the latest scan per finding wins.
+func (s *Server) fixValidationVerdicts(baseline []db.Finding, ref string) []fixValidationVerify {
+	if len(baseline) == 0 {
+		return nil
+	}
+	ids := make([]uint, len(baseline))
+	titleByID := make(map[uint]string, len(baseline))
+	for i, f := range baseline {
+		ids[i] = f.ID
+		titleByID[f.ID] = f.Title
+	}
+
+	var scans []db.Scan
+	s.DB.Select("finding_id, status, report").
+		Where("finding_id IN ? AND skill_name = ? AND ref = ?", ids, verifySkillName, ref).
+		Order("id desc").
+		Find(&scans)
+
+	seen := map[uint]bool{}
+	var out []fixValidationVerify
+	for _, sc := range scans {
+		if sc.FindingID == nil || seen[*sc.FindingID] {
+			continue
+		}
+		seen[*sc.FindingID] = true
+		status := verifyStatusPending
+		if sc.Status == db.ScanDone {
+			if st := parseVerifyStatus(sc.Report); st != "" {
+				status = st
+			}
+		}
+		out = append(out, fixValidationVerify{FindingID: *sc.FindingID, Title: titleByID[*sc.FindingID], Status: status})
+	}
+	return out
+}

--- a/internal/web/validate_fix_enqueue_test.go
+++ b/internal/web/validate_fix_enqueue_test.go
@@ -1,0 +1,286 @@
+package web
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"strings"
+	"testing"
+
+	"scrutineer/internal/db"
+)
+
+type validateFixFixture struct {
+	s          *Server
+	repoID     uint
+	baselineID uint
+	deepDiveID uint
+	verifyID   uint
+	f1, f2     db.Finding
+}
+
+// validateFixSetup builds a repo with an active deep-dive and verify skill, a
+// done baseline deep-dive scan, and two findings under it — the starting state
+// a fix-validation run acts on.
+func validateFixSetup(t *testing.T) (validateFixFixture, func()) {
+	t.Helper()
+	s, done := newTestServer(t)
+	repo := db.Repository{URL: "https://example.com/r", Name: "r"}
+	s.DB.Create(&repo)
+	deepdive := db.Skill{Name: deepDiveSkillName, OutputFile: "report.json", OutputKind: "findings", Version: 1, Active: true}
+	verify := db.Skill{Name: verifySkillName, OutputFile: "report.json", OutputKind: "verify", Version: 1, Active: true}
+	s.DB.Create(&deepdive)
+	s.DB.Create(&verify)
+	baseline := db.Scan{RepositoryID: repo.ID, Status: db.ScanDone, SkillID: &deepdive.ID, SkillName: deepDiveSkillName}
+	s.DB.Create(&baseline)
+	f1 := db.Finding{ScanID: baseline.ID, RepositoryID: repo.ID, Title: "f1", Severity: "High", Fingerprint: "fp1", Status: db.FindingNew}
+	f2 := db.Finding{ScanID: baseline.ID, RepositoryID: repo.ID, Title: "f2", Severity: "Critical", Fingerprint: "fp2", Status: db.FindingNew}
+	s.DB.Create(&f1)
+	s.DB.Create(&f2)
+	return validateFixFixture{s, repo.ID, baseline.ID, deepdive.ID, verify.ID, f1, f2}, done
+}
+
+func validateFixPost(s *Server, repoID uint, ref string, findingIDs ...uint) *httptest.ResponseRecorder {
+	form := url.Values{}
+	if ref != "" {
+		form.Set("ref", ref)
+	}
+	for _, id := range findingIDs {
+		form.Add("finding_ids", strconv.FormatUint(uint64(id), 10))
+	}
+	r := httptest.NewRequest("POST", fmt.Sprintf("/repositories/%d/validate-fix", repoID), strings.NewReader(form.Encode()))
+	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	r.Host = testHost
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, r)
+	return w
+}
+
+func validationAnchorCount(s *Server) int64 {
+	var n int64
+	s.DB.Model(&db.Scan{}).Where("baseline_scan_id IS NOT NULL").Count(&n)
+	return n
+}
+
+func TestValidateFix_happy(t *testing.T) {
+	fx, done := validateFixSetup(t)
+	defer done()
+
+	w := validateFixPost(fx.s, fx.repoID, "fix-branch", fx.f1.ID, fx.f2.ID)
+
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("status = %d, want 303; body=%s", w.Code, w.Body.String())
+	}
+	var anchor db.Scan
+	if err := fx.s.DB.Where("repository_id = ? AND baseline_scan_id = ? AND ref = ?",
+		fx.repoID, fx.baselineID, "fix-branch").First(&anchor).Error; err != nil {
+		t.Fatalf("anchor scan not created: %v", err)
+	}
+	if anchor.SkillID == nil || *anchor.SkillID != fx.deepDiveID {
+		t.Fatalf("anchor skill = %v, want deep-dive %d", anchor.SkillID, fx.deepDiveID)
+	}
+	if loc := w.Header().Get("Location"); loc != fmt.Sprintf("/scans/%d", anchor.ID) {
+		t.Fatalf("redirect = %q, want /scans/%d", loc, anchor.ID)
+	}
+	var verifyCount int64
+	fx.s.DB.Model(&db.Scan{}).
+		Where("skill_id = ? AND ref = ? AND finding_id IN ?", fx.verifyID, "fix-branch", []uint{fx.f1.ID, fx.f2.ID}).
+		Count(&verifyCount)
+	if verifyCount != 2 {
+		t.Fatalf("verify-against-ref scans = %d, want 2", verifyCount)
+	}
+}
+
+func TestValidateFix_rejects(t *testing.T) {
+	t.Run("missing ref", func(t *testing.T) {
+		fx, done := validateFixSetup(t)
+		defer done()
+		w := validateFixPost(fx.s, fx.repoID, "", fx.f1.ID)
+		assertValidateFixRejected(t, fx.s, w, fx.repoID)
+	})
+	t.Run("invalid ref", func(t *testing.T) {
+		fx, done := validateFixSetup(t)
+		defer done()
+		w := validateFixPost(fx.s, fx.repoID, "--bad ref", fx.f1.ID)
+		assertValidateFixRejected(t, fx.s, w, fx.repoID)
+	})
+	t.Run("no finding ids", func(t *testing.T) {
+		fx, done := validateFixSetup(t)
+		defer done()
+		w := validateFixPost(fx.s, fx.repoID, "fix-branch")
+		assertValidateFixRejected(t, fx.s, w, fx.repoID)
+	})
+	t.Run("finding not on repo", func(t *testing.T) {
+		fx, done := validateFixSetup(t)
+		defer done()
+		w := validateFixPost(fx.s, fx.repoID, "fix-branch", fx.f1.ID, 999999)
+		assertValidateFixRejected(t, fx.s, w, fx.repoID)
+	})
+	t.Run("findings from different scans", func(t *testing.T) {
+		fx, done := validateFixSetup(t)
+		defer done()
+		other := db.Scan{RepositoryID: fx.repoID, Status: db.ScanDone, SkillID: &fx.deepDiveID, SkillName: deepDiveSkillName}
+		fx.s.DB.Create(&other)
+		stray := db.Finding{ScanID: other.ID, RepositoryID: fx.repoID, Title: "stray", Severity: "Low", Fingerprint: "fpx"}
+		fx.s.DB.Create(&stray)
+		w := validateFixPost(fx.s, fx.repoID, "fix-branch", fx.f1.ID, stray.ID)
+		assertValidateFixRejected(t, fx.s, w, fx.repoID)
+	})
+	t.Run("baseline scan has no skill", func(t *testing.T) {
+		fx, done := validateFixSetup(t)
+		defer done()
+		noSkill := db.Scan{RepositoryID: fx.repoID, Status: db.ScanDone, SkillName: "import"}
+		fx.s.DB.Create(&noSkill)
+		imported := db.Finding{ScanID: noSkill.ID, RepositoryID: fx.repoID, Title: "imp", Severity: "Low", Fingerprint: "fpi"}
+		fx.s.DB.Create(&imported)
+		w := validateFixPost(fx.s, fx.repoID, "fix-branch", imported.ID)
+		assertValidateFixRejected(t, fx.s, w, fx.repoID)
+	})
+}
+
+func assertValidateFixRejected(t *testing.T, s *Server, w *httptest.ResponseRecorder, repoID uint) {
+	t.Helper()
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("status = %d, want 303 redirect; body=%s", w.Code, w.Body.String())
+	}
+	if loc := w.Header().Get("Location"); loc != fmt.Sprintf("/repositories/%d", repoID) {
+		t.Fatalf("redirect = %q, want repo page /repositories/%d", loc, repoID)
+	}
+	if n := validationAnchorCount(s); n != 0 {
+		t.Fatalf("rejected request still created %d anchor scan(s)", n)
+	}
+}
+
+func TestAutoComputeFixValidation_writesReport(t *testing.T) {
+	fx, done := validateFixSetup(t)
+	defer done()
+
+	anchor := db.Scan{RepositoryID: fx.repoID, Status: db.ScanDone, SkillName: deepDiveSkillName, Ref: "fix", BaselineScanID: &fx.baselineID}
+	fx.s.DB.Create(&anchor)
+	// f1 survived (re-observed by the anchor), f2 resolved (not re-observed).
+	fx.s.DB.Model(&db.Finding{}).Where("id = ?", fx.f1.ID).Update("last_seen_scan_id", anchor.ID)
+	fx.s.DB.Model(&db.Finding{}).Where("id = ?", fx.f2.ID).Update("last_seen_scan_id", fx.baselineID)
+	newF := db.Finding{ScanID: anchor.ID, RepositoryID: fx.repoID, Title: "new on fix ref", Severity: "Medium", Fingerprint: "fpnew"}
+	fx.s.DB.Create(&newF)
+	verifyScan := db.Scan{RepositoryID: fx.repoID, Status: db.ScanDone, SkillName: verifySkillName, Ref: "fix", FindingID: &fx.f1.ID, Report: `{"status":"confirmed"}`}
+	fx.s.DB.Create(&verifyScan)
+
+	fx.s.autoComputeFixValidation(&anchor)
+
+	var reloaded db.Scan
+	fx.s.DB.First(&reloaded, anchor.ID)
+	var rep fixValidationReport
+	if err := json.Unmarshal([]byte(reloaded.Report), &rep); err != nil {
+		t.Fatalf("report is not valid JSON: %v; report=%q", err, reloaded.Report)
+	}
+	if (rep.Counts != fixValidationCounts{Resolved: 1, Surviving: 1, New: 1}) {
+		t.Fatalf("counts = %+v, want {1 1 1}", rep.Counts)
+	}
+	if len(rep.Resolved) != 1 || rep.Resolved[0].FindingID != fx.f2.ID {
+		t.Fatalf("resolved = %+v, want [f2 id=%d]", rep.Resolved, fx.f2.ID)
+	}
+	if len(rep.Surviving) != 1 || rep.Surviving[0].FindingID != fx.f1.ID {
+		t.Fatalf("surviving = %+v, want [f1 id=%d]", rep.Surviving, fx.f1.ID)
+	}
+	if len(rep.Verify) != 1 || rep.Verify[0].FindingID != fx.f1.ID || rep.Verify[0].Status != "confirmed" {
+		t.Fatalf("verify = %+v, want [f1 confirmed]", rep.Verify)
+	}
+}
+
+func TestAutoComputeFixValidation_pendingVerify(t *testing.T) {
+	fx, done := validateFixSetup(t)
+	defer done()
+	anchor := db.Scan{RepositoryID: fx.repoID, Status: db.ScanDone, SkillName: deepDiveSkillName, Ref: "fix", BaselineScanID: &fx.baselineID}
+	fx.s.DB.Create(&anchor)
+	// A verify against the fix ref that has not finished yet.
+	verifyScan := db.Scan{RepositoryID: fx.repoID, Status: db.ScanRunning, SkillName: verifySkillName, Ref: "fix", FindingID: &fx.f1.ID}
+	fx.s.DB.Create(&verifyScan)
+
+	fx.s.autoComputeFixValidation(&anchor)
+
+	var reloaded db.Scan
+	fx.s.DB.First(&reloaded, anchor.ID)
+	var rep fixValidationReport
+	if err := json.Unmarshal([]byte(reloaded.Report), &rep); err != nil {
+		t.Fatalf("report is not valid JSON: %v", err)
+	}
+	if len(rep.Verify) != 1 || rep.Verify[0].Status != verifyStatusPending {
+		t.Fatalf("verify = %+v, want [f1 pending]", rep.Verify)
+	}
+}
+
+func TestAutoComputeFixValidation_ignoresOrdinaryScan(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	repo := db.Repository{URL: "https://example.com/r", Name: "r"}
+	s.DB.Create(&repo)
+	scan := db.Scan{RepositoryID: repo.ID, Status: db.ScanDone, SkillName: deepDiveSkillName, Report: "untouched"}
+	s.DB.Create(&scan)
+	s.autoComputeFixValidation(&scan)
+	var reloaded db.Scan
+	s.DB.First(&reloaded, scan.ID)
+	if reloaded.Report != "untouched" {
+		t.Fatalf("ordinary scan report changed to %q", reloaded.Report)
+	}
+}
+
+func TestAutoComputeFixValidation_nilScan(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	s.autoComputeFixValidation(nil)
+}
+
+// TestFixValidationAnchor_skipsAutoFunnel proves a validation anchor (a
+// deep-dive re-run carrying BaselineScanID) does not feed its findings back
+// into the revalidate or finding-dedup auto-funnel.
+func TestFixValidationAnchor_skipsAutoFunnel(t *testing.T) {
+	fx, done := validateFixSetup(t)
+	defer done()
+	dedup := db.Skill{Name: findingDedupSkillName, OutputFile: "report.json", OutputKind: "finding_dedup", Version: 1, Active: true}
+	reval := db.Skill{Name: revalidateSkillName, OutputFile: "report.json", OutputKind: "revalidate", Version: 1, Active: true}
+	fx.s.DB.Create(&dedup)
+	fx.s.DB.Create(&reval)
+
+	anchor := db.Scan{RepositoryID: fx.repoID, Status: db.ScanDone, SkillName: deepDiveSkillName, Ref: "fix", BaselineScanID: &fx.baselineID}
+	fx.s.DB.Create(&anchor)
+	anchorFinding := db.Finding{ScanID: anchor.ID, RepositoryID: fx.repoID, Title: "anchor finding", Severity: "Critical", Fingerprint: "afp"}
+	fx.s.DB.Create(&anchorFinding)
+
+	fx.s.autoEnqueueRevalidate(&anchor, &anchorFinding)
+	fx.s.onScanFinalized(&anchor)
+
+	var revalQ, dedupQ int64
+	fx.s.DB.Model(&db.Scan{}).Where("skill_id = ? AND status = ?", reval.ID, db.ScanQueued).Count(&revalQ)
+	fx.s.DB.Model(&db.Scan{}).Where("skill_id = ? AND status = ?", dedup.ID, db.ScanQueued).Count(&dedupQ)
+	if revalQ != 0 || dedupQ != 0 {
+		t.Fatalf("anchor scan triggered the auto-funnel: revalidate=%d dedup=%d, want 0/0", revalQ, dedupQ)
+	}
+}
+
+func TestParseFindingIDs(t *testing.T) {
+	form := func(values ...string) *http.Request {
+		v := url.Values{}
+		for _, val := range values {
+			v.Add("finding_ids", val)
+		}
+		r := httptest.NewRequest("POST", "/x", strings.NewReader(v.Encode()))
+		r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		return r
+	}
+	got, err := parseFindingIDs(form("3", "1,2", "3"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 3 || got[0] != 3 || got[1] != 1 || got[2] != 2 {
+		t.Fatalf("ids = %v, want [3 1 2] (split, de-duped, order-preserving)", got)
+	}
+	if _, err := parseFindingIDs(form()); err == nil {
+		t.Fatal("empty finding_ids: expected error")
+	}
+	if _, err := parseFindingIDs(form("notanumber")); err == nil {
+		t.Fatal("non-numeric finding id: expected error")
+	}
+}

--- a/internal/web/validate_fix_test.go
+++ b/internal/web/validate_fix_test.go
@@ -1,0 +1,96 @@
+package web
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"scrutineer/internal/db"
+)
+
+func TestClassifyFixValidation(t *testing.T) {
+	const baselineID, fixID = uint(10), uint(20)
+	baseline := []db.Finding{
+		{ID: 1, Fingerprint: "fp-survive", LastSeenScanID: fixID},       // re-observed by the fix scan
+		{ID: 2, Fingerprint: "fp-resolved", LastSeenScanID: baselineID}, // missed by the fix scan
+		{ID: 3, Fingerprint: "fp-stale", LastSeenScanID: 0},             // never re-observed at all
+	}
+	fixNew := []db.Finding{{ID: 4, Fingerprint: "fp-new", ScanID: fixID}}
+
+	resolved, surviving, newF := classifyFixValidation(baseline, fixNew, fixID)
+
+	if len(surviving) != 1 || surviving[0].ID != 1 {
+		t.Fatalf("surviving = %+v, want [id 1]", surviving)
+	}
+	if len(resolved) != 2 {
+		t.Fatalf("resolved = %+v, want 2 (ids 2,3)", resolved)
+	}
+	if len(newF) != 1 || newF[0].ID != 4 {
+		t.Fatalf("new = %+v, want [id 4]", newF)
+	}
+}
+
+func TestClassifyFixValidation_empty(t *testing.T) {
+	resolved, surviving, newF := classifyFixValidation(nil, nil, 20)
+	if len(resolved) != 0 || len(surviving) != 0 || len(newF) != 0 {
+		t.Fatalf("expected all empty, got r=%d s=%d n=%d", len(resolved), len(surviving), len(newF))
+	}
+}
+
+func TestBuildFixValidationReport(t *testing.T) {
+	const baselineID, fixID = uint(10), uint(20)
+	fixScan := db.Scan{ID: fixID, Ref: "fix-branch", SkillName: "security-deep-dive", Commit: "abc123"}
+	baseline := []db.Finding{
+		{ID: 1, Fingerprint: "b", Title: "low survivor", Severity: "Low", LastSeenScanID: fixID},
+		{ID: 2, Fingerprint: "a", Title: "critical survivor", Severity: "Critical", LastSeenScanID: fixID},
+		{ID: 3, Fingerprint: "c", Title: "resolved one", Severity: "High", LastSeenScanID: baselineID},
+	}
+	fixNew := []db.Finding{{ID: 4, Fingerprint: "n", Title: "new medium", Severity: "Medium", ScanID: fixID}}
+	verify := []fixValidationVerify{
+		{FindingID: 3, Title: "resolved one", Status: "fixed"},
+		{FindingID: 2, Title: "critical survivor", Status: "confirmed"},
+	}
+
+	rep := buildFixValidationReport(fixScan, baselineID, baseline, fixNew, verify)
+
+	if rep.FixRef != "fix-branch" || rep.Skill != "security-deep-dive" ||
+		rep.BaselineScanID != baselineID || rep.FixScanID != fixID || rep.FixCommit != "abc123" {
+		t.Fatalf("metadata wrong: %+v", rep)
+	}
+	if (rep.Counts != fixValidationCounts{Resolved: 1, Surviving: 2, New: 1}) {
+		t.Fatalf("counts = %+v, want {1 2 1}", rep.Counts)
+	}
+	// Surviving sorted severity high to low: Critical (id 2) before Low (id 1).
+	if len(rep.Surviving) != 2 || rep.Surviving[0].FindingID != 2 || rep.Surviving[1].FindingID != 1 {
+		t.Fatalf("surviving order = %+v, want [id2, id1]", rep.Surviving)
+	}
+	// Verify sorted by finding id ascending: 2 then 3.
+	if len(rep.Verify) != 2 || rep.Verify[0].FindingID != 2 || rep.Verify[1].FindingID != 3 {
+		t.Fatalf("verify order = %+v, want [id2, id3]", rep.Verify)
+	}
+}
+
+func TestBuildFixValidationReport_emptyBucketsMarshalAsArrays(t *testing.T) {
+	rep := buildFixValidationReport(db.Scan{ID: 20}, 10, nil, nil, nil)
+	b, err := json.Marshal(rep)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{`"resolved":[]`, `"surviving":[]`, `"new":[]`, `"verify":[]`} {
+		if !strings.Contains(string(b), want) {
+			t.Fatalf("empty report JSON missing %s:\n%s", want, b)
+		}
+	}
+}
+
+func TestParseVerifyStatus(t *testing.T) {
+	if got := parseVerifyStatus(`{"status":"fixed","notes":"no longer triggers"}`); got != "fixed" {
+		t.Fatalf("valid report: got %q, want fixed", got)
+	}
+	if got := parseVerifyStatus(`not json at all`); got != "" {
+		t.Fatalf("bad json: got %q, want empty", got)
+	}
+	if got := parseVerifyStatus(``); got != "" {
+		t.Fatalf("empty report: got %q, want empty", got)
+	}
+}


### PR DESCRIPTION
Part of #365

`POST /repositories/{id}/validate-fix` (repo, fix ref, finding ids) verifies each finding against the fix ref, re-scans with its producing skill, and writes one report on the anchor scan: resolved/surviving/new by fingerprint, plus the verify verdicts.

Follow-ups: no UI trigger yet, it's HTTP only; "default skill set" means the finding's producing skill, not `triage`, so the diff stays same-skill; and verify on an unmerged ref marks the finding `fixed`, which a follow-up could limit to the default branch.