### PR TITLE
fix: prefer active scan for repo list status badge

### DIFF
--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -558,6 +558,7 @@ func paginate(r *http.Request, total int64) Page {
 type repoRow struct {
 	db.Repository
 	LastScan      *db.Scan
+	StatusScan    *db.Scan
 	FindingsTotal int
 	DiskBytes     int64
 	// Branches lists the distinct non-default refs this repo has been
@@ -676,6 +677,33 @@ func (s *Server) repoList(w http.ResponseWriter, r *http.Request) {
 			lastScans[scans[i].RepositoryID] = &scans[i]
 		}
 	}
+	statusScans := map[uint]*db.Scan{}
+	if len(repoIDs) > 0 {
+		// Status badge prefers active work over recency, so an older running
+		// scan outranks a newer queued one. Rank from status, not the
+		// denormalized status_priority (which can go stale); keep in lockstep
+		// with db.StatusPriorityFor.
+		var scans []db.Scan
+		s.DB.Raw(`
+			SELECT * FROM (
+				SELECT s.*, ROW_NUMBER() OVER (
+					PARTITION BY s.repository_id
+					ORDER BY CASE s.status
+						WHEN ? THEN 0
+						WHEN ? THEN 1
+						WHEN ? THEN 2
+						ELSE 3
+					END, s.id DESC
+				) AS rn
+				FROM scans s
+				WHERE s.repository_id IN ?
+			) ranked
+			WHERE rn = 1
+		`, db.ScanRunning, db.ScanQueued, db.ScanPaused, repoIDs).Scan(&scans)
+		for i := range scans {
+			statusScans[scans[i].RepositoryID] = &scans[i]
+		}
+	}
 
 	branchesByRepo := map[uint][]string{}
 	if len(repoIDs) > 0 {
@@ -701,6 +729,7 @@ func (s *Server) repoList(w http.ResponseWriter, r *http.Request) {
 		rows = append(rows, repoRow{
 			Repository:    repo,
 			LastScan:      lastScans[repo.ID],
+			StatusScan:    statusScans[repo.ID],
 			FindingsTotal: findingCounts[repo.ID],
 			// Read the cached size from the row; the worker refreshes it on
 			// each scan and a startup backfill seeds it, so the list never

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -3478,6 +3478,91 @@ func TestRepoList_showsLastScanDate(t *testing.T) {
 	}
 }
 
+func TestRepoList_statusScanPrecedence(t *testing.T) {
+	type scanSeed struct {
+		status db.ScanStatus
+		at     time.Time
+	}
+	cases := []struct {
+		name       string
+		scans      []scanSeed
+		wantBadge  string
+		wantAbsent string
+		wantLatest string
+	}{
+		{
+			name: "running beats newer queued",
+			scans: []scanSeed{
+				{status: db.ScanRunning, at: time.Date(2026, time.July, 1, 9, 45, 0, 0, time.UTC)},
+				{status: db.ScanQueued, at: time.Date(2026, time.July, 1, 9, 47, 0, 0, time.UTC)},
+			},
+			wantBadge:  "running",
+			wantAbsent: "queued",
+			wantLatest: "2026-07-01 09:47",
+		},
+		{
+			name: "queued beats newer paused",
+			scans: []scanSeed{
+				{status: db.ScanQueued, at: time.Date(2026, time.July, 1, 10, 1, 0, 0, time.UTC)},
+				{status: db.ScanPaused, at: time.Date(2026, time.July, 1, 10, 2, 0, 0, time.UTC)},
+			},
+			wantBadge:  "queued",
+			wantLatest: "2026-07-01 10:02",
+		},
+		{
+			name: "paused beats newer terminal",
+			scans: []scanSeed{
+				{status: db.ScanPaused, at: time.Date(2026, time.July, 1, 10, 3, 0, 0, time.UTC)},
+				{status: db.ScanDone, at: time.Date(2026, time.July, 1, 10, 4, 0, 0, time.UTC)},
+			},
+			wantBadge:  "paused",
+			wantLatest: "2026-07-01 10:04",
+		},
+		{
+			name: "terminal only uses latest terminal",
+			scans: []scanSeed{
+				{status: db.ScanDone, at: time.Date(2026, time.July, 1, 10, 5, 0, 0, time.UTC)},
+				{status: db.ScanFailed, at: time.Date(2026, time.July, 1, 10, 6, 0, 0, time.UTC)},
+			},
+			wantBadge:  "failed",
+			wantLatest: "2026-07-01 10:06",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s, done := newTestServer(t)
+			defer done()
+			repo := db.Repository{URL: "https://github.com/homebrew/ruby-macho/" + strings.ReplaceAll(tc.name, " ", "-"), Name: "ruby-macho"}
+			s.DB.Create(&repo)
+			for i, seed := range tc.scans {
+				s.DB.Create(&db.Scan{
+					RepositoryID: repo.ID,
+					Kind:         "skill",
+					SkillName:    fmt.Sprintf("skill-%d", i),
+					Status:       seed.status,
+					CreatedAt:    seed.at,
+				})
+			}
+
+			w := httptest.NewRecorder()
+			s.Handler().ServeHTTP(w, localReq("GET", "/"))
+			if w.Code != http.StatusOK {
+				t.Fatalf("status %d: %s", w.Code, w.Body)
+			}
+			row := requireRepoListRow(t, w.Body.String(), repo.ID)
+			if !strings.Contains(row, " "+tc.wantBadge+"</span>") {
+				t.Errorf("repo row status = %s, want %s", row, tc.wantBadge)
+			}
+			if tc.wantAbsent != "" && strings.Contains(row, " "+tc.wantAbsent+"</span>") {
+				t.Errorf("repo row should not render %s: %s", tc.wantAbsent, row)
+			}
+			if !strings.Contains(row, tc.wantLatest) {
+				t.Errorf("last scan timestamp should still come from the newest scan: %s", row)
+			}
+		})
+	}
+}
+
 func TestLayout_linksToProjectResources(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()

--- a/internal/web/templates/repo_list.html
+++ b/internal/web/templates/repo_list.html
@@ -53,7 +53,7 @@
         </td>
         <td class="text-muted-foreground">{{if .Languages}}{{.Languages}}{{else}}-{{end}}</td>
         <td>{{if .LastScan}}<span title="{{.LastScan.CreatedAt.Format "2006-01-02 15:04:05 MST"}}">{{.LastScan.CreatedAt.Format "2006-01-02 15:04"}}</span>{{else}}never{{end}}</td>
-        <td>{{if .LastScan}}{{template "status-badge" (status .LastScan.Status)}}{{end}}</td>
+        <td>{{if .StatusScan}}{{template "status-badge" (status .StatusScan.Status)}}{{end}}</td>
         <td>{{template "findings-badge" .FindingsTotal}}</td>
         <td class="text-muted-foreground">{{if .DiskBytes}}{{bytes .DiskBytes}}{{else}}-{{end}}</td>
         <td>


### PR DESCRIPTION
The Repositories list showed a repo as `queued` when it had a newer queued scan, even though an older scan was still `running`. The repo's own Scans tab correctly showed `running`, so the list and the detail page disagreed.

The repository-level status badge now prefers active work over recency, ranking each repo's scans `running > queued > paused > newest terminal` in a single batched query and driving the badge from that. The "Last scan" column is unchanged and still reflects the newest scan for recency. Ranking is computed from `status` rather than the denormalized `status_priority` column so a stale value cannot skew the badge, and the precedence is documented to stay in lockstep with `db.StatusPriorityFor`.

Covered by a new table-driven test (`TestRepoList_statusScanPrecedence`) exercising each precedence rung plus the terminal-only fallback, and the existing list-page query-count bound still holds (the badge adds one batched query, independent of row count).
