### PR TITLE
test: make git-backed tests hermetic

### DIFF
--- a/internal/skills/git_test.go
+++ b/internal/skills/git_test.go
@@ -79,6 +79,7 @@ func mustRun(t *testing.T, dir string, args ...string) string {
 	t.Helper()
 	cmd := exec.Command("git", args...)
 	cmd.Dir = dir
+	cmd.Env = testGitEnv()
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("git %v: %s: %v", args, out, err)

--- a/internal/skills/git_testenv_test.go
+++ b/internal/skills/git_testenv_test.go
@@ -1,0 +1,15 @@
+package skills
+
+import "os"
+
+func testGitEnv() []string {
+	env := append([]string{}, os.Environ()...)
+	return append(env,
+		"GIT_CONFIG_GLOBAL="+os.DevNull,
+		"GIT_CONFIG_NOSYSTEM=1",
+		"GIT_AUTHOR_NAME=Scrutineer Tests",
+		"GIT_AUTHOR_EMAIL=scrutineer-tests@example.invalid",
+		"GIT_COMMITTER_NAME=Scrutineer Tests",
+		"GIT_COMMITTER_EMAIL=scrutineer-tests@example.invalid",
+	)
+}

--- a/internal/web/code_browser_test.go
+++ b/internal/web/code_browser_test.go
@@ -92,6 +92,7 @@ func seedRepoCache(t *testing.T, dataDir, url string) (commit1, commit2 string) 
 	}
 	run := func(args ...string) string {
 		cmd := exec.Command("git", append([]string{"-C", cacheSrc}, args...)...)
+		cmd.Env = testGitEnv()
 		out, err := cmd.CombinedOutput()
 		if err != nil {
 			t.Fatalf("git %v: %v\n%s", args, err, out)
@@ -200,6 +201,7 @@ func TestGitShowBlob_capsAtMaxBrowserBytes(t *testing.T) {
 	dir := t.TempDir()
 	run := func(args ...string) {
 		cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+		cmd.Env = testGitEnv()
 		if out, err := cmd.CombinedOutput(); err != nil {
 			t.Fatalf("git %v: %v\n%s", args, err, out)
 		}
@@ -213,7 +215,9 @@ func TestGitShowBlob_capsAtMaxBrowserBytes(t *testing.T) {
 	}
 	run("add", "big.txt")
 	run("commit", "--quiet", "-m", "big")
-	headOut, err := exec.Command("git", "-C", dir, "rev-parse", "HEAD").Output()
+	cmd := exec.Command("git", "-C", dir, "rev-parse", "HEAD")
+	cmd.Env = testGitEnv()
+	headOut, err := cmd.Output()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/web/git_testenv_test.go
+++ b/internal/web/git_testenv_test.go
@@ -1,0 +1,15 @@
+package web
+
+import "os"
+
+func testGitEnv() []string {
+	env := append([]string{}, os.Environ()...)
+	return append(env,
+		"GIT_CONFIG_GLOBAL="+os.DevNull,
+		"GIT_CONFIG_NOSYSTEM=1",
+		"GIT_AUTHOR_NAME=Scrutineer Tests",
+		"GIT_AUTHOR_EMAIL=scrutineer-tests@example.invalid",
+		"GIT_COMMITTER_NAME=Scrutineer Tests",
+		"GIT_COMMITTER_EMAIL=scrutineer-tests@example.invalid",
+	)
+}

--- a/internal/worker/clone_test.go
+++ b/internal/worker/clone_test.go
@@ -99,7 +99,7 @@ func TestFetchRefChecksOutRequestedRef(t *testing.T) {
 		t.Helper()
 		cmd := exec.Command("git", args...)
 		cmd.Dir = dir
-		cmd.Env = append(os.Environ(), "GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_NOSYSTEM=1")
+		cmd.Env = testGitEnv()
 		out, err := cmd.CombinedOutput()
 		if err != nil {
 			t.Fatalf("git %v: %s: %v", args, out, err)

--- a/internal/worker/git_testenv_test.go
+++ b/internal/worker/git_testenv_test.go
@@ -1,0 +1,15 @@
+package worker
+
+import "os"
+
+func testGitEnv() []string {
+	env := append([]string{}, os.Environ()...)
+	return append(env,
+		"GIT_CONFIG_GLOBAL="+os.DevNull,
+		"GIT_CONFIG_NOSYSTEM=1",
+		"GIT_AUTHOR_NAME=Scrutineer Tests",
+		"GIT_AUTHOR_EMAIL=scrutineer-tests@example.invalid",
+		"GIT_COMMITTER_NAME=Scrutineer Tests",
+		"GIT_COMMITTER_EMAIL=scrutineer-tests@example.invalid",
+	)
+}

--- a/internal/worker/patch_gate_test.go
+++ b/internal/worker/patch_gate_test.go
@@ -154,6 +154,7 @@ func gateRepo(t *testing.T, dir string) (relPath, diff string) {
 	write(lines)
 	run := func(args ...string) string {
 		cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+		cmd.Env = testGitEnv()
 		out, err := cmd.CombinedOutput()
 		if err != nil {
 			t.Fatalf("git %v: %v: %s", args, err, out)

--- a/internal/worker/patch_gate_test.go
+++ b/internal/worker/patch_gate_test.go
@@ -217,6 +217,7 @@ func TestGatePatch_dirtyWorkspaceFromSkill(t *testing.T) {
 	src := t.TempDir()
 	rel, diff := gateRepo(t, src)
 	apply := exec.Command("git", "-C", src, "apply", "-")
+	apply.Env = testGitEnv()
 	apply.Stdin = strings.NewReader(diff)
 	if out, err := apply.CombinedOutput(); err != nil {
 		t.Fatalf("seed dirty workspace: %v: %s", err, out)

--- a/internal/worker/repo_cache_test.go
+++ b/internal/worker/repo_cache_test.go
@@ -134,7 +134,9 @@ func TestEnsureCommit_reachableCommitIsNoOp(t *testing.T) {
 		t.Fatal(err)
 	}
 	run := func(args ...string) string {
-		out, err := exec.Command("git", append([]string{"-C", cacheSrc}, args...)...).CombinedOutput()
+		cmd := exec.Command("git", append([]string{"-C", cacheSrc}, args...)...)
+		cmd.Env = testGitEnv()
+		out, err := cmd.CombinedOutput()
 		if err != nil {
 			t.Fatalf("git %v: %v\n%s", args, err, out)
 		}
@@ -166,7 +168,9 @@ func TestEnsureCommit_unreachableNonShallowIsNoOp(t *testing.T) {
 	if err := os.MkdirAll(cacheSrc, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	out, err := exec.Command("git", "-C", cacheSrc, "init", "--quiet", "-b", "main").CombinedOutput()
+	cmd := exec.Command("git", "-C", cacheSrc, "init", "--quiet", "-b", "main")
+	cmd.Env = testGitEnv()
+	out, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("git init: %v\n%s", err, out)
 	}


### PR DESCRIPTION
Several test helpers shell out to git to build fixture repos but didn't isolate git's configuration, so they inherited the host's global and system config. On a machine configured to sign commits, the `git commit`/`git tag` calls trigger an interactive signing prompt partway through the test run.

This routes every git invocation in the affected tests through a small per-package `testGitEnv()` helper that pins `GIT_CONFIG_GLOBAL` to `os.DevNull`, sets `GIT_CONFIG_NOSYSTEM=1`, and supplies a fixed author/committer identity. Host and system config (including signing) are never read, and commits still succeed without relying on host config.

`clone_test.go` already neutralized global config inline; this folds that into the shared helper and applies the same treatment to the skills, web, and worker suites.

No production code changes. `go test -race`, `go vet`, and `golangci-lint run` all pass locally.
