### PR TITLE
Show operator workflow when no dependents exist

### DIFF
--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -1506,6 +1506,7 @@ func (s *Server) advisoriesList(w http.ResponseWriter, r *http.Request) {
 type findingWorkflowData struct {
 	db.Finding
 	VerifyInFlight bool
+	HasDependents  bool
 }
 
 func (s *Server) findingShow(w http.ResponseWriter, r *http.Request) {
@@ -1543,6 +1544,9 @@ func (s *Server) findingShow(w http.ResponseWriter, r *http.Request) {
 		selected[l.Name] = true
 	}
 	_, verifyInFlight := s.openFindingSkillScan(f.ID, verifySkillName)
+	var dependentCount int64
+	s.DB.Model(&db.Dependent{}).Where("repository_id = ?", scan.RepositoryID).Count(&dependentCount)
+	hasDependents := dependentCount > 0
 
 	type exposureRow struct {
 		Dep    db.Dependent
@@ -1589,14 +1593,16 @@ func (s *Server) findingShow(w http.ResponseWriter, r *http.Request) {
 		"LatestRevalidate": latestRevalidate,
 		"AllLabels":        labels,
 		"Selected":         selected,
-		"Workflow":         findingWorkflowData{Finding: f, VerifyInFlight: verifyInFlight},
-		"Exposures":        exposures,
-		"ShowExposure":     findingSupportsExposure(scan),
+		"Workflow": findingWorkflowData{
+			Finding:        f,
+			VerifyInFlight: verifyInFlight,
+			HasDependents:  hasDependents,
+		},
+		"Exposures":    exposures,
+		"ShowExposure": findingSupportsExposure(scan),
 	}
 	if data["ShowExposure"].(bool) {
-		var depCount int64
-		s.DB.Model(&db.Dependent{}).Where("repository_id = ?", scan.RepositoryID).Count(&depCount)
-		data["HasDependents"] = depCount > 0
+		data["HasDependents"] = hasDependents
 	}
 	if id, c, ok := LookupCWE(f.CWE); ok {
 		data["CWE"] = map[string]any{"ID": id, "Name": c.Name, "Description": c.Description}

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -1669,6 +1669,81 @@ func TestFindingShow_hidesPublicIssueActionForHighSeverityReadyFinding(t *testin
 	}
 }
 
+func TestFindingShow_operatorWorkflowWhenNoDependents(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	repo := db.Repository{URL: "https://github.com/foo/app", Name: "app"}
+	s.DB.Create(&repo)
+	scan := db.Scan{RepositoryID: repo.ID, Kind: "skill", Status: db.ScanDone, SkillName: deepDiveSkillName}
+	s.DB.Create(&scan)
+
+	cases := []struct {
+		status db.FindingLifecycle
+		want   []string
+	}{
+		{db.FindingTriaged, []string{"Triaged, ready for operator handoff", "patch or mitigation"}},
+		{db.FindingReady, []string{"Remediation handoff ready", "share with the operator", "Mark shared"}},
+		{db.FindingReported, []string{"Shared with operator", "remediation owner"}},
+		{db.FindingAcknowledged, []string{"Operator acknowledged", "remediation owner is working on a fix"}},
+		{db.FindingFixed, []string{"internal advisory"}},
+		{db.FindingPublished, []string{"Closed out", "Internal advisory or remediation follow-up is complete"}},
+	}
+	for _, tc := range cases {
+		f := db.Finding{ScanID: scan.ID, RepositoryID: repo.ID, Title: string(tc.status) + " finding",
+			Severity: "High", Status: tc.status}
+		s.DB.Create(&f)
+
+		w := httptest.NewRecorder()
+		s.Handler().ServeHTTP(w, localReq("GET", fmt.Sprintf("/findings/%d", f.ID)))
+		body := w.Body.String()
+		if w.Code != http.StatusOK {
+			t.Fatalf("%s status %d: %s", tc.status, w.Code, body)
+		}
+		for _, want := range tc.want {
+			if !strings.Contains(body, want) {
+				t.Errorf("%s finding page missing no-dependent workflow text %q", tc.status, want)
+			}
+		}
+		for _, gone := range []string{"send to the maintainer", "Mark as reported"} {
+			if strings.Contains(body, gone) {
+				t.Errorf("%s finding page should not render dependent-disclosure text %q", tc.status, gone)
+			}
+		}
+	}
+}
+
+func TestFindingShow_dependentWorkflowWhenDependentsExist(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	repo := db.Repository{URL: "https://github.com/foo/lib", Name: "lib"}
+	s.DB.Create(&repo)
+	scan := db.Scan{RepositoryID: repo.ID, Kind: "skill", Status: db.ScanDone, SkillName: deepDiveSkillName}
+	s.DB.Create(&scan)
+	s.DB.Create(&db.Dependent{RepositoryID: repo.ID, Name: "downstream", Ecosystem: "npm"})
+	f := db.Finding{ScanID: scan.ID, RepositoryID: repo.ID, Title: "ready finding",
+		Severity: "High", Status: db.FindingReady}
+	s.DB.Create(&f)
+
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq("GET", fmt.Sprintf("/findings/%d", f.ID)))
+	body := w.Body.String()
+	if w.Code != http.StatusOK {
+		t.Fatalf("status %d: %s", w.Code, body)
+	}
+	for _, want := range []string{"Disclosure draft ready", "send to the maintainer", "Mark as reported"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("dependent workflow missing %q", want)
+		}
+	}
+	for _, gone := range []string{"Remediation handoff ready", "Mark shared"} {
+		if strings.Contains(body, gone) {
+			t.Errorf("dependent workflow should not render no-dependent text %q", gone)
+		}
+	}
+}
+
 func TestOrgReport_rendersFindingsAcrossRepos(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()

--- a/internal/web/templates/finding_workflow.html
+++ b/internal/web/templates/finding_workflow.html
@@ -12,23 +12,52 @@
         <p class="text-sm mb-1 font-medium">Verification complete</p>
         <p class="text-sm text-muted-foreground">The confirm job ran and validated this finding. Review the evidence and triage.</p>
       {{else if eq $s "triaged"}}
-        <p class="text-sm mb-1 font-medium">Triaged, ready to prepare disclosure</p>
-        <p class="text-sm text-muted-foreground">You've confirmed this is a real finding. Run the disclose skill to get a GHSA-shaped draft, review and edit, then mark ready.</p>
+        {{if .HasDependents}}
+          <p class="text-sm mb-1 font-medium">Triaged, ready to prepare disclosure</p>
+          <p class="text-sm text-muted-foreground">You've confirmed this is a real finding. Run the disclose skill to get a GHSA-shaped draft, review and edit, then mark ready.</p>
+        {{else}}
+          <p class="text-sm mb-1 font-medium">Triaged, ready for operator handoff</p>
+          <p class="text-sm text-muted-foreground">You've confirmed this is a real finding. No dependents are recorded, so prepare an operator handoff with a patch or mitigation, then mark ready.</p>
+        {{end}}
       {{else if eq $s "ready"}}
-        <p class="text-sm mb-1 font-medium">Disclosure draft ready</p>
-        <p class="text-sm text-muted-foreground">The draft is prepared. Review it in the notes, edit if needed, then send to the maintainer.</p>
+        {{if .HasDependents}}
+          <p class="text-sm mb-1 font-medium">Disclosure draft ready</p>
+          <p class="text-sm text-muted-foreground">The draft is prepared. Review it in the notes, edit if needed, then send to the maintainer.</p>
+        {{else}}
+          <p class="text-sm mb-1 font-medium">Remediation handoff ready</p>
+          <p class="text-sm text-muted-foreground">Review the patch or mitigation notes, edit if needed, then share with the operator or remediation owner.</p>
+        {{end}}
       {{else if eq $s "reported"}}
-        <p class="text-sm mb-1 font-medium">Reported to maintainer</p>
-        <p class="text-sm text-muted-foreground">Waiting for a response. Update the status when they acknowledge.</p>
+        {{if .HasDependents}}
+          <p class="text-sm mb-1 font-medium">Reported to maintainer</p>
+          <p class="text-sm text-muted-foreground">Waiting for a response. Update the status when they acknowledge.</p>
+        {{else}}
+          <p class="text-sm mb-1 font-medium">Shared with operator</p>
+          <p class="text-sm text-muted-foreground">Waiting for the remediation owner to acknowledge. Update the status when they do.</p>
+        {{end}}
       {{else if eq $s "acknowledged"}}
-        <p class="text-sm mb-1 font-medium">Maintainer acknowledged</p>
-        <p class="text-sm text-muted-foreground">The maintainer is working on a fix. Update when the fix ships.</p>
+        {{if .HasDependents}}
+          <p class="text-sm mb-1 font-medium">Maintainer acknowledged</p>
+          <p class="text-sm text-muted-foreground">The maintainer is working on a fix. Update when the fix ships.</p>
+        {{else}}
+          <p class="text-sm mb-1 font-medium">Operator acknowledged</p>
+          <p class="text-sm text-muted-foreground">The remediation owner is working on a fix. Update when the fix ships.</p>
+        {{end}}
       {{else if eq $s "fixed"}}
         <p class="text-sm mb-1 font-medium">Fix available</p>
-        <p class="text-sm text-muted-foreground">A fix has been released. Publish the advisory when ready.</p>
+        {{if .HasDependents}}
+          <p class="text-sm text-muted-foreground">A fix has been released. Publish the advisory when ready.</p>
+        {{else}}
+          <p class="text-sm text-muted-foreground">A fix has been released. Publish or close out the internal advisory when ready.</p>
+        {{end}}
       {{else if eq $s "published"}}
-        <p class="text-sm mb-1 font-medium">Published</p>
-        <p class="text-sm text-muted-foreground">Advisory is public. This finding is complete.</p>
+        {{if .HasDependents}}
+          <p class="text-sm mb-1 font-medium">Published</p>
+          <p class="text-sm text-muted-foreground">Advisory is public. This finding is complete.</p>
+        {{else}}
+          <p class="text-sm mb-1 font-medium">Closed out</p>
+          <p class="text-sm text-muted-foreground">Internal advisory or remediation follow-up is complete.</p>
+        {{end}}
       {{else if eq $s "rejected"}}
         <p class="text-sm mb-1 font-medium">Rejected</p>
         <p class="text-sm text-muted-foreground">This finding was determined to be invalid. Reopen if new evidence appears.</p>
@@ -101,7 +130,7 @@
         {{end}}
         <button type="submit" name="status" value="reported" class="btn"
                 hx-post="/findings/{{$id}}/status">
-          <i data-lucide="send"></i> Mark as reported
+          <i data-lucide="send"></i> {{if .HasDependents}}Mark as reported{{else}}Mark shared{{end}}
         </button>
 
       {{else if eq $s "reported"}}


### PR DESCRIPTION
## Summary

Part of #22.

This updates the finding workflow copy for repositories without recorded dependents. Instead of presenting those findings as downstream disclosure/advisory work, the page now frames them as operator remediation handoffs.

## Changes

- Pass dependent availability into the finding workflow view.
- Keep the existing maintainer/disclosure wording when dependents exist.
- Show operator/remediation handoff wording when no dependents are recorded.
- Reuse the same dependent-count signal for the exposure controls.
- Add tests for both dependent and no-dependent workflow paths.

## Testing

- `git diff --check`
- `go test ./internal/web -run 'TestFindingShow_(operatorWorkflowWhenNoDependents|dependentWorkflowWhenDependentsExist|rendersPublicIssueActionForReadyFinding|hidesPublicIssueActionForHighSeverityReadyFinding|hidesExposureForZizmorFindings)'`
- `go test ./internal/web`
- `go test ./...`
- `go vet ./...`
- `go vet -tags podman ./...`
- `go test -race ./...`