### PR TITLE
Rename Sonnet model option to Sonnet 4.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ The config file can also replace the model pick list and pin the fallback defaul
 
     default_model: claude-sonnet-4-6
     models:
-      - name: Sonnet
+      - name: Sonnet 4.6
         id:   claude-sonnet-4-6
       - name: Opus
         id:   claude-opus-4-7

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -48,7 +48,7 @@ data: /var/lib/scrutineer
 effort: medium
 default_model: claude-sonnet-4-6
 models:
-  - name: Sonnet
+  - name: Sonnet 4.6
     id:   claude-sonnet-4-6
   - name: Opus
     id:   claude-opus-4-6
@@ -76,7 +76,7 @@ metadata_dir: .ossprey/
 	if c.Addr != "0.0.0.0:9000" || c.DefaultModel != "claude-sonnet-4-6" {
 		t.Errorf("flat fields: %+v", c)
 	}
-	if len(c.Models) != 2 || c.Models[0].Name != "Sonnet" {
+	if len(c.Models) != 2 || c.Models[0].Name != "Sonnet 4.6" {
 		t.Errorf("models: %+v", c.Models)
 	}
 	if len(c.Skills) != 2 {

--- a/internal/web/models.go
+++ b/internal/web/models.go
@@ -40,7 +40,7 @@ var Models = []Model{
 	{"Opus 4.6", "claude-opus-4-6"},
 	{"Opus 4.7", "claude-opus-4-7"},
 	{"Opus 4.8", "claude-opus-4-8"},
-	{"Sonnet", "claude-sonnet-4-6"},
+	{"Sonnet 4.6", "claude-sonnet-4-6"},
 	{"Fable 5", "claude-fable-5[1m]"},
 }
 

--- a/scrutineer.sample.yaml
+++ b/scrutineer.sample.yaml
@@ -127,9 +127,9 @@
 # anthropic_base_url: https://my-proxy.corp.com/v1
 
 # The model picker in the UI. Replacing this list replaces the built-in
-# set (Sonnet, Opus). Leave it out to keep the built-in list.
+# set (Sonnet 4.6, Opus). Leave it out to keep the built-in list.
 # models:
-#   - name: Sonnet
+#   - name: Sonnet 4.6
 #     id:   claude-sonnet-4-6
 #   - name: Opus
 #     id:   claude-opus-4-7


### PR DESCRIPTION
## Summary

Closes #531.

This clarifies the built-in Sonnet model picker label by renaming `Sonnet` to `Sonnet 4.6`, matching the configured model ID `claude-sonnet-4-6`.

## Changes

- Rename the built-in model display name from `Sonnet` to `Sonnet 4.6`.
- Update README model configuration example.
- Update `scrutineer.sample.yaml` model picker example.
- Update config parsing test fixture and expectation.

## Testing

- `go test ./internal/web -run 'Test.*Model|TestParseSkillModel|TestSettingsUpdateModel'`
- `go test ./internal/config`
- `go test ./internal/web ./internal/config`
- `git diff --check`
- `go test ./...`
- `go vet ./...`
- `go vet -tags podman ./...`
- `go test -race ./...`