### PR TITLE
fix: SQL injection via raw {id} path param in GORM inline conditions

### DIFF
--- a/internal/web/finding_disclosure.go
+++ b/internal/web/finding_disclosure.go
@@ -5,6 +5,7 @@ import (
 	"html/template"
 	"net/http"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"scrutineer/internal/db"
@@ -59,7 +60,12 @@ const disclosureHTMLPage = `<!doctype html>
 // out as a plain email body rather than a GitHub advisory.
 func (s *Server) findingDisclosureHTML(w http.ResponseWriter, r *http.Request) {
 	var f db.Finding
-	if err := s.DB.First(&f, r.PathValue("id")).Error; err != nil {
+	id, err := strconv.Atoi(r.PathValue("id"))
+	if err != nil {
+		http.NotFound(w, r)
+		return
+	}
+	if err := s.DB.First(&f, id).Error; err != nil {
 		http.NotFound(w, r)
 		return
 	}

--- a/internal/web/finding_report.go
+++ b/internal/web/finding_report.go
@@ -3,6 +3,7 @@ package web
 import (
 	"fmt"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -20,7 +21,12 @@ import (
 // finding inside a scan or repo report.
 func (s *Server) findingReport(w http.ResponseWriter, r *http.Request) {
 	var f db.Finding
-	if err := s.DB.First(&f, r.PathValue("id")).Error; err != nil {
+	id, err := strconv.Atoi(r.PathValue("id"))
+	if err != nil {
+		http.NotFound(w, r)
+		return
+	}
+	if err := s.DB.First(&f, id).Error; err != nil {
 		http.NotFound(w, r)
 		return
 	}

--- a/internal/web/maintainers.go
+++ b/internal/web/maintainers.go
@@ -107,7 +107,12 @@ func (s *Server) maintainerDoNotContact(w http.ResponseWriter, r *http.Request) 
 
 func (s *Server) maintainerShow(w http.ResponseWriter, r *http.Request) {
 	var m db.Maintainer
-	if err := s.DB.Preload("Repositories").First(&m, r.PathValue("id")).Error; err != nil {
+	id, err := strconv.Atoi(r.PathValue("id"))
+	if err != nil {
+		http.NotFound(w, r)
+		return
+	}
+	if err := s.DB.Preload("Repositories").First(&m, id).Error; err != nil {
 		http.NotFound(w, r)
 		return
 	}

--- a/internal/web/sboms.go
+++ b/internal/web/sboms.go
@@ -92,22 +92,33 @@ func (s *Server) sbomUpload(w http.ResponseWriter, r *http.Request) {
 	s.redirect(w, r, fmt.Sprintf("/sboms/%d", up.ID))
 }
 
+// anyPackageHasScope reports whether at least one package carries a
+// direct/transitive scope value; flat-list SBOMs leave them all blank, in
+// which case the scope filter is hidden.
+func anyPackageHasScope(pkgs []db.SBOMPackage) bool {
+	for _, p := range pkgs {
+		if p.Scope != "" {
+			return true
+		}
+	}
+	return false
+}
+
 func (s *Server) sbomShow(w http.ResponseWriter, r *http.Request) {
 	var up db.SBOMUpload
-	if err := s.DB.Preload("Packages.Repository").First(&up, r.PathValue("id")).Error; err != nil {
+	id, err := strconv.Atoi(r.PathValue("id"))
+	if err != nil {
+		http.NotFound(w, r)
+		return
+	}
+	if err := s.DB.Preload("Packages.Repository").First(&up, id).Error; err != nil {
 		http.NotFound(w, r)
 		return
 	}
 
 	// The scope filter only makes sense when at least one package has a
 	// known direct/transitive value; flat-list SBOMs leave them all blank.
-	hasScope := false
-	for _, p := range up.Packages {
-		if p.Scope != "" {
-			hasScope = true
-			break
-		}
-	}
+	hasScope := anyPackageHasScope(up.Packages)
 
 	scope := r.URL.Query().Get("scope")
 	pkgs := up.Packages

--- a/internal/web/sboms.go
+++ b/internal/web/sboms.go
@@ -116,8 +116,6 @@ func (s *Server) sbomShow(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// The scope filter only makes sense when at least one package has a
-	// known direct/transitive value; flat-list SBOMs leave them all blank.
 	hasScope := anyPackageHasScope(up.Packages)
 
 	scope := r.URL.Query().Get("scope")

--- a/internal/web/scan_report.go
+++ b/internal/web/scan_report.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -23,7 +24,12 @@ import (
 // scalar fields, no arrays of objects).
 func (s *Server) scanReport(w http.ResponseWriter, r *http.Request) {
 	var scan db.Scan
-	if err := s.DB.Preload("Repository").First(&scan, r.PathValue("id")).Error; err != nil {
+	id, err := strconv.Atoi(r.PathValue("id"))
+	if err != nil {
+		http.NotFound(w, r)
+		return
+	}
+	if err := s.DB.Preload("Repository").First(&scan, id).Error; err != nil {
 		http.NotFound(w, r)
 		return
 	}

--- a/internal/web/scans.go
+++ b/internal/web/scans.go
@@ -103,7 +103,12 @@ func (s *Server) scanSkillNames() []string {
 
 func (s *Server) scanShow(w http.ResponseWriter, r *http.Request) {
 	var scan db.Scan
-	if err := s.DB.Preload("Repository").Preload("Findings").First(&scan, r.PathValue("id")).Error; err != nil {
+	id, err := strconv.Atoi(r.PathValue("id"))
+	if err != nil {
+		http.NotFound(w, r)
+		return
+	}
+	if err := s.DB.Preload("Repository").Preload("Findings").First(&scan, id).Error; err != nil {
 		http.NotFound(w, r)
 		return
 	}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -749,7 +749,12 @@ var severityOrder = func() string {
 //nolint:ireturn // T is a concrete struct at every call site, not an interface
 func loadByID[T any](s *Server, w http.ResponseWriter, r *http.Request) (T, bool) {
 	var v T
-	if err := s.DB.First(&v, r.PathValue("id")).Error; err != nil {
+	id, err := strconv.Atoi(r.PathValue("id"))
+	if err != nil {
+		http.NotFound(w, r)
+		return v, false
+	}
+	if err := s.DB.First(&v, id).Error; err != nil {
 		http.NotFound(w, r)
 		return v, false
 	}
@@ -1415,7 +1420,12 @@ func (s *Server) packages(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) packageShow(w http.ResponseWriter, r *http.Request) {
 	var p db.Package
-	if err := s.DB.Preload("Repository").First(&p, r.PathValue("id")).Error; err != nil {
+	id, err := strconv.Atoi(r.PathValue("id"))
+	if err != nil {
+		http.NotFound(w, r)
+		return
+	}
+	if err := s.DB.Preload("Repository").First(&p, id).Error; err != nil {
 		http.NotFound(w, r)
 		return
 	}
@@ -1476,7 +1486,12 @@ type findingWorkflowData struct {
 
 func (s *Server) findingShow(w http.ResponseWriter, r *http.Request) {
 	var f db.Finding
-	if err := s.DB.Preload("Labels").First(&f, r.PathValue("id")).Error; err != nil {
+	id, err := strconv.Atoi(r.PathValue("id"))
+	if err != nil {
+		http.NotFound(w, r)
+		return
+	}
+	if err := s.DB.Preload("Labels").First(&f, id).Error; err != nil {
 		http.NotFound(w, r)
 		return
 	}

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -109,6 +109,29 @@ func TestLoadByID(t *testing.T) {
 	if _, ok := loadByID[db.Repository](s, w, r); ok || w.Code != http.StatusNotFound {
 		t.Errorf("missing id: ok=%v code=%d, want false/404", ok, w.Code)
 	}
+
+	// A non-numeric id must 404 before reaching the DB rather than being
+	// spliced into the GORM inline condition as raw SQL (the SQLi this
+	// fix closes).
+	r.SetPathValue("id", "1; DROP TABLE repositories")
+	w = httptest.NewRecorder()
+	if _, ok := loadByID[db.Repository](s, w, r); ok || w.Code != http.StatusNotFound {
+		t.Errorf("injection id: ok=%v code=%d, want false/404", ok, w.Code)
+	}
+}
+
+// TestFindingShow_nonNumericID covers the same SQLi guard on a handler
+// that loads via Preload("...").First, exercising the second code path
+// (handlers that parse the id inline rather than through loadByID).
+func TestFindingShow_nonNumericID(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq("GET", "/findings/abc"))
+	if w.Code != http.StatusNotFound {
+		t.Errorf("non-numeric finding id: code=%d, want 404", w.Code)
+	}
 }
 
 func TestRepoList_batchedFindingsCountAcrossRepos(t *testing.T) {


### PR DESCRIPTION
This fixes https://github.com/alpha-omega-security/scrutineer/security/advisories/GHSA-2v2f-6322-446q by resolving a SQLi hole in a few places.

I ran another scan over the entire repo to look for any similar issues, and didn't find anything else beyond what was fixed here. But given that a new instance of the problem was introduced since I initially reported it, we should probably add a lint rule or something to protect against reintroducing this issue in the future.

## Summary

Several web handlers route a record ID through GORM's inline `First`/`Delete` condition by passing `r.PathValue("id")` — a **raw string** — straight into the query. With `gorm.io/gorm` v1.31.1, a non-numeric inline-condition string is emitted as a raw SQL expression rather than a parameterized `WHERE id = ?`.

The fix parses the path id with `strconv.Atoi` up front and 404s on a non-numeric value, then queries with the `int` so GORM parameterizes it. This matches the existing `strconv.Atoi` handlers and is behavior-preserving for legitimate traffic (numeric ids unchanged; non-numeric ids already 404'd via SQL error and still do).

## Sinks fixed

`loadByID` (server.go), `packageShow`, `findingShow`, `sbomShow`, `scanReport`, `scanShow`, `findingReport`, `maintainerShow`, and `findingDisclosureHTML` (`finding_disclosure.go`).

Notes vs. the original draft of this fix:
- `findingDisclosureHTML` is a sink that was introduced *after* the fix was first drafted; it's the same vulnerability class, so it's included here.
- `sbomDelete` was already parameterized on `main` by a later transaction-based refactor, so no change was needed there.

## Codebase-wide audit

I swept the whole codebase for this class. Every other SQL sink is safe: numeric (`uint`/`int`) inline conditions are GORM-parameterized, `Where` clauses use `?` placeholders, struct conditions (`Where(db.Repository{...})`) are parameterized, and `Order`/column-name usages resolve through constants or whitelists. No further instances of this class remain.

## Other changes

Extracted `anyPackageHasScope` from `sbomShow` to keep it under the gocognit cap once the id-parse branch is added.

## Testing

- `go build ./internal/web/...` — OK
- `golangci-lint run ./internal/web/...` — 0 issues
- `go test ./internal/web/...` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)