### PR TITLE
Gate CSAF export on dependents

### DIFF
--- a/internal/web/finding_csaf.go
+++ b/internal/web/finding_csaf.go
@@ -91,6 +91,12 @@ func (s *Server) findingCSAF(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "finding is a duplicate; export not available", http.StatusGone)
 		return
 	}
+	var dependentCount int64
+	s.DB.Model(&db.Dependent{}).Where("repository_id = ?", f.RepositoryID).Count(&dependentCount)
+	if dependentCount == 0 {
+		http.Error(w, "CSAF VEX export is unavailable because this repository has no recorded dependents", http.StatusNotFound)
+		return
+	}
 	schema, err := getCSAFSchema()
 	if err != nil {
 		s.Log.Error("csaf schema", "err", err)

--- a/internal/web/finding_csaf_test.go
+++ b/internal/web/finding_csaf_test.go
@@ -42,6 +42,32 @@ func seedCSAFFinding(t *testing.T, s *Server, mut func(*db.Finding)) db.Finding 
 		mut(&f)
 	}
 	s.DB.Create(&f)
+	dep := db.Dependent{RepositoryID: repo.ID, Name: "downstream-app", Ecosystem: "npm", RepositoryURL: "https://github.com/example/downstream-app"}
+	s.DB.Create(&dep)
+	return f
+}
+
+func seedCSAFFindingWithoutDependents(t *testing.T, s *Server) db.Finding {
+	t.Helper()
+	repo := db.Repository{
+		URL:      "https://github.com/example/app.git",
+		Name:     "app",
+		FullName: "example/app",
+		HTMLURL:  "https://github.com/example/app",
+	}
+	s.DB.Create(&repo)
+	scan := db.Scan{RepositoryID: repo.ID, Kind: "skill", Status: db.ScanDone, SkillName: "security-deep-dive"}
+	s.DB.Create(&scan)
+	f := db.Finding{
+		ScanID:       scan.ID,
+		RepositoryID: repo.ID,
+		FindingID:    "F1",
+		Title:        "Unsafe redirect in app route",
+		Severity:     "Medium",
+		Status:       db.FindingTriaged,
+		CWE:          "CWE-601",
+	}
+	s.DB.Create(&f)
 	return f
 }
 
@@ -102,6 +128,20 @@ func TestFindingCSAF_validatesAgainstOfficialSchema(t *testing.T) {
 	ps := v["product_status"].(map[string]any)
 	if _, ok := ps["known_affected"]; !ok {
 		t.Errorf("product_status missing known_affected: %+v", ps)
+	}
+}
+
+func TestFindingCSAF_noDependentsReturns404(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	f := seedCSAFFindingWithoutDependents(t, s)
+	w := getCSAF(t, s, f.ID)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status %d, want 404: %s", w.Code, w.Body)
+	}
+	if !strings.Contains(w.Body.String(), "no recorded dependents") {
+		t.Errorf("body should explain missing dependents: %s", w.Body)
 	}
 }
 

--- a/internal/web/finding_exploited_test.go
+++ b/internal/web/finding_exploited_test.go
@@ -145,6 +145,7 @@ func TestCSAFExport_includesExploitedInWildNote(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()
 	f := newFindingForExploitedTest(t, s)
+	s.DB.Create(&db.Dependent{RepositoryID: f.RepositoryID, Name: "downstream", Ecosystem: "npm"})
 	s.DB.Model(f).Updates(map[string]any{
 		"exploited_in_wild":          "yes",
 		"exploited_in_wild_evidence": "in-the-wild traffic observed",


### PR DESCRIPTION
Part of #22, Follow-up according to  https://github.com/alpha-omega-security/scrutineer/pull/552#pullrequestreview-4620253695

## Summary

This applies the same dependent-aware gate to the direct CSAF endpoint that #552 added for the finding page and disclosure bundle. Repositories without recorded dependents no longer expose a VEX-shaped CSAF export.

## Changes

- Return `404` from `/findings/{id}/csaf.json` when the finding repository has no recorded dependents.
- Use the repo-level `db.Dependent` count, matching the finding page and bundle behavior.
- Keep CSAF export behavior unchanged for repositories with dependents.
- Add endpoint coverage for the no-dependent case.
- Update existing CSAF tests to seed dependents where CSAF generation is under test.

## Testing

- `git diff --check`
- `go test ./internal/web -run 'TestFindingCSAF|TestCSAF|TestFindingBundle|TestFindingShow_(hidesExposureWhenNoDependents|rendersExposureWhenDependentsExist)'`
- `go test ./internal/web`
- `go test ./...`