### PR TITLE
feat: auto-resume scans after a Claude rate-limit reset

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ Then start scrutineer:
 
 Then open http://127.0.0.1:8080.
 
+Large batches pause and resume automatically at a Claude rate-limit wall, with no extra configuration. When claude-code (running with a Claude subscription token) reports an account-level rate/usage limit, scrutineer pauses the remaining queued scans, reads the reset time from the `rate_limit_event` claude-code emits in its own output, and re-queues the paused batch after that reset. If no reset is reported (for example an API-key account, which does not emit those events), the batch stays paused for manual resume. The most recent per-window status is shown on the `/usage` page.
+
 Scrutineer detects Docker and starts using it automatically: each scan runs in an ephemeral container with a read-only source mount and an egress allowlist proxy. The runner image (`ghcr.io/alpha-omega-security/scrutineer-runner`) is pulled on first use, so the first scan is slower while it downloads. If Docker isn't available scans run directly on the host with no isolation; see the Security section before doing that.
 
 Click **Add repository** in the sidebar, paste a git HTTPS URL, and scrutineer enqueues the `triage` skill. To scan a maintained branch instead of the default, fill the **Branch** field (it suggests the remote's branches as you type and also accepts a tag or commit), or append a `/tree/<branch>` suffix to the URL; the suffix also works one-per-line when bulk-importing. Triage then enqueues the rest of the pipeline in parallel. Metadata and package lookups finish in seconds; the security deep-dive takes a few minutes depending on repo size. Open the repo page and switch to the Scans tab to watch progress, or wait for the Findings tab to fill in.
@@ -103,7 +105,7 @@ When the containerised runner is active (the default when a container runtime is
 - **Skill HTTP API** -- running skills can call back into scrutineer to list prior scans and enqueue further skills; surface documented in `openapi.yaml`
 - **Live updates** -- SSE streaming of scan logs and status changes, no polling
 - **Organisation rollup** -- repos, findings, and maintainers grouped by owning org, with per-org markdown exports
-- **Usage tracking** -- per-scan token and cost figures plus a `/usage` page totalling spend per skill
+- **Usage tracking** -- per-scan token and cost figures plus a `/usage` page totalling spend per skill; on a Claude subscription token, a rate-limit wall auto-pauses the batch and resumes it after the reported reset, with per-window status shown on `/usage`
 - **Themes** -- six colour themes plus a light/dark/system toggle, set on the Settings page
 
 ## The default pipeline

--- a/cmd/scrutineer/main_test.go
+++ b/cmd/scrutineer/main_test.go
@@ -82,7 +82,10 @@ func TestFlagsMerge_cliFlagWins(t *testing.T) {
 	f := &flags{
 		addr: "127.0.0.1:8080", cloneMode: "shallow", concurrency: 2,
 		anthropicBaseURL: "https://my-flag.example.com/v1",
-		set:              map[string]bool{"addr": true, "clone": true, "concurrency": true, "anthropic-base-url": true},
+		set: map[string]bool{
+			"addr": true, "clone": true, "concurrency": true,
+			"anthropic-base-url": true,
+		},
 	}
 	f.merge(cfg)
 	if f.addr != "127.0.0.1:8080" {

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -251,6 +251,9 @@ type Scan struct {
 	Report string
 	Log    string
 	Error  string
+	// PausedUntil is set for model-account pauses with a known reset time.
+	// Nil means a manual pause or an account pause without a reported reset.
+	PausedUntil *time.Time `gorm:"index"`
 
 	// ImportPayload carries the raw uploaded report for an ingest-skill
 	// run created by the /v1/import fallback. The worker stages it into

--- a/internal/web/list_performance_test.go
+++ b/internal/web/list_performance_test.go
@@ -55,7 +55,7 @@ func TestScanListStatsAggregatesCounts(t *testing.T) {
 		RepositoryID: repo.ID,
 		Kind:         "skill",
 		Status:       db.ScanPaused,
-		Error:        "Claude account access paused. Queued scan held automatically; resume once the account recovers.",
+		Error:        "Claude account access paused. Queued scan paused automatically; resume once the account recovers.",
 	})
 	s.DB.Create(&db.Scan{
 		RepositoryID: repo.ID,

--- a/internal/web/scans.go
+++ b/internal/web/scans.go
@@ -60,6 +60,7 @@ func (s *Server) jobs(w http.ResponseWriter, r *http.Request) {
 		"Skill": skillName, "Status": status, "Sort": sort, "Skills": skillNames,
 		"AnySubPath": anySubPath, "QueuedCount": stats.QueuedCount, "PausedCount": stats.PausedCount,
 		"AccountPausedCount": stats.AccountPausedCount,
+		"NextAccountResume":  stats.NextAccountResume,
 	})
 }
 
@@ -67,6 +68,7 @@ type scanListStats struct {
 	QueuedCount        int64
 	PausedCount        int64
 	AccountPausedCount int64
+	NextAccountResume  *time.Time
 }
 
 func (s *Server) scanListStats() scanListStats {
@@ -82,6 +84,13 @@ func (s *Server) scanListStats() scanListStats {
 			worker.ClaudeAccountPausePrefix+"%",
 		).
 		Scan(&stats)
+	var next db.Scan
+	s.DB.Select("id", "paused_until").
+		Where("status = ? AND error LIKE ? AND paused_until IS NOT NULL", db.ScanPaused, worker.ClaudeAccountPausePrefix+"%").
+		Order("paused_until ASC").
+		Limit(1).
+		Find(&next)
+	stats.NextAccountResume = next.PausedUntil
 	return stats
 }
 
@@ -315,6 +324,7 @@ func (s *Server) resumeScan(ctx context.Context, scan *db.Scan) error {
 		"status_priority": db.StatusPriorityFor(db.ScanQueued),
 		errorKey:          "",
 		"finished_at":     nil,
+		"paused_until":    nil,
 	}).Error
 }
 

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -4384,12 +4384,14 @@ func TestJobs_showsAccountPauseResumeActions(t *testing.T) {
 
 	repo := db.Repository{URL: "https://example.com/x.git", Name: "x"}
 	s.DB.Create(&repo)
+	resetAt := time.Date(2026, 7, 1, 12, 30, 0, 0, time.UTC)
 	// A scan auto-paused because the account hit an account-level Claude problem.
 	// The banner should surface it and the Resume-paused action should be offered.
 	s.DB.Create(&db.Scan{
 		RepositoryID: repo.ID, Kind: "skill", Status: db.ScanPaused,
 		StatusPriority: db.StatusPriorityFor(db.ScanPaused),
-		Error:          "Claude account access paused. Queued scan held automatically; resume once the account recovers.",
+		Error:          "Claude account access paused. Queued scan paused automatically; resume once the account recovers.",
+		PausedUntil:    &resetAt,
 	})
 
 	w := httptest.NewRecorder()
@@ -4398,7 +4400,7 @@ func TestJobs_showsAccountPauseResumeActions(t *testing.T) {
 		t.Fatalf("status %d: %s", w.Code, w.Body)
 	}
 	body := w.Body.String()
-	for _, want := range []string{"Claude account access paused", "/scans/resume-paused"} {
+	for _, want := range []string{"Claude account access paused", "/scans/resume-paused", "2026-07-01 12:30 UTC"} {
 		if !strings.Contains(body, want) {
 			t.Errorf("missing %q in jobs body", want)
 		}

--- a/internal/web/templates/jobs.html
+++ b/internal/web/templates/jobs.html
@@ -81,7 +81,8 @@
     <i data-lucide="triangle-alert"></i>
     <section>
       <strong>Claude account access paused.</strong>
-      Queued scans were held automatically. Resume them once the account recovers.
+      Queued scans were paused automatically.
+      {{if .NextAccountResume}}Scrutineer will resume them after {{.NextAccountResume.UTC.Format "2006-01-02 15:04 UTC"}}.{{else}}Resume them once the account recovers.{{end}}
     </section>
   </div>
 {{end}}

--- a/internal/web/templates/usage.html
+++ b/internal/web/templates/usage.html
@@ -20,6 +20,33 @@
   </div>
 </div>
 
+{{if .RateLimit.Rows}}
+<div class="card p-4 mb-6">
+  <div class="flex items-center justify-between gap-4 mb-3">
+    <h3 class="text-sm font-semibold flex items-center gap-2">
+      <i data-lucide="gauge"></i> Claude subscription limits
+    </h3>
+    <span class="text-xs text-muted-foreground">latest per window since restart</span>
+  </div>
+  <table class="table w-full">
+    <thead><tr>
+      <th>Window</th>
+      <th>Status</th>
+      <th class="text-right">Resets</th>
+    </tr></thead>
+    <tbody>
+    {{range .RateLimit.Rows}}
+      <tr>
+        <td class="font-medium">{{.Window}}</td>
+        <td class="text-muted-foreground">{{.Status}}</td>
+        <td class="text-right text-muted-foreground">{{if .ResetAt}}{{.ResetAt}}{{else}}—{{end}}</td>
+      </tr>
+    {{end}}
+    </tbody>
+  </table>
+</div>
+{{end}}
+
 {{if eq .View "day"}}
   {{if .DayRows}}
     <table class="table w-full">

--- a/internal/web/usage.go
+++ b/internal/web/usage.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 
 	"scrutineer/internal/db"
+	"scrutineer/internal/worker"
 )
 
 // SkillUsage is one row of the /usage page: aggregate cost and turn
@@ -117,6 +118,7 @@ func (s *Server) usage(w http.ResponseWriter, r *http.Request) {
 		"TotalCost": totalCost,
 		"TotalRuns": totalRuns,
 		"View":      view,
+		"RateLimit": buildRateLimitPanel(s.Worker.RateLimitStatus()),
 	})
 }
 
@@ -157,4 +159,40 @@ func percentile(sorted []float64, p float64) float64 {
 		return sorted[len(sorted)-1]
 	}
 	return sorted[lo] + frac*(sorted[lo+1]-sorted[lo])
+}
+
+// rateLimitPanel is the usage page's in-memory Claude rate-limit snapshot.
+type rateLimitPanel struct {
+	Rows []rateLimitRow
+}
+
+type rateLimitRow struct {
+	Window  string
+	Status  string
+	ResetAt string
+}
+
+func rateLimitWindowLabel(t string) string {
+	switch t {
+	case "five_hour":
+		return "5-hour"
+	case "seven_day":
+		return "7-day"
+	default:
+		return t
+	}
+}
+
+// buildRateLimitPanel formats the worker's latest per-window stream status.
+func buildRateLimitPanel(statuses []worker.RateLimitInfo) rateLimitPanel {
+	var p rateLimitPanel
+	for _, st := range statuses {
+		row := rateLimitRow{Window: rateLimitWindowLabel(st.Type), Status: st.Status}
+		if t := st.ResetTime(); t != nil {
+			row.ResetAt = t.UTC().Format("2006-01-02 15:04 UTC")
+		}
+		p.Rows = append(p.Rows, row)
+	}
+	sort.Slice(p.Rows, func(i, j int) bool { return p.Rows[i].Window < p.Rows[j].Window })
+	return p
 }

--- a/internal/web/usage_test.go
+++ b/internal/web/usage_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"scrutineer/internal/db"
+	"scrutineer/internal/worker"
 )
 
 func almostEq(a, b float64) bool { return math.Abs(a-b) < 1e-9 }
@@ -111,6 +112,42 @@ func TestUsage_perSkillStatsAndOrdering(t *testing.T) {
 	// Ordered by total cost desc: deep-dive ($12) before metadata ($0.0046).
 	if strings.Index(body, "security-deep-dive") > strings.Index(body, ">metadata<") {
 		t.Errorf("expected deep-dive row before metadata row")
+	}
+}
+
+func TestBuildRateLimitPanel(t *testing.T) {
+	reset := time.Date(2026, 7, 1, 12, 30, 0, 0, time.UTC)
+	// Unsorted input across both windows; the panel sorts by window label.
+	statuses := []worker.RateLimitInfo{
+		{Type: "seven_day", Status: "allowed", ResetsAt: reset.Add(48 * time.Hour).Unix()},
+		{Type: "five_hour", Status: "rejected", ResetsAt: reset.Unix()},
+	}
+	p := buildRateLimitPanel(statuses)
+	if len(p.Rows) != 2 {
+		t.Fatalf("rows = %d, want 2", len(p.Rows))
+	}
+	if p.Rows[0].Window != "5-hour" || p.Rows[1].Window != "7-day" {
+		t.Fatalf("window order = %q,%q, want 5-hour,7-day", p.Rows[0].Window, p.Rows[1].Window)
+	}
+	if p.Rows[0].Status != "rejected" {
+		t.Errorf("status = %q, want rejected", p.Rows[0].Status)
+	}
+	if p.Rows[0].ResetAt != "2026-07-01 12:30 UTC" {
+		t.Errorf("reset = %q, want formatted UTC", p.Rows[0].ResetAt)
+	}
+	if got := buildRateLimitPanel(nil); len(got.Rows) != 0 {
+		t.Errorf("nil statuses yielded %d rows, want 0", len(got.Rows))
+	}
+}
+
+func TestUsage_hidesRateLimitPanelWhenNoStatus(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	// No rate_limit_event captured -> panel is absent.
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq("GET", "/usage"))
+	if strings.Contains(w.Body.String(), "Claude subscription limits") {
+		t.Error("rate-limit panel rendered with no captured status")
 	}
 }
 

--- a/internal/worker/claude.go
+++ b/internal/worker/claude.go
@@ -153,13 +153,11 @@ func (l LocalClaude) RunSkill(ctx context.Context, sj SkillJob, emit func(Event)
 
 	emit(Event{Kind: KindText, Text: "$ claude -p <skill:" + sj.Name + ">"})
 	accountErrText := ""
-	var lastRateLimit *RateLimitInfo
+	var rateLimitReset *RateLimitInfo
 	wrappedEmit := func(e Event) {
 		accountErrText = preferAccountErrText(accountErrText, claudeAccountErrorText(e.Text))
-		// Keep the latest reported window; account-pause extension reconciles
-		// concurrent scans to the furthest reset.
 		if e.Kind == KindRateLimit && e.RateLimit != nil {
-			lastRateLimit = e.RateLimit
+			rateLimitReset = preferRateLimitReset(rateLimitReset, e.RateLimit)
 		}
 		emit(e)
 	}
@@ -191,7 +189,7 @@ func (l LocalClaude) RunSkill(ctx context.Context, sj SkillJob, emit func(Event)
 			return res, &MaxTurnsReachedError{}
 		}
 		if accountErrText != "" {
-			return res, &ClaudeAccountError{Detail: accountErrText, ResetAt: resumableReset(accountErrText, lastRateLimit)}
+			return res, &ClaudeAccountError{Detail: accountErrText, ResetAt: resumableReset(accountErrText, rateLimitReset)}
 		}
 		return res, fmt.Errorf("claude exited: %w", waitErr)
 	}

--- a/internal/worker/claude.go
+++ b/internal/worker/claude.go
@@ -153,9 +153,13 @@ func (l LocalClaude) RunSkill(ctx context.Context, sj SkillJob, emit func(Event)
 
 	emit(Event{Kind: KindText, Text: "$ claude -p <skill:" + sj.Name + ">"})
 	accountErrText := ""
+	var lastRateLimit *RateLimitInfo
 	wrappedEmit := func(e Event) {
-		if accountErrText == "" {
-			accountErrText = claudeAccountErrorText(e.Text)
+		accountErrText = preferAccountErrText(accountErrText, claudeAccountErrorText(e.Text))
+		// Keep the latest reported window; account-pause extension reconciles
+		// concurrent scans to the furthest reset.
+		if e.Kind == KindRateLimit && e.RateLimit != nil {
+			lastRateLimit = e.RateLimit
 		}
 		emit(e)
 	}
@@ -187,7 +191,7 @@ func (l LocalClaude) RunSkill(ctx context.Context, sj SkillJob, emit func(Event)
 			return res, &MaxTurnsReachedError{}
 		}
 		if accountErrText != "" {
-			return res, &ClaudeAccountError{Detail: accountErrText}
+			return res, &ClaudeAccountError{Detail: accountErrText, ResetAt: resumableReset(accountErrText, lastRateLimit)}
 		}
 		return res, fmt.Errorf("claude exited: %w", waitErr)
 	}

--- a/internal/worker/claude_limit.go
+++ b/internal/worker/claude_limit.go
@@ -123,9 +123,24 @@ func preferAccountErrText(current, candidate string) string {
 	}
 }
 
+func preferRateLimitReset(current, candidate *RateLimitInfo) *RateLimitInfo {
+	if candidate == nil || !candidate.Rejected() || candidate.ResetTime() == nil {
+		return current
+	}
+	if current == nil {
+		return candidate
+	}
+	curReset := current.ResetTime()
+	candReset := candidate.ResetTime()
+	if curReset == nil || candReset.After(*curReset) {
+		return candidate
+	}
+	return current
+}
+
 // resumableReset returns a captured reset only for transient account limits.
 func resumableReset(errText string, rl *RateLimitInfo) *time.Time {
-	if !accountErrorResumable(errText) {
+	if !accountErrorResumable(errText) || rl == nil || !rl.Rejected() {
 		return nil
 	}
 	return rl.ResetTime()

--- a/internal/worker/claude_limit.go
+++ b/internal/worker/claude_limit.go
@@ -1,6 +1,9 @@
 package worker
 
-import "strings"
+import (
+	"strings"
+	"time"
+)
 
 // ClaudeAccountPausePrefix is the stable leading sentence shared by every
 // account-pause message: the scan that hit the wall (ClaudeAccountError) and the
@@ -10,20 +13,17 @@ import "strings"
 // web/templates/jobs.html in sync.
 const ClaudeAccountPausePrefix = "Claude account access paused."
 
-// ClaudeAccountError is returned when claude-code reports an account-level
-// problem -- a usage/plan limit, or access being disabled or revoked -- rather
-// than a per-scan failure. The worker pauses the scan and the rest of the queue
-// instead of failing each one, because retrying cannot succeed until the
-// account recovers: a usage limit resets, an admin re-enables access, or the
-// operator switches to an Anthropic API key. The claude message is carried in
-// Detail so the operator sees the real reason instead of a bare container exit
-// status.
+// ClaudeAccountError is returned for account-level Claude failures. The worker
+// pauses the batch instead of failing every scan; Detail preserves Claude's text.
 type ClaudeAccountError struct {
 	Detail string
+	// ResetAt is the reported recovery time for transient limits. Nil means
+	// manual resume.
+	ResetAt *time.Time
 }
 
 func (e *ClaudeAccountError) Error() string {
-	const base = ClaudeAccountPausePrefix + " This scan and the queued batch were held; " +
+	const base = ClaudeAccountPausePrefix + " This scan and queued scans were paused; " +
 		"resume once the account recovers."
 	if e.Detail == "" {
 		return base
@@ -31,38 +31,102 @@ func (e *ClaudeAccountError) Error() string {
 	return base + " Claude reported: " + e.Detail
 }
 
+// transientLimitPhrases mark limits that can auto-resume after reset.
+var transientLimitPhrases = []string{
+	"usage limit",
+	"session limit",
+	"plan limit",
+	"rate limit",
+	"rate_limit",
+	"too many requests",
+	"quota exceeded",
+	"credit balance",
+	"429",
+}
+
+// accessRevokedPhrases mark account problems that need operator action, not a
+// timed resume. Keep these close to Claude Code's auth-denied wording.
+var accessRevokedPhrases = []string{
+	"disabled claude subscription access",
+	"use an anthropic api key instead",
+	"ask your admin to enable access",
+}
+
 // claudeAccountErrorText returns s when it looks like an account-level message
 // from claude-code -- a usage/plan/rate limit, or access being disabled or
 // revoked -- and "" otherwise. The caller only consults it when the run already
 // failed (non-zero exit), so a stray "rate limit" in normal scan output never
-// pauses a healthy scan. The access phrases are deliberately specific (verbatim
-// fragments of Claude Code's auth-denied message) so a repository's own content
-// cannot trip them.
+// pauses a healthy scan.
 func claudeAccountErrorText(s string) string {
 	text := strings.TrimSpace(s)
 	if text == "" {
 		return ""
 	}
 	lower := strings.ToLower(text)
-	for _, phrase := range []string{
-		// usage / plan / rate limits (transient: resume after the limit resets)
-		"usage limit",
-		"session limit",
-		"plan limit",
-		"rate limit",
-		"rate_limit",
-		"too many requests",
-		"quota exceeded",
-		"credit balance",
-		"429",
-		// access disabled or revoked (account-level: retrying cannot help)
-		"disabled claude subscription access",
-		"use an anthropic api key instead",
-		"ask your admin to enable access",
-	} {
+	for _, phrase := range transientLimitPhrases {
+		if strings.Contains(lower, phrase) {
+			return text
+		}
+	}
+	for _, phrase := range accessRevokedPhrases {
 		if strings.Contains(lower, phrase) {
 			return text
 		}
 	}
 	return ""
+}
+
+// accountErrorAccessRevoked reports whether s mentions account access being
+// disabled or revoked -- a permanent problem that must never drive an automatic
+// resume, regardless of any transient wording elsewhere in the run.
+func accountErrorAccessRevoked(s string) bool {
+	lower := strings.ToLower(s)
+	for _, phrase := range accessRevokedPhrases {
+		if strings.Contains(lower, phrase) {
+			return true
+		}
+	}
+	return false
+}
+
+// accountErrorResumable returns false for access/admin errors even when the
+// message also mentions a limit.
+func accountErrorResumable(s string) bool {
+	if accountErrorAccessRevoked(s) {
+		return false
+	}
+	lower := strings.ToLower(s)
+	for _, phrase := range transientLimitPhrases {
+		if strings.Contains(lower, phrase) {
+			return true
+		}
+	}
+	return false
+}
+
+// preferAccountErrText picks which account-error message a run should keep as it
+// streams lines: the first account-error line seen, except that a later
+// access-revoked line overrides an earlier transient one. This keeps a
+// permanently revoked account from being auto-resumed just because a transient
+// line was printed first. candidate is claudeAccountErrorText(line) ("" for a
+// non-account line), so this can be folded over every emitted line.
+func preferAccountErrText(current, candidate string) string {
+	switch {
+	case candidate == "":
+		return current
+	case current == "":
+		return candidate
+	case accountErrorAccessRevoked(candidate) && !accountErrorAccessRevoked(current):
+		return candidate
+	default:
+		return current
+	}
+}
+
+// resumableReset returns a captured reset only for transient account limits.
+func resumableReset(errText string, rl *RateLimitInfo) *time.Time {
+	if !accountErrorResumable(errText) {
+		return nil
+	}
+	return rl.ResetTime()
 }

--- a/internal/worker/claude_limit_test.go
+++ b/internal/worker/claude_limit_test.go
@@ -54,11 +54,37 @@ func TestPreferAccountErrText(t *testing.T) {
 	}
 }
 
+func TestPreferRateLimitReset(t *testing.T) {
+	allowed := &RateLimitInfo{Status: "allowed", ResetsAt: 100, Type: "five_hour"}
+	rejected := &RateLimitInfo{Status: "rejected", ResetsAt: 200, Type: "five_hour"}
+	overageRejected := &RateLimitInfo{Status: "allowed", OverageStatus: "rejected", ResetsAt: 300, Type: "seven_day"}
+	shorterRejected := &RateLimitInfo{Status: "rejected", ResetsAt: 150, Type: "five_hour"}
+
+	if got := preferRateLimitReset(nil, allowed); got != nil {
+		t.Errorf("allowed reset selected: %+v", got)
+	}
+	if got := preferRateLimitReset(nil, rejected); got != rejected {
+		t.Errorf("rejected reset = %+v, want %+v", got, rejected)
+	}
+	if got := preferRateLimitReset(rejected, overageRejected); got != overageRejected {
+		t.Errorf("furthest rejected reset = %+v, want %+v", got, overageRejected)
+	}
+	if got := preferRateLimitReset(overageRejected, shorterRejected); got != overageRejected {
+		t.Errorf("shorter rejected reset replaced furthest: %+v", got)
+	}
+	if got := preferRateLimitReset(nil, &RateLimitInfo{Status: "rejected"}); got != nil {
+		t.Errorf("missing reset selected: %+v", got)
+	}
+}
+
 func TestResumableReset(t *testing.T) {
-	rl := &RateLimitInfo{Type: "five_hour", ResetsAt: 1782990000}
-	// Transient limit -> the captured reset flows through.
+	rl := &RateLimitInfo{Status: "rejected", Type: "five_hour", ResetsAt: 1782990000}
+	// Transient limit -> the captured rejected reset flows through.
 	if got := resumableReset("usage limit reached", rl); got == nil || got.Unix() != 1782990000 {
 		t.Errorf("transient reset = %v, want captured reset", got)
+	}
+	if got := resumableReset("usage limit reached", &RateLimitInfo{Status: "allowed", ResetsAt: 1782990000}); got != nil {
+		t.Errorf("allowed reset = %v, want nil", got)
 	}
 	// Permanent access error -> nil even with a captured event (no auto-resume).
 	if got := resumableReset("ask your admin to enable access", rl); got != nil {

--- a/internal/worker/claude_limit_test.go
+++ b/internal/worker/claude_limit_test.go
@@ -1,0 +1,71 @@
+package worker
+
+import "testing"
+
+func TestAccountErrorResumable(t *testing.T) {
+	cases := []struct {
+		name string
+		text string
+		want bool
+	}{
+		{"usage limit", "Claude usage limit reached", true},
+		{"429", "error 429 too many requests", true},
+		{"credit balance", "your credit balance is too low", true},
+		{"access disabled", "This organization has disabled Claude subscription access", false},
+		{"use api key", "Please use an Anthropic API key instead", false},
+		{"admin enable", "ask your admin to enable access for your account", false},
+		{"limit wording but access-revoked wins", "rate limit; use an Anthropic API key instead", false},
+		{"unrelated", "some other failure", false},
+	}
+	for _, tc := range cases {
+		if got := accountErrorResumable(tc.text); got != tc.want {
+			t.Errorf("%s: accountErrorResumable(%q) = %v, want %v", tc.name, tc.text, got, tc.want)
+		}
+	}
+}
+
+func TestPreferAccountErrText(t *testing.T) {
+	transient := "Claude usage limit reached"
+	access := "ask your admin to enable access"
+
+	// First account-error line is kept when nothing overrides it.
+	if got := preferAccountErrText("", transient); got != transient {
+		t.Errorf("first line = %q, want %q", got, transient)
+	}
+	// Non-account lines (candidate "") never change the capture.
+	if got := preferAccountErrText(transient, ""); got != transient {
+		t.Errorf("empty candidate changed capture to %q", got)
+	}
+	// A later access-revoked line overrides an earlier transient one.
+	if got := preferAccountErrText(transient, access); got != access {
+		t.Errorf("access line did not override transient: %q", got)
+	}
+	// The reverse does not: once access-revoked, a later transient line loses.
+	if got := preferAccountErrText(access, transient); got != access {
+		t.Errorf("transient line overrode access: %q", got)
+	}
+	// Fold over a run that prints transient then access: not resumable.
+	got := ""
+	for _, line := range []string{"working", transient, "more output", access} {
+		got = preferAccountErrText(got, claudeAccountErrorText(line))
+	}
+	if accountErrorResumable(got) {
+		t.Errorf("run ending access-revoked classified resumable via %q", got)
+	}
+}
+
+func TestResumableReset(t *testing.T) {
+	rl := &RateLimitInfo{Type: "five_hour", ResetsAt: 1782990000}
+	// Transient limit -> the captured reset flows through.
+	if got := resumableReset("usage limit reached", rl); got == nil || got.Unix() != 1782990000 {
+		t.Errorf("transient reset = %v, want captured reset", got)
+	}
+	// Permanent access error -> nil even with a captured event (no auto-resume).
+	if got := resumableReset("ask your admin to enable access", rl); got != nil {
+		t.Errorf("access-revoked reset = %v, want nil", got)
+	}
+	// No captured event -> nil.
+	if got := resumableReset("usage limit reached", nil); got != nil {
+		t.Errorf("nil rate-limit reset = %v, want nil", got)
+	}
+}

--- a/internal/worker/claude_limit_test.go
+++ b/internal/worker/claude_limit_test.go
@@ -57,7 +57,8 @@ func TestPreferAccountErrText(t *testing.T) {
 func TestPreferRateLimitReset(t *testing.T) {
 	allowed := &RateLimitInfo{Status: "allowed", ResetsAt: 100, Type: "five_hour"}
 	rejected := &RateLimitInfo{Status: "rejected", ResetsAt: 200, Type: "five_hour"}
-	overageRejected := &RateLimitInfo{Status: "allowed", OverageStatus: "rejected", ResetsAt: 300, Type: "seven_day"}
+	allowedOverageUnavailable := &RateLimitInfo{Status: "allowed", OverageStatus: "rejected", ResetsAt: 300, Type: "seven_day"}
+	activeOverageRejected := &RateLimitInfo{Status: "allowed", OverageStatus: "rejected", IsUsingOverage: true, ResetsAt: 300, Type: "seven_day"}
 	shorterRejected := &RateLimitInfo{Status: "rejected", ResetsAt: 150, Type: "five_hour"}
 
 	if got := preferRateLimitReset(nil, allowed); got != nil {
@@ -66,10 +67,13 @@ func TestPreferRateLimitReset(t *testing.T) {
 	if got := preferRateLimitReset(nil, rejected); got != rejected {
 		t.Errorf("rejected reset = %+v, want %+v", got, rejected)
 	}
-	if got := preferRateLimitReset(rejected, overageRejected); got != overageRejected {
-		t.Errorf("furthest rejected reset = %+v, want %+v", got, overageRejected)
+	if got := preferRateLimitReset(rejected, allowedOverageUnavailable); got != rejected {
+		t.Errorf("allowed overage-unavailable reset = %+v, want %+v", got, rejected)
 	}
-	if got := preferRateLimitReset(overageRejected, shorterRejected); got != overageRejected {
+	if got := preferRateLimitReset(rejected, activeOverageRejected); got != activeOverageRejected {
+		t.Errorf("active overage rejection = %+v, want %+v", got, activeOverageRejected)
+	}
+	if got := preferRateLimitReset(activeOverageRejected, shorterRejected); got != activeOverageRejected {
 		t.Errorf("shorter rejected reset replaced furthest: %+v", got)
 	}
 	if got := preferRateLimitReset(nil, &RateLimitInfo{Status: "rejected"}); got != nil {
@@ -85,6 +89,9 @@ func TestResumableReset(t *testing.T) {
 	}
 	if got := resumableReset("usage limit reached", &RateLimitInfo{Status: "allowed", ResetsAt: 1782990000}); got != nil {
 		t.Errorf("allowed reset = %v, want nil", got)
+	}
+	if got := resumableReset("usage limit reached", &RateLimitInfo{Status: "allowed", OverageStatus: "rejected", ResetsAt: 1782990000}); got != nil {
+		t.Errorf("allowed overage-unavailable reset = %v, want nil", got)
 	}
 	// Permanent access error -> nil even with a captured event (no auto-resume).
 	if got := resumableReset("ask your admin to enable access", rl); got != nil {

--- a/internal/worker/container.go
+++ b/internal/worker/container.go
@@ -271,11 +271,11 @@ func (d ContainerRunner) RunSkill(ctx context.Context, sj SkillJob, emit func(Ev
 
 	h := d.harness()
 	accountErrText := ""
-	var lastRateLimit *RateLimitInfo
+	var rateLimitReset *RateLimitInfo
 	wrappedEmit := func(e Event) {
 		accountErrText = preferAccountErrText(accountErrText, h.AccountErrorText(e.Text))
 		if e.Kind == KindRateLimit && e.RateLimit != nil {
-			lastRateLimit = e.RateLimit
+			rateLimitReset = preferRateLimitReset(rateLimitReset, e.RateLimit)
 		}
 		emit(e)
 	}
@@ -305,7 +305,7 @@ func (d ContainerRunner) RunSkill(ctx context.Context, sj SkillJob, emit func(Ev
 			return res, &MaxTurnsReachedError{}
 		}
 		if accountErrText != "" {
-			return res, &ClaudeAccountError{Detail: accountErrText, ResetAt: resumableReset(accountErrText, lastRateLimit)}
+			return res, &ClaudeAccountError{Detail: accountErrText, ResetAt: resumableReset(accountErrText, rateLimitReset)}
 		}
 		return res, fmt.Errorf("%s exited: %w", d.Runtime.bin(), waitErr)
 	}

--- a/internal/worker/container.go
+++ b/internal/worker/container.go
@@ -271,9 +271,11 @@ func (d ContainerRunner) RunSkill(ctx context.Context, sj SkillJob, emit func(Ev
 
 	h := d.harness()
 	accountErrText := ""
+	var lastRateLimit *RateLimitInfo
 	wrappedEmit := func(e Event) {
-		if accountErrText == "" {
-			accountErrText = h.AccountErrorText(e.Text)
+		accountErrText = preferAccountErrText(accountErrText, h.AccountErrorText(e.Text))
+		if e.Kind == KindRateLimit && e.RateLimit != nil {
+			lastRateLimit = e.RateLimit
 		}
 		emit(e)
 	}
@@ -303,7 +305,7 @@ func (d ContainerRunner) RunSkill(ctx context.Context, sj SkillJob, emit func(Ev
 			return res, &MaxTurnsReachedError{}
 		}
 		if accountErrText != "" {
-			return res, &ClaudeAccountError{Detail: accountErrText}
+			return res, &ClaudeAccountError{Detail: accountErrText, ResetAt: resumableReset(accountErrText, lastRateLimit)}
 		}
 		return res, fmt.Errorf("%s exited: %w", d.Runtime.bin(), waitErr)
 	}

--- a/internal/worker/stream.go
+++ b/internal/worker/stream.go
@@ -37,9 +37,10 @@ type Event struct {
 // RateLimitInfo is the subscription limit status claude-code reports in a
 // rate_limit_event line; it feeds auto-resume and the usage page panel.
 type RateLimitInfo struct {
-	Status   string `json:"status"`
-	ResetsAt int64  `json:"resetsAt"`
-	Type     string `json:"rateLimitType"`
+	Status        string `json:"status"`
+	OverageStatus string `json:"overageStatus"`
+	ResetsAt      int64  `json:"resetsAt"`
+	Type          string `json:"rateLimitType"`
 }
 
 // ResetTime converts the epoch-seconds resetsAt into a UTC time, or nil when
@@ -50,6 +51,13 @@ func (r *RateLimitInfo) ResetTime() *time.Time {
 	}
 	t := time.Unix(r.ResetsAt, 0).UTC()
 	return &t
+}
+
+func (r *RateLimitInfo) Rejected() bool {
+	if r == nil {
+		return false
+	}
+	return strings.EqualFold(r.Status, "rejected") || strings.EqualFold(r.OverageStatus, "rejected")
 }
 
 // Usage is the token breakdown from a result event.

--- a/internal/worker/stream.go
+++ b/internal/worker/stream.go
@@ -37,10 +37,11 @@ type Event struct {
 // RateLimitInfo is the subscription limit status claude-code reports in a
 // rate_limit_event line; it feeds auto-resume and the usage page panel.
 type RateLimitInfo struct {
-	Status        string `json:"status"`
-	OverageStatus string `json:"overageStatus"`
-	ResetsAt      int64  `json:"resetsAt"`
-	Type          string `json:"rateLimitType"`
+	Status         string `json:"status"`
+	OverageStatus  string `json:"overageStatus"`
+	IsUsingOverage bool   `json:"isUsingOverage"`
+	ResetsAt       int64  `json:"resetsAt"`
+	Type           string `json:"rateLimitType"`
 }
 
 // ResetTime converts the epoch-seconds resetsAt into a UTC time, or nil when
@@ -57,7 +58,12 @@ func (r *RateLimitInfo) Rejected() bool {
 	if r == nil {
 		return false
 	}
-	return strings.EqualFold(r.Status, "rejected") || strings.EqualFold(r.OverageStatus, "rejected")
+	if strings.EqualFold(r.Status, "rejected") {
+		return true
+	}
+	// overageStatus:"rejected" is normal for accounts without extra-usage
+	// billing; it only blocks when the account is currently using overage.
+	return r.IsUsingOverage && strings.EqualFold(r.OverageStatus, "rejected")
 }
 
 // Usage is the token breakdown from a result event.

--- a/internal/worker/stream.go
+++ b/internal/worker/stream.go
@@ -6,15 +6,17 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"time"
 )
 
 const (
-	KindThinking = "thinking"
-	KindText     = "text"
-	KindTool     = "tool"
-	KindResult   = "result"
-	KindError    = "error"
-	KindSession  = "session"
+	KindThinking  = "thinking"
+	KindText      = "text"
+	KindTool      = "tool"
+	KindResult    = "result"
+	KindError     = "error"
+	KindSession   = "session"
+	KindRateLimit = "rate_limit"
 
 	lineLimit = 300
 )
@@ -25,10 +27,29 @@ type Event struct {
 	Kind      string
 	Tool      string // for KindTool
 	Text      string
-	CostUSD   float64 // for KindResult
-	Turns     int     // for KindResult
-	Usage     Usage   // for KindResult
-	SessionID string  // for KindSession
+	CostUSD   float64        // for KindResult
+	Turns     int            // for KindResult
+	Usage     Usage          // for KindResult
+	SessionID string         // for KindSession
+	RateLimit *RateLimitInfo // for KindRateLimit
+}
+
+// RateLimitInfo is the subscription limit status claude-code reports in a
+// rate_limit_event line; it feeds auto-resume and the usage page panel.
+type RateLimitInfo struct {
+	Status   string `json:"status"`
+	ResetsAt int64  `json:"resetsAt"`
+	Type     string `json:"rateLimitType"`
+}
+
+// ResetTime converts the epoch-seconds resetsAt into a UTC time, or nil when
+// the event carried no usable reset (nil receiver or non-positive timestamp).
+func (r *RateLimitInfo) ResetTime() *time.Time {
+	if r == nil || r.ResetsAt <= 0 {
+		return nil
+	}
+	t := time.Unix(r.ResetsAt, 0).UTC()
+	return &t
 }
 
 // Usage is the token breakdown from a result event.
@@ -40,16 +61,17 @@ type Usage struct {
 }
 
 type streamMessage struct {
-	Type      string          `json:"type"`
-	Subtype   string          `json:"subtype"`
-	SessionID string          `json:"session_id"`
-	Message   *assistantMsg   `json:"message"`
-	Result    json.RawMessage `json:"result"`
-	CostUSD   *float64        `json:"total_cost_usd"`
-	Duration  *int64          `json:"duration_ms"`
-	NumTurns  *int            `json:"num_turns"`
-	Usage     *Usage          `json:"usage"`
-	Error     json.RawMessage `json:"error"`
+	Type          string          `json:"type"`
+	Subtype       string          `json:"subtype"`
+	SessionID     string          `json:"session_id"`
+	Message       *assistantMsg   `json:"message"`
+	Result        json.RawMessage `json:"result"`
+	CostUSD       *float64        `json:"total_cost_usd"`
+	Duration      *int64          `json:"duration_ms"`
+	NumTurns      *int            `json:"num_turns"`
+	Usage         *Usage          `json:"usage"`
+	Error         json.RawMessage `json:"error"`
+	RateLimitInfo *RateLimitInfo  `json:"rate_limit_info"`
 }
 
 type assistantMsg struct {
@@ -127,6 +149,10 @@ func parseStreamLine(raw []byte, emit func(Event)) {
 			s = string(msg.Error)
 		}
 		emit(Event{Kind: KindError, Text: s})
+	case "rate_limit_event":
+		if msg.RateLimitInfo != nil {
+			emit(Event{Kind: KindRateLimit, RateLimit: msg.RateLimitInfo})
+		}
 	}
 }
 
@@ -213,6 +239,15 @@ func FormatEvent(e Event) string {
 		return fmt.Sprintf("[result] cost=$%.4f turns=%d %s", e.CostUSD, e.Turns, truncate(e.Text))
 	case KindSession:
 		return "[session] " + e.SessionID
+	case KindRateLimit:
+		if e.RateLimit == nil {
+			return "[rate-limit]"
+		}
+		line := "[rate-limit] " + e.RateLimit.Type + " " + e.RateLimit.Status
+		if t := e.RateLimit.ResetTime(); t != nil {
+			line += " resets " + t.Format("2006-01-02 15:04 UTC")
+		}
+		return line
 	case KindError:
 		return "[error] " + e.Text
 	default:

--- a/internal/worker/stream_test.go
+++ b/internal/worker/stream_test.go
@@ -56,7 +56,7 @@ func TestParseStream_RateLimitEvent(t *testing.T) {
 	if got[0].Kind != KindRateLimit || rl == nil {
 		t.Fatalf("ev0: %+v", got[0])
 	}
-	if rl.Status != "allowed" || rl.Type != "five_hour" || rl.ResetsAt != 1782990000 {
+	if rl.Status != "allowed" || rl.OverageStatus != "rejected" || rl.Type != "five_hour" || rl.ResetsAt != 1782990000 {
 		t.Errorf("rate_limit_info = %+v", rl)
 	}
 	if reset := rl.ResetTime(); reset == nil || reset.Unix() != 1782990000 {

--- a/internal/worker/stream_test.go
+++ b/internal/worker/stream_test.go
@@ -44,6 +44,35 @@ not json at all
 	}
 }
 
+func TestParseStream_RateLimitEvent(t *testing.T) {
+	// The exact shape claude-code emits on a subscription run.
+	in := `{"type":"rate_limit_event","rate_limit_info":{"status":"allowed","resetsAt":1782990000,"rateLimitType":"five_hour","overageStatus":"rejected","isUsingOverage":false}}` + "\n"
+	var got []Event
+	ParseStream(strings.NewReader(in), func(e Event) { got = append(got, e) })
+	if len(got) != 1 {
+		t.Fatalf("want 1 event, got %d: %+v", len(got), got)
+	}
+	rl := got[0].RateLimit
+	if got[0].Kind != KindRateLimit || rl == nil {
+		t.Fatalf("ev0: %+v", got[0])
+	}
+	if rl.Status != "allowed" || rl.Type != "five_hour" || rl.ResetsAt != 1782990000 {
+		t.Errorf("rate_limit_info = %+v", rl)
+	}
+	if reset := rl.ResetTime(); reset == nil || reset.Unix() != 1782990000 {
+		t.Errorf("ResetTime() = %v", reset)
+	}
+}
+
+func TestRateLimitInfo_ResetTime_Absent(t *testing.T) {
+	if (*RateLimitInfo)(nil).ResetTime() != nil {
+		t.Error("nil receiver should yield nil reset")
+	}
+	if (&RateLimitInfo{ResetsAt: 0}).ResetTime() != nil {
+		t.Error("zero resetsAt should yield nil reset")
+	}
+}
+
 func TestParseStream_SessionID(t *testing.T) {
 	in := `
 {"type":"system","subtype":"init","session_id":"sess-abc","tools":[]}

--- a/internal/worker/stream_test.go
+++ b/internal/worker/stream_test.go
@@ -56,7 +56,7 @@ func TestParseStream_RateLimitEvent(t *testing.T) {
 	if got[0].Kind != KindRateLimit || rl == nil {
 		t.Fatalf("ev0: %+v", got[0])
 	}
-	if rl.Status != "allowed" || rl.OverageStatus != "rejected" || rl.Type != "five_hour" || rl.ResetsAt != 1782990000 {
+	if rl.Status != "allowed" || rl.OverageStatus != "rejected" || rl.IsUsingOverage || rl.Type != "five_hour" || rl.ResetsAt != 1782990000 {
 		t.Errorf("rate_limit_info = %+v", rl)
 	}
 	if reset := rl.ResetTime(); reset == nil || reset.Unix() != 1782990000 {

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -503,6 +503,10 @@ func (w *Worker) finalizeScan(ctx context.Context, scan *db.Scan, report string,
 				w.scheduleAccountResumeAt(*effective)
 			}
 		}
+		// resolveAccountReset emitted after the Save above; persist that log tail.
+		if logErr := w.DB.Model(&db.Scan{}).Where("id = ?", scan.ID).Update("log", scan.Log).Error; logErr != nil {
+			w.Log.Warn("account-pause log update failed", "scan", scan.ID, "err", logErr)
+		}
 	}
 	// The clone cache may have grown (clone/fetch/unshallow); refresh the
 	// cached size so the repo list reads it from the row instead of walking

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -492,7 +492,7 @@ func (w *Worker) finalizeScan(ctx context.Context, scan *db.Scan, report string,
 	}
 	w.maybeFireScanFinalized(scan, err)
 	if accErr, isAccountErr := errors.AsType[*ClaudeAccountError](err); isAccountErr && scan.Status == db.ScanPaused {
-		w.pauseQueuedOnAccountError(scan.ID, nil)
+		w.pauseQueuedOnAccountError(scan.ID)
 		if rawReset := w.resolveAccountReset(accErr, emit); rawReset != nil {
 			effective, applyErr := w.applyAccountPauseReset(scan.ID, scan.Error, rawReset)
 			if applyErr != nil {
@@ -531,17 +531,18 @@ func (w *Worker) resolveAccountReset(accErr *ClaudeAccountError, emit func(Event
 		emit(Event{Kind: KindText, Text: "no rate-limit reset reported; leaving paused for manual resume"})
 		return nil
 	}
-	resetAt := accErr.ResetAt
-	if !resetAt.After(w.now()) {
+	now := w.now().UTC()
+	resetAt := accErr.ResetAt.UTC()
+	if !resetAt.After(now) {
 		emit(Event{Kind: KindText, Text: "rate-limit reset time is already in the past"})
 		return nil
 	}
-	if wait := resetAt.Sub(w.now()); wait > w.maxRateLimitAutoResumeDelay() {
+	if wait := resetAt.Sub(now); wait > w.maxRateLimitAutoResumeDelay() {
 		emit(Event{Kind: KindText, Text: fmt.Sprintf("rate-limit reset time %s is beyond auto-resume limit %s", resetAt.UTC().Format(time.RFC3339), w.maxRateLimitAutoResumeDelay())})
 		return nil
 	}
 	emit(Event{Kind: KindText, Text: "rate limit reset detected; auto-resume after " + resetAt.UTC().Format(time.RFC3339)})
-	return resetAt
+	return &resetAt
 }
 
 // maybeFireScanFinalized invokes the OnScanFinalized hook once a scan has
@@ -664,9 +665,9 @@ func appendAutoResumeFailure(msg string, err error) string {
 
 // pauseQueuedOnAccountError pauses every queued scan behind an account-level
 // Claude failure; queued jobs later drop themselves when wrap sees the DB state.
-func (w *Worker) pauseQueuedOnAccountError(triggerID uint, resetAt *time.Time) {
-	now := w.now()
-	reason := accountPauseReason(resetAt)
+func (w *Worker) pauseQueuedOnAccountError(triggerID uint) {
+	now := w.now().UTC()
+	reason := accountPauseReason(nil)
 	res := w.DB.Model(&db.Scan{}).
 		Where("status = ?", db.ScanQueued).
 		Updates(map[string]any{
@@ -674,7 +675,6 @@ func (w *Worker) pauseQueuedOnAccountError(triggerID uint, resetAt *time.Time) {
 			"status_priority": db.StatusPriorityFor(db.ScanPaused),
 			"error":           reason,
 			"finished_at":     &now,
-			"paused_until":    resetAt,
 		})
 	if res.Error != nil {
 		w.Log.Warn("pause-on-account-error failed", "trigger", triggerID, "err", res.Error)
@@ -691,10 +691,12 @@ func (w *Worker) applyAccountPauseReset(triggerID uint, baseError string, resetA
 	if resetAt == nil {
 		return nil, nil
 	}
+	resetAtUTC := resetAt.UTC()
+	resetAt = &resetAtUTC
 	// A concurrent scan may already have found a later binding reset. Ignore any
 	// row already beyond the auto-resume window, so a stale or manually-set
 	// far-future pause cannot drag every subsequent batch out to it.
-	maxAcceptable := w.now().Add(w.maxRateLimitAutoResumeDelay())
+	maxAcceptable := w.now().UTC().Add(w.maxRateLimitAutoResumeDelay())
 	var latest db.Scan
 	if err := w.DB.Select("paused_until").
 		Where("id != ? AND status = ? AND error LIKE ? AND paused_until IS NOT NULL AND paused_until <= ?",
@@ -785,11 +787,11 @@ func (w *Worker) scheduleAccountResumeAfter(delay time.Duration) {
 	if delay < w.autoResumeRetryDelay() {
 		delay = w.autoResumeRetryDelay()
 	}
-	w.scheduleAutoResumeAt(w.now().Add(delay))
+	w.scheduleAutoResumeAt(w.now().UTC().Add(delay))
 }
 
 func (w *Worker) scheduleAutoResumeAt(when time.Time) {
-	delay := when.Sub(w.now())
+	delay := when.Sub(w.now().UTC())
 	if delay < 0 {
 		delay = 0
 	}
@@ -843,7 +845,7 @@ func (w *Worker) resumeAccountPaused(ctx context.Context) (int, error) {
 	var scans []db.Scan
 	if err := w.DB.Select("id", "kind", "finding_id", "error", "paused_until").
 		Where("status = ? AND error LIKE ? AND paused_until IS NOT NULL AND paused_until <= ?",
-			db.ScanPaused, ClaudeAccountPausePrefix+"%", w.now()).
+			db.ScanPaused, ClaudeAccountPausePrefix+"%", w.now().UTC()).
 		Order("id").
 		Find(&scans).Error; err != nil {
 		return 0, err
@@ -869,7 +871,7 @@ func (w *Worker) resumeAccountPaused(ctx context.Context) (int, error) {
 			priority = PrioFinding
 		}
 		if err := w.Queue.Enqueue(ctx, sc.Kind, sc.ID, priority); err != nil {
-			now := w.now()
+			now := w.now().UTC()
 			restoreErr := w.DB.Model(&db.Scan{}).Where("id = ?", sc.ID).Updates(map[string]any{
 				"status":          db.ScanPaused,
 				"status_priority": db.StatusPriorityFor(db.ScanPaused),

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -150,6 +151,56 @@ type Worker struct {
 	// a tiny or huge value to assert flush behaviour without sleeping.
 	// Zero falls through to the const default.
 	LogFlushInterval time.Duration
+
+	// AutoResumeBuffer is added to the reset timestamp before the worker
+	// resumes paused scans. Zero falls through to the default buffer.
+	AutoResumeBuffer time.Duration
+	// AutoResumeRetryDelay backs off retry attempts when a due auto-resume
+	// cannot re-enqueue one or more scans. Zero falls through to the default.
+	AutoResumeRetryDelay time.Duration
+	// MaxRateLimitAutoResumeDelay bounds provider reset times accepted for
+	// automatic resume. A reset farther out is treated as unreliable and leaves
+	// the batch paused for manual operator action.
+	MaxRateLimitAutoResumeDelay time.Duration
+	// Now overrides time.Now in tests.
+	Now func() time.Time
+
+	autoResumeMu    sync.Mutex
+	autoResumeTimer *time.Timer
+	autoResumeAt    time.Time
+
+	// rlStatus holds the latest in-memory rate_limit_event per window type.
+	rlStatusMu sync.Mutex
+	rlStatus   map[string]RateLimitInfo
+}
+
+// recordRateLimit stores the latest rate-limit status for its window type.
+func (w *Worker) recordRateLimit(info RateLimitInfo) {
+	if info.Type == "" {
+		return
+	}
+	w.rlStatusMu.Lock()
+	if w.rlStatus == nil {
+		w.rlStatus = map[string]RateLimitInfo{}
+	}
+	w.rlStatus[info.Type] = info
+	w.rlStatusMu.Unlock()
+}
+
+// RateLimitStatus returns a snapshot of the latest rate-limit status per window,
+// for the usage page. Empty when no subscription rate_limit_event has been seen
+// (fresh process, or an API-key account that does not report them).
+func (w *Worker) RateLimitStatus() []RateLimitInfo {
+	if w == nil {
+		return nil
+	}
+	w.rlStatusMu.Lock()
+	defer w.rlStatusMu.Unlock()
+	out := make([]RateLimitInfo, 0, len(w.rlStatus))
+	for _, v := range w.rlStatus {
+		out = append(out, v)
+	}
+	return out
 }
 
 func (w *Worker) logFlushInterval() time.Duration {
@@ -157,6 +208,43 @@ func (w *Worker) logFlushInterval() time.Duration {
 		return w.LogFlushInterval
 	}
 	return defaultLogFlushInterval
+}
+
+func (w *Worker) now() time.Time {
+	if w.Now != nil {
+		return w.Now()
+	}
+	return time.Now()
+}
+
+const (
+	defaultAutoResumeBuffer     = 5 * time.Second
+	defaultAutoResumeRetryDelay = 30 * time.Second
+	// defaultMaxRateLimitAutoResumeAge bounds how far out a reported reset can
+	// be before it is treated as unreliable. Anthropic subscription windows are
+	// five-hour and seven-day, so allow a little over a week.
+	defaultMaxRateLimitAutoResumeAge = 8 * 24 * time.Hour
+)
+
+func (w *Worker) autoResumeBuffer() time.Duration {
+	if w.AutoResumeBuffer > 0 {
+		return w.AutoResumeBuffer
+	}
+	return defaultAutoResumeBuffer
+}
+
+func (w *Worker) autoResumeRetryDelay() time.Duration {
+	if w.AutoResumeRetryDelay > 0 {
+		return w.AutoResumeRetryDelay
+	}
+	return defaultAutoResumeRetryDelay
+}
+
+func (w *Worker) maxRateLimitAutoResumeDelay() time.Duration {
+	if w.MaxRateLimitAutoResumeDelay > 0 {
+		return w.MaxRateLimitAutoResumeDelay
+	}
+	return defaultMaxRateLimitAutoResumeAge
 }
 
 // Cancel aborts an in-flight scan. Returns true if a running job was found and
@@ -274,6 +362,9 @@ func (w *Worker) scanEmitter(scan *db.Scan) func(Event) {
 			}
 			return
 		}
+		if e.Kind == KindRateLimit && e.RateLimit != nil {
+			w.recordRateLimit(*e.RateLimit)
+		}
 		line := FormatEvent(e)
 		scan.Log += line + "\n"
 		if time.Since(lastFlush) >= interval {
@@ -308,6 +399,7 @@ func (w *Worker) Register(q *queue.Queue) {
 	w.Queue = q
 	q.Register(JobSkill, w.wrap(w.doSkill))
 	q.Register(JobExposure, w.wrap(w.doExposure))
+	w.scheduleNextAccountResume()
 }
 
 // handler does the actual work for one job kind. It receives the loaded scan
@@ -399,8 +491,18 @@ func (w *Worker) finalizeScan(ctx context.Context, scan *db.Scan, report string,
 		return saveErr
 	}
 	w.maybeFireScanFinalized(scan, err)
-	if _, isAccountErr := errors.AsType[*ClaudeAccountError](err); isAccountErr && scan.Status == db.ScanPaused {
-		w.pauseQueuedOnAccountError(scan.ID)
+	if accErr, isAccountErr := errors.AsType[*ClaudeAccountError](err); isAccountErr && scan.Status == db.ScanPaused {
+		w.pauseQueuedOnAccountError(scan.ID, nil)
+		if rawReset := w.resolveAccountReset(accErr, emit); rawReset != nil {
+			effective, applyErr := w.applyAccountPauseReset(scan.ID, scan.Error, rawReset)
+			if applyErr != nil {
+				w.Log.Warn("account-pause reset update failed", "scan", scan.ID, "err", applyErr)
+			} else if effective != nil {
+				scan.PausedUntil = effective
+				scan.Error = appendAutoResume(scan.Error, effective)
+				w.scheduleAccountResumeAt(*effective)
+			}
+		}
 	}
 	// The clone cache may have grown (clone/fetch/unshallow); refresh the
 	// cached size so the repo list reads it from the row instead of walking
@@ -416,6 +518,26 @@ func (w *Worker) finalizeScan(ctx context.Context, scan *db.Scan, report string,
 	w.publish(scan.ID, scan.RepositoryID, "scan-status", string(scan.Status))
 	w.Log.Info("job finished", "scan", scan.ID, "kind", scan.Kind, "status", scan.Status)
 	return nil
+}
+
+// resolveAccountReset accepts only fresh, plausible reset times; nil leaves the
+// batch paused for manual resume.
+func (w *Worker) resolveAccountReset(accErr *ClaudeAccountError, emit func(Event)) *time.Time {
+	if accErr == nil || accErr.ResetAt == nil {
+		emit(Event{Kind: KindText, Text: "no rate-limit reset reported; leaving paused for manual resume"})
+		return nil
+	}
+	resetAt := accErr.ResetAt
+	if !resetAt.After(w.now()) {
+		emit(Event{Kind: KindText, Text: "rate-limit reset time is already in the past"})
+		return nil
+	}
+	if wait := resetAt.Sub(w.now()); wait > w.maxRateLimitAutoResumeDelay() {
+		emit(Event{Kind: KindText, Text: fmt.Sprintf("rate-limit reset time %s is beyond auto-resume limit %s", resetAt.UTC().Format(time.RFC3339), w.maxRateLimitAutoResumeDelay())})
+		return nil
+	}
+	emit(Event{Kind: KindText, Text: "rate limit reset detected; auto-resume after " + resetAt.UTC().Format(time.RFC3339)})
+	return resetAt
 }
 
 // maybeFireScanFinalized invokes the OnScanFinalized hook once a scan has
@@ -473,11 +595,8 @@ func finishErroredScan(scan *db.Scan, report string, err error, emit func(Event)
 	case schemaValidation:
 		scan.Report = report
 	case accountErr:
-		// An account-level problem (usage/credit limit, or access disabled or
-		// revoked) is not this scan's fault and retrying cannot succeed until the
-		// account recovers, so pause rather than fail: the operator resumes the
-		// batch once it does instead of burning a retry per scan. The remaining
-		// queued scans are paused by the worker loop (pauseQueuedOnAccountError).
+		// Account-level Claude failures pause the batch instead of failing scans
+		// one by one.
 		scan.Status = db.ScanPaused
 		emit(Event{Kind: KindError, Text: scan.Error})
 	default:
@@ -485,29 +604,73 @@ func finishErroredScan(scan *db.Scan, report string, err error, emit func(Event)
 	}
 }
 
-// accountPauseReason is recorded on scans auto-paused because another scan hit
-// an account-level Claude problem (a usage/credit limit, or access being
-// disabled or revoked). It shares ClaudeAccountPausePrefix with the triggering
-// scan's error so the scans page matches both and surfaces them together in the
-// account banner.
-const accountPauseReason = ClaudeAccountPausePrefix + " Queued scan held automatically; resume once the account recovers."
+// accountPauseReasonBase shares ClaudeAccountPausePrefix with trigger rows so
+// the scans page can group the batch together.
+const accountPauseReasonBase = ClaudeAccountPausePrefix + " Queued scan paused automatically"
 
-// pauseQueuedOnAccountError pauses every still-queued scan after one scan hit an
-// account-level Claude problem (limit, or access disabled/revoked). It is
-// account-wide, so the rest of the queue would only run into the same wall;
-// pausing keeps the batch intact for a later resume instead of failing it scan
-// by scan. The worker loop drops the now-stale queue jobs when they fire (see
-// wrap), exactly as a manual "pause queued" does, so updating the rows here is
-// enough.
-func (w *Worker) pauseQueuedOnAccountError(triggerID uint) {
-	now := time.Now()
+func accountPauseReason(resetAt *time.Time) string {
+	if resetAt == nil || resetAt.IsZero() {
+		return accountPauseReasonBase + "; resume once the account recovers."
+	}
+	return appendAutoResume(accountPauseReasonBase+" until the Claude rate limit resets.", resetAt)
+}
+
+func appendAutoResume(msg string, resetAt *time.Time) string {
+	if resetAt == nil || resetAt.IsZero() {
+		return msg
+	}
+	return msg + autoResumeAfterPrefix + resetAt.UTC().Format(time.RFC3339) + "."
+}
+
+// replaceAutoResume swaps the reset suffix without clobbering the row's detail.
+func replaceAutoResume(msg string, resetAt *time.Time) string {
+	return appendAutoResume(stripAutoResume(msg), resetAt)
+}
+
+// stripAutoResume removes existing auto-resume metadata before rewriting it.
+func stripAutoResume(msg string) string {
+	if i := strings.Index(msg, autoResumeAfterPrefix); i >= 0 {
+		return strings.TrimRight(msg[:i], " ")
+	}
+	if i := strings.Index(msg, autoResumeFailurePrefix); i >= 0 {
+		return strings.TrimRight(msg[:i], " ")
+	}
+	return msg
+}
+
+const (
+	autoResumeAfterPrefix   = " Auto-resume after "
+	autoResumeFailurePrefix = " Auto-resume failed: "
+	maxAutoResumeErrorBytes = 600
+)
+
+func appendAutoResumeFailure(msg string, err error) string {
+	if msg == "" {
+		msg = accountPauseReason(nil)
+	}
+	if i := strings.Index(msg, autoResumeFailurePrefix); i >= 0 {
+		msg = strings.TrimSpace(msg[:i])
+	}
+	detail := err.Error()
+	if len(detail) > maxAutoResumeErrorBytes {
+		detail = detail[:maxAutoResumeErrorBytes] + "..."
+	}
+	return msg + autoResumeFailurePrefix + detail
+}
+
+// pauseQueuedOnAccountError pauses every queued scan behind an account-level
+// Claude failure; queued jobs later drop themselves when wrap sees the DB state.
+func (w *Worker) pauseQueuedOnAccountError(triggerID uint, resetAt *time.Time) {
+	now := w.now()
+	reason := accountPauseReason(resetAt)
 	res := w.DB.Model(&db.Scan{}).
 		Where("status = ?", db.ScanQueued).
 		Updates(map[string]any{
 			"status":          db.ScanPaused,
 			"status_priority": db.StatusPriorityFor(db.ScanPaused),
-			"error":           accountPauseReason,
+			"error":           reason,
 			"finished_at":     &now,
+			"paused_until":    resetAt,
 		})
 	if res.Error != nil {
 		w.Log.Warn("pause-on-account-error failed", "trigger", triggerID, "err", res.Error)
@@ -516,4 +679,203 @@ func (w *Worker) pauseQueuedOnAccountError(triggerID uint) {
 	if res.RowsAffected > 0 {
 		w.Log.Info("paused queued scans after Claude account error", "count", res.RowsAffected, "trigger", triggerID)
 	}
+}
+
+// applyAccountPauseReset moves the trigger and batch to the furthest known
+// reset, returning that effective reset for scheduling.
+func (w *Worker) applyAccountPauseReset(triggerID uint, baseError string, resetAt *time.Time) (*time.Time, error) {
+	if resetAt == nil {
+		return nil, nil
+	}
+	// A concurrent scan may already have found a later binding reset. Ignore any
+	// row already beyond the auto-resume window, so a stale or manually-set
+	// far-future pause cannot drag every subsequent batch out to it.
+	maxAcceptable := w.now().Add(w.maxRateLimitAutoResumeDelay())
+	var latest db.Scan
+	if err := w.DB.Select("paused_until").
+		Where("id != ? AND status = ? AND error LIKE ? AND paused_until IS NOT NULL AND paused_until <= ?",
+			triggerID, db.ScanPaused, ClaudeAccountPausePrefix+"%", maxAcceptable).
+		Order("paused_until DESC").Limit(1).Find(&latest).Error; err != nil {
+		return nil, err
+	}
+	effective := resetAt
+	if latest.PausedUntil != nil && latest.PausedUntil.After(*resetAt) {
+		effective = latest.PausedUntil
+	}
+
+	// Update the triggering scan's reset, keeping its Claude detail. Forward-only
+	// so a concurrent finalizer that already pushed this row to a later reset is
+	// not pulled back; if the guard skips it, re-read so the returned effective
+	// reset reflects the row's actual (possibly later) value.
+	trigRes := w.DB.Model(&db.Scan{}).
+		Where("id = ? AND status = ? AND (paused_until IS NULL OR paused_until < ?)", triggerID, db.ScanPaused, effective).
+		Updates(map[string]any{
+			"error":        appendAutoResume(baseError, effective),
+			"paused_until": effective,
+		})
+	if trigRes.Error != nil {
+		return nil, trigRes.Error
+	}
+	if trigRes.RowsAffected == 0 {
+		// The guard skipped the row: it was either extended to a later reset by a
+		// concurrent finalizer, or is no longer account-paused (manually resumed).
+		// Only adopt a later reset while the row is still account-paused; a
+		// resumed/absent row matches nothing here, so we never revive a stale one.
+		var cur db.Scan
+		if err := w.DB.Select("paused_until").
+			Where("id = ? AND status = ? AND error LIKE ? AND paused_until IS NOT NULL",
+				triggerID, db.ScanPaused, ClaudeAccountPausePrefix+"%").
+			Find(&cur).Error; err != nil {
+			return nil, err
+		}
+		if cur.PausedUntil != nil && cur.PausedUntil.After(*effective) {
+			effective = cur.PausedUntil
+		}
+	}
+	// Shared queued rows carry the same message, so extend them in bulk.
+	if err := w.DB.Model(&db.Scan{}).
+		Where("id != ? AND status = ? AND error LIKE ? AND (paused_until IS NULL OR paused_until < ?)",
+			triggerID, db.ScanPaused, accountPauseReasonBase+"%", effective).
+		Updates(map[string]any{
+			"error":        accountPauseReason(effective),
+			"paused_until": effective,
+		}).Error; err != nil {
+		return nil, err
+	}
+	// Trigger rows carry Claude detail, so rewrite them individually. The
+	// update re-checks the guard to avoid clobbering concurrent changes.
+	var triggers []db.Scan
+	if err := w.DB.Select("id", "error").
+		Where("id != ? AND status = ? AND error LIKE ? AND error NOT LIKE ? AND (paused_until IS NULL OR paused_until < ?)",
+			triggerID, db.ScanPaused, ClaudeAccountPausePrefix+"%", accountPauseReasonBase+"%", effective).
+		Find(&triggers).Error; err != nil {
+		return nil, err
+	}
+	for _, tr := range triggers {
+		res := w.DB.Model(&db.Scan{}).
+			Where("id = ? AND status = ? AND error LIKE ? AND error NOT LIKE ? AND (paused_until IS NULL OR paused_until < ?)",
+				tr.ID, db.ScanPaused, ClaudeAccountPausePrefix+"%", accountPauseReasonBase+"%", effective).
+			Updates(map[string]any{
+				"error":        replaceAutoResume(tr.Error, effective),
+				"paused_until": effective,
+			})
+		if res.Error != nil {
+			return nil, res.Error
+		}
+	}
+	return effective, nil
+}
+
+func (w *Worker) scheduleAccountResumeAt(resetAt time.Time) {
+	if resetAt.IsZero() || w.DB == nil || w.Queue == nil {
+		return
+	}
+	when := resetAt.Add(w.autoResumeBuffer())
+	w.scheduleAutoResumeAt(when)
+}
+
+func (w *Worker) scheduleAccountResumeAfter(delay time.Duration) {
+	if w.DB == nil || w.Queue == nil {
+		return
+	}
+	if delay < w.autoResumeRetryDelay() {
+		delay = w.autoResumeRetryDelay()
+	}
+	w.scheduleAutoResumeAt(w.now().Add(delay))
+}
+
+func (w *Worker) scheduleAutoResumeAt(when time.Time) {
+	delay := when.Sub(w.now())
+	if delay < 0 {
+		delay = 0
+	}
+
+	w.autoResumeMu.Lock()
+	defer w.autoResumeMu.Unlock()
+	if w.autoResumeTimer != nil && !when.Before(w.autoResumeAt) {
+		return
+	}
+	if w.autoResumeTimer != nil {
+		w.autoResumeTimer.Stop()
+	}
+	w.autoResumeAt = when
+	w.autoResumeTimer = time.AfterFunc(delay, func() {
+		resumed, err := w.resumeAccountPaused(context.Background())
+		w.autoResumeMu.Lock()
+		w.autoResumeTimer = nil
+		w.autoResumeAt = time.Time{}
+		w.autoResumeMu.Unlock()
+		if err != nil {
+			w.Log.Warn("auto-resume account-paused scans failed", "err", err)
+			w.scheduleAccountResumeAfter(w.autoResumeRetryDelay())
+			return
+		} else if resumed > 0 {
+			w.Log.Info("auto-resumed account-paused scans", "count", resumed)
+		}
+		w.scheduleNextAccountResume()
+	})
+}
+
+func (w *Worker) scheduleNextAccountResume() {
+	if w.DB == nil || w.Queue == nil {
+		return
+	}
+	var scan db.Scan
+	err := w.DB.Select("id", "paused_until").
+		Where("status = ? AND error LIKE ? AND paused_until IS NOT NULL", db.ScanPaused, ClaudeAccountPausePrefix+"%").
+		Order("paused_until ASC").
+		Limit(1).
+		Find(&scan).Error
+	if err != nil || scan.ID == 0 || scan.PausedUntil == nil {
+		return
+	}
+	w.scheduleAccountResumeAt(*scan.PausedUntil)
+}
+
+func (w *Worker) resumeAccountPaused(ctx context.Context) (int, error) {
+	if w.Queue == nil {
+		return 0, errors.New("queue not configured")
+	}
+	var scans []db.Scan
+	if err := w.DB.Select("id", "kind", "finding_id", "error", "paused_until").
+		Where("status = ? AND error LIKE ? AND paused_until IS NOT NULL AND paused_until <= ?",
+			db.ScanPaused, ClaudeAccountPausePrefix+"%", w.now()).
+		Order("id").
+		Find(&scans).Error; err != nil {
+		return 0, err
+	}
+	var resumed int
+	for _, sc := range scans {
+		updates := map[string]any{
+			"status":          db.ScanQueued,
+			"status_priority": db.StatusPriorityFor(db.ScanQueued),
+			"error":           "",
+			"finished_at":     nil,
+			"paused_until":    nil,
+		}
+		res := w.DB.Model(&db.Scan{}).Where("id = ? AND status = ?", sc.ID, db.ScanPaused).Updates(updates)
+		if res.Error != nil {
+			return resumed, res.Error
+		}
+		if res.RowsAffected == 0 {
+			continue
+		}
+		priority := PrioScan
+		if sc.FindingID != nil {
+			priority = PrioFinding
+		}
+		if err := w.Queue.Enqueue(ctx, sc.Kind, sc.ID, priority); err != nil {
+			now := w.now()
+			restoreErr := w.DB.Model(&db.Scan{}).Where("id = ?", sc.ID).Updates(map[string]any{
+				"status":          db.ScanPaused,
+				"status_priority": db.StatusPriorityFor(db.ScanPaused),
+				"error":           appendAutoResumeFailure(sc.Error, err),
+				"finished_at":     &now,
+				"paused_until":    sc.PausedUntil,
+			}).Error
+			return resumed, errors.Join(err, restoreErr)
+		}
+		resumed++
+	}
+	return resumed, nil
 }

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -653,9 +653,7 @@ func appendAutoResumeFailure(msg string, err error) string {
 	if msg == "" {
 		msg = accountPauseReason(nil)
 	}
-	if i := strings.Index(msg, autoResumeFailurePrefix); i >= 0 {
-		msg = strings.TrimSpace(msg[:i])
-	}
+	msg = stripAutoResume(msg)
 	detail := err.Error()
 	if len(detail) > maxAutoResumeErrorBytes {
 		detail = detail[:maxAutoResumeErrorBytes] + "..."

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -431,6 +431,34 @@ func TestWorker_applyAccountPauseResetIgnoresFarFutureRow(t *testing.T) {
 	}
 }
 
+func TestWorker_applyAccountPauseResetMaxUsesUTCComparison(t *testing.T) {
+	gdb, err := db.Open(filepath.Join(t.TempDir(), "max-utc.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo := db.Repository{URL: "https://example.com/x", Name: "x"}
+	gdb.Create(&repo)
+
+	nowUTC := time.Date(2026, 7, 1, 12, 1, 0, 0, time.UTC)
+	nowLocal := nowUTC.In(time.FixedZone("PDT", -7*60*60))
+	fiveHour := nowUTC.Add(15 * time.Minute)
+	validLater := nowUTC.Add(8*24*time.Hour - time.Minute)
+
+	longPaused := db.Scan{RepositoryID: repo.ID, Kind: JobSkill, Status: db.ScanPaused, Error: accountPauseReason(&validLater), PausedUntil: &validLater}
+	trigger := db.Scan{RepositoryID: repo.ID, Kind: JobSkill, Status: db.ScanPaused, Error: (&ClaudeAccountError{Detail: "rate limit reached"}).Error(), PausedUntil: nil}
+	gdb.Create(&longPaused)
+	gdb.Create(&trigger)
+
+	w := &Worker{DB: gdb, Log: slog.New(slog.NewTextHandler(io.Discard, nil)), Now: func() time.Time { return nowLocal }}
+	effective, err := w.applyAccountPauseReset(trigger.ID, trigger.Error, &fiveHour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if effective == nil || !effective.Equal(validLater) {
+		t.Fatalf("effective = %v, want valid later reset %v", effective, validLater)
+	}
+}
+
 func TestWorker_applyAccountPauseResetSkipsResumedTrigger(t *testing.T) {
 	gdb, err := db.Open(filepath.Join(t.TempDir(), "resumed-trigger.db"))
 	if err != nil {
@@ -542,6 +570,44 @@ func TestWorker_resumeAccountPaused(t *testing.T) {
 	}
 	if gotManual.Status != db.ScanPaused {
 		t.Errorf("manual status = %s, want paused", gotManual.Status)
+	}
+}
+
+func TestWorker_resumeAccountPausedUsesUTCComparison(t *testing.T) {
+	gdb, err := db.Open(filepath.Join(t.TempDir(), "resume-account-utc.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	sqldb, err := gdb.DB()
+	if err != nil {
+		t.Fatal(err)
+	}
+	q, err := queue.New(sqldb, slog.New(slog.NewTextHandler(io.Discard, nil)), 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo := db.Repository{URL: "https://example.com/x", Name: "x"}
+	gdb.Create(&repo)
+	skill := db.Skill{Name: "limited", Description: "x", Body: "b", Active: true, Source: "ui", Version: 1}
+	gdb.Create(&skill)
+
+	resetAt := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	nowLocal := resetAt.Add(time.Minute).In(time.FixedZone("PDT", -7*60*60))
+	due := db.Scan{RepositoryID: repo.ID, Kind: JobSkill, Status: db.ScanPaused, SkillID: &skill.ID, Error: accountPauseReason(&resetAt), PausedUntil: &resetAt}
+	gdb.Create(&due)
+
+	w := &Worker{
+		DB:    gdb,
+		Queue: q,
+		Log:   slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Now:   func() time.Time { return nowLocal },
+	}
+	resumed, err := w.resumeAccountPaused(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resumed != 1 {
+		t.Fatalf("resumed = %d, want 1", resumed)
 	}
 }
 

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -228,12 +228,13 @@ func TestWorker_claudeAccountErrorRecordsResetTime(t *testing.T) {
 	now := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
 	resetAt := now.Add(15 * time.Minute)
 	w := &Worker{
-		DB:             gdb,
-		Log:            slog.New(slog.NewTextHandler(io.Discard, nil)),
-		DataDir:        t.TempDir(),
-		Runner:         fakeRunner{skillErr: &ClaudeAccountError{Detail: "rate limit reached", ResetAt: &resetAt}},
-		PrepareRepoSrc: stubPrepareRepoSrc,
-		Now:            func() time.Time { return now },
+		DB:               gdb,
+		Log:              slog.New(slog.NewTextHandler(io.Discard, nil)),
+		DataDir:          t.TempDir(),
+		Runner:           fakeRunner{skillErr: &ClaudeAccountError{Detail: "rate limit reached", ResetAt: &resetAt}},
+		PrepareRepoSrc:   stubPrepareRepoSrc,
+		Now:              func() time.Time { return now },
+		LogFlushInterval: time.Hour,
 	}
 	body, _ := json.Marshal(queue.Payload{ScanID: scan.ID})
 	if err := w.wrap(w.doSkill)(context.Background(), body); err != nil {
@@ -248,6 +249,9 @@ func TestWorker_claudeAccountErrorRecordsResetTime(t *testing.T) {
 		}
 		if !strings.Contains(got.Error, "Auto-resume after 2026-07-01T12:15:00Z") {
 			t.Errorf("scan %d error = %q, want auto-resume timestamp", id, got.Error)
+		}
+		if id == scan.ID && !strings.Contains(got.Log, "rate limit reset detected; auto-resume after 2026-07-01T12:15:00Z") {
+			t.Errorf("trigger log = %q, want persisted reset diagnostic", got.Log)
 		}
 	}
 }

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -211,6 +211,394 @@ func TestWorker_claudeAccountErrorPausesScanAndQueue(t *testing.T) {
 	}
 }
 
+func TestWorker_claudeAccountErrorRecordsResetTime(t *testing.T) {
+	gdb, err := db.Open(filepath.Join(t.TempDir(), "limit-reset.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo := db.Repository{URL: "https://example.com/x", Name: "x"}
+	gdb.Create(&repo)
+	skill := db.Skill{Name: "limited", Description: "x", Body: "b", Active: true, Source: "ui", Version: 1}
+	gdb.Create(&skill)
+	scan := db.Scan{RepositoryID: repo.ID, Kind: JobSkill, Status: db.ScanQueued, SkillID: &skill.ID}
+	gdb.Create(&scan)
+	other := db.Scan{RepositoryID: repo.ID, Kind: JobSkill, Status: db.ScanQueued, SkillID: &skill.ID}
+	gdb.Create(&other)
+
+	now := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	resetAt := now.Add(15 * time.Minute)
+	w := &Worker{
+		DB:             gdb,
+		Log:            slog.New(slog.NewTextHandler(io.Discard, nil)),
+		DataDir:        t.TempDir(),
+		Runner:         fakeRunner{skillErr: &ClaudeAccountError{Detail: "rate limit reached", ResetAt: &resetAt}},
+		PrepareRepoSrc: stubPrepareRepoSrc,
+		Now:            func() time.Time { return now },
+	}
+	body, _ := json.Marshal(queue.Payload{ScanID: scan.ID})
+	if err := w.wrap(w.doSkill)(context.Background(), body); err != nil {
+		t.Fatalf("wrap: %v", err)
+	}
+
+	for _, id := range []uint{scan.ID, other.ID} {
+		var got db.Scan
+		gdb.First(&got, id)
+		if got.PausedUntil == nil || !got.PausedUntil.Equal(resetAt) {
+			t.Fatalf("scan %d paused_until = %v, want %v", id, got.PausedUntil, resetAt)
+		}
+		if !strings.Contains(got.Error, "Auto-resume after 2026-07-01T12:15:00Z") {
+			t.Errorf("scan %d error = %q, want auto-resume timestamp", id, got.Error)
+		}
+	}
+}
+
+func TestWorker_claudeAccountErrorRejectsFarFutureReset(t *testing.T) {
+	gdb, err := db.Open(filepath.Join(t.TempDir(), "limit-far-reset.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo := db.Repository{URL: "https://example.com/x", Name: "x"}
+	gdb.Create(&repo)
+	skill := db.Skill{Name: "limited", Description: "x", Body: "b", Active: true, Source: "ui", Version: 1}
+	gdb.Create(&skill)
+	scan := db.Scan{RepositoryID: repo.ID, Kind: JobSkill, Status: db.ScanQueued, SkillID: &skill.ID}
+	gdb.Create(&scan)
+	other := db.Scan{RepositoryID: repo.ID, Kind: JobSkill, Status: db.ScanQueued, SkillID: &skill.ID}
+	gdb.Create(&other)
+
+	now := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	resetAt := now.Add(9 * 24 * time.Hour) // beyond the 8-day auto-resume cap
+	w := &Worker{
+		DB:             gdb,
+		Log:            slog.New(slog.NewTextHandler(io.Discard, nil)),
+		DataDir:        t.TempDir(),
+		Runner:         fakeRunner{skillErr: &ClaudeAccountError{Detail: "rate limit reached", ResetAt: &resetAt}},
+		PrepareRepoSrc: stubPrepareRepoSrc,
+		Now:            func() time.Time { return now },
+	}
+	body, _ := json.Marshal(queue.Payload{ScanID: scan.ID})
+	if err := w.wrap(w.doSkill)(context.Background(), body); err != nil {
+		t.Fatalf("wrap: %v", err)
+	}
+
+	for _, id := range []uint{scan.ID, other.ID} {
+		var got db.Scan
+		gdb.First(&got, id)
+		if got.PausedUntil != nil {
+			t.Fatalf("scan %d paused_until = %v, want nil for far reset", id, got.PausedUntil)
+		}
+	}
+}
+
+func TestWorker_applyAccountPauseResetExtendsBatchForward(t *testing.T) {
+	gdb, err := db.Open(filepath.Join(t.TempDir(), "extend-batch.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo := db.Repository{URL: "https://example.com/x", Name: "x"}
+	gdb.Create(&repo)
+
+	now := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	fiveHour := now.Add(15 * time.Minute)
+	sevenDay := now.Add(7 * 24 * time.Hour)
+	later := sevenDay.Add(24 * time.Hour)
+	wantReset := later
+
+	paused1 := db.Scan{RepositoryID: repo.ID, Kind: JobSkill, Status: db.ScanPaused, Error: accountPauseReason(&fiveHour), PausedUntil: &fiveHour}
+	paused2 := db.Scan{RepositoryID: repo.ID, Kind: JobSkill, Status: db.ScanPaused, Error: accountPauseReason(&fiveHour), PausedUntil: &fiveHour}
+	// Prior trigger row with its own Claude detail.
+	triggerAErr := appendAutoResume((&ClaudeAccountError{Detail: "rate limit reached"}).Error(), &fiveHour)
+	triggerA := db.Scan{RepositoryID: repo.ID, Kind: JobSkill, Status: db.ScanPaused, Error: triggerAErr, PausedUntil: &fiveHour}
+	triggerD := db.Scan{RepositoryID: repo.ID, Kind: JobSkill, Status: db.ScanPaused, Error: "Claude account access paused. Claude reported: rate limit", PausedUntil: nil}
+	manual := db.Scan{RepositoryID: repo.ID, Kind: JobSkill, Status: db.ScanPaused, Error: "paused by user", PausedUntil: &fiveHour}
+	longPaused := db.Scan{RepositoryID: repo.ID, Kind: JobSkill, Status: db.ScanPaused, Error: accountPauseReason(&later), PausedUntil: &later}
+	gdb.Create(&paused1)
+	gdb.Create(&paused2)
+	gdb.Create(&triggerA)
+	gdb.Create(&triggerD)
+	gdb.Create(&manual)
+	gdb.Create(&longPaused)
+
+	w := &Worker{DB: gdb, Log: slog.New(slog.NewTextHandler(io.Discard, nil)), Now: func() time.Time { return now }}
+	effective, err := w.applyAccountPauseReset(triggerD.ID, triggerD.Error, &sevenDay)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if effective == nil || !effective.Equal(wantReset) {
+		t.Fatalf("effective reset = %v, want %v", effective, wantReset)
+	}
+
+	get := func(id uint) db.Scan {
+		var s db.Scan
+		gdb.First(&s, id)
+		return s
+	}
+	if d := get(triggerD.ID); d.PausedUntil == nil || !d.PausedUntil.Equal(wantReset) {
+		t.Errorf("trigger paused_until = %v, want %v", d.PausedUntil, wantReset)
+	}
+	for _, id := range []uint{paused1.ID, paused2.ID} {
+		if s := get(id); s.PausedUntil == nil || !s.PausedUntil.Equal(wantReset) {
+			t.Errorf("paused scan %d paused_until = %v, want extended to %v", id, s.PausedUntil, wantReset)
+		}
+	}
+	if a := get(triggerA.ID); a.PausedUntil == nil || !a.PausedUntil.Equal(wantReset) {
+		t.Errorf("earlier trigger paused_until = %v, want extended to %v", a.PausedUntil, wantReset)
+	}
+	if a := get(triggerA.ID); !strings.Contains(a.Error, "Claude reported: rate limit reached") {
+		t.Errorf("earlier trigger lost its detail: %q", a.Error)
+	}
+	if a := get(triggerA.ID); !strings.Contains(a.Error, "Auto-resume after "+wantReset.UTC().Format(time.RFC3339)) ||
+		strings.Contains(a.Error, fiveHour.UTC().Format(time.RFC3339)) {
+		t.Errorf("earlier trigger suffix not swapped to effective reset: %q", a.Error)
+	}
+	if s := get(manual.ID); s.PausedUntil == nil || !s.PausedUntil.Equal(fiveHour) || s.Error != "paused by user" {
+		t.Errorf("manual pause modified: paused_until=%v error=%q", s.PausedUntil, s.Error)
+	}
+	if s := get(longPaused.ID); s.PausedUntil == nil || !s.PausedUntil.Equal(later) {
+		t.Errorf("long-paused row paused_until = %v, want unchanged %v", s.PausedUntil, later)
+	}
+}
+
+func TestWorker_applyAccountPauseResetTriggerForwardOnly(t *testing.T) {
+	gdb, err := db.Open(filepath.Join(t.TempDir(), "trigger-forward.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo := db.Repository{URL: "https://example.com/x", Name: "x"}
+	gdb.Create(&repo)
+
+	now := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	fiveHour := now.Add(15 * time.Minute)
+	sevenDay := now.Add(7 * 24 * time.Hour)
+
+	// A concurrent finalizer already pushed this scan's own row to seven days.
+	triggerErr := appendAutoResume((&ClaudeAccountError{Detail: "rate limit reached"}).Error(), &sevenDay)
+	trigger := db.Scan{RepositoryID: repo.ID, Kind: JobSkill, Status: db.ScanPaused, Error: triggerErr, PausedUntil: &sevenDay}
+	gdb.Create(&trigger)
+
+	w := &Worker{DB: gdb, Log: slog.New(slog.NewTextHandler(io.Discard, nil)), Now: func() time.Time { return now }}
+	// This finalizer's own reset is an earlier five-hour: it must not pull the
+	// row back, and must return the row's actual later reset.
+	effective, err := w.applyAccountPauseReset(trigger.ID, (&ClaudeAccountError{Detail: "rate limit reached"}).Error(), &fiveHour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if effective == nil || !effective.Equal(sevenDay) {
+		t.Fatalf("effective = %v, want seven-day %v (re-read)", effective, sevenDay)
+	}
+	var got db.Scan
+	gdb.First(&got, trigger.ID)
+	if got.PausedUntil == nil || !got.PausedUntil.Equal(sevenDay) {
+		t.Errorf("trigger pulled back to %v, want kept at %v", got.PausedUntil, sevenDay)
+	}
+}
+
+func TestWorker_applyAccountPauseResetIgnoresFarFutureRow(t *testing.T) {
+	gdb, err := db.Open(filepath.Join(t.TempDir(), "far-future.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo := db.Repository{URL: "https://example.com/x", Name: "x"}
+	gdb.Create(&repo)
+
+	now := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	fiveHour := now.Add(15 * time.Minute)
+	farFuture := now.Add(30 * 24 * time.Hour) // beyond the 8-day auto-resume cap
+
+	// A stale/manual account-paused row far beyond the auto-resume window.
+	far := db.Scan{RepositoryID: repo.ID, Kind: JobSkill, Status: db.ScanPaused, Error: accountPauseReason(&farFuture), PausedUntil: &farFuture}
+	trigger := db.Scan{RepositoryID: repo.ID, Kind: JobSkill, Status: db.ScanPaused, Error: (&ClaudeAccountError{Detail: "rate limit reached"}).Error(), PausedUntil: nil}
+	gdb.Create(&far)
+	gdb.Create(&trigger)
+
+	w := &Worker{DB: gdb, Log: slog.New(slog.NewTextHandler(io.Discard, nil)), Now: func() time.Time { return now }}
+	effective, err := w.applyAccountPauseReset(trigger.ID, trigger.Error, &fiveHour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The far-future row must not drag the batch out; effective stays five-hour.
+	if effective == nil || !effective.Equal(fiveHour) {
+		t.Fatalf("effective = %v, want five-hour %v (far row ignored)", effective, fiveHour)
+	}
+	var gotFar db.Scan
+	gdb.First(&gotFar, far.ID)
+	if gotFar.PausedUntil == nil || !gotFar.PausedUntil.Equal(farFuture) {
+		t.Errorf("far row modified: %v, want unchanged %v", gotFar.PausedUntil, farFuture)
+	}
+}
+
+func TestWorker_applyAccountPauseResetSkipsResumedTrigger(t *testing.T) {
+	gdb, err := db.Open(filepath.Join(t.TempDir(), "resumed-trigger.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo := db.Repository{URL: "https://example.com/x", Name: "x"}
+	gdb.Create(&repo)
+
+	now := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	fiveHour := now.Add(15 * time.Minute)
+
+	// The trigger was manually resumed (queued, no reset) before this reset
+	// landed: the reset must not revive it, and effective must not be bumped off
+	// its stale value.
+	trigger := db.Scan{RepositoryID: repo.ID, Kind: JobSkill, Status: db.ScanQueued, Error: "", PausedUntil: nil}
+	gdb.Create(&trigger)
+
+	w := &Worker{DB: gdb, Log: slog.New(slog.NewTextHandler(io.Discard, nil)), Now: func() time.Time { return now }}
+	effective, err := w.applyAccountPauseReset(trigger.ID, (&ClaudeAccountError{Detail: "rate limit reached"}).Error(), &fiveHour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if effective == nil || !effective.Equal(fiveHour) {
+		t.Fatalf("effective = %v, want five-hour %v (no stale bump)", effective, fiveHour)
+	}
+	var got db.Scan
+	gdb.First(&got, trigger.ID)
+	if got.Status != db.ScanQueued || got.PausedUntil != nil {
+		t.Errorf("resumed trigger resurrected: status=%s paused_until=%v", got.Status, got.PausedUntil)
+	}
+}
+
+func TestWorker_recordRateLimitStatus(t *testing.T) {
+	w := &Worker{}
+	if len(w.RateLimitStatus()) != 0 {
+		t.Fatal("empty worker should report no rate-limit status")
+	}
+	w.recordRateLimit(RateLimitInfo{Type: "five_hour", Status: "allowed", ResetsAt: 100})
+	w.recordRateLimit(RateLimitInfo{Type: "seven_day", Status: "allowed", ResetsAt: 200})
+	w.recordRateLimit(RateLimitInfo{Type: "five_hour", Status: "rejected", ResetsAt: 300}) // latest wins per type
+	w.recordRateLimit(RateLimitInfo{Type: ""})                                             // no type: ignored
+
+	got := w.RateLimitStatus()
+	if len(got) != 2 {
+		t.Fatalf("status count = %d, want 2", len(got))
+	}
+	byType := map[string]RateLimitInfo{}
+	for _, s := range got {
+		byType[s.Type] = s
+	}
+	if byType["five_hour"].Status != "rejected" || byType["five_hour"].ResetsAt != 300 {
+		t.Errorf("five_hour = %+v, want latest rejected/300", byType["five_hour"])
+	}
+	if byType["seven_day"].ResetsAt != 200 {
+		t.Errorf("seven_day = %+v, want 200", byType["seven_day"])
+	}
+}
+
+func TestWorker_resumeAccountPaused(t *testing.T) {
+	gdb, err := db.Open(filepath.Join(t.TempDir(), "resume-account.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	sqldb, err := gdb.DB()
+	if err != nil {
+		t.Fatal(err)
+	}
+	q, err := queue.New(sqldb, slog.New(slog.NewTextHandler(io.Discard, nil)), 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo := db.Repository{URL: "https://example.com/x", Name: "x"}
+	gdb.Create(&repo)
+	skill := db.Skill{Name: "limited", Description: "x", Body: "b", Active: true, Source: "ui", Version: 1}
+	gdb.Create(&skill)
+	now := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	past := now.Add(-time.Minute)
+	future := now.Add(time.Minute)
+	due := db.Scan{RepositoryID: repo.ID, Kind: JobSkill, Status: db.ScanPaused, SkillID: &skill.ID, Error: accountPauseReason(&past), PausedUntil: &past}
+	notDue := db.Scan{RepositoryID: repo.ID, Kind: JobSkill, Status: db.ScanPaused, SkillID: &skill.ID, Error: accountPauseReason(&future), PausedUntil: &future}
+	manual := db.Scan{RepositoryID: repo.ID, Kind: JobSkill, Status: db.ScanPaused, SkillID: &skill.ID, Error: "paused by user", PausedUntil: &past}
+	gdb.Create(&due)
+	gdb.Create(&notDue)
+	gdb.Create(&manual)
+
+	w := &Worker{
+		DB:    gdb,
+		Queue: q,
+		Log:   slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Now:   func() time.Time { return now },
+	}
+	resumed, err := w.resumeAccountPaused(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resumed != 1 {
+		t.Fatalf("resumed = %d, want 1", resumed)
+	}
+
+	var gotDue, gotNotDue, gotManual db.Scan
+	gdb.First(&gotDue, due.ID)
+	gdb.First(&gotNotDue, notDue.ID)
+	gdb.First(&gotManual, manual.ID)
+	if gotDue.Status != db.ScanQueued || gotDue.PausedUntil != nil || gotDue.Error != "" {
+		t.Errorf("due scan = status %s paused_until %v error %q", gotDue.Status, gotDue.PausedUntil, gotDue.Error)
+	}
+	if gotNotDue.Status != db.ScanPaused {
+		t.Errorf("notDue status = %s, want paused", gotNotDue.Status)
+	}
+	if gotManual.Status != db.ScanPaused {
+		t.Errorf("manual status = %s, want paused", gotManual.Status)
+	}
+}
+
+func TestWorker_resumeAccountPausedRestoreOnEnqueueError(t *testing.T) {
+	gdb, err := db.Open(filepath.Join(t.TempDir(), "resume-account-restore.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	sqldb, err := gdb.DB()
+	if err != nil {
+		t.Fatal(err)
+	}
+	q, err := queue.New(sqldb, slog.New(slog.NewTextHandler(io.Discard, nil)), 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo := db.Repository{URL: "https://example.com/x", Name: "x"}
+	gdb.Create(&repo)
+	skill := db.Skill{Name: "limited", Description: "x", Body: "b", Active: true, Source: "ui", Version: 1}
+	gdb.Create(&skill)
+	now := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	past := now.Add(-time.Minute)
+	errText := accountPauseReason(&past) + autoResumeFailurePrefix + "old error"
+	due := db.Scan{
+		RepositoryID: repo.ID, Kind: JobSkill, Status: db.ScanPaused, SkillID: &skill.ID,
+		Error: errText, PausedUntil: &past,
+	}
+	gdb.Create(&due)
+
+	w := &Worker{
+		DB:    gdb,
+		Queue: q,
+		Log:   slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Now:   func() time.Time { return now },
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	resumed, err := w.resumeAccountPaused(ctx)
+	if err == nil {
+		t.Fatal("resumeAccountPaused error = nil, want enqueue error")
+	}
+	if resumed != 0 {
+		t.Fatalf("resumed = %d, want 0", resumed)
+	}
+
+	var got db.Scan
+	gdb.First(&got, due.ID)
+	if got.Status != db.ScanPaused {
+		t.Fatalf("status = %s, want paused", got.Status)
+	}
+	if got.FinishedAt == nil {
+		t.Fatal("finished_at = nil, want restored pause timestamp")
+	}
+	if strings.Count(got.Error, autoResumeFailurePrefix) != 1 {
+		t.Fatalf("error = %q, want one auto-resume failure suffix", got.Error)
+	}
+	if strings.Contains(got.Error, "old error") {
+		t.Fatalf("error = %q, old failure detail should have been replaced", got.Error)
+	}
+}
+
 func TestWorker_skipsPausedScan(t *testing.T) {
 	gdb, err := db.Open(filepath.Join(t.TempDir(), "paused.db"))
 	if err != nil {

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -611,6 +611,46 @@ func TestWorker_resumeAccountPausedUsesUTCComparison(t *testing.T) {
 	}
 }
 
+func TestAppendAutoResumeFailure(t *testing.T) {
+	reset := time.Date(2026, 7, 1, 12, 15, 0, 0, time.UTC)
+	base := (&ClaudeAccountError{Detail: "rate limit reached"}).Error()
+	enqErr := errors.New("enqueue: closed")
+
+	// A row carrying an auto-resume timestamp: the stale timestamp is dropped
+	// so the message doesn't claim resume-at-past alongside a failure.
+	withReset := appendAutoResume(base, &reset)
+	got := appendAutoResumeFailure(withReset, enqErr)
+	if strings.Contains(got, autoResumeAfterPrefix) || strings.Contains(got, "2026-07-01T12:15:00Z") {
+		t.Errorf("stale auto-resume timestamp kept: %q", got)
+	}
+	if !strings.Contains(got, "rate limit reached") {
+		t.Errorf("Claude detail lost: %q", got)
+	}
+	if !strings.HasSuffix(got, autoResumeFailurePrefix+"enqueue: closed") {
+		t.Errorf("failure suffix = %q", got)
+	}
+
+	// A prior failure suffix is replaced, not stacked.
+	got2 := appendAutoResumeFailure(got, errors.New("enqueue: still closed"))
+	if strings.Count(got2, autoResumeFailurePrefix) != 1 || strings.Contains(got2, "enqueue: closed"+autoResumeFailurePrefix) {
+		t.Errorf("failure suffix stacked: %q", got2)
+	}
+	if !strings.HasSuffix(got2, "enqueue: still closed") {
+		t.Errorf("second failure = %q", got2)
+	}
+
+	// Empty message falls through to the shared account-pause reason.
+	if got := appendAutoResumeFailure("", enqErr); !strings.HasPrefix(got, ClaudeAccountPausePrefix) {
+		t.Errorf("empty msg = %q, want account-pause prefix", got)
+	}
+
+	// Oversized detail is truncated.
+	long := strings.Repeat("x", maxAutoResumeErrorBytes+100)
+	if got := appendAutoResumeFailure(base, errors.New(long)); len(got) > len(base)+len(autoResumeFailurePrefix)+maxAutoResumeErrorBytes+10 {
+		t.Errorf("failure detail not truncated: %d bytes", len(got))
+	}
+}
+
 func TestWorker_resumeAccountPausedRestoreOnEnqueueError(t *testing.T) {
 	gdb, err := db.Open(filepath.Join(t.TempDir(), "resume-account-restore.db"))
 	if err != nil {
@@ -666,6 +706,9 @@ func TestWorker_resumeAccountPausedRestoreOnEnqueueError(t *testing.T) {
 	}
 	if strings.Contains(got.Error, "old error") {
 		t.Fatalf("error = %q, old failure detail should have been replaced", got.Error)
+	}
+	if strings.Contains(got.Error, autoResumeAfterPrefix) {
+		t.Fatalf("error = %q, stale auto-resume timestamp should have been dropped", got.Error)
 	}
 }
 

--- a/scrutineer.sample.yaml
+++ b/scrutineer.sample.yaml
@@ -126,6 +126,9 @@
 # environment variable when empty.
 # anthropic_base_url: https://my-proxy.corp.com/v1
 
+# Claude subscription rate-limit auto-resume needs no configuration. Reset times
+# come from claude-code stream output; latest window status appears on /usage.
+
 # The model picker in the UI. Replacing this list replaces the built-in
 # set (Opus, Sonnet, Fable). Leave it out to keep the built-in list.
 # models:


### PR DESCRIPTION
When claude-code hits an account-level rate or usage limit on a Claude subscription token, scrutineer now pauses the triggering scan and the rest of the queued batch, reads the reset time from the `rate_limit_event` claude-code emits in its own stream output, and re-queues the batch automatically once that reset passes. No configuration is required.

The reset comes from the stream scrutineer already parses, so there is no extra API call, credential, or scope to manage. A batch is bound to the latest exhausted window: if concurrent scans hit different windows (five-hour vs seven-day), the whole batch waits for the furthest reset rather than waking early and re-pausing. Permanent account problems (access disabled or revoked) and API-key accounts report no reset, so they pause for manual resume instead of looping.

The `/usage` page shows the latest per-window status (window, status, and reset) captured from recent scans.


<img width="669" height="178" alt="Screenshot 2026-07-02 at 10 08 35" src="https://github.com/user-attachments/assets/e47fa50d-8fd7-49c9-9f8e-032b18ac26cb" />
