### PR TITLE
Fix #466: Simplify maintainers skill using summarization script

### DIFF
--- a/skills/maintainers/SKILL.md
+++ b/skills/maintainers/SKILL.md
@@ -2,7 +2,7 @@
 name: maintainers
 description: Identify the real maintainers of a repository and the best way to contact them about a security issue. Distinguishes active leads from occasional contributors and bots, using commit history, issue activity, and registry ownership. Use when preparing a disclosure and needing to know who to reach.
 license: MIT
-compatibility: Needs network access to commits.ecosyste.ms, issues.ecosyste.ms, packages.ecosyste.ms, and api.github.com (to verify private vulnerability reporting before proposing the GitHub advisories channel).
+compatibility: Uses a python script (scripts/summarise.py) to aggregate cached ecosyste.ms data, parse local security files, and check PVR status, saving LLM tokens.
 metadata:
   scrutineer.version: 1
   scrutineer.output_file: report.json
@@ -29,17 +29,11 @@ You are identifying who maintains a repository so a security disclosure can reac
 
 ## Data sources
 
-Fetch each of these using your fetch tool. Each returns JSON. Include the repository URL from `context.json` as the query parameter.
+Run `python3 .claude/skills/maintainers/scripts/summarise.py`
+The script uses `context.json` to query the Scrutineer API for cached commits, issues, and packages data, parses `SECURITY.md` and `CODEOWNERS`, and hits the GitHub PVR endpoint if applicable.
 
-1. **Commits**: `https://commits.ecosyste.ms/api/v1/repositories/lookup?url={repo_url}` — who has written code, how much, past-year activity. Follow redirects.
-2. **Issues and PRs**: `https://issues.ecosyste.ms/api/v1/repositories/lookup?url={repo_url}` — who reviews, responds, closes issues. Follow redirects.
-3. **Packages**: `https://packages.ecosyste.ms/api/v1/packages/lookup?repository_url={repo_url}` — registry owners and publishers.
-
-URL-encode the repository URL before substituting it into the query string.
-
-If all three lookups return empty or 404, fall back to `git -C ./src shortlog -sne --since='1 year ago'` plus `git -C ./src log --no-merges -20 --format='%aN <%aE>'` and classify from that alone; say so in `notes`.
-
-Also read `SECURITY.md`, `.github/SECURITY.md`, `CODEOWNERS`, and `README.md` in `./src` if they exist. These often name a security contact directly.
+After running the script, read `summary.json`. It contains all the necessary data to classify the maintainers and pick a disclosure channel.
+If the API data is missing, the script will fall back to git logs, which will be present in `summary.json`.
 
 ## How to classify
 
@@ -57,10 +51,10 @@ Filter bots out of the final list unless the repo's only active account is a bot
 
 ## Disclosure channel
 
-Pick the best one, based on what you found:
+Pick the best one, based on what you found in `summary.json`:
 
 - `SECURITY.md` email or contact block if present
-- GitHub Security Advisories **only when private vulnerability reporting is actually enabled**: fetch `https://api.github.com/repos/{owner}/{repo}/private-vulnerability-reporting` (no auth needed for public repos) and require `{"enabled": true}`. If it returns `{"enabled": false}`, a 404, or any error, the GitHub advisories URL would 404 for a reporter — skip this option and fall through to the next channel. Do not infer this from a SECURITY.md that merely *says* "report via GitHub advisories"; the maintainer may not have turned the feature on.
+- GitHub Security Advisories **only when private vulnerability reporting is actually enabled**: check `pvr_enabled` in `summary.json`. If it is `false` or not present, skip this option and fall through to the next channel. Do not infer this from a SECURITY.md that merely *says* "report via GitHub advisories"; the maintainer may not have turned the feature on.
 - Registry owner contact if packages data surfaced one
 - The lead's git-log author email if none of the above; if it is a `noreply.github.com` address, skip it
 

