### PR TITLE
Move container env onto the Harness interface

### DIFF
--- a/internal/worker/container.go
+++ b/internal/worker/container.go
@@ -372,21 +372,16 @@ func (d ContainerRunner) buildRunArgs(absWork, image string, hnet hardenedNet, c
 		"--cap-drop", "ALL",
 		"--user", fmt.Sprintf("%d:%d", os.Getuid(), os.Getgid()),
 		"-e", "HOME=/tmp",
-		"-e", "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1",
-		// Suppress telemetry traffic
-		// Denied by the egress proxy anyway, but noisy in the log.
-		"-e", "OTEL_SDK_DISABLED=true",
-		"-e", "DISABLE_TELEMETRY=1",
-		"-e", "DISABLE_ERROR_REPORTING=1",
-		"-e", "DISABLE_BUG_COMMAND=1",
-		"-e", "DISABLE_AUTOUPDATER=1",
-		// Disable auxiliary calls not useful in headless mode
-		"-e", "DISABLE_NON_ESSENTIAL_MODEL_CALLS=1",
 		"-e", "SEMGREP_SEND_METRICS=off",
 		"--tmpfs", "/tmp:rw,noexec,nosuid,size=256m",
 		"-v", bindMount(absWork, "/work", d.SELinuxRelabel),
 		"-w", "/work",
 	)
+	// Harness-specific env: model-API credential, base URL, and the
+	// harness's own telemetry / autoupdate suppressors.
+	for _, e := range d.harness().Env(d.AnthropicBaseURL) {
+		args = append(args, "-e", e)
+	}
 	if d.Runtime.supportsHostGatewayAddHost() {
 		args = append(args, "--add-host", HostGatewayAlias+":"+gwTarget)
 	}
@@ -458,18 +453,6 @@ func (d ContainerRunner) buildRunArgs(absWork, image string, hnet hardenedNet, c
 		)
 	} else if !d.Hardened {
 		args = append(args, "--network", "none")
-	}
-	// Forwarding the host Anthropic credential into the container is a known
-	// residual: in-container code (T1) can read it. Closing it needs proxy-side
-	// credential injection -- see threatmodel.md T1/T13.
-	if os.Getenv("ANTHROPIC_API_KEY") != "" {
-		args = append(args, "-e", "ANTHROPIC_API_KEY")
-	}
-	if os.Getenv("CLAUDE_CODE_OAUTH_TOKEN") != "" {
-		args = append(args, "-e", "CLAUDE_CODE_OAUTH_TOKEN")
-	}
-	if d.AnthropicBaseURL != "" {
-		args = append(args, "-e", "ANTHROPIC_BASE_URL="+d.AnthropicBaseURL)
 	}
 	return append(args, "--", image)
 }

--- a/internal/worker/harness.go
+++ b/internal/worker/harness.go
@@ -1,6 +1,9 @@
 package worker
 
-import "io"
+import (
+	"io"
+	"os"
+)
 
 // A Harness is the agent CLI the container runner execs to drive a skill.
 // It owns everything that varies between claude-code and an alternative
@@ -11,7 +14,7 @@ import "io"
 // inside the container changes.
 //
 // The interface is grown incrementally as call sites are wired to it
