### PR TITLE
feat: bucket vuln-scan findings into Findings instead of Scanners

### DIFF
--- a/internal/web/finding_dedup_enqueue.go
+++ b/internal/web/finding_dedup_enqueue.go
@@ -62,7 +62,7 @@ func (s *Server) autoEnqueueFindingDedup(scan *db.Scan) {
 	var openNonScanner int64
 	if err := s.DB.Model(&db.Finding{}).
 		Where("repository_id = ?", scan.RepositoryID).
-		Where(nonScannerScanFilter, deepDiveSkillName).
+		Where(nonScannerScanFilter).
 		Where("status NOT IN (" + db.ClosedFindingLifecycleSQLValues() + ")").
 		Count(&openNonScanner).Error; err != nil {
 		s.Log.Warn("auto-enqueue finding-dedup: count open findings",

--- a/internal/web/finding_dedup_enqueue.go
+++ b/internal/web/finding_dedup_enqueue.go
@@ -21,15 +21,16 @@ const dedupMinFindings = 2
 // committed. We enqueue a repository-scoped finding-dedup run only when both
 // conditions the dedup pass needs to be worth its model spend hold:
 //
-//  1. The scan is a security-deep-dive that produced at least one *new*
-//     finding. Re-observed findings keep the scan_id of the run that first
-//     created them, so counting findings with scan_id == this scan counts
-//     exactly the new rows. Nothing new means nothing fresh to dedup.
+//  1. The scan is a curated LLM audit (security-deep-dive or vuln-scan) that
+//     produced at least one *new* finding. Re-observed findings keep the
+//     scan_id of the run that first created them, so counting findings with
+//     scan_id == this scan counts exactly the new rows. Nothing new means
+//     nothing fresh to dedup.
 //  2. The repository now holds at least two open non-scanner findings in
 //     total (the new rows count toward this). Dedup needs a pair to compare,
-//     but the pair need not predate this scan: a first-ever deep-dive that
-//     emits several findings describing the same bug from different subagent
-//     angles is exactly what dedup exists to collapse.
+//     but the pair need not predate this scan: a first-ever audit that emits
+//     several findings describing the same bug from different subagent angles
+//     is exactly what dedup exists to collapse.
 //
 // "Non-scanner" matches the Findings-tab toggle exactly (nonScannerScanFilter):
 // the cheap tool scanners (semgrep, zizmor) and tool imports (CodeQL, Snyk)
@@ -40,10 +41,10 @@ const dedupMinFindings = 2
 // Errors are logged and swallowed: failing to enqueue the dedup pass must
 // never fail the upstream scan.
 func (s *Server) autoEnqueueFindingDedup(scan *db.Scan) {
-	// A fix-validation anchor (validate_fix.go) re-runs deep-dive on a fix ref
+	// A fix-validation anchor (validate_fix.go) re-runs an audit on a fix ref
 	// purely to diff fingerprints; its findings are validation scratch, not a
 	// repo's working set, so they must not trigger a dedup pass.
-	if scan == nil || scan.SkillName != deepDiveSkillName || scan.BaselineScanID != nil {
+	if scan == nil || !isLLMAuditSkill(scan.SkillName) || scan.BaselineScanID != nil {
 		return
 	}
 

--- a/internal/web/finding_dedup_enqueue_test.go
+++ b/internal/web/finding_dedup_enqueue_test.go
@@ -40,9 +40,10 @@ func dedupQueued(s *Server, repoID, dedupID uint) int64 {
 }
 
 // TestAutoEnqueueFindingDedup_conditions covers the two gating conditions:
-// the deep dive must produce at least one new finding, and the repo must end
-// up with at least two open non-scanner findings to compare against (the new
-// rows count, so a first-ever deep-dive emitting several findings qualifies).
+// a curated LLM audit (security-deep-dive or vuln-scan) must produce at least
+// one new finding, and the repo must end up with at least two open non-scanner
+// findings to compare against (the new rows count, so a first-ever audit
+// emitting several findings qualifies).
 func TestAutoEnqueueFindingDedup_conditions(t *testing.T) {
 	cases := []struct {
 		name string
@@ -74,6 +75,18 @@ func TestAutoEnqueueFindingDedup_conditions(t *testing.T) {
 			name:        "prior legacy (empty skill) finding also counts",
 			scanSkill:   "security-deep-dive",
 			newFindings: 1, hasPrior: true, priorSkill: "", priorStatus: db.FindingNew,
+			wantQueued: true,
+		},
+		{
+			name:        "first-ever vuln-scan emitting two new findings",
+			scanSkill:   "vuln-scan",
+			newFindings: 2, hasPrior: false,
+			wantQueued: true,
+		},
+		{
+			name:        "vuln-scan new finding with prior vuln-scan finding",
+			scanSkill:   "vuln-scan",
+			newFindings: 1, hasPrior: true, priorSkill: "vuln-scan", priorStatus: db.FindingNew,
 			wantQueued: true,
 		},
 		{

--- a/internal/web/import_test.go
+++ b/internal/web/import_test.go
@@ -187,7 +187,7 @@ func TestImportFindings_skipsRevalidateWhenSkillAbsent(t *testing.T) {
 	}
 }
 
-func TestAutoEnqueueRevalidate_onlyHighAndCriticalFromDeepDive(t *testing.T) {
+func TestAutoEnqueueRevalidate_onlyHighAndCriticalFromLLMAudits(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()
 	repo := db.Repository{URL: "https://example.com/r", Name: "r"}
@@ -205,6 +205,9 @@ func TestAutoEnqueueRevalidate_onlyHighAndCriticalFromDeepDive(t *testing.T) {
 		{"deep-dive High", "security-deep-dive", "High", true},
 		{"deep-dive Medium", "security-deep-dive", "Medium", false},
 		{"deep-dive Low", "security-deep-dive", "Low", false},
+		{"vuln-scan Critical", "vuln-scan", "Critical", true},
+		{"vuln-scan High", "vuln-scan", "High", true},
+		{"vuln-scan Medium", "vuln-scan", "Medium", false},
 		{"semgrep High", "semgrep", "High", false},
 		{"zizmor Critical", "zizmor", "Critical", false},
 	}

--- a/internal/web/maintainers.go
+++ b/internal/web/maintainers.go
@@ -58,18 +58,19 @@ func (s *Server) maintainersList(w http.ResponseWriter, r *http.Request) {
 			N            int
 		}
 		var counts []row
-		// LEFT JOIN scans so the COUNT only includes deep-dive findings.
-		// Scanner output (zizmor, semgrep) is per-repo lint noise and
-		// shouldn't drive maintainer routing.
+		// LEFT JOIN scans so the COUNT only includes curated LLM-audit findings
+		// (security-deep-dive, vuln-scan). Scanner output (zizmor, semgrep) is
+		// per-repo lint noise and shouldn't drive maintainer routing. Mirrors
+		// findingsBucketSkillSQL, qualified to the scans alias for the join.
 		s.DB.Raw(`
 			SELECT rm.maintainer_id, COUNT(f.id) AS n
 			FROM repository_maintainers rm
 			LEFT JOIN findings f ON f.repository_id = rm.repository_id
 			LEFT JOIN scans s ON s.id = f.scan_id
 			WHERE rm.maintainer_id IN ?
-			  AND (s.skill_name IS NULL OR s.skill_name = '' OR s.skill_name = ?)
+			  AND (s.skill_name IS NULL OR s.skill_name = '' OR s.skill_name IN (?, ?))
 			GROUP BY rm.maintainer_id
-		`, ids, deepDiveSkillName).Scan(&counts)
+		`, ids, deepDiveSkillName, vulnScanSkillName).Scan(&counts)
 		for _, c := range counts {
 			findingCounts[c.MaintainerID] = c.N
 		}

--- a/internal/web/orgs.go
+++ b/internal/web/orgs.go
@@ -70,18 +70,20 @@ func (s *Server) orgsList(w http.ResponseWriter, r *http.Request) {
 			N     int
 		}
 		var counts []c
-		// LEFT JOIN scans so the COUNT only includes findings whose scan is
-		// the curated audit. Tool-scanner output (zizmor, semgrep) is shown
-		// per-repo in the Scanners tab, not in cross-org totals.
+		// LEFT JOIN scans so the COUNT only includes findings whose scan is one
+		// of the curated LLM audits (security-deep-dive, vuln-scan). Tool-scanner
+		// output (zizmor, semgrep) is shown per-repo in the Scanners tab, not in
+		// cross-org totals. Mirrors findingsBucketSkillSQL, qualified to the
+		// scans alias for the join.
 		s.DB.Raw(`
 			SELECT r.owner, COUNT(f.id) AS n
 			FROM repositories r
 			LEFT JOIN findings f ON f.repository_id = r.id
 			LEFT JOIN scans s ON s.id = f.scan_id
 			WHERE r.owner != ''
-			  AND (s.skill_name IS NULL OR s.skill_name = '' OR s.skill_name = ?)
+			  AND (s.skill_name IS NULL OR s.skill_name = '' OR s.skill_name IN (?, ?))
 			GROUP BY r.owner
-		`, deepDiveSkillName).Scan(&counts)
+		`, deepDiveSkillName, vulnScanSkillName).Scan(&counts)
 		for _, x := range counts {
 			findingCounts[x.Owner] = x.N
 		}

--- a/internal/web/revalidate_enqueue.go
+++ b/internal/web/revalidate_enqueue.go
@@ -7,8 +7,9 @@ import (
 )
 
 // revalidateSkillName is the cheap finding classifier auto-enqueued for
-// High/Critical findings from security-deep-dive and for every finding
-// created via the /v1/import path. See skills/revalidate/SKILL.md.
+// High/Critical findings from the LLM audits (security-deep-dive, vuln-scan)
+// and for every finding created via the /v1/import path.
+// See skills/revalidate/SKILL.md.
 const revalidateSkillName = "revalidate"
 
 // verifySkillName is shared with server.go: the heavier
@@ -17,12 +18,15 @@ const revalidateSkillName = "revalidate"
 
 // autoEnqueueRevalidate is wired onto Worker.OnFindingCreated. The worker
 // calls it after persisting each fresh Finding row from a findings-emitting
-// scan. We only act for High/Critical findings produced by
-// security-deep-dive: smaller scanners (semgrep, zizmor) and finding-scoped
-// re-runs go straight to a human, and lower severities are not worth the
-// model spend at this stage of the funnel. Re-running deep-dive on the same
-// repo bumps the existing finding's seen_count rather than creating a new
-// one, so we never enqueue against an observed-again row.
+// scan. We only act for High/Critical findings produced by the curated LLM
+// audits (security-deep-dive, vuln-scan): smaller scanners (semgrep, zizmor)
+// and finding-scoped re-runs go straight to a human, and lower severities are
+// not worth the model spend at this stage of the funnel. vuln-scan is the
+// high-recall skill, so its High/Critical output needs the cheap revalidate
+// pre-sort most — without it those candidates would sit untriaged in the same
+// queue as triaged deep-dive rows. Re-running an audit on the same repo bumps
+// the existing finding's seen_count rather than creating a new one, so we
+// never enqueue against an observed-again row.
 //
 // Errors are logged and swallowed: failing to enqueue the pre-sort step
 // must never fail the upstream scan.
@@ -34,7 +38,7 @@ func (s *Server) autoEnqueueRevalidate(scan *db.Scan, f *db.Finding) {
 	// ref only to diff fingerprints; feeding its findings back into the
 	// revalidate -> verify funnel would double the spend and race the
 	// finding-scoped verify the pipeline already enqueued against that ref.
-	if scan.SkillName != deepDiveSkillName || scan.BaselineScanID != nil {
+	if !isLLMAuditSkill(scan.SkillName) || scan.BaselineScanID != nil {
 		return
 	}
 	if !db.SeverityAtLeast(f.Severity, "High") {

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -1055,12 +1055,13 @@ const (
 	// findingsBucketSkillSQL is the single source of truth for which scans'
 	// findings populate the curated Findings bucket: the LLM audit skills
 	// (security-deep-dive, vuln-scan) plus legacy claude jobs with an empty or
-	// NULL skill_name. The skill names are inlined as a literal rather than
-	// bound parameters because this fragment is embedded raw into larger SQL
-	// (e.g. an Order clause) that can't carry args; the listed names mirror the
-	// deepDiveSkillName and vulnScanSkillName constants above. Parenthesised so
-	// it can be embedded in larger expressions without precedence surprises.
-	findingsBucketSkillSQL = "(skill_name IN ('security-deep-dive', 'vuln-scan') OR skill_name = '' OR skill_name IS NULL)"
+	// NULL skill_name. The names are spliced in as literals rather than bound
+	// parameters because this fragment is embedded raw into larger SQL (e.g. an
+	// Order clause) that can't carry args; built from the skill-name constants
+	// via const string concatenation so a rename only touches one line.
+	// Parenthesised so it can be embedded in larger expressions without
+	// precedence surprises.
+	findingsBucketSkillSQL = "(skill_name IN ('" + deepDiveSkillName + "', '" + vulnScanSkillName + "') OR skill_name = '' OR skill_name IS NULL)"
 	// nonScannerScanFilter selects findings whose parent scan is one of the LLM
 	// audits (security-deep-dive, vuln-scan), a legacy claude job (empty skill
 	// name), or has no recorded source — everything the UI groups under
@@ -1099,7 +1100,8 @@ func findingsScanIDs(gdb *gorm.DB) *gorm.DB {
 
 // isLLMAuditSkill reports whether a finalized scan is one of the curated LLM
 // audits (security-deep-dive, vuln-scan) whose fresh output drives the
-// auto-triage funnels (finding-dedup). Unlike findingsBucketSkillSQL this
+// auto-triage funnels (finding-dedup and the revalidate pre-sort). Unlike
+// findingsBucketSkillSQL this
 // deliberately excludes legacy empty/NULL skill_name rows: those are inert
 // imports, not a live scan that just produced new findings worth triaging.
 func isLLMAuditSkill(skillName string) bool {

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -1055,11 +1055,12 @@ const (
 	// findingsBucketSkillSQL is the single source of truth for which scans'
 	// findings populate the curated Findings bucket: the LLM audit skills
 	// (security-deep-dive, vuln-scan) plus legacy claude jobs with an empty or
-	// NULL skill_name. The skill names are compile-time constants, so inlining
-	// them keeps every bucket filter agreeing on what "non-scanner" means
-	// without threading a bound parameter through each call site. Parenthesised
-	// so it can be embedded in larger expressions without precedence surprises.
-	findingsBucketSkillSQL = "(skill_name IN ('" + deepDiveSkillName + "', '" + vulnScanSkillName + "') OR skill_name = '' OR skill_name IS NULL)"
+	// NULL skill_name. The skill names are inlined as a literal rather than
+	// bound parameters because this fragment is embedded raw into larger SQL
+	// (e.g. an Order clause) that can't carry args; the listed names mirror the
+	// deepDiveSkillName and vulnScanSkillName constants above. Parenthesised so
+	// it can be embedded in larger expressions without precedence surprises.
+	findingsBucketSkillSQL = "(skill_name IN ('security-deep-dive', 'vuln-scan') OR skill_name = '' OR skill_name IS NULL)"
 	// nonScannerScanFilter selects findings whose parent scan is one of the LLM
 	// audits (security-deep-dive, vuln-scan), a legacy claude job (empty skill
 	// name), or has no recorded source — everything the UI groups under

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -915,7 +915,6 @@ func (s *Server) findingToggleCounts(r *http.Request, scanners bool) (int64, int
 
 	scannerWhere, scannerArgs := findingIndexWhereSQL(r, true, true)
 	scannerWhere = append(scannerWhere, scannerScanFilter)
-	scannerArgs = append(scannerArgs, deepDiveSkillName)
 
 	var counts struct {
 		MissedTotal  int64
@@ -938,7 +937,6 @@ func findingIndexWhereSQL(r *http.Request, includeScanners, includeMissed bool) 
 	var args []any
 	if !includeScanners {
 		where = append(where, nonScannerScanFilter)
-		args = append(args, deepDiveSkillName)
 	}
 	if sev := r.URL.Query().Get("severity"); sev != "" {
 		where = append(where, "severity = ?")
@@ -1049,16 +1047,29 @@ const (
 	// deepDiveSkillName is the skill whose reports feed the Summary, Findings
 	// and Threat Model tabs on the repository page.
 	deepDiveSkillName = "security-deep-dive"
-	// nonScannerScanFilter selects findings whose parent scan is the
-	// security-deep-dive scanner, the legacy claude job (empty skill name),
-	// or has no recorded source — everything the UI groups under
+	// vulnScanSkillName is the LLM-driven high-recall candidate scan. Like
+	// security-deep-dive it uses a model to find real vulnerabilities, so its
+	// findings belong in the curated Findings bucket alongside the deep-dive
+	// audit rather than the Scanners tab full of cheap tool output (#458).
+	vulnScanSkillName = "vuln-scan"
+	// findingsBucketSkillSQL is the single source of truth for which scans'
+	// findings populate the curated Findings bucket: the LLM audit skills
+	// (security-deep-dive, vuln-scan) plus legacy claude jobs with an empty or
+	// NULL skill_name. The skill names are compile-time constants, so inlining
+	// them keeps every bucket filter agreeing on what "non-scanner" means
+	// without threading a bound parameter through each call site. Parenthesised
+	// so it can be embedded in larger expressions without precedence surprises.
+	findingsBucketSkillSQL = "(skill_name IN ('" + deepDiveSkillName + "', '" + vulnScanSkillName + "') OR skill_name = '' OR skill_name IS NULL)"
+	// nonScannerScanFilter selects findings whose parent scan is one of the LLM
+	// audits (security-deep-dive, vuln-scan), a legacy claude job (empty skill
+	// name), or has no recorded source — everything the UI groups under
 	// "non-scanner". scannerScanFilter is its structural inverse: the cheap
-	// tool scanners (semgrep, zizmor) and imported reports (CodeQL, Snyk,
-	// which carry the tool name as skill_name). Both take deepDiveSkillName
-	// as the single bound parameter; deriving one from the other keeps the
-	// Findings toggle and the dedup auto-enqueue agreeing on what "scanner"
-	// means without a second copy of the subquery to keep in sync.
-	nonScannerScanFilter = "scan_id IN (SELECT id FROM scans WHERE skill_name = ? OR skill_name = '' OR skill_name IS NULL)"
+	// tool scanners (semgrep, zizmor) and imported reports (CodeQL, Snyk, which
+	// carry the tool name as skill_name). Both derive from findingsBucketSkillSQL
+	// so the Findings toggle, the repo Findings tab, and the dedup auto-enqueue
+	// agree on what "scanner" means without a second copy of the subquery to
+	// keep in sync.
+	nonScannerScanFilter = "scan_id IN (SELECT id FROM scans WHERE " + findingsBucketSkillSQL + ")"
 	scannerScanFilter    = "NOT (" + nonScannerScanFilter + ")"
 	// threatModelSkillName is the skill whose report feeds the Threat Model
 	// tab when present; repos that predate it fall back to the boundaries
@@ -1067,23 +1078,22 @@ const (
 	zizmorSkillName      = "zizmor"
 )
 
-// deepDiveFindingsCountSQL is a correlated subselect that counts deep-dive
+// deepDiveFindingsCountSQL is a correlated subselect that counts curated
 // findings for the surrounding repositories row. Used in the repos list
 // "findings" sort. Tool-scanner skills are excluded so the ordering matches
-// the counts shown in the Findings column.
+// the counts shown in the Findings column; the LLM audit skills
+// (security-deep-dive, vuln-scan) and legacy rows count via findingsBucketSkillSQL.
 var deepDiveFindingsCountSQL = `SELECT COUNT(*) FROM findings f
 	    WHERE f.repository_id = repositories.id
 	      AND f.status NOT IN (` + db.ClosedFindingLifecycleSQLValues() + `)
-	      AND f.scan_id IN (SELECT id FROM scans
-	        WHERE skill_name = '` + deepDiveSkillName + `' OR skill_name = '' OR skill_name IS NULL)`
+	      AND f.scan_id IN (SELECT id FROM scans WHERE ` + findingsBucketSkillSQL + `)`
 
 // findingsScanIDs returns a GORM subquery selecting scan IDs that belong to
-// the curated audit (security-deep-dive) or to legacy/empty skill_name rows.
-// Use it as a `scan_id IN (?)` filter to keep listings consistent with the
-// repo Findings tab.
+// the curated LLM audits (security-deep-dive, vuln-scan) or to legacy/empty
+// skill_name rows. Use it as a `scan_id IN (?)` filter to keep listings
+// consistent with the repo Findings tab.
 func findingsScanIDs(gdb *gorm.DB) *gorm.DB {
-	return gdb.Model(&db.Scan{}).Select("id").
-		Where("skill_name = ? OR skill_name = '' OR skill_name IS NULL", deepDiveSkillName)
+	return gdb.Model(&db.Scan{}).Select("id").Where(findingsBucketSkillSQL)
 }
 
 func findingSupportsExposure(scan db.Scan) bool {

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -1097,6 +1097,15 @@ func findingsScanIDs(gdb *gorm.DB) *gorm.DB {
 	return gdb.Model(&db.Scan{}).Select("id").Where(findingsBucketSkillSQL)
 }
 
+// isLLMAuditSkill reports whether a finalized scan is one of the curated LLM
+// audits (security-deep-dive, vuln-scan) whose fresh output drives the
+// auto-triage funnels (finding-dedup). Unlike findingsBucketSkillSQL this
+// deliberately excludes legacy empty/NULL skill_name rows: those are inert
+// imports, not a live scan that just produced new findings worth triaging.
+func isLLMAuditSkill(skillName string) bool {
+	return skillName == deepDiveSkillName || skillName == vulnScanSkillName
+}
+
 func findingSupportsExposure(scan db.Scan) bool {
 	return scan.SkillName != zizmorSkillName
 }

--- a/internal/web/vuln_scan_bucket_test.go
+++ b/internal/web/vuln_scan_bucket_test.go
@@ -1,0 +1,68 @@
+package web
+
+import (
+	"testing"
+
+	"scrutineer/internal/db"
+)
+
+// findingIDs collects the IDs of a finding slice for membership assertions.
+func findingIDs(fs []db.Finding) map[uint]bool {
+	ids := make(map[uint]bool, len(fs))
+	for _, f := range fs {
+		ids[f.ID] = true
+	}
+	return ids
+}
+
+// TestVulnScanBucketedAsFinding pins issue #458: findings produced by the
+// LLM-driven vuln-scan skill belong in the curated Findings bucket alongside
+// security-deep-dive, not in the Scanners tab with semgrep/zizmor noise. It
+// covers both bucket paths — the repo Findings tab (findingsScanIDs, via
+// loadRepoFindings) and the cross-repo findings index totals (scannerScanFilter,
+// via findingToggleCounts) — so the two definitions of "scanner" stay in sync.
+func TestVulnScanBucketedAsFinding(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	repo := db.Repository{URL: "https://example.com/r", Name: "r"}
+	s.DB.Create(&repo)
+
+	vulnScan := db.Scan{RepositoryID: repo.ID, Kind: "skill", Status: db.ScanDone,
+		SkillName: vulnScanSkillName, Commit: "deadbee"}
+	s.DB.Create(&vulnScan)
+	vulnFinding := db.Finding{RepositoryID: repo.ID, ScanID: vulnScan.ID,
+		Title: "vuln-scan candidate", Severity: "High", Status: db.FindingNew}
+	s.DB.Create(&vulnFinding)
+
+	semgrepScan := db.Scan{RepositoryID: repo.ID, Kind: "skill", Status: db.ScanDone,
+		SkillName: "semgrep", Commit: "deadbee"}
+	s.DB.Create(&semgrepScan)
+	semgrepFinding := db.Finding{RepositoryID: repo.ID, ScanID: semgrepScan.ID,
+		Title: "semgrep lint", Severity: "Low", Status: db.FindingNew}
+	s.DB.Create(&semgrepFinding)
+
+	// Repo Findings tab: vuln-scan lands in Findings, semgrep stays in Scanners.
+	rf := loadRepoFindings(s.DB, repo.ID, "")
+	dd, sc := findingIDs(rf.DeepDive), findingIDs(rf.Scanners)
+	if !dd[vulnFinding.ID] {
+		t.Errorf("vuln-scan finding should be in the Findings bucket; DeepDive=%v", rf.DeepDive)
+	}
+	if sc[vulnFinding.ID] {
+		t.Errorf("vuln-scan finding should not be in the Scanners bucket")
+	}
+	if !sc[semgrepFinding.ID] {
+		t.Errorf("semgrep finding should remain in the Scanners bucket")
+	}
+	if dd[semgrepFinding.ID] {
+		t.Errorf("semgrep finding should not be in the Findings bucket")
+	}
+
+	// Cross-repo findings index: the scanner total counts only the semgrep
+	// finding, confirming the vuln-scan finding is excluded from scannerScanFilter
+	// and its positional SQL args still line up after dropping the bound skill.
+	_, scannerTotal := s.findingToggleCounts(localReq("GET", "/findings"), false)
+	if scannerTotal != 1 {
+		t.Errorf("findings index scanner total = %d, want 1 (semgrep only)", scannerTotal)
+	}
+}


### PR DESCRIPTION
The `vuln-scan` skill's output should be in the Findings bucket like `security-deep-dive`, but its findings were filed under the Scanners tab alongside semgrep/zizmor noise.

This PR promotes vuln-scan into the proper Findings bucket so we can handle them like proper findings from other skills.

Fixes #458.

Generated with Claude Code, tested and reviewed by me.