### PR TITLE
Populate dependents table from ecosystems prefetch

### DIFF
--- a/internal/worker/ecosystems.go
+++ b/internal/worker/ecosystems.go
@@ -255,6 +255,7 @@ func updateDependentsTable(gdb *gorm.DB, repoID uint, payload []byte) error {
 		return fmt.Errorf("decode dependents cache: %w", err)
 	}
 	rows := make([]db.Dependent, 0)
+	seen := make(map[string]bool)
 	for _, entry := range result {
 		for _, raw := range entry.Dependents {
 			var d struct {
@@ -272,6 +273,12 @@ func updateDependentsTable(gdb *gorm.DB, repoID uint, payload []byte) error {
 			}
 			if err := json.Unmarshal(raw, &d); err != nil {
 				return fmt.Errorf("decode dependent: %w", err)
+			}
+			if d.PURL != "" {
+				if seen[d.PURL] {
+					continue
+				}
+				seen[d.PURL] = true
 			}
 			repoURL := d.RepositoryURL
 			if repoURL == "" {

--- a/internal/worker/ecosystems.go
+++ b/internal/worker/ecosystems.go
@@ -121,6 +121,12 @@ func refreshEcosystems(ctx context.Context, gdb *gorm.DB, repoID uint, staleOnly
 			src.fetchedCol: now,
 		}).Error; err != nil {
 			log.Warn("ecosystems cache write failed", "repo", repoID, "source", src.key, "err", err)
+			continue
+		}
+		if src.key == "dependents" {
+			if err := updateDependentsTable(gdb, repoID, body); err != nil {
+				log.Warn("ecosystems dependents table write failed", "repo", repoID, "err", err)
+			}
 		}
 	}
 	return nil
@@ -241,6 +247,60 @@ func fetchDependents(ctx context.Context, ep ecosystemsEndpoints, repoURL string
 		out = append(out, dependentsEntry{Package: p.Name, Ecosystem: p.Ecosystem, Dependents: deps})
 	}
 	return json.Marshal(out)
+}
+
+func updateDependentsTable(gdb *gorm.DB, repoID uint, payload []byte) error {
+	var result []dependentsEntry
+	if err := json.Unmarshal(payload, &result); err != nil {
+		return fmt.Errorf("decode dependents cache: %w", err)
+	}
+	rows := make([]db.Dependent, 0)
+	for _, entry := range result {
+		for _, raw := range entry.Dependents {
+			var d struct {
+				Name          string `json:"name"`
+				Ecosystem     string `json:"ecosystem"`
+				PURL          string `json:"purl"`
+				RepositoryURL string `json:"repository_url"`
+				RepoMetadata  struct {
+					HTMLURL string `json:"html_url"`
+				} `json:"repo_metadata"`
+				Downloads           int64  `json:"downloads"`
+				DependentReposCount int    `json:"dependent_repos_count"`
+				RegistryURL         string `json:"registry_url"`
+				LatestReleaseNumber string `json:"latest_release_number"`
+			}
+			if err := json.Unmarshal(raw, &d); err != nil {
+				return fmt.Errorf("decode dependent: %w", err)
+			}
+			repoURL := d.RepositoryURL
+			if repoURL == "" {
+				repoURL = d.RepoMetadata.HTMLURL
+			}
+			rows = append(rows, db.Dependent{
+				RepositoryID:   repoID,
+				Name:           d.Name,
+				Ecosystem:      db.EcosystemType(d.PURL, d.Ecosystem),
+				PURL:           d.PURL,
+				RepositoryURL:  repoURL,
+				Downloads:      d.Downloads,
+				DependentRepos: d.DependentReposCount,
+				RegistryURL:    d.RegistryURL,
+				LatestVersion:  d.LatestReleaseNumber,
+			})
+		}
+	}
+	return gdb.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Where("repository_id = ?", repoID).Delete(&db.Dependent{}).Error; err != nil {
+			return fmt.Errorf("delete old dependents: %w", err)
+		}
+		if len(rows) > 0 {
+			if err := tx.CreateInBatches(&rows, insertBatchSize).Error; err != nil {
+				return fmt.Errorf("save dependents: %w", err)
+			}
+		}
+		return nil
+	})
 }
 
 func ecosystemsGet(ctx context.Context, endpoint string) ([]byte, error) {

--- a/internal/worker/ecosystems_test.go
+++ b/internal/worker/ecosystems_test.go
@@ -247,6 +247,21 @@ func TestUpdateDependentsTable_mapsUpstreamPayload(t *testing.T) {
 				}`),
 			},
 		},
+		{
+			Package:   "widget-extra",
+			Ecosystem: "npm",
+			Dependents: []json.RawMessage{
+				json.RawMessage(`{
+					"name":"rails-x-duplicate",
+					"ecosystem":"rubygems",
+					"purl":"pkg:gem/rails-x",
+					"downloads":9999,
+					"dependent_repos_count":999,
+					"repository_url":"https://github.com/acme/rails-x-duplicate",
+					"latest_release_number":"9.9.9"
+				}`),
+			},
+		},
 	}
 	body, err := json.Marshal(payload)
 	if err != nil {

--- a/internal/worker/ecosystems_test.go
+++ b/internal/worker/ecosystems_test.go
@@ -2,6 +2,7 @@ package worker
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"log/slog"
 	"net/http"
@@ -211,6 +212,71 @@ func TestRefreshEcosystems_missingRepoErrors(t *testing.T) {
 	gdb := openEcosystemsTestDB(t)
 	if err := refreshEcosystems(context.Background(), gdb, 9999, false, slog.Default(), defaultEcosystemsEndpoints); err == nil {
 		t.Fatal("want error for missing repository, got nil")
+	}
+}
+
+func TestUpdateDependentsTable_mapsUpstreamPayload(t *testing.T) {
+	gdb := openEcosystemsTestDB(t)
+	repo := db.Repository{URL: "https://github.com/acme/widget", Name: "widget"}
+	gdb.Create(&repo)
+	gdb.Create(&db.Dependent{RepositoryID: repo.ID, Name: "stale", Ecosystem: "npm"})
+
+	payload := []dependentsEntry{
+		{
+			Package:   "widget",
+			Ecosystem: "npm",
+			Dependents: []json.RawMessage{
+				json.RawMessage(`{
+					"name":"rails-x",
+					"ecosystem":"rubygems",
+					"purl":"pkg:gem/rails-x",
+					"downloads":5000,
+					"dependent_repos_count":200,
+					"registry_url":"https://rubygems.org/gems/rails-x",
+					"latest_release_number":"7.0.0",
+					"repo_metadata":{"html_url":"https://github.com/acme/rails-x"}
+				}`),
+				json.RawMessage(`{
+					"name":"action-user",
+					"ecosystem":"github-actions",
+					"purl":"pkg:githubactions/acme/action-user",
+					"repository_url":"https://github.com/acme/action-user",
+					"downloads":42,
+					"dependent_repos_count":9,
+					"latest_release_number":"v1"
+				}`),
+			},
+		},
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := updateDependentsTable(gdb, repo.ID, body); err != nil {
+		t.Fatalf("update dependents table: %v", err)
+	}
+
+	var rows []db.Dependent
+	gdb.Where("repository_id = ?", repo.ID).Order("name").Find(&rows)
+	if len(rows) != 2 {
+		t.Fatalf("rows = %+v, want 2", rows)
+	}
+	if rows[0].Name != "action-user" ||
+		rows[0].Ecosystem != "githubactions" ||
+		rows[0].RepositoryURL != "https://github.com/acme/action-user" ||
+		rows[0].DependentRepos != 9 ||
+		rows[0].LatestVersion != "v1" {
+		t.Errorf("action row = %+v", rows[0])
+	}
+	if rows[1].Name != "rails-x" ||
+		rows[1].Ecosystem != "gem" ||
+		rows[1].RepositoryURL != "https://github.com/acme/rails-x" ||
+		rows[1].DependentRepos != 200 ||
+		rows[1].LatestVersion != "7.0.0" ||
+		rows[1].RegistryURL != "https://rubygems.org/gems/rails-x" ||
+		rows[1].Downloads != 5000 {
+		t.Errorf("rails row = %+v", rows[1])
 	}
 }
 


### PR DESCRIPTION
## Summary

Part of #411

This is the first additive split from the dependents-skill removal work. It keeps the existing `dependents` skill in place, but makes the ecosyste.ms dependents prefetch also populate the typed `db.Dependent` table.

## Changes

- Add `updateDependentsTable` after the dependents ecosyste.ms cache write.
- Map upstream ecosyste.ms fields into `db.Dependent`:
  - `dependent_repos_count` -> `DependentRepos`
  - `latest_release_number` -> `LatestVersion`
  - `repository_url`, falling back to `repo_metadata.html_url`
- Canonicalize dependent ecosystem values through `db.EcosystemType`.
- Add a focused test using upstream payload field names.

## Testing

- `go test ./internal/worker -run 'Test(UpdateDependentsTable|RefreshEcosystems)'`
- `go test ./internal/worker`
- `go test ./...`
- `go vet ./...`
- `go vet -tags podman ./...`
- `git diff --check`
- `go test -race ./...`