### PR TITLE
chore(skills): move hardcoded sonnet pins to model tiers

### DIFF
--- a/skills/breaking-change/SKILL.md
+++ b/skills/breaking-change/SKILL.md
@@ -7,7 +7,7 @@ metadata:
   scrutineer.version: 1
   scrutineer.output_file: report.json
   scrutineer.output_kind: breaking_change
-  scrutineer.model: claude-sonnet-4-6
+  scrutineer.model: mid
   scrutineer.requires_remote: true
 ---
 

--- a/skills/ingest/SKILL.md
+++ b/skills/ingest/SKILL.md
@@ -7,7 +7,6 @@ metadata:
   scrutineer.version: 1
   scrutineer.output_file: report.json
   scrutineer.output_kind: findings
-  scrutineer.model: claude-sonnet-4-6
 ---
 
 # ingest

--- a/skills/mitigate/SKILL.md
+++ b/skills/mitigate/SKILL.md
@@ -7,7 +7,6 @@ metadata:
   scrutineer.version: 1
   scrutineer.output_file: report.json
   scrutineer.output_kind: mitigation
-  scrutineer.model: claude-sonnet-4-6
   scrutineer.requires_remote: true
 ---
 

--- a/skills/release-watch/SKILL.md
+++ b/skills/release-watch/SKILL.md
@@ -8,7 +8,7 @@ metadata:
   scrutineer.output_file: report.json
   scrutineer.output_kind: release_watch
   scrutineer.requires_remote: true
-  scrutineer.model: claude-sonnet-4-6
+  scrutineer.model: mid
 ---
 
 # release-watch

--- a/skills/revalidate/SKILL.md
+++ b/skills/revalidate/SKILL.md
@@ -7,7 +7,7 @@ metadata:
   scrutineer.version: 1
   scrutineer.output_file: report.json
   scrutineer.output_kind: revalidate
-  scrutineer.model: claude-sonnet-4-6
+  scrutineer.model: mid
 ---
 
 # revalidate


### PR DESCRIPTION
Fixes #504

### Description
This PR addresses issue #504 by migrating five bundled skills that were still using hardcoded concrete model IDs (`claude-sonnet-4-6`) to the designated tier system introduced in #359.

This prevents the model pins from going stale and ensures they follow the proper tier mappings configured on the Settings page.

### Changes Made
- Updated `scrutineer.model` to `mid` for `breaking-change`, `release-watch`, and `revalidate`, as these are lightweight script wrappers.
- Removed the hardcoded model pin entirely for `ingest` and `mitigate`. This causes them to correctly default to the `high` tier, honoring the fact that they perform more complex reasoning (normalizing text reports and drafting mitigations/semgrep rules).

### Testing
- `go fmt ./...` and `go test ./...` have both successfully run and passed.