### PR TITLE
Paginate ecosyste.ms package and dependent prefetches

### DIFF
--- a/internal/worker/ecosystems.go
+++ b/internal/worker/ecosystems.go
@@ -342,6 +342,7 @@ func ecosystemsJSONArray(ctx context.Context, endpoint string, maxItems int, log
 
 func appendEcosystemsPages(ctx context.Context, rows []json.RawMessage, total int, next string, pagesLeft int, maxItems int, log *slog.Logger, warnMsg string, attrs ...any) ([]json.RawMessage, error) {
 	rows, capped := capEcosystemsRows(rows, maxItems)
+	capped = capped || total >= maxResponseBody
 	for next != "" && pagesLeft > 0 && !capped && (maxItems <= 0 || len(rows) < maxItems) {
 		body, link, err := ecosystemsGetWithLink(ctx, next)
 		if err != nil {

--- a/internal/worker/ecosystems.go
+++ b/internal/worker/ecosystems.go
@@ -59,8 +59,8 @@ const (
 	// package. Both bound the N+1 fan-out, and truncation is logged.
 	maxDependentPackages    = 25
 	maxDependentsPerPackage = 30
-	// maxAdvisoryPages bounds how far the advisories pagination is followed.
-	maxAdvisoryPages = 20
+	// maxEcosystemsPages bounds how far ecosyste.ms Link pagination is followed.
+	maxEcosystemsPages = 20
 )
 
 // ecosystemsSource describes one cached upstream payload: which columns it
@@ -157,12 +157,13 @@ func ecosystemsFetchedAt(repo db.Repository, key string) *time.Time {
 	return nil
 }
 
-// lookupFetcher builds a fetcher for the single-response ?param={repoURL}
-// lookup endpoints (repo, packages, commits, issues).
+// lookupFetcher builds a fetcher for the ?param={repoURL} lookup endpoints.
+// Object responses stay single-page; array responses follow Link pagination
+// until the page or cumulative-size cap.
 func lookupFetcher(param string, endpoint func(ecosystemsEndpoints) string) func(context.Context, ecosystemsEndpoints, string, *slog.Logger) ([]byte, error) {
-	return func(ctx context.Context, ep ecosystemsEndpoints, repoURL string, _ *slog.Logger) ([]byte, error) {
+	return func(ctx context.Context, ep ecosystemsEndpoints, repoURL string, log *slog.Logger) ([]byte, error) {
 		q := url.Values{param: {repoURL}}
-		return ecosystemsGet(ctx, endpoint(ep)+"?"+q.Encode())
+		return ecosystemsLookup(ctx, endpoint(ep)+"?"+q.Encode(), log, "lookup pagination capped", "repo", repoURL)
 	}
 }
 
@@ -174,7 +175,7 @@ func fetchAdvisories(ctx context.Context, ep ecosystemsEndpoints, repoURL string
 	next := ep.advisories + "?" + q.Encode()
 	all := []json.RawMessage{}
 	total := 0
-	for page := 0; next != "" && page < maxAdvisoryPages; page++ {
+	for page := 0; next != "" && page < maxEcosystemsPages; page++ {
 		body, link, err := ecosystemsGetWithLink(ctx, next)
 		if err != nil {
 			return nil, err
@@ -193,7 +194,7 @@ func fetchAdvisories(ctx context.Context, ep ecosystemsEndpoints, repoURL string
 		next = link
 	}
 	if next != "" {
-		log.Warn("advisories pagination capped", "repo", repoURL, "pages", maxAdvisoryPages)
+		log.Warn("advisories pagination capped", "repo", repoURL, "pages", maxEcosystemsPages)
 	}
 	return json.Marshal(all)
 }
@@ -205,44 +206,42 @@ type dependentsEntry struct {
 }
 
 // fetchDependents chains off the packages lookup: for each published package
-// it follows dependent_packages_url and keeps the first page (capped). Output
-// is sorted by package name so the cached blob is reproducible.
+// it follows dependent_packages_url and keeps results up to the configured
+// caps. Output is sorted by package name so the cached blob is reproducible.
 func fetchDependents(ctx context.Context, ep ecosystemsEndpoints, repoURL string, log *slog.Logger) ([]byte, error) {
 	q := url.Values{"repository_url": {repoURL}}
-	body, err := ecosystemsGet(ctx, ep.packages+"?"+q.Encode())
+	pkgRows, err := ecosystemsJSONArray(ctx, ep.packages+"?"+q.Encode(), maxDependentPackages, log,
+		"dependents package fan-out capped", "repo", repoURL, "cap", maxDependentPackages)
 	if err != nil {
 		return nil, err
 	}
-	var pkgs []struct {
+	pkgs := make([]struct {
 		Name                 string `json:"name"`
 		Ecosystem            string `json:"ecosystem"`
 		DependentPackagesURL string `json:"dependent_packages_url"`
-	}
-	if err := json.Unmarshal(body, &pkgs); err != nil {
-		return nil, fmt.Errorf("decode packages: %w", err)
+	}, 0, len(pkgRows))
+	for _, raw := range pkgRows {
+		var p struct {
+			Name                 string `json:"name"`
+			Ecosystem            string `json:"ecosystem"`
+			DependentPackagesURL string `json:"dependent_packages_url"`
+		}
+		if err := json.Unmarshal(raw, &p); err != nil {
+			return nil, fmt.Errorf("decode packages: %w", err)
+		}
+		pkgs = append(pkgs, p)
 	}
 	sort.Slice(pkgs, func(i, j int) bool { return pkgs[i].Name < pkgs[j].Name })
-	if len(pkgs) > maxDependentPackages {
-		log.Warn("dependents package fan-out capped", "repo", repoURL, "packages", len(pkgs), "cap", maxDependentPackages)
-		pkgs = pkgs[:maxDependentPackages]
-	}
 	out := make([]dependentsEntry, 0, len(pkgs))
 	for _, p := range pkgs {
 		if p.DependentPackagesURL == "" {
 			continue
 		}
-		depBody, err := ecosystemsGet(ctx, p.DependentPackagesURL)
+		deps, err := ecosystemsJSONArray(ctx, p.DependentPackagesURL, maxDependentsPerPackage, log,
+			"dependents fetch capped", "repo", repoURL, "package", p.Name, "cap", maxDependentsPerPackage)
 		if err != nil {
 			log.Warn("dependents fetch failed", "repo", repoURL, "package", p.Name, "err", err)
 			continue
-		}
-		var deps []json.RawMessage
-		if err := json.Unmarshal(depBody, &deps); err != nil {
-			log.Warn("dependents decode failed", "repo", repoURL, "package", p.Name, "err", err)
-			continue
-		}
-		if len(deps) > maxDependentsPerPackage {
-			deps = deps[:maxDependentsPerPackage]
 		}
 		out = append(out, dependentsEntry{Package: p.Name, Ecosystem: p.Ecosystem, Dependents: deps})
 	}
@@ -313,6 +312,70 @@ func updateDependentsTable(gdb *gorm.DB, repoID uint, payload []byte) error {
 func ecosystemsGet(ctx context.Context, endpoint string) ([]byte, error) {
 	body, _, err := ecosystemsGetWithLink(ctx, endpoint)
 	return body, err
+}
+
+func ecosystemsLookup(ctx context.Context, endpoint string, log *slog.Logger, warnMsg string, attrs ...any) ([]byte, error) {
+	body, link, err := ecosystemsGetWithLink(ctx, endpoint)
+	if err != nil {
+		return nil, err
+	}
+	if link == "" {
+		return body, nil
+	}
+	var first []json.RawMessage
+	if err := json.Unmarshal(body, &first); err != nil {
+		return body, nil
+	}
+	rows, err := appendEcosystemsPages(ctx, first, len(body), link, maxEcosystemsPages-1, 0, log, warnMsg, attrs...)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(rows)
+}
+
+func ecosystemsJSONArray(ctx context.Context, endpoint string, maxItems int, log *slog.Logger, warnMsg string, attrs ...any) ([]json.RawMessage, error) {
+	body, link, err := ecosystemsGetWithLink(ctx, endpoint)
+	if err != nil {
+		return nil, err
+	}
+	var first []json.RawMessage
+	if err := json.Unmarshal(body, &first); err != nil {
+		return nil, err
+	}
+	return appendEcosystemsPages(ctx, first, len(body), link, maxEcosystemsPages-1, maxItems, log, warnMsg, attrs...)
+}
+
+func appendEcosystemsPages(ctx context.Context, rows []json.RawMessage, total int, next string, pagesLeft int, maxItems int, log *slog.Logger, warnMsg string, attrs ...any) ([]json.RawMessage, error) {
+	rows, capped := capEcosystemsRows(rows, maxItems)
+	for next != "" && pagesLeft > 0 && !capped && (maxItems <= 0 || len(rows) < maxItems) {
+		body, link, err := ecosystemsGetWithLink(ctx, next)
+		if err != nil {
+			return nil, err
+		}
+		var batch []json.RawMessage
+		if err := json.Unmarshal(body, &batch); err != nil {
+			return nil, err
+		}
+		rows = append(rows, batch...)
+		rows, capped = capEcosystemsRows(rows, maxItems)
+		total += len(body)
+		next = link
+		pagesLeft--
+		if total >= maxResponseBody {
+			capped = true
+		}
+	}
+	if next != "" || capped {
+		log.Warn(warnMsg, append(attrs, "pages", maxEcosystemsPages, "items", len(rows))...)
+	}
+	return rows, nil
+}
+
+func capEcosystemsRows(rows []json.RawMessage, maxItems int) ([]json.RawMessage, bool) {
+	if maxItems <= 0 || len(rows) <= maxItems {
+		return rows, false
+	}
+	return rows[:maxItems], true
 }
 
 // ecosystemsGetWithLink performs one GET and returns the size-capped body plus

--- a/internal/worker/ecosystems.go
+++ b/internal/worker/ecosystems.go
@@ -309,11 +309,6 @@ func updateDependentsTable(gdb *gorm.DB, repoID uint, payload []byte) error {
 	})
 }
 
-func ecosystemsGet(ctx context.Context, endpoint string) ([]byte, error) {
-	body, _, err := ecosystemsGetWithLink(ctx, endpoint)
-	return body, err
-}
-
 func ecosystemsLookup(ctx context.Context, endpoint string, log *slog.Logger, warnMsg string, attrs ...any) ([]byte, error) {
 	body, link, err := ecosystemsGetWithLink(ctx, endpoint)
 	if err != nil {

--- a/internal/worker/ecosystems_test.go
+++ b/internal/worker/ecosystems_test.go
@@ -202,6 +202,35 @@ func TestFetchDependentsPaginationStopsAtCaps(t *testing.T) {
 	}
 }
 
+func TestAppendEcosystemsPagesStopsWhenInitialBodyHitsCap(t *testing.T) {
+	hits := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits++
+		_, _ = io.WriteString(w, `[{"name":"second"}]`)
+	}))
+	t.Cleanup(srv.Close)
+
+	rows, err := appendEcosystemsPages(
+		context.Background(),
+		[]json.RawMessage{json.RawMessage(`{"name":"first"}`)},
+		maxResponseBody,
+		srv.URL,
+		maxEcosystemsPages-1,
+		0,
+		slog.Default(),
+		"test pagination cap",
+	)
+	if err != nil {
+		t.Fatalf("appendEcosystemsPages: %v", err)
+	}
+	if hits != 0 {
+		t.Fatalf("fetched next page after first page hit response cap: hits=%d", hits)
+	}
+	if len(rows) != 1 || !strings.Contains(string(rows[0]), "first") {
+		t.Fatalf("rows = %s, want only initial row", mustMarshal(t, rows))
+	}
+}
+
 func writeJSONArray(w io.Writer, start, end int, item func(int) string) {
 	_, _ = io.WriteString(w, `[`)
 	for i := start; i < end; i++ {

--- a/internal/worker/ecosystems_test.go
+++ b/internal/worker/ecosystems_test.go
@@ -3,6 +3,7 @@ package worker
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
@@ -30,9 +31,14 @@ func ecosystemsTestServer(t *testing.T) (*httptest.Server, *int) {
 	mux.HandleFunc("/packages", func(w http.ResponseWriter, r *http.Request) {
 		hits++
 		base := "http://" + r.Host
+		if r.URL.Query().Get("page") == "2" {
+			_, _ = io.WriteString(w, `[`+
+				`{"name":"acme","ecosystem":"npm","dependent_packages_url":"`+base+`/deps/acme"}]`)
+			return
+		}
+		w.Header().Set("Link", `<http://`+r.Host+`/packages?page=2>; rel="next"`)
 		_, _ = io.WriteString(w, `[`+
-			`{"name":"widget","ecosystem":"npm","dependent_packages_url":"`+base+`/deps/widget"},`+
-			`{"name":"acme","ecosystem":"npm","dependent_packages_url":"`+base+`/deps/acme"}]`)
+			`{"name":"widget","ecosystem":"npm","dependent_packages_url":"`+base+`/deps/widget"}]`)
 	})
 	mux.HandleFunc("/advisories", func(w http.ResponseWriter, r *http.Request) {
 		hits++
@@ -51,7 +57,12 @@ func ecosystemsTestServer(t *testing.T) (*httptest.Server, *int) {
 		hits++
 		_, _ = io.WriteString(w, `{"issues":[{"login":"bob"}]}`)
 	})
-	mux.HandleFunc("/deps/widget", func(w http.ResponseWriter, _ *http.Request) {
+	mux.HandleFunc("/deps/widget", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("page") == "2" {
+			_, _ = io.WriteString(w, `[{"repo":"downstream-1b"}]`)
+			return
+		}
+		w.Header().Set("Link", `<http://`+r.Host+`/deps/widget?page=2>; rel="next"`)
 		_, _ = io.WriteString(w, `[{"repo":"downstream-1"}]`)
 	})
 	mux.HandleFunc("/deps/acme", func(w http.ResponseWriter, _ *http.Request) {
@@ -120,9 +131,104 @@ func TestRefreshEcosystems_populatesAllSources(t *testing.T) {
 	if !strings.Contains(got.EcosystemsAdvisoriesData, "GHSA-2") {
 		t.Errorf("advisories did not follow pagination: %q", got.EcosystemsAdvisoriesData)
 	}
+	if !strings.Contains(got.EcosystemsPackagesData, "acme") {
+		t.Errorf("packages did not follow pagination: %q", got.EcosystemsPackagesData)
+	}
 	if !strings.Contains(got.EcosystemsDependentsData, "downstream-2") {
 		t.Errorf("dependents missing second package: %q", got.EcosystemsDependentsData)
 	}
+	if !strings.Contains(got.EcosystemsDependentsData, "downstream-1b") {
+		t.Errorf("dependents did not follow dependent_packages_url pagination: %q", got.EcosystemsDependentsData)
+	}
+}
+
+func TestFetchDependentsPaginationStopsAtCaps(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/packages", func(w http.ResponseWriter, r *http.Request) {
+		base := "http://" + r.Host
+		start, end := 0, 24
+		if r.URL.Query().Get("page") == "2" {
+			start, end = 24, 26
+		} else {
+			w.Header().Set("Link", `<http://`+r.Host+`/packages?page=2>; rel="next"`)
+		}
+		writeJSONArray(w, start, end, func(i int) string {
+			name := fmt.Sprintf("pkg%02d", i)
+			return fmt.Sprintf(`{"name":%q,"ecosystem":"npm","dependent_packages_url":%q}`, name, base+"/deps/"+name)
+		})
+	})
+	mux.HandleFunc("/deps/pkg00", func(w http.ResponseWriter, r *http.Request) {
+		start, end := 0, 29
+		if r.URL.Query().Get("page") == "2" {
+			start, end = 29, 31
+		} else {
+			w.Header().Set("Link", `<http://`+r.Host+`/deps/pkg00?page=2>; rel="next"`)
+		}
+		writeJSONArray(w, start, end, func(i int) string {
+			return fmt.Sprintf(`{"name":"dep%02d","purl":"pkg:npm/dep%02d"}`, i, i)
+		})
+	})
+	mux.HandleFunc("/deps/", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `[]`)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	body, err := fetchDependents(context.Background(), ecosystemsEndpoints{packages: srv.URL + "/packages"},
+		"https://github.com/acme/widget", slog.Default())
+	if err != nil {
+		t.Fatalf("fetchDependents: %v", err)
+	}
+	var entries []dependentsEntry
+	if err := json.Unmarshal(body, &entries); err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != maxDependentPackages {
+		t.Fatalf("dependents entries = %d, want cap %d: %s", len(entries), maxDependentPackages, body)
+	}
+	if findDependentsEntry(entries, "pkg25") != nil {
+		t.Fatalf("package past cap was fetched: %s", body)
+	}
+	pkg00 := findDependentsEntry(entries, "pkg00")
+	if pkg00 == nil {
+		t.Fatalf("pkg00 entry missing: %s", body)
+	}
+	if len(pkg00.Dependents) != maxDependentsPerPackage {
+		t.Fatalf("pkg00 dependents = %d, want cap %d", len(pkg00.Dependents), maxDependentsPerPackage)
+	}
+	joined := string(mustMarshal(t, pkg00.Dependents))
+	if !strings.Contains(joined, "dep29") || strings.Contains(joined, "dep30") {
+		t.Fatalf("dependent pagination/cap wrong: %s", joined)
+	}
+}
+
+func writeJSONArray(w io.Writer, start, end int, item func(int) string) {
+	_, _ = io.WriteString(w, `[`)
+	for i := start; i < end; i++ {
+		if i > start {
+			_, _ = io.WriteString(w, `,`)
+		}
+		_, _ = io.WriteString(w, item(i))
+	}
+	_, _ = io.WriteString(w, `]`)
+}
+
+func findDependentsEntry(entries []dependentsEntry, name string) *dependentsEntry {
+	for i := range entries {
+		if entries[i].Package == name {
+			return &entries[i]
+		}
+	}
+	return nil
+}
+
+func mustMarshal(t *testing.T, v any) []byte {
+	t.Helper()
+	body, err := json.Marshal(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return body
 }
 
 func TestRefreshEcosystems_staleOnlySkipsFresh(t *testing.T) {


### PR DESCRIPTION
Fixes #542

## Summary

Fixes missing ecosyste.ms pagination during repository ecosystem prefetching.

The package lookup and dependent package fetch paths now follow `Link: rel="next"` pagination instead of only reading the first page. Existing item caps are preserved so large upstream responses remain bounded.

## Changes

- Follow paginated ecosyste.ms package lookup responses
- Follow paginated dependent package responses
- Preserve existing caps for package and dependent prefetches
- Add tests for multi-page package/dependent responses and cap behavior

## Tests

- `go test ./internal/worker -run 'TestRefreshEcosystems|TestFetchDependentsPaginationStopsAtCaps|TestNextLink|TestUpdateDependentsTable'`
- `go test ./internal/worker`
- `go test ./...`
- `git diff --check`

