### PR TITLE
fix(docker): disable cargo http multiplexing to prevent framing layer…

### DIFF
--- a/Dockerfile.runner
+++ b/Dockerfile.runner
@@ -11,6 +11,7 @@ RUN GOBIN=/out go install github.com/git-pkgs/git-pkgs@v0.15.3 && \
     GOBIN=/out go install github.com/git-pkgs/brief/cmd/brief@v0.6.0
 
 FROM rust:1.96-trixie@sha256:6df234c1eb92b0545468fab8c18fc5f9adfb994e7d4f67d81d45fe2fcabf5657 AS zizmor-build
+ENV CARGO_HTTP_MULTIPLEXING=false
 RUN cargo install --locked --root /out zizmor@1.26.1
 
 FROM debian:trixie-slim@sha256:28de0877c2189802884ccd20f15ee41c203573bd87bb6b883f5f46362d24c5c2


### PR DESCRIPTION
### Description
This PR addresses the `[16] Error in the HTTP2 framing layer` issue that intermittently causes the `cargo install --locked zizmor` step to fail during CI runs.

Found in #506, mentioned in https://github.com/alpha-omega-security/scrutineer/pull/506#discussion_r3481847543

This is a known, flaky bug where Cargo's underlying `libcurl` struggles with HTTP/2 multiplexing when downloading crates in certain CI runner network conditions. Because it is highly dependent on network timing, the CI will often randomly pass if re-run, but the underlying flaw remains.

By setting `ENV CARGO_HTTP_MULTIPLEXING=false`, we force Cargo to disable HTTP/2 multiplexing. This safely circumvents the framing layer bug, making the Docker build 100% reliable and preventing frustrating random CI failures for future PRs.

