### PR TITLE
Hide empty dependencies tab on repo pages

### DIFF
--- a/internal/web/repo_show_test.go
+++ b/internal/web/repo_show_test.go
@@ -156,6 +156,24 @@ func TestRepoShow_dependenciesTab_plainManifestWithoutDoneScan(t *testing.T) {
 	}
 }
 
+func TestRepoShow_dependenciesTabHiddenWhenNoDependencies(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	repo := db.Repository{URL: "https://example.com/r", Name: "r"}
+	s.DB.Create(&repo)
+
+	body := getRepoPage(t, s, repo.ID)
+	for _, hidden := range []string{
+		`id="rt5"`,
+		`id="rp5"`,
+		"No dependencies indexed yet",
+	} {
+		if strings.Contains(body, hidden) {
+			t.Errorf("repo with no dependencies should not render %q", hidden)
+		}
+	}
+}
+
 func TestRepoShow_dependenciesTab_hidesNonRuntimeByDefault(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()
@@ -175,6 +193,9 @@ func TestRepoShow_dependenciesTab_hidesNonRuntimeByDefault(t *testing.T) {
 	}
 	if !strings.Contains(body, "Include test/build/dev") {
 		t.Errorf("default view should render non-runtime toggle")
+	}
+	if !strings.Contains(body, `id="rt5"`) || !strings.Contains(body, `id="rp5"`) {
+		t.Errorf("dependencies tab should still render when only filtered dependency rows are hidden")
 	}
 
 	body = getRepoPagePath(t, s, fmt.Sprintf("/repositories/%d?deps=all", repo.ID))

--- a/internal/web/repo_show_test.go
+++ b/internal/web/repo_show_test.go
@@ -166,7 +166,6 @@ func TestRepoShow_dependenciesTabHiddenWhenNoDependencies(t *testing.T) {
 	for _, hidden := range []string{
 		`id="rt5"`,
 		`id="rp5"`,
-		"No dependencies indexed yet",
 	} {
 		if strings.Contains(body, hidden) {
 			t.Errorf("repo with no dependencies should not render %q", hidden)

--- a/internal/web/templates/repo_show.html
+++ b/internal/web/templates/repo_show.html
@@ -391,8 +391,6 @@
       {{end}}
     {{else if .HiddenDeps}}
       <p class="text-muted-foreground text-sm p-4">No runtime dependencies in the default view.</p>
-    {{else}}
-      <p class="text-muted-foreground text-sm p-4">No dependencies indexed yet. The git-pkgs job populates this.</p>
     {{end}}
   </div>
   {{end}}

--- a/internal/web/templates/repo_show.html
+++ b/internal/web/templates/repo_show.html
@@ -77,9 +77,11 @@
       Packages
     </button>
     {{end}}
-    <button type="button" role="tab" id="rt5" aria-controls="rp5" aria-selected="false">
-      Dependencies
-    </button>
+    {{if or .Deps .HiddenDeps}}
+      <button type="button" role="tab" id="rt5" aria-controls="rp5" aria-selected="false">
+        Dependencies
+      </button>
+    {{end}}
     {{if .ThreatModel}}
     <button type="button" role="tab" id="rt10" aria-controls="rp10" aria-selected="false">
       Threat Model
@@ -350,20 +352,19 @@
   </div>
   {{end}}
 
+  {{if or .Deps .HiddenDeps}}
   <div role="tabpanel" id="rp5" aria-labelledby="rt5" hidden>
-    {{if or .Deps .HiddenDeps}}
-      <div class="flex items-center justify-between gap-3 mb-3">
-        <p class="text-sm text-muted-foreground">
-          {{if .ShowAllDeps}}Showing all dependency phases.{{else}}Showing runtime dependencies.{{end}}
-          {{if .HiddenDeps}}{{.HiddenDeps}} test/build/dev row(s) hidden.{{end}}
-        </p>
-        {{if .ShowAllDeps}}
-          <a class="btn-sm-outline" href="/repositories/{{.Repo.ID}}#rt5">Runtime only</a>
-        {{else if .HiddenDeps}}
-          <a class="btn-sm-outline" href="/repositories/{{.Repo.ID}}?deps=all#rt5">Include test/build/dev</a>
-        {{end}}
-      </div>
-    {{end}}
+    <div class="flex items-center justify-between gap-3 mb-3">
+      <p class="text-sm text-muted-foreground">
+        {{if .ShowAllDeps}}Showing all dependency phases.{{else}}Showing runtime dependencies.{{end}}
+        {{if .HiddenDeps}}{{.HiddenDeps}} test/build/dev row(s) hidden.{{end}}
+      </p>
+      {{if .ShowAllDeps}}
+        <a class="btn-sm-outline" href="/repositories/{{.Repo.ID}}#rt5">Runtime only</a>
+      {{else if .HiddenDeps}}
+        <a class="btn-sm-outline" href="/repositories/{{.Repo.ID}}?deps=all#rt5">Include test/build/dev</a>
+      {{end}}
+    </div>
     {{if .Deps}}
       <table class="table w-full">
         <thead><tr>
@@ -394,6 +395,7 @@
       <p class="text-muted-foreground text-sm p-4">No dependencies indexed yet. The git-pkgs job populates this.</p>
     {{end}}
   </div>
+  {{end}}
 
   {{if .ThreatModel}}
   <div role="tabpanel" id="rp10" aria-labelledby="rt10" hidden>


### PR DESCRIPTION
## Summary

Part of #22.

This updates the repository detail page to hide the Dependencies tab when a repository has no indexed dependency rows, matching the existing feature-gating behavior for Packages and Dependents.

## Changes

- Hide the Dependencies tab and panel when no dependencies are present.
- Keep the Dependencies tab visible when non-runtime dependencies exist but are hidden by the default runtime-only filter.
- Add repo page tests for both cases.

## Testing

- `git diff --check`
- `go test ./internal/web -run 'TestRepoShow_dependenciesTab|TestRepoShow_depsCap'`
- `go test ./internal/web`
- `go test ./...`
- `go vet ./...`
- `go vet -tags podman ./...`
- `go test -race ./...`