### PR TITLE
feat: pause the queue on any Claude account error, not just usage limits

### DIFF
--- a/internal/web/list_performance_test.go
+++ b/internal/web/list_performance_test.go
@@ -48,14 +48,14 @@ func TestScanListStatsAggregatesCounts(t *testing.T) {
 	for _, status := range []db.ScanStatus{db.ScanQueued, db.ScanQueued, db.ScanPaused, db.ScanRunning} {
 		s.DB.Create(&db.Scan{RepositoryID: repo.ID, Kind: "skill", Status: status})
 	}
-	// A scan paused because the account hit the Claude token/credit limit
+	// A scan paused because the account hit an account-level Claude problem
 	// (auto-paused by the worker), plus an unrelated failure that must not
 	// be counted.
 	s.DB.Create(&db.Scan{
 		RepositoryID: repo.ID,
 		Kind:         "skill",
 		Status:       db.ScanPaused,
-		Error:        "Claude plan limit reached. Queued scan paused automatically; resume after the limit resets.",
+		Error:        "Claude account access paused. Queued scan held automatically; resume once the account recovers.",
 	})
 	s.DB.Create(&db.Scan{
 		RepositoryID: repo.ID,
@@ -64,11 +64,11 @@ func TestScanListStatsAggregatesCounts(t *testing.T) {
 		Error:        "different failure",
 	})
 
-	// PausedCount counts both the bare paused scan and the plan-limit one;
-	// PlanLimitPausedCount counts only the latter.
+	// PausedCount counts both the bare paused scan and the account-paused one;
+	// AccountPausedCount counts only the latter.
 	stats := s.scanListStats()
-	if stats.QueuedCount != 2 || stats.PausedCount != 2 || stats.PlanLimitPausedCount != 1 {
-		t.Fatalf("scanListStats = %+v, want queued=2 paused=2 plan-limit-paused=1", stats)
+	if stats.QueuedCount != 2 || stats.PausedCount != 2 || stats.AccountPausedCount != 1 {
+		t.Fatalf("scanListStats = %+v, want queued=2 paused=2 account-paused=1", stats)
 	}
 }
 

--- a/internal/web/scans.go
+++ b/internal/web/scans.go
@@ -59,14 +59,14 @@ func (s *Server) jobs(w http.ResponseWriter, r *http.Request) {
 		"Scans": scans, "Page": page,
 		"Skill": skillName, "Status": status, "Sort": sort, "Skills": skillNames,
 		"AnySubPath": anySubPath, "QueuedCount": stats.QueuedCount, "PausedCount": stats.PausedCount,
-		"PlanLimitPausedCount": stats.PlanLimitPausedCount,
+		"AccountPausedCount": stats.AccountPausedCount,
 	})
 }
 
 type scanListStats struct {
-	QueuedCount          int64
-	PausedCount          int64
-	PlanLimitPausedCount int64
+	QueuedCount        int64
+	PausedCount        int64
+	AccountPausedCount int64
 }
 
 func (s *Server) scanListStats() scanListStats {
@@ -75,11 +75,11 @@ func (s *Server) scanListStats() scanListStats {
 		Select(
 			"COUNT(CASE WHEN status = ? THEN 1 END) AS queued_count, "+
 				"COUNT(CASE WHEN status = ? THEN 1 END) AS paused_count, "+
-				"COUNT(CASE WHEN status = ? AND error LIKE ? THEN 1 END) AS plan_limit_paused_count",
+				"COUNT(CASE WHEN status = ? AND error LIKE ? THEN 1 END) AS account_paused_count",
 			db.ScanQueued,
 			db.ScanPaused,
 			db.ScanPaused,
-			"Claude plan limit reached.%",
+			worker.ClaudeAccountPausePrefix+"%",
 		).
 		Scan(&stats)
 	return stats

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -3970,18 +3970,18 @@ func TestScanResumePaused(t *testing.T) {
 	}
 }
 
-func TestJobs_showsPlanLimitResumeActions(t *testing.T) {
+func TestJobs_showsAccountPauseResumeActions(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()
 
 	repo := db.Repository{URL: "https://example.com/x.git", Name: "x"}
 	s.DB.Create(&repo)
-	// A scan auto-paused because the account hit the Claude token limit. The
-	// banner should surface it and the Resume-paused action should be offered.
+	// A scan auto-paused because the account hit an account-level Claude problem.
+	// The banner should surface it and the Resume-paused action should be offered.
 	s.DB.Create(&db.Scan{
 		RepositoryID: repo.ID, Kind: "skill", Status: db.ScanPaused,
 		StatusPriority: db.StatusPriorityFor(db.ScanPaused),
-		Error:          "Claude plan limit reached. Queued scan paused automatically; resume after the limit resets.",
+		Error:          "Claude account access paused. Queued scan held automatically; resume once the account recovers.",
 	})
 
 	w := httptest.NewRecorder()
@@ -3990,7 +3990,7 @@ func TestJobs_showsPlanLimitResumeActions(t *testing.T) {
 		t.Fatalf("status %d: %s", w.Code, w.Body)
 	}
 	body := w.Body.String()
-	for _, want := range []string{"Claude plan limit reached", "/scans/resume-paused"} {
+	for _, want := range []string{"Claude account access paused", "/scans/resume-paused"} {
 		if !strings.Contains(body, want) {
 			t.Errorf("missing %q in jobs body", want)
 		}

--- a/internal/web/templates/jobs.html
+++ b/internal/web/templates/jobs.html
@@ -76,12 +76,12 @@
   </div>
 </div>
 
-{{if .PlanLimitPausedCount}}
+{{if .AccountPausedCount}}
   <div class="alert-destructive mb-6">
     <i data-lucide="triangle-alert"></i>
     <section>
-      <strong>Claude plan limit reached.</strong>
-      Queued scans were paused automatically. Resume them after the limit resets.
+      <strong>Claude account access paused.</strong>
+      Queued scans were held automatically. Resume them once the account recovers.
     </section>
   </div>
 {{end}}

--- a/internal/worker/claude.go
+++ b/internal/worker/claude.go
@@ -141,17 +141,17 @@ func (l LocalClaude) RunSkill(ctx context.Context, sj SkillJob, emit func(Event)
 	}
 
 	emit(Event{Kind: KindText, Text: "$ claude -p <skill:" + sj.Name + ">"})
-	planLimitText := ""
+	accountErrText := ""
 	wrappedEmit := func(e Event) {
-		if planLimitText == "" {
-			planLimitText = claudePlanLimitText(e.Text)
+		if accountErrText == "" {
+			accountErrText = claudeAccountErrorText(e.Text)
 		}
 		emit(e)
 	}
 	args := buildClaudeArgs(sj, l.Effort, l.MaxTurns)
 	hitMaxTurns, sessionID, waitErr := l.runClaudeOnce(ctx, args, work, wrappedEmit)
 
-	if waitErr != nil && sj.ResumeSessionID != "" && sessionID == "" && planLimitText == "" {
+	if waitErr != nil && sj.ResumeSessionID != "" && sessionID == "" && accountErrText == "" {
 		if sj.ResumePrompt != "" {
 			emit(Event{Kind: KindText, Text: "resume of session " + sj.ResumeSessionID + " failed; " + resumePromptNoFreshFallbackText})
 			return SkillResult{Commit: commit}, fmt.Errorf("claude exited: %w", waitErr)
@@ -175,8 +175,8 @@ func (l LocalClaude) RunSkill(ctx context.Context, sj SkillJob, emit func(Event)
 		if hitMaxTurns {
 			return res, &MaxTurnsReachedError{}
 		}
-		if planLimitText != "" {
-			return res, &ClaudePlanLimitError{Detail: planLimitText}
+		if accountErrText != "" {
+			return res, &ClaudeAccountError{Detail: accountErrText}
 		}
 		return res, fmt.Errorf("claude exited: %w", waitErr)
 	}

--- a/internal/worker/claude_limit.go
+++ b/internal/worker/claude_limit.go
@@ -2,28 +2,50 @@ package worker
 
 import "strings"
 
-// ClaudePlanLimitError is returned when claude-code reports an account or plan
-// limit rather than a skill failure. The worker pauses the scan (and the rest
-// of the queue) instead of failing it, so the operator resumes the batch once
-// the limit resets rather than retrying each scan.
-type ClaudePlanLimitError struct {
+// ClaudeAccountPausePrefix is the stable leading sentence shared by every
+// account-pause message: the scan that hit the wall (ClaudeAccountError) and the
+// scans paused behind it (accountPauseReason). The scans page matches on it
+// (web.scanListStats) to surface them together in the account banner, so these
+// strings and that query share this prefix. Keep the heading in
+// web/templates/jobs.html in sync.
+const ClaudeAccountPausePrefix = "Claude account access paused."
+
+// ClaudeAccountError is returned when claude-code reports an account-level
+// problem -- a usage/plan limit, or access being disabled or revoked -- rather
+// than a per-scan failure. The worker pauses the scan and the rest of the queue
+// instead of failing each one, because retrying cannot succeed until the
+// account recovers: a usage limit resets, an admin re-enables access, or the
+// operator switches to an Anthropic API key. The claude message is carried in
+// Detail so the operator sees the real reason instead of a bare container exit
+// status.
+type ClaudeAccountError struct {
 	Detail string
 }
 
-func (e *ClaudePlanLimitError) Error() string {
+func (e *ClaudeAccountError) Error() string {
+	const base = ClaudeAccountPausePrefix + " This scan and the queued batch were held; " +
+		"resume once the account recovers."
 	if e.Detail == "" {
-		return "Claude plan limit reached. Queued scans were paused; resume after your limit resets."
+		return base
 	}
-	return "Claude plan limit reached. Queued scans were paused; resume after your limit resets. " + e.Detail
+	return base + " Claude reported: " + e.Detail
 }
 
-func claudePlanLimitText(s string) string {
+// claudeAccountErrorText returns s when it looks like an account-level message
+// from claude-code -- a usage/plan/rate limit, or access being disabled or
+// revoked -- and "" otherwise. The caller only consults it when the run already
+// failed (non-zero exit), so a stray "rate limit" in normal scan output never
+// pauses a healthy scan. The access phrases are deliberately specific (verbatim
+// fragments of Claude Code's auth-denied message) so a repository's own content
+// cannot trip them.
+func claudeAccountErrorText(s string) string {
 	text := strings.TrimSpace(s)
 	if text == "" {
 		return ""
 	}
 	lower := strings.ToLower(text)
 	for _, phrase := range []string{
+		// usage / plan / rate limits (transient: resume after the limit resets)
 		"usage limit",
 		"session limit",
 		"plan limit",
@@ -33,6 +55,10 @@ func claudePlanLimitText(s string) string {
 		"quota exceeded",
 		"credit balance",
 		"429",
+		// access disabled or revoked (account-level: retrying cannot help)
+		"disabled claude subscription access",
+		"use an anthropic api key instead",
+		"ask your admin to enable access",
 	} {
 		if strings.Contains(lower, phrase) {
 			return text

--- a/internal/worker/claude_test.go
+++ b/internal/worker/claude_test.go
@@ -292,18 +292,21 @@ func TestLocalClaude_ResumePromptDoesNotFallbackToFresh(t *testing.T) {
 	}
 }
 
-func TestClaudePlanLimitText(t *testing.T) {
+func TestClaudeAccountErrorText(t *testing.T) {
 	for _, text := range []string{
+		// usage / rate / quota limits
 		"Claude usage limit reached. Your limit will reset later.",
 		"API Error: 429 Too Many Requests",
 		"quota exceeded for this account",
+		// access disabled or revoked (the message a suspended account returns)
+		"Your organization has disabled Claude subscription access for Claude Code · Use an Anthropic API key instead, or ask your admin to enable access",
 	} {
-		if got := claudePlanLimitText(text); got == "" {
-			t.Errorf("claudePlanLimitText(%q) did not match", text)
+		if got := claudeAccountErrorText(text); got == "" {
+			t.Errorf("claudeAccountErrorText(%q) did not match", text)
 		}
 	}
-	if got := claudePlanLimitText("syntax error in generated report"); got != "" {
-		t.Errorf("claudePlanLimitText returned false positive %q", got)
+	if got := claudeAccountErrorText("syntax error in generated report"); got != "" {
+		t.Errorf("claudeAccountErrorText returned false positive %q", got)
 	}
 }
 

--- a/internal/worker/container.go
+++ b/internal/worker/container.go
@@ -176,16 +176,16 @@ func (d ContainerRunner) RunSkill(ctx context.Context, sj SkillJob, emit func(Ev
 	}
 	emit(Event{Kind: KindText, Text: logLine})
 
-	planLimitText := ""
+	accountErrText := ""
 	wrappedEmit := func(e Event) {
-		if planLimitText == "" {
-			planLimitText = claudePlanLimitText(e.Text)
+		if accountErrText == "" {
+			accountErrText = claudeAccountErrorText(e.Text)
 		}
 		emit(e)
 	}
 	hitMaxTurns, sessionID, waitErr := d.runContainerOnce(ctx, runBase, sj, wrappedEmit)
 
-	if waitErr != nil && sj.ResumeSessionID != "" && sessionID == "" && planLimitText == "" {
+	if waitErr != nil && sj.ResumeSessionID != "" && sessionID == "" && accountErrText == "" {
 		if sj.ResumePrompt != "" {
 			emit(Event{Kind: KindText, Text: "resume of session " + sj.ResumeSessionID + " failed; " + resumePromptNoFreshFallbackText})
 			return SkillResult{Commit: commit, Profile: profile}, fmt.Errorf("%s exited: %w", d.Runtime.bin(), waitErr)
@@ -208,8 +208,8 @@ func (d ContainerRunner) RunSkill(ctx context.Context, sj SkillJob, emit func(Ev
 		if hitMaxTurns {
 			return res, &MaxTurnsReachedError{}
 		}
-		if planLimitText != "" {
-			return res, &ClaudePlanLimitError{Detail: planLimitText}
+		if accountErrText != "" {
+			return res, &ClaudeAccountError{Detail: accountErrText}
 		}
 		return res, fmt.Errorf("%s exited: %w", d.Runtime.bin(), waitErr)
 	}

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -382,8 +382,8 @@ func (w *Worker) wrap(h handler) func(context.Context, []byte) error {
 
 // finalizeScan persists the terminal/paused scan state, fires
 // post-completion hooks, bulk-pauses the rest of the queue when this scan
-// hit a Claude token limit, cleans up the workspace, and publishes the
-// status. It returns an error only when the terminal save fails, which
+// hit an account-level Claude problem, cleans up the workspace, and publishes
+// the status. It returns an error only when the terminal save fails, which
 // wrap propagates to goqite.
 func (w *Worker) finalizeScan(ctx context.Context, scan *db.Scan, report string, err error, timeout time.Duration, emit func(Event)) error {
 	finishScan(ctx, scan, report, err, timeout, emit)
@@ -395,8 +395,8 @@ func (w *Worker) finalizeScan(ctx context.Context, scan *db.Scan, report string,
 		return saveErr
 	}
 	w.maybeFireScanFinalized(scan, err)
-	if _, isLimit := errors.AsType[*ClaudePlanLimitError](err); isLimit && scan.Status == db.ScanPaused {
-		w.pauseQueuedOnTokenLimit(scan.ID)
+	if _, isAccountErr := errors.AsType[*ClaudeAccountError](err); isAccountErr && scan.Status == db.ScanPaused {
+		w.pauseQueuedOnAccountError(scan.ID)
 	}
 	// The clone cache may have grown (clone/fetch/unshallow); refresh the
 	// cached size so the repo list reads it from the row instead of walking
@@ -455,7 +455,7 @@ func finishErroredScan(scan *db.Scan, report string, err error, emit func(Event)
 	_, maxTurns := errors.AsType[*MaxTurnsReachedError](err)
 	_, failOnThreshold := errors.AsType[*FailOnThresholdError](err)
 	_, schemaValidation := errors.AsType[*SchemaValidationError](err)
-	_, planLimit := errors.AsType[*ClaudePlanLimitError](err)
+	_, accountErr := errors.AsType[*ClaudeAccountError](err)
 	switch {
 	case maxTurns:
 		scan.Status = db.ScanDone
@@ -468,11 +468,12 @@ func finishErroredScan(scan *db.Scan, report string, err error, emit func(Event)
 		emit(Event{Kind: KindError, Text: scan.Error})
 	case schemaValidation:
 		scan.Report = report
-	case planLimit:
-		// A token/credit limit is not this scan's fault and is recoverable
-		// once the limit resets, so pause rather than fail: the operator
-		// resumes the batch instead of retrying each scan. The remaining
-		// queued scans are paused by the worker loop (pauseQueuedOnTokenLimit).
+	case accountErr:
+		// An account-level problem (usage/credit limit, or access disabled or
+		// revoked) is not this scan's fault and retrying cannot succeed until the
+		// account recovers, so pause rather than fail: the operator resumes the
+		// batch once it does instead of burning a retry per scan. The remaining
+		// queued scans are paused by the worker loop (pauseQueuedOnAccountError).
 		scan.Status = db.ScanPaused
 		emit(Event{Kind: KindError, Text: scan.Error})
 	default:
@@ -480,33 +481,35 @@ func finishErroredScan(scan *db.Scan, report string, err error, emit func(Event)
 	}
 }
 
-// tokenLimitPauseReason is recorded on scans auto-paused because another
-// scan hit the account's Claude token/credit limit. It keeps the "Claude
-// plan limit reached." prefix the scans page matches on, so these paused
-// scans surface in the limit banner alongside the one that triggered it.
-const tokenLimitPauseReason = "Claude plan limit reached. Queued scan paused automatically; resume after the limit resets."
+// accountPauseReason is recorded on scans auto-paused because another scan hit
+// an account-level Claude problem (a usage/credit limit, or access being
+// disabled or revoked). It shares ClaudeAccountPausePrefix with the triggering
+// scan's error so the scans page matches both and surfaces them together in the
+// account banner.
+const accountPauseReason = ClaudeAccountPausePrefix + " Queued scan held automatically; resume once the account recovers."
 
-// pauseQueuedOnTokenLimit pauses every still-queued scan after one scan
-// hit a Claude token/credit limit. The limit is account-wide, so the rest
-// of the queue would only run into the same wall; pausing keeps the batch
-// intact for a later resume instead of failing it scan by scan. The worker
-// loop drops the now-stale queue jobs when they fire (see wrap), exactly as
-// a manual "pause queued" does, so updating the rows here is enough.
-func (w *Worker) pauseQueuedOnTokenLimit(triggerID uint) {
+// pauseQueuedOnAccountError pauses every still-queued scan after one scan hit an
+// account-level Claude problem (limit, or access disabled/revoked). It is
+// account-wide, so the rest of the queue would only run into the same wall;
+// pausing keeps the batch intact for a later resume instead of failing it scan
+// by scan. The worker loop drops the now-stale queue jobs when they fire (see
+// wrap), exactly as a manual "pause queued" does, so updating the rows here is
+// enough.
+func (w *Worker) pauseQueuedOnAccountError(triggerID uint) {
 	now := time.Now()
 	res := w.DB.Model(&db.Scan{}).
 		Where("status = ?", db.ScanQueued).
 		Updates(map[string]any{
 			"status":          db.ScanPaused,
 			"status_priority": db.StatusPriorityFor(db.ScanPaused),
-			"error":           tokenLimitPauseReason,
+			"error":           accountPauseReason,
 			"finished_at":     &now,
 		})
 	if res.Error != nil {
-		w.Log.Warn("pause-on-token-limit failed", "trigger", triggerID, "err", res.Error)
+		w.Log.Warn("pause-on-account-error failed", "trigger", triggerID, "err", res.Error)
 		return
 	}
 	if res.RowsAffected > 0 {
-		w.Log.Info("paused queued scans after Claude token limit", "count", res.RowsAffected, "trigger", triggerID)
+		w.Log.Info("paused queued scans after Claude account error", "count", res.RowsAffected, "trigger", triggerID)
 	}
 }

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -156,7 +156,7 @@ func TestWorker_maxTurnsReachedCompletesNotFails(t *testing.T) {
 	}
 }
 
-func TestWorker_claudePlanLimitPausesScanAndQueue(t *testing.T) {
+func TestWorker_claudeAccountErrorPausesScanAndQueue(t *testing.T) {
 	gdb, err := db.Open(filepath.Join(t.TempDir(), "limit.db"))
 	if err != nil {
 		t.Fatal(err)
@@ -176,7 +176,7 @@ func TestWorker_claudePlanLimitPausesScanAndQueue(t *testing.T) {
 		DB:             gdb,
 		Log:            slog.New(slog.NewTextHandler(io.Discard, nil)),
 		DataDir:        t.TempDir(),
-		Runner:         fakeRunner{skillErr: &ClaudePlanLimitError{Detail: "usage limit reached"}},
+		Runner:         fakeRunner{skillErr: &ClaudeAccountError{Detail: "usage limit reached"}},
 		PrepareRepoSrc: stubPrepareRepoSrc,
 	}
 	body, _ := json.Marshal(queue.Payload{ScanID: scan.ID})
@@ -189,7 +189,7 @@ func TestWorker_claudePlanLimitPausesScanAndQueue(t *testing.T) {
 	if got.Status != db.ScanPaused {
 		t.Errorf("triggering scan status = %s, want paused", got.Status)
 	}
-	if !strings.Contains(got.Error, "Claude plan limit reached") {
+	if !strings.Contains(got.Error, "Claude account access paused") {
 		t.Errorf("error = %q", got.Error)
 	}
 
@@ -198,8 +198,8 @@ func TestWorker_claudePlanLimitPausesScanAndQueue(t *testing.T) {
 	if gotOther.Status != db.ScanPaused {
 		t.Errorf("other queued scan status = %s, want paused", gotOther.Status)
 	}
-	if !strings.Contains(gotOther.Error, "Claude plan limit reached") {
-		t.Errorf("other scan error = %q, want plan-limit prefix", gotOther.Error)
+	if !strings.Contains(gotOther.Error, "Claude account access paused") {
+		t.Errorf("other scan error = %q, want account-pause prefix", gotOther.Error)
 	}
 }
 


### PR DESCRIPTION
A suspended or access-revoked Claude account surfaced as a bare `<runtime> exited: exit status 1` and failed every queued scan one at a time, even though retrying cannot succeed until the account recovers. Only usage and rate limits were treated as account-level problems; access-disabled errors fell through to a generic container failure.

Generalizes `ClaudePlanLimitError` to `ClaudeAccountError` and routes access-disabled/revoked errors through the pause path usage limits already used.

- Detection adds the verbatim fragments Claude Code emits when access is off (`disabled Claude subscription access`, `use an Anthropic API key instead`, `ask your admin to enable access`), alongside the existing usage/rate/quota phrases. It only runs on a non-zero exit, so normal scan output can't trip it.
- The triggering scan and the rest of the queue are paused rather than failed, and the scan error carries Claude's actual message instead of an exit code, so the operator sees the real reason and resumes once the account recovers.
- A shared `ClaudeAccountPausePrefix` keeps the scan error, the auto-pause reason, the scans-page banner, and its `LIKE` query in sync, so the scan that hit the wall and the ones held behind it surface together.

The change is runtime-agnostic and leaves healthy scans unchanged.