-// (#211). Skill staging, credentials and exit classification follow.
+// (#211). Skill staging and exit classification follow.
 type Harness interface {
 	// Binary is the executable on the runner image's PATH.
 	Binary() string
@@ -36,6 +39,14 @@ type Harness interface {
 	// container can talk to its provider; the static allowlists are
 	// harness-neutral and contain none of these.
 	EgressHosts() []string
+	// Env returns the harness-specific environment for the container, in
+	// docker -e form: a bare "KEY" passes the host value through, and
+	// "KEY=VALUE" sets it explicitly. Covers the model-API credential and
+	// the harness's own telemetry / autoupdate suppressors. baseURL is the
+	// operator's model-API base-URL override (-anthropic-base-url today);
+	// "" means none. Harness-neutral env (HOME, the proxy vars, semgrep)
+	// stays in buildRunArgs.
+	Env(baseURL string) []string
 }
 
 // ClaudeHarness is the default and (for now) only harness: it wraps the
@@ -58,3 +69,32 @@ func (ClaudeHarness) ParseStream(r io.Reader, emit func(Event)) {
 func (ClaudeHarness) GuideFilename() string { return "CLAUDE.md" }
 
 func (ClaudeHarness) EgressHosts() []string { return []string{"*.anthropic.com"} }
+
+func (ClaudeHarness) Env(baseURL string) []string {
+	env := []string{
+		// claude-code's own opt-outs: telemetry, autoupdate, bug command,
+		// and the non-essential model calls (haiku title generation etc.)
+		// that a headless run does not need. Denied by the egress proxy
+		// anyway, but suppressing them keeps the scan log quiet.
+		"CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1",
+		"OTEL_SDK_DISABLED=true",
+		"DISABLE_TELEMETRY=1",
+		"DISABLE_ERROR_REPORTING=1",
+		"DISABLE_BUG_COMMAND=1",
+		"DISABLE_AUTOUPDATER=1",
+		"DISABLE_NON_ESSENTIAL_MODEL_CALLS=1",
+	}
+	// Forwarding the host credential into the container is a known
+	// residual: in-container code (T1) can read it. Closing it needs
+	// proxy-side credential injection -- see threatmodel.md T1/T13.
+	if os.Getenv("ANTHROPIC_API_KEY") != "" {
+		env = append(env, "ANTHROPIC_API_KEY")
+	}
+	if os.Getenv("CLAUDE_CODE_OAUTH_TOKEN") != "" {
+		env = append(env, "CLAUDE_CODE_OAUTH_TOKEN")
+	}
+	if baseURL != "" {
+		env = append(env, "ANTHROPIC_BASE_URL="+baseURL)
+	}
+	return env
+}

--- a/internal/worker/harness_test.go
+++ b/internal/worker/harness_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -78,6 +79,7 @@ type stubHarness struct {
 	bin    string
 	guide  string
 	egress []string
+	env    []string
 }
 
 func (s stubHarness) Binary() string                      { return s.bin }
@@ -85,6 +87,107 @@ func (s stubHarness) Args(SkillJob, string, int) []string { return []string{"--s
 func (s stubHarness) ParseStream(io.Reader, func(Event))  {}
 func (s stubHarness) GuideFilename() string               { return s.guide }
 func (s stubHarness) EgressHosts() []string               { return s.egress }
+func (s stubHarness) Env(string) []string                 { return s.env }
+
+func TestClaudeHarness_Env(t *testing.T) {
+	// With both credentials set on the host and a base URL, Env must
+	// pass both through (bare KEY) and set the base URL explicitly,
+	// alongside the fixed telemetry suppressors.
+	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "oat-test")
+	got := ClaudeHarness{}.Env("https://proxy.corp.com/v1")
+	for _, want := range []string{
+		"CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1",
+		"OTEL_SDK_DISABLED=true",
+		"DISABLE_TELEMETRY=1",
+		"DISABLE_ERROR_REPORTING=1",
+		"DISABLE_BUG_COMMAND=1",
+		"DISABLE_AUTOUPDATER=1",
+		"DISABLE_NON_ESSENTIAL_MODEL_CALLS=1",
+		"ANTHROPIC_API_KEY",
+		"CLAUDE_CODE_OAUTH_TOKEN",
+		"ANTHROPIC_BASE_URL=https://proxy.corp.com/v1",
+	} {
+		if !slices.Contains(got, want) {
+			t.Errorf("Env() missing %q: %v", want, got)
+		}
+	}
+}
+
+func TestClaudeHarness_EnvOmitsUnsetCredentials(t *testing.T) {
+	// docker -e KEY (bare) reads the host value at run time; when the
+	// host has none, passing the bare key would clear an inherited value
+	// and is just noise. Env must omit credentials the host does not set,
+	// and omit the base URL when none is configured.
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "")
+	got := ClaudeHarness{}.Env("")
+	for _, absent := range []string{"ANTHROPIC_API_KEY", "CLAUDE_CODE_OAUTH_TOKEN"} {
+		if slices.Contains(got, absent) {
+			t.Errorf("Env() included unset credential %q: %v", absent, got)
+		}
+	}
+	for _, e := range got {
+		if strings.HasPrefix(e, "ANTHROPIC_BASE_URL=") {
+			t.Errorf("Env() set base URL with none configured: %v", got)
+		}
+	}
+}
+
+func TestBuildRunArgs_includesHarnessEnv(t *testing.T) {
+	// The harness's Env() entries land on the container command line
+	// each as its own `-e <entry>` pair, and a non-claude harness
+	// contributes only its own keys -- nothing claude-specific leaks
+	// from buildRunArgs itself.
+	d := ContainerRunner{Harness: stubHarness{env: []string{"OPENAI_API_KEY", "STUB_OPT=1"}}}
+	got := d.buildRunArgs("/work/abs", "img:latest", hardenedNet{}, "")
+
+	if !containsEnvFlag(got, "OPENAI_API_KEY") || !containsEnvFlag(got, "STUB_OPT=1") {
+		t.Errorf("harness env not wired into run args: %v", got)
+	}
+	for _, leaked := range []string{
+		"ANTHROPIC_API_KEY", "CLAUDE_CODE_OAUTH_TOKEN",
+		"CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1", "DISABLE_AUTOUPDATER=1",
+	} {
+		if containsEnvFlag(got, leaked) {
+			t.Errorf("non-claude harness leaked claude env %q: %v", leaked, got)
+		}
+	}
+	// Harness-neutral env stays put regardless of harness.
+	if !containsEnvFlag(got, "HOME=/tmp") || !containsEnvFlag(got, "SEMGREP_SEND_METRICS=off") {
+		t.Errorf("harness-neutral env dropped: %v", got)
+	}
+}
+
+func TestBuildRunArgs_defaultHarnessKeepsClaudeEnv(t *testing.T) {
+	// The zero ContainerRunner{} (no Harness set) must keep producing
+	// the claude env it always has, so this refactor is no behaviour
+	// change for existing deployments.
+	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+	d := ContainerRunner{AnthropicBaseURL: "https://proxy.corp.com/v1"}
+	got := d.buildRunArgs("/work/abs", "img:latest", hardenedNet{}, "")
+	for _, want := range []string{
+		"ANTHROPIC_API_KEY",
+		"ANTHROPIC_BASE_URL=https://proxy.corp.com/v1",
+		"CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1",
+		"DISABLE_AUTOUPDATER=1",
+	} {
+		if !containsEnvFlag(got, want) {
+			t.Errorf("default harness dropped claude env %q: %v", want, got)
+		}
+	}
+}
+
+// containsEnvFlag reports whether the docker/podman argv s carries the
+// pair `-e entry`. Adjacency matters: `-e A -e B` must not match `-e B A`.
+func containsEnvFlag(s []string, entry string) bool {
+	for i := 0; i+1 < len(s); i++ {
+		if s[i] == "-e" && s[i+1] == entry {
+			return true
+		}
+	}
+	return false
+}
 
 func TestInjectProfileGuide_writesHarnessFilename(t *testing.T) {
 	profilesDir := t.TempDir()


### PR DESCRIPTION
Continues #211, follows #530.

Adds `Env(baseURL string) []string` to `Harness` so the model-API credential, base URL, and the harness's own telemetry/autoupdate suppressors come from the harness rather than being hardcoded in `buildRunArgs`. Entries are in docker `-e` form: bare `KEY` passes the host value through, `KEY=VALUE` sets it.

`ClaudeHarness.Env` returns the seven claude-code suppressors (`CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC`, `DISABLE_TELEMETRY`, `DISABLE_AUTOUPDATER`, ...) plus `ANTHROPIC_API_KEY` / `CLAUDE_CODE_OAUTH_TOKEN` (passthrough when set on the host) and `ANTHROPIC_BASE_URL` when configured. The T1/T13 threat-model comment moves with the credential passthrough. `buildRunArgs` loops the harness env into `-e` flags. `HOME=/tmp` and `SEMGREP_SEND_METRICS=off` stay harness-neutral.

`CLAUDE_CONFIG_DIR` is left in place for now since it's coupled to a bind mount and the session-resume mechanism; that's its own seam.

The default container argv carries the same `-e` flags as before in a slightly different order (harness env now follows the bind mount instead of being interleaved). New tests prove the zero `ContainerRunner{}` is unchanged and a non-claude harness contributes only its own keys with no claude leakage.

Next: skill staging (`.claude/skills/` path), which needs a decision on how non-claude harnesses receive SKILL.md — inlined into the prompt vs appended to AGENTS.md.