### PR TITLE
Carry the resolved profile onto auto-enqueued revalidate/verify scans

### DIFF
--- a/internal/web/import.go
+++ b/internal/web/import.go
@@ -299,7 +299,10 @@ func (s *Server) importFindings(scan *db.Scan, res ingest.Result, revalidate boo
 		// findings such as a trusted sharing bundle.
 		if revalidate {
 			fcopy := f
-			s.enqueueRevalidateForFinding(context.Background(), &fcopy)
+			// Imports have no parent scan and hence no resolved profile to carry;
+			// revalidate detects fresh, and its resolved profile then carries into
+			// the chained verify (autoChainVerifyAfterRevalidate). See #548.
+			s.enqueueRevalidateForFinding(context.Background(), &fcopy, "")
 		}
 	}
 	return created, observed

--- a/internal/web/revalidate_enqueue.go
+++ b/internal/web/revalidate_enqueue.go
@@ -44,7 +44,7 @@ func (s *Server) autoEnqueueRevalidate(scan *db.Scan, f *db.Finding) {
 	if !db.SeverityAtLeast(f.Severity, "High") {
 		return
 	}
-	s.enqueueRevalidateForFinding(context.Background(), f)
+	s.enqueueRevalidateForFinding(context.Background(), f, scan.Profile)
 }
 
 // enqueueRevalidateForFinding looks up the active revalidate skill and
@@ -53,7 +53,12 @@ func (s *Server) autoEnqueueRevalidate(scan *db.Scan, f *db.Finding) {
 // rather than failing the upstream scan. A revalidate run already queued
 // or in flight for this finding is also a no-op so re-imports and rescans
 // do not pile up duplicate work.
-func (s *Server) enqueueRevalidateForFinding(ctx context.Context, f *db.Finding) {
+//
+// profile carries the parent scan's resolved runner profile onto the derived
+// scan so it skips DetectProfile (a container-spawning `brief` run) and
+// reproduces on the same image the finding came from. Empty means detect
+// fresh — the import path passes "" because there is no parent scan. See #548.
+func (s *Server) enqueueRevalidateForFinding(ctx context.Context, f *db.Finding, profile string) {
 	var skill db.Skill
 	if err := s.DB.Where("name = ? AND active = ?", revalidateSkillName, true).First(&skill).Error; err != nil {
 		return
@@ -62,7 +67,7 @@ func (s *Server) enqueueRevalidateForFinding(ctx context.Context, f *db.Finding)
 		return
 	}
 	fid := f.ID
-	if _, err := s.enqueueSkillWith(ctx, f.RepositoryID, skill.ID, ScanOpts{FindingID: &fid}); err != nil {
+	if _, err := s.enqueueSkillWith(ctx, f.RepositoryID, skill.ID, ScanOpts{FindingID: &fid, Profile: profile}); err != nil {
 		s.Log.Warn("auto-enqueue revalidate",
 			"finding", f.ID, "repo", f.RepositoryID, "skill", revalidateSkillName, "err", err)
 	}
@@ -105,7 +110,7 @@ func (s *Server) hasOpenScan(scope string, args ...any) bool {
 //
 // Errors are logged and swallowed; failing to chain verify must not
 // roll back the revalidate verdict.
-func (s *Server) autoChainVerifyAfterRevalidate(_ *db.Scan, f *db.Finding, verdict, severity string) {
+func (s *Server) autoChainVerifyAfterRevalidate(scan *db.Scan, f *db.Finding, verdict, severity string) {
 	if f == nil {
 		return
 	}
@@ -115,13 +120,23 @@ func (s *Server) autoChainVerifyAfterRevalidate(_ *db.Scan, f *db.Finding, verdi
 	if !db.SeverityAtLeast(severity, "High") {
 		return
 	}
-	s.enqueueVerifyForFinding(context.Background(), f)
+	// Carry the revalidate scan's resolved profile so verify reproduces on the
+	// same image (an ASan crash needs the ruby-ext interpreter, not a
+	// re-detected guess) and skips a redundant DetectProfile container spawn.
+	// scan is never nil in production (the worker passes the revalidate scan);
+	// nil-safe for direct callers. See #548.
+	var profile string
+	if scan != nil {
+		profile = scan.Profile
+	}
+	s.enqueueVerifyForFinding(context.Background(), f, profile)
 }
 
 // enqueueVerifyForFinding looks up the active verify skill and enqueues a
 // finding-scoped run, with the same absent-skill, already-queued, and
-// log-but-do-not-fail behaviour as the revalidate enqueue.
-func (s *Server) enqueueVerifyForFinding(ctx context.Context, f *db.Finding) {
+// log-but-do-not-fail behaviour as the revalidate enqueue. profile carries
+// the parent scan's resolved runner profile; empty means detect fresh.
+func (s *Server) enqueueVerifyForFinding(ctx context.Context, f *db.Finding, profile string) {
 	var skill db.Skill
 	if err := s.DB.Where("name = ? AND active = ?", verifySkillName, true).First(&skill).Error; err != nil {
 		return
@@ -130,7 +145,7 @@ func (s *Server) enqueueVerifyForFinding(ctx context.Context, f *db.Finding) {
 		return
 	}
 	fid := f.ID
-	if _, err := s.enqueueSkillWith(ctx, f.RepositoryID, skill.ID, ScanOpts{FindingID: &fid}); err != nil {
+	if _, err := s.enqueueSkillWith(ctx, f.RepositoryID, skill.ID, ScanOpts{FindingID: &fid, Profile: profile}); err != nil {
 		s.Log.Warn("auto-chain verify after revalidate",
 			"finding", f.ID, "repo", f.RepositoryID, "skill", verifySkillName, "err", err)
 	}

--- a/internal/web/revalidate_enqueue_test.go
+++ b/internal/web/revalidate_enqueue_test.go
@@ -1,0 +1,79 @@
+package web
+
+import (
+	"testing"
+
+	"scrutineer/internal/db"
+)
+
+// TestAutoEnqueueRevalidate_carriesParentProfile locks #548: the auto-enqueued
+// revalidate scan inherits the parent scan's resolved runner profile so it
+// skips DetectProfile and runs on the same image the finding came from.
+func TestAutoEnqueueRevalidate_carriesParentProfile(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	repo := db.Repository{URL: "https://example.com/r", Name: "r"}
+	s.DB.Create(&repo)
+	revalidate := db.Skill{Name: "revalidate", OutputFile: "report.json", OutputKind: "revalidate", Version: 1, Active: true}
+	s.DB.Create(&revalidate)
+	// Parent scan already has its auto-detected profile persisted
+	// (skill.go writes res.Profile back before OnFindingCreated fires).
+	scan := db.Scan{RepositoryID: repo.ID, Status: db.ScanDone, SkillName: "security-deep-dive", Profile: "ruby-ext"}
+	s.DB.Create(&scan)
+	f := db.Finding{ScanID: scan.ID, RepositoryID: repo.ID, Title: "t", Severity: "High"}
+	s.DB.Create(&f)
+
+	s.autoEnqueueRevalidate(&scan, &f)
+
+	var derived db.Scan
+	if err := s.DB.Where("finding_id = ? AND skill_id = ?", f.ID, revalidate.ID).First(&derived).Error; err != nil {
+		t.Fatalf("derived revalidate scan not enqueued: %v", err)
+	}
+	if derived.Profile != "ruby-ext" {
+		t.Errorf("derived Profile = %q, want %q (carried from parent)", derived.Profile, "ruby-ext")
+	}
+}
+
+// TestAutoChainVerify_carriesRevalidateProfile locks #548: the auto-chained
+// verify scan inherits the revalidate scan's resolved profile so it reproduces
+// on the same image (an ASan crash needs the ruby-ext interpreter, not a
+// re-detected guess) and skips a redundant DetectProfile container spawn.
+func TestAutoChainVerify_carriesRevalidateProfile(t *testing.T) {
+	s, done, verify, newFinding := chainTestSetup(t)
+	defer done()
+	f := newFinding("High")
+	// The revalidate scan whose verdict is being applied; its own profile was
+	// resolved (auto-detected or itself carried from the deep-dive parent) and
+	// persisted before OnRevalidateVerdict fires.
+	parent := db.Scan{RepositoryID: f.RepositoryID, Status: db.ScanDone, SkillName: "revalidate", Profile: "ruby-ext"}
+	s.DB.Create(&parent)
+
+	s.autoChainVerifyAfterRevalidate(&parent, f, "true_positive", "High")
+
+	var derived db.Scan
+	if err := s.DB.Where("finding_id = ? AND skill_id = ?", f.ID, verify.ID).First(&derived).Error; err != nil {
+		t.Fatalf("derived verify scan not enqueued: %v", err)
+	}
+	if derived.Profile != "ruby-ext" {
+		t.Errorf("derived Profile = %q, want %q (carried from revalidate)", derived.Profile, "ruby-ext")
+	}
+}
+
+// TestAutoChainVerify_nilScanDetectsFresh locks the nil-safe read: a nil scan
+// (never happens in production but the callback is a public seam) still chains
+// verify with an empty profile — detect fresh — rather than panicking.
+func TestAutoChainVerify_nilScanDetectsFresh(t *testing.T) {
+	s, done, verify, newFinding := chainTestSetup(t)
+	defer done()
+	f := newFinding("High")
+
+	s.autoChainVerifyAfterRevalidate(nil, f, "true_positive", "High")
+
+	var derived db.Scan
+	if err := s.DB.Where("finding_id = ? AND skill_id = ?", f.ID, verify.ID).First(&derived).Error; err != nil {
+		t.Fatalf("derived verify scan not enqueued: %v", err)
+	}
+	if derived.Profile != "" {
+		t.Errorf("derived Profile = %q, want empty (detect fresh)", derived.Profile)
+	}
+}

--- a/internal/worker/profile.go
+++ b/internal/worker/profile.go
@@ -121,11 +121,11 @@ var builtinProfiles = []Profile{
 		// installs Brakeman (see docker/profiles/ruby-ext/Dockerfile) — so a
 		// gem that also looks like a Rails app still gets Rails SAST despite
 		// matching here first, and a false match against a *Ruby* repo only
-		// costs build time, never coverage. Robust detection also lets the
-		// verify skill (which re-detects rather than carrying the scan's
-		// profile) re-pick ruby-ext and actually reproduce an ASan crash,
-		// instead of landing on stock ruby and reporting the finding
-		// inconclusive.
+		// costs build time, never coverage. The auto-chained revalidate/verify
+		// scans now inherit the parent scan's resolved profile (#548), so verify
+		// reproduces an ASan crash on this same image; robust detection still
+		// matters for a manual re-run or the /v1/import path, which detect
+		// fresh.
 		//
 		// It is NOT a superset of the rust profile (no Miri, only a minimal
 		// rustc for rb-sys shims), so the Cargo.toml marker below is gated on


### PR DESCRIPTION
Closes #548. Follow-up from #546.

The auto-chained revalidate and verify scans were created with an empty `Profile`, so each re-ran `DetectProfile` (a container-spawning `brief` run) against the same commit the parent already detected. `ScanOpts` already has a `Profile` field and `resolveProfile` already skips detection when it is set; the callbacks just weren't passing it.

Thread `scan.Profile` through `enqueueRevalidateForFinding` / `enqueueVerifyForFinding`. The parent's detected profile is written back to the scan row at `skill.go:173` before `parseSkillOutput` runs, and both `OnFindingCreated` and `OnRevalidateVerdict` fire from inside `parseSkillOutput`, so `scan.Profile` is populated at enqueue time. Imports have no parent scan and pass `""`; revalidate detects once and verify then inherits.

Net: a deep-dive → revalidate → verify chain drops from three `DetectProfile` container spawns to one; import → revalidate → verify drops from two to one. Also makes verify reproduce on the exact image the finding came from rather than a re-detected guess.

Updated the stale ruby-ext registry comment that described the old behaviour.

Left out of scope: persisting `"default"` as a sentinel so default-profile scans also skip re-detection (touches UI display and `Profile == ""` checks), and `validate_fix_enqueue.go:110` (verify against a fix ref, parent scan not in hand).