### PR TITLE
docs: update docs and provide test harness for profiles introduced for deeper scanning of ruby native extensions and rails

### DIFF
--- a/docs/exercise-ruby-profiles.sh
+++ b/docs/exercise-ruby-profiles.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env sh
+# Exercise the ruby-ext / ruby-rails profiles at RUNTIME — the part a clean
+# `docker build` does NOT prove (that a sanitizer actually aborts, that the
+# UBSan alignment check reaches the extension, that Brakeman actually runs).
+# Runnable companion to docs/ruby-ext-validation.md (§3–§7).
+#
+# Prereq: images built (docs/ruby-ext-validation.md §1):
+#   scrutineer-profile-ruby-ext, scrutineer-profile-ruby-rails
+#   (override with EXT_IMG / RAILS_IMG)
+#
+#   sh docs/exercise-ruby-profiles.sh
+set -eu
+EXT_IMG="${EXT_IMG:-scrutineer-profile-ruby-ext}"
+RAILS_IMG="${RAILS_IMG:-scrutineer-profile-ruby-rails}"
+
+# Fail fast if the images aren't built locally — otherwise podman's short-name
+# resolver errors cryptically ("cannot prompt without a TTY"). inspect never pulls.
+for img in "$EXT_IMG" "$RAILS_IMG"; do
+  docker image inspect "$img" >/dev/null 2>&1 || {
+    echo "image '$img' not found locally — build it (docs/ruby-ext-validation.md §1) or set the name:" >&2
+    echo "  EXT_IMG=rp-ruby-ext RAILS_IMG=rp-ruby-rails sh docs/exercise-ruby-profiles.sh" >&2
+    exit 1
+  }
+done
+
+W="$(mktemp -d)"; trap 'rm -rf "$W"' EXIT
+# :z relabels the bind mount for SELinux hosts (mirrors DetectProfile's :ro,z);
+# harmless where SELinux is off / on Docker Desktop.
+run() { docker run --rm --user root -v "$W:/src:z" -w /src --entrypoint sh "$1" -c "$2" 2>&1 || true; }
+
+# 1) ASan aborts on a heap-buffer-overflow in a native extension — the core of ruby-ext.
+mkdir -p "$W/ext/boom"
+printf 'require "mkmf"\ncreate_makefile("boom")\n' > "$W/ext/boom/extconf.rb"
+cat > "$W/ext/boom/boom.c" <<'C'
+#include <ruby.h>
+#include <string.h>
+/* rb_str_new + xfree USE the buffer, so -O1 can't dead-store-eliminate the memcpy. */
+static VALUE go(VALUE self, VALUE x){
+  long n = RSTRING_LEN(x);
+  char *b = xmalloc(16);
+  memcpy(b, RSTRING_PTR(x), n);   /* heap-buffer-overflow when n > 16 */
+  VALUE r = rb_str_new(b, n);
+  xfree(b);
+  return r;
+}
+void Init_boom(void){ rb_define_module_function(rb_define_module("Boom"), "go", go, 1); }
+C
+o=$(run "$EXT_IMG" 'cd ext/boom && ruby extconf.rb >/dev/null && make >/dev/null 2>&1 && cd /src && ruby -e "require_relative %q(ext/boom/boom); Boom.go(%q(A)*64)"')
+if echo "$o" | grep -q "heap-buffer-overflow"; then echo "PASS  asan-overflow"; else echo "FAIL  asan-overflow"; echo "$o"; exit 1; fi
+
+# 2) UBSan alignment check reaches the extension at runtime — the rbconfig-rewrite half of #5.
+mkdir -p "$W/ext/aln"
+printf 'require "mkmf"\ncreate_makefile("aln")\n' > "$W/ext/aln/extconf.rb"
+cat > "$W/ext/aln/aln.c" <<'C'
+#include <ruby.h>
+struct a8 { long x; };
+static VALUE go(VALUE self){ char *b = xmalloc(32); struct a8 *p = (struct a8 *)(b + 1); p->x = 42; return LONG2NUM(p->x); }
+void Init_aln(void){ rb_define_module_function(rb_define_module("Aln"), "go", go, 0); }
+C
+o=$(run "$EXT_IMG" 'cd ext/aln && ruby extconf.rb >/dev/null && make >/dev/null 2>&1 && cd /src && ruby -e "require_relative %q(ext/aln/aln); Aln.go"')
+if echo "$o" | grep -q "misaligned"; then echo "PASS  ubsan-alignment"; else echo "FAIL  ubsan-alignment"; echo "$o"; exit 1; fi
+
+# 3) Brakeman flags a Rails SQLi — the #3 add (ruby-ext ships it) and #6 (ruby-rails). Best-effort.
+mkdir -p "$W/rails/app/controllers" "$W/rails/config"
+printf 'source "https://rubygems.org"\ngem "rails"\n' > "$W/rails/Gemfile"
+printf 'module Demo\n  class Application < Rails::Application; end\nend\n' > "$W/rails/config/application.rb"
+cat > "$W/rails/app/controllers/users_controller.rb" <<'RB'
+class UsersController < ApplicationController
+  def show; User.where("name = '#{params[:name]}'"); end
+end
+RB
+for img in "$EXT_IMG" "$RAILS_IMG"; do
+  o=$(run "$img" 'cd /src/rails && brakeman -q --no-pager . 2>&1')
+  if echo "$o" | grep -qi "SQL Injection"; then echo "PASS  brakeman-sqli [$img]"; else echo "WARN  brakeman-sqli [$img]: no SQLi warning — check: $(echo "$o" | tail -1)"; fi
+done
+
+echo "done"

