### PR TITLE
Extract Harness interface around the in-container agent CLI

### DIFF
--- a/internal/worker/container.go
+++ b/internal/worker/container.go
@@ -28,8 +28,13 @@ const DefaultRunnerImage = "ghcr.io/alpha-omega-security/scrutineer-runner:lates
 // docker, podman, or Apple's container (selected via the Runtime field) and
 // implements SkillRunner.
 type ContainerRunner struct {
-	Image            string
-	Effort           string
+	Image  string
+	Effort string
+	// Harness is the agent CLI exec'd inside the container. nil means
+	// claude-code (the historical default), so a bare ContainerRunner{}
+	// keeps working and no caller needs to set it until a second harness
+	// exists.
+	Harness          Harness
 	ProxyURL         string // http://user:token@host-or-gateway:port; "" disables egress
 	FullClone        bool
 	MaxTurns         int
@@ -310,8 +315,9 @@ func (d ContainerRunner) RunSkill(ctx context.Context, sj SkillJob, emit func(Ev
 // max-turns cap, and the session id from the init event (empty when no init
 // event arrived, e.g. a --resume that could not find the conversation).
 func (d ContainerRunner) runContainerOnce(ctx context.Context, runBase []string, sj SkillJob, emit func(Event)) (hitMaxTurns bool, sessionID string, waitErr error) {
-	claudeArgs := append([]string{"claude"}, buildClaudeArgs(sj, d.Effort, d.MaxTurns)...)
-	runArgs := append(append([]string{}, runBase...), claudeArgs...)
+	h := d.harness()
+	harnessArgs := append([]string{h.Binary()}, h.Args(sj, d.Effort, d.MaxTurns)...)
+	runArgs := append(append([]string{}, runBase...), harnessArgs...)
 
 	cmd := exec.CommandContext(ctx, d.Runtime.bin(), runArgs...)
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
@@ -542,7 +548,8 @@ func (d ContainerRunner) injectProfileGuide(profile, absWork string, emit func(E
 	if guide == "" {
 		return
 	}
-	target := filepath.Join(absWork, "CLAUDE.md")
+	name := d.harness().GuideFilename()
+	target := filepath.Join(absWork, name)
 	data, err := os.ReadFile(guide)
 	if err != nil {
 		emit(Event{Kind: KindText, Text: "profile guide: read " + guide + ": " + err.Error()})
@@ -552,7 +559,17 @@ func (d ContainerRunner) injectProfileGuide(profile, absWork string, emit func(E
 		emit(Event{Kind: KindText, Text: "profile guide: write " + target + ": " + err.Error()})
 		return
 	}
-	emit(Event{Kind: KindText, Text: "profile guide: " + guide + " -> /work/CLAUDE.md"})
+	emit(Event{Kind: KindText, Text: "profile guide: " + guide + " -> /work/" + name})
+}
+
+// harness returns the agent CLI to exec inside the container, defaulting
+// to claude-code when none is set so the zero ContainerRunner{} keeps its
+// historical behaviour.
+func (d ContainerRunner) harness() Harness { //nolint:ireturn // nil-default accessor; the field IS the interface
+	if d.Harness != nil {
+		return d.Harness
+	}
+	return claudeHarness{}
 }
 
 // profileGuidePath returns the profile's on-disk PROFILE.md if present.

--- a/internal/worker/harness.go
+++ b/internal/worker/harness.go
@@ -1,0 +1,40 @@
+package worker
+
+// A Harness is the agent CLI the container runner execs to drive a skill.
+// It owns everything that varies between claude-code and an alternative
+// agent (codex, opencode): the binary name, the argv it takes, and the
+// project-memory filename it auto-loads. The container, egress proxy and
+// workspace layout stay the same regardless of harness; only what runs
+// inside the container changes.
+//
+// The interface is grown one chunk at a time as call sites are wired to it
+// (#211). Today it covers exec argv and the profile-guide filename; later
+// chunks add stream parsing, skill staging, credentials, egress hosts and
+// exit classification.
+type Harness interface {
+	// Binary is the executable on the runner image's PATH.
+	Binary() string
+	// Args is the argv (without the binary) for one skill run. effort is
+	// the runner's configured default; globalMaxTurns is the runner's
+	// -max-turns flag. Per-scan overrides on sj win over both.
+	Args(sj SkillJob, effort string, globalMaxTurns int) []string
+	// GuideFilename is the workspace-relative path the harness auto-loads
+	// as project memory, where injectProfileGuide writes the profile's
+	// PROFILE.md. claude-code reads CLAUDE.md; codex and opencode read
+	// AGENTS.md.
+	GuideFilename() string
+}
+
+// claudeHarness is the default and (for now) only harness: it wraps the
+// existing buildClaudeArgs so behaviour is byte-for-byte unchanged. New
+// harnesses sit alongside it; LocalClaude keeps calling buildClaudeArgs
+// directly because the no-container fallback is claude-only by design.
+type claudeHarness struct{}
+
+func (claudeHarness) Binary() string { return "claude" }
+
+func (claudeHarness) Args(sj SkillJob, effort string, globalMaxTurns int) []string {
+	return buildClaudeArgs(sj, effort, globalMaxTurns)
+}
+
+func (claudeHarness) GuideFilename() string { return "CLAUDE.md" }

--- a/internal/worker/harness_test.go
+++ b/internal/worker/harness_test.go
@@ -1,0 +1,104 @@
+package worker
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestClaudeHarness_argsMatchBuildClaudeArgs(t *testing.T) {
+	// claudeHarness.Args must be byte-for-byte identical to the function
+	// it wraps so introducing the seam is a no-behaviour-change refactor.
+	// The buildClaudeArgs table tests in claude_test.go cover the argv
+	// shape; this just proves the harness delegates to them.
+	for _, sj := range []SkillJob{
+		{Name: "deep-dive", Model: "m"},
+		{Name: "deep-dive", Model: "m", AllowedTools: "Read,Write", Effort: "low", MaxTurns: 7},
+		{Name: "deep-dive", Model: "m", ResumeSessionID: "sess-1", OutputFile: "report.json"},
+	} {
+		got := claudeHarness{}.Args(sj, "high", 30)
+		want := buildClaudeArgs(sj, "high", 30)
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("claudeHarness.Args(%+v) = %v, want %v", sj, got, want)
+		}
+	}
+}
+
+func TestClaudeHarness_binaryAndGuide(t *testing.T) {
+	h := claudeHarness{}
+	if h.Binary() != "claude" {
+		t.Errorf("Binary() = %q, want claude", h.Binary())
+	}
+	if h.GuideFilename() != "CLAUDE.md" {
+		t.Errorf("GuideFilename() = %q, want CLAUDE.md", h.GuideFilename())
+	}
+}
+
+func TestContainerRunner_harnessDefaultsToClaude(t *testing.T) {
+	// The zero ContainerRunner{} must keep exec'ing claude so no caller
+	// needs to set the field until a second harness exists.
+	var d ContainerRunner
+	if _, ok := d.harness().(claudeHarness); !ok {
+		t.Errorf("zero ContainerRunner harness = %T, want claudeHarness", d.harness())
+	}
+	stub := stubHarness{bin: "codex", guide: "AGENTS.md"}
+	d = ContainerRunner{Harness: stub}
+	if d.harness() != stub {
+		t.Errorf("explicit harness not returned: got %T", d.harness())
+	}
+}
+
+// stubHarness is a test-only Harness for exercising the seam without a
+// real second implementation. The set of harnesses is open-ended; this
+// stands in for any of them.
+type stubHarness struct {
+	bin   string
+	guide string
+}
+
+func (s stubHarness) Binary() string                      { return s.bin }
+func (s stubHarness) Args(SkillJob, string, int) []string { return []string{"--stub"} }
+func (s stubHarness) GuideFilename() string               { return s.guide }
+
+func TestInjectProfileGuide_writesHarnessFilename(t *testing.T) {
+	profilesDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(profilesDir, "ruby"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := []byte("# Ruby scanning container\n")
+	if err := os.WriteFile(filepath.Join(profilesDir, "ruby", "PROFILE.md"), body, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Default harness: PROFILE.md lands at CLAUDE.md, the historical
+	// behaviour this refactor must preserve.
+	work := t.TempDir()
+	d := ContainerRunner{ProfilesDir: profilesDir}
+	d.injectProfileGuide("ruby", work, func(Event) {})
+	if got, _ := os.ReadFile(filepath.Join(work, "CLAUDE.md")); string(got) != string(body) {
+		t.Errorf("default harness wrote %q to CLAUDE.md, want %q", got, body)
+	}
+
+	// Non-claude harness: same PROFILE.md, different target filename, so
+	// codex/opencode (which read AGENTS.md) get the same orientation.
+	work = t.TempDir()
+	d = ContainerRunner{ProfilesDir: profilesDir, Harness: stubHarness{guide: "AGENTS.md"}}
+	d.injectProfileGuide("ruby", work, func(Event) {})
+	if got, _ := os.ReadFile(filepath.Join(work, "AGENTS.md")); string(got) != string(body) {
+		t.Errorf("stub harness wrote %q to AGENTS.md, want %q", got, body)
+	}
+	if _, err := os.Stat(filepath.Join(work, "CLAUDE.md")); err == nil {
+		t.Error("stub harness wrote CLAUDE.md, should only write its own GuideFilename")
+	}
+}
+
+func TestInjectProfileGuide_noopWithoutProfile(t *testing.T) {
+	work := t.TempDir()
+	ContainerRunner{ProfilesDir: t.TempDir()}.injectProfileGuide("", work, func(Event) {})
+	ContainerRunner{}.injectProfileGuide("ruby", work, func(Event) {})
+	entries, _ := os.ReadDir(work)
+	if len(entries) != 0 {
+		t.Errorf("no-profile / no-profiles-dir wrote %d files, want 0", len(entries))
+	}
+}


### PR DESCRIPTION
First step towards #211. Defines a `Harness` interface for the agent CLI the container runner execs — binary name, argv, project-memory filename — and moves the existing claude invocation behind a `claudeHarness` implementation. `ContainerRunner` gains a `Harness` field that defaults to claude when nil, so a bare `ContainerRunner{}` is unchanged and no caller needs to set it yet.

`runContainerOnce` now builds argv via the harness, and `injectProfileGuide` writes `PROFILE.md` to the harness's `GuideFilename()` instead of hardcoding `CLAUDE.md` (so a codex or opencode harness can have it land at `AGENTS.md`). Adds test coverage for `injectProfileGuide`, which had none.

`LocalClaude` stays claude-only; non-claude harnesses will require the container, per the discussion on #239.

No behaviour change: `claudeHarness.Args` delegates to the existing `buildClaudeArgs`, and every existing test passes unmodified.

Follow-ups will move `ParseStream`, skill staging, credentials/env, egress hosts and exit classification onto the interface one at a time, then add a `HarnessByName` registry and the `-backend` flag alongside the first non-claude implementation. Codex is the likely first addition given OSS maintainers are now getting Codex Pro accounts; opencode and others slot in the same way.