### PR TITLE
Add opencode backend (-backend opencode)

### DIFF
--- a/Dockerfile.runner
+++ b/Dockerfile.runner
@@ -5,6 +5,7 @@
 
 ARG CLAUDE_VERSION=2.1.173
 ARG CODEX_VERSION=0.142.5
+ARG OPENCODE_VERSION=1.17.12
 ARG SEMGREP_VERSION=1.167.0
 
 FROM golang:1.26.4-trixie@sha256:68b7145ec43d1820b9a56704554b53d1520aa2a15cb5233e374188a31b2a1bce AS go-tools
@@ -30,6 +31,7 @@ RUN CGO_ENABLED=0 go build -o /out/scrutineer ./cmd/scrutineer
 FROM debian:trixie-slim@sha256:28de0877c2189802884ccd20f15ee41c203573bd87bb6b883f5f46362d24c5c2
 ARG CLAUDE_VERSION
 ARG CODEX_VERSION
+ARG OPENCODE_VERSION
 ARG SEMGREP_VERSION
 
 ENV DEBIAN_FRONTEND=noninteractive
@@ -86,6 +88,21 @@ RUN set -eux; \
     install -m 0755 "/tmp/codex-${triple}" /usr/local/bin/codex; \
     rm /tmp/codex.tgz "/tmp/codex-${triple}"; \
     codex --version
