### PR TITLE
Move state-dir env and account-error detection onto the Harness interface

### DIFF
--- a/internal/worker/container.go
+++ b/internal/worker/container.go
@@ -269,10 +269,11 @@ func (d ContainerRunner) RunSkill(ctx context.Context, sj SkillJob, emit func(Ev
 	}
 	emit(Event{Kind: KindText, Text: logLine})
 
+	h := d.harness()
 	accountErrText := ""
 	wrappedEmit := func(e Event) {
 		if accountErrText == "" {
-			accountErrText = claudeAccountErrorText(e.Text)
+			accountErrText = h.AccountErrorText(e.Text)
 		}
 		emit(e)
 	}
@@ -393,15 +394,17 @@ func (d ContainerRunner) buildRunArgs(absWork, image string, hnet hardenedNet, c
 		args = append(args, "--userns=keep-id")
 	}
 	if claudeConfigDir != "" {
-		// Persist the resumable claude session store outside the container.
-		// Without this it lands in the /tmp tmpfs and dies with the
-		// container, so --resume on a retry would find nothing. The bind
-		// mount stays writable even under hardened mode's --read-only
-		// rootfs, so resume works there too.
-		args = append(args,
-			"-v", bindMount(claudeConfigDir, "/claude-config", d.SELinuxRelabel),
-			"-e", "CLAUDE_CONFIG_DIR=/claude-config",
-		)
+		// Persist the harness's resumable session store outside the
+		// container. Without this it lands in the /tmp tmpfs and dies
+		// with the container, so a retry could not resume the agent
+		// loop. The bind mount stays writable even under hardened
+		// mode's --read-only rootfs. The /claude-config mountpoint name
+		// is historical; only the env var that points the harness at it
+		// varies (CLAUDE_CONFIG_DIR, CODEX_HOME, OPENCODE_CONFIG_DIR).
+		args = append(args, "-v", bindMount(claudeConfigDir, "/claude-config", d.SELinuxRelabel))
+		for _, e := range d.harness().StateEnv("/claude-config") {
+			args = append(args, "-e", e)
+		}
 	}
 	if d.Hardened || d.HardenedRuntimeOnly {
 		// Read-only rootfs + no-new-privileges close the residual paths a

--- a/internal/worker/harness.go
+++ b/internal/worker/harness.go
@@ -15,7 +15,9 @@ import (
 // inside the container changes.
 //
 // The interface is grown incrementally as call sites are wired to it
-// (#211). Exit classification follows.
+// (#211). All seams the container runner needs are now covered; the
+// codex implementation, -backend flag, and HarnessByName registry land
+// next.
 type Harness interface {
 	// Binary is the executable on the runner image's PATH.
 	Binary() string
@@ -57,6 +59,21 @@ type Harness interface {
 	// "" means none. Harness-neutral env (HOME, the proxy vars, semgrep)
 	// stays in buildRunArgs.
 	Env(baseURL string) []string
+	// StateEnv returns the env entries (KEY=VALUE) that point the harness
+	// at containerPath as its persistent state/config directory. The
+	// runner bind-mounts a per-scan host directory there so the session
+	// store survives the container, letting a retry resume the agent
+	// loop. claude reads CLAUDE_CONFIG_DIR; codex reads CODEX_HOME;
+	// opencode reads OPENCODE_CONFIG_DIR and OPENCODE_DB.
+	StateEnv(containerPath string) []string
+	// AccountErrorText returns s when it looks like an account-level
+	// failure from the harness's provider (a usage/rate/plan limit, or
+	// access disabled/revoked) and "" otherwise. The runner consults it
+	// only after the harness exited non-zero, so a stray phrase in
+	// normal output never triggers. A non-empty match becomes a
+	// ClaudeAccountError that pauses the queue, since retrying cannot
+	// succeed until the account recovers.
+	AccountErrorText(s string) string
 }
 
 // ClaudeHarness is the default and (for now) only harness: it wraps the
@@ -111,4 +128,12 @@ func (ClaudeHarness) Env(baseURL string) []string {
 		env = append(env, "ANTHROPIC_BASE_URL="+baseURL)
 	}
 	return env
+}
+
+func (ClaudeHarness) StateEnv(containerPath string) []string {
+	return []string{"CLAUDE_CONFIG_DIR=" + containerPath}
+}
+
+func (ClaudeHarness) AccountErrorText(s string) string {
+	return claudeAccountErrorText(s)
 }

--- a/internal/worker/harness_test.go
+++ b/internal/worker/harness_test.go
@@ -106,10 +106,12 @@ func TestContainerRunner_harnessDefaultsToClaude(t *testing.T) {
 // real second implementation. The set of harnesses is open-ended; this
 // stands in for any of them.
 type stubHarness struct {
-	bin    string
-	guide  string
-	egress []string
-	env    []string
+	bin     string
+	guide   string
+	egress  []string
+	env     []string
+	state   []string
+	acctErr string
 }
 
 func (s stubHarness) Binary() string                      { return s.bin }
@@ -119,6 +121,68 @@ func (s stubHarness) SkillDir(wr, n string) string        { return filepath.Join
 func (s stubHarness) GuideFilename() string               { return s.guide }
 func (s stubHarness) EgressHosts() []string               { return s.egress }
 func (s stubHarness) Env(string) []string                 { return s.env }
+func (s stubHarness) StateEnv(string) []string            { return s.state }
+func (s stubHarness) AccountErrorText(t string) string {
+	if s.acctErr != "" && strings.Contains(t, s.acctErr) {
+		return t
+	}
+	return ""
+}
+
+func TestClaudeHarness_StateEnv(t *testing.T) {
+	got := ClaudeHarness{}.StateEnv("/claude-config")
+	want := []string{"CLAUDE_CONFIG_DIR=/claude-config"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("StateEnv(/claude-config) = %v, want %v", got, want)
+	}
+}
+
+func TestClaudeHarness_AccountErrorTextDelegates(t *testing.T) {
+	// The harness method must classify exactly as the package function
+	// does so the queue-pause behaviour is unchanged.
+	for _, s := range []string{
+		"Error: Claude usage limit reached",
+		"429 too many requests",
+		"this is fine",
+		"",
+	} {
+		if got, want := (ClaudeHarness{}).AccountErrorText(s), claudeAccountErrorText(s); got != want {
+			t.Errorf("AccountErrorText(%q) = %q, want %q", s, got, want)
+		}
+	}
+}
+
+func TestBuildRunArgs_stateEnvFromHarness(t *testing.T) {
+	// With a config dir, the runner bind-mounts it and asks the harness
+	// for the env entries that point at the mount. A non-claude harness
+	// must NOT get CLAUDE_CONFIG_DIR; it gets only what its StateEnv
+	// returns.
+	d := ContainerRunner{Harness: stubHarness{state: []string{"CODEX_HOME=/claude-config", "CODEX_SQLITE_HOME=/claude-config"}}}
+	got := d.buildRunArgs("/work/abs", "img:latest", hardenedNet{}, "/data/cfg/scan-7")
+
+	if !containsEnvFlag(got, "CODEX_HOME=/claude-config") || !containsEnvFlag(got, "CODEX_SQLITE_HOME=/claude-config") {
+		t.Errorf("harness StateEnv not wired: %v", got)
+	}
+	if containsEnvFlag(got, "CLAUDE_CONFIG_DIR=/claude-config") {
+		t.Errorf("non-claude harness leaked CLAUDE_CONFIG_DIR: %v", got)
+	}
+	// The bind mount itself is harness-neutral and must still be present.
+	mounted := false
+	for i := 0; i+1 < len(got); i++ {
+		if got[i] == "-v" && strings.HasPrefix(got[i+1], "/data/cfg/scan-7:/claude-config") {
+			mounted = true
+		}
+	}
+	if !mounted {
+		t.Errorf("state dir bind mount missing: %v", got)
+	}
+
+	// Default harness keeps the historical env var.
+	def := ContainerRunner{}.buildRunArgs("/work/abs", "img:latest", hardenedNet{}, "/data/cfg/scan-7")
+	if !containsEnvFlag(def, "CLAUDE_CONFIG_DIR=/claude-config") {
+		t.Errorf("default harness dropped CLAUDE_CONFIG_DIR: %v", def)
+	}
+}
 
 func TestClaudeHarness_Env(t *testing.T) {
 	// With both credentials set on the host and a base URL, Env must


### PR DESCRIPTION
Completes the #211 interface extraction, follows #533.

Adds `StateEnv(containerPath)` and `AccountErrorText(s)` to `Harness` so the last two claude-coupled bits of the container runner go through the seam.

`ClaudeHarness.StateEnv` returns `["CLAUDE_CONFIG_DIR="+path]`; `ClaudeHarness.AccountErrorText` delegates to `claudeAccountErrorText`. `buildRunArgs` keeps the `/claude-config` bind mount but pulls the env var(s) from the harness instead of hardcoding `CLAUDE_CONFIG_DIR` — codex would return `CODEX_HOME`, opencode `OPENCODE_CONFIG_DIR` + `OPENCODE_DB`. The `wrappedEmit` closure in `ContainerRunner.RunSkill` calls `h.AccountErrorText` instead of the package function directly.

Max-turns detection needed no new method: it lives inside `ParseStream` (already on the interface), which emits the harness-neutral `{KindError, "hit max turns"}` event the runner reacts to. Any harness's `ParseStream` emits the same Event when it sees its own turn-cap signal.

The `/claude-config` mountpoint, the `{DataDir}/claude-config/scan-N` host path, `SkillJob.ClaudeConfigDir`, and the `ClaudeAccountError` type name are kept as-is so existing resume stores aren't orphaned and the diff stays focused; renaming those is a separate cosmetic pass once a second harness exists.

Tests: `StateEnv` returns the historical env; `AccountErrorText` matches the package function exactly across hit/miss inputs; `TestBuildRunArgs_stateEnvFromHarness` proves a non-claude harness gets only its own state-dir vars with no `CLAUDE_CONFIG_DIR` leak, the bind mount stays, and the default harness keeps the historical env.

Next: `CodexHarness` implementing all nine methods, `-backend` flag, `HarnessByName` registry, and the codex binary in `Dockerfile.runner`. #239 can be closed pointing here once that's up.