### PR TITLE
Move skill staging path onto the Harness interface

### DIFF
--- a/internal/worker/claude.go
+++ b/internal/worker/claude.go
@@ -30,6 +30,11 @@ func (MaxTurnsReachedError) Error() string { return "hit max turns cap" }
 // substitute the process launch without touching the queue plumbing.
 type SkillRunner interface {
 	RunSkill(ctx context.Context, sj SkillJob, emit func(Event)) (SkillResult, error)
+	// SkillDir is where the worker stages SKILL.md/schema.json before
+	// calling RunSkill, so the runner's harness discovers it. The path
+	// varies per harness (.claude/skills/{name}, skills/{name},
+	// .opencode/skill/{name}); the staged content does not.
+	SkillDir(workRoot, name string) string
 }
 
 // SkillJob is a scan driven by an on-disk claude-code skill. The runner
@@ -108,6 +113,12 @@ type LocalClaude struct {
 	Effort    string
 	FullClone bool
 	MaxTurns  int
+}
+
+// SkillDir is fixed at claude's discovery path: the no-container
+// fallback is claude-only by design.
+func (LocalClaude) SkillDir(workRoot, name string) string {
+	return ClaudeHarness{}.SkillDir(workRoot, name)
 }
 
 // RunSkill runs claude against a staged skill in a local workspace. The