+
+# opencode CLI (-backend opencode). The musl tarball contains a single
+# `opencode` binary.
+RUN set -eux; \
+    case "${TARGETARCH}" in \
+      amd64) ocarch=x64;   sha=40b3210f6720ea8466fe885138e7b5f9310bb13103479f6ea52024b5c91a8c32 ;; \
+      arm64) ocarch=arm64; sha=069de507f4b2d646a2b02a6f27f3e1f4f40aa3a1b59cebc707da676282508853 ;; \
+      *) echo "unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;; \
+    esac; \
+    curl -fsSL -o /tmp/opencode.tgz \
+      "https://github.com/sst/opencode/releases/download/v${OPENCODE_VERSION}/opencode-linux-${ocarch}-musl.tar.gz"; \
+    echo "${sha}  /tmp/opencode.tgz" | sha256sum -c -; \
+    tar -xzf /tmp/opencode.tgz -C /usr/local/bin opencode; \
+    rm /tmp/opencode.tgz; \
+    opencode --version
 
 COPY --from=go-tools /out/* /usr/local/bin/
 COPY --from=zizmor-build /out/bin/zizmor /usr/local/bin/zizmor

--- a/Dockerfile.runner
+++ b/Dockerfile.runner
@@ -37,7 +37,7 @@ ARG SEMGREP_VERSION
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        ca-certificates curl git bash coreutils \
+        ca-certificates curl git bash coreutils musl \
         python3 python3-venv \
  && install -d -m 0755 /etc/apt/keyrings \
  && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \

--- a/Dockerfile.runner
+++ b/Dockerfile.runner
@@ -100,7 +100,7 @@ RUN set -eux; \
       *) echo "unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;; \
     esac; \
     curl -fsSL -o /tmp/opencode.tgz \
-      "https://github.com/sst/opencode/releases/download/v${OPENCODE_VERSION}/opencode-linux-${ocarch}.tar.gz"; \
+      "https://github.com/anomalyco/opencode/releases/download/v${OPENCODE_VERSION}/opencode-linux-${ocarch}.tar.gz"; \
     echo "${sha}  /tmp/opencode.tgz" | sha256sum -c -; \
     tar -xzf /tmp/opencode.tgz -C /usr/local/bin opencode; \
     rm /tmp/opencode.tgz; \

--- a/Dockerfile.runner
+++ b/Dockerfile.runner
@@ -37,8 +37,9 @@ ARG SEMGREP_VERSION
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        ca-certificates curl git bash coreutils musl \
+        ca-certificates curl git bash coreutils \
         python3 python3-venv \
+        libstdc++6 \
  && install -d -m 0755 /etc/apt/keyrings \
  && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
         -o /etc/apt/keyrings/githubcli-archive-keyring.gpg \
@@ -89,16 +90,17 @@ RUN set -eux; \
     rm /tmp/codex.tgz "/tmp/codex-${triple}"; \
     codex --version
 
-# opencode CLI (-backend opencode). The musl tarball contains a single
-# `opencode` binary.
+# opencode CLI (-backend opencode). The glibc tarball contains a single
+# `opencode` binary; it links libstdc++ dynamically (bun runtime), which
+# is why libstdc++6 is in the apt install list above.
 RUN set -eux; \
     case "${TARGETARCH}" in \
-      amd64) ocarch=x64;   sha=40b3210f6720ea8466fe885138e7b5f9310bb13103479f6ea52024b5c91a8c32 ;; \
-      arm64) ocarch=arm64; sha=069de507f4b2d646a2b02a6f27f3e1f4f40aa3a1b59cebc707da676282508853 ;; \
+      amd64) ocarch=x64;   sha=b41e3ae69b5033f6fba8b9fcf4cb19f0dc8093d449266ef01a5cd142f6f7064d ;; \
+      arm64) ocarch=arm64; sha=b36060c4c5bc8fee8e507a600af0ad8b2aa5e0c451f7f34cc3763a0d557b44d6 ;; \
       *) echo "unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;; \
     esac; \
     curl -fsSL -o /tmp/opencode.tgz \
-      "https://github.com/sst/opencode/releases/download/v${OPENCODE_VERSION}/opencode-linux-${ocarch}-musl.tar.gz"; \
+      "https://github.com/sst/opencode/releases/download/v${OPENCODE_VERSION}/opencode-linux-${ocarch}.tar.gz"; \
     echo "${sha}  /tmp/opencode.tgz" | sha256sum -c -; \
     tar -xzf /tmp/opencode.tgz -C /usr/local/bin opencode; \
     rm /tmp/opencode.tgz; \

--- a/Dockerfile.runner
+++ b/Dockerfile.runner
@@ -39,7 +39,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y --no-install-recommends \
         ca-certificates curl git bash coreutils \
         python3 python3-venv \
-        libstdc++6 \
+        libstdc++6 ripgrep \
  && install -d -m 0755 /etc/apt/keyrings \
  && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
         -o /etc/apt/keyrings/githubcli-archive-keyring.gpg \

--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ The `docker build` commands shown for the runner image and profiles can be run a
 | `-effort` | `high` | Claude effort level |
 | `-skills` | - | Local directory to load SKILL.md files from (repeatable) |
 | `-skills-repo` | - | `owner/repo[@ref]` or git HTTPS URL `https://host/path[@ref]` to clone skills from on startup; `@ref` pins a branch, tag or commit and the resolved SHA is recorded on every scan |
-| `-backend` | `claude` | Agent CLI the container runner execs: `claude` or `codex`. Non-claude backends require the containerised runner |
+| `-backend` | `claude` | Agent CLI the container runner execs: `claude`, `codex`, or `opencode`. Non-claude backends require the containerised runner |
 | `--runtime` | `docker` | Container runtime: `docker`, `podman` (rootless podman supported), or `apple` (Apple, experimental) |
 | `--selinux` | `auto` | Bind-mount SELinux relabeling: `auto` (relabel when SELinux is detected), `on`, or `off` |
 | `--no-container` | false | Disable the containerised runner; run claude directly on the host (no isolation). Deprecated alias: `--no-docker` |
@@ -334,6 +334,15 @@ The container, egress proxy, language profiles and skill staging stay the same; 
 
 See [docs/codex.md](docs/codex.md) for what differs from claude (argv, skill staging, credentials, egress), which model ids the pinned codex version accepts, and why codex's own sandbox is disabled inside scrutineer's container.
 
+## Opencode backend
+
+[opencode](https://opencode.ai) is provider-agnostic, so `-backend opencode` runs whichever model you configure (Anthropic, OpenAI, or anything opencode supports). The runner image bundles the `opencode` binary; set the credential for your provider and the model id in `provider/model` form:
+
+    backend: opencode
+    default_model: anthropic/claude-sonnet-4-6
+
+The egress allowlist covers `models.dev` plus the Anthropic and OpenAI API hosts; other providers go in `egress_allow:`. Like codex, the opencode backend requires the containerised runner. See [docs/opencode.md](docs/opencode.md) for provider-credential handling and what differs from claude.
+
 ## Sandboxed Claude Code configs
 
 In `--no-container` mode the `claude` subprocess inherits your `~/.claude/settings.json`, so [sandbox settings](https://code.claude.com/docs/en/sandboxing) that restrict network or filesystem access there will fail skills that need them. Point `claude` at a separate config directory just for scrutineer runs:
@@ -356,6 +365,7 @@ See [SECURITY.md](SECURITY.md) for the reporting policy and [threatmodel.md](thr
 - [docs/development.md](docs/development.md) -- project layout, regenerating embedded data, running tests
 - [docs/encrypted-sharing.md](docs/encrypted-sharing.md) -- encrypted findings sharing between contributors (age + SSH keys, team keyring management)
 - [docs/codex.md](docs/codex.md) -- the codex backend: what differs from claude, sandbox interaction, adding another harness
+- [docs/opencode.md](docs/opencode.md) -- the opencode backend: provider-agnostic credentials and egress
 - [docs/podman.md](docs/podman.md) -- security model and known gaps for the podman / rootless runtime (sandbox isolation, hardened-mode verification)
 - [docs/egress-sidecar.md](docs/egress-sidecar.md) -- operator validation checklist for the rootless `--hardened` egress proxy sidecar
 

--- a/docs/opencode.md
+++ b/docs/opencode.md
@@ -1,0 +1,102 @@
+# Opencode backend
+
+Scrutineer can drive [opencode](https://opencode.ai) instead of claude-code,
+selected with `-backend opencode` (or `backend: opencode` in
+`scrutineer.yaml`). Unlike claude and codex, opencode is provider-agnostic:
+the model you configure determines which API it talks to, so credential and
+egress handling are looser than for the single-provider backends.
+
+## Setup
+
+The runner image bundles the `opencode` binary, so there's nothing to install.
+opencode reads provider credentials from its auth config or from the
+provider's own env var; the harness passes through `ANTHROPIC_API_KEY`,
+`OPENAI_API_KEY`, `OPENCODE_CONFIG_CONTENT` and `OPENCODE_AUTH_CONTENT` from
+the host so the common cases work without extra setup:
+
+    export ANTHROPIC_API_KEY=sk-ant-...
+    go run ./cmd/scrutineer -skills ./skills -backend opencode
+
+or in `scrutineer.yaml`:
+
+    backend: opencode
+    default_model: anthropic/claude-sonnet-4-6
+    models:
+      - name: Sonnet (via opencode)
+        id:   anthropic/claude-sonnet-4-6
+      - name: GPT-5 (via opencode)
+        id:   openai/gpt-5
+
+Model ids are in opencode's `provider/model` form. For providers other than
+Anthropic and OpenAI, set `OPENCODE_CONFIG_CONTENT` (an inline JSON config
+opencode reads at startup) with the provider block, and add the provider's
+API host to `egress_allow:` so the proxy lets it through.
+
+The opencode backend requires the containerised runner. `--no-container` with
+`-backend opencode` is rejected at startup.
+
+## How the harness maps
+
+| Aspect | claude | opencode |
+| --- | --- | --- |
+| Binary | `claude` | `opencode` |
+| Argv | `claude -p --output-format stream-json ...` | `opencode run --format json --auto ...` |
+| Skill staging | `./.claude/skills/{name}/SKILL.md` | `./.opencode/skill/{name}/SKILL.md` |
+| Project memory | `CLAUDE.md` | `AGENTS.md` |
+| Egress hosts | `*.anthropic.com` | `models.dev`, `api.openai.com`, `*.anthropic.com` |
+| Credential env | `ANTHROPIC_API_KEY`, `CLAUDE_CODE_OAUTH_TOKEN` | `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `OPENCODE_CONFIG_CONTENT`, `OPENCODE_AUTH_CONTENT` |
+| State dir env | `CLAUDE_CONFIG_DIR` | `OPENCODE_CONFIG_DIR`, `OPENCODE_DB` |
+| Account-error phrases | claude usage/plan/access messages | union of common provider rate-limit / quota / invalid-key messages |
+
+opencode globs `./.opencode/{skill,skills}/**/SKILL.md` with symlinks enabled,
+so `stageSkill` writes the same files it always has into
+`./.opencode/skill/{name}/`. The activation prompt points at that path
+explicitly (opencode discovers but does not auto-invoke skills in headless
+`run` mode). `PROFILE.md` lands at `AGENTS.md`, which opencode walks from cwd
+up to the project root.
+
+`--auto` and `OPENCODE_PERMISSION=allow` suppress opencode's interactive
+permission prompts; the container is the sandbox. `--replay=false` on a
+resumed session keeps the scan log from re-emitting the prior run's events.
+`OPENCODE_DISABLE_MODELS_FETCH=1` stops opencode fetching `models.dev` at
+startup (the host is still on the egress allowlist for runs that do need it).
+
+The session store (`OPENCODE_DB`, a SQLite file) and config
+(`OPENCODE_CONFIG_DIR`) are bind-mounted the same way claude's session store
+is, so a retried scan continues with `--session <id>`.
+
+## Egress
+
+Because opencode can talk to any provider, the harness's `EgressHosts()`
+returns the two common ones plus opencode's own model registry. That covers
+Anthropic and OpenAI out of the box; anything else (Bedrock, Azure, Ollama on
+another host, Cloudflare Workers AI) needs an `egress_allow:` entry. Under
+`--hardened` only the harness's hosts plus the host skill API are permitted,
+so a third-party provider under hardened mode is a deliberate widening.
+
+The threat-model T1 residual applies the same: whichever provider credential
+is set passes into the container as an env var and is readable by
+in-container code.
+
+## Known gaps
+
+opencode has no per-turn cap in `run` mode, so `-max-turns` is ignored. The
+`-scan-timeout` wall-clock limit still applies.
+
+Claude's `-effort` setting has no opencode equivalent and is ignored.
+
+`-anthropic-base-url` is accepted for interface symmetry but ignored: opencode
+has no single base-URL override; per-provider endpoints go in
+`OPENCODE_CONFIG_CONTENT`.
+
+The stream parser (`OpencodeHarness.ParseStream`) maps `step_start`
+(session id), `tool_use`, `text`/`reasoning`, and `error` events from
+`opencode run --format json` onto the scan log, dropping `step_finish` noise.
+Unknown event types pass through as raw text.
+
+## See also
+
+- `docs/codex.md`: the codex backend, including the "Adding another harness"
+  section that opencode follows.
+- `internal/worker/harness_opencode.go`: the `OpencodeHarness` implementation.
+- #211: tracking issue for alternative harnesses.

--- a/docs/opencode.md
+++ b/docs/opencode.md
@@ -55,10 +55,9 @@ explicitly (opencode discovers but does not auto-invoke skills in headless
 `run` mode). `PROFILE.md` lands at `AGENTS.md`, which opencode walks from cwd
 up to the project root.
 
-`--auto` and `OPENCODE_PERMISSION=allow` suppress opencode's interactive
-permission prompts; the container is the sandbox. `--replay=false` on a
-resumed session keeps the scan log from re-emitting the prior run's events.
-`OPENCODE_DISABLE_MODELS_FETCH=1` stops opencode fetching `models.dev` at
+`--auto` suppresses opencode's interactive permission prompts; the container
+is the sandbox. `OPENCODE_DISABLE_MODELS_FETCH=1` stops opencode fetching
+`models.dev` at
 startup (the host is still on the egress allowlist for runs that do need it).
 
 The session store (`OPENCODE_DB`, a SQLite file) and config
@@ -85,14 +84,15 @@ opencode has no per-turn cap in `run` mode, so `-max-turns` is ignored. The
 
 Claude's `-effort` setting has no opencode equivalent and is ignored.
 
-`-anthropic-base-url` is accepted for interface symmetry but ignored: opencode
+`-model-base-url` is accepted for interface symmetry but ignored: opencode
 has no single base-URL override; per-provider endpoints go in
 `OPENCODE_CONFIG_CONTENT`.
 
 The stream parser (`OpencodeHarness.ParseStream`) maps `step_start`
-(session id), `tool_use`, `text`/`reasoning`, and `error` events from
-`opencode run --format json` onto the scan log, dropping `step_finish` noise.
-Unknown event types pass through as raw text.
+(session id), `tool`, `text`/`reasoning`, and `error` events from
+`opencode run --format json` onto the scan log; `step_finish` carries
+per-step cost and token counts and is emitted as a result event so the
+scan row records usage. Unknown event types pass through as raw text.
 
 ## See also
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -32,10 +32,9 @@ type Config struct {
 	// Backend selects the agent CLI the container runner execs:
 	// "claude" (default), "codex", or "opencode". Empty leaves the
 	// built-in default (claude). Non-claude backends require the
-	// containerised runner;
-	// --no-container with a non-claude backend is rejected at startup.
-	// Validated against worker.HarnessByName so the set of accepted
-	// values stays in one place.
+	// containerised runner: --no-container with a non-claude backend
+	// is rejected at startup. Validated against worker.HarnessByName
+	// so the set of accepted values stays in one place.
 	Backend string `yaml:"backend"`
 	// NoContainer disables the containerised runner so claude runs directly on
 	// the host (no isolation). NoDocker is the pre-rename alias, still honoured

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -30,8 +30,9 @@ type Config struct {
 	Skills       []string `yaml:"skills"`
 	SkillsRepo   string   `yaml:"skills_repo"`
 	// Backend selects the agent CLI the container runner execs:
-	// "claude" (default) or "codex". Empty leaves the built-in default
-	// (claude). Non-claude backends require the containerised runner;
+	// "claude" (default), "codex", or "opencode". Empty leaves the
+	// built-in default (claude). Non-claude backends require the
+	// containerised runner;
 	// --no-container with a non-claude backend is rejected at startup.
 	// Validated against worker.HarnessByName so the set of accepted
 	// values stays in one place.

--- a/internal/worker/harness.go
+++ b/internal/worker/harness.go
@@ -14,9 +14,10 @@ import (
 // The empty string and "claude" both resolve to ClaudeHarness so an
 // unset backend keeps the historical default.
 var harnesses = map[string]Harness{
-	"":       ClaudeHarness{},
-	"claude": ClaudeHarness{},
-	"codex":  CodexHarness{},
+	"":         ClaudeHarness{},
+	"claude":   ClaudeHarness{},
+	"codex":    CodexHarness{},
+	"opencode": OpencodeHarness{},
 }
 
 // HarnessByName resolves a -backend value to its Harness, or returns

--- a/internal/worker/harness_opencode.go
+++ b/internal/worker/harness_opencode.go
@@ -203,6 +203,17 @@ func (OpencodeHarness) StateEnv(containerPath string) []string {
 	}
 }
 
+func (OpencodeHarness) DefaultModels() []ModelDefault {
+	// opencode is provider-agnostic; it drives whichever provider the
+	// operator's OPENCODE_CONFIG_CONTENT / auth config points at. The
+	// default matches the credentials Env passes through with no extra
+	// config: with ANTHROPIC_API_KEY set, opencode drives Anthropic and
+	// the claude model list applies; an operator pointing it at a
+	// different provider sets models: in config. Reusing the claude
+	// list keeps the pricing tripwire satisfied without a second copy.
+	return ClaudeHarness{}.DefaultModels()
+}
+
 func (OpencodeHarness) AccountErrorText(s string) string {
 	text := strings.TrimSpace(s)
 	if text == "" {

--- a/internal/worker/harness_opencode.go
+++ b/internal/worker/harness_opencode.go
@@ -170,7 +170,10 @@ func (OpencodeHarness) EgressHosts() []string {
 	return []string{"models.dev", "api.openai.com", "*.anthropic.com"}
 }
 
-func (OpencodeHarness) Env(baseURL string) []string {
+// Env returns opencode's container environment. baseURL is accepted for
+// interface symmetry and ignored: opencode has no single base-url
+// override; the operator sets it per-provider via OPENCODE_CONFIG_CONTENT.
+func (OpencodeHarness) Env(_ string) []string {
 	env := []string{
 		"OPENCODE_DISABLE_AUTOUPDATE=1",
 		"OPENCODE_DISABLE_MODELS_FETCH=1",
@@ -186,12 +189,6 @@ func (OpencodeHarness) Env(baseURL string) []string {
 		if os.Getenv(k) != "" {
 			env = append(env, k)
 		}
-	}
-	if baseURL != "" {
-		// opencode has no single base-url override; the operator sets
-		// it per-provider via OPENCODE_CONFIG_CONTENT. baseURL is
-		// accepted for interface symmetry and ignored.
-		_ = baseURL
 	}
 	return env
 }

--- a/internal/worker/harness_opencode.go
+++ b/internal/worker/harness_opencode.go
@@ -216,8 +216,9 @@ func (OpencodeHarness) Env(_ string) []string {
 	// container is the sandbox. OPENCODE_PERMISSION is not set because
 	// opencode JSON-parses it and there is no scalar "allow all" value.
 	env := []string{
-		"OPENCODE_DISABLE_AUTOUPDATE=1",
-		"OPENCODE_DISABLE_MODELS_FETCH=1",
+		"OPENCODE_DISABLE_AUTOUPDATE=true",
+		"OPENCODE_DISABLE_MODELS_FETCH=true",
+		"OPENCODE_DISABLE_SHARE=true",
 	}
 	// opencode reads provider credentials from its auth config or from
 	// the provider's own env var; pass through whichever the operator

--- a/internal/worker/harness_opencode.go
+++ b/internal/worker/harness_opencode.go
@@ -77,11 +77,16 @@ func (OpencodeHarness) ParseStream(r io.Reader, emit func(Event)) {
 type opencodeLine struct {
 	Type      string          `json:"type"`
 	SessionID string          `json:"sessionID"`
-	Text      string          `json:"text"`
-	Tool      string          `json:"tool"`
-	Name      string          `json:"name"`
-	Input     json.RawMessage `json:"input"`
-	Error     string          `json:"error"`
+	Part      *opencodePart   `json:"part"`
+	Error     json.RawMessage `json:"error"`
+}
+
+type opencodePart struct {
+	Type  string          `json:"type"`
+	Text  string          `json:"text"`
+	Tool  string          `json:"tool"`
+	Name  string          `json:"name"`
+	Input json.RawMessage `json:"input"`
 }
 
 func parseOpencodeLine(raw []byte, emit func(Event)) {
@@ -97,25 +102,58 @@ func parseOpencodeLine(raw []byte, emit func(Event)) {
 	switch {
 	case ev.Type == "step_start" && ev.SessionID != "":
 		emit(Event{Kind: KindSession, SessionID: ev.SessionID})
-	case ev.Type == "tool_use":
-		name := ev.Tool
+	case isOpencodeToolEvent(ev):
+		name := ev.Part.Tool
 		if name == "" {
-			name = ev.Name
+			name = ev.Part.Name
 		}
-		emit(Event{Kind: KindTool, Tool: name, Text: summariseInput(name, ev.Input)})
-	case ev.Type == "error" || ev.Error != "":
-		msg := ev.Error
-		if msg == "" {
-			msg = ev.Text
-		}
-		emit(Event{Kind: KindError, Text: msg})
-	case ev.Type == "text" || ev.Type == "reasoning":
-		emit(Event{Kind: KindText, Text: ev.Text})
+		emit(Event{Kind: KindTool, Tool: name, Text: summariseInput(name, ev.Part.Input)})
+	case ev.Type == "error" || len(ev.Error) > 0:
+		emit(Event{Kind: KindError, Text: opencodeErrorText(ev.Error, line)})
+	case isOpencodeTextEvent(ev):
+		emit(Event{Kind: KindText, Text: ev.Part.Text})
 	case ev.Type == "step_finish":
 		// noise; the scan log doesn't need step boundaries
 	default:
 		emit(Event{Kind: KindText, Text: line})
 	}
+}
+
+func isOpencodeToolEvent(ev opencodeLine) bool {
+	if ev.Part == nil {
+		return false
+	}
+	return ev.Type == "tool_use" || ev.Part.Type == "tool_use" || ev.Part.Tool != "" || ev.Part.Name != ""
+}
+
+func isOpencodeTextEvent(ev opencodeLine) bool {
+	if ev.Part == nil || ev.Part.Text == "" {
+		return false
+	}
+	return ev.Type == "text" || ev.Type == "reasoning" || ev.Part.Type == "text" || ev.Part.Type == "reasoning"
+}
+
+func opencodeErrorText(raw json.RawMessage, fallback string) string {
+	if len(raw) == 0 {
+		return fallback
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		return s
+	}
+	var e struct {
+		Message string `json:"message"`
+		Name    string `json:"name"`
+		Code    string `json:"code"`
+	}
+	if err := json.Unmarshal(raw, &e); err == nil {
+		for _, text := range []string{e.Message, e.Code, e.Name} {
+			if text != "" {
+				return text
+			}
+		}
+	}
+	return strings.TrimSpace(string(raw))
 }
 
 func (OpencodeHarness) SkillDir(workRoot, name string) string {

--- a/internal/worker/harness_opencode.go
+++ b/internal/worker/harness_opencode.go
@@ -1,0 +1,188 @@
+package worker
+
+import (
+	"bufio"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// OpencodeHarness drives the sst/opencode CLI in headless `opencode run`
+// mode. opencode is provider-agnostic -- the model's provider determines
+// which API host it dials -- so EgressHosts and Env cover the two common
+// providers (Anthropic and OpenAI) plus opencode's own model registry;
+// operators using another provider add its host via egress_allow.
+type OpencodeHarness struct{}
+
+func (OpencodeHarness) Binary() string { return "opencode" }
+
+// Args builds the `opencode run` argv. Like codex, opencode discovers
+// SKILL.md but does not auto-invoke it, so the prompt points at it
+// explicitly. --auto suppresses interactive permission prompts (the
+// container is the sandbox); --format json yields a JSONL event stream.
+func (OpencodeHarness) Args(sj SkillJob, _ string, _ int) []string {
+	args := []string{
+		"run",
+		"--format", "json",
+		"--auto",
+	}
+	if sj.Model != "" {
+		args = append(args, "--model", sj.Model)
+	}
+	if sj.ResumeSessionID != "" {
+		args = append(args, "--session", sj.ResumeSessionID, "--replay=false")
+	}
+	if sj.ResumeSessionID != "" && sj.ResumePrompt != "" {
+		return append(args, sj.ResumePrompt)
+	}
+	return append(args, opencodeSkillPrompt(sj.Name, sj.OutputFile, sj.ResumeSessionID != ""))
+}
+
+func opencodeSkillPrompt(name, outputFile string, resume bool) string {
+	verb := "Follow"
+	if resume {
+		verb = "Continue following"
+	}
+	p := verb + " the instructions in ./.opencode/skill/" + name +
+		"/SKILL.md against the repository cloned at ./src."
+	if outputFile != "" {
+		p += " Write your structured output to ./" + outputFile + " as the skill specifies."
+		p += schemaValidationHint(outputFile)
+	}
+	return p
+}
+
+func (OpencodeHarness) ParseStream(r io.Reader, emit func(Event)) {
+	br := bufio.NewReader(r)
+	for {
+		raw, readErr := br.ReadBytes('\n')
+		if len(raw) > 0 {
+			parseOpencodeLine(raw, emit)
+		}
+		if readErr == io.EOF {
+			return
+		}
+		if readErr != nil {
+			emit(Event{Kind: KindError, Text: "stream read: " + readErr.Error()})
+			return
+		}
+	}
+}
+
+// opencodeLine is the subset of `opencode run --format json` event
+// fields the harness needs. The shape is {type, sessionID, ...} per
+// packages/opencode/src/cli/cmd/run.ts.
+type opencodeLine struct {
+	Type      string          `json:"type"`
+	SessionID string          `json:"sessionID"`
+	Text      string          `json:"text"`
+	Tool      string          `json:"tool"`
+	Name      string          `json:"name"`
+	Input     json.RawMessage `json:"input"`
+	Error     string          `json:"error"`
+}
+
+func parseOpencodeLine(raw []byte, emit func(Event)) {
+	line := strings.TrimSpace(string(raw))
+	if line == "" {
+		return
+	}
+	var ev opencodeLine
+	if err := json.Unmarshal(raw, &ev); err != nil {
+		emit(Event{Kind: KindText, Text: line})
+		return
+	}
+	switch {
+	case ev.Type == "step_start" && ev.SessionID != "":
+		emit(Event{Kind: KindSession, SessionID: ev.SessionID})
+	case ev.Type == "tool_use":
+		name := ev.Tool
+		if name == "" {
+			name = ev.Name
+		}
+		emit(Event{Kind: KindTool, Tool: name, Text: summariseInput(name, ev.Input)})
+	case ev.Type == "error" || ev.Error != "":
+		msg := ev.Error
+		if msg == "" {
+			msg = ev.Text
+		}
+		emit(Event{Kind: KindError, Text: msg})
+	case ev.Type == "text" || ev.Type == "reasoning":
+		emit(Event{Kind: KindText, Text: ev.Text})
+	case ev.Type == "step_finish":
+		// noise; the scan log doesn't need step boundaries
+	default:
+		emit(Event{Kind: KindText, Text: line})
+	}
+}
+
+func (OpencodeHarness) SkillDir(workRoot, name string) string {
+	return filepath.Join(workRoot, ".opencode", "skill", name)
+}
+
+func (OpencodeHarness) GuideFilename() string { return "AGENTS.md" }
+
+func (OpencodeHarness) EgressHosts() []string {
+	// opencode is provider-agnostic; cover its own model-definition
+	// registry plus the two providers operators are most likely to use.
+	// Anything else (Bedrock, Azure, Cloudflare, ...) goes in
+	// egress_allow.
+	return []string{"models.dev", "api.openai.com", "*.anthropic.com"}
+}
+
+func (OpencodeHarness) Env(baseURL string) []string {
+	env := []string{
+		"OPENCODE_DISABLE_AUTOUPDATE=1",
+		"OPENCODE_DISABLE_MODELS_FETCH=1",
+		// The container is the sandbox; opencode's own permission
+		// gate would just block headless runs.
+		"OPENCODE_PERMISSION=allow",
+	}
+	// opencode reads provider credentials from its auth config or from
+	// the provider's own env var; pass through whichever the operator
+	// has set so the common providers work without extra config. Same
+	// T1/T13 residual as the other harnesses.
+	for _, k := range []string{"OPENAI_API_KEY", "ANTHROPIC_API_KEY", "OPENCODE_CONFIG_CONTENT", "OPENCODE_AUTH_CONTENT"} {
+		if os.Getenv(k) != "" {
+			env = append(env, k)
+		}
+	}
+	if baseURL != "" {
+		// opencode has no single base-url override; the operator sets
+		// it per-provider via OPENCODE_CONFIG_CONTENT. baseURL is
+		// accepted for interface symmetry and ignored.
+		_ = baseURL
+	}
+	return env
+}
+
+func (OpencodeHarness) StateEnv(containerPath string) []string {
+	return []string{
+		"OPENCODE_CONFIG_DIR=" + containerPath,
+		"OPENCODE_DB=" + containerPath + "/opencode.db",
+	}
+}
+
+func (OpencodeHarness) AccountErrorText(s string) string {
+	text := strings.TrimSpace(s)
+	if text == "" {
+		return ""
+	}
+	lower := strings.ToLower(text)
+	for _, phrase := range []string{
+		// opencode surfaces the underlying provider's message, so
+		// match the union of the common providers' account-level
+		// failure phrases.
+		"rate limit", "rate_limit", "too many requests", "429",
+		"usage limit", "quota", "insufficient_quota",
+		"invalid_api_key", "incorrect api key",
+		"credit balance", "billing",
+	} {
+		if strings.Contains(lower, phrase) {
+			return text
+		}
+	}
+	return ""
+}

--- a/internal/worker/harness_opencode.go
+++ b/internal/worker/harness_opencode.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 )
 
-// OpencodeHarness drives the sst/opencode CLI in headless `opencode run`
+// OpencodeHarness drives the anomalyco/opencode CLI in headless `opencode run`
 // mode. opencode is provider-agnostic -- the model's provider determines
 // which API host it dials -- so EgressHosts and Env cover the two common
 // providers (Anthropic and OpenAI) plus opencode's own model registry;
@@ -32,7 +32,7 @@ func (OpencodeHarness) Args(sj SkillJob, _ string, _ int, _ string) []string {
 		args = append(args, "--model", sj.Model)
 	}
 	if sj.ResumeSessionID != "" {
-		args = append(args, "--session", sj.ResumeSessionID, "--replay=false")
+		args = append(args, "--session", sj.ResumeSessionID)
 	}
 	if sj.ResumeSessionID != "" && sj.ResumePrompt != "" {
 		return append(args, sj.ResumePrompt)
@@ -73,20 +73,37 @@ func (OpencodeHarness) ParseStream(r io.Reader, emit func(Event)) {
 
 // opencodeLine is the subset of `opencode run --format json` event
 // fields the harness needs. The shape is {type, sessionID, ...} per
-// packages/opencode/src/cli/cmd/run.ts.
+// packages/opencode/src/cli/cmd/run.ts; step_finish carries per-step
+// cost and token counts alongside.
 type opencodeLine struct {
 	Type      string          `json:"type"`
 	SessionID string          `json:"sessionID"`
 	Part      *opencodePart   `json:"part"`
 	Error     json.RawMessage `json:"error"`
+	Cost      float64         `json:"cost"`
+	Tokens    *opencodeTokens `json:"tokens"`
 }
 
 type opencodePart struct {
-	Type  string          `json:"type"`
-	Text  string          `json:"text"`
-	Tool  string          `json:"tool"`
-	Name  string          `json:"name"`
+	Type  string            `json:"type"`
+	Text  string            `json:"text"`
+	Tool  string            `json:"tool"`
+	Name  string            `json:"name"`
+	State opencodeToolState `json:"state"`
+}
+
+type opencodeToolState struct {
 	Input json.RawMessage `json:"input"`
+}
+
+type opencodeTokens struct {
+	Input     int `json:"input"`
+	Output    int `json:"output"`
+	Reasoning int `json:"reasoning"`
+	Cache     struct {
+		Read  int `json:"read"`
+		Write int `json:"write"`
+	} `json:"cache"`
 }
 
 func parseOpencodeLine(raw []byte, emit func(Event)) {
@@ -107,15 +124,30 @@ func parseOpencodeLine(raw []byte, emit func(Event)) {
 		if name == "" {
 			name = ev.Part.Name
 		}
-		emit(Event{Kind: KindTool, Tool: name, Text: summariseInput(name, ev.Part.Input)})
+		emit(Event{Kind: KindTool, Tool: name, Text: summariseInput(name, ev.Part.State.Input)})
 	case ev.Type == "error" || len(ev.Error) > 0:
 		emit(Event{Kind: KindError, Text: opencodeErrorText(ev.Error, line)})
 	case isOpencodeTextEvent(ev):
 		emit(Event{Kind: KindText, Text: ev.Part.Text})
 	case ev.Type == "step_finish":
-		// noise; the scan log doesn't need step boundaries
+		emit(Event{Kind: KindResult, CostUSD: ev.Cost, Usage: opencodeUsage(ev.Tokens)})
 	default:
 		emit(Event{Kind: KindText, Text: line})
+	}
+}
+
+func opencodeUsage(t *opencodeTokens) Usage {
+	if t == nil {
+		return Usage{}
+	}
+	// opencode reports reasoning tokens separately; the scan row only
+	// tracks input/output/cache, so fold reasoning into output for the
+	// per-scan total.
+	return Usage{
+		InputTokens:      t.Input,
+		OutputTokens:     t.Output + t.Reasoning,
+		CacheReadTokens:  t.Cache.Read,
+		CacheWriteTokens: t.Cache.Write,
 	}
 }
 
@@ -123,7 +155,7 @@ func isOpencodeToolEvent(ev opencodeLine) bool {
 	if ev.Part == nil {
 		return false
 	}
-	return ev.Type == "tool_use" || ev.Part.Type == "tool_use" || ev.Part.Tool != "" || ev.Part.Name != ""
+	return ev.Type == "tool" || ev.Part.Type == "tool" || ev.Part.Tool != "" || ev.Part.Name != ""
 }
 
 func isOpencodeTextEvent(ev opencodeLine) bool {
@@ -145,9 +177,15 @@ func opencodeErrorText(raw json.RawMessage, fallback string) string {
 		Message string `json:"message"`
 		Name    string `json:"name"`
 		Code    string `json:"code"`
+		// opencode's typed provider errors nest the provider's own
+		// message under data (ProviderAuthError, APIError, ...); that is
+		// where "rate limit"/"quota" phrases live, so prefer it.
+		Data struct {
+			Message string `json:"message"`
+		} `json:"data"`
 	}
 	if err := json.Unmarshal(raw, &e); err == nil {
-		for _, text := range []string{e.Message, e.Code, e.Name} {
+		for _, text := range []string{e.Data.Message, e.Message, e.Code, e.Name} {
 			if text != "" {
 				return text
 			}
@@ -174,12 +212,12 @@ func (OpencodeHarness) EgressHosts() []string {
 // interface symmetry and ignored: opencode has no single base-url
 // override; the operator sets it per-provider via OPENCODE_CONFIG_CONTENT.
 func (OpencodeHarness) Env(_ string) []string {
+	// --auto (see Args) grants tool permissions in headless mode; the
+	// container is the sandbox. OPENCODE_PERMISSION is not set because
+	// opencode JSON-parses it and there is no scalar "allow all" value.
 	env := []string{
 		"OPENCODE_DISABLE_AUTOUPDATE=1",
 		"OPENCODE_DISABLE_MODELS_FETCH=1",
-		// The container is the sandbox; opencode's own permission
-		// gate would just block headless runs.
-		"OPENCODE_PERMISSION=allow",
 	}
 	// opencode reads provider credentials from its auth config or from
 	// the provider's own env var; pass through whichever the operator
@@ -204,11 +242,16 @@ func (OpencodeHarness) DefaultModels() []ModelDefault {
 	// opencode is provider-agnostic; it drives whichever provider the
 	// operator's OPENCODE_CONFIG_CONTENT / auth config points at. The
 	// default matches the credentials Env passes through with no extra
-	// config: with ANTHROPIC_API_KEY set, opencode drives Anthropic and
-	// the claude model list applies; an operator pointing it at a
-	// different provider sets models: in config. Reusing the claude
-	// list keeps the pricing tripwire satisfied without a second copy.
-	return ClaudeHarness{}.DefaultModels()
+	// config: with ANTHROPIC_API_KEY set, opencode drives Anthropic. IDs
+	// are in opencode's provider/model form; --model without the prefix
+	// fails resolution. normalizeModelID strips the prefix for the
+	// pricing lookup so the table needs no per-provider copies.
+	defs := ClaudeHarness{}.DefaultModels()
+	out := make([]ModelDefault, len(defs))
+	for i, d := range defs {
+		out[i] = ModelDefault{Name: d.Name, ID: "anthropic/" + d.ID, Tier: d.Tier}
+	}
+	return out
 }
 
 func (OpencodeHarness) AccountErrorText(s string) string {

--- a/internal/worker/harness_opencode.go
+++ b/internal/worker/harness_opencode.go
@@ -72,16 +72,13 @@ func (OpencodeHarness) ParseStream(r io.Reader, emit func(Event)) {
 }
 
 // opencodeLine is the subset of `opencode run --format json` event
-// fields the harness needs. The shape is {type, sessionID, ...} per
-// packages/opencode/src/cli/cmd/run.ts; step_finish carries per-step
-// cost and token counts alongside.
+// fields the harness needs. The shape is {type, sessionID, part} per
+// packages/opencode/src/cli/cmd/run.ts; every payload nests under part.
 type opencodeLine struct {
 	Type      string          `json:"type"`
 	SessionID string          `json:"sessionID"`
 	Part      *opencodePart   `json:"part"`
 	Error     json.RawMessage `json:"error"`
-	Cost      float64         `json:"cost"`
-	Tokens    *opencodeTokens `json:"tokens"`
 }
 
 type opencodePart struct {
@@ -90,6 +87,10 @@ type opencodePart struct {
 	Tool  string            `json:"tool"`
 	Name  string            `json:"name"`
 	State opencodeToolState `json:"state"`
+	// step_finish (part.type "step-finish") carries per-step cost and
+	// token counts here, not at the event top level.
+	Cost   float64         `json:"cost"`
+	Tokens *opencodeTokens `json:"tokens"`
 }
 
 type opencodeToolState struct {
@@ -129,8 +130,10 @@ func parseOpencodeLine(raw []byte, emit func(Event)) {
 		emit(Event{Kind: KindError, Text: opencodeErrorText(ev.Error, line)})
 	case isOpencodeTextEvent(ev):
 		emit(Event{Kind: KindText, Text: ev.Part.Text})
+	case ev.Type == "step_finish" && ev.Part != nil:
+		emit(Event{Kind: KindResult, CostUSD: ev.Part.Cost, Turns: 1, Usage: opencodeUsage(ev.Part.Tokens)})
 	case ev.Type == "step_finish":
-		emit(Event{Kind: KindResult, CostUSD: ev.Cost, Usage: opencodeUsage(ev.Tokens)})
+		// no part: nothing to record, but drop it rather than dump raw JSON
 	default:
 		emit(Event{Kind: KindText, Text: line})
 	}
@@ -267,7 +270,7 @@ func (OpencodeHarness) AccountErrorText(s string) string {
 		// failure phrases.
 		"rate limit", "rate_limit", "too many requests", "429",
 		"usage limit", "quota", "insufficient_quota",
-		"invalid_api_key", "incorrect api key",
+		"invalid_api_key", "incorrect api key", "invalid x-api-key",
 		"credit balance", "billing",
 	} {
 		if strings.Contains(lower, phrase) {

--- a/internal/worker/harness_opencode.go
+++ b/internal/worker/harness_opencode.go
@@ -22,7 +22,7 @@ func (OpencodeHarness) Binary() string { return "opencode" }
 // SKILL.md but does not auto-invoke it, so the prompt points at it
 // explicitly. --auto suppresses interactive permission prompts (the
 // container is the sandbox); --format json yields a JSONL event stream.
-func (OpencodeHarness) Args(sj SkillJob, _ string, _ int) []string {
+func (OpencodeHarness) Args(sj SkillJob, _ string, _ int, _ string) []string {
 	args := []string{
 		"run",
 		"--format", "json",

--- a/internal/worker/harness_opencode_test.go
+++ b/internal/worker/harness_opencode_test.go
@@ -130,10 +130,10 @@ func TestOpencodeHarness_AccountErrorText(t *testing.T) {
 
 func TestOpencodeHarness_ParseStream(t *testing.T) {
 	in := `{"type":"step_start","sessionID":"ses-1"}