--- a/skills/maintainers/SKILL.md
+++ b/skills/maintainers/SKILL.md
@@ -2,7 +2,7 @@
 name: maintainers
 description: Identify the real maintainers of a repository and the best way to contact them about a security issue. Distinguishes active leads from occasional contributors and bots, using commit history, issue activity, and registry ownership. Use when preparing a disclosure and needing to know who to reach.
 license: MIT
-compatibility: Uses a python script (scripts/summarise.py) to aggregate cached ecosyste.ms data, parse local security files, and check PVR status, saving LLM tokens.
+compatibility: Requires python3 on PATH; needs network access to the scrutineer API and api.github.com.
 metadata:
   scrutineer.version: 1
   scrutineer.output_file: report.json
@@ -30,7 +30,7 @@ You are identifying who maintains a repository so a security disclosure can reac
 ## Data sources
 
 Run `python3 .claude/skills/maintainers/scripts/summarise.py`
-The script uses `context.json` to query the Scrutineer API for cached commits, issues, and packages data, parses `SECURITY.md` and `CODEOWNERS`, and hits the GitHub PVR endpoint if applicable.
+The script uses `context.json` to query the Scrutineer API for cached commits, issues, and packages data, parses `SECURITY.md`, `CODEOWNERS`, and `README.md`, and hits the GitHub PVR endpoint if applicable.
 
 After running the script, read `summary.json`. It contains all the necessary data to classify the maintainers and pick a disclosure channel.
 If the API data is missing, the script will fall back to git logs, which will be present in `summary.json`.

--- a/skills/maintainers/scripts/summarise.py
+++ b/skills/maintainers/scripts/summarise.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+import json
+import os
+import urllib.request
+import subprocess
+import re
+import sys
+
+def get_json(url, token=None):
+    req = urllib.request.Request(url)
+    if token:
+        req.add_header('Authorization', f'Bearer {token}')
+    try:
+        with urllib.request.urlopen(req) as response:
+            if response.status == 200:
+                data = response.read().decode('utf-8')
+                if data:
+                    return json.loads(data)
+    except Exception:
+        pass
+    return None
+
+def main():
+    if not os.path.exists('context.json'):
+        print("No context.json found")
+        sys.exit(1)
+
+    with open('context.json', 'r') as f:
+        ctx = json.load(f)
+
+    api_base = ctx.get('scrutineer', {}).get('api_base')
+    token = ctx.get('scrutineer', {}).get('token')
+    repo_id = ctx.get('scrutineer', {}).get('repository_id')
+    repo_url = ctx.get('repository', {}).get('url', '')
+
+    summary = {
+        'commits_data': None,
+        'issues_data': None,
+        'packages_data': None,
+        'fallback_git_shortlog': None,
+        'fallback_git_log': None,
+        'security_md': None,
+        'codeowners': None,
+        'pvr_enabled': False,
+        'pvr_checked': False
+    }
+
+    if api_base and token and repo_id:
+        base_url = f"{api_base}/repositories/{repo_id}/ecosystems"
+        summary['commits_data'] = get_json(f"{base_url}/commits/raw", token)
+        summary['issues_data'] = get_json(f"{base_url}/issues/raw", token)
+        summary['packages_data'] = get_json(f"{base_url}/packages/raw", token)
+
+    if not summary['commits_data'] and not summary['issues_data'] and not summary['packages_data']:
+        try:
+            summary['fallback_git_shortlog'] = subprocess.check_output(
+                ['git', '-C', './src', 'shortlog', '-sne', '--since=1 year ago'], 
+                text=True, stderr=subprocess.DEVNULL
+            )
+            summary['fallback_git_log'] = subprocess.check_output(
+                ['git', '-C', './src', 'log', '--no-merges', '-20', '--format=%aN <%aE>'], 
+                text=True, stderr=subprocess.DEVNULL
+            )
+        except Exception:
+            pass
+
+    for path in ['SECURITY.md', '.github/SECURITY.md']:
+        full_path = os.path.join('./src', path)
+        if os.path.exists(full_path):
+            with open(full_path, 'r', errors='ignore') as f:
+                summary['security_md'] = f.read()
+            break
+
+    codeowners_path = os.path.join('./src', 'CODEOWNERS')
+    if os.path.exists(codeowners_path):
+        with open(codeowners_path, 'r', errors='ignore') as f:
+            summary['codeowners'] = f.read()
+
+    match = re.search(r'github\.com/([^/]+)/([^/]+?)(?:\.git)?$', repo_url)
+    if match:
+        owner, repo = match.groups()
+        pvr_url = f"https://api.github.com/repos/{owner}/{repo}/private-vulnerability-reporting"
+        req = urllib.request.Request(pvr_url)
+        req.add_header('Accept', 'application/vnd.github+json')
+        try:
+            with urllib.request.urlopen(req) as response:
+                if response.status == 200:
+                    data = json.loads(response.read().decode('utf-8'))
+                    summary['pvr_checked'] = True
+                    summary['pvr_enabled'] = data.get('enabled', False)
+        except urllib.error.HTTPError as e:
+            summary['pvr_checked'] = True
+        except Exception:
+            pass
+
+    with open('summary.json', 'w') as f:
+        json.dump(summary, f, indent=2)
+
+if __name__ == '__main__':
+    main()

