### PR TITLE
Move stream parsing and egress hosts onto the Harness interface

### DIFF
--- a/cmd/scrutineer/main.go
+++ b/cmd/scrutineer/main.go
@@ -141,7 +141,7 @@ func registerFlags(fs *flag.FlagSet, f *flags) {
 	fs.StringVar(&f.selinux, "selinux", "auto", "SELinux bind-mount relabeling: auto (relabel when SELinux is detected on the host), on (always), off (never). Relabeling (\":z\") lets the container read /work and write its output on enforcing-SELinux hosts")
 	fs.BoolVar(&f.noContainer, "no-container", false, "disable the containerised runner and run claude directly on the host (no isolation), even if a container runtime is available")
 	fs.BoolVar(&f.noContainer, "no-docker", false, "deprecated alias for --no-container")
-	fs.BoolVar(&f.hardened, "hardened", false, "strict sandbox mode: container runtime required (no --no-container fallback), egress restricted to *.anthropic.com + host skill API, read-only rootfs, internal network")
+	fs.BoolVar(&f.hardened, "hardened", false, "strict sandbox mode: container runtime required (no --no-container fallback), egress restricted to the harness's model API + host skill API, read-only rootfs, internal network")
 	fs.BoolVar(&f.hardenedRuntimeOnly, "hardened-runtime-only", false, "the non-network half of --hardened (read-only rootfs + no-new-privileges + 2 GiB post-clone workspace cap) WITHOUT the per-scan --internal network, so it works under rootless podman where --hardened cannot; --cap-drop ALL + non-root user + tmpfs apply regardless. Implied by --hardened")
 	fs.BoolVar(&f.hardenedRuntimeOnly, "hardened-rootless-runtime", false, "deprecated alias for --hardened-runtime-only")
 	fs.StringVar(&f.runnerImage, "runner-image", worker.DefaultRunnerImage, "container image for per-job containers (a custom image needs curl, and under rootless --hardened the scrutineer binary for the egress sidecar; build from Dockerfile.runner)")
@@ -652,8 +652,13 @@ func setupRunner(f *flags, cfg *config.Config, log *slog.Logger) (worker.SkillRu
 	if err != nil {
 		return nil, "", err
 	}
+	// The harness is resolved here, before the egress allowlist, so its
+	// model-API hosts are on the proxy from the start. With no -backend
+	// flag yet (#211) it is always claude; once the flag exists this
+	// becomes a name lookup and nothing downstream changes.
+	h := worker.ClaudeHarness{}
 	var egress worker.EgressSidecarConfig
-	allow := buildEgressAllow(f.hardened, cfg, f.anthropicBaseURL, log)
+	allow := buildEgressAllow(h.EgressHosts(), f.hardened, cfg, f.anthropicBaseURL, log)
 	if apiHost != worker.HostGatewayAlias {
 		allow = append(allow, apiHost)
 	}
@@ -688,6 +693,7 @@ func setupRunner(f *flags, cfg *config.Config, log *slog.Logger) (worker.SkillRu
 	return worker.ContainerRunner{
 		Image:               f.runnerImage,
 		Effort:              f.effort,
+		Harness:             h,
 		ProxyURL:            worker.ProxyURLForHost(token, apiHost, port),
 		FullClone:           f.fullClone(),
 		MaxTurns:            f.maxTurns,
@@ -783,12 +789,13 @@ func resolveEgressSidecar(rt worker.ContainerRuntime, f *flags, allow []string, 
 	return worker.EgressSidecarConfig{Token: token, Allow: allow, APIPort: addrPort(f.addr), GatewayIP: egressGwIP}, nil
 }
 
-// buildEgressAllow assembles the proxy allowlist. Hardened mode starts
-// from HardenedEgressAllow and ignores cfg.EgressAllow (the operator
-// must drop --hardened to widen). The anthropic base URL host is still
-// auto-added in both modes since it routes the same Anthropic API.
-func buildEgressAllow(hardened bool, cfg *config.Config, anthropicBaseURL string, log *slog.Logger) []string {
-	var allow []string
+// buildEgressAllow assembles the proxy allowlist: the harness's
+// model-API hosts first, then the harness-neutral base. Hardened mode
+// starts from HardenedEgressAllow and ignores cfg.EgressAllow (the
+// operator must drop --hardened to widen). The anthropic base URL host
+// is still auto-added in both modes since it routes the same model API.
+func buildEgressAllow(harnessHosts []string, hardened bool, cfg *config.Config, anthropicBaseURL string, log *slog.Logger) []string {
+	allow := append([]string{}, harnessHosts...)
 	if hardened {
 		allow = append(allow, worker.HardenedEgressAllow...)
 		if cfg != nil && len(cfg.EgressAllow) > 0 {

--- a/cmd/scrutineer/main_test.go
+++ b/cmd/scrutineer/main_test.go
@@ -195,8 +195,11 @@ func TestFlagsMerge_hardenedRuntimeOnlyConfigAlias(t *testing.T) {
 
 func TestBuildEgressAllow_defaultIncludesConfigAndAnthropicHost(t *testing.T) {
 	cfg := &config.Config{EgressAllow: []string{"artifactory.internal", "*.mycorp.net"}}
-	allow := buildEgressAllow(false, cfg, "https://proxy.corp.com/v1", quietLog())
+	allow := buildEgressAllow(worker.ClaudeHarness{}.EgressHosts(), false, cfg, "https://proxy.corp.com/v1", quietLog())
 
+	if !slices.Contains(allow, "*.anthropic.com") {
+		t.Errorf("default mode dropped harness egress hosts: %v", allow)
+	}
 	if !slices.Contains(allow, "*.ecosyste.ms") {
 		t.Errorf("default mode dropped DefaultEgressAllow entries: %v", allow)
 	}
@@ -208,9 +211,9 @@ func TestBuildEgressAllow_defaultIncludesConfigAndAnthropicHost(t *testing.T) {
 	}
 }
 
-func TestBuildEgressAllow_hardenedDropsConfigKeepsAnthropic(t *testing.T) {
+func TestBuildEgressAllow_hardenedDropsConfigKeepsHarness(t *testing.T) {
 	cfg := &config.Config{EgressAllow: []string{"artifactory.internal"}}
-	allow := buildEgressAllow(true, cfg, "https://proxy.corp.com/v1", quietLog())
+	allow := buildEgressAllow(worker.ClaudeHarness{}.EgressHosts(), true, cfg, "https://proxy.corp.com/v1", quietLog())
 
 	if slices.Contains(allow, "*.ecosyste.ms") {
 		t.Errorf("hardened leaked DefaultEgressAllow entries: %v", allow)
@@ -218,7 +221,10 @@ func TestBuildEgressAllow_hardenedDropsConfigKeepsAnthropic(t *testing.T) {
 	if slices.Contains(allow, "artifactory.internal") {
 		t.Errorf("hardened honoured egress_allow when it must not: %v", allow)
 	}
-	if !slices.Contains(allow, "*.anthropic.com") || !slices.Contains(allow, worker.HostGatewayAlias) {
+	if !slices.Contains(allow, "*.anthropic.com") {
+		t.Errorf("hardened did not include the harness egress hosts: %v", allow)
+	}
+	if !slices.Contains(allow, worker.HostGatewayAlias) {
 		t.Errorf("hardened did not include HardenedEgressAllow entries: %v", allow)
 	}
 	if !slices.Contains(allow, "proxy.corp.com") {
@@ -227,9 +233,22 @@ func TestBuildEgressAllow_hardenedDropsConfigKeepsAnthropic(t *testing.T) {
 }
 
 func TestBuildEgressAllow_hardenedNilConfig(t *testing.T) {
-	allow := buildEgressAllow(true, nil, "", quietLog())
-	if len(allow) != len(worker.HardenedEgressAllow) {
-		t.Errorf("hardened minimal allow = %v, want exactly HardenedEgressAllow", allow)
+	harnessHosts := worker.ClaudeHarness{}.EgressHosts()
+	allow := buildEgressAllow(harnessHosts, true, nil, "", quietLog())
+	if len(allow) != len(harnessHosts)+len(worker.HardenedEgressAllow) {
+		t.Errorf("hardened minimal allow = %v, want exactly harness hosts + HardenedEgressAllow", allow)
+	}
+}
+
+func TestBuildEgressAllow_nonClaudeHarnessExcludesAnthropic(t *testing.T) {
+	// A non-claude harness must not inherit *.anthropic.com from the
+	// static lists; only the hosts it declares are added.
+	allow := buildEgressAllow([]string{"api.openai.com"}, true, nil, "", quietLog())
+	if slices.Contains(allow, "*.anthropic.com") {
+		t.Errorf("non-claude harness allowlist still contains anthropic: %v", allow)
+	}
+	if !slices.Contains(allow, "api.openai.com") {
+		t.Errorf("non-claude harness hosts not included: %v", allow)
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -49,8 +49,8 @@ type Config struct {
 	// write its output. Non-SELinux hosts are unaffected. See docs/podman.md.
 	SELinux string `yaml:"selinux"`
 	// Hardened enforces the strictest sandbox mode: a container runtime is
-	// required (no --no-container fallback), egress is restricted to
-	// *.anthropic.com plus the runtime's host endpoint, the container rootfs is
+	// required (no --no-container fallback), egress is restricted to the
+	// harness's model API plus the runtime's host endpoint, the container rootfs is
 	// read-only, and the runner attaches to an internal network whose only route
 	// out is scrutineer's allowlisting proxy. egress_allow is ignored under
 	// hardened mode; the operator must drop hardened to widen it.

--- a/internal/worker/container.go
+++ b/internal/worker/container.go
@@ -341,7 +341,7 @@ func (d ContainerRunner) runContainerOnce(ctx context.Context, runBase []string,
 		}
 		emit(e)
 	}
-	ParseStream(stdout, wrappedEmit)
+	h.ParseStream(stdout, wrappedEmit)
 	waitErr = cmd.Wait()
 	if cmd.Process != nil {
 		_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGTERM)
@@ -569,7 +569,7 @@ func (d ContainerRunner) harness() Harness { //nolint:ireturn // nil-default acc
 	if d.Harness != nil {
 		return d.Harness
 	}
-	return claudeHarness{}
+	return ClaudeHarness{}
 }
 
 // profileGuidePath returns the profile's on-disk PROFILE.md if present.

--- a/internal/worker/egress.go
+++ b/internal/worker/egress.go
@@ -23,27 +23,26 @@ import (
 // callers pass that host through EgressProxy.APIHosts.
 const HostGatewayAlias = "host.docker.internal"
 
-// HardenedEgressAllow is the strict allowlist used when --hardened is
-// set. Only the Anthropic API and the host skill API (reached through
-// host.docker.internal) are permitted; anything else returns 403 at
-// the proxy. Skills that need ecosyste.ms or a package registry must
-// route through the host API, or the operator must drop hardened mode.
+// HardenedEgressAllow is the strict harness-neutral allowlist used when
+// --hardened is set. Only the host skill API (reached through
+// host.docker.internal) is permitted; the harness's model-API hosts
+// (Harness.EgressHosts) are appended at startup so the agent can talk to
+// its provider, and anything else returns 403 at the proxy. Skills that
+// need ecosyste.ms or a package registry must route through the host
+// API, or the operator must drop hardened mode.
 var HardenedEgressAllow = []string{
-	"*.anthropic.com",
 	HostGatewayAlias,
 }
 
-// DefaultEgressAllow is the built-in host allowlist for the container
-// runner's egress proxy. It covers what the bundled skills actually
-// reach: the Anthropic API, ecosyste.ms services, the major code forges,
-// the package registries those forges publish to, and the advisory
-// sources the security skills consult. Entries are matched
+// DefaultEgressAllow is the built-in harness-neutral host allowlist for
+// the container runner's egress proxy. It covers what the bundled skills
+// actually reach: ecosyste.ms services, the major code forges, the
+// package registries those forges publish to, and the advisory sources
+// the security skills consult. The harness's model-API hosts
+// (Harness.EgressHosts) are appended at startup. Entries are matched
 // case-insensitively against the CONNECT/request host with the port
 // stripped; a leading "*." matches any subdomain.
 var DefaultEgressAllow = []string{
-	// model
-	"*.anthropic.com",
-
 	// scrutineer skill API on the host
 	HostGatewayAlias,
 

--- a/internal/worker/egress_test.go
+++ b/internal/worker/egress_test.go
@@ -21,16 +21,19 @@ func quietLog() *slog.Logger {
 }
 
 func TestHardenedEgressAllow_minimalSurface(t *testing.T) {
-	// HardenedEgressAllow must allow Anthropic and the host skill API,
-	// and reject every host that DefaultEgressAllow opens up. Adding a
-	// new entry here is a deliberate widening of the hardened surface
-	// and should not happen accidentally.
+	// HardenedEgressAllow is harness-neutral: it must allow only the
+	// host skill API. The harness's own model-API hosts (e.g.
+	// *.anthropic.com for claude) are layered on at startup, so they
+	// must NOT appear in the static list -- a non-claude harness would
+	// otherwise inherit anthropic by accident. Adding a new entry here
+	// is a deliberate widening of the hardened surface and should not
+	// happen accidentally.
 	allow := HardenedEgressAllow
-	if !HostAllowed(allow, "api.anthropic.com") {
-		t.Errorf("hardened blocked api.anthropic.com")
-	}
 	if !HostAllowed(allow, HostGatewayAlias) {
 		t.Errorf("hardened blocked %s", HostGatewayAlias)
+	}
+	if HostAllowed(allow, "api.anthropic.com") {
+		t.Errorf("hardened static list still contains anthropic; that belongs in ClaudeHarness.EgressHosts")
 	}
 	for _, host := range []string{
 		"packages.ecosyste.ms",
@@ -495,8 +498,11 @@ func TestProxyURLForEndpointShape(t *testing.T) {
 }
 
 func TestDefaultEgressAllowCoversSkillHosts(t *testing.T) {
+	// DefaultEgressAllow is harness-neutral; the model-API hosts come
+	// from Harness.EgressHosts and are layered on at startup. This test
+	// covers the static list only -- api.anthropic.com belonging in the
+	// claude harness is asserted by TestClaudeHarness_binaryGuideEgress.
 	for _, h := range []string{
-		"api.anthropic.com",
 		"packages.ecosyste.ms",
 		"repos.ecosyste.ms",
 		"advisories.ecosyste.ms",

--- a/internal/worker/harness.go
+++ b/internal/worker/harness.go
@@ -1,16 +1,17 @@
 package worker
 
+import "io"
+
 // A Harness is the agent CLI the container runner execs to drive a skill.
 // It owns everything that varies between claude-code and an alternative
-// agent (codex, opencode): the binary name, the argv it takes, and the
-// project-memory filename it auto-loads. The container, egress proxy and
+// agent (codex, opencode, ...): the binary name, the argv it takes, the
+// output format it streams, the project-memory filename it auto-loads,
+// and the model-API hosts it must reach. The container, egress proxy and
 // workspace layout stay the same regardless of harness; only what runs
 // inside the container changes.
 //
-// The interface is grown one chunk at a time as call sites are wired to it
-// (#211). Today it covers exec argv and the profile-guide filename; later
-// chunks add stream parsing, skill staging, credentials, egress hosts and
-// exit classification.
+// The interface is grown incrementally as call sites are wired to it
+// (#211). Skill staging, credentials and exit classification follow.
 type Harness interface {
 	// Binary is the executable on the runner image's PATH.
 	Binary() string
@@ -18,23 +19,42 @@ type Harness interface {
 	// the runner's configured default; globalMaxTurns is the runner's
 	// -max-turns flag. Per-scan overrides on sj win over both.
 	Args(sj SkillJob, effort string, globalMaxTurns int) []string
+	// ParseStream reads the harness's combined stdout/stderr and emits one
+	// Event per logical line. The Event vocabulary (KindText, KindTool,
+	// KindSession, KindError, ...) is harness-neutral; this method maps
+	// the harness's own output format onto it so the scan log, session
+	// capture and max-turns detection work the same regardless of agent.
+	ParseStream(r io.Reader, emit func(Event))
 	// GuideFilename is the workspace-relative path the harness auto-loads
 	// as project memory, where injectProfileGuide writes the profile's
 	// PROFILE.md. claude-code reads CLAUDE.md; codex and opencode read
 	// AGENTS.md.
 	GuideFilename() string
+	// EgressHosts is the model-API hostnames the harness must reach, in
+	// the same wildcard form as DefaultEgressAllow. They are appended to
+	// the egress proxy's allowlist at startup so the agent inside the
+	// container can talk to its provider; the static allowlists are
+	// harness-neutral and contain none of these.
+	EgressHosts() []string
 }
 
-// claudeHarness is the default and (for now) only harness: it wraps the
-// existing buildClaudeArgs so behaviour is byte-for-byte unchanged. New
-// harnesses sit alongside it; LocalClaude keeps calling buildClaudeArgs
-// directly because the no-container fallback is claude-only by design.
-type claudeHarness struct{}
+// ClaudeHarness is the default and (for now) only harness: it wraps the
+// existing buildClaudeArgs and ParseStream so behaviour is byte-for-byte
+// unchanged. Other harnesses (codex, opencode, ...) sit alongside it;
+// LocalClaude keeps calling those functions directly because the
+// no-container fallback is claude-only by design.
+type ClaudeHarness struct{}
 
-func (claudeHarness) Binary() string { return "claude" }
+func (ClaudeHarness) Binary() string { return "claude" }
 
-func (claudeHarness) Args(sj SkillJob, effort string, globalMaxTurns int) []string {
+func (ClaudeHarness) Args(sj SkillJob, effort string, globalMaxTurns int) []string {
 	return buildClaudeArgs(sj, effort, globalMaxTurns)
 }
 
-func (claudeHarness) GuideFilename() string { return "CLAUDE.md" }
+func (ClaudeHarness) ParseStream(r io.Reader, emit func(Event)) {
+	ParseStream(r, emit)
+}
+
+func (ClaudeHarness) GuideFilename() string { return "CLAUDE.md" }
+
+func (ClaudeHarness) EgressHosts() []string { return []string{"*.anthropic.com"} }

--- a/internal/worker/harness_test.go
+++ b/internal/worker/harness_test.go
@@ -1,14 +1,16 @@
 package worker
 
 import (
+	"io"
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 )
 
 func TestClaudeHarness_argsMatchBuildClaudeArgs(t *testing.T) {
-	// claudeHarness.Args must be byte-for-byte identical to the function
+	// ClaudeHarness.Args must be byte-for-byte identical to the function
 	// it wraps so introducing the seam is a no-behaviour-change refactor.
 	// The buildClaudeArgs table tests in claude_test.go cover the argv
 	// shape; this just proves the harness delegates to them.
@@ -17,21 +19,41 @@ func TestClaudeHarness_argsMatchBuildClaudeArgs(t *testing.T) {
 		{Name: "deep-dive", Model: "m", AllowedTools: "Read,Write", Effort: "low", MaxTurns: 7},
 		{Name: "deep-dive", Model: "m", ResumeSessionID: "sess-1", OutputFile: "report.json"},
 	} {
-		got := claudeHarness{}.Args(sj, "high", 30)
+		got := ClaudeHarness{}.Args(sj, "high", 30)
 		want := buildClaudeArgs(sj, "high", 30)
 		if !reflect.DeepEqual(got, want) {
-			t.Errorf("claudeHarness.Args(%+v) = %v, want %v", sj, got, want)
+			t.Errorf("ClaudeHarness.Args(%+v) = %v, want %v", sj, got, want)
 		}
 	}
 }
 
-func TestClaudeHarness_binaryAndGuide(t *testing.T) {
-	h := claudeHarness{}
+func TestClaudeHarness_parseStreamMatchesParseStream(t *testing.T) {
+	// Same delegation guarantee for the stream parser: the harness
+	// method must emit exactly what the package function does, so the
+	// scan log, session capture and max-turns signal are unchanged.
+	in := `{"type":"system","subtype":"init","session_id":"sess-1"}
+{"type":"assistant","message":{"content":[{"type":"text","text":"hello"}]}}
+not json
+`
+	var viaHarness, viaFunc []Event
+	ClaudeHarness{}.ParseStream(strings.NewReader(in), func(e Event) { viaHarness = append(viaHarness, e) })
+	ParseStream(strings.NewReader(in), func(e Event) { viaFunc = append(viaFunc, e) })
+	if !reflect.DeepEqual(viaHarness, viaFunc) {
+		t.Errorf("ClaudeHarness.ParseStream emitted %v, want %v", viaHarness, viaFunc)
+	}
+}
+
+func TestClaudeHarness_binaryGuideEgress(t *testing.T) {
+	h := ClaudeHarness{}
 	if h.Binary() != "claude" {
 		t.Errorf("Binary() = %q, want claude", h.Binary())
 	}
 	if h.GuideFilename() != "CLAUDE.md" {
 		t.Errorf("GuideFilename() = %q, want CLAUDE.md", h.GuideFilename())
+	}
+	want := []string{"*.anthropic.com"}
+	if got := h.EgressHosts(); !reflect.DeepEqual(got, want) {
+		t.Errorf("EgressHosts() = %v, want %v", got, want)
 	}
 }
 
@@ -39,12 +61,12 @@ func TestContainerRunner_harnessDefaultsToClaude(t *testing.T) {
 	// The zero ContainerRunner{} must keep exec'ing claude so no caller
 	// needs to set the field until a second harness exists.
 	var d ContainerRunner
-	if _, ok := d.harness().(claudeHarness); !ok {
-		t.Errorf("zero ContainerRunner harness = %T, want claudeHarness", d.harness())
+	if _, ok := d.harness().(ClaudeHarness); !ok {
+		t.Errorf("zero ContainerRunner harness = %T, want ClaudeHarness", d.harness())
 	}
 	stub := stubHarness{bin: "codex", guide: "AGENTS.md"}
 	d = ContainerRunner{Harness: stub}
-	if d.harness() != stub {
+	if got, ok := d.harness().(stubHarness); !ok || !reflect.DeepEqual(got, stub) {
 		t.Errorf("explicit harness not returned: got %T", d.harness())
 	}
 }
@@ -53,13 +75,16 @@ func TestContainerRunner_harnessDefaultsToClaude(t *testing.T) {
 // real second implementation. The set of harnesses is open-ended; this
 // stands in for any of them.
 type stubHarness struct {
-	bin   string
-	guide string
+	bin    string
+	guide  string
+	egress []string
 }
 
 func (s stubHarness) Binary() string                      { return s.bin }
 func (s stubHarness) Args(SkillJob, string, int) []string { return []string{"--stub"} }
+func (s stubHarness) ParseStream(io.Reader, func(Event))  {}
 func (s stubHarness) GuideFilename() string               { return s.guide }
+func (s stubHarness) EgressHosts() []string               { return s.egress }
 
 func TestInjectProfileGuide_writesHarnessFilename(t *testing.T) {
 	profilesDir := t.TempDir()


### PR DESCRIPTION
Continues #211, follows #529.

Adds `ParseStream` and `EgressHosts` to the `Harness` interface and exports `ClaudeHarness` so `main.go` can construct it.

`runContainerOnce` now reads the agent's output via `h.ParseStream`; `ClaudeHarness` delegates to the existing package-level `ParseStream`, so behaviour is unchanged. `LocalClaude` keeps calling that function directly since the no-container fallback is claude-only.

`*.anthropic.com` is pulled out of `DefaultEgressAllow` and `HardenedEgressAllow`; both static lists are now harness-neutral. `setupRunner` constructs the harness before building the egress allowlist and passes `h.EgressHosts()` as the first segment, so the assembled list is identical to before for claude while a non-claude harness no longer inherits anthropic by accident. The `-hardened` flag help and `config.Hardened` comment are reworded to match.

New tests: the `ParseStream` delegation emits identically to the package function, the static lists no longer carry anthropic, and a harness declaring `api.openai.com` gets exactly that and not anthropic.

Next: skill staging (`.claude/skills/` vs prompt-inlined) and credentials/env onto the interface, then the `-backend` flag and harness-by-name lookup alongside the first non-claude implementation.