### PR TITLE
feat: fall back Opus->Sonnet while a subscription is on overage

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ When the containerised runner is active (the default when a container runtime is
 - **Skill HTTP API** -- running skills can call back into scrutineer to list prior scans and enqueue further skills; surface documented in `openapi.yaml`
 - **Live updates** -- SSE streaming of scan logs and status changes, no polling
 - **Organisation rollup** -- repos, findings, and maintainers grouped by owning org, with per-org markdown exports
-- **Usage tracking** -- per-scan token and cost figures plus a `/usage` page totalling spend per skill; on a Claude subscription token, a rate-limit wall auto-pauses the batch and resumes it after the reported reset, with per-window status shown on `/usage`. Optionally (`downgrade_on_overage`), once the account crosses into overage the model tier falls back from max/high to Sonnet for new scans until the window resets -- announced in the log, on the jobs page, and on `/usage`
+- **Usage tracking** -- per-scan token and cost figures plus a `/usage` page totalling spend per skill; on a Claude subscription token, a rate-limit wall auto-pauses the batch and resumes it after the reported reset, with per-window status shown on `/usage`. Optionally (`downgrade_on_overage`), once the account crosses into overage the model tier falls back from max/high to the mid tier for new scans until the window resets -- announced in the log, on the jobs page, and on `/usage`
 - **Themes** -- six colour themes plus a light/dark/system toggle, set on the Settings page
 
 ## The default pipeline

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ When the containerised runner is active (the default when a container runtime is
 - **Skill HTTP API** -- running skills can call back into scrutineer to list prior scans and enqueue further skills; surface documented in `openapi.yaml`
 - **Live updates** -- SSE streaming of scan logs and status changes, no polling
 - **Organisation rollup** -- repos, findings, and maintainers grouped by owning org, with per-org markdown exports
-- **Usage tracking** -- per-scan token and cost figures plus a `/usage` page totalling spend per skill; on a Claude subscription token, a rate-limit wall auto-pauses the batch and resumes it after the reported reset, with per-window status shown on `/usage`
+- **Usage tracking** -- per-scan token and cost figures plus a `/usage` page totalling spend per skill; on a Claude subscription token, a rate-limit wall auto-pauses the batch and resumes it after the reported reset, with per-window status shown on `/usage`. Optionally (`downgrade_on_overage`), once the account crosses into overage the model tier falls back from max/high to Sonnet for new scans until the window resets -- announced in the log, on the jobs page, and on `/usage`
 - **Themes** -- six colour themes plus a light/dark/system toggle, set on the Settings page
 
 ## The default pipeline

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ When the containerised runner is active (the default when a container runtime is
 - **Skill HTTP API** -- running skills can call back into scrutineer to list prior scans and enqueue further skills; surface documented in `openapi.yaml`
 - **Live updates** -- SSE streaming of scan logs and status changes, no polling
 - **Organisation rollup** -- repos, findings, and maintainers grouped by owning org, with per-org markdown exports
-- **Usage tracking** -- per-scan token and cost figures plus a `/usage` page totalling spend per skill; on a Claude subscription token, a rate-limit wall auto-pauses the batch and resumes it after the reported reset, with per-window status shown on `/usage`. Optionally (`downgrade_on_overage`), once the account crosses into overage the model tier falls back from max/high to the mid tier for new scans until the window resets -- announced in the log, on the jobs page, and on `/usage`
+- **Usage tracking** -- per-scan token and cost figures plus a `/usage` page totalling spend per skill; on a Claude subscription token, a rate-limit wall auto-pauses the batch and resumes it after the reported reset, with per-window status shown on `/usage`. Optionally (`downgrade_on_overage`), once the account crosses into overage the model tier falls back from max/high to the mid tier for new scans until overage clears (typically when the window resets) -- announced in the log, on the jobs page, and on `/usage`
 - **Themes** -- six colour themes plus a light/dark/system toggle, set on the Settings page
 
 ## The default pipeline

--- a/cmd/scrutineer/main.go
+++ b/cmd/scrutineer/main.go
@@ -156,7 +156,7 @@ func registerFlags(fs *flag.FlagSet, f *flags) {
 	fs.StringVar(&f.anthropicBaseURL, "anthropic-base-url", "", "custom Anthropic API base URL (env: ANTHROPIC_BASE_URL)")
 	fs.StringVar(&f.forkOrg, "fork-org", "", "GitHub org the fork skill forks into and files draft advisories against")
 	fs.BoolVar(&f.schemaStrict, "schema-strict", false, "fail scans whose report.json does not validate against the skill's schema (default: warn and continue)")
-	fs.BoolVar(&f.downgradeOnOverage, "downgrade-on-overage", false, "on a subscription token, fall the model tier back from max/high to mid (Opus->Sonnet) for new scans while the account is on overage; restores when the window resets")
+	fs.BoolVar(&f.downgradeOnOverage, "downgrade-on-overage", false, "on a subscription token, fall the model tier back from max/high to the mid tier for new scans while the account is on overage; restores when the window resets")
 	fs.StringVar(&f.recipientsFile, "recipients-file", "", "age recipients file (public keys) for encrypted export")
 	fs.StringVar(&f.identityFile, "identity-file", "", "age identity file or SSH private key for decrypting imports")
 	fs.IntVar(&f.autoRejectMissedCount, "auto-reject-missed-count", 0, "auto-reject findings after this many consecutive missed rescans (0 disables)")

--- a/cmd/scrutineer/main.go
+++ b/cmd/scrutineer/main.go
@@ -109,6 +109,7 @@ type flags struct {
 	forkOrg               string
 	metadataDir           string
 	schemaStrict          bool
+	downgradeOnOverage    bool
 	recipientsFile        string
 	identityFile          string
 	autoRejectMissedCount int
@@ -155,6 +156,7 @@ func registerFlags(fs *flag.FlagSet, f *flags) {
 	fs.StringVar(&f.anthropicBaseURL, "anthropic-base-url", "", "custom Anthropic API base URL (env: ANTHROPIC_BASE_URL)")
 	fs.StringVar(&f.forkOrg, "fork-org", "", "GitHub org the fork skill forks into and files draft advisories against")
 	fs.BoolVar(&f.schemaStrict, "schema-strict", false, "fail scans whose report.json does not validate against the skill's schema (default: warn and continue)")
+	fs.BoolVar(&f.downgradeOnOverage, "downgrade-on-overage", false, "on a subscription token, fall the model tier back from max/high to mid (Opus->Sonnet) for new scans while the account is on overage; restores when the window resets")
 	fs.StringVar(&f.recipientsFile, "recipients-file", "", "age recipients file (public keys) for encrypted export")
 	fs.StringVar(&f.identityFile, "identity-file", "", "age identity file or SSH private key for decrypting imports")
 	fs.IntVar(&f.autoRejectMissedCount, "auto-reject-missed-count", 0, "auto-reject findings after this many consecutive missed rescans (0 disables)")
@@ -232,6 +234,9 @@ func (f *flags) merge(cfg *config.Config) {
 	}
 	if cfg.SchemaStrict != nil && !f.set["schema-strict"] {
 		f.schemaStrict = *cfg.SchemaStrict
+	}
+	if cfg.DowngradeOnOverage != nil && !f.set["downgrade-on-overage"] {
+		f.downgradeOnOverage = *cfg.DowngradeOnOverage
 	}
 	if cfg.RecipientsFile != "" && !f.set["recipients-file"] {
 		f.recipientsFile = cfg.RecipientsFile
@@ -437,6 +442,7 @@ func run(log *slog.Logger) error {
 		Runner:                runner,
 		ScanTimeout:           f.scanTimeout,
 		SchemaStrict:          f.schemaStrict,
+		DowngradeOnOverage:    f.downgradeOnOverage,
 		AutoRejectMissedCount: f.autoRejectMissedCount,
 		OnEvent: func(scanID, repoID uint, name, data string) {
 			broker.Publish(web.Event{Name: name, Data: data, ScanID: scanID, RepoID: repoID})

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -103,6 +103,12 @@ type Config struct {
 	// emitted to the scan log and the kind-specific parser still runs.
 	// Intended as a development aid while iterating on a skill.
 	SchemaStrict *bool `yaml:"schema_strict"`
+	// DowngradeOnOverage falls the model tier back from max/high to mid (Opus ->
+	// Sonnet) for newly enqueued scans while the Claude subscription is past its
+	// included quota (on overage), restoring it when the window resets. Only a
+	// subscription token reports overage. Off by default; the switch is logged
+	// and shown on the jobs page and /usage.
+	DowngradeOnOverage *bool `yaml:"downgrade_on_overage"`
 	// RecipientsFile is a flat text file of public keys (one per line,
 	// age X25519 or SSH) used to encrypt format=bundle exports. Empty
 	// disables encrypted export.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -103,9 +103,9 @@ type Config struct {
 	// emitted to the scan log and the kind-specific parser still runs.
 	// Intended as a development aid while iterating on a skill.
 	SchemaStrict *bool `yaml:"schema_strict"`
-	// DowngradeOnOverage falls the model tier back from max/high to mid (Opus ->
-	// Sonnet) for newly enqueued scans while the Claude subscription is past its
-	// included quota (on overage), restoring it when the window resets. Only a
+	// DowngradeOnOverage falls the model tier back from max/high to the mid tier
+	// for newly enqueued scans while the Claude subscription is past its included
+	// quota (on overage), restoring it when the window resets. Only a
 	// subscription token reports overage. Off by default; the switch is logged
 	// and shown on the jobs page and /usage.
 	DowngradeOnOverage *bool `yaml:"downgrade_on_overage"`

--- a/internal/web/models.go
+++ b/internal/web/models.go
@@ -191,3 +191,11 @@ func resolveModelPreference(gdb *gorm.DB, preference, fallback string) string {
 	}
 	return ModelForTier(gdb, ModelTierHigh, fallback)
 }
+
+// isDowngradableTier reports whether a model preference is one of the expensive
+// tiers (max/high) or the empty default (which resolves to high), which the
+// overage fallback rewrites to mid. A concrete model id or the mid tier is left
+// as-is, so an explicit per-scan model choice is always honoured.
+func isDowngradableTier(preference string) bool {
+	return preference == "" || preference == ModelTierHigh || preference == ModelTierMax
+}

--- a/internal/web/models.go
+++ b/internal/web/models.go
@@ -199,3 +199,14 @@ func resolveModelPreference(gdb *gorm.DB, preference, fallback string) string {
 func isDowngradableTier(preference string) bool {
 	return preference == "" || preference == ModelTierHigh || preference == ModelTierMax
 }
+
+// applyOverageDowngrade rewrites an expensive tier preference to mid when the
+// overage fallback is active; otherwise it returns the preference unchanged.
+// Kept as a pure function so the (active x preference) matrix is unit-testable
+// without a live worker on overage.
+func applyOverageDowngrade(preference string, active bool) string {
+	if active && isDowngradableTier(preference) {
+		return ModelTierMid
+	}
+	return preference
+}

--- a/internal/web/models_downgrade_test.go
+++ b/internal/web/models_downgrade_test.go
@@ -1,0 +1,20 @@
+package web
+
+import "testing"
+
+func TestIsDowngradableTier(t *testing.T) {
+	// The expensive tiers and the empty default (which resolves to high) are
+	// rewritten to mid during overage.
+	for _, p := range []string{"", ModelTierHigh, ModelTierMax} {
+		if !isDowngradableTier(p) {
+			t.Errorf("isDowngradableTier(%q) = false, want true", p)
+		}
+	}
+	// A concrete model id or the mid tier is left alone, so an explicit choice
+	// (or an already-cheap tier) is never touched.
+	for _, p := range []string{ModelTierMid, "claude-opus-4-8", "claude-sonnet-4-6", "garbage"} {
+		if isDowngradableTier(p) {
+			t.Errorf("isDowngradableTier(%q) = true, want false", p)
+		}
+	}
+}

--- a/internal/web/models_downgrade_test.go
+++ b/internal/web/models_downgrade_test.go
@@ -18,3 +18,29 @@ func TestIsDowngradableTier(t *testing.T) {
 		}
 	}
 }
+
+func TestApplyOverageDowngrade(t *testing.T) {
+	cases := []struct {
+		pref   string
+		active bool
+		want   string
+	}{
+		// active + expensive tier (or empty default) -> mid
+		{"", true, ModelTierMid},
+		{ModelTierHigh, true, ModelTierMid},
+		{ModelTierMax, true, ModelTierMid},
+		// active but mid or a concrete id -> left alone (explicit choice honoured)
+		{ModelTierMid, true, ModelTierMid},
+		{"claude-opus-4-8", true, "claude-opus-4-8"},
+		{"claude-sonnet-4-6", true, "claude-sonnet-4-6"},
+		// inactive -> everything unchanged
+		{"", false, ""},
+		{ModelTierMax, false, ModelTierMax},
+		{"claude-opus-4-8", false, "claude-opus-4-8"},
+	}
+	for _, tc := range cases {
+		if got := applyOverageDowngrade(tc.pref, tc.active); got != tc.want {
+			t.Errorf("applyOverageDowngrade(%q, %v) = %q, want %q", tc.pref, tc.active, got, tc.want)
+		}
+	}
+}

--- a/internal/web/scans.go
+++ b/internal/web/scans.go
@@ -61,6 +61,7 @@ func (s *Server) jobs(w http.ResponseWriter, r *http.Request) {
 		"AnySubPath": anySubPath, "QueuedCount": stats.QueuedCount, "PausedCount": stats.PausedCount,
 		"AccountPausedCount": stats.AccountPausedCount,
 		"NextAccountResume":  stats.NextAccountResume,
+		"ModelDowngraded":    s.Worker.ShouldDowngradeModel(),
 	})
 }
 

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -2349,9 +2349,7 @@ func (s *Server) enqueueSkillWith(ctx context.Context, repoID, skillID uint, opt
 	// to mid (Sonnet), when enabled. An explicit concrete model id is left alone.
 	// The resolved model is snapshotted onto the scan below, so this applies to
 	// scans enqueued from now on (including triage's fan-out), not queued ones.
-	if s.Worker.ShouldDowngradeModel() && isDowngradableTier(opts.Model) {
-		opts.Model = ModelTierMid
-	}
+	opts.Model = applyOverageDowngrade(opts.Model, s.Worker.ShouldDowngradeModel())
 	opts.Model = resolveModelPreference(s.DB, opts.Model, s.DefaultModel())
 	if !ValidEffort(opts.Effort) {
 		opts.Effort = s.DefaultEffort()

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -2344,6 +2344,14 @@ func (s *Server) enqueueSkillWith(ctx context.Context, repoID, skillID uint, opt
 	if !ValidModelPreference(opts.Model) && hasSkill {
 		opts.Model = sk.Model
 	}
+	// Overage fallback: while the subscription is past its included quota, rewrite
+	// the expensive tiers (max/high, and the empty default that resolves to high)
+	// to mid (Sonnet), when enabled. An explicit concrete model id is left alone.
+	// The resolved model is snapshotted onto the scan below, so this applies to
+	// scans enqueued from now on (including triage's fan-out), not queued ones.
+	if s.Worker.ShouldDowngradeModel() && isDowngradableTier(opts.Model) {
+		opts.Model = ModelTierMid
+	}
 	opts.Model = resolveModelPreference(s.DB, opts.Model, s.DefaultModel())
 	if !ValidEffort(opts.Effort) {
 		opts.Effort = s.DefaultEffort()

--- a/internal/web/templates/jobs.html
+++ b/internal/web/templates/jobs.html
@@ -92,7 +92,7 @@
     <i data-lucide="triangle-alert"></i>
     <section>
       <strong>Model fallback active.</strong>
-      The account is on overage, so new scans run on the mid (Sonnet) tier instead of max/high. Restores automatically when the window resets.
+      The account is on overage, so new scans run on the mid tier instead of max/high. Restores automatically when the window resets.
     </section>
   </div>
 {{end}}

--- a/internal/web/templates/jobs.html
+++ b/internal/web/templates/jobs.html
@@ -92,7 +92,7 @@
     <i data-lucide="triangle-alert"></i>
     <section>
       <strong>Model fallback active.</strong>
-      The account is on overage, so new scans run on the mid tier instead of max/high. Restores automatically when the window resets.
+      The account is on overage, so new scans run on the mid tier instead of max/high. Restores automatically when overage clears.
     </section>
   </div>
 {{end}}

--- a/internal/web/templates/jobs.html
+++ b/internal/web/templates/jobs.html
@@ -87,6 +87,16 @@
   </div>
 {{end}}
 
+{{if .ModelDowngraded}}
+  <div class="alert-warning mb-6">
+    <i data-lucide="triangle-alert"></i>
+    <section>
+      <strong>Model fallback active.</strong>
+      The account is on overage, so new scans run on the mid (Sonnet) tier instead of max/high. Restores automatically when the window resets.
+    </section>
+  </div>
+{{end}}
+
 {{if .Scans}}
   <table class="table">
     <thead>

--- a/internal/web/templates/usage.html
+++ b/internal/web/templates/usage.html
@@ -38,12 +38,15 @@
     {{range .RateLimit.Rows}}
       <tr>
         <td class="font-medium">{{.Window}}</td>
-        <td class="text-muted-foreground">{{.Status}}</td>
+        <td class="text-muted-foreground">{{.Status}}{{if .Overage}} · overage{{end}}</td>
         <td class="text-right text-muted-foreground">{{if .ResetAt}}{{.ResetAt}}{{else}}—{{end}}</td>
       </tr>
     {{end}}
     </tbody>
   </table>
+  {{if .RateLimit.Downgrading}}
+    <p class="text-xs mt-3 flex items-center gap-2"><i data-lucide="triangle-alert"></i> Account on overage — new scans use the mid (Sonnet) tier until the window resets.</p>
+  {{end}}
 </div>
 {{end}}
 

--- a/internal/web/templates/usage.html
+++ b/internal/web/templates/usage.html
@@ -45,7 +45,7 @@
     </tbody>
   </table>
   {{if .RateLimit.Downgrading}}
-    <p class="text-xs mt-3 flex items-center gap-2"><i data-lucide="triangle-alert"></i> Account on overage — new scans use the mid tier until the window resets.</p>
+    <p class="text-xs mt-3 flex items-center gap-2"><i data-lucide="triangle-alert"></i> Account on overage — new scans use the mid tier until the overage clears.</p>
   {{end}}
 </div>
 {{end}}

--- a/internal/web/templates/usage.html
+++ b/internal/web/templates/usage.html
@@ -45,7 +45,7 @@
     </tbody>
   </table>
   {{if .RateLimit.Downgrading}}
-    <p class="text-xs mt-3 flex items-center gap-2"><i data-lucide="triangle-alert"></i> Account on overage — new scans use the mid (Sonnet) tier until the window resets.</p>
+    <p class="text-xs mt-3 flex items-center gap-2"><i data-lucide="triangle-alert"></i> Account on overage — new scans use the mid tier until the window resets.</p>
   {{end}}
 </div>
 {{end}}

--- a/internal/web/usage.go
+++ b/internal/web/usage.go
@@ -112,13 +112,15 @@ func (s *Server) usage(w http.ResponseWriter, r *http.Request) {
 	}
 	sort.Slice(dayRows, func(i, j int) bool { return dayRows[i].Date > dayRows[j].Date })
 
+	rl := buildRateLimitPanel(s.Worker.RateLimitStatus())
+	rl.Downgrading = s.Worker.ShouldDowngradeModel()
 	s.render(w, r, "usage.html", map[string]any{
 		"Rows":      rows,
 		"DayRows":   dayRows,
 		"TotalCost": totalCost,
 		"TotalRuns": totalRuns,
 		"View":      view,
-		"RateLimit": buildRateLimitPanel(s.Worker.RateLimitStatus()),
+		"RateLimit": rl,
 	})
 }
 
@@ -164,12 +166,16 @@ func percentile(sorted []float64, p float64) float64 {
 // rateLimitPanel is the usage page's in-memory Claude rate-limit snapshot.
 type rateLimitPanel struct {
 	Rows []rateLimitRow
+	// Downgrading is true when the overage model fallback is enabled and active,
+	// i.e. new scans are running on the mid (Sonnet) tier instead of max/high.
+	Downgrading bool
 }
 
 type rateLimitRow struct {
 	Window  string
 	Status  string
 	ResetAt string
+	Overage bool
 }
 
 func rateLimitWindowLabel(t string) string {
@@ -187,7 +193,7 @@ func rateLimitWindowLabel(t string) string {
 func buildRateLimitPanel(statuses []worker.RateLimitInfo) rateLimitPanel {
 	var p rateLimitPanel
 	for _, st := range statuses {
-		row := rateLimitRow{Window: rateLimitWindowLabel(st.Type), Status: st.Status}
+		row := rateLimitRow{Window: rateLimitWindowLabel(st.Type), Status: st.Status, Overage: st.IsUsingOverage}
 		if t := st.ResetTime(); t != nil {
 			row.ResetAt = t.UTC().Format("2006-01-02 15:04 UTC")
 		}

--- a/internal/worker/overage_test.go
+++ b/internal/worker/overage_test.go
@@ -1,0 +1,86 @@
+package worker
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestWorker_OnOverageAndShouldDowngrade(t *testing.T) {
+	now := time.Date(2026, 7, 4, 12, 0, 0, 0, time.UTC)
+	w := &Worker{Now: func() time.Time { return now }}
+
+	var nilW *Worker
+	if nilW.OnOverage() || nilW.ShouldDowngradeModel() {
+		t.Fatal("nil worker must be false and not panic")
+	}
+	if w.OnOverage() || w.ShouldDowngradeModel() {
+		t.Fatal("no events: not on overage, no downgrade")
+	}
+
+	// An allowed window without overage does not trigger.
+	w.recordRateLimit(RateLimitInfo{Type: "five_hour", Status: "allowed", ResetsAt: now.Add(time.Hour).Unix()})
+	if w.OnOverage() {
+		t.Fatal("allowed window is not overage")
+	}
+
+	// A window on overage with a future reset is on overage.
+	w.recordRateLimit(RateLimitInfo{Type: "seven_day", Status: "allowed", IsUsingOverage: true, ResetsAt: now.Add(24 * time.Hour).Unix()})
+	if !w.OnOverage() {
+		t.Fatal("overage window with future reset should be on overage")
+	}
+	if w.ShouldDowngradeModel() {
+		t.Fatal("downgrade stays off until the feature is enabled")
+	}
+	w.DowngradeOnOverage = true
+	if !w.ShouldDowngradeModel() {
+		t.Fatal("downgrade should be active when enabled and on overage")
+	}
+
+	// An expired overage reset no longer counts (stale window).
+	w.recordRateLimit(RateLimitInfo{Type: "seven_day", Status: "allowed", IsUsingOverage: true, ResetsAt: now.Add(-time.Minute).Unix()})
+	if w.OnOverage() {
+		t.Fatal("expired overage window must not count")
+	}
+
+	// Overage with no reset timestamp counts (unknown reset -> stay on the cheaper tier).
+	w.recordRateLimit(RateLimitInfo{Type: "five_hour", Status: "allowed", IsUsingOverage: true})
+	if !w.OnOverage() {
+		t.Fatal("overage with no reset should count as active")
+	}
+}
+
+func TestWorker_recordRateLimitAnnouncesTransition(t *testing.T) {
+	now := time.Date(2026, 7, 4, 12, 0, 0, 0, time.UTC)
+	var buf bytes.Buffer
+	w := &Worker{Now: func() time.Time { return now }, Log: slog.New(slog.NewTextHandler(&buf, nil)), DowngradeOnOverage: true}
+
+	// allowed -> no transition, no log
+	w.recordRateLimit(RateLimitInfo{Type: "seven_day", Status: "allowed"})
+	if strings.Contains(buf.String(), "overage fallback") {
+		t.Fatalf("unexpected transition log: %q", buf.String())
+	}
+	// crossing into overage logs "engaged"
+	w.recordRateLimit(RateLimitInfo{Type: "seven_day", Status: "allowed", IsUsingOverage: true, ResetsAt: now.Add(time.Hour).Unix()})
+	if !strings.Contains(buf.String(), "engaged") {
+		t.Fatalf("expected 'engaged' log, got: %q", buf.String())
+	}
+	// leaving overage logs "lifted"
+	buf.Reset()
+	w.recordRateLimit(RateLimitInfo{Type: "seven_day", Status: "allowed", IsUsingOverage: false})
+	if !strings.Contains(buf.String(), "lifted") {
+		t.Fatalf("expected 'lifted' log, got: %q", buf.String())
+	}
+}
+
+func TestWorker_recordRateLimitNoLogWhenDisabled(t *testing.T) {
+	now := time.Date(2026, 7, 4, 12, 0, 0, 0, time.UTC)
+	var buf bytes.Buffer
+	w := &Worker{Now: func() time.Time { return now }, Log: slog.New(slog.NewTextHandler(&buf, nil))} // feature off
+	w.recordRateLimit(RateLimitInfo{Type: "seven_day", Status: "allowed", IsUsingOverage: true, ResetsAt: now.Add(time.Hour).Unix()})
+	if strings.Contains(buf.String(), "overage fallback") {
+		t.Fatalf("must not log the fallback when disabled: %q", buf.String())
+	}
+}

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -220,7 +220,8 @@ func (w *Worker) RateLimitStatus() []RateLimitInfo {
 }
 
 // onOverageLocked reports whether any tracked window is currently on overage
-// (past the included quota) with an unexpired reset. Caller holds rlStatusMu.
+// (past the included quota) with an unexpired reset, or with no reset timestamp
+// (unknown reset). Caller holds rlStatusMu.
 func (w *Worker) onOverageLocked() bool {
 	now := w.now().UTC()
 	for _, info := range w.rlStatus {
@@ -234,8 +235,8 @@ func (w *Worker) onOverageLocked() bool {
 }
 
 // OnOverage reports whether the Claude account is currently past its included
-// subscription quota (any tracked window isUsingOverage with an unexpired
-// reset). An API-key account never reports overage, so this stays false there.
+// subscription quota (any tracked window isUsingOverage with an unexpired reset
+// or no reset timestamp). An API-key account never reports overage, so this stays false there.
 func (w *Worker) OnOverage() bool {
 	if w == nil {
 		return false

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -162,10 +162,10 @@ type Worker struct {
 	// automatic resume. A reset farther out is treated as unreliable and leaves
 	// the batch paused for manual operator action.
 	MaxRateLimitAutoResumeDelay time.Duration
-	// DowngradeOnOverage falls the model tier back from max/high to mid (Opus ->
-	// Sonnet) for newly enqueued scans while the subscription is past its included
-	// quota (on overage), restoring it when the window resets. Off by default; only
-	// a subscription token reports overage, so it is inert on an API key.
+	// DowngradeOnOverage falls the model tier back from max/high to the mid tier
+	// for newly enqueued scans while the subscription is past its included quota
+	// (on overage), restoring it when the window resets. Off by default; only a
+	// subscription token reports overage, so it is inert on an API key.
 	DowngradeOnOverage bool
 	// Now overrides time.Now in tests.
 	Now func() time.Time
@@ -181,7 +181,7 @@ type Worker struct {
 
 // recordRateLimit stores the latest rate-limit status for its window type and,
 // when the overage fallback is enabled, logs the transition into or out of
-// overage so the switch to/from the mid (Sonnet) tier is visible in the log.
+// overage so the switch to/from the mid tier is visible in the log.
 func (w *Worker) recordRateLimit(info RateLimitInfo) {
 	if info.Type == "" {
 		return
@@ -196,7 +196,7 @@ func (w *Worker) recordRateLimit(info RateLimitInfo) {
 	w.rlStatusMu.Unlock()
 	if w.DowngradeOnOverage && before != after && w.Log != nil {
 		if after {
-			w.Log.Info("model overage fallback engaged: account on overage, new scans use the mid (Sonnet) tier")
+			w.Log.Info("model overage fallback engaged: account on overage, new scans use the mid tier")
 		} else {
 			w.Log.Info("model overage fallback lifted: overage cleared, new scans use the max/high tier again")
 		}
@@ -245,8 +245,8 @@ func (w *Worker) OnOverage() bool {
 	return w.onOverageLocked()
 }
 
-// ShouldDowngradeModel reports whether the Opus->Sonnet overage fallback is both
-// enabled and currently active. The web layer calls it at enqueue to rewrite
+// ShouldDowngradeModel reports whether the max/high-to-mid overage fallback is
+// both enabled and currently active. The web layer calls it at enqueue to rewrite
 // max/high tier preferences to mid, and to surface the fallback banner.
 func (w *Worker) ShouldDowngradeModel() bool {
 	return w != nil && w.DowngradeOnOverage && w.OnOverage()

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -162,6 +162,11 @@ type Worker struct {
 	// automatic resume. A reset farther out is treated as unreliable and leaves
 	// the batch paused for manual operator action.
 	MaxRateLimitAutoResumeDelay time.Duration
+	// DowngradeOnOverage falls the model tier back from max/high to mid (Opus ->
+	// Sonnet) for newly enqueued scans while the subscription is past its included
+	// quota (on overage), restoring it when the window resets. Off by default; only
+	// a subscription token reports overage, so it is inert on an API key.
+	DowngradeOnOverage bool
 	// Now overrides time.Now in tests.
 	Now func() time.Time
 
@@ -174,7 +179,9 @@ type Worker struct {
 	rlStatus   map[string]RateLimitInfo
 }
 
-// recordRateLimit stores the latest rate-limit status for its window type.
+// recordRateLimit stores the latest rate-limit status for its window type and,
+// when the overage fallback is enabled, logs the transition into or out of
+// overage so the switch to/from the mid (Sonnet) tier is visible in the log.
 func (w *Worker) recordRateLimit(info RateLimitInfo) {
 	if info.Type == "" {
 		return
@@ -183,8 +190,17 @@ func (w *Worker) recordRateLimit(info RateLimitInfo) {
 	if w.rlStatus == nil {
 		w.rlStatus = map[string]RateLimitInfo{}
 	}
+	before := w.onOverageLocked()
 	w.rlStatus[info.Type] = info
+	after := w.onOverageLocked()
 	w.rlStatusMu.Unlock()
+	if w.DowngradeOnOverage && before != after && w.Log != nil {
+		if after {
+			w.Log.Info("model overage fallback engaged: account on overage, new scans use the mid (Sonnet) tier")
+		} else {
+			w.Log.Info("model overage fallback lifted: overage cleared, new scans use the max/high tier again")
+		}
+	}
 }
 
 // RateLimitStatus returns a snapshot of the latest rate-limit status per window,
@@ -201,6 +217,39 @@ func (w *Worker) RateLimitStatus() []RateLimitInfo {
 		out = append(out, v)
 	}
 	return out
+}
+
+// onOverageLocked reports whether any tracked window is currently on overage
+// (past the included quota) with an unexpired reset. Caller holds rlStatusMu.
+func (w *Worker) onOverageLocked() bool {
+	now := w.now().UTC()
+	for _, info := range w.rlStatus {
+		if info.IsUsingOverage {
+			if t := info.ResetTime(); t == nil || t.After(now) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// OnOverage reports whether the Claude account is currently past its included
+// subscription quota (any tracked window isUsingOverage with an unexpired
+// reset). An API-key account never reports overage, so this stays false there.
+func (w *Worker) OnOverage() bool {
+	if w == nil {
+		return false
+	}
+	w.rlStatusMu.Lock()
+	defer w.rlStatusMu.Unlock()
+	return w.onOverageLocked()
+}
+
+// ShouldDowngradeModel reports whether the Opus->Sonnet overage fallback is both
+// enabled and currently active. The web layer calls it at enqueue to rewrite
+// max/high tier preferences to mid, and to surface the fallback banner.
+func (w *Worker) ShouldDowngradeModel() bool {
+	return w != nil && w.DowngradeOnOverage && w.OnOverage()
 }
 
 func (w *Worker) logFlushInterval() time.Duration {

--- a/scrutineer.sample.yaml
+++ b/scrutineer.sample.yaml
@@ -129,8 +129,8 @@
 # Claude subscription rate-limit auto-resume needs no configuration. Reset times
 # come from claude-code stream output; latest window status appears on /usage.
 
-# Fall the model tier back from max/high to mid (Opus -> Sonnet) for newly
-# enqueued scans while a Claude subscription is on overage (past its included
+# Fall the model tier back from max/high to the mid tier for newly enqueued
+# scans while a Claude subscription is on overage (past its included
 # quota), restoring it when the window resets. Off by default; only a
 # subscription token reports overage, so it is inert on an API key. The switch is
 # logged and shown on the jobs page and /usage. Flag: -downgrade-on-overage.

--- a/scrutineer.sample.yaml
+++ b/scrutineer.sample.yaml
@@ -129,6 +129,13 @@
 # Claude subscription rate-limit auto-resume needs no configuration. Reset times
 # come from claude-code stream output; latest window status appears on /usage.
 
+# Fall the model tier back from max/high to mid (Opus -> Sonnet) for newly
+# enqueued scans while a Claude subscription is on overage (past its included
+# quota), restoring it when the window resets. Off by default; only a
+# subscription token reports overage, so it is inert on an API key. The switch is
+# logged and shown on the jobs page and /usage. Flag: -downgrade-on-overage.
+# downgrade_on_overage: false
+
 # The model picker in the UI. Replacing this list replaces the built-in
 # set (Opus, Sonnet, Fable). Leave it out to keep the built-in list.
 # models:

--- a/scrutineer.sample.yaml
+++ b/scrutineer.sample.yaml
@@ -131,9 +131,9 @@
 
 # Fall the model tier back from max/high to the mid tier for newly enqueued
 # scans while a Claude subscription is on overage (past its included
-# quota), restoring it when the window resets. Off by default; only a
-# subscription token reports overage, so it is inert on an API key. The switch is
-# logged and shown on the jobs page and /usage. Flag: -downgrade-on-overage.
+# quota), restoring it when overage clears (typically when the window resets).
+# Off by default; only a subscription token reports overage, so it is inert on
+# an API key. The switch is logged and shown on the jobs page and /usage. Flag: -downgrade-on-overage.
 # downgrade_on_overage: false
 
 # The model picker in the UI. Replacing this list replaces the built-in


### PR DESCRIPTION
feat: fall back Opus->Sonnet while a subscription is on overage

Opt-in (`downgrade_on_overage` / `-downgrade-on-overage`, default off): newly
enqueued scans resolve the max/high model tier to mid (Sonnet) while the Claude
subscription is on overage (claude-code's `isUsingOverage` rate_limit signal),
and revert to max/high once the window resets. Only tier preferences are
rewritten -- an explicit concrete model id is respected -- and the model is
snapshotted at enqueue, so it affects new scans (including triage's fan-out),
not ones already queued. Inert on an API key, which reports no overage.

Announced on the engage/lift transition: a worker log line, a banner on the jobs
page, and an "on overage" note on /usage; each scan already records its concrete
model, so the switch is visible per row in /api/v1/scans.

- worker: OnOverage/ShouldDowngradeModel + DowngradeOnOverage field; transition
  logged in recordRateLimit
- web: isDowngradableTier + enqueueSkillWith hook; jobs banner; /usage panel
- config/flag: downgrade_on_overage (default false); README + sample.yaml
- tests: worker overage/expiry/transition/gating; web tier predicate