### PR TITLE
Remove unused ProxyURL wrapper

### DIFF
--- a/internal/worker/egress.go
+++ b/internal/worker/egress.go
@@ -306,14 +306,9 @@ func NewProxyToken() string {
 	return hex.EncodeToString(b[:])
 }
 
-// ProxyURL builds the http_proxy-style URL for Docker/Podman containers
-// reaching the in-process host proxy via the host-gateway alias.
-func ProxyURL(token string, port int) string {
-	return ProxyURLForHost(token, HostGatewayAlias, port)
-}
-
-// ProxyURLForHost builds the http_proxy-style URL for containers whose host
-// gateway is runtime-specific.
+// ProxyURLForHost builds the http_proxy-style URL for containers reaching the
+// in-process host proxy. Docker/Podman pass HostGatewayAlias; Apple's
+// container runtime passes the resolved gateway IP.
 func ProxyURLForHost(token, host string, port int) string {
 	return fmt.Sprintf("http://scrutineer:%s@%s:%d", token, host, port)
 }

--- a/internal/worker/egress_test.go
+++ b/internal/worker/egress_test.go
@@ -471,8 +471,8 @@ func TestEgressProxy_NoPortRestrictionForOtherHosts(t *testing.T) {
 	}
 }
 
-func TestProxyURLShape(t *testing.T) {
-	got := ProxyURL("abc", 1234)
+func TestProxyURLForHostShape(t *testing.T) {
+	got := ProxyURLForHost("abc", HostGatewayAlias, 1234)
 	want := "http://scrutineer:abc@host.docker.internal:1234"
 	if got != want {
 		t.Errorf("got %q want %q", got, want)

--- a/internal/worker/podman_integration_test.go
+++ b/internal/worker/podman_integration_test.go
@@ -180,7 +180,7 @@ func TestIntegration_VerifyHardenedNetwork(t *testing.T) {
 		t.Skip("host-gateway unresolved on this network; cannot test proxy reachability")
 	}
 
-	d := ContainerRunner{Runtime: rt, Hardened: true, ProxyURL: ProxyURL(token, port)}
+	d := ContainerRunner{Runtime: rt, Hardened: true, ProxyURL: ProxyURLForHost(token, HostGatewayAlias, port)}
 	if err := d.verifyHardenedNetwork(hardenedNet{name: netName, gatewayIP: gwIP}, image); err != nil {
 		t.Fatalf("verifyHardenedNetwork on a correct internal network: %v", err)
 	}


### PR DESCRIPTION
`ProxyURL` became dead in #513 when `main.setupRunner` switched to `ProxyURLForHost` so it could pass the Apple-runtime gateway IP instead of hardcoding `host.docker.internal`. The only remaining callers were its own unit test and the podman integration test; `deadcode` ignores `_test.go` files so it correctly flagged the wrapper as unreachable.

Inlines `ProxyURLForHost(token, HostGatewayAlias, port)` at the two test sites and folds the doc comment into `ProxyURLForHost`. `deadcode ./...` is now clean.