### PR TITLE
Extract repository dependents gate helper

### DIFF
--- a/internal/web/finding_bundle.go
+++ b/internal/web/finding_bundle.go
@@ -114,10 +114,7 @@ func (s *Server) bundleEntries(f *db.Finding, repo *db.Repository) ([]bundleEntr
 		return nil, fmt.Errorf("load finding dependents: %w", err)
 	}
 	deps := loadFindingDependents(s, fdRows)
-	var dependentCount int64
-	if err := s.DB.Model(&db.Dependent{}).Where("repository_id = ?", f.RepositoryID).Count(&dependentCount).Error; err != nil {
-		return nil, fmt.Errorf("count dependents: %w", err)
-	}
+	hasDependents := repoHasDependents(s.DB, f.RepositoryID)
 	// Scan load is best-effort: a finding with a missing parent scan
 	// row (e.g. a scan that was deleted) still has a valid bundle to
 	// produce, since the bundle does not embed scan-specific fields.
@@ -141,7 +138,7 @@ func (s *Server) bundleEntries(f *db.Finding, repo *db.Repository) ([]bundleEntr
 	entries = append(entries, bundleEntry{Name: "osv.json", Data: osvRaw})
 	contents["osv.json"] = "OSV 1.6.0 record (machine-readable advisory)"
 
-	if dependentCount > 0 {
+	if hasDependents {
 		csafRaw, err := json.MarshalIndent(buildCSAF(*f, *repo, refs, pkgs, fdRows, deps), "", "  ")
 		if err != nil {
 			return nil, fmt.Errorf("build CSAF: %w", err)

--- a/internal/web/finding_bundle.go
+++ b/internal/web/finding_bundle.go
@@ -114,7 +114,10 @@ func (s *Server) bundleEntries(f *db.Finding, repo *db.Repository) ([]bundleEntr
 		return nil, fmt.Errorf("load finding dependents: %w", err)
 	}
 	deps := loadFindingDependents(s, fdRows)
-	hasDependents := repoHasDependents(s.DB, f.RepositoryID)
+	hasDependents, err := repoHasDependents(s.DB, f.RepositoryID)
+	if err != nil {
+		return nil, fmt.Errorf("count dependents: %w", err)
+	}
 	// Scan load is best-effort: a finding with a missing parent scan
 	// row (e.g. a scan that was deleted) still has a valid bundle to
 	// produce, since the bundle does not embed scan-specific fields.

--- a/internal/web/finding_csaf.go
+++ b/internal/web/finding_csaf.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/santhosh-tekuri/jsonschema/v6"
+	"gorm.io/gorm"
 
 	"scrutineer/internal/db"
 )
@@ -91,9 +92,7 @@ func (s *Server) findingCSAF(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "finding is a duplicate; export not available", http.StatusGone)
 		return
 	}
-	var dependentCount int64
-	s.DB.Model(&db.Dependent{}).Where("repository_id = ?", f.RepositoryID).Count(&dependentCount)
-	if dependentCount == 0 {
+	if !repoHasDependents(s.DB, f.RepositoryID) {
 		http.Error(w, "CSAF VEX export is unavailable because this repository has no recorded dependents", http.StatusNotFound)
 		return
 	}
@@ -299,6 +298,12 @@ func loadFindingDependents(s *Server, rows []db.FindingDependent) map[uint]db.De
 		out[d.ID] = d
 	}
 	return out
+}
+
+func repoHasDependents(gdb *gorm.DB, repoID uint) bool {
+	var dependentCount int64
+	gdb.Model(&db.Dependent{}).Where("repository_id = ?", repoID).Count(&dependentCount)
+	return dependentCount > 0
 }
 
 func dependentProductID(d db.Dependent) string {

--- a/internal/web/finding_csaf.go
+++ b/internal/web/finding_csaf.go
@@ -92,7 +92,13 @@ func (s *Server) findingCSAF(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "finding is a duplicate; export not available", http.StatusGone)
 		return
 	}
-	if !repoHasDependents(s.DB, f.RepositoryID) {
+	hasDependents, err := repoHasDependents(s.DB, f.RepositoryID)
+	if err != nil {
+		s.Log.Error("count dependents", "repo", f.RepositoryID, "err", err)
+		http.Error(w, "failed to count repository dependents", http.StatusInternalServerError)
+		return
+	}
+	if !hasDependents {
 		http.Error(w, "CSAF VEX export is unavailable because this repository has no recorded dependents", http.StatusNotFound)
 		return
 	}
@@ -300,10 +306,12 @@ func loadFindingDependents(s *Server, rows []db.FindingDependent) map[uint]db.De
 	return out
 }
 
-func repoHasDependents(gdb *gorm.DB, repoID uint) bool {
+func repoHasDependents(gdb *gorm.DB, repoID uint) (bool, error) {
 	var dependentCount int64
-	gdb.Model(&db.Dependent{}).Where("repository_id = ?", repoID).Count(&dependentCount)
-	return dependentCount > 0
+	if err := gdb.Model(&db.Dependent{}).Where("repository_id = ?", repoID).Count(&dependentCount).Error; err != nil {
+		return false, err
+	}
+	return dependentCount > 0, nil
 }
 
 func dependentProductID(d db.Dependent) string {

--- a/internal/web/finding_csaf_test.go
+++ b/internal/web/finding_csaf_test.go
@@ -14,6 +14,23 @@ import (
 
 const wantAttackVectorNetwork = "NETWORK"
 
+func TestRepoHasDependentsReturnsCountError(t *testing.T) {
+	gdb, err := db.Open(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	sqldb, err := gdb.DB()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := sqldb.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := repoHasDependents(gdb, 1); err == nil {
+		t.Fatal("expected count error after closing database")
+	}
+}
+
 func seedCSAFFinding(t *testing.T, s *Server, mut func(*db.Finding)) db.Finding {
 	t.Helper()
 	repo := db.Repository{

--- a/internal/web/finding_csaf_test.go
+++ b/internal/web/finding_csaf_test.go
@@ -47,30 +47,6 @@ func seedCSAFFinding(t *testing.T, s *Server, mut func(*db.Finding)) db.Finding 
 	return f
 }
 
-func seedCSAFFindingWithoutDependents(t *testing.T, s *Server) db.Finding {
-	t.Helper()
-	repo := db.Repository{
-		URL:      "https://github.com/example/app.git",
-		Name:     "app",
-		FullName: "example/app",
-		HTMLURL:  "https://github.com/example/app",
-	}
-	s.DB.Create(&repo)
-	scan := db.Scan{RepositoryID: repo.ID, Kind: "skill", Status: db.ScanDone, SkillName: "security-deep-dive"}
-	s.DB.Create(&scan)
-	f := db.Finding{
-		ScanID:       scan.ID,
-		RepositoryID: repo.ID,
-		FindingID:    "F1",
-		Title:        "Unsafe redirect in app route",
-		Severity:     "Medium",
-		Status:       db.FindingTriaged,
-		CWE:          "CWE-601",
-	}
-	s.DB.Create(&f)
-	return f
-}
-
 func decodeCSAF(t *testing.T, body []byte) map[string]any {
 	t.Helper()
 	var m map[string]any
@@ -135,7 +111,8 @@ func TestFindingCSAF_noDependentsReturns404(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()
 
-	f := seedCSAFFindingWithoutDependents(t, s)
+	f := seedCSAFFinding(t, s, nil)
+	s.DB.Where("repository_id = ?", f.RepositoryID).Delete(&db.Dependent{})
 	w := getCSAF(t, s, f.ID)
 	if w.Code != http.StatusNotFound {
 		t.Fatalf("status %d, want 404: %s", w.Code, w.Body)

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -1574,7 +1574,10 @@ func (s *Server) findingShow(w http.ResponseWriter, r *http.Request) {
 		selected[l.Name] = true
 	}
 	_, verifyInFlight := s.openFindingSkillScan(f.ID, verifySkillName)
-	hasDependents := repoHasDependents(s.DB, scan.RepositoryID)
+	hasDependents, err := repoHasDependents(s.DB, scan.RepositoryID)
+	if err != nil {
+		s.Log.Warn("count dependents", "repo", scan.RepositoryID, "err", err)
+	}
 
 	type exposureRow struct {
 		Dep    db.Dependent

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -1574,9 +1574,7 @@ func (s *Server) findingShow(w http.ResponseWriter, r *http.Request) {
 		selected[l.Name] = true
 	}
 	_, verifyInFlight := s.openFindingSkillScan(f.ID, verifySkillName)
-	var dependentCount int64
-	s.DB.Model(&db.Dependent{}).Where("repository_id = ?", scan.RepositoryID).Count(&dependentCount)
-	hasDependents := dependentCount > 0
+	hasDependents := repoHasDependents(s.DB, scan.RepositoryID)
 
 	type exposureRow struct {
 		Dep    db.Dependent


### PR DESCRIPTION
Fixes #564

## Summary

Extracts the repeated “repository has recorded dependents” check into a shared helper so the finding page, disclosure bundle, and CSAF export all use the same gate.

## Changes

- Add `repoHasDependents(gdb, repoID)` helper in `internal/web`
- Use the helper in:
  - finding detail display
  - disclosure bundle CSAF inclusion
  - direct CSAF export gating
- Remove the duplicated `seedCSAFFindingWithoutDependents` test helper by reusing `seedCSAFFinding` and deleting the seeded dependent in the specific test

## Tests

- `go test ./internal/web -run 'TestFindingCSAF|TestFindingDisclosureBundle|TestFindingShow|TestFindingOSV'`
- `go test ./...`
- `git diff --check`