### PR TITLE
chore(skills): use Sonnet-level agent for sbom and repo-overview

### DIFF
--- a/skills/repo-overview/SKILL.md
+++ b/skills/repo-overview/SKILL.md
@@ -4,7 +4,7 @@ description: Run `brief --json` to produce a structured overview of the reposito
 license: MIT
 compatibility: Requires the `brief` CLI (https://github.com/git-pkgs/brief) on PATH.
 metadata:
-  scrutineer.model: claude-sonnet-4-6
+  scrutineer.model: mid
   scrutineer.version: 1
   scrutineer.output_file: report.json
   scrutineer.output_kind: repo_overview

--- a/skills/repo-overview/SKILL.md
+++ b/skills/repo-overview/SKILL.md
@@ -4,6 +4,7 @@ description: Run `brief --json` to produce a structured overview of the reposito
 license: MIT
 compatibility: Requires the `brief` CLI (https://github.com/git-pkgs/brief) on PATH.
 metadata:
+  scrutineer.model: claude-sonnet-4-6
   scrutineer.version: 1
   scrutineer.output_file: report.json
   scrutineer.output_kind: repo_overview

--- a/skills/sbom/SKILL.md
+++ b/skills/sbom/SKILL.md
@@ -4,7 +4,7 @@ description: Generate a CycloneDX SBOM for the repository via `git-pkgs sbom`. S
 license: MIT
 compatibility: Requires the `git-pkgs` CLI on PATH.
 metadata:
-  scrutineer.model: claude-sonnet-4-6
+  scrutineer.model: mid
   scrutineer.version: 1
   scrutineer.output_file: report.json
   scrutineer.output_kind: freeform

--- a/skills/sbom/SKILL.md
+++ b/skills/sbom/SKILL.md
@@ -4,6 +4,7 @@ description: Generate a CycloneDX SBOM for the repository via `git-pkgs sbom`. S
 license: MIT
 compatibility: Requires the `git-pkgs` CLI on PATH.
 metadata:
+  scrutineer.model: claude-sonnet-4-6
   scrutineer.version: 1
   scrutineer.output_file: report.json
   scrutineer.output_kind: freeform


### PR DESCRIPTION
Fixes #501

### Description
This PR addresses issue #501 by configuring the `sbom` and `repo-overview` skills to use the Sonnet-level agent (`claude-sonnet-4-6`).

Since both of these skills primarily execute predefined scripts under the hood (`git-pkgs sbom` and `brief --json`), there is no need to waste tokens by allocating them to a more capable/expensive model.

### Changes Made
- Added `scrutineer.model: claude-sonnet-4-6` to the metadata of `skills/repo-overview/SKILL.md`.
- Added `scrutineer.model: claude-sonnet-4-6` to the metadata of `skills/sbom/SKILL.md`.

### Testing
- Code formatting and the full test suite (`go test ./...`) have run and passed successfully.