### PR TITLE
feat: Only auto-triage direct dependencies on SBOM import

### DIFF
--- a/internal/web/api_ecosystems_test.go
+++ b/internal/web/api_ecosystems_test.go
@@ -87,7 +87,7 @@ func TestCreateOrTriageRepo_prefetchesNewRemoteRepo(t *testing.T) {
 
 	repo, _, err := s.createOrTriageRepo(context.Background(), RepoInput{
 		CloneURL: "https://github.com/acme/widget", Owner: "acme", Name: "widget",
-	}, "")
+	}, "", true)
 	if err != nil {
 		t.Fatalf("createOrTriageRepo: %v", err)
 	}
@@ -104,7 +104,7 @@ func TestCreateOrTriageRepo_skipsPrefetchForLocalRepo(t *testing.T) {
 
 	if _, _, err := s.createOrTriageRepo(context.Background(), RepoInput{
 		CloneURL: LocalScheme + t.TempDir(), Name: "local", Local: true,
-	}, ""); err != nil {
+	}, "", true); err != nil {
 		t.Fatalf("createOrTriageRepo: %v", err)
 	}
 	if called {
@@ -119,10 +119,10 @@ func TestCreateOrTriageRepo_skipsPrefetchForExistingRepo(t *testing.T) {
 	s.prefetchEcosystems = func(id uint) { got = append(got, id) }
 
 	in := RepoInput{CloneURL: "https://github.com/acme/widget", Owner: "acme", Name: "widget"}
-	if _, _, err := s.createOrTriageRepo(context.Background(), in, ""); err != nil {
+	if _, _, err := s.createOrTriageRepo(context.Background(), in, "", true); err != nil {
 		t.Fatalf("first add: %v", err)
 	}
-	if _, _, err := s.createOrTriageRepo(context.Background(), in, ""); err != nil {
+	if _, _, err := s.createOrTriageRepo(context.Background(), in, "", true); err != nil {
 		t.Fatalf("second add: %v", err)
 	}
 	if len(got) != 1 {

--- a/internal/web/org_import.go
+++ b/internal/web/org_import.go
@@ -223,7 +223,7 @@ func (s *Server) repoOrgImport(w http.ResponseWriter, r *http.Request) {
 		if input.Owner != "" {
 			landingOwner = input.Owner
 		}
-		_, isNew, err := s.createOrTriageRepo(r.Context(), input, r.FormValue("model"))
+		_, isNew, err := s.createOrTriageRepo(r.Context(), input, r.FormValue("model"), true)
 		if err != nil {
 			invalid = append(invalid, repo.FullName)
 			continue

--- a/internal/web/sboms.go
+++ b/internal/web/sboms.go
@@ -263,7 +263,7 @@ func (s *Server) resolveSBOMPackages(uploadID uint) {
 			s.DB.Model(p).Update("resolve_error", err.Error())
 			continue
 		}
-		repo, _, err := s.createOrTriageRepo(ctx, input, "")
+		repo, _, err := s.createOrTriageRepo(ctx, input, "", p.Scope == scopeDirect)
 		if err != nil {
 			s.DB.Model(p).Update("resolve_error", err.Error())
 			continue

--- a/internal/web/sboms.go
+++ b/internal/web/sboms.go
@@ -263,7 +263,7 @@ func (s *Server) resolveSBOMPackages(uploadID uint) {
 			s.DB.Model(p).Update("resolve_error", err.Error())
 			continue
 		}
-		repo, _, err := s.createOrTriageRepo(ctx, input, "", p.Scope == scopeDirect)
+		repo, _, err := s.createOrTriageRepo(ctx, input, "", p.Scope != scopeTransitive)
 		if err != nil {
 			s.DB.Model(p).Update("resolve_error", err.Error())
 			continue

--- a/internal/web/sboms_test.go
+++ b/internal/web/sboms_test.go
@@ -223,6 +223,9 @@ func TestSBOMResolve_linksRepoAndEnqueuesTriage(t *testing.T) {
 		if strings.Contains(purl, "lodash") {
 			return "https://github.com/lodash/lodash"
 		}
+		if strings.Contains(purl, "flat") {
+			return "https://github.com/lodash/flat"
+		}
 		if strings.Contains(purl, "transitive") {
 			return "https://github.com/lodash/transitive"
 		}
@@ -233,6 +236,7 @@ func TestSBOMResolve_linksRepoAndEnqueuesTriage(t *testing.T) {
 
 	up := db.SBOMUpload{Name: "demo", Packages: []db.SBOMPackage{
 		{Name: "lodash", PURL: "pkg:npm/lodash@4.17.21", Scope: scopeDirect},
+		{Name: "flat", PURL: "pkg:npm/flat@1.0.0"},
 		{Name: "transitive", PURL: "pkg:npm/transitive@1.0.0", Scope: scopeTransitive},
 		{Name: "nopurl"},
 		{Name: "noresolve", PURL: "pkg:npm/ghost@1.0.0"},
@@ -259,18 +263,26 @@ func TestSBOMResolve_linksRepoAndEnqueuesTriage(t *testing.T) {
 	}
 
 	if pkgs[1].RepositoryID == nil {
-		t.Fatalf("transitive not linked: %+v", pkgs[1])
+		t.Fatalf("flat-scope package not linked: %+v", pkgs[1])
 	}
 	s.DB.Model(&db.Scan{}).Where("repository_id = ?", *pkgs[1].RepositoryID).Count(&scans)
+	if scans != 1 {
+		t.Errorf("triage scan not enqueued for flat-scope dependency, scans = %d", scans)
+	}
+
+	if pkgs[2].RepositoryID == nil {
+		t.Fatalf("transitive not linked: %+v", pkgs[2])
+	}
+	s.DB.Model(&db.Scan{}).Where("repository_id = ?", *pkgs[2].RepositoryID).Count(&scans)
 	if scans != 0 {
 		t.Errorf("triage scan enqueued for transitive dependency, scans = %d", scans)
 	}
 
-	if pkgs[2].ResolveError != "no purl" {
-		t.Errorf("nopurl error = %q", pkgs[2].ResolveError)
+	if pkgs[3].ResolveError != "no purl" {
+		t.Errorf("nopurl error = %q", pkgs[3].ResolveError)
 	}
-	if pkgs[3].ResolveError != "no repository_url for purl" {
-		t.Errorf("noresolve error = %q", pkgs[3].ResolveError)
+	if pkgs[4].ResolveError != "no repository_url for purl" {
+		t.Errorf("noresolve error = %q", pkgs[4].ResolveError)
 	}
 }
 

--- a/internal/web/sboms_test.go
+++ b/internal/web/sboms_test.go
@@ -223,13 +223,17 @@ func TestSBOMResolve_linksRepoAndEnqueuesTriage(t *testing.T) {
 		if strings.Contains(purl, "lodash") {
 			return "https://github.com/lodash/lodash"
 		}
+		if strings.Contains(purl, "transitive") {
+			return "https://github.com/lodash/transitive"
+		}
 		return ""
 	}
 	triage := db.Skill{Name: defaultSkillName, Body: "b", Active: true}
 	s.DB.Create(&triage)
 
 	up := db.SBOMUpload{Name: "demo", Packages: []db.SBOMPackage{
-		{Name: "lodash", PURL: "pkg:npm/lodash@4.17.21"},
+		{Name: "lodash", PURL: "pkg:npm/lodash@4.17.21", Scope: scopeDirect},
+		{Name: "transitive", PURL: "pkg:npm/transitive@1.0.0", Scope: scopeTransitive},
 		{Name: "nopurl"},
 		{Name: "noresolve", PURL: "pkg:npm/ghost@1.0.0"},
 	}}
@@ -251,14 +255,22 @@ func TestSBOMResolve_linksRepoAndEnqueuesTriage(t *testing.T) {
 	var scans int64
 	s.DB.Model(&db.Scan{}).Where("repository_id = ?", repo.ID).Count(&scans)
 	if scans != 1 {
-		t.Errorf("triage scan not enqueued, scans = %d", scans)
+		t.Errorf("triage scan not enqueued for direct dependency, scans = %d", scans)
 	}
 
-	if pkgs[1].ResolveError != "no purl" {
-		t.Errorf("nopurl error = %q", pkgs[1].ResolveError)
+	if pkgs[1].RepositoryID == nil {
+		t.Fatalf("transitive not linked: %+v", pkgs[1])
 	}
-	if pkgs[2].ResolveError != "no repository_url for purl" {
-		t.Errorf("noresolve error = %q", pkgs[2].ResolveError)
+	s.DB.Model(&db.Scan{}).Where("repository_id = ?", *pkgs[1].RepositoryID).Count(&scans)
+	if scans != 0 {
+		t.Errorf("triage scan enqueued for transitive dependency, scans = %d", scans)
+	}
+
+	if pkgs[2].ResolveError != "no purl" {
+		t.Errorf("nopurl error = %q", pkgs[2].ResolveError)
+	}
+	if pkgs[3].ResolveError != "no repository_url for purl" {
+		t.Errorf("noresolve error = %q", pkgs[3].ResolveError)
 	}
 }
 

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -1674,6 +1674,9 @@ func (s *Server) createOrTriageRepo(ctx context.Context, input RepoInput, model 
 	if isNew && !repo.IsLocal() && s.prefetchEcosystems != nil {
 		s.prefetchEcosystems(repo.ID)
 	}
+	if !triage {
+		return repo, isNew, nil
+	}
 	if !isNew && input.Branch == "" && input.SubPath == "" {
 		return repo, false, nil
 	}
@@ -1686,14 +1689,12 @@ func (s *Server) createOrTriageRepo(ctx context.Context, input RepoInput, model 
 		s.Log.Info("default skill requires remote, skipping for local repo", "skill", skill.Name, "repo", repo.URL)
 		return repo, isNew, nil
 	}
-	if triage {
-		if _, err := s.enqueueSkillWith(ctx, repo.ID, skill.ID, ScanOpts{
-			Model:   model,
-			SubPath: input.SubPath,
-			Ref:     input.Branch,
-		}); err != nil {
-			return repo, isNew, err
-		}
+	if _, err := s.enqueueSkillWith(ctx, repo.ID, skill.ID, ScanOpts{
+		Model:   model,
+		SubPath: input.SubPath,
+		Ref:     input.Branch,
+	}); err != nil {
+		return repo, isNew, err
 	}
 	return repo, isNew, nil
 }

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -1075,7 +1075,7 @@ func (s *Server) addRepoAndScan(w http.ResponseWriter, r *http.Request, repoURL 
 		http.Error(w, err.Error(), http.StatusUnprocessableEntity)
 		return
 	}
-	repo, _, err := s.createOrTriageRepo(r.Context(), input, "")
+	repo, _, err := s.createOrTriageRepo(r.Context(), input, "", true)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -1507,7 +1507,7 @@ func (s *Server) repoCreate(w http.ResponseWriter, r *http.Request) {
 	if ref := strings.TrimSpace(r.FormValue("ref")); ref != "" {
 		input.Branch = ref
 	}
-	repo, _, err := s.createOrTriageRepo(r.Context(), input, r.FormValue("model"))
+	repo, _, err := s.createOrTriageRepo(r.Context(), input, r.FormValue("model"), true)
 	if err != nil {
 		s.repoCreateError(w, r, "Couldn't add repository", err, http.StatusInternalServerError)
 		return
@@ -1590,7 +1590,7 @@ func (s *Server) repoBulkCreate(w http.ResponseWriter, r *http.Request) {
 			invalid = append(invalid, line)
 			continue
 		}
-		_, isNew, err := s.createOrTriageRepo(r.Context(), input, r.FormValue("model"))
+		_, isNew, err := s.createOrTriageRepo(r.Context(), input, r.FormValue("model"), true)
 		if err != nil {
 			invalid = append(invalid, line)
 			continue
@@ -1614,10 +1614,10 @@ func (s *Server) repoBulkCreate(w http.ResponseWriter, r *http.Request) {
 }
 
 // createOrTriageRepo is the shared path for both single-add and bulk-add.
-// It FirstOrCreates the Repository row and, when the row is new, enqueues
-// the default skill. isNew reports whether the repo was actually created
-// (so callers can distinguish "queued" from "already present").
-func (s *Server) createOrTriageRepo(ctx context.Context, input RepoInput, model string) (db.Repository, bool, error) {
+// It FirstOrCreates the Repository row and, when the row is new and triage
+// is true, enqueues the default skill. isNew reports whether the repo was
+// actually created (so callers can distinguish "queued" from "already present").
+func (s *Server) createOrTriageRepo(ctx context.Context, input RepoInput, model string, triage bool) (db.Repository, bool, error) {
 	if input.Local {
 		path := strings.TrimPrefix(input.CloneURL, LocalScheme)
 		info, err := os.Stat(path)
@@ -1659,12 +1659,14 @@ func (s *Server) createOrTriageRepo(ctx context.Context, input RepoInput, model 
 		s.Log.Info("default skill requires remote, skipping for local repo", "skill", skill.Name, "repo", repo.URL)
 		return repo, isNew, nil
 	}
-	if _, err := s.enqueueSkillWith(ctx, repo.ID, skill.ID, ScanOpts{
-		Model:   model,
-		SubPath: input.SubPath,
-		Ref:     input.Branch,
-	}); err != nil {
-		return repo, isNew, err
+	if triage {
+		if _, err := s.enqueueSkillWith(ctx, repo.ID, skill.ID, ScanOpts{
+			Model:   model,
+			SubPath: input.SubPath,
+			Ref:     input.Branch,
+		}); err != nil {
+			return repo, isNew, err
+		}
 	}
 	return repo, isNew, nil
 }


### PR DESCRIPTION
Part of #464

### Description
This PR updates the SBOM import flow to prevent massive scan queue flooding when importing large SBOMs.

Previously, importing an SBOM would automatically enqueue triage scans for *every* parsed package, which could overwhelm the system for repos with hundreds of transitive dependencies.

Now, `createOrTriageRepo` accepts a `triage bool` parameter. During an SBOM import, we check the package scope and only pass `triage = true` for **direct dependencies** (`p.Scope == scopeDirect`). Transitive dependencies still get their repository rows created (so the SBOM view remains complete), but they skip the expensive auto-enqueuing step.

### Changes
*   Added `triage bool` to `createOrTriageRepo` signature.
*   Updated SBOM resolution to conditionally triage based on package scope.
*   Updated all other callers to default to `true`.
*   Added tests verifying that direct dependencies enqueue a scan while transitive ones do not.