### PR TITLE
feat: auto-reject findings after N consecutive misses

### DIFF
--- a/cmd/scrutineer/main.go
+++ b/cmd/scrutineer/main.go
@@ -87,31 +87,32 @@ func main() {
 // parseFlags fills defaults and CLI overrides; merge layers the config
 // file underneath any flag the user set explicitly.
 type flags struct {
-	configPath       string
-	addr             string
-	dataDir          string
-	effort           string
-	defaultModel     string
-	noContainer      bool
-	runtime          string
-	selinux          string
-	hardened         bool
-	hardenedRootless bool
-	runnerImage      string
-	profilesDir      string
-	skillsRepo       string
-	concurrency      int
-	cloneMode        string
-	scanTimeout      time.Duration
-	smokeTimeout     time.Duration
-	maxTurns         int
-	anthropicBaseURL string
-	forkOrg          string
-	metadataDir      string
-	schemaStrict     bool
-	recipientsFile   string
-	identityFile     string
-	skillLocal       skillDirs
+	configPath            string
+	addr                  string
+	dataDir               string
+	effort                string
+	defaultModel          string
+	noContainer           bool
+	runtime               string
+	selinux               string
+	hardened              bool
+	hardenedRootless      bool
+	runnerImage           string
+	profilesDir           string
+	skillsRepo            string
+	concurrency           int
+	cloneMode             string
+	scanTimeout           time.Duration
+	smokeTimeout          time.Duration
+	maxTurns              int
+	anthropicBaseURL      string
+	forkOrg               string
+	metadataDir           string
+	schemaStrict          bool
+	recipientsFile        string
+	identityFile          string
+	autoRejectMissedCount int
+	skillLocal            skillDirs
 
 	// set records which flags were passed on the command line so merge
 	// knows not to let the config file override them.
@@ -155,6 +156,7 @@ func registerFlags(fs *flag.FlagSet, f *flags) {
 	fs.BoolVar(&f.schemaStrict, "schema-strict", false, "fail scans whose report.json does not validate against the skill's schema (default: warn and continue)")
 	fs.StringVar(&f.recipientsFile, "recipients-file", "", "age recipients file (public keys) for encrypted export")
 	fs.StringVar(&f.identityFile, "identity-file", "", "age identity file or SSH private key for decrypting imports")
+	fs.IntVar(&f.autoRejectMissedCount, "auto-reject-missed-count", 0, "auto-reject findings after this many consecutive missed rescans (0 disables)")
 	fs.Var(&f.skillLocal, "skills", "directory to load SKILL.md files from (repeatable)")
 }
 
@@ -230,6 +232,9 @@ func (f *flags) merge(cfg *config.Config) {
 	}
 	if cfg.IdentityFile != "" && !f.set["identity-file"] {
 		f.identityFile = cfg.IdentityFile
+	}
+	if cfg.AutoRejectMissedCount > 0 && !f.set["auto-reject-missed-count"] {
+		f.autoRejectMissedCount = cfg.AutoRejectMissedCount
 	}
 
 	if len(cfg.Models) > 0 {
@@ -416,15 +421,16 @@ func run(log *slog.Logger) error {
 	}
 
 	w := &worker.Worker{
-		DB:           gdb,
-		Log:          log,
-		DataDir:      filepath.Join(f.dataDir, "work"),
-		APIBase:      apiBase,
-		ForkOrg:      f.forkOrg,
-		MetadataDir:  f.metadataDir,
-		Runner:       runner,
-		ScanTimeout:  f.scanTimeout,
-		SchemaStrict: f.schemaStrict,
+		DB:                    gdb,
+		Log:                   log,
+		DataDir:               filepath.Join(f.dataDir, "work"),
+		APIBase:               apiBase,
+		ForkOrg:               f.forkOrg,
+		MetadataDir:           f.metadataDir,
+		Runner:                runner,
+		ScanTimeout:           f.scanTimeout,
+		SchemaStrict:          f.schemaStrict,
+		AutoRejectMissedCount: f.autoRejectMissedCount,
 		OnEvent: func(scanID, repoID uint, name, data string) {
 			broker.Publish(web.Event{Name: name, Data: data, ScanID: scanID, RepoID: repoID})
 		},

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -107,6 +107,10 @@ type Config struct {
 	// IdentityFile is an age identity file or SSH private key used to
 	// decrypt encrypted imports. Empty disables encrypted import.
 	IdentityFile string `yaml:"identity_file"`
+	// AutoRejectMissedCount is the threshold of consecutive missed rescans at
+	// which an open finding is automatically transitioned to 'rejected'.
+	// 0 (the default) means this feature is disabled.
+	AutoRejectMissedCount int `yaml:"auto_reject_missed_count"`
 }
 
 // ParseScanTimeout validates and parses a scan_timeout string. Empty

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -453,6 +453,7 @@ const (
 	SourceTool    FindingSource = "tool"
 	SourceModel   FindingSource = "model_suggested"
 	SourceAnalyst FindingSource = "analyst"
+	SourceSystem  FindingSource = "system"
 )
 
 // Finding is one vulnerability reported by a scan. The Finding row holds

--- a/internal/worker/findings_dedup_test.go
+++ b/internal/worker/findings_dedup_test.go
@@ -572,6 +572,79 @@ func TestParseFindingsOutput_reobservationResetsMissedCount(t *testing.T) {
 	}
 }
 
+func TestParseFindingsOutput_autoRejectReversibility(t *testing.T) {
+	gdb, err := db.Open(filepath.Join(t.TempDir(), "p.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo := db.Repository{URL: "https://x/r", Name: "r"}
+	gdb.Create(&repo)
+	w := &Worker{DB: gdb, Log: slog.New(slog.NewTextHandler(io.Discard, nil)), AutoRejectMissedCount: 2}
+	emit := func(Event) {}
+
+	report := `{"findings":[{"id":"F1","title":"x","severity":"High","cwe":"CWE-89","location":"a.rb:1"}]}`
+	mkScan := func(commit string) *db.Scan {
+		s := &db.Scan{RepositoryID: repo.ID, Kind: JobSkill, SkillName: "security-deep-dive",
+			Status: db.ScanDone, Commit: commit}
+		gdb.Create(s)
+		return s
+	}
+
+	// 1. Initial observation
+	if err := w.parseFindingsOutput(&db.Skill{}, mkScan("aaa"), report, emit); err != nil {
+		t.Fatal(err)
+	}
+
+	// Set the status to triaged manually to verify it restores to triaged, not new
+	var f db.Finding
+	gdb.First(&f)
+	gdb.Model(&f).Update("status", db.FindingTriaged)
+	gdb.Create(&db.FindingHistory{FindingID: f.ID, Field: "status", OldValue: "new", NewValue: "triaged", Source: db.SourceAnalyst, By: "test"})
+
+	// 2. Missed twice -> auto-rejected
+	if err := w.parseFindingsOutput(&db.Skill{}, mkScan("bbb"), `{"findings":[]}`, emit); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.parseFindingsOutput(&db.Skill{}, mkScan("ccc"), `{"findings":[]}`, emit); err != nil {
+		t.Fatal(err)
+	}
+
+	gdb.First(&f)
+	if f.Status != db.FindingRejected {
+		t.Fatalf("finding should be auto-rejected after 2 misses, got %s", f.Status)
+	}
+
+	// 3. Re-observed -> status restored
+	if err := w.parseFindingsOutput(&db.Skill{}, mkScan("ddd"), report, emit); err != nil {
+		t.Fatal(err)
+	}
+
+	gdb.First(&f)
+	if f.Status != db.FindingTriaged {
+		t.Fatalf("finding should be restored to triaged, got %s", f.Status)
+	}
+
+	var hist db.FindingHistory
+	gdb.Where("finding_id = ? AND field = 'status'", f.ID).Order("id desc").First(&hist)
+	if hist.Source != db.SourceSystem || hist.NewValue != "triaged" {
+		t.Errorf("expected SourceSystem reopen history row, got source=%s new_value=%s", hist.Source, hist.NewValue)
+	}
+
+	// 4. Analyst rejects it
+	gdb.Model(&f).Update("status", db.FindingRejected)
+	gdb.Create(&db.FindingHistory{FindingID: f.ID, Field: "status", OldValue: "triaged", NewValue: "rejected", Source: db.SourceAnalyst, By: "tester"})
+
+	// 5. Re-observed again -> remains rejected because last change was analyst
+	if err := w.parseFindingsOutput(&db.Skill{}, mkScan("eee"), report, emit); err != nil {
+		t.Fatal(err)
+	}
+
+	gdb.First(&f)
+	if f.Status != db.FindingRejected {
+		t.Fatalf("analyst-rejected finding should not reopen, got %s", f.Status)
+	}
+}
+
 func TestParseFindingsOutput_notObservedSkipsClosedFindings(t *testing.T) {
 	gdb, err := db.Open(filepath.Join(t.TempDir(), "p.db"))
 	if err != nil {

--- a/internal/worker/skill.go
+++ b/internal/worker/skill.go
@@ -582,10 +582,24 @@ func (w *Worker) markNotObserved(scan *db.Scan, seen map[string]bool) int {
 		if seen[f.Fingerprint] {
 			continue
 		}
-		if uerr := w.DB.Model(&db.Finding{}).Where("id = ?", f.ID).Updates(map[string]any{
-			"missed_count":        f.MissedCount + 1,
+
+		missedCount := f.MissedCount + 1
+		updates := map[string]any{
+			"missed_count":        missedCount,
 			"last_missed_scan_id": scan.ID,
-		}).Error; uerr != nil {
+		}
+
+		autoReject := false
+		if w.AutoRejectMissedCount > 0 && missedCount >= w.AutoRejectMissedCount {
+			if f.Status == db.FindingNew || f.Status == db.FindingEnriched || f.Status == db.FindingTriaged || f.Status == db.FindingReady {
+				if !w.hasEverBeenReportedOrAcknowledged(f.ID) {
+					autoReject = true
+					updates["status"] = db.FindingRejected
+				}
+			}
+		}
+
+		if uerr := w.DB.Model(&db.Finding{}).Where("id = ?", f.ID).Updates(updates).Error; uerr != nil {
 			w.Log.Error("mark finding not-observed", "finding", f.ID, "err", uerr)
 			continue
 		}
@@ -596,9 +610,31 @@ func (w *Worker) markNotObserved(scan *db.Scan, seen map[string]bool) int {
 			Source:    db.SourceTool,
 			By:        scan.SkillName,
 		}).Error
+
+		if autoReject {
+			_ = w.DB.Create(&db.FindingHistory{
+				FindingID: f.ID,
+				Field:     "status",
+				OldValue:  string(f.Status),
+				NewValue:  string(db.FindingRejected),
+				Source:    db.SourceSystem,
+				By:        fmt.Sprintf("not observed in %d consecutive rescans", missedCount),
+			}).Error
+		}
+
 		missed++
 	}
 	return missed
+}
+
+// hasEverBeenReportedOrAcknowledged checks if the finding ever reached reported or acknowledged status.
+func (w *Worker) hasEverBeenReportedOrAcknowledged(findingID uint) bool {
+	var count int64
+	w.DB.Model(&db.FindingHistory{}).
+		Where("finding_id = ? AND field = ? AND (new_value = ? OR new_value = ?)",
+			findingID, "status", string(db.FindingReported), string(db.FindingAcknowledged)).
+		Count(&count)
+	return count > 0
 }
 
 // parseMaintainersOutput upserts Maintainer rows and links them to the

--- a/internal/worker/skill.go
+++ b/internal/worker/skill.go
@@ -449,6 +449,19 @@ func (w *Worker) reobserveFinding(existing, f *db.Finding, scan *db.Scan) error 
 		"location":            f.Location,
 		"locations":           f.Locations,
 	}
+
+	var statusRestore string
+	if existing.Status == db.FindingRejected {
+		var lastStatus db.FindingHistory
+		if err := w.DB.Where("finding_id = ? AND field = ?", existing.ID, "status").
+			Order("id desc").First(&lastStatus).Error; err == nil {
+			if lastStatus.Source == db.SourceSystem {
+				statusRestore = lastStatus.OldValue
+				updates["status"] = statusRestore
+			}
+		}
+	}
+
 	// Refresh the VID and snippet so they track the code as it drifts,
 	// but never wipe a stored one just because this run could not capture
 	// it (vid binary missing, location gone, checkout evicted).
@@ -473,6 +486,20 @@ func (w *Worker) reobserveFinding(existing, f *db.Finding, scan *db.Scan) error 
 	}).Error; err != nil {
 		w.Log.Warn("record observed-again finding history", "finding", existing.ID, "scan", scan.ID, "err", err)
 	}
+
+	if statusRestore != "" {
+		if err := w.DB.Create(&db.FindingHistory{
+			FindingID: existing.ID,
+			Field:     "status",
+			OldValue:  string(db.FindingRejected),
+			NewValue:  statusRestore,
+			Source:    db.SourceSystem,
+			By:        "re-observed in scan",
+		}).Error; err != nil {
+			w.Log.Warn("record finding status reopen history", "finding", existing.ID, "scan", scan.ID, "err", err)
+		}
+	}
+
 	return nil
 }
 

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -97,6 +97,10 @@ type Worker struct {
 	// of its own so this callback is the seam.
 	OnScanFinalized func(scan *db.Scan)
 	ScanTimeout     time.Duration
+	// AutoRejectMissedCount is the threshold of consecutive missed rescans at
+	// which an open finding is automatically transitioned to 'rejected'.
+	// 0 means disabled.
+	AutoRejectMissedCount int
 
 	// Queue is the queue this worker is registered on. Required for the
 	// prereq gate to re-enqueue a scan whose upstream skills have not yet

--- a/scrutineer.sample.yaml
+++ b/scrutineer.sample.yaml
@@ -114,6 +114,10 @@
 # mistakes surface as a scan failure rather than a buried log line.
 # schema_strict: false
 
+# Auto-reject open findings if they are not observed in this many
+# consecutive rescans of the same repository and subpath. 0 disables.
+# auto_reject_missed_count: 0
+
 # Custom Anthropic API base URL. When set, the hostname is automatically
 # added to the egress allowlist. Falls back to the ANTHROPIC_BASE_URL
 # environment variable when empty.


### PR DESCRIPTION
Resolves #514

This PR implements an automated lifecycle transition for findings that disappear upstream. Currently, `markNotObserved` increments `Finding. MissedCount` but takes no further action, leaving stale findings open indefinitely.

This introduces a configurable threshold (via `scrutineer.yaml` or the CLI flag `-auto-reject-missed-count`) where an open finding is automatically marked as `rejected` once it is missed across `N` consecutive rescans.

### Key Changes
- **Configuration:** Added `auto_reject_missed_count` to `config.Config` and `scrutineer.sample.yaml`, alongside a corresponding CLI flag. It defaults to `0` (disabled).
- **Auto-Rejection Logic:** When an open finding (in the `new`, `enriched`, `triaged` or `ready` lifecycle state) reaches the consecutive miss threshold, its status automatically transitions to `rejected`.
- **Maintainer Safeguard:** Findings that have *ever* reached the `reported` or `acknowledged` status are proactively skipped. This ensures the system does not auto-close issues actively seen or tracked by human maintainers.
- **History Traceability:** Auto-rejections append a `FindingHistory` note stating `"not observed in <N> consecutive rescans"`. A new `db. SourceSystem` source was added to cleanly distinguish these automated transitions from human analyst reviews.
- **Reversibility:** If a later rescan observes the same fingerprint, it triggers the existing `reobserveFinding` logic, cleanly updating the finding, writing an `observed` history row and resetting the `MissedCount` to 0.

### Testing Done
- [x] Compiled and passed all formatting checks (`go fmt ./...`)
- [x] Passed all unit test suites (`go test ./...`)