--- a/skills/maintainers/scripts/summarise.py
+++ b/skills/maintainers/scripts/summarise.py
@@ -6,95 +6,112 @@ import subprocess
 import re
 import sys
 
+
 def get_json(url, token=None):
     req = urllib.request.Request(url)
     if token:
-        req.add_header('Authorization', f'Bearer {token}')
+        req.add_header("Authorization", f"Bearer {token}")
     try:
         with urllib.request.urlopen(req) as response:
             if response.status == 200:
-                data = response.read().decode('utf-8')
+                data = response.read().decode("utf-8")
                 if data:
                     return json.loads(data)
     except Exception:
         pass
     return None
 
+
 def main():
-    if not os.path.exists('context.json'):
+    if not os.path.exists("context.json"):
         print("No context.json found")
         sys.exit(1)
 
-    with open('context.json', 'r') as f:
+    with open("context.json", "r") as f:
         ctx = json.load(f)
 
-    api_base = ctx.get('scrutineer', {}).get('api_base')
-    token = ctx.get('scrutineer', {}).get('token')
-    repo_id = ctx.get('scrutineer', {}).get('repository_id')
-    repo_url = ctx.get('repository', {}).get('url', '')
+    api_base = ctx.get("scrutineer", {}).get("api_base")
+    token = ctx.get("scrutineer", {}).get("token")
+    repo_id = ctx.get("scrutineer", {}).get("repository_id")
+    repo_url = ctx.get("repository", {}).get("url", "")
 
     summary = {
-        'commits_data': None,
-        'issues_data': None,
-        'packages_data': None,
-        'fallback_git_shortlog': None,
-        'fallback_git_log': None,
-        'security_md': None,
-        'codeowners': None,
-        'pvr_enabled': False,
-        'pvr_checked': False
+        "commits_data": None,
+        "issues_data": None,
+        "packages_data": None,
+        "fallback_git_shortlog": None,
+        "fallback_git_log": None,
+        "security_md": None,
+        "codeowners": None,
+        "pvr_enabled": False,
+        "pvr_checked": False,
     }
 
     if api_base and token and repo_id:
         base_url = f"{api_base}/repositories/{repo_id}/ecosystems"
-        summary['commits_data'] = get_json(f"{base_url}/commits/raw", token)
-        summary['issues_data'] = get_json(f"{base_url}/issues/raw", token)
-        summary['packages_data'] = get_json(f"{base_url}/packages/raw", token)
+        summary["commits_data"] = get_json(f"{base_url}/commits/raw", token)
+        summary["issues_data"] = get_json(f"{base_url}/issues/raw", token)
+        summary["packages_data"] = get_json(f"{base_url}/packages/raw", token)
 
