### PR TITLE
Gate exposure and VEX exports on dependents

### DIFF
--- a/internal/web/finding_bundle.go
+++ b/internal/web/finding_bundle.go
@@ -114,6 +114,10 @@ func (s *Server) bundleEntries(f *db.Finding, repo *db.Repository) ([]bundleEntr
 		return nil, fmt.Errorf("load finding dependents: %w", err)
 	}
 	deps := loadFindingDependents(s, fdRows)
+	var dependentCount int64
+	if err := s.DB.Model(&db.Dependent{}).Where("repository_id = ?", f.RepositoryID).Count(&dependentCount).Error; err != nil {
+		return nil, fmt.Errorf("count dependents: %w", err)
+	}
 	// Scan load is best-effort: a finding with a missing parent scan
 	// row (e.g. a scan that was deleted) still has a valid bundle to
 	// produce, since the bundle does not embed scan-specific fields.
@@ -137,12 +141,14 @@ func (s *Server) bundleEntries(f *db.Finding, repo *db.Repository) ([]bundleEntr
 	entries = append(entries, bundleEntry{Name: "osv.json", Data: osvRaw})
 	contents["osv.json"] = "OSV 1.6.0 record (machine-readable advisory)"
 
-	csafRaw, err := json.MarshalIndent(buildCSAF(*f, *repo, refs, pkgs, fdRows, deps), "", "  ")
-	if err != nil {
-		return nil, fmt.Errorf("build CSAF: %w", err)
+	if dependentCount > 0 {
+		csafRaw, err := json.MarshalIndent(buildCSAF(*f, *repo, refs, pkgs, fdRows, deps), "", "  ")
+		if err != nil {
+			return nil, fmt.Errorf("build CSAF: %w", err)
+		}
+		entries = append(entries, bundleEntry{Name: "csaf.json", Data: csafRaw})
+		contents["csaf.json"] = "CSAF 2.0 document (with VEX product_status for dependents)"
 	}
-	entries = append(entries, bundleEntry{Name: "csaf.json", Data: csafRaw})
-	contents["csaf.json"] = "CSAF 2.0 document (with VEX product_status for dependents)"
 
 	report := renderFindingReport(s.DB, f, &scan, repo)
 	entries = append(entries, bundleEntry{Name: "report.md", Data: []byte(report)})

--- a/internal/web/finding_bundle_test.go
+++ b/internal/web/finding_bundle_test.go
@@ -65,10 +65,24 @@ func setUpBundleFinding(t *testing.T, s *Server, withPatch bool) *db.Finding {
 	return &f
 }
 
+func seedBundleDependent(t *testing.T, s *Server, repoID uint) {
+	t.Helper()
+	dep := db.Dependent{
+		RepositoryID:   repoID,
+		Name:           "downstream-app",
+		Ecosystem:      "go",
+		PURL:           "pkg:golang/example.com/downstream-app",
+		RepositoryURL:  "https://github.com/acme/downstream-app",
+		DependentRepos: 10,
+	}
+	s.DB.Create(&dep)
+}
+
 func TestFindingBundle_containsManifestAndExports(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()
 	f := setUpBundleFinding(t, s, true)
+	seedBundleDependent(t, s, f.RepositoryID)
 
 	r := httptest.NewRequest(http.MethodGet,
 		"/findings/"+strconv.Itoa(int(f.ID))+"/bundle.tar.gz", nil)
@@ -109,6 +123,9 @@ func TestFindingBundle_containsManifestAndExports(t *testing.T) {
 	if _, ok := m.Contents["patch.diff"]; !ok {
 		t.Errorf("manifest.contents missing patch.diff: %+v", m.Contents)
 	}
+	if _, ok := m.Contents["csaf.json"]; !ok {
+		t.Errorf("manifest.contents missing csaf.json: %+v", m.Contents)
+	}
 
 	// The per-file exports must equal what the corresponding /findings/{id}/{file}
 	// endpoint serves. The OSV and report endpoints are the strongest check:
@@ -120,6 +137,33 @@ func TestFindingBundle_containsManifestAndExports(t *testing.T) {
 	s.Handler().ServeHTTP(osvRec, osvReq)
 	if !bytes.Equal(files["osv.json"], osvRec.Body.Bytes()) {
 		t.Errorf("bundle osv.json differs from /findings/%d/osv.json", f.ID)
+	}
+}
+
+func TestFindingBundle_omitsCSAFWhenNoDependents(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	f := setUpBundleFinding(t, s, true)
+
+	r := httptest.NewRequest(http.MethodGet,
+		"/findings/"+strconv.Itoa(int(f.ID))+"/bundle.tar.gz", nil)
+	r.Host = "127.0.0.1:8080"
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, r)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	files := readArchive(t, w.Body.Bytes())
+	if _, ok := files["csaf.json"]; ok {
+		t.Errorf("archive should omit csaf.json when repository has no dependents")
+	}
+
+	var m bundleManifest
+	if err := json.Unmarshal(files["manifest.json"], &m); err != nil {
+		t.Fatalf("decode manifest: %v", err)
+	}
+	if _, ok := m.Contents["csaf.json"]; ok {
+		t.Errorf("manifest.contents should omit csaf.json without dependents")
 	}
 }
 

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -1598,11 +1598,9 @@ func (s *Server) findingShow(w http.ResponseWriter, r *http.Request) {
 			VerifyInFlight: verifyInFlight,
 			HasDependents:  hasDependents,
 		},
-		"Exposures":    exposures,
-		"ShowExposure": findingSupportsExposure(scan),
-	}
-	if data["ShowExposure"].(bool) {
-		data["HasDependents"] = hasDependents
+		"Exposures":     exposures,
+		"HasDependents": hasDependents,
+		"ShowExposure":  findingSupportsExposure(scan) && hasDependents,
 	}
 	if id, c, ok := LookupCWE(f.CWE); ok {
 		data["CWE"] = map[string]any{"ID": id, "Name": c.Name, "Description": c.Description}

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -1617,6 +1617,57 @@ func TestFindingShow_hidesExposureForZizmorFindings(t *testing.T) {
 	}
 }
 
+func TestFindingShow_hidesExposureWhenNoDependents(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	repo := db.Repository{URL: "https://example.com/r", Name: "r"}
+	s.DB.Create(&repo)
+	scan := db.Scan{RepositoryID: repo.ID, Kind: "skill", Status: db.ScanDone, SkillName: deepDiveSkillName}
+	s.DB.Create(&scan)
+	f := db.Finding{ScanID: scan.ID, RepositoryID: repo.ID, Title: "app issue", Severity: "High"}
+	s.DB.Create(&f)
+
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq("GET", fmt.Sprintf("/findings/%d", f.ID)))
+	body := w.Body.String()
+	if w.Code != http.StatusOK {
+		t.Fatalf("status %d: %s", w.Code, body)
+	}
+	if strings.Contains(body, "Dependent exposure") || strings.Contains(body, "/exposure") {
+		t.Error("findings without dependents should not render dependent exposure controls")
+	}
+	if strings.Contains(body, "CSAF VEX") {
+		t.Error("findings without dependents should not advertise CSAF VEX in the disclosure bundle")
+	}
+}
+
+func TestFindingShow_rendersExposureWhenDependentsExist(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	repo := db.Repository{URL: "https://example.com/r", Name: "r"}
+	s.DB.Create(&repo)
+	scan := db.Scan{RepositoryID: repo.ID, Kind: "skill", Status: db.ScanDone, SkillName: deepDiveSkillName}
+	s.DB.Create(&scan)
+	f := db.Finding{ScanID: scan.ID, RepositoryID: repo.ID, Title: "library issue", Severity: "High"}
+	s.DB.Create(&f)
+	dep := db.Dependent{RepositoryID: repo.ID, Name: "downstream", Ecosystem: "go", RepositoryURL: "https://example.com/downstream"}
+	s.DB.Create(&dep)
+
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq("GET", fmt.Sprintf("/findings/%d", f.ID)))
+	body := w.Body.String()
+	if w.Code != http.StatusOK {
+		t.Fatalf("status %d: %s", w.Code, body)
+	}
+	for _, want := range []string{"Dependent exposure", "/exposure", "CSAF VEX"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("dependent-backed finding missing %q", want)
+		}
+	}
+}
+
 func TestFindingShow_rendersPublicIssueActionForReadyFinding(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()

--- a/internal/web/templates/finding_show.html
+++ b/internal/web/templates/finding_show.html
@@ -19,7 +19,7 @@
       <i data-lucide="download"></i> Export report
     </a>
     <a href="/findings/{{$f.ID}}/bundle.tar.gz" class="btn-outline"
-       title="OSV + CSAF + markdown report + patch + manifest, packaged for a disclosure recipient"
+       title="{{if .HasDependents}}OSV + CSAF VEX + markdown report + patch + manifest{{else}}OSV + markdown report + patch + manifest{{end}}, packaged for a disclosure recipient"
        download>
       <i data-lucide="package"></i> Disclosure bundle
     </a>
@@ -277,10 +277,10 @@
     <section class="pb-4 grid gap-3">
       <div class="flex items-center gap-2">
         <form method="post" action="/findings/{{$f.ID}}/exposure" hx-post="/findings/{{$f.ID}}/exposure" hx-swap="none" hx-confirm="Run exposure on up to 10 dependents? This can enqueue up to 10 full scans.">
-          <button type="submit" class="btn-sm" {{if not .HasDependents}}disabled title="This repository has no recorded dependents."{{end}}>Run exposure on top-10 dependents</button>
+          <button type="submit" class="btn-sm">Run exposure on top-10 dependents</button>
         </form>
         <span class="text-xs text-muted-foreground">
-          {{if .HasDependents}}Clones each dependent and audits whether this finding is reachable in its code.{{else}}No dependents recorded for this repository.{{end}}
+          Clones each dependent and audits whether this finding is reachable in its code.
         </span>
       </div>
       {{if .Exposures}}


### PR DESCRIPTION
Part of #22

## Summary

This finishes another application-vs-library feature gate by hiding dependent exposure and VEX bundle output when a repository has no recorded dependents.

## Changes

- Hide the dependent exposure section on finding pages unless dependents exist.
- Keep exposure controls visible for findings whose repository has dependents.
- Stop advertising CSAF VEX in the disclosure bundle tooltip for no-dependent repos.
- Omit `csaf.json` from disclosure bundles when there are no dependents.
- Add tests for both dependent and no-dependent finding/bundle paths.

## Testing

- `git diff --check`
- `go test ./internal/web -run 'TestFindingShow_(hidesExposureForZizmorFindings|hidesExposureWhenNoDependents|rendersExposureWhenDependentsExist)|TestFindingBundle_(containsManifestAndExports|omitsCSAFWhenNoDependents|skipsPatchWhenAbsent)'`
- `go test ./internal/web`
- `go test ./...`