### PR TITLE
feat(web): add fix-validation trigger to the finding page

### DIFF
--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -1320,6 +1320,34 @@ func TestFindingShow_disablesVerifyActionWhenVerifyInFlight(t *testing.T) {
 	}
 }
 
+func TestFindingShow_rendersValidateFixForm(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	repo := db.Repository{URL: "https://example.com/r", Name: "r"}
+	s.DB.Create(&repo)
+	scan := db.Scan{RepositoryID: repo.ID, Kind: "skill", Status: db.ScanDone, SkillName: "security-deep-dive"}
+	s.DB.Create(&scan)
+	f := db.Finding{ScanID: scan.ID, RepositoryID: repo.ID, Title: "needs a fix", Severity: "High", Status: db.FindingTriaged}
+	s.DB.Create(&f)
+
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq("GET", fmt.Sprintf("/findings/%d", f.ID)))
+	body := w.Body.String()
+	if w.Code != http.StatusOK {
+		t.Fatalf("status %d: %s", w.Code, body)
+	}
+	if !strings.Contains(body, fmt.Sprintf(`action="/repositories/%d/validate-fix"`, repo.ID)) {
+		t.Errorf("expected a validate-fix form posting to the repo endpoint, body=%s", body)
+	}
+	if !strings.Contains(body, fmt.Sprintf(`name="finding_ids" value="%d"`, f.ID)) {
+		t.Error("expected this finding's id wired into the validate-fix form")
+	}
+	if !strings.Contains(body, `name="ref"`) {
+		t.Error("expected a ref input in the validate-fix form")
+	}
+}
+
 func TestFindingShow_ghsaLinksToRepoAdvisory(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()

--- a/internal/web/templates/finding_show.html
+++ b/internal/web/templates/finding_show.html
@@ -306,6 +306,32 @@
   </details>
   {{end}}
 
+  <details class="group border-b">
+    <summary class="w-full outline-none rounded-md focus-visible:ring-ring/50 focus-visible:ring-[3px]">
+      <h3 class="flex flex-1 items-center justify-between gap-4 py-4 text-sm font-medium hover:underline">
+        Fix validation
+        <i data-lucide="chevron-down" class="text-muted-foreground size-4 shrink-0 transition-transform duration-200 group-open:rotate-180"></i>
+      </h3>
+    </summary>
+    <section class="pb-4 grid gap-3">
+      <p class="text-xs text-muted-foreground">
+        Re-scan a candidate fix ref with this finding's skill and re-run verify against it, then diff the
+        findings by fingerprint: resolved, surviving, or newly introduced. The validation report lands on
+        the scan it kicks off.
+      </p>
+      <form method="post" action="/repositories/{{$repo.ID}}/validate-fix"
+            hx-post="/repositories/{{$repo.ID}}/validate-fix" hx-swap="none"
+            class="flex flex-wrap items-center gap-2">
+        <input type="hidden" name="finding_ids" value="{{$f.ID}}">
+        <input class="input max-w-xs" type="text" name="ref" required
+               placeholder="fix branch, tag, or commit">
+        <button type="submit" class="btn-sm">
+          <i data-lucide="git-compare"></i> Validate fix
+        </button>
+      </form>
+    </section>
+  </details>
+
   {{if $f.Mitigation}}
   <details open class="group border-b">
     <summary class="w-full outline-none rounded-md focus-visible:ring-ring/50 focus-visible:ring-[3px]">

--- a/internal/worker/skill_parsers.go
+++ b/internal/worker/skill_parsers.go
@@ -666,7 +666,15 @@ func (w *Worker) parseVerifyOutput(scan *db.Scan, report string, emit func(Event
 			nextStatus = db.FindingEnriched
 		}
 	case "fixed":
-		nextStatus = db.FindingFixed
+		// Only a verify against the default branch (empty Ref) moves the
+		// finding to fixed. A "fixed" verdict on an explicit fix ref — the
+		// validate-fix pipeline points verify at a candidate ref, often an
+		// unmerged PR branch — means the fix works there, not that a release
+		// carries it; the note below and the fix-validation report still
+		// capture the per-ref verdict.
+		if scan.Ref == "" {
+			nextStatus = db.FindingFixed
+		}
 	case "inconclusive":
 		// Leave status alone.
 	default:

--- a/internal/worker/skill_parsers_test.go
+++ b/internal/worker/skill_parsers_test.go
@@ -505,6 +505,40 @@ func TestParseVerify_fixedJumpsToFixed(t *testing.T) {
 	}
 }
 
+func TestParseVerify_fixedAgainstRefDoesNotFlipStatus(t *testing.T) {
+	gdb, err := db.Open(filepath.Join(t.TempDir(), "v.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo := db.Repository{URL: "https://example.com/x", Name: "x"}
+	gdb.Create(&repo)
+	priorScan := db.Scan{RepositoryID: repo.ID, Kind: JobSkill, Status: db.ScanDone, SkillName: "security-deep-dive"}
+	gdb.Create(&priorScan)
+	finding := db.Finding{ScanID: priorScan.ID, RepositoryID: repo.ID, Title: "x", Severity: "High", Status: db.FindingTriaged}
+	gdb.Create(&finding)
+	// A verify scan the validate-fix pipeline points at a candidate fix ref,
+	// not the default branch.
+	scan := db.Scan{RepositoryID: repo.ID, Kind: JobSkill, Status: db.ScanRunning,
+		SkillName: "verify", FindingID: new(finding.ID), Ref: "fix-branch"}
+	gdb.Create(&scan)
+
+	w := &Worker{DB: gdb, Log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	report := `{"status":"fixed","evidence":"no longer reproduces on the PR branch"}`
+	if err := w.parseVerifyOutput(&scan, report, func(Event) {}); err != nil {
+		t.Fatal(err)
+	}
+
+	var refreshed db.Finding
+	gdb.First(&refreshed, finding.ID)
+	if refreshed.Status != db.FindingTriaged {
+		t.Errorf("status = %s, want triaged: a fixed verdict on a specific ref must not flip the lifecycle", refreshed.Status)
+	}
+	notes := findingNotes(gdb, finding.ID)
+	if len(notes) == 0 || !strings.Contains(notes[0].Body, "fixed") {
+		t.Errorf("the per-ref verdict should still be recorded in notes: %+v", notes)
+	}
+}
+
 func TestParseVerify_inconclusiveLeavesStatus(t *testing.T) {
 	report := `{"status":"inconclusive","notes":"tooling missing"}`
 	f, gdb := runSkillWithFinding(t, "verify", report, db.FindingNew)


### PR DESCRIPTION
Fix #365 

One design choice to confirm: "scan the fix ref with the default skill set" is realized by re-running the finding's producing skill, not `triage`, so the fingerprint diff compares same-skill against same-skill.