-    if not summary['commits_data'] and not summary['issues_data'] and not summary['packages_data']:
+    if (
+        not summary["commits_data"]
+        and not summary["issues_data"]
+        and not summary["packages_data"]
+    ):
         try:
-            summary['fallback_git_shortlog'] = subprocess.check_output(
-                ['git', '-C', './src', 'shortlog', '-sne', '--since=1 year ago'], 
-                text=True, stderr=subprocess.DEVNULL
+            summary["fallback_git_shortlog"] = subprocess.check_output(
+                ["git", "-C", "./src", "shortlog", "-sne", "--since=1 year ago"],
+                text=True,
+                stderr=subprocess.DEVNULL,
             )
-            summary['fallback_git_log'] = subprocess.check_output(
-                ['git', '-C', './src', 'log', '--no-merges', '-20', '--format=%aN <%aE>'], 
-                text=True, stderr=subprocess.DEVNULL
+            summary["fallback_git_log"] = subprocess.check_output(
+                [
+                    "git",
+                    "-C",
+                    "./src",
+                    "log",
+                    "--no-merges",
+                    "-20",
+                    "--format=%aN <%aE>",
+                ],
+                text=True,
+                stderr=subprocess.DEVNULL,
             )
         except Exception:
             pass
 
-    for path in ['SECURITY.md', '.github/SECURITY.md']:
-        full_path = os.path.join('./src', path)
+    for path in ["SECURITY.md", ".github/SECURITY.md"]:
+        full_path = os.path.join("./src", path)
         if os.path.exists(full_path):
-            with open(full_path, 'r', errors='ignore') as f:
-                summary['security_md'] = f.read()
+            with open(full_path, "r", errors="ignore") as f:
+                summary["security_md"] = f.read()
             break
 
-    codeowners_path = os.path.join('./src', 'CODEOWNERS')
+    codeowners_path = os.path.join("./src", "CODEOWNERS")
     if os.path.exists(codeowners_path):
-        with open(codeowners_path, 'r', errors='ignore') as f:
-            summary['codeowners'] = f.read()
+        with open(codeowners_path, "r", errors="ignore") as f:
+            summary["codeowners"] = f.read()
 
-    match = re.search(r'github\.com/([^/]+)/([^/]+?)(?:\.git)?$', repo_url)
+    match = re.search(r"github\.com/([^/]+)/([^/]+?)(?:\.git)?$", repo_url)
     if match:
         owner, repo = match.groups()
         pvr_url = f"https://api.github.com/repos/{owner}/{repo}/private-vulnerability-reporting"
         req = urllib.request.Request(pvr_url)
-        req.add_header('Accept', 'application/vnd.github+json')
+        req.add_header("Accept", "application/vnd.github+json")
         try:
             with urllib.request.urlopen(req) as response:
                 if response.status == 200:
-                    data = json.loads(response.read().decode('utf-8'))
-                    summary['pvr_checked'] = True
-                    summary['pvr_enabled'] = data.get('enabled', False)
+                    data = json.loads(response.read().decode("utf-8"))
+                    summary["pvr_checked"] = True
+                    summary["pvr_enabled"] = data.get("enabled", False)
         except urllib.error.HTTPError as e:
-            summary['pvr_checked'] = True
+            summary["pvr_checked"] = True
         except Exception:
             pass
 
-    with open('summary.json', 'w') as f:
+    with open("summary.json", "w") as f:
         json.dump(summary, f, indent=2)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()

--- a/skills/maintainers/scripts/summarise.py
+++ b/skills/maintainers/scripts/summarise.py
@@ -5,7 +5,6 @@ import urllib.request
 import subprocess
 import re
 import sys
-from collections import Counter
 import urllib.error
 
 
@@ -51,30 +50,23 @@ def main():
 
     if api_base and token and repo_id:
         base_url = f"{api_base}/repositories/{repo_id}/ecosystems"
-        summary["commits_data"] = get_json(f"{base_url}/commits/raw", token)
-        if summary["commits_data"] and isinstance(summary["commits_data"], dict):
-            commits = summary["commits_data"].get("commits", [])
-            if commits:
-                authors = [
-                    c.get("author_name")
-                    or c.get("login")
-                    or (c.get("author") or {}).get("login")
-                    or "unknown"
-                    for c in commits
-                ]
-                top = Counter(authors).most_common(20)
-                summary["commits_data"] = {"top_committers": top}
+        raw = get_json(f"{base_url}/commits/raw", token)
+        if isinstance(raw, dict):
+            summary["commits_data"] = {
+                "past_year_committers": (raw.get("past_year_committers") or [])[:20],
+                "total_committers": raw.get("total_committers"),
+            }
 
-        summary["issues_data"] = get_json(f"{base_url}/issues/raw", token)
-        if summary["issues_data"] and isinstance(summary["issues_data"], dict):
-            issues = summary["issues_data"].get("issues", [])
-            if issues:
-                actors = [
-                    i.get("user") or i.get("closed_by") or i.get("login") or "unknown"
-                    for i in issues
-                ]
-                top = Counter(actors).most_common(20)
-                summary["issues_data"] = {"top_issue_actors": top}
+        raw = get_json(f"{base_url}/issues/raw", token)
+        if isinstance(raw, dict):
+            summary["issues_data"] = {
+                "maintainers": raw.get("maintainers"),
+                "active_maintainers": raw.get("active_maintainers"),
+                "past_year_issue_authors": raw.get("past_year_issue_authors"),
+                "past_year_pull_request_authors": raw.get(
+                    "past_year_pull_request_authors"
+                ),
+            }
 
         summary["packages_data"] = get_json(f"{base_url}/packages/raw", token)
 
@@ -146,7 +138,7 @@ def main():
                     data = json.loads(response.read().decode("utf-8"))
                     summary["pvr_checked"] = True
                     summary["pvr_enabled"] = data.get("enabled", False)
-        except urllib.error.HTTPError as e:
+        except urllib.error.HTTPError:
             summary["pvr_checked"] = True
         except Exception:
             pass

--- a/skills/maintainers/scripts/summarise.py
+++ b/skills/maintainers/scripts/summarise.py
@@ -5,6 +5,8 @@ import urllib.request
 import subprocess
 import re
 import sys
+from collections import Counter
+import urllib.error
 
 
 def get_json(url, token=None):
@@ -12,7 +14,7 @@ def get_json(url, token=None):
     if token:
         req.add_header("Authorization", f"Bearer {token}")
     try:
-        with urllib.request.urlopen(req) as response:
+        with urllib.request.urlopen(req, timeout=10) as response:
             if response.status == 200:
                 data = response.read().decode("utf-8")
                 if data:
@@ -50,7 +52,30 @@ def main():
     if api_base and token and repo_id:
         base_url = f"{api_base}/repositories/{repo_id}/ecosystems"
         summary["commits_data"] = get_json(f"{base_url}/commits/raw", token)
+        if summary["commits_data"] and isinstance(summary["commits_data"], dict):
+            commits = summary["commits_data"].get("commits", [])
+            if commits:
+                authors = [
+                    c.get("author_name")
+                    or c.get("login")
+                    or (c.get("author") or {}).get("login")
+                    or "unknown"
+                    for c in commits
+                ]
+                top = Counter(authors).most_common(20)
+                summary["commits_data"] = {"top_committers": top}
+
         summary["issues_data"] = get_json(f"{base_url}/issues/raw", token)
+        if summary["issues_data"] and isinstance(summary["issues_data"], dict):
+            issues = summary["issues_data"].get("issues", [])
+            if issues:
+                actors = [
+                    i.get("user") or i.get("closed_by") or i.get("login") or "unknown"
+                    for i in issues
+                ]
+                top = Counter(actors).most_common(20)
+                summary["issues_data"] = {"top_issue_actors": top}
+
         summary["packages_data"] = get_json(f"{base_url}/packages/raw", token)
 
     if (
@@ -60,7 +85,15 @@ def main():
     ):
         try:
             summary["fallback_git_shortlog"] = subprocess.check_output(
-                ["git", "-C", "./src", "shortlog", "-sne", "--since=1 year ago"],
+                [
+                    "git",
+                    "-C",
+                    "./src",
+                    "shortlog",
+                    "-sne",
+                    "--since=1 year ago",
+                    "HEAD",
+                ],
                 text=True,
                 stderr=subprocess.DEVNULL,
             )
@@ -87,10 +120,19 @@ def main():
                 summary["security_md"] = f.read()
             break
 
-    codeowners_path = os.path.join("./src", "CODEOWNERS")
-    if os.path.exists(codeowners_path):
-        with open(codeowners_path, "r", errors="ignore") as f:
-            summary["codeowners"] = f.read()
+    for path in ["CODEOWNERS", ".github/CODEOWNERS", "docs/CODEOWNERS"]:
+        codeowners_path = os.path.join("./src", path)
+        if os.path.exists(codeowners_path):
+            with open(codeowners_path, "r", errors="ignore") as f:
+                summary["codeowners"] = f.read()
+            break
+
+    for path in ["README.md", "README", "README.txt", "readme.md"]:
+        readme_path = os.path.join("./src", path)
+        if os.path.exists(readme_path):
+            with open(readme_path, "r", errors="ignore") as f:
+                summary["readme_md"] = f.read()
+            break
 
     match = re.search(r"github\.com/([^/]+)/([^/]+?)(?:\.git)?$", repo_url)
     if match:
@@ -99,7 +141,7 @@ def main():
         req = urllib.request.Request(pvr_url)
         req.add_header("Accept", "application/vnd.github+json")
         try:
-            with urllib.request.urlopen(req) as response:
+            with urllib.request.urlopen(req, timeout=10) as response:
                 if response.status == 200:
                     data = json.loads(response.read().decode("utf-8"))
                     summary["pvr_checked"] = True

--- a/skills/security-deep-dive/SKILL.md
+++ b/skills/security-deep-dive/SKILL.md
@@ -15,7 +15,6 @@ metadata:
     - advisories
     - packages
     - dependents
-    - maintainers
 ---
 
 # security-deep-dive

--- a/skills/triage/SKILL.md
+++ b/skills/triage/SKILL.md
@@ -51,7 +51,6 @@ If `scrutineer.scan_ref` is set in `context.json`, include it in the POST body a
 Always:
 
 - `metadata`
-- `maintainers`
 - `repo-overview`
 - `packages`
 - `advisories`


### PR DESCRIPTION
Resolves #466.

### Summary of Changes

- **Added `summarise.py` Script**: Shifted the heavy lifting of data aggregation to a new Python script (`skills/maintainers/scripts/summarise.py`). This script queries the cached commits, issues and packages data via the Scrutineer API (introduced in PR #478), parses local `SECURITY.md`/`CODEOWNERS` files and checks the GitHub private vulnerability reporting (PVR) endpoint.
- **Updated `maintainers` Skill Instructions**: Modified `skills/maintainers/SKILL.md` to instruct the LLM to run the new script instead of making direct HTTP tool calls. The LLM now only needs to read the generated `summary.json`, which drastically reduces context size, token usage and runtime.
- The maintainers skill is now entirely manual-only and is no longer automatically enqueued by triage or security-deep-dive.

This ensures the `maintainers` skill is significantly cheaper, faster to run and won't consume unnecessary resources during standard triage runs.