### PR TITLE
Add Sonnet 5 model option

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,8 @@ The config file can also replace the model pick list and pin the fallback defaul
     models:
       - name: Sonnet 4.6
         id:   claude-sonnet-4-6
+      - name: Sonnet 5.0
+        id:   claude-sonnet-5
       - name: Opus
         id:   claude-opus-4-7
 

--- a/internal/web/models.go
+++ b/internal/web/models.go
@@ -41,6 +41,7 @@ var Models = []Model{
 	{"Opus 4.7", "claude-opus-4-7"},
 	{"Opus 4.8", "claude-opus-4-8"},
 	{"Sonnet 4.6", "claude-sonnet-4-6"},
+	{"Sonnet 5.0", "claude-sonnet-5"},
 	{"Fable 5", "claude-fable-5[1m]"},
 }
 

--- a/internal/web/models_test.go
+++ b/internal/web/models_test.go
@@ -36,6 +36,12 @@ func TestServerDefaultModel(t *testing.T) {
 	}
 }
 
+func TestBuiltInModelsIncludeSonnet5(t *testing.T) {
+	if !ValidModel("claude-sonnet-5") {
+		t.Fatal("built-in model list should include Sonnet 5.0")
+	}
+}
+
 func TestModelTiers(t *testing.T) {
 	withTestModels(t, []Model{
 		{Name: "High", ID: "test-high"},

--- a/scrutineer.sample.yaml
+++ b/scrutineer.sample.yaml
@@ -127,10 +127,12 @@
 # anthropic_base_url: https://my-proxy.corp.com/v1
 
 # The model picker in the UI. Replacing this list replaces the built-in
-# set (Sonnet 4.6, Opus). Leave it out to keep the built-in list.
+# set (Opus, Sonnet, Fable). Leave it out to keep the built-in list.
 # models:
 #   - name: Sonnet 4.6
 #     id:   claude-sonnet-4-6
+#   - name: Sonnet 5.0
+#     id:   claude-sonnet-5
 #   - name: Opus
 #     id:   claude-opus-4-7
 


### PR DESCRIPTION
- add Sonnet 5.0 (`claude-sonnet-5`) to the built-in model picker
- document the option in README and sample config examples
- add a regression test that the built-in list accepts the Sonnet 5 model id