--- a/internal/worker/container.go
+++ b/internal/worker/container.go
@@ -545,6 +545,12 @@ func (d ContainerRunner) injectProfileGuide(profile, absWork string, emit func(E
 	emit(Event{Kind: KindText, Text: "profile guide: " + guide + " -> /work/" + name})
 }
 
+// SkillDir delegates to the harness so the worker stages SKILL.md
+// where this runner's agent CLI will discover it.
+func (d ContainerRunner) SkillDir(workRoot, name string) string {
+	return d.harness().SkillDir(workRoot, name)
+}
+
 // harness returns the agent CLI to exec inside the container, defaulting
 // to claude-code when none is set so the zero ContainerRunner{} keeps its
 // historical behaviour.

--- a/internal/worker/exposure.go
+++ b/internal/worker/exposure.go
@@ -162,7 +162,7 @@ func (w *Worker) doExposure(ctx context.Context, scan *db.Scan, emit func(Event)
 		return "", fmt.Errorf("apply path filters: %w", err)
 	}
 
-	skillDir := filepath.Join(workRoot, ".claude", "skills", skill.Name)
+	skillDir := w.Runner.SkillDir(workRoot, skill.Name)
 	if err := stageContext(workRoot, w.APIBase, w.ForkOrg, w.metadataDir(), scan, &scan.Repository); err != nil {
 		return "", fmt.Errorf("stage context: %w", err)
 	}

--- a/internal/worker/harness.go
+++ b/internal/worker/harness.go
@@ -3,6 +3,7 @@ package worker
 import (
 	"io"
 	"os"
+	"path/filepath"
 )
 
 // A Harness is the agent CLI the container runner execs to drive a skill.
@@ -14,7 +15,7 @@ import (
 // inside the container changes.
 //
 // The interface is grown incrementally as call sites are wired to it
-// (#211). Skill staging and exit classification follow.
+// (#211). Exit classification follows.
 type Harness interface {
 	// Binary is the executable on the runner image's PATH.
 	Binary() string
@@ -28,6 +29,15 @@ type Harness interface {
 	// the harness's own output format onto it so the scan log, session
 	// capture and max-turns detection work the same regardless of agent.
 	ParseStream(r io.Reader, emit func(Event))
+	// SkillDir is the directory under workRoot where stageSkill writes
+	// SKILL.md, schema.json, and the skill's auxiliary files so this
+	// harness's own discovery picks them up. All three current harnesses
+	// look for a file literally named SKILL.md and follow symlinks, so
+	// only the directory differs: claude reads .claude/skills/{name},
+	// codex reads skills/{name}, opencode reads .opencode/skill/{name}.
+	// The activation prompt that points the agent at the skill is the
+	// harness's own concern, inside Args.
+	SkillDir(workRoot, name string) string
 	// GuideFilename is the workspace-relative path the harness auto-loads
 	// as project memory, where injectProfileGuide writes the profile's
 	// PROFILE.md. claude-code reads CLAUDE.md; codex and opencode read
@@ -64,6 +74,10 @@ func (ClaudeHarness) Args(sj SkillJob, effort string, globalMaxTurns int) []stri
 
 func (ClaudeHarness) ParseStream(r io.Reader, emit func(Event)) {
 	ParseStream(r, emit)
+}
+
+func (ClaudeHarness) SkillDir(workRoot, name string) string {
+	return filepath.Join(workRoot, ".claude", "skills", name)
 }
 
 func (ClaudeHarness) GuideFilename() string { return "CLAUDE.md" }

--- a/internal/worker/harness_test.go
+++ b/internal/worker/harness_test.go
@@ -44,6 +44,36 @@ not json
 	}
 }
 
+func TestClaudeHarness_SkillDir(t *testing.T) {
+	// claude-code discovers skills at ./.claude/skills/{name}; this is
+	// the path stageSkill has always written to, so the seam preserves
+	// it exactly.
+	got := ClaudeHarness{}.SkillDir("/work/scan-7", "deep-dive")
+	want := filepath.Join("/work/scan-7", ".claude", "skills", "deep-dive")
+	if got != want {
+		t.Errorf("ClaudeHarness.SkillDir = %q, want %q", got, want)
+	}
+	// LocalClaude is claude-only and must agree.
+	if lc := (LocalClaude{}).SkillDir("/work/scan-7", "deep-dive"); lc != want {
+		t.Errorf("LocalClaude.SkillDir = %q, want %q", lc, want)
+	}
+}
+
+func TestContainerRunner_SkillDirDelegatesToHarness(t *testing.T) {
+	// The runner exposes SkillDir on SkillRunner so the worker can stage
+	// SKILL.md before calling RunSkill; it must delegate to whatever
+	// harness is configured and default to claude when none is.
+	claudePath := ClaudeHarness{}.SkillDir("/w", "s")
+	if got := (ContainerRunner{}).SkillDir("/w", "s"); got != claudePath {
+		t.Errorf("default ContainerRunner.SkillDir = %q, want claude path %q", got, claudePath)
+	}
+	d := ContainerRunner{Harness: stubHarness{}}
+	want := filepath.Join("/w", "stub-skills", "s")
+	if got := d.SkillDir("/w", "s"); got != want {
+		t.Errorf("stub-harness ContainerRunner.SkillDir = %q, want %q", got, want)
+	}
+}
+
 func TestClaudeHarness_binaryGuideEgress(t *testing.T) {
 	h := ClaudeHarness{}
 	if h.Binary() != "claude" {
@@ -85,6 +115,7 @@ type stubHarness struct {
 func (s stubHarness) Binary() string                      { return s.bin }
 func (s stubHarness) Args(SkillJob, string, int) []string { return []string{"--stub"} }
 func (s stubHarness) ParseStream(io.Reader, func(Event))  {}
+func (s stubHarness) SkillDir(wr, n string) string        { return filepath.Join(wr, "stub-skills", n) }
 func (s stubHarness) GuideFilename() string               { return s.guide }
 func (s stubHarness) EgressHosts() []string               { return s.egress }
 func (s stubHarness) Env(string) []string                 { return s.env }

--- a/internal/worker/max_turns_test.go
+++ b/internal/worker/max_turns_test.go
@@ -21,6 +21,10 @@ func (c *captureRunner) RunSkill(_ context.Context, sj SkillJob, _ func(Event)) 
 	return SkillResult{}, nil
 }
 
+func (*captureRunner) SkillDir(workRoot, name string) string {
+	return ClaudeHarness{}.SkillDir(workRoot, name)
+}
+
 func TestWorker_resolvesDefaultMaxTurns(t *testing.T) {
 	tests := []struct {
 		name         string

--- a/internal/worker/schema_validate_test.go
+++ b/internal/worker/schema_validate_test.go
@@ -113,6 +113,10 @@ type sequenceRunner struct {
 	jobs    []SkillJob
 }
 
+func (*sequenceRunner) SkillDir(workRoot, name string) string {
+	return ClaudeHarness{}.SkillDir(workRoot, name)
+}
+
 func (r *sequenceRunner) RunSkill(_ context.Context, sj SkillJob, emit func(Event)) (SkillResult, error) {
 	r.jobs = append(r.jobs, sj)
 	emit(Event{Kind: KindText, Text: "running skill " + sj.Name})

--- a/internal/worker/skill.go
+++ b/internal/worker/skill.go
@@ -136,7 +136,7 @@ func (w *Worker) doSkill(ctx context.Context, scan *db.Scan, emit func(Event)) (
 		return "", fmt.Errorf("apply path filters: %w", err)
 	}
 
-	skillDir := filepath.Join(workRoot, ".claude", "skills", skill.Name)
+	skillDir := w.Runner.SkillDir(workRoot, skill.Name)
 	if err := w.stageWorkspace(workRoot, skillDir, scan, &skill); err != nil {
 		return "", err
 	}

--- a/internal/worker/worker_resume_test.go
+++ b/internal/worker/worker_resume_test.go
@@ -30,6 +30,10 @@ func (r *recordingRunner) RunSkill(_ context.Context, sj SkillJob, emit func(Eve
 	return r.res, r.err
 }
 
+func (*recordingRunner) SkillDir(workRoot, name string) string {
+	return ClaudeHarness{}.SkillDir(workRoot, name)
+}
+
 func newResumeTestWorker(t *testing.T, runner SkillRunner) (*Worker, *db.Skill, uint) {
 	t.Helper()
 	gdb, err := db.Open(filepath.Join(t.TempDir(), "r.db"))

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -41,6 +41,10 @@ func (f fakeRunner) RunSkill(_ context.Context, sj SkillJob, emit func(Event)) (
 	return f.skillRes, f.skillErr
 }
 
+func (fakeRunner) SkillDir(workRoot, name string) string {
+	return ClaudeHarness{}.SkillDir(workRoot, name)
+}
+
 type blockingRunner struct {
 	started chan struct{}
 }
@@ -49,6 +53,10 @@ func (b blockingRunner) RunSkill(ctx context.Context, _ SkillJob, _ func(Event))
 	close(b.started)
 	<-ctx.Done()
 	return SkillResult{}, ctx.Err()
+}
+
+func (blockingRunner) SkillDir(workRoot, name string) string {
+	return ClaudeHarness{}.SkillDir(workRoot, name)
 }
 
 func TestWorker_CancelStopsRunningScan(t *testing.T) {


### PR DESCRIPTION
Continues #211, follows #532.

Adds `SkillDir(workRoot, name)` to `Harness` and `SkillRunner` so the worker stages `SKILL.md`/`schema.json` where the configured agent CLI will discover it, instead of hardcoding `.claude/skills/{name}`.

All three target harnesses look for a file literally named `SKILL.md` and follow symlinks in their discovery; only the directory differs:

- claude-code: `./.claude/skills/{name}/`
- codex: `./skills/{name}/` (`codex-rs/core-skills/src/loader.rs`, `SymlinkPolicy::FollowDirectories`)
- opencode: `./.opencode/skill/{name}/` (`packages/opencode/src/skill/index.ts`, glob with `symlink: true`)

So `stageSkill` writes the same content to whichever path the runner returns; scrutineer's extra frontmatter keys (`output_kind`, `requires_profile`, ...) are unknown to codex/opencode and ignored. The activation prompt that points the agent at the skill stays inside each harness's `Args()`.

`ClaudeHarness.SkillDir` returns the historical path so behaviour is unchanged; `ContainerRunner.SkillDir` delegates to the harness and `LocalClaude.SkillDir` is fixed at the claude path. The two call sites in `skill.go` and `exposure.go` now ask the runner. Five test runner mocks gain a one-line `SkillDir` delegating to `ClaudeHarness`.

Next: exit classification (the last seam), then the `-backend` flag, `HarnessByName` registry, codex in `Dockerfile.runner`, and the `CodexHarness` implementation.