-{"type":"text","text":"hello"}
-{"type":"reasoning","text":"thinking"}
-{"type":"tool_use","tool":"bash","input":{"command":"ls"}}
-{"type":"error","error":"rate_limit"}
+{"type":"text","part":{"type":"text","text":"hello"}}
+{"type":"reasoning","part":{"type":"reasoning","text":"thinking"}}
+{"type":"tool_use","part":{"type":"tool_use","tool":"bash","input":{"command":"ls"}}}
+{"type":"error","error":{"message":"rate_limit"}}
 {"type":"step_finish"}
 not json
 `
@@ -156,14 +156,14 @@ not json
 	if sessions != 1 || got[0].SessionID != "ses-1" {
 		t.Errorf("session event not extracted: %v", got)
 	}
-	if tools != 1 {
-		t.Errorf("tool events = %d, want 1: %v", tools, got)
+	if tools != 1 || got[3].Tool != "bash" || got[3].Text == "" {
+		t.Errorf("tool event not mapped: %v", got)
 	}
-	if errs != 1 {
-		t.Errorf("error events = %d, want 1: %v", errs, got)
+	if errs != 1 || got[4].Text != "rate_limit" {
+		t.Errorf("error event not mapped: %v", got)
 	}
 	// "hello", "thinking", and the non-JSON line; step_finish is dropped.
-	if texts != 3 {
+	if texts != 3 || got[1].Text != "hello" || got[2].Text != "thinking" {
 		t.Errorf("text events = %d, want 3: %v", texts, got)
 	}
 }

--- a/internal/worker/harness_opencode_test.go
+++ b/internal/worker/harness_opencode_test.go
@@ -135,7 +135,7 @@ func TestOpencodeHarness_ParseStream(t *testing.T) {
 {"type":"reasoning","part":{"type":"reasoning","text":"thinking"}}
 {"type":"tool","part":{"type":"tool","tool":"bash","state":{"status":"completed","input":{"command":"ls"}}}}
 {"type":"error","error":{"name":"ProviderAuthError","data":{"message":"insufficient_quota: exceeded"}}}
-{"type":"step_finish","cost":0.0123,"tokens":{"input":100,"output":40,"reasoning":10,"cache":{"read":20,"write":5}}}
+{"type":"step_finish","sessionID":"ses-1","part":{"type":"step-finish","cost":0.0123,"tokens":{"input":100,"output":40,"reasoning":10,"cache":{"read":20,"write":5}}}}
 not json
 `
 	var got []Event
@@ -168,7 +168,7 @@ not json
 	if (OpencodeHarness{}).AccountErrorText(got[4].Text) == "" {
 		t.Errorf("parsed error text %q not recognised as account error", got[4].Text)
 	}
-	if results != 1 || got[5].CostUSD != 0.0123 {
+	if results != 1 || got[5].CostUSD != 0.0123 || got[5].Turns != 1 {
 		t.Errorf("step_finish not mapped to result: %+v", got[5])
 	}
 	wantUsage := Usage{InputTokens: 100, OutputTokens: 50, CacheReadTokens: 20, CacheWriteTokens: 5}

--- a/internal/worker/harness_opencode_test.go
+++ b/internal/worker/harness_opencode_test.go
@@ -90,7 +90,7 @@ func TestOpencodeHarness_Env(t *testing.T) {
 	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-test")
 	t.Setenv("OPENCODE_CONFIG_CONTENT", "")
 	got := OpencodeHarness{}.Env("https://ignored")
-	for _, want := range []string{"OPENCODE_DISABLE_AUTOUPDATE=1", "OPENCODE_DISABLE_MODELS_FETCH=1", "OPENAI_API_KEY", "ANTHROPIC_API_KEY"} {
+	for _, want := range []string{"OPENCODE_DISABLE_AUTOUPDATE=true", "OPENCODE_DISABLE_MODELS_FETCH=true", "OPENCODE_DISABLE_SHARE=true", "OPENAI_API_KEY", "ANTHROPIC_API_KEY"} {
 		if !slices.Contains(got, want) {
 			t.Errorf("Env() missing %q: %v", want, got)
 		}

--- a/internal/worker/harness_opencode_test.go
+++ b/internal/worker/harness_opencode_test.go
@@ -44,7 +44,7 @@ func TestOpencodeHarness_seamConstants(t *testing.T) {
 
 func TestOpencodeHarness_Args(t *testing.T) {
 	h := OpencodeHarness{}
-	got := h.Args(SkillJob{Name: "deep-dive", Model: "anthropic/claude-sonnet-4-6", OutputFile: "report.json"}, "high", 30)
+	got := h.Args(SkillJob{Name: "deep-dive", Model: "anthropic/claude-sonnet-4-6", OutputFile: "report.json"}, "high", 30, "https://ignored")
 
 	for _, want := range []string{"run", "--auto"} {
 		if !slices.Contains(got, want) {
@@ -71,7 +71,7 @@ func TestOpencodeHarness_Args(t *testing.T) {
 
 func TestOpencodeHarness_ArgsResume(t *testing.T) {
 	h := OpencodeHarness{}
-	got := h.Args(SkillJob{Name: "deep-dive", ResumeSessionID: "ses-7"}, "", 0)
+	got := h.Args(SkillJob{Name: "deep-dive", ResumeSessionID: "ses-7"}, "", 0, "")
 	if i := slices.Index(got, "--session"); i < 0 || got[i+1] != "ses-7" {
 		t.Errorf("resume args missing '--session ses-7': %v", got)
 	}
@@ -82,7 +82,7 @@ func TestOpencodeHarness_ArgsResume(t *testing.T) {
 		t.Errorf("resume prompt does not say continue: %q", got[len(got)-1])
 	}
 
-	got = h.Args(SkillJob{Name: "deep-dive", ResumeSessionID: "ses-7", ResumePrompt: "fix the report"}, "", 0)
+	got = h.Args(SkillJob{Name: "deep-dive", ResumeSessionID: "ses-7", ResumePrompt: "fix the report"}, "", 0, "")
 	if got[len(got)-1] != "fix the report" {
 		t.Errorf("explicit ResumePrompt not used: %q", got[len(got)-1])
 	}

--- a/internal/worker/harness_opencode_test.go
+++ b/internal/worker/harness_opencode_test.go
@@ -1,0 +1,169 @@
+package worker
+
+import (
+	"path/filepath"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestHarnessByName_opencode(t *testing.T) {
+	h, err := HarnessByName("opencode")
+	if err != nil {
+		t.Fatalf("HarnessByName(opencode): %v", err)
+	}
+	if _, ok := h.(OpencodeHarness); !ok {
+		t.Errorf("HarnessByName(opencode) = %T, want OpencodeHarness", h)
+	}
+	if !strings.Contains(HarnessNames(), "opencode") {
+		t.Errorf("HarnessNames() = %q, want opencode listed", HarnessNames())
+	}
+}
+
+func TestOpencodeHarness_seamConstants(t *testing.T) {
+	h := OpencodeHarness{}
+	if h.Binary() != "opencode" {
+		t.Errorf("Binary() = %q, want opencode", h.Binary())
+	}
+	if h.GuideFilename() != "AGENTS.md" {
+		t.Errorf("GuideFilename() = %q, want AGENTS.md", h.GuideFilename())
+	}
+	wantDir := filepath.Join("/work/scan-7", ".opencode", "skill", "deep-dive")
+	if got := h.SkillDir("/work/scan-7", "deep-dive"); got != wantDir {
+		t.Errorf("SkillDir = %q, want %q", got, wantDir)
+	}
+	wantState := []string{"OPENCODE_CONFIG_DIR=/claude-config", "OPENCODE_DB=/claude-config/opencode.db"}
+	if got := h.StateEnv("/claude-config"); !reflect.DeepEqual(got, wantState) {
+		t.Errorf("StateEnv = %v, want %v", got, wantState)
+	}
+	if !slices.Contains(h.EgressHosts(), "models.dev") {
+		t.Errorf("EgressHosts() = %v, want models.dev included", h.EgressHosts())
+	}
+}
+
+func TestOpencodeHarness_Args(t *testing.T) {
+	h := OpencodeHarness{}
+	got := h.Args(SkillJob{Name: "deep-dive", Model: "anthropic/claude-sonnet-4-6", OutputFile: "report.json"}, "high", 30)
+
+	for _, want := range []string{"run", "--auto"} {
+		if !slices.Contains(got, want) {
+			t.Errorf("Args missing %q: %v", want, got)
+		}
+	}
+	if i := slices.Index(got, "--format"); i < 0 || got[i+1] != "json" {
+		t.Errorf("Args missing --format json: %v", got)
+	}
+	if i := slices.Index(got, "--model"); i < 0 || got[i+1] != "anthropic/claude-sonnet-4-6" {
+		t.Errorf("Args missing --model: %v", got)
+	}
+	prompt := got[len(got)-1]
+	if !strings.Contains(prompt, "./.opencode/skill/deep-dive/SKILL.md") || !strings.Contains(prompt, "./src") {
+		t.Errorf("activation prompt does not point at the staged skill: %q", prompt)
+	}
+	if !strings.Contains(prompt, "./report.json") {
+		t.Errorf("activation prompt does not name the output file: %q", prompt)
+	}
+	if slices.Contains(got, "--session") {
+		t.Errorf("non-resume run included --session: %v", got)
+	}
+}
+
+func TestOpencodeHarness_ArgsResume(t *testing.T) {
+	h := OpencodeHarness{}
+	got := h.Args(SkillJob{Name: "deep-dive", ResumeSessionID: "ses-7"}, "", 0)
+	if i := slices.Index(got, "--session"); i < 0 || got[i+1] != "ses-7" {
+		t.Errorf("resume args missing '--session ses-7': %v", got)
+	}
+	if !slices.Contains(got, "--replay=false") {
+		t.Errorf("resume args missing --replay=false: %v", got)
+	}
+	if !strings.Contains(got[len(got)-1], "Continue") {
+		t.Errorf("resume prompt does not say continue: %q", got[len(got)-1])
+	}
+
+	got = h.Args(SkillJob{Name: "deep-dive", ResumeSessionID: "ses-7", ResumePrompt: "fix the report"}, "", 0)
+	if got[len(got)-1] != "fix the report" {
+		t.Errorf("explicit ResumePrompt not used: %q", got[len(got)-1])
+	}
+}
+
+func TestOpencodeHarness_Env(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "sk-test")
+	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+	t.Setenv("OPENCODE_CONFIG_CONTENT", "")
+	got := OpencodeHarness{}.Env("https://ignored")
+	for _, want := range []string{"OPENCODE_DISABLE_AUTOUPDATE=1", "OPENCODE_DISABLE_MODELS_FETCH=1", "OPENAI_API_KEY", "ANTHROPIC_API_KEY"} {
+		if !slices.Contains(got, want) {
+			t.Errorf("Env() missing %q: %v", want, got)
+		}
+	}
+	if slices.Contains(got, "OPENCODE_CONFIG_CONTENT") {
+		t.Errorf("Env() included unset OPENCODE_CONFIG_CONTENT: %v", got)
+	}
+	for _, e := range got {
+		if strings.Contains(e, "https://ignored") {
+			t.Errorf("Env() set a base URL when opencode has none: %v", got)
+		}
+	}
+}
+
+func TestOpencodeHarness_AccountErrorText(t *testing.T) {
+	h := OpencodeHarness{}
+	for in, want := range map[string]bool{
+		"Error: rate_limit_exceeded": true,
+		"usage limit reached":        true,
+		"insufficient_quota":         true,
+		"invalid_api_key":            true,
+		"compiling skill":            false,
+		"":                           false,
+	} {
+		got := h.AccountErrorText(in)
+		if want && got == "" {
+			t.Errorf("AccountErrorText(%q) = empty, want non-empty", in)
+		}
+		if !want && got != "" {
+			t.Errorf("AccountErrorText(%q) = %q, want empty", in, got)
+		}
+	}
+}
+
+func TestOpencodeHarness_ParseStream(t *testing.T) {
+	in := `{"type":"step_start","sessionID":"ses-1"}
+{"type":"text","text":"hello"}
+{"type":"reasoning","text":"thinking"}
+{"type":"tool_use","tool":"bash","input":{"command":"ls"}}
+{"type":"error","error":"rate_limit"}
+{"type":"step_finish"}
+not json
+`
+	var got []Event
+	OpencodeHarness{}.ParseStream(strings.NewReader(in), func(e Event) { got = append(got, e) })
+
+	var sessions, texts, tools, errs int
+	for _, e := range got {
+		switch e.Kind {
+		case KindSession:
+			sessions++
+		case KindText:
+			texts++
+		case KindTool:
+			tools++
+		case KindError:
+			errs++
+		}
+	}
+	if sessions != 1 || got[0].SessionID != "ses-1" {
+		t.Errorf("session event not extracted: %v", got)
+	}
+	if tools != 1 {
+		t.Errorf("tool events = %d, want 1: %v", tools, got)
+	}
+	if errs != 1 {
+		t.Errorf("error events = %d, want 1: %v", errs, got)
+	}
+	// "hello", "thinking", and the non-JSON line; step_finish is dropped.
+	if texts != 3 {
+		t.Errorf("text events = %d, want 3: %v", texts, got)
+	}
+}

--- a/internal/worker/harness_opencode_test.go
+++ b/internal/worker/harness_opencode_test.go
@@ -75,9 +75,6 @@ func TestOpencodeHarness_ArgsResume(t *testing.T) {
 	if i := slices.Index(got, "--session"); i < 0 || got[i+1] != "ses-7" {
 		t.Errorf("resume args missing '--session ses-7': %v", got)
 	}
-	if !slices.Contains(got, "--replay=false") {
-		t.Errorf("resume args missing --replay=false: %v", got)
-	}
 	if !strings.Contains(got[len(got)-1], "Continue") {
 		t.Errorf("resume prompt does not say continue: %q", got[len(got)-1])
 	}
@@ -129,18 +126,22 @@ func TestOpencodeHarness_AccountErrorText(t *testing.T) {
 }
 
 func TestOpencodeHarness_ParseStream(t *testing.T) {
+	// Fixture matches `opencode run --format json` at v1.17.12 (packages/
+	// opencode/src/cli/cmd/run.ts): tool input nests under part.state,
+	// part.type is "tool" not "tool_use", provider errors nest the message
+	// under error.data.message, and step_finish carries cost + tokens.
 	in := `{"type":"step_start","sessionID":"ses-1"}
 {"type":"text","part":{"type":"text","text":"hello"}}
 {"type":"reasoning","part":{"type":"reasoning","text":"thinking"}}
-{"type":"tool_use","part":{"type":"tool_use","tool":"bash","input":{"command":"ls"}}}
-{"type":"error","error":{"message":"rate_limit"}}
-{"type":"step_finish"}
+{"type":"tool","part":{"type":"tool","tool":"bash","state":{"status":"completed","input":{"command":"ls"}}}}
+{"type":"error","error":{"name":"ProviderAuthError","data":{"message":"insufficient_quota: exceeded"}}}
+{"type":"step_finish","cost":0.0123,"tokens":{"input":100,"output":40,"reasoning":10,"cache":{"read":20,"write":5}}}
 not json
 `
 	var got []Event
 	OpencodeHarness{}.ParseStream(strings.NewReader(in), func(e Event) { got = append(got, e) })
 
-	var sessions, texts, tools, errs int
+	var sessions, texts, tools, errs, results int
 	for _, e := range got {
 		switch e.Kind {
 		case KindSession:
@@ -151,19 +152,46 @@ not json
 			tools++
 		case KindError:
 			errs++
+		case KindResult:
+			results++
 		}
 	}
 	if sessions != 1 || got[0].SessionID != "ses-1" {
 		t.Errorf("session event not extracted: %v", got)
 	}
-	if tools != 1 || got[3].Tool != "bash" || got[3].Text == "" {
-		t.Errorf("tool event not mapped: %v", got)
+	if tools != 1 || got[3].Tool != "bash" || !strings.Contains(got[3].Text, "ls") {
+		t.Errorf("tool event not mapped from part.state.input: %v", got[3])
 	}
-	if errs != 1 || got[4].Text != "rate_limit" {
-		t.Errorf("error event not mapped: %v", got)
+	if errs != 1 || got[4].Text != "insufficient_quota: exceeded" {
+		t.Errorf("error text not read from error.data.message: %q", got[4].Text)
 	}
-	// "hello", "thinking", and the non-JSON line; step_finish is dropped.
+	if (OpencodeHarness{}).AccountErrorText(got[4].Text) == "" {
+		t.Errorf("parsed error text %q not recognised as account error", got[4].Text)
+	}
+	if results != 1 || got[5].CostUSD != 0.0123 {
+		t.Errorf("step_finish not mapped to result: %+v", got[5])
+	}
+	wantUsage := Usage{InputTokens: 100, OutputTokens: 50, CacheReadTokens: 20, CacheWriteTokens: 5}
+	if got[5].Usage != wantUsage {
+		t.Errorf("Usage = %+v, want %+v (reasoning folded into output)", got[5].Usage, wantUsage)
+	}
+	// "hello", "thinking", and the non-JSON line.
 	if texts != 3 || got[1].Text != "hello" || got[2].Text != "thinking" {
 		t.Errorf("text events = %d, want 3: %v", texts, got)
+	}
+}
+
+func TestOpencodeHarness_DefaultModelsUseProviderPrefix(t *testing.T) {
+	defs := OpencodeHarness{}.DefaultModels()
+	if len(defs) == 0 {
+		t.Fatal("DefaultModels() is empty")
+	}
+	for _, d := range defs {
+		if !strings.HasPrefix(d.ID, "anthropic/") {
+			t.Errorf("model id %q lacks provider/ prefix; opencode --model needs it", d.ID)
+		}
+		if _, ok := modelPricing[normalizeModelID(d.ID)]; !ok {
+			t.Errorf("model id %q not priced after normalizeModelID", d.ID)
+		}
 	}
 }

--- a/internal/worker/pricing.go
+++ b/internal/worker/pricing.go
@@ -70,10 +70,14 @@ func costFromUsage(model string, u Usage) float64 {
 		float64(u.OutputTokens)*p.Out) / perMillion
 }
 
-// normalizeModelID strips a trailing [...] variant suffix (e.g.
-// "claude-fable-5[1m]" -> "claude-fable-5") so pricing keys stay on the
-// base model id regardless of context-window or routing variants.
+// normalizeModelID strips a leading provider/ prefix (opencode's
+// "anthropic/claude-opus-4-8" form) and a trailing [...] variant suffix
+// ("claude-fable-5[1m]" -> "claude-fable-5") so pricing keys stay on the
+// base model id regardless of harness or context-window variant.
 func normalizeModelID(id string) string {
+	if i := strings.LastIndexByte(id, '/'); i >= 0 {
+		id = id[i+1:]
+	}
 	if i := strings.IndexByte(id, '['); i > 0 {
 		return id[:i]
 	}

--- a/internal/worker/pricing_test.go
+++ b/internal/worker/pricing_test.go
@@ -53,9 +53,11 @@ func TestCostFromUsage_zeroUsageIsZero(t *testing.T) {
 
 func TestNormalizeModelID_stripsBracketSuffix(t *testing.T) {
 	for in, want := range map[string]string{
-		"claude-fable-5[1m]": "claude-fable-5",
-		"claude-opus-4-8":    "claude-opus-4-8",
-		"":                   "",
+		"claude-fable-5[1m]":           "claude-fable-5",
+		"claude-opus-4-8":              "claude-opus-4-8",
+		"anthropic/claude-opus-4-8":    "claude-opus-4-8",
+		"anthropic/claude-fable-5[1m]": "claude-fable-5",
+		"":                             "",
 	} {
 		if got := normalizeModelID(in); got != want {
 			t.Errorf("normalizeModelID(%q) = %q, want %q", in, got, want)


### PR DESCRIPTION
Stacked on #535 (now merged). Adds `OpencodeHarness` implementing the `Harness` interface, registers it, bundles the `opencode` binary in `Dockerfile.runner` (sha256-pinned musl static for both arches, plus `ripgrep` so opencode's grep/glob tools don't try to download it at runtime), and adds `docs/opencode.md` plus a README section.

The interface held: nothing in `container.go`, `main.go`, or the test mocks needed touching beyond registration. The opencode-specific bits:

- **Provider-agnostic.** `EgressHosts()` returns `models.dev` plus `api.openai.com` and `*.anthropic.com`; `Env()` passes through whichever of `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` / `OPENCODE_CONFIG_CONTENT` / `OPENCODE_AUTH_CONTENT` the host has, and disables opencode's autoupdate/share/models-fetch. Other providers need an `egress_allow:` entry. `-model-base-url` is accepted and ignored (opencode configures per-provider endpoints via `OPENCODE_CONFIG_CONTENT`).
- **Model IDs** are opencode's `provider/model` form; `DefaultModels()` returns `anthropic/`-prefixed Claude IDs and `normalizeModelID` strips the prefix for pricing lookup.
- **Two-key state dir.** `StateEnv()` returns both `OPENCODE_CONFIG_DIR` and `OPENCODE_DB`.
- **Argv.** `opencode run --format json --auto --model provider/id [--session <id>] <prompt>`; the prompt points at `./.opencode/skill/{name}/SKILL.md` explicitly.

`ParseStream` was verified against a live opencode 1.17.12 run (full triage fan-out on base62/base62.js under `openai/gpt-5.4`): `step_start` → session, `part.type == "tool"` with `part.state.input` → tool events with args, `part.text` → text, `error.data.message` → error, `step_finish` with `part.cost`/`part.tokens` → result with usage and per-step turn count. All ten fan-out skills completed with cost and token counts on each row.

Closes #211. #239 can be closed pointing here.