### PR TITLE
fix(worker): bind egress sidecar to its internal leg only; skip host proxy under rootless hardened

### DIFF
--- a/cmd/scrutineer/main.go
+++ b/cmd/scrutineer/main.go
@@ -670,23 +670,32 @@ func setupRunner(f *flags, cfg *config.Config, log *slog.Logger) (worker.SkillRu
 		allow = append(allow, apiHost)
 	}
 	token := worker.NewProxyToken()
-	port, err := worker.StartEgressProxy(&worker.EgressProxy{
-		Allow:    allow,
-		Token:    token,
-		APIPort:  addrPort(f.addr),
-		APIHosts: []string{apiHost},
-		Log:      log,
-	})
-	if err != nil {
-		return nil, "", fmt.Errorf("start egress proxy: %w", err)
-	}
-	// Rootless --hardened runs the egress proxy as a sidecar reusing the host
-	// proxy's allow-list and token, so resolve its config now that both exist.
+	// Rootless --hardened runs the egress proxy as a per-scan sidecar reusing
+	// this allow-list and token; resolve it before the in-process host proxy so
+	// the latter can be skipped when the sidecar is in charge.
 	if f.hardened {
 		egress, err = resolveEgressSidecar(rt, f, allow, token, log)
 		if err != nil {
 			return nil, "", err
 		}
+	}
+	// With a sidecar every scan routes through it (buildRunArgs shadows
+	// ProxyURL with the sidecar endpoint), so the host proxy would only open an
+	// unused host port -- skip it and leave port at 0 / ProxyURL empty.
+	var port int
+	var proxyURL string
+	if egress.GatewayIP == "" {
+		port, err = worker.StartEgressProxy(&worker.EgressProxy{
+			Allow:    allow,
+			Token:    token,
+			APIPort:  addrPort(f.addr),
+			APIHosts: []string{apiHost},
+			Log:      log,
+		})
+		if err != nil {
+			return nil, "", fmt.Errorf("start egress proxy: %w", err)
+		}
+		proxyURL = worker.ProxyURLForHost(token, apiHost, port)
 	}
 	log.Info("container runtime detected, using containerised runner",
 		"runtime", rt.Bin, "rootless", rt.Rootless, "image", f.runnerImage,
@@ -701,7 +710,7 @@ func setupRunner(f *flags, cfg *config.Config, log *slog.Logger) (worker.SkillRu
 		Image:               f.runnerImage,
 		Effort:              f.effort,
 		Harness:             h,
-		ProxyURL:            worker.ProxyURLForHost(token, apiHost, port),
+		ProxyURL:            proxyURL,
 		FullClone:           f.fullClone(),
 		MaxTurns:            f.maxTurns,
 		AnthropicBaseURL:    f.anthropicBaseURL,

--- a/cmd/scrutineer/proxy.go
+++ b/cmd/scrutineer/proxy.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"fmt"
 	"log/slog"
+	"net"
 	"os"
 	"strings"
 	"time"
@@ -83,6 +84,25 @@ func envOr(getenv func(string) string, key, def string) string {
 	return def
 }
 
+// resolveListen turns the SidecarListenFirstIface keyword in the listen host
+// into the concrete IPv4 of the sidecar's first interface -- its per-scan
+// --internal leg -- so the listener never faces the default bridge the egress
+// leg is attached to. Any other listen value passes through untouched (manual
+// runs; a malformed one fails at bind time). A resolution failure is fatal:
+// falling back to all interfaces would silently re-open the probe surface the
+// keyword exists to remove. firstIfaceIPv4 is injected for tests.
+func resolveListen(listen string, firstIfaceIPv4 func() (string, error)) (string, error) {
+	host, port, err := net.SplitHostPort(listen)
+	if err != nil || host != worker.SidecarListenFirstIface {
+		return listen, nil
+	}
+	ip, err := firstIfaceIPv4()
+	if err != nil {
+		return "", fmt.Errorf("resolve %s listen address: %w", worker.SidecarListenFirstIface, err)
+	}
+	return net.JoinHostPort(ip, port), nil
+}
+
 // runProxy is the entrypoint for `scrutineer proxy`: the egress-proxy sidecar
 // the container runner attaches to a hardened scan's --internal network under
 // rootless podman. The scan container points HTTPS_PROXY at this
@@ -99,6 +119,9 @@ func runProxy(args []string) error {
 			return nil // usage already printed by Parse
 		}
 		return err
+	}
+	if cfg.listen, err = resolveListen(cfg.listen, worker.FirstIfaceIPv4); err != nil {
+		return fmt.Errorf("egress proxy refusing to start: %w", err)
 	}
 
 	if cfg.apiHost != "" && cfg.apiPort != "" {

--- a/cmd/scrutineer/proxy_test.go
+++ b/cmd/scrutineer/proxy_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"errors"
 	"reflect"
 	"strings"
 	"testing"
@@ -105,7 +106,7 @@ func TestEgressSidecarEnvContract(t *testing.T) {
 		GatewayIP: "192.0.2.9",
 	}
 	env := map[string]string{}
-	for _, kv := range worker.EgressSidecarEnv(cfg, ":3128") {
+	for _, kv := range worker.EgressSidecarEnv(cfg, worker.SidecarListenFirstIface+":3128") {
 		k, v, _ := strings.Cut(kv, "=")
 		env[k] = v
 	}
@@ -123,11 +124,42 @@ func TestEgressSidecarEnvContract(t *testing.T) {
 	if got.apiPort != cfg.APIPort {
 		t.Errorf("api port: host set %q, sidecar read %q", cfg.APIPort, got.apiPort)
 	}
-	if got.listen != ":3128" {
-		t.Errorf("listen: sidecar read %q, want :3128", got.listen)
+	if got.listen != worker.SidecarListenFirstIface+":3128" {
+		t.Errorf("listen: sidecar read %q, want %s:3128", got.listen, worker.SidecarListenFirstIface)
 	}
 	if !reflect.DeepEqual(got.allow, cfg.Allow) {
 		t.Errorf("allow: host set %v, sidecar read %v", cfg.Allow, got.allow)
+	}
+	// The keyword the host injects is the one resolveListen recognises, closing
+	// the loop: the sidecar ends up bound to its --internal leg, not :3128.
+	resolved, err := resolveListen(got.listen, func() (string, error) { return "10.89.1.2", nil })
+	if err != nil || resolved != "10.89.1.2:3128" {
+		t.Errorf("resolveListen(%q) = %q, %v, want 10.89.1.2:3128", got.listen, resolved, err)
+	}
+}
+
+func TestResolveListen(t *testing.T) {
+	// Anything that is not the keyword passes through untouched and must not
+	// consult the interfaces -- covers manual runs (-listen :3128 or an explicit
+	// address) and leaves bad values to fail at bind time.
+	for _, listen := range []string{":3128", "0.0.0.0:3128", "10.0.0.1:3128", "not-a-hostport"} {
+		called := false
+		got, err := resolveListen(listen, func() (string, error) { called = true; return "", nil })
+		if err != nil || got != listen || called {
+			t.Errorf("resolveListen(%q) = %q, %v (resolver called: %v), want passthrough", listen, got, err, called)
+		}
+	}
+
+	got, err := resolveListen(worker.SidecarListenFirstIface+":3128", func() (string, error) { return "10.89.1.2", nil })
+	if err != nil || got != "10.89.1.2:3128" {
+		t.Errorf("keyword listen = %q, %v, want 10.89.1.2:3128", got, err)
+	}
+
+	// No resolvable first interface means the sidecar cannot bind its internal
+	// leg; serving on all interfaces instead would defeat the point, so the
+	// resolver's failure must fail the whole resolution (fail closed).
+	if _, err := resolveListen(worker.SidecarListenFirstIface+":3128", func() (string, error) { return "", errors.New("no iface") }); err == nil {
+		t.Error("expected a resolver failure to fail listen resolution")
 	}
 }
 

--- a/docs/egress-sidecar.md
+++ b/docs/egress-sidecar.md
@@ -16,8 +16,11 @@ the rootless network backend.
 
 Under rootless podman `--hardened`, the scan container is attached to a per-scan
 `--internal` network with no route out. scrutineer starts a sidecar
-(`scrutineer proxy`, run from the **runner image**) on the default bridge network,
-then connects it to the `--internal` network too. That `--internal` network is
+(`scrutineer proxy`, run from the **runner image**) on that `--internal` network,
+then connects the default bridge network to it as its egress leg. Internal-first
+ordering lets the sidecar bind its listener to its **`--internal` address only**,
+so the proxy port is unreachable from the shared default bridge — other
+containers of the same user can't even probe it. That `--internal` network is
 created with `--disable-dns` — its embedded resolver can't forward external lookups
 and would shadow the sidecar's working one — so the scan resolves no names and
 points `HTTPS_PROXY` at the sidecar's **IP** on the network (`<ip>:3128`), dialing

--- a/internal/worker/container.go
+++ b/internal/worker/container.go
@@ -122,7 +122,8 @@ func hardenedNetworkName(scanID uint) string {
 const proxySidecarPrefix = "scrutineer-proxy-"
 
 // proxySidecarPort is the fixed port the egress proxy sidecar listens on inside
-// its own network namespace. It does not collide with anything: each sidecar is
+// its own network namespace, bound to its --internal address only (see
+// SidecarListenFirstIface). It does not collide with anything: each sidecar is
 // alone in its container, and the scan reaches it by its --internal IP (e.g.
 // 10.89.1.2:3128), not on a shared host port.
 const proxySidecarPort = "3128"
@@ -792,12 +793,17 @@ func (d ContainerRunner) setupHardenedNetwork(sj SkillJob, image string) (harden
 }
 
 // startProxySidecar launches the egress proxy as a detached container on the
-// default (egress) network, then connects it to the per-scan --internal network
-// so the scan can reach it. It returns the host:port the scan points HTTPS_PROXY
-// at and a cleanup that force-removes the container. The sidecar self-gates its
-// listener on reaching the host skill API (see runProxy / WaitHostAPIReachable),
-// so a successful proxy-reach probe in verifyHardenedNetwork transitively proves
-// the whole scan -> sidecar -> host-API chain.
+// per-scan --internal network, then connects the default (egress) network as a
+// second leg. Internal-first ordering is load-bearing: it makes the internal
+// leg the sidecar's first interface, which is the one its listener binds to
+// (see SidecarListenFirstIface), keeping the proxy port unreachable from the
+// shared default bridge. The sidecar cannot reach the host skill API until the
+// egress leg attaches; its readiness probe polls through that window. It
+// returns the host:port the scan points HTTPS_PROXY at and a cleanup that
+// force-removes the container. The sidecar self-gates its listener on reaching
+// the host skill API (see runProxy / WaitHostAPIReachable), so a successful
+// proxy-reach probe in verifyHardenedNetwork transitively proves the whole
+// scan -> sidecar -> host-API chain.
 func (d ContainerRunner) startProxySidecar(sj SkillJob, network string) (endpoint string, cleanup func(), err error) {
 	noop := func() {}
 	if d.Egress.GatewayIP == "" {
@@ -811,14 +817,17 @@ func (d ContainerRunner) startProxySidecar(sj SkillJob, network string) (endpoin
 	// and pin the network; remove it first (no-op when absent).
 	rmName()
 
-	if out, e := exec.Command(d.Runtime.bin(), d.proxySidecarRunArgs(name)...).CombinedOutput(); e != nil {
+	if out, e := exec.Command(d.Runtime.bin(), d.proxySidecarRunArgs(name, network)...).CombinedOutput(); e != nil {
 		rmName() // a failed `run -d` can still leave a created container behind
 		return "", noop, fmt.Errorf("%s run sidecar: %w: %s", d.Runtime.bin(), e, strings.TrimSpace(string(out)))
 	}
 
-	if out, e := exec.Command(d.Runtime.bin(), "network", "connect", "--", network, name).CombinedOutput(); e != nil {
+	// The egress leg. `network connect` only works on netavark bridges, so pin
+	// the named default bridge rather than the rootless default (pasta), which
+	// rejects it ("pasta is not supported: invalid network mode").
+	if out, e := exec.Command(d.Runtime.bin(), "network", "connect", "--", "podman", name).CombinedOutput(); e != nil {
 		rmName()
-		return "", noop, fmt.Errorf("%s network connect %s: %w: %s", d.Runtime.bin(), network, e, strings.TrimSpace(string(out)))
+		return "", noop, fmt.Errorf("%s network connect podman: %w: %s", d.Runtime.bin(), e, strings.TrimSpace(string(out)))
 	}
 	// The --internal network runs no DNS, so the scan must reach the sidecar by
 	// its address on that network rather than by name.
@@ -849,31 +858,29 @@ func (d ContainerRunner) sidecarNetworkIP(name, network string) (string, error) 
 
 // proxySidecarRunArgs builds the detached `run` args for the egress proxy
 // sidecar: locked down (cap-drop ALL, read-only rootfs, no-new-privileges, a
-// small noexec /tmp tmpfs), on the default egress network with the host-gateway
-// alias wired to the resolved IPv4 so it reaches the host skill API, running
-// `scrutineer proxy` with its config passed via env. It deliberately runs the
+// small noexec /tmp tmpfs), on the per-scan --internal network with the
+// host-gateway alias wired to the resolved IPv4 so it reaches the host skill
+// API once its egress leg attaches, running `scrutineer proxy` with its config
+// passed via env. The --internal network MUST be the run-time network: that
+// makes it the sidecar's first interface, the one the SidecarListenFirstIface
+// listen keyword binds to; startProxySidecar connects the default (egress)
+// bridge afterwards, so the listener never faces it. It deliberately runs the
 // DEFAULT runner image (d.image()), which is guaranteed to carry the scrutineer
-// binary, not the per-scan profile image. It is NOT attached to the --internal
-// network here; startProxySidecar connects that leg after the container exists.
-// No --rm, so a sidecar that exits on an unreachable host API lingers long
-// enough for verifyHardenedNetwork to capture its logs.
-func (d ContainerRunner) proxySidecarRunArgs(name string) []string {
+// binary, not the per-scan profile image. No --rm, so a sidecar that exits on
+// an unreachable host API lingers long enough for verifyHardenedNetwork to
+// capture its logs.
+func (d ContainerRunner) proxySidecarRunArgs(name, network string) []string {
 	args := []string{
 		"run", "-d",
 		"--name", name,
-		// The sidecar is dual-homed: startProxySidecar attaches the per-scan
-		// --internal network to it after launch with `podman network connect`,
-		// which only works on a netavark bridge. The rootless default (pasta)
-		// rejects it ("pasta is not supported: invalid network mode"), so pin the
-		// default bridge for the egress leg rather than inheriting pasta.
-		"--network", "podman",
+		"--network", network,
 		"--cap-drop", "ALL",
 		"--security-opt", "no-new-privileges",
 		"--read-only",
 		"--tmpfs", "/tmp:rw,noexec,nosuid,size=16m",
 		"--add-host", HostGatewayAlias + ":" + d.Egress.GatewayIP,
 	}
-	for _, e := range EgressSidecarEnv(d.Egress, ":"+proxySidecarPort) {
+	for _, e := range EgressSidecarEnv(d.Egress, SidecarListenFirstIface+":"+proxySidecarPort) {
 		args = append(args, "-e", e)
 	}
 	return append(args, "--", d.image(), "scrutineer", "proxy")
@@ -883,7 +890,10 @@ func (d ContainerRunner) proxySidecarRunArgs(name string) []string {
 // container runner injects into the egress proxy sidecar. It is the single
 // source of truth for the host<->sidecar env contract: the runner sets these
 // (proxySidecarRunArgs) and `scrutineer proxy` reads them back, so both sides
-// must agree on the names. listen is the full listen address (e.g. ":3128").
+// must agree on the names. listen is the full listen address; its host may be
+// the SidecarListenFirstIface keyword, which the sidecar resolves to its own
+// --internal address at startup (the host cannot know it before the container
+// exists).
 func EgressSidecarEnv(cfg EgressSidecarConfig, listen string) []string {
 	return []string{
 		"SCRUTINEER_PROXY_TOKEN=" + cfg.Token,

--- a/internal/worker/container_test.go
+++ b/internal/worker/container_test.go
@@ -559,7 +559,7 @@ func TestProxySidecarRunArgs(t *testing.T) {
 			GatewayIP: "192.0.2.9",
 		},
 	}
-	args := d.proxySidecarRunArgs("scrutineer-proxy-7")
+	args := d.proxySidecarRunArgs("scrutineer-proxy-7", "scrutineer-hardened-7")
 
 	// Detached and locked down -- the sidecar runs scrutineer's own trusted code
 	// but gets the same defense-in-depth as the scan container.
@@ -579,19 +579,24 @@ func TestProxySidecarRunArgs(t *testing.T) {
 	if !hasAdjacent(args, "--add-host", HostGatewayAlias+":192.0.2.9") {
 		t.Errorf("missing host-gateway add-host: %v", args)
 	}
-	// Must start on a connectable bridge, not the rootless default (pasta): the
-	// per-scan --internal network is attached later with `podman network
-	// connect`, which pasta-mode containers reject ("invalid network mode").
-	if !hasAdjacent(args, "--network", "podman") {
-		t.Errorf("sidecar must start on a bridge network so --internal can be connected: %v", args)
+	// Must start on the per-scan --internal network so it is the sidecar's
+	// FIRST interface -- the one the first-iface listen keyword binds to. The
+	// default bridge (egress leg) is connected by startProxySidecar afterwards
+	// and must never appear here, or the listener would face it.
+	if !hasAdjacent(args, "--network", "scrutineer-hardened-7") {
+		t.Errorf("sidecar must start on the per-scan --internal network: %v", args)
 	}
-	// Config via env.
+	if hasAdjacent(args, "--network", "podman") {
+		t.Errorf("the egress leg must be connected after launch, not at run time: %v", args)
+	}
+	// Config via env; the listen host is the keyword the sidecar resolves to its
+	// --internal leg, not an all-interfaces bind.
 	for _, kv := range []string{
 		"SCRUTINEER_PROXY_TOKEN=tok",
 		"SCRUTINEER_PROXY_ALLOW=*.anthropic.com,host.docker.internal",
 		"SCRUTINEER_PROXY_API_HOST=192.0.2.9",
 		"SCRUTINEER_PROXY_API_PORT=8080",
-		"SCRUTINEER_PROXY_LISTEN=:3128",
+		"SCRUTINEER_PROXY_LISTEN=" + SidecarListenFirstIface + ":3128",
 	} {
 		if !hasAdjacent(args, "-e", kv) {
 			t.Errorf("missing env %q in %v", kv, args)

--- a/internal/worker/egress.go
+++ b/internal/worker/egress.go
@@ -294,7 +294,8 @@ func StartEgressProxy(p *EgressProxy) (int, error) {
 	}
 	srv := &http.Server{Handler: p, ReadHeaderTimeout: egressDialTimeout}
 	// The proxy lives for the process lifetime: it is started once from
-	// main.setupRunner and every container talks through it. There is no
+	// main.setupRunner (skipped under rootless --hardened, where the per-scan
+	// sidecar replaces it) and every container talks through it. There is no
 	// per-scan teardown, so no Shutdown wiring is needed; process exit
 	// closes the listener.
 	go func() { _ = srv.Serve(ln) }()
@@ -375,6 +376,65 @@ func ServeEgressProxy(p *EgressProxy, addr string) error {
 	p.init()
 	srv := &http.Server{Addr: addr, Handler: p, ReadHeaderTimeout: egressDialTimeout}
 	return srv.ListenAndServe()
+}
+
+// SidecarListenFirstIface is the listen-host keyword that makes `scrutineer
+// proxy` bind to the IPv4 of its first non-loopback interface instead of all
+// interfaces. The container runner creates the sidecar attached only to the
+// per-scan --internal network and connects the default (egress) bridge
+// afterwards, so the first interface IS the internal leg -- binding there keeps
+// the listener off the shared default bridge, where other containers of the
+// same rootless user could otherwise probe it.
+const SidecarListenFirstIface = "first-iface"
+
+// ifaceAddrs is the slice of one interface's state firstIfaceIPv4 needs,
+// decoupled from net.Interface so tests can fabricate interface layouts.
+type ifaceAddrs struct {
+	flags net.Flags
+	addrs []net.Addr
+}
+
+// FirstIfaceIPv4 returns the IPv4 of the sidecar's first up, non-loopback
+// interface. The sidecar always runs in a Linux container (rootless podman is
+// the only sidecar runtime), where interface indexes grow with attachment
+// order and net.Interfaces returns the netlink dump in index order -- so this
+// is the leg the container was created with, the per-scan --internal network,
+// even when the egress leg has already been connected by the time it runs.
+func FirstIfaceIPv4() (string, error) {
+	ifs, err := net.Interfaces()
+	if err != nil {
+		return "", err
+	}
+	all := make([]ifaceAddrs, 0, len(ifs))
+	for _, i := range ifs {
+		addrs, err := i.Addrs()
+		if err != nil {
+			return "", fmt.Errorf("addresses of %s: %w", i.Name, err)
+		}
+		all = append(all, ifaceAddrs{flags: i.Flags, addrs: addrs})
+	}
+	return firstIfaceIPv4(all)
+}
+
+// firstIfaceIPv4 picks the IPv4 of the first up, non-loopback interface. It
+// fails when that interface has no IPv4 rather than falling through to a later
+// one: a later interface is the egress leg, and silently binding there would
+// re-open the listener to the shared default bridge.
+func firstIfaceIPv4(ifaces []ifaceAddrs) (string, error) {
+	for _, i := range ifaces {
+		if i.flags&net.FlagLoopback != 0 || i.flags&net.FlagUp == 0 {
+			continue
+		}
+		for _, a := range i.addrs {
+			if ipnet, ok := a.(*net.IPNet); ok {
+				if ip4 := ipnet.IP.To4(); ip4 != nil {
+					return ip4.String(), nil
+				}
+			}
+		}
+		return "", errors.New("first non-loopback interface has no IPv4 address")
+	}
+	return "", errors.New("no non-loopback interface is up")
 }
 
 // dnsCandidates reduces an egress allowlist to resolvable hostnames for the

--- a/internal/worker/egress_test.go
+++ b/internal/worker/egress_test.go
@@ -544,3 +544,53 @@ func TestDefaultEgressAllowCoversSkillHosts(t *testing.T) {
 		t.Errorf("default allowlist should not match arbitrary hosts")
 	}
 }
+
+func TestFirstIfaceIPv4(t *testing.T) {
+	ipv4 := func(s string) net.Addr { return &net.IPNet{IP: net.ParseIP(s), Mask: net.CIDRMask(24, 32)} }
+	ipv6 := func(s string) net.Addr { return &net.IPNet{IP: net.ParseIP(s), Mask: net.CIDRMask(64, 128)} }
+	lo := ifaceAddrs{flags: net.FlagUp | net.FlagLoopback, addrs: []net.Addr{ipv4("127.0.0.1")}}
+
+	cases := []struct {
+		name    string
+		ifaces  []ifaceAddrs
+		want    string
+		wantErr bool
+	}{
+		{"internal leg only", []ifaceAddrs{lo,
+			{flags: net.FlagUp, addrs: []net.Addr{ipv4("10.89.1.2")}},
+		}, "10.89.1.2", false},
+		// The egress leg may already be connected by the time the sidecar
+		// enumerates; the run-time leg has the lower index and must still win.
+		{"egress leg already connected", []ifaceAddrs{lo,
+			{flags: net.FlagUp, addrs: []net.Addr{ipv4("10.89.1.2")}},
+			{flags: net.FlagUp, addrs: []net.Addr{ipv4("10.88.0.7")}},
+		}, "10.89.1.2", false},
+		{"down interface skipped", []ifaceAddrs{lo,
+			{flags: 0, addrs: []net.Addr{ipv4("10.89.1.2")}},
+			{flags: net.FlagUp, addrs: []net.Addr{ipv4("10.88.0.7")}},
+		}, "10.88.0.7", false},
+		{"ipv6 listed before ipv4 on the same interface", []ifaceAddrs{lo,
+			{flags: net.FlagUp, addrs: []net.Addr{ipv6("fd00::2"), ipv4("10.89.1.2")}},
+		}, "10.89.1.2", false},
+		{"loopback only", []ifaceAddrs{lo}, "", true},
+		{"no interfaces", nil, "", true},
+		// Falling through to a later interface would bind the egress leg and
+		// re-open the listener to the default bridge: fail closed instead.
+		{"first candidate ipv6-only fails closed", []ifaceAddrs{lo,
+			{flags: net.FlagUp, addrs: []net.Addr{ipv6("fd00::2")}},
+			{flags: net.FlagUp, addrs: []net.Addr{ipv4("10.88.0.7")}},
+		}, "", true},
+	}
+	for _, c := range cases {
+		got, err := firstIfaceIPv4(c.ifaces)
+		if c.wantErr {
+			if err == nil {
+				t.Errorf("%s: expected an error, got %q", c.name, got)
+			}
+			continue
+		}
+		if err != nil || got != c.want {
+			t.Errorf("%s: firstIfaceIPv4 = %q, %v, want %q", c.name, got, err, c.want)
+		}
+	}
+}

--- a/internal/worker/podman_integration_test.go
+++ b/internal/worker/podman_integration_test.go
@@ -302,7 +302,21 @@ func TestIntegration_ProxySidecarEnforcedEgress(t *testing.T) {
 		t.Errorf("non-allowlisted egress via sidecar: got status %q, want 403", denied)
 	}
 
-	// (3) Teardown removes the sidecar and then its network.
+	// (3) The listener faces the --internal leg only: from the shared default
+	// bridge -- where any other container of the same rootless user could probe
+	// it -- the sidecar's egress-leg IP must not answer on the proxy port. Any
+	// HTTP status here (even 407) means something listened.
+	egressIP, err := d.sidecarNetworkIP(proxySidecarName(sj.ScanID), "podman")
+	if err != nil {
+		t.Fatalf("resolve sidecar egress-leg IP: %v", err)
+	}
+	bridgeProbe := containerScriptOutput(t, rt, []string{"--network", "podman"}, image,
+		"curl -s -m 5 -o /dev/null -w '%{http_code}' http://"+egressIP+":"+proxySidecarPort+"/ || true")
+	if bridgeProbe != "000" {
+		t.Errorf("sidecar answered on its egress leg from the default bridge (status %q); it must bind its --internal address only", bridgeProbe)
+	}
+
+	// (4) Teardown removes the sidecar and then its network.
 	cleanup()
 	cleanedUp = true
 	name := proxySidecarName(sj.ScanID)


### PR DESCRIPTION
Fix #525