--- a/docs/ruby-ext-validation.md
+++ b/docs/ruby-ext-validation.md
@@ -1,7 +1,15 @@
-# Validating the `ruby-ext` ASan recipe
+# Validating the `ruby-ext` recipe (sanitizers + Brakeman)
 
-One-time check that the sanitized interpreter actually catches a memory-safety or UB bug in a native gem.
-Needs Docker + network. The image build compiles Ruby (and Rust) from source — ~15–20 min.
+One-time check that the sanitized interpreter actually catches a memory-safety or UB bug in a
+native gem, and that Brakeman runs. Needs Docker + network. The image build compiles Ruby (and
+Rust) from source — ~15–20 min.
+
+> `docs/exercise-ruby-profiles.sh` runs §3–§7 end-to-end against pre-built images — use it for a
+> quick pass; the sections below are the manual/explanatory form.
+>
+> **SELinux hosts:** every `docker run -v …:/src` below uses `:z` to relabel the mount (mirroring
+> the scanner's `:ro,z`). Without it the container — even as root — gets `Permission denied`
+> reading the mounted files. Harmless where SELinux is off / on Docker Desktop.
 
 ## 1. Build the images
 
@@ -60,10 +68,14 @@ puts "NO CRASH"
 RB
 ```
 
+> The extension deliberately *uses* the buffer (`rb_str_new(buf, n)` then `xfree`): at the
+> profile's `-O1`, a `memcpy` into a buffer that is never read or freed gets dead-store-eliminated
+> and the overflow silently disappears. Keep the read/free or the reproducer won't fire.
+
 ## 4. Build under ASan + trigger
 
 ```bash
-docker run --rm --user root -v /tmp/boom:/src -w /src scrutineer-profile-ruby-ext sh -c '
+docker run --rm --user root -v /tmp/boom:/src:z -w /src scrutineer-profile-ruby-ext sh -c '
   cd ext/boom && ruby extconf.rb && make && cd /src && ruby poc.rb'
 ```
 
@@ -73,7 +85,7 @@ docker run --rm --user root -v /tmp/boom:/src -w /src scrutineer-profile-ruby-ex
 Negative control (must print `NO CRASH`, no ASan output):
 
 ```bash
-docker run --rm --user root -v /tmp/boom:/src -w /src scrutineer-profile-ruby-ext sh -c '
+docker run --rm --user root -v /tmp/boom:/src:z -w /src scrutineer-profile-ruby-ext sh -c '
   cd /src && ruby -e "require_relative %q(ext/boom/boom); Boom.copy(%q(short)); puts %q(NO CRASH)"'
 ```
 
@@ -109,7 +121,7 @@ void Init_aln(void) {
 }
 C
 
-docker run --rm --user root -v /tmp/aln:/src -w /src scrutineer-profile-ruby-ext sh -c '
+docker run --rm --user root -v /tmp/aln:/src:z -w /src scrutineer-profile-ruby-ext sh -c '
   cd ext/aln && ruby extconf.rb && make V=1 && cd /src &&
   ruby -e "require_relative %q(ext/aln/aln); Aln.go"'
 ```
@@ -140,13 +152,36 @@ docker run --rm scrutineer-profile-ruby-ext sh -c '
 Stock interpreter, separate uninstrumented build:
 
 ```bash
-docker run --rm --user root -v /tmp/boom:/src -w /src scrutineer-profile-ruby-ext sh -c '
+docker run --rm --user root -v /tmp/boom:/src:z -w /src scrutineer-profile-ruby-ext sh -c '
   cd ext/boom && rm -f *.o *.so Makefile && /usr/bin/ruby extconf.rb && make && cd /src &&
   valgrind --suppressions=/usr/local/share/ruby-ext/ruby.supp --error-exitcode=99 /usr/bin/ruby poc.rb'
 ```
 
 **Pass:** `Invalid write of size …` in `boom_copy`, exit 99, with no GC-noise errors leaking past
 the suppressions.
+
+## 7. Brakeman (Rails SAST)
+
+`ruby-ext` ships Brakeman too — a native gem that is also a Rails app must still get Rails SAST,
+and `ruby-rails` is the same check on the stock interpreter. Scaffold a minimal app with a SQL
+injection and confirm Brakeman flags it:
+
+```bash
+mkdir -p /tmp/rails/app/controllers /tmp/rails/config
+printf 'source "https://rubygems.org"\ngem "rails"\n' > /tmp/rails/Gemfile
+printf 'module Demo\n  class Application < Rails::Application; end\nend\n' > /tmp/rails/config/application.rb
+cat > /tmp/rails/app/controllers/users_controller.rb <<'RB'
+class UsersController < ApplicationController
+  def show; User.where("name = '#{params[:name]}'"); end   # SQLi
+end
+RB
+
+docker run --rm --user root -v /tmp/rails:/src:z -w /src scrutineer-profile-ruby-ext sh -c '
+  cd /src && brakeman -q --no-pager .'
+```
+
+**Pass:** the report lists a `SQL Injection` warning in `users_controller.rb`. Repeat with
+`scrutineer-profile-ruby-rails` for the ruby-rails profile — same result.
 
 ## If a sanitizer doesn't fire / the interpreter crashes in the GC
 


### PR DESCRIPTION
Minor doc tweaks off the back of https://github.com/alpha-omega-security/scrutineer/pull/546 + a test script for the profiles created by it