### PR TITLE
Add expected findings benchmark support

### DIFF
--- a/docs/database.md
+++ b/docs/database.md
@@ -64,6 +64,7 @@ One row per skill execution or external import. `skill_name` / `skill_version` p
 | effort | text | Claude `--effort` level (`low`–`max`) snapshotted from the runtime setting at enqueue. Empty on legacy rows; the runner falls back to its configured default. |
 | skill_id | integer FK | References `skills.id`. Null for legacy non-skill rows. |
 | skill_version | integer | Version of the skill at run time; the skill row's `version` bumps on every edit so older scans stay readable. |
+| skill_schema_version | integer | Snapshot of the skill frontmatter `metadata.scrutineer.version` at enqueue time. Used by the benchmark page to attribute expected-finding results to the report schema/version the skill was asked to emit. |
 | skill_name | text | Denormalised skill name for UI display. |
 | finding_id | integer FK | Set when the scan is finding-scoped (verify/patch/disclose/exposure). References `findings.id`. |
 | dependent_id | integer FK | Set on `exposure` scans only. References `dependents.id`; identifies which downstream consumer the skill is auditing for reachability of the upstream finding. |
@@ -89,6 +90,21 @@ One row per skill execution or external import. `skill_name` / `skill_version` p
 | log | text | Line-by-line transcript of the scan. Streamed to the UI via SSE. |
 | error | text | Error message if the scan failed. |
 | findings_count | integer | Denormalised count of findings parsed from the report. |
+| created_at | datetime | |
+| updated_at | datetime | |
+
+## expected_findings
+
+Operator-supplied benchmark targets for a repository. Each row is a known file/CWE pair that model-backed scans should rediscover. Matching ignores line numbers, treats CWE case-insensitively, and currently compares Medium+ findings for benchmark metrics.
+
+| Column | Type | Notes |
+|--------|------|-------|
+| id | integer PK | |
+| repository_id | integer FK | References `repositories.id`. Cascade delete. Part of the unique key with `file` and `cwe`. |
+| file | text | Repository-root-relative path, without line number. Absolute paths and parent-directory traversal are rejected by the write path. Part of the unique key with `repository_id` and `cwe`. |
+| cwe | text | Normalised CWE identifier, e.g. `CWE-79`. Part of the unique key with `repository_id` and `file`. |
+| cve | text | Optional external CVE identifier for operator context. Not used for matching. |
+| note | text | Optional free-text note explaining the expected target. |
 | created_at | datetime | |
 | updated_at | datetime | |
 

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -106,8 +106,9 @@ type Repository struct {
 	CreatedAt time.Time
 	UpdatedAt time.Time
 
-	Scans       []Scan       `gorm:"constraint:OnDelete:CASCADE"`
-	Maintainers []Maintainer `gorm:"many2many:repository_maintainers"`
+	Scans            []Scan            `gorm:"constraint:OnDelete:CASCADE"`
+	ExpectedFindings []ExpectedFinding `gorm:"constraint:OnDelete:CASCADE"`
+	Maintainers      []Maintainer      `gorm:"many2many:repository_maintainers"`
 }
 
 // IsLocal reports whether this Repository points at a directory on disk
@@ -160,9 +161,10 @@ type Scan struct {
 	// the skill is deleted. APIToken is a random bearer generated per-run
 	// so skills can call back into scrutineer's HTTP API from inside the
 	// workspace; it is cleared when the scan reaches a terminal state.
-	SkillID      *uint `gorm:"index"`
-	SkillVersion int
-	SkillName    string `gorm:"index"`
+	SkillID            *uint `gorm:"index"`
+	SkillVersion       int
+	SkillSchemaVersion int
+	SkillName          string `gorm:"index"`
 	// FindingID is set when a scan is finding-scoped (verify, patch,
 	// disclose). Skills read it from context.json to know which finding
 	// they are acting on.
@@ -441,6 +443,24 @@ type Dependency struct {
 	ManifestPath          string
 	ManifestKind          string
 	CreatedAt             time.Time
+}
+
+// ExpectedFinding is an operator-supplied benchmark target for a repository.
+// It records a known vulnerable file/CWE pair that model-backed scans should
+// rediscover. Matching intentionally ignores line numbers because they drift
+// between versions.
+type ExpectedFinding struct {
+	ID           uint `gorm:"primarykey"`
+	RepositoryID uint `gorm:"index;not null;uniqueIndex:idx_expected_repo_file_cwe,priority:1"`
+	Repository   Repository
+
+	File string `gorm:"not null;uniqueIndex:idx_expected_repo_file_cwe,priority:2"`
+	CWE  string `gorm:"not null;uniqueIndex:idx_expected_repo_file_cwe,priority:3"`
+	CVE  string
+	Note string `gorm:"type:text"`
+
+	CreatedAt time.Time
+	UpdatedAt time.Time
 }
 
 // FindingResolution says how a finding got resolved. Set by the analyst
@@ -1083,7 +1103,7 @@ func Open(dsn string) (*gorm.DB, error) {
 		&Repository{}, &Scan{},
 		&Finding{}, &FindingLabel{}, &FindingNote{},
 		&FindingCommunication{}, &FindingReference{}, &FindingHistory{}, &FindingReview{},
-		&Dependency{}, &Package{}, &Dependent{}, &FindingDependent{}, &Advisory{},
+		&Dependency{}, &ExpectedFinding{}, &Package{}, &Dependent{}, &FindingDependent{}, &Advisory{},
 		&Maintainer{}, &Skill{}, &Subproject{},
 		&SBOMUpload{}, &SBOMPackage{}, &CNA{}, &Setting{},
 	); err != nil {

--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -94,6 +94,9 @@ func (s *Server) apiHandler() http.Handler {
 	mux.HandleFunc("GET /repositories/{id}/advisories", s.apiListAdvisories)
 	mux.HandleFunc("GET /repositories/{id}/dependents", s.apiListDependents)
 	mux.HandleFunc("GET /repositories/{id}/ecosystems/{source}/raw", s.apiGetEcosystemsRaw)
+	mux.HandleFunc("GET /repositories/{id}/expected", s.apiListExpectedFindings)
+	mux.HandleFunc("POST /repositories/{id}/expected", s.apiAddExpectedFinding)
+	mux.HandleFunc("DELETE /repositories/{id}/expected/{expected_id}", s.apiDeleteExpectedFinding)
 	mux.HandleFunc("GET /repositories/{id}/dependencies", s.apiListDependencies)
 	mux.HandleFunc("GET /repositories/{id}/findings", s.apiListFindings)
 	mux.HandleFunc("POST /repositories/{id}/findings", s.apiStreamFinding)
@@ -454,18 +457,19 @@ func (s *Server) apiListSkills(w http.ResponseWriter, r *http.Request) {
 
 func scanSummary(sc db.Scan) map[string]any {
 	m := map[string]any{
-		"id":            sc.ID,
-		"repository_id": sc.RepositoryID,
-		"kind":          sc.Kind,
-		statusKey:       string(sc.Status),
-		"model":         sc.Model,
-		"commit":        sc.Commit,
-		"skill_name":    sc.SkillName,
-		"skill_version": sc.SkillVersion,
-		"started_at":    sc.StartedAt,
-		"finished_at":   sc.FinishedAt,
-		"max_turns_hit": sc.MaxTurnsHit,
-		errorKey:        sc.Error,
+		"id":                   sc.ID,
+		"repository_id":        sc.RepositoryID,
+		"kind":                 sc.Kind,
+		statusKey:              string(sc.Status),
+		"model":                sc.Model,
+		"commit":               sc.Commit,
+		"skill_name":           sc.SkillName,
+		"skill_version":        sc.SkillVersion,
+		"skill_schema_version": sc.SkillSchemaVersion,
+		"started_at":           sc.StartedAt,
+		"finished_at":          sc.FinishedAt,
+		"max_turns_hit":        sc.MaxTurnsHit,
+		errorKey:               sc.Error,
 	}
 	if sc.Ref != "" {
 		m["ref"] = sc.Ref

--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -95,8 +95,6 @@ func (s *Server) apiHandler() http.Handler {
 	mux.HandleFunc("GET /repositories/{id}/dependents", s.apiListDependents)
 	mux.HandleFunc("GET /repositories/{id}/ecosystems/{source}/raw", s.apiGetEcosystemsRaw)
 	mux.HandleFunc("GET /repositories/{id}/expected", s.apiListExpectedFindings)
-	mux.HandleFunc("POST /repositories/{id}/expected", s.apiAddExpectedFinding)
-	mux.HandleFunc("DELETE /repositories/{id}/expected/{expected_id}", s.apiDeleteExpectedFinding)
 	mux.HandleFunc("GET /repositories/{id}/dependencies", s.apiListDependencies)
 	mux.HandleFunc("GET /repositories/{id}/findings", s.apiListFindings)
 	mux.HandleFunc("POST /repositories/{id}/findings", s.apiStreamFinding)

--- a/internal/web/benchmark.go
+++ b/internal/web/benchmark.go
@@ -10,27 +10,29 @@ import (
 )
 
 type benchmarkRow struct {
-	Repo               db.Repository
-	Scan               *db.Scan
-	Expected           int
-	Matched            int
-	Findings           int
-	Recall             float64
-	Precision          float64
-	F1                 float64
-	Skill              string
-	Model              string
-	HarnessSHA         string
-	SkillSchemaVersion int
+	Repo                 db.Repository
+	Scan                 *db.Scan
+	Expected             int
+	Matched              int
+	Findings             int
+	TruePositiveFindings int
+	Recall               float64
+	Precision            float64
+	F1                   float64
+	Skill                string
+	Model                string
+	HarnessSHA           string
+	SkillSchemaVersion   int
 }
 
 type benchmarkTotals struct {
-	Expected  int
-	Matched   int
-	Findings  int
-	Recall    float64
-	Precision float64
-	F1        float64
+	Expected             int
+	Matched              int
+	Findings             int
+	TruePositiveFindings int
+	Recall               float64
+	Precision            float64
+	F1                   float64
 }
 
 func (s *Server) benchmark(w http.ResponseWriter, r *http.Request) {
@@ -66,21 +68,23 @@ func loadBenchmarkRows(gdb *gorm.DB, skill, model, harness string) ([]benchmarkR
 			row.Scan = scan
 			row.Matched = matches.MatchedTotal
 			row.Findings = matches.FindingTotal
+			row.TruePositiveFindings = matches.TruePositiveFindings
 			row.Skill = scan.SkillName
 			row.Model = scan.Model
 			row.HarnessSHA = scan.SkillsRepoSHA
 			row.SkillSchemaVersion = scan.SkillSchemaVersion
 			row.Recall = ratio(row.Matched, row.Expected)
-			row.Precision = ratio(row.Matched, row.Findings)
+			row.Precision = ratio(row.TruePositiveFindings, row.Findings)
 			row.F1 = f1(row.Recall, row.Precision)
 		}
 		totals.Expected += row.Expected
 		totals.Matched += row.Matched
 		totals.Findings += row.Findings
+		totals.TruePositiveFindings += row.TruePositiveFindings
 		rows = append(rows, row)
 	}
 	totals.Recall = ratio(totals.Matched, totals.Expected)
-	totals.Precision = ratio(totals.Matched, totals.Findings)
+	totals.Precision = ratio(totals.TruePositiveFindings, totals.Findings)
 	totals.F1 = f1(totals.Recall, totals.Precision)
 	return rows, totals
 }

--- a/internal/web/benchmark.go
+++ b/internal/web/benchmark.go
@@ -1,0 +1,121 @@
+package web
+
+import (
+	"net/http"
+	"strings"
+
+	"gorm.io/gorm"
+
+	"scrutineer/internal/db"
+)
+
+type benchmarkRow struct {
+	Repo               db.Repository
+	Scan               *db.Scan
+	Expected           int
+	Matched            int
+	Findings           int
+	Recall             float64
+	Precision          float64
+	F1                 float64
+	Skill              string
+	Model              string
+	HarnessSHA         string
+	SkillSchemaVersion int
+}
+
+type benchmarkTotals struct {
+	Expected  int
+	Matched   int
+	Findings  int
+	Recall    float64
+	Precision float64
+	F1        float64
+}
+
+func (s *Server) benchmark(w http.ResponseWriter, r *http.Request) {
+	skill := strings.TrimSpace(r.URL.Query().Get("skill"))
+	model := strings.TrimSpace(r.URL.Query().Get("model"))
+	harness := strings.TrimSpace(r.URL.Query().Get("harness"))
+	rows, totals := loadBenchmarkRows(s.DB, skill, model, harness)
+	s.render(w, r, "benchmark.html", map[string]any{
+		"Rows":    rows,
+		"Totals":  totals,
+		"Skill":   skill,
+		"Model":   model,
+		"Harness": harness,
+	})
+}
+
+func loadBenchmarkRows(gdb *gorm.DB, skill, model, harness string) ([]benchmarkRow, benchmarkTotals) {
+	var repos []db.Repository
+	gdb.Joins("JOIN expected_findings ef ON ef.repository_id = repositories.id").
+		Group("repositories.id").
+		Order("repositories.name").
+		Find(&repos)
+
+	rows := make([]benchmarkRow, 0, len(repos))
+	var totals benchmarkTotals
+	for _, repo := range repos {
+		var expected []db.ExpectedFinding
+		gdb.Where("repository_id = ?", repo.ID).Order("file, cwe").Find(&expected)
+		row := benchmarkRow{Repo: repo, Expected: len(expected)}
+		scan := latestBenchmarkScan(gdb, repo.ID, skill, model, harness)
+		if scan != nil {
+			matches := expectedMatchesForRows(gdb, repo.ID, scan.ID, expected)
+			row.Scan = scan
+			row.Matched = matches.MatchedTotal
+			row.Findings = matches.FindingTotal
+			row.Skill = scan.SkillName
+			row.Model = scan.Model
+			row.HarnessSHA = scan.SkillsRepoSHA
+			row.SkillSchemaVersion = scan.SkillSchemaVersion
+			row.Recall = ratio(row.Matched, row.Expected)
+			row.Precision = ratio(row.Matched, row.Findings)
+			row.F1 = f1(row.Recall, row.Precision)
+		}
+		totals.Expected += row.Expected
+		totals.Matched += row.Matched
+		totals.Findings += row.Findings
+		rows = append(rows, row)
+	}
+	totals.Recall = ratio(totals.Matched, totals.Expected)
+	totals.Precision = ratio(totals.Matched, totals.Findings)
+	totals.F1 = f1(totals.Recall, totals.Precision)
+	return rows, totals
+}
+
+func latestBenchmarkScan(gdb *gorm.DB, repoID uint, skill, model, harness string) *db.Scan {
+	q := gdb.Where("repository_id = ? AND status = ?", repoID, db.ScanDone)
+	if skill != "" {
+		q = q.Where("skill_name = ?", skill)
+	} else {
+		q = q.Where("skill_name IN ?", []string{deepDiveSkillName, vulnScanSkillName})
+	}
+	if model != "" {
+		q = q.Where("model = ?", model)
+	}
+	if harness != "" {
+		q = q.Where("skills_repo_sha = ?", harness)
+	}
+	var scan db.Scan
+	if err := q.Order("id desc").First(&scan).Error; err != nil {
+		return nil
+	}
+	return &scan
+}
+
+func ratio(n, d int) float64 {
+	if d == 0 {
+		return 0
+	}
+	return float64(n) / float64(d)
+}
+
+func f1(recall, precision float64) float64 {
+	if recall == 0 || precision == 0 {
+		return 0
+	}
+	const harmonicMeanScale = 2
+	return harmonicMeanScale * recall * precision / (recall + precision)
+}

--- a/internal/web/expected_findings.go
+++ b/internal/web/expected_findings.go
@@ -1,0 +1,306 @@
+package web
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"path"
+	"strconv"
+	"strings"
+
+	"gorm.io/gorm"
+
+	"scrutineer/internal/db"
+)
+
+type expectedFindingResponse struct {
+	ID           uint   `json:"id"`
+	RepositoryID uint   `json:"repository_id"`
+	File         string `json:"file"`
+	CWE          string `json:"cwe"`
+	CVE          string `json:"cve,omitempty"`
+	Note         string `json:"note,omitempty"`
+}
+
+func (s *Server) apiListExpectedFindings(w http.ResponseWriter, r *http.Request) {
+	repoID, ok := s.repoScopedID(w, r)
+	if !ok {
+		return
+	}
+	var rows []db.ExpectedFinding
+	if err := s.DB.Where("repository_id = ?", repoID).Order("file, cwe").Find(&rows).Error; err != nil {
+		writeAPIError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, expectedFindingResponses(rows))
+}
+
+func (s *Server) apiAddExpectedFinding(w http.ResponseWriter, r *http.Request) {
+	repoID, ok := s.repoScopedID(w, r)
+	if !ok {
+		return
+	}
+	var body struct {
+		File string `json:"file"`
+		CWE  string `json:"cwe"`
+		CVE  string `json:"cve"`
+		Note string `json:"note"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeAPIError(w, http.StatusBadRequest, "body must be JSON")
+		return
+	}
+	row, err := buildExpectedFinding(repoID, body.File, body.CWE, body.CVE, body.Note)
+	if err != nil {
+		writeAPIError(w, http.StatusUnprocessableEntity, err.Error())
+		return
+	}
+	if err := s.DB.Create(&row).Error; err != nil {
+		writeAPIError(w, http.StatusUnprocessableEntity, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusCreated, expectedFindingResponseFrom(row))
+}
+
+func (s *Server) apiDeleteExpectedFinding(w http.ResponseWriter, r *http.Request) {
+	repoID, ok := s.repoScopedID(w, r)
+	if !ok {
+		return
+	}
+	expectedID, err := strconv.Atoi(r.PathValue("expected_id"))
+	if err != nil {
+		writeAPIError(w, http.StatusBadRequest, "invalid expected finding id")
+		return
+	}
+	res := s.DB.Where("repository_id = ? AND id = ?", repoID, expectedID).Delete(&db.ExpectedFinding{})
+	if res.Error != nil {
+		writeAPIError(w, http.StatusInternalServerError, res.Error.Error())
+		return
+	}
+	if res.RowsAffected == 0 {
+		writeAPIError(w, http.StatusNotFound, "expected finding not found")
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *Server) repoExpectedFindingCreate(w http.ResponseWriter, r *http.Request) {
+	repo, ok := loadByID[db.Repository](s, w, r)
+	if !ok {
+		return
+	}
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	row, err := buildExpectedFinding(repo.ID, r.FormValue("file"), r.FormValue("cwe"), r.FormValue("cve"), r.FormValue("note"))
+	if err != nil {
+		setFlash(w, Flash{Category: errorKey, Title: err.Error()})
+		s.redirect(w, r, fmt.Sprintf("/repositories/%d#rt13", repo.ID))
+		return
+	}
+	if err := s.DB.Create(&row).Error; err != nil {
+		setFlash(w, Flash{Category: errorKey, Title: "Expected finding not saved", Description: err.Error()})
+		s.redirect(w, r, fmt.Sprintf("/repositories/%d#rt13", repo.ID))
+		return
+	}
+	setFlash(w, Flash{Category: successKey, Title: "Expected finding saved"})
+	s.redirect(w, r, fmt.Sprintf("/repositories/%d#rt13", repo.ID))
+}
+
+func (s *Server) repoExpectedFindingDelete(w http.ResponseWriter, r *http.Request) {
+	repo, ok := loadByID[db.Repository](s, w, r)
+	if !ok {
+		return
+	}
+	expectedID, err := strconv.Atoi(r.PathValue("expected_id"))
+	if err != nil {
+		http.NotFound(w, r)
+		return
+	}
+	res := s.DB.Where("repository_id = ? AND id = ?", repo.ID, expectedID).Delete(&db.ExpectedFinding{})
+	if res.Error != nil {
+		setFlash(w, Flash{Category: errorKey, Title: "Expected finding not deleted", Description: res.Error.Error()})
+	} else if res.RowsAffected > 0 {
+		setFlash(w, Flash{Category: successKey, Title: "Expected finding deleted"})
+	}
+	s.redirect(w, r, fmt.Sprintf("/repositories/%d#rt13", repo.ID))
+}
+
+func buildExpectedFinding(repoID uint, file, cwe, cve, note string) (db.ExpectedFinding, error) {
+	row := db.ExpectedFinding{
+		RepositoryID: repoID,
+		File:         normalizeExpectedFile(file),
+		CWE:          strings.ToUpper(strings.TrimSpace(cwe)),
+		CVE:          strings.TrimSpace(cve),
+		Note:         strings.TrimSpace(note),
+	}
+	if row.File == "" || row.File == "." {
+		return row, fmt.Errorf("file is required")
+	}
+	if row.CWE == "" {
+		return row, fmt.Errorf("cwe is required")
+	}
+	return row, nil
+}
+
+func expectedFindingResponses(rows []db.ExpectedFinding) []expectedFindingResponse {
+	out := make([]expectedFindingResponse, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, expectedFindingResponseFrom(row))
+	}
+	return out
+}
+
+func expectedFindingResponseFrom(row db.ExpectedFinding) expectedFindingResponse {
+	return expectedFindingResponse{
+		ID:           row.ID,
+		RepositoryID: row.RepositoryID,
+		File:         row.File,
+		CWE:          row.CWE,
+		CVE:          row.CVE,
+		Note:         row.Note,
+	}
+}
+
+func skillSchemaVersion(skill db.Skill) int {
+	if skill.Metadata == "" {
+		return 0
+	}
+	var meta map[string]any
+	if err := json.Unmarshal([]byte(skill.Metadata), &meta); err != nil {
+		return 0
+	}
+	switch v := meta["scrutineer.version"].(type) {
+	case float64:
+		return int(v)
+	case int:
+		return v
+	default:
+		return 0
+	}
+}
+
+type expectedFindingStatus struct {
+	Expected  db.ExpectedFinding
+	Matched   bool
+	FindingID uint
+}
+
+type expectedMatchSet struct {
+	Expected      []expectedFindingStatus
+	FindingStatus map[uint]bool
+	MatchedTotal  int
+	FindingTotal  int
+}
+
+func expectedMatchesForScan(gdb *gorm.DB, repoID, scanID uint) expectedMatchSet {
+	var expected []db.ExpectedFinding
+	gdb.Where("repository_id = ?", repoID).Order("file, cwe").Find(&expected)
+	return expectedMatchesForRows(gdb, repoID, scanID, expected)
+}
+
+func expectedMatchesForRows(gdb *gorm.DB, repoID, scanID uint, expected []db.ExpectedFinding) expectedMatchSet {
+	out := expectedMatchSet{
+		Expected:      make([]expectedFindingStatus, 0, len(expected)),
+		FindingStatus: map[uint]bool{},
+	}
+	for _, row := range expected {
+		out.Expected = append(out.Expected, expectedFindingStatus{Expected: row})
+	}
+	if scanID == 0 || len(expected) == 0 {
+		return out
+	}
+	var findings []db.Finding
+	gdb.Where("repository_id = ? AND scan_id = ?", repoID, scanID).Find(&findings)
+	for _, f := range findings {
+		if db.SeverityAtLeast(f.Severity, "Medium") {
+			out.FindingTotal++
+		}
+		for i := range out.Expected {
+			if findingMatchesExpected(f, out.Expected[i].Expected) {
+				out.FindingStatus[f.ID] = true
+				if !out.Expected[i].Matched {
+					out.Expected[i].Matched = true
+					out.Expected[i].FindingID = f.ID
+					out.MatchedTotal++
+				}
+			}
+		}
+	}
+	return out
+}
+
+func expectedStatusForFindings(findings []db.Finding, expected []db.ExpectedFinding) map[uint]bool {
+	out := make(map[uint]bool, len(findings))
+	for _, f := range findings {
+		for _, row := range expected {
+			if findingMatchesExpected(f, row) {
+				out[f.ID] = true
+				break
+			}
+		}
+	}
+	return out
+}
+
+func findingMatchesExpected(f db.Finding, expected db.ExpectedFinding) bool {
+	if strings.TrimSpace(f.CWE) != strings.TrimSpace(expected.CWE) {
+		return false
+	}
+	want := normalizeExpectedFile(expected.File)
+	for _, loc := range findingLocations(f) {
+		if normalizeLocationFile(loc) == want {
+			return true
+		}
+	}
+	return false
+}
+
+func findingLocations(f db.Finding) []string {
+	locs := f.LocationList()
+	if len(locs) > 0 {
+		return locs
+	}
+	if strings.TrimSpace(f.Location) == "" {
+		return nil
+	}
+	return []string{f.Location}
+}
+
+func normalizeExpectedFile(file string) string {
+	return cleanRepoPath(file)
+}
+
+func normalizeLocationFile(loc string) string {
+	loc = strings.TrimSpace(strings.Split(strings.TrimSpace(loc), "\n")[0])
+	for {
+		i := strings.LastIndexByte(loc, ':')
+		if i < 0 || !allDigits(loc[i+1:]) {
+			break
+		}
+		loc = loc[:i]
+	}
+	return cleanRepoPath(loc)
+}
+
+func cleanRepoPath(p string) string {
+	p = strings.TrimSpace(strings.ReplaceAll(p, "\\", "/"))
+	p = strings.TrimPrefix(p, "./")
+	if p == "" {
+		return ""
+	}
+	return path.Clean(p)
+}
+
+func allDigits(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/web/expected_findings.go
+++ b/internal/web/expected_findings.go
@@ -194,6 +194,27 @@ type expectedMatchSet struct {
 	FindingTotal  int
 }
 
+type repoExpectedView struct {
+	Matches       expectedMatchSet
+	FindingStatus map[uint]bool
+}
+
+func loadRepoExpectedView(gdb *gorm.DB, repoID uint, latest *db.Scan, rf repoFindings) repoExpectedView {
+	var expected []db.ExpectedFinding
+	gdb.Where("repository_id = ?", repoID).Order("file, cwe").Find(&expected)
+	latestScanID := uint(0)
+	if latest != nil {
+		latestScanID = latest.ID
+	}
+	visibleFindings := make([]db.Finding, 0, len(rf.DeepDive)+len(rf.Scanners))
+	visibleFindings = append(visibleFindings, rf.DeepDive...)
+	visibleFindings = append(visibleFindings, rf.Scanners...)
+	return repoExpectedView{
+		Matches:       expectedMatchesForRows(gdb, repoID, latestScanID, expected),
+		FindingStatus: expectedStatusForFindings(visibleFindings, expected),
+	}
+}
+
 func expectedMatchesForScan(gdb *gorm.DB, repoID, scanID uint) expectedMatchSet {
 	var expected []db.ExpectedFinding
 	gdb.Where("repository_id = ?", repoID).Order("file, cwe").Find(&expected)

--- a/internal/web/expected_findings.go
+++ b/internal/web/expected_findings.go
@@ -126,8 +126,6 @@ func skillSchemaVersion(skill db.Skill) int {
 	switch v := meta["scrutineer.version"].(type) {
 	case float64:
 		return int(v)
-	case int:
-		return v
 	default:
 		return 0
 	}

--- a/internal/web/expected_findings.go
+++ b/internal/web/expected_findings.go
@@ -35,55 +35,6 @@ func (s *Server) apiListExpectedFindings(w http.ResponseWriter, r *http.Request)
 	writeJSON(w, http.StatusOK, expectedFindingResponses(rows))
 }
 
-func (s *Server) apiAddExpectedFinding(w http.ResponseWriter, r *http.Request) {
-	repoID, ok := s.repoScopedID(w, r)
-	if !ok {
-		return
-	}
-	var body struct {
-		File string `json:"file"`
-		CWE  string `json:"cwe"`
-		CVE  string `json:"cve"`
-		Note string `json:"note"`
-	}
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-		writeAPIError(w, http.StatusBadRequest, "body must be JSON")
-		return
-	}
-	row, err := buildExpectedFinding(repoID, body.File, body.CWE, body.CVE, body.Note)
-	if err != nil {
-		writeAPIError(w, http.StatusUnprocessableEntity, err.Error())
-		return
-	}
-	if err := s.DB.Create(&row).Error; err != nil {
-		writeAPIError(w, http.StatusUnprocessableEntity, err.Error())
-		return
-	}
-	writeJSON(w, http.StatusCreated, expectedFindingResponseFrom(row))
-}
-
-func (s *Server) apiDeleteExpectedFinding(w http.ResponseWriter, r *http.Request) {
-	repoID, ok := s.repoScopedID(w, r)
-	if !ok {
-		return
-	}
-	expectedID, err := strconv.Atoi(r.PathValue("expected_id"))
-	if err != nil {
-		writeAPIError(w, http.StatusBadRequest, "invalid expected finding id")
-		return
-	}
-	res := s.DB.Where("repository_id = ? AND id = ?", repoID, expectedID).Delete(&db.ExpectedFinding{})
-	if res.Error != nil {
-		writeAPIError(w, http.StatusInternalServerError, res.Error.Error())
-		return
-	}
-	if res.RowsAffected == 0 {
-		writeAPIError(w, http.StatusNotFound, "expected finding not found")
-		return
-	}
-	w.WriteHeader(http.StatusNoContent)
-}
-
 func (s *Server) repoExpectedFindingCreate(w http.ResponseWriter, r *http.Request) {
 	repo, ok := loadByID[db.Repository](s, w, r)
 	if !ok {
@@ -128,15 +79,16 @@ func (s *Server) repoExpectedFindingDelete(w http.ResponseWriter, r *http.Reques
 }
 
 func buildExpectedFinding(repoID uint, file, cwe, cve, note string) (db.ExpectedFinding, error) {
+	cleanFile, err := cleanExpectedFileInput(file)
+	if err != nil {
+		return db.ExpectedFinding{}, err
+	}
 	row := db.ExpectedFinding{
 		RepositoryID: repoID,
-		File:         normalizeExpectedFile(file),
-		CWE:          strings.ToUpper(strings.TrimSpace(cwe)),
+		File:         cleanFile,
+		CWE:          normalizeCWE(cwe),
 		CVE:          strings.TrimSpace(cve),
 		Note:         strings.TrimSpace(note),
-	}
-	if row.File == "" || row.File == "." {
-		return row, fmt.Errorf("file is required")
 	}
 	if row.CWE == "" {
 		return row, fmt.Errorf("cwe is required")
@@ -206,9 +158,16 @@ func loadRepoExpectedView(gdb *gorm.DB, repoID uint, latest *db.Scan, rf repoFin
 	if latest != nil {
 		latestScanID = latest.ID
 	}
-	visibleFindings := make([]db.Finding, 0, len(rf.DeepDive)+len(rf.Scanners))
+	visibleCap := len(rf.DeepDive) + len(rf.Scanners)
+	if latest != nil {
+		visibleCap += len(latest.Findings)
+	}
+	visibleFindings := make([]db.Finding, 0, visibleCap)
 	visibleFindings = append(visibleFindings, rf.DeepDive...)
 	visibleFindings = append(visibleFindings, rf.Scanners...)
+	if latest != nil {
+		visibleFindings = append(visibleFindings, latest.Findings...)
+	}
 	return repoExpectedView{
 		Matches:       expectedMatchesForRows(gdb, repoID, latestScanID, expected),
 		FindingStatus: expectedStatusForFindings(visibleFindings, expected),
@@ -235,9 +194,10 @@ func expectedMatchesForRows(gdb *gorm.DB, repoID, scanID uint, expected []db.Exp
 	var findings []db.Finding
 	gdb.Where("repository_id = ? AND scan_id = ?", repoID, scanID).Find(&findings)
 	for _, f := range findings {
-		if db.SeverityAtLeast(f.Severity, "Medium") {
-			out.FindingTotal++
+		if !db.SeverityAtLeast(f.Severity, "Medium") {
+			continue
 		}
+		out.FindingTotal++
 		for i := range out.Expected {
 			if findingMatchesExpected(f, out.Expected[i].Expected) {
 				out.FindingStatus[f.ID] = true
@@ -266,7 +226,7 @@ func expectedStatusForFindings(findings []db.Finding, expected []db.ExpectedFind
 }
 
 func findingMatchesExpected(f db.Finding, expected db.ExpectedFinding) bool {
-	if strings.TrimSpace(f.CWE) != strings.TrimSpace(expected.CWE) {
+	if normalizeCWE(f.CWE) != normalizeCWE(expected.CWE) {
 		return false
 	}
 	want := normalizeExpectedFile(expected.File)
@@ -293,6 +253,25 @@ func normalizeExpectedFile(file string) string {
 	return cleanRepoPath(file)
 }
 
+func cleanExpectedFileInput(file string) (string, error) {
+	raw := strings.TrimSpace(strings.ReplaceAll(file, "\\", "/"))
+	if raw == "" {
+		return "", fmt.Errorf("file is required")
+	}
+	if path.IsAbs(raw) || hasParentPathSegment(raw) {
+		return "", fmt.Errorf("file must be relative to the repository root")
+	}
+	clean := cleanRepoPath(raw)
+	if clean == "" || clean == "." || path.IsAbs(clean) || hasParentPathSegment(clean) {
+		return "", fmt.Errorf("file must be relative to the repository root")
+	}
+	return clean, nil
+}
+
+func normalizeCWE(cwe string) string {
+	return strings.ToUpper(strings.TrimSpace(cwe))
+}
+
 func normalizeLocationFile(loc string) string {
 	loc = strings.TrimSpace(strings.Split(strings.TrimSpace(loc), "\n")[0])
 	for {
@@ -307,11 +286,22 @@ func normalizeLocationFile(loc string) string {
 
 func cleanRepoPath(p string) string {
 	p = strings.TrimSpace(strings.ReplaceAll(p, "\\", "/"))
-	p = strings.TrimPrefix(p, "./")
+	for strings.HasPrefix(p, "./") {
+		p = strings.TrimPrefix(p, "./")
+	}
 	if p == "" {
 		return ""
 	}
 	return path.Clean(p)
+}
+
+func hasParentPathSegment(p string) bool {
+	for _, part := range strings.Split(p, "/") {
+		if part == ".." {
+			return true
+		}
+	}
+	return false
 }
 
 func allDigits(s string) bool {

--- a/internal/web/expected_findings.go
+++ b/internal/web/expected_findings.go
@@ -140,10 +140,11 @@ type expectedFindingStatus struct {
 }
 
 type expectedMatchSet struct {
-	Expected      []expectedFindingStatus
-	FindingStatus map[uint]bool
-	MatchedTotal  int
-	FindingTotal  int
+	Expected             []expectedFindingStatus
+	FindingStatus        map[uint]bool
+	MatchedTotal         int
+	FindingTotal         int
+	TruePositiveFindings int
 }
 
 type repoExpectedView struct {
@@ -155,8 +156,8 @@ func loadRepoExpectedView(gdb *gorm.DB, repoID uint, latest *db.Scan, rf repoFin
 	var expected []db.ExpectedFinding
 	gdb.Where("repository_id = ?", repoID).Order("file, cwe").Find(&expected)
 	latestScanID := uint(0)
-	if latest != nil {
-		latestScanID = latest.ID
+	if scan := latestBenchmarkScan(gdb, repoID, "", "", ""); scan != nil {
+		latestScanID = scan.ID
 	}
 	visibleCap := len(rf.DeepDive) + len(rf.Scanners)
 	if latest != nil {
@@ -198,15 +199,20 @@ func expectedMatchesForRows(gdb *gorm.DB, repoID, scanID uint, expected []db.Exp
 			continue
 		}
 		out.FindingTotal++
+		findingMatched := false
 		for i := range out.Expected {
 			if findingMatchesExpected(f, out.Expected[i].Expected) {
 				out.FindingStatus[f.ID] = true
+				findingMatched = true
 				if !out.Expected[i].Matched {
 					out.Expected[i].Matched = true
 					out.Expected[i].FindingID = f.ID
 					out.MatchedTotal++
 				}
 			}
+		}
+		if findingMatched {
+			out.TruePositiveFindings++
 		}
 	}
 	return out

--- a/internal/web/expected_findings_test.go
+++ b/internal/web/expected_findings_test.go
@@ -119,7 +119,7 @@ func TestExpectedFindingMatchingIgnoresLineNumbers(t *testing.T) {
 	s.DB.Create(&unexpected)
 
 	got := expectedMatchesForScan(s.DB, repo.ID, scan.ID)
-	if got.MatchedTotal != 1 || got.FindingTotal != 2 {
+	if got.MatchedTotal != 1 || got.FindingTotal != 2 || got.TruePositiveFindings != 1 {
 		t.Fatalf("matches = %+v", got)
 	}
 	if !got.FindingStatus[matched.ID] || got.FindingStatus[unexpected.ID] {
@@ -127,6 +127,42 @@ func TestExpectedFindingMatchingIgnoresLineNumbers(t *testing.T) {
 	}
 	if len(got.Expected) != 1 || !got.Expected[0].Matched || got.Expected[0].FindingID != matched.ID {
 		t.Fatalf("expected status = %+v", got.Expected)
+	}
+}
+
+func TestExpectedFindingPrecisionUsesTruePositiveFindings(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	repo := db.Repository{URL: "https://example.com/bench-precision", Name: "bench-precision"}
+	s.DB.Create(&repo)
+	scan := db.Scan{RepositoryID: repo.ID, Kind: "skill", SkillName: "vuln-scan", Status: db.ScanDone}
+	s.DB.Create(&scan)
+	s.DB.Create(&db.ExpectedFinding{RepositoryID: repo.ID, File: "src/a.go", CWE: "CWE-79"})
+	s.DB.Create(&db.ExpectedFinding{RepositoryID: repo.ID, File: "src/b.go", CWE: "CWE-79"})
+	finding := db.Finding{
+		RepositoryID: repo.ID,
+		ScanID:       scan.ID,
+		Title:        "xss",
+		Severity:     "High",
+		CWE:          "CWE-79",
+		Location:     "src/a.go:7",
+		Locations:    "src/a.go:7\nsrc/b.go:9",
+	}
+	s.DB.Create(&finding)
+
+	got := expectedMatchesForScan(s.DB, repo.ID, scan.ID)
+	if got.MatchedTotal != 2 || got.FindingTotal != 1 || got.TruePositiveFindings != 1 {
+		t.Fatalf("matches = %+v", got)
+	}
+	rows, totals := loadBenchmarkRows(s.DB, "vuln-scan", "", "")
+	if len(rows) != 1 {
+		t.Fatalf("rows = %+v", rows)
+	}
+	if rows[0].Recall != 1 || rows[0].Precision != 1 || rows[0].F1 != 1 {
+		t.Fatalf("row metrics = recall %.2f precision %.2f f1 %.2f", rows[0].Recall, rows[0].Precision, rows[0].F1)
+	}
+	if totals.Recall != 1 || totals.Precision != 1 || totals.F1 != 1 {
+		t.Fatalf("totals = %+v", totals)
 	}
 }
 
@@ -142,7 +178,7 @@ func TestExpectedFindingMatchingIgnoresLowSeverityForBenchmarkTotals(t *testing.
 	s.DB.Create(&low)
 
 	got := expectedMatchesForScan(s.DB, repo.ID, scan.ID)
-	if got.MatchedTotal != 0 || got.FindingTotal != 0 || got.FindingStatus[low.ID] {
+	if got.MatchedTotal != 0 || got.FindingTotal != 0 || got.TruePositiveFindings != 0 || got.FindingStatus[low.ID] {
 		t.Fatalf("low severity finding affected benchmark totals/status: %+v", got)
 	}
 }
@@ -197,6 +233,32 @@ func TestRepoShowExpectedFindingBadges(t *testing.T) {
 	}
 	if !strings.Contains(fixedRow, "expected") || strings.Contains(fixedRow, "unexpected") {
 		t.Fatalf("closed latest finding badge row = %s", fixedRow)
+	}
+}
+
+func TestRepoShowBenchmarkTabUsesLatestVulnScan(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	repo := db.Repository{URL: "https://example.com/bench-vuln", Name: "bench-vuln"}
+	s.DB.Create(&repo)
+	scan := db.Scan{RepositoryID: repo.ID, Kind: "skill", SkillName: vulnScanSkillName, Status: db.ScanDone, Model: "test-model"}
+	s.DB.Create(&scan)
+	s.DB.Create(&db.ExpectedFinding{RepositoryID: repo.ID, File: "src/app.go", CWE: "CWE-79"})
+	s.DB.Create(&db.Finding{RepositoryID: repo.ID, ScanID: scan.ID, Title: "scanner xss", Severity: "High", CWE: "CWE-79", Location: "src/app.go:7", Status: db.FindingNew})
+
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq(http.MethodGet, fmt.Sprintf("/repositories/%d", repo.ID)))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+	body := w.Body.String()
+	for _, want := range []string{"Benchmark", "1/1", "scanner xss", "expected"} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("body missing %q:\n%s", want, body)
+		}
+	}
+	if strings.Contains(body, "missed") {
+		t.Fatalf("vuln-scan-only expected row was marked missed:\n%s", body)
 	}
 }
 

--- a/internal/web/expected_findings_test.go
+++ b/internal/web/expected_findings_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strconv"
 	"strings"
 	"testing"
@@ -16,6 +17,8 @@ func TestExpectedFindingsAPI(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()
 	repo, scan := seedRunningScan(t, s)
+	row := db.ExpectedFinding{RepositoryID: repo.ID, File: "src/app.go", CWE: "CWE-79", CVE: "CVE-2026-0001", Note: "known sink"}
+	s.DB.Create(&row)
 
 	req := httptest.NewRequest(http.MethodPost, "/api/repositories/"+strconv.FormatUint(uint64(repo.ID), 10)+"/expected",
 		strings.NewReader(`{"file":"./src/app.go","cwe":"cwe-79","cve":"CVE-2026-0001","note":"known sink"}`))
@@ -23,15 +26,8 @@ func TestExpectedFindingsAPI(t *testing.T) {
 	req.Header.Set("Authorization", "Bearer "+scan.APIToken)
 	w := httptest.NewRecorder()
 	s.Handler().ServeHTTP(w, req)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("POST status %d: %s", w.Code, w.Body)
-	}
-	var created expectedFindingResponse
-	if err := json.NewDecoder(w.Body).Decode(&created); err != nil {
-		t.Fatalf("decode create: %v", err)
-	}
-	if created.File != "src/app.go" || created.CWE != "CWE-79" {
-		t.Fatalf("created = %+v", created)
+	if w.Code == http.StatusCreated || w.Code == http.StatusOK || w.Code == http.StatusNoContent {
+		t.Fatalf("scan-token POST unexpectedly succeeded: status %d", w.Code)
 	}
 
 	req = httptest.NewRequest(http.MethodGet, "/api/repositories/"+strconv.FormatUint(uint64(repo.ID), 10)+"/expected", nil)
@@ -46,18 +42,60 @@ func TestExpectedFindingsAPI(t *testing.T) {
 	if err := json.NewDecoder(w.Body).Decode(&rows); err != nil {
 		t.Fatalf("decode list: %v", err)
 	}
-	if len(rows) != 1 || rows[0].ID != created.ID {
+	if len(rows) != 1 || rows[0].ID != row.ID {
 		t.Fatalf("rows = %+v", rows)
 	}
 
 	req = httptest.NewRequest(http.MethodDelete,
-		fmt.Sprintf("/api/repositories/%d/expected/%d", repo.ID, created.ID), nil)
+		fmt.Sprintf("/api/repositories/%d/expected/%d", repo.ID, row.ID), nil)
 	req.Host = testHost
 	req.Header.Set("Authorization", "Bearer "+scan.APIToken)
 	w = httptest.NewRecorder()
 	s.Handler().ServeHTTP(w, req)
-	if w.Code != http.StatusNoContent {
-		t.Fatalf("DELETE status %d: %s", w.Code, w.Body)
+	if w.Code == http.StatusNoContent || w.Code == http.StatusOK {
+		t.Fatalf("scan-token DELETE unexpectedly succeeded: status %d", w.Code)
+	}
+	var count int64
+	s.DB.Model(&db.ExpectedFinding{}).Where("repository_id = ?", repo.ID).Count(&count)
+	if count != 1 {
+		t.Fatalf("expected findings count = %d, want unchanged row", count)
+	}
+}
+
+func TestExpectedFindingForms(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	repo := db.Repository{URL: "https://example.com/bench-form", Name: "bench-form"}
+	s.DB.Create(&repo)
+
+	form := url.Values{
+		"file": {"./src/app.go"},
+		"cwe":  {"cwe-79"},
+		"cve":  {"CVE-2026-0001"},
+		"note": {"known sink"},
+	}
+	req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/repositories/%d/expected", repo.ID), strings.NewReader(form.Encode()))
+	req.Host = testHost
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("create status %d: %s", w.Code, w.Body)
+	}
+	var row db.ExpectedFinding
+	if err := s.DB.Where("repository_id = ?", repo.ID).First(&row).Error; err != nil {
+		t.Fatalf("expected finding was not created: %v", err)
+	}
+	if row.File != "src/app.go" || row.CWE != "CWE-79" {
+		t.Fatalf("created row = %+v", row)
+	}
+
+	req = httptest.NewRequest(http.MethodPost, fmt.Sprintf("/repositories/%d/expected/%d/delete", repo.ID, row.ID), nil)
+	req.Host = testHost
+	w = httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("delete status %d: %s", w.Code, w.Body)
 	}
 	var count int64
 	s.DB.Model(&db.ExpectedFinding{}).Where("repository_id = ?", repo.ID).Count(&count)
@@ -75,7 +113,7 @@ func TestExpectedFindingMatchingIgnoresLineNumbers(t *testing.T) {
 	s.DB.Create(&scan)
 	expected := db.ExpectedFinding{RepositoryID: repo.ID, File: "src/app.go", CWE: "CWE-79"}
 	s.DB.Create(&expected)
-	matched := db.Finding{RepositoryID: repo.ID, ScanID: scan.ID, Title: "xss", Severity: "High", CWE: "CWE-79", Location: "src/app.go:77:4"}
+	matched := db.Finding{RepositoryID: repo.ID, ScanID: scan.ID, Title: "xss", Severity: "High", CWE: "cwe-79", Location: "src/app.go:77:4"}
 	unexpected := db.Finding{RepositoryID: repo.ID, ScanID: scan.ID, Title: "sqli", Severity: "Medium", CWE: "CWE-89", Location: "src/app.go:88"}
 	s.DB.Create(&matched)
 	s.DB.Create(&unexpected)
@@ -92,6 +130,39 @@ func TestExpectedFindingMatchingIgnoresLineNumbers(t *testing.T) {
 	}
 }
 
+func TestExpectedFindingMatchingIgnoresLowSeverityForBenchmarkTotals(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	repo := db.Repository{URL: "https://example.com/bench-low", Name: "bench-low"}
+	s.DB.Create(&repo)
+	scan := db.Scan{RepositoryID: repo.ID, Kind: "skill", SkillName: "vuln-scan", Status: db.ScanDone}
+	s.DB.Create(&scan)
+	s.DB.Create(&db.ExpectedFinding{RepositoryID: repo.ID, File: "src/app.go", CWE: "CWE-79"})
+	low := db.Finding{RepositoryID: repo.ID, ScanID: scan.ID, Title: "low xss", Severity: "Low", CWE: "CWE-79", Location: "src/app.go:77"}
+	s.DB.Create(&low)
+
+	got := expectedMatchesForScan(s.DB, repo.ID, scan.ID)
+	if got.MatchedTotal != 0 || got.FindingTotal != 0 || got.FindingStatus[low.ID] {
+		t.Fatalf("low severity finding affected benchmark totals/status: %+v", got)
+	}
+}
+
+func TestBuildExpectedFindingRejectsNonRepoRelativePaths(t *testing.T) {
+	bad := []string{"/etc/passwd", "../x.go", "src/../x.go", `src\..\x.go`}
+	for _, file := range bad {
+		if _, err := buildExpectedFinding(1, file, "CWE-79", "", ""); err == nil {
+			t.Fatalf("buildExpectedFinding(%q) succeeded, want error", file)
+		}
+	}
+	row, err := buildExpectedFinding(1, "./src/app.go", "cwe-79", "", "")
+	if err != nil {
+		t.Fatalf("valid expected finding rejected: %v", err)
+	}
+	if row.File != "src/app.go" || row.CWE != "CWE-79" {
+		t.Fatalf("normalized row = %+v", row)
+	}
+}
+
 func TestRepoShowExpectedFindingBadges(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()
@@ -100,7 +171,9 @@ func TestRepoShowExpectedFindingBadges(t *testing.T) {
 	scan := db.Scan{RepositoryID: repo.ID, Kind: "skill", SkillName: deepDiveSkillName, Status: db.ScanDone, Model: "test-model"}
 	s.DB.Create(&scan)
 	s.DB.Create(&db.ExpectedFinding{RepositoryID: repo.ID, File: "src/app.go", CWE: "CWE-79"})
+	s.DB.Create(&db.ExpectedFinding{RepositoryID: repo.ID, File: "src/fixed.go", CWE: "CWE-22"})
 	s.DB.Create(&db.Finding{RepositoryID: repo.ID, ScanID: scan.ID, Title: "expected xss", Severity: "High", CWE: "CWE-79", Location: "src/app.go:7", Status: db.FindingNew})
+	s.DB.Create(&db.Finding{RepositoryID: repo.ID, ScanID: scan.ID, Title: "fixed path traversal", Severity: "High", CWE: "CWE-22", Location: "src/fixed.go:9", Status: db.FindingFixed})
 	s.DB.Create(&db.Finding{RepositoryID: repo.ID, ScanID: scan.ID, Title: "surprise sqli", Severity: "High", CWE: "CWE-89", Location: "src/db.go:9", Status: db.FindingNew})
 
 	w := httptest.NewRecorder()
@@ -109,10 +182,21 @@ func TestRepoShowExpectedFindingBadges(t *testing.T) {
 		t.Fatalf("status %d: %s", w.Code, w.Body)
 	}
 	body := w.Body.String()
-	for _, want := range []string{"Benchmark", "1/1", "matched", "expected xss", "unexpected"} {
+	for _, want := range []string{"Benchmark", "2/2", "matched", "expected xss", "unexpected"} {
 		if !strings.Contains(body, want) {
 			t.Fatalf("body missing %q:\n%s", want, body)
 		}
+	}
+	fixedIdx := strings.Index(body, "fixed path traversal")
+	if fixedIdx < 0 {
+		t.Fatalf("body missing closed latest finding:\n%s", body)
+	}
+	fixedRow := body[fixedIdx:]
+	if end := strings.Index(fixedRow, "</tr>"); end >= 0 {
+		fixedRow = fixedRow[:end]
+	}
+	if !strings.Contains(fixedRow, "expected") || strings.Contains(fixedRow, "unexpected") {
+		t.Fatalf("closed latest finding badge row = %s", fixedRow)
 	}
 }
 

--- a/internal/web/expected_findings_test.go
+++ b/internal/web/expected_findings_test.go
@@ -1,0 +1,156 @@
+package web
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	"scrutineer/internal/db"
+)
+
+func TestExpectedFindingsAPI(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	repo, scan := seedRunningScan(t, s)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/repositories/"+strconv.FormatUint(uint64(repo.ID), 10)+"/expected",
+		strings.NewReader(`{"file":"./src/app.go","cwe":"cwe-79","cve":"CVE-2026-0001","note":"known sink"}`))
+	req.Host = testHost
+	req.Header.Set("Authorization", "Bearer "+scan.APIToken)
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("POST status %d: %s", w.Code, w.Body)
+	}
+	var created expectedFindingResponse
+	if err := json.NewDecoder(w.Body).Decode(&created); err != nil {
+		t.Fatalf("decode create: %v", err)
+	}
+	if created.File != "src/app.go" || created.CWE != "CWE-79" {
+		t.Fatalf("created = %+v", created)
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/api/repositories/"+strconv.FormatUint(uint64(repo.ID), 10)+"/expected", nil)
+	req.Host = testHost
+	req.Header.Set("Authorization", "Bearer "+scan.APIToken)
+	w = httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET status %d: %s", w.Code, w.Body)
+	}
+	var rows []expectedFindingResponse
+	if err := json.NewDecoder(w.Body).Decode(&rows); err != nil {
+		t.Fatalf("decode list: %v", err)
+	}
+	if len(rows) != 1 || rows[0].ID != created.ID {
+		t.Fatalf("rows = %+v", rows)
+	}
+
+	req = httptest.NewRequest(http.MethodDelete,
+		fmt.Sprintf("/api/repositories/%d/expected/%d", repo.ID, created.ID), nil)
+	req.Host = testHost
+	req.Header.Set("Authorization", "Bearer "+scan.APIToken)
+	w = httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("DELETE status %d: %s", w.Code, w.Body)
+	}
+	var count int64
+	s.DB.Model(&db.ExpectedFinding{}).Where("repository_id = ?", repo.ID).Count(&count)
+	if count != 0 {
+		t.Fatalf("expected findings count = %d, want 0", count)
+	}
+}
+
+func TestExpectedFindingMatchingIgnoresLineNumbers(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	repo := db.Repository{URL: "https://example.com/bench", Name: "bench"}
+	s.DB.Create(&repo)
+	scan := db.Scan{RepositoryID: repo.ID, Kind: "skill", SkillName: "vuln-scan", Status: db.ScanDone}
+	s.DB.Create(&scan)
+	expected := db.ExpectedFinding{RepositoryID: repo.ID, File: "src/app.go", CWE: "CWE-79"}
+	s.DB.Create(&expected)
+	matched := db.Finding{RepositoryID: repo.ID, ScanID: scan.ID, Title: "xss", Severity: "High", CWE: "CWE-79", Location: "src/app.go:77:4"}
+	unexpected := db.Finding{RepositoryID: repo.ID, ScanID: scan.ID, Title: "sqli", Severity: "Medium", CWE: "CWE-89", Location: "src/app.go:88"}
+	s.DB.Create(&matched)
+	s.DB.Create(&unexpected)
+
+	got := expectedMatchesForScan(s.DB, repo.ID, scan.ID)
+	if got.MatchedTotal != 1 || got.FindingTotal != 2 {
+		t.Fatalf("matches = %+v", got)
+	}
+	if !got.FindingStatus[matched.ID] || got.FindingStatus[unexpected.ID] {
+		t.Fatalf("finding status = %+v", got.FindingStatus)
+	}
+	if len(got.Expected) != 1 || !got.Expected[0].Matched || got.Expected[0].FindingID != matched.ID {
+		t.Fatalf("expected status = %+v", got.Expected)
+	}
+}
+
+func TestRepoShowExpectedFindingBadges(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	repo := db.Repository{URL: "https://example.com/bench-ui", Name: "bench-ui"}
+	s.DB.Create(&repo)
+	scan := db.Scan{RepositoryID: repo.ID, Kind: "skill", SkillName: deepDiveSkillName, Status: db.ScanDone, Model: "test-model"}
+	s.DB.Create(&scan)
+	s.DB.Create(&db.ExpectedFinding{RepositoryID: repo.ID, File: "src/app.go", CWE: "CWE-79"})
+	s.DB.Create(&db.Finding{RepositoryID: repo.ID, ScanID: scan.ID, Title: "expected xss", Severity: "High", CWE: "CWE-79", Location: "src/app.go:7", Status: db.FindingNew})
+	s.DB.Create(&db.Finding{RepositoryID: repo.ID, ScanID: scan.ID, Title: "surprise sqli", Severity: "High", CWE: "CWE-89", Location: "src/db.go:9", Status: db.FindingNew})
+
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq(http.MethodGet, fmt.Sprintf("/repositories/%d", repo.ID)))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+	body := w.Body.String()
+	for _, want := range []string{"Benchmark", "1/1", "matched", "expected xss", "unexpected"} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("body missing %q:\n%s", want, body)
+		}
+	}
+}
+
+func TestBenchmarkPageRollupUsesLatestCompletedScan(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	repo := db.Repository{URL: "https://example.com/bench-rollup", Name: "bench-rollup"}
+	s.DB.Create(&repo)
+	s.DB.Create(&db.ExpectedFinding{RepositoryID: repo.ID, File: "src/a.go", CWE: "CWE-79"})
+	s.DB.Create(&db.ExpectedFinding{RepositoryID: repo.ID, File: "src/b.go", CWE: "CWE-89"})
+	oldScan := db.Scan{RepositoryID: repo.ID, Kind: "skill", SkillName: "vuln-scan", Status: db.ScanDone, Model: "old"}
+	s.DB.Create(&oldScan)
+	newScan := db.Scan{RepositoryID: repo.ID, Kind: "skill", SkillName: "vuln-scan", Status: db.ScanDone, Model: "claude-test", SkillsRepoSHA: "abc123456789", SkillSchemaVersion: 1}
+	s.DB.Create(&newScan)
+	metadataScan := db.Scan{RepositoryID: repo.ID, Kind: "skill", SkillName: "metadata", Status: db.ScanDone, Model: "claude-test"}
+	s.DB.Create(&metadataScan)
+	s.DB.Create(&db.Finding{RepositoryID: repo.ID, ScanID: oldScan.ID, Title: "old", Severity: "High", CWE: "CWE-89", Location: "src/b.go:1"})
+	s.DB.Create(&db.Finding{RepositoryID: repo.ID, ScanID: newScan.ID, Title: "xss", Severity: "High", CWE: "CWE-79", Location: "src/a.go:1"})
+	s.DB.Create(&db.Finding{RepositoryID: repo.ID, ScanID: newScan.ID, Title: "extra", Severity: "Medium", CWE: "CWE-22", Location: "src/c.go:1"})
+
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq(http.MethodGet, "/benchmark?skill=vuln-scan"))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+	body := w.Body.String()
+	for _, want := range []string{"bench-rollup", "50%", "1 / 2", "claude-test", "v1", "abc123456789"} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("body missing %q:\n%s", want, body)
+		}
+	}
+
+	w = httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq(http.MethodGet, "/benchmark"))
+	if w.Code != http.StatusOK {
+		t.Fatalf("default status %d: %s", w.Code, w.Body)
+	}
+	if strings.Contains(w.Body.String(), fmt.Sprintf("/scans/%d", metadataScan.ID)) {
+		t.Fatalf("default benchmark selected metadata scan:\n%s", w.Body)
+	}
+}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -322,6 +322,8 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("POST /repositories/bulk", s.repoBulkCreate)
 	mux.HandleFunc("POST /repositories/org", s.repoOrgImport)
 	mux.HandleFunc("GET /repositories/{id}", s.repoShow)
+	mux.HandleFunc("POST /repositories/{id}/expected", s.repoExpectedFindingCreate)
+	mux.HandleFunc("POST /repositories/{id}/expected/{expected_id}/delete", s.repoExpectedFindingDelete)
 	mux.HandleFunc("GET /repositories/{id}/blob/{commit}/{path...}", s.repoBlob)
 	mux.HandleFunc("GET /repositories/{id}/report.md", s.repoReport)
 	mux.HandleFunc("POST /repositories/{id}/scan", s.repoScan)
@@ -341,6 +343,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("GET /maintainers/{id}", s.maintainerShow)
 	mux.HandleFunc("POST /maintainers/{id}/do-not-contact", s.maintainerDoNotContact)
 	mux.HandleFunc("GET /findings", s.findings)
+	mux.HandleFunc("GET /benchmark", s.benchmark)
 	mux.HandleFunc("GET /audit", s.auditPage)
 	mux.HandleFunc("POST /findings/{id}/reviews", s.findingReviewCreate)
 	mux.HandleFunc("GET /findings/{id}", s.findingShow)
@@ -480,7 +483,7 @@ func navKey(path string) string {
 	for _, p := range []struct{ prefix, key string }{
 		{"/settings", "settings"}, {"/usage", "usage"}, {"/skills", "skills"}, {"/maintainers", "maintainers"},
 		{"/orgs", "orgs"}, {"/packages", "packages"}, {"/advisories", "advisories"},
-		{"/findings", "findings"}, {"/scans", "scans"}, {"/sboms", "sboms"}, {"/audit", "audit"},
+		{"/findings", "findings"}, {"/benchmark", "benchmark"}, {"/scans", "scans"}, {"/sboms", "sboms"}, {"/audit", "audit"},
 	} {
 		if strings.HasPrefix(path, p.prefix) {
 			return p.key
@@ -1993,6 +1996,17 @@ func (s *Server) repoShow(w http.ResponseWriter, r *http.Request) {
 
 	category := r.URL.Query().Get("category")
 	rf := loadRepoFindings(s.DB, repo.ID, category)
+	var expectedRows []db.ExpectedFinding
+	s.DB.Where("repository_id = ?", repo.ID).Order("file, cwe").Find(&expectedRows)
+	latestScanID := uint(0)
+	if latest != nil {
+		latestScanID = latest.ID
+	}
+	expectedMatches := expectedMatchesForRows(s.DB, repo.ID, latestScanID, expectedRows)
+	visibleFindings := make([]db.Finding, 0, len(rf.DeepDive)+len(rf.Scanners))
+	visibleFindings = append(visibleFindings, rf.DeepDive...)
+	visibleFindings = append(visibleFindings, rf.Scanners...)
+	expectedFindingStatus := expectedStatusForFindings(visibleFindings, expectedRows)
 
 	// Count deep-dive findings still awaiting verification, scoped to the
 	// same category filter as the visible list. Drives the "Verify all new"
@@ -2096,17 +2110,20 @@ func (s *Server) repoShow(w http.ResponseWriter, r *http.Request) {
 
 	data := map[string]any{
 		"Repo": repo, "Scans": scans, "Latest": latest,
-		"Findings":             rf.DeepDive,
-		"FindingsTotal":        rf.DeepDiveTotal,
-		"ScannerFindings":      rf.Scanners,
-		"ScannerFindingsTotal": rf.ScannersTotal,
-		"ScanSkill":            rf.ScanSkill,
-		"ScanCommit":           rf.ScanCommit,
-		"NewFindingCount":      int(newFindings),
-		"FailedScans":          failedScans,
-		"ActiveScans":          int(activeScans),
-		"PausedScans":          int(pausedScans),
-		"TotalCost":            totalCost,
+		"Findings":              rf.DeepDive,
+		"FindingsTotal":         rf.DeepDiveTotal,
+		"ScannerFindings":       rf.Scanners,
+		"ScannerFindingsTotal":  rf.ScannersTotal,
+		"ScanSkill":             rf.ScanSkill,
+		"ScanCommit":            rf.ScanCommit,
+		"ExpectedFindings":      expectedMatches.Expected,
+		"ExpectedMatched":       expectedMatches.MatchedTotal,
+		"ExpectedFindingStatus": expectedFindingStatus,
+		"NewFindingCount":       int(newFindings),
+		"FailedScans":           failedScans,
+		"ActiveScans":           int(activeScans),
+		"PausedScans":           int(pausedScans),
+		"TotalCost":             totalCost,
 		// Cached on the row, refreshed by the worker after each scan (#126).
 		"DiskBytes":  repo.DiskBytes,
 		"TMCommit":   tmCommit,
@@ -2407,7 +2424,7 @@ func (s *Server) enqueueSkillWith(ctx context.Context, repoID, skillID uint, opt
 		return 0, err
 	}
 	var sk db.Skill
-	hasSkill := s.DB.Select("name, requires_remote, requires_profile, model").First(&sk, skillID).Error == nil
+	hasSkill := s.DB.Select("name, version, metadata, requires_remote, requires_profile, model").First(&sk, skillID).Error == nil
 	if repo.IsLocal() && hasSkill && sk.RequiresRemote {
 		return 0, fmt.Errorf("%w: %q", ErrSkillRequiresRemote, sk.Name)
 	}
@@ -2435,26 +2452,28 @@ func (s *Server) enqueueSkillWith(ctx context.Context, repoID, skillID uint, opt
 		kind = worker.JobExposure
 	}
 	scan := db.Scan{
-		RepositoryID:      repoID,
-		Kind:              kind,
-		Status:            db.ScanQueued,
-		StatusPriority:    db.StatusPriorityFor(db.ScanQueued),
-		Model:             opts.Model,
-		Effort:            opts.Effort,
-		SkillID:           &skillID,
-		SkillName:         sk.Name,
-		FindingID:         opts.FindingID,
-		DependentID:       opts.DependentID,
-		BaselineScanID:    opts.BaselineScanID,
-		SubPath:           opts.SubPath,
-		ScanGroup:         opts.ScanGroup,
-		Ref:               opts.Ref,
-		Profile:           opts.Profile,
-		SessionID:         opts.SessionID,
-		ResumedFromScanID: opts.ResumedFromScanID,
-		ImportPayload:     opts.ImportPayload,
-		SkillsRepoSHA:     s.SkillsRepoSHA,
-		APIToken:          NewAPIToken(),
+		RepositoryID:       repoID,
+		Kind:               kind,
+		Status:             db.ScanQueued,
+		StatusPriority:     db.StatusPriorityFor(db.ScanQueued),
+		Model:              opts.Model,
+		Effort:             opts.Effort,
+		SkillID:            &skillID,
+		SkillVersion:       sk.Version,
+		SkillSchemaVersion: skillSchemaVersion(sk),
+		SkillName:          sk.Name,
+		FindingID:          opts.FindingID,
+		DependentID:        opts.DependentID,
+		BaselineScanID:     opts.BaselineScanID,
+		SubPath:            opts.SubPath,
+		ScanGroup:          opts.ScanGroup,
+		Ref:                opts.Ref,
+		Profile:            opts.Profile,
+		SessionID:          opts.SessionID,
+		ResumedFromScanID:  opts.ResumedFromScanID,
+		ImportPayload:      opts.ImportPayload,
+		SkillsRepoSHA:      s.SkillsRepoSHA,
+		APIToken:           NewAPIToken(),
 	}
 	if err := s.DB.Create(&scan).Error; err != nil {
 		return 0, err

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -1940,12 +1940,156 @@ func (s *Server) repoShow(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
+	scans := loadRepoLatestScans(s.DB, repo.ID)
+	latest, tmScan := s.repoPrimaryScans(scans)
+	view := s.loadRepoShowView(repo, scans, latest, tmScan, r.URL.Query())
+	s.render(w, r, "repo_show.html", view.renderData())
+}
+
+type repoShowView struct {
+	Repo            db.Repository
+	Scans           []db.Scan
+	Latest          *db.Scan
+	Findings        repoFindings
+	Expected        repoExpectedView
+	Dependencies    repoDependencyView
+	Inventory       repoInventoryView
+	Subprojects     repoSubprojectView
+	Maintainers     []db.Maintainer
+	Skills          []db.Skill
+	Workbench       Workbench
+	ThreatModel     map[string]any
+	Category        string
+	TMCommit        string
+	NewFindingCount int
+	FailedScans     int
+	ActiveScans     int
+	PausedScans     int
+	TotalCost       float64
+}
+
+func (s *Server) loadRepoShowView(
+	repo db.Repository,
+	scans []db.Scan,
+	latest, tmScan *db.Scan,
+	query url.Values,
+) repoShowView {
+	category := query.Get("category")
+	findings := loadRepoFindings(s.DB, repo.ID, category)
+	deps := s.loadRepoDependencyView(repo.ID, query.Get("deps") == "all")
+	activeScans, pausedScans := s.repoScanActionCounts(repo.ID)
+	return repoShowView{
+		Repo:            repo,
+		Scans:           scans,
+		Latest:          latest,
+		Findings:        findings,
+		Expected:        loadRepoExpectedView(s.DB, repo.ID, latest, findings),
+		Dependencies:    deps,
+		Inventory:       s.loadRepoInventoryView(repo.ID, deps.Groups),
+		Subprojects:     s.loadRepoSubprojectView(repo.ID),
+		Maintainers:     s.repoMaintainers(repo.ID),
+		Skills:          s.activeRepoSkills(),
+		Workbench:       loadWorkbench(s.DB, &repo, workbenchSeed(tmScan)),
+		ThreatModel:     scanThreatModelReport(tmScan),
+		Category:        category,
+		TMCommit:        scanCommit(tmScan),
+		NewFindingCount: int(repoNewFindingsCount(s.DB, repo.ID, category)),
+		FailedScans:     countFailedScans(scans),
+		ActiveScans:     int(activeScans),
+		PausedScans:     int(pausedScans),
+		TotalCost:       repoTotalCost(s.DB, repo.ID),
+	}
+}
+
+func (v repoShowView) renderData() map[string]any {
+	return map[string]any{
+		"Repo":                  v.Repo,
+		"Scans":                 v.Scans,
+		"Latest":                v.Latest,
+		"Findings":              v.Findings.DeepDive,
+		"FindingsTotal":         v.Findings.DeepDiveTotal,
+		"ScannerFindings":       v.Findings.Scanners,
+		"ScannerFindingsTotal":  v.Findings.ScannersTotal,
+		"ScanSkill":             v.Findings.ScanSkill,
+		"ScanCommit":            v.Findings.ScanCommit,
+		"ExpectedFindings":      v.Expected.Matches.Expected,
+		"ExpectedMatched":       v.Expected.Matches.MatchedTotal,
+		"ExpectedFindingStatus": v.Expected.FindingStatus,
+		"NewFindingCount":       v.NewFindingCount,
+		"FailedScans":           v.FailedScans,
+		"ActiveScans":           v.ActiveScans,
+		"PausedScans":           v.PausedScans,
+		"TotalCost":             v.TotalCost,
+		"DiskBytes":             v.Repo.DiskBytes,
+		"TMCommit":              v.TMCommit,
+		"DepsCommit":            v.Dependencies.Commit,
+		"Deps":                  v.Dependencies.Groups,
+		"DepsTotal":             v.Dependencies.Total,
+		"Pkgs":                  v.Inventory.Packages,
+		"Dependents":            v.Inventory.Dependents,
+		"DependentsTotal":       v.Inventory.DependentsTotal,
+		"Advisories":            v.Inventory.Advisories,
+		"AdvisoriesTotal":       v.Inventory.AdvisoriesTotal,
+		"Maintainers":           v.Maintainers,
+		"ThreatModel":           v.ThreatModel,
+		"KnownURLs":             v.Inventory.KnownURLs,
+		"KnownPURLs":            v.Inventory.KnownPURLs,
+		"ShowAllDeps":           v.Dependencies.ShowAll,
+		"HiddenDeps":            v.Dependencies.Hidden,
+		"Skills":                v.Skills,
+		"Subprojects":           v.Subprojects.Rows,
+		"SubScanCount":          v.Subprojects.ScanCount,
+		"Workbench":             v.Workbench,
+		"Category":              v.Category,
+		"Categories":            CWECategories(),
+		"Uncategorized":         UncategorizedCWE,
+		"TabRowCap":             int64(tabRowCap),
+	}
+}
+
+func scanThreatModelReport(scan *db.Scan) map[string]any {
+	if scan == nil {
+		return nil
+	}
+	var report map[string]any
+	_ = json.Unmarshal([]byte(scan.Report), &report)
+	return report
+}
+
+func scanCommit(scan *db.Scan) string {
+	if scan == nil {
+		return ""
+	}
+	return scan.Commit
+}
+
+func repoTotalCost(gdb *gorm.DB, repoID uint) float64 {
+	var total float64
+	gdb.Model(&db.Scan{}).Where("repository_id = ?", repoID).
+		Select("COALESCE(SUM(cost_usd), 0)").Scan(&total)
+	return total
+}
+
+func (s *Server) repoMaintainers(repoID uint) []db.Maintainer {
+	var maintainers []db.Maintainer
+	s.DB.Joins("JOIN repository_maintainers ON repository_maintainers.maintainer_id = maintainers.id").
+		Where("repository_maintainers.repository_id = ?", repoID).Find(&maintainers)
+	return maintainers
+}
+
+func (s *Server) activeRepoSkills() []db.Skill {
+	var skills []db.Skill
+	s.DB.Where("active = ?", true).Order("name").Find(&skills)
+	return skills
+}
+
+func loadRepoLatestScans(gdb *gorm.DB, repoID uint) []db.Scan {
 	var scans []db.Scan
 	// Per (skill_name, sub_path) we want just the latest scan — the repo
 	// page should read like "this is the state of each job on this repo",
 	// not a scroll of every historical attempt. Older runs are still
 	// reachable via /scans/{id} and the global /scans index.
-	s.DB.Raw(`
+	gdb.Raw(`
 		SELECT s.* FROM scans s
 		JOIN (
 			SELECT COALESCE(skill_name, '') AS sn, COALESCE(sub_path, '') AS sp, MAX(id) AS max_id
@@ -1953,14 +2097,17 @@ func (s *Server) repoShow(w http.ResponseWriter, r *http.Request) {
 			GROUP BY sn, sp
 		) latest ON latest.max_id = s.id
 		ORDER BY s.id DESC
-	`, repo.ID).Scan(&scans)
+	`, repoID).Scan(&scans)
+	return scans
+}
 
+func (s *Server) repoPrimaryScans(scans []db.Scan) (latest, threatModel *db.Scan) {
 	// The security-deep-dive skill owns the structured audit report; the
 	// Summary and Findings tabs render from its scans. The Threat Model tab
 	// renders the threat-model skill's report when one exists, falling back
 	// to the deep-dive report's boundaries/inventory section so repositories
 	// scanned before the threat-model skill landed keep their tab content.
-	var latest, tmScan, tmFallback *db.Scan
+	var fallback *db.Scan
 	for i := range scans {
 		sc := &scans[i]
 		switch sc.SkillName {
@@ -1969,172 +2116,129 @@ func (s *Server) repoShow(w http.ResponseWriter, r *http.Request) {
 				latest = sc
 				s.DB.Where("scan_id = ?", latest.ID).Find(&latest.Findings)
 			}
-			if tmFallback == nil && sc.Status == db.ScanDone && sc.Report != "" {
-				tmFallback = sc
+			if fallback == nil && sc.Status == db.ScanDone && sc.Report != "" {
+				fallback = sc
 			}
 		case threatModelSkillName:
-			if tmScan == nil && sc.Status == db.ScanDone && sc.Report != "" {
-				tmScan = sc
+			if threatModel == nil && sc.Status == db.ScanDone && sc.Report != "" {
+				threatModel = sc
 			}
 		}
-		if latest != nil && tmScan != nil && tmFallback != nil {
+		if latest != nil && threatModel != nil && fallback != nil {
 			break
 		}
 	}
-	if tmScan == nil {
-		tmScan = tmFallback
+	if threatModel == nil {
+		threatModel = fallback
 	}
-	var threatModel map[string]any
-	if tmScan != nil {
-		_ = json.Unmarshal([]byte(tmScan.Report), &threatModel)
-	}
-	wb := loadWorkbench(s.DB, &repo, workbenchSeed(tmScan))
+	return latest, threatModel
+}
 
-	var totalCost float64
-	s.DB.Model(&db.Scan{}).Where("repository_id = ?", repo.ID).
-		Select("COALESCE(SUM(cost_usd), 0)").Scan(&totalCost)
-
-	category := r.URL.Query().Get("category")
-	rf := loadRepoFindings(s.DB, repo.ID, category)
-	expectedView := loadRepoExpectedView(s.DB, repo.ID, latest, rf)
-
+func repoNewFindingsCount(gdb *gorm.DB, repoID uint, category string) int64 {
 	// Count deep-dive findings still awaiting verification, scoped to the
 	// same category filter as the visible list. Drives the "Verify all new"
 	// button on the Findings tab; the bulk handler acts on this exact set.
-	newFindingsQuery := s.DB.Model(&db.Finding{}).
+	q := gdb.Model(&db.Finding{}).
 		Where("repository_id = ? AND status = ? AND scan_id IN (?)",
-			repo.ID, db.FindingNew, findingsScanIDs(s.DB))
+			repoID, db.FindingNew, findingsScanIDs(gdb))
 	if category != "" {
-		newFindingsQuery = applyCWECategoryFilter(newFindingsQuery, category)
+		q = applyCWECategoryFilter(q, category)
 	}
-	var newFindings int64
-	newFindingsQuery.Count(&newFindings)
+	var total int64
+	q.Count(&total)
+	return total
+}
 
-	var maintainers []db.Maintainer
-	s.DB.Joins("JOIN repository_maintainers ON repository_maintainers.maintainer_id = maintainers.id").
-		Where("repository_maintainers.repository_id = ?", repo.ID).Find(&maintainers)
+type repoDependencyView struct {
+	Groups  []DepGroup
+	Total   int64
+	Hidden  int64
+	ShowAll bool
+	Commit  string
+}
 
+func (s *Server) loadRepoDependencyView(repoID uint, showAll bool) repoDependencyView {
 	// Apply the runtime-only filter in SQL before capping, so the first N
 	// rows on the default tab are runtime deps, not whatever sorts first
 	// by name. hiddenDeps and depsTotal both describe the same set the tab
 	// is rendering.
-	showAllDeps := r.URL.Query().Get("deps") == "all"
 	hiddenTypes := []string{db.DependencyDev, db.DependencyTest, db.DependencyBuild}
-	var hiddenDeps int64
+	var hidden int64
 	s.DB.Model(&db.Dependency{}).
-		Where("repository_id = ? AND dependency_type IN ?", repo.ID, hiddenTypes).
-		Count(&hiddenDeps)
-	depQ := s.DB.Model(&db.Dependency{}).Where("repository_id = ?", repo.ID)
-	if !showAllDeps {
-		depQ = depQ.Where("dependency_type NOT IN ?", hiddenTypes)
+		Where("repository_id = ? AND dependency_type IN ?", repoID, hiddenTypes).
+		Count(&hidden)
+	q := s.DB.Model(&db.Dependency{}).Where("repository_id = ?", repoID)
+	if !showAll {
+		q = q.Where("dependency_type NOT IN ?", hiddenTypes)
 	}
-	var depsTotal int64
-	depQ.Count(&depsTotal)
+	var total int64
+	q.Count(&total)
 	var rawDeps []db.Dependency
-	depQ.Order("ecosystem, name, manifest_kind desc").Limit(tabRowCap).Find(&rawDeps)
-	deps := groupDeps(rawDeps)
-
-	var depsCommit string
-	if len(deps) > 0 {
-		depsCommit = s.latestDepsCommit(repo.ID)
+	q.Order("ecosystem, name, manifest_kind desc").Limit(tabRowCap).Find(&rawDeps)
+	groups := groupDeps(rawDeps)
+	commit := ""
+	if len(groups) > 0 {
+		commit = s.latestDepsCommit(repoID)
 	}
+	return repoDependencyView{Groups: groups, Total: total, Hidden: hidden, ShowAll: showAll, Commit: commit}
+}
 
-	var pkgs []db.Package
-	s.DB.Where("repository_id = ?", repo.ID).Order("dependent_repos desc, downloads desc").Find(&pkgs)
+type repoInventoryView struct {
+	Packages        []db.Package
+	Dependents      []db.Dependent
+	DependentsTotal int64
+	Advisories      []db.Advisory
+	AdvisoriesTotal int64
+	KnownPURLs      map[string]uint
+	KnownURLs       map[string]uint
+}
 
-	var dependents []db.Dependent
-	var dependentsTotal int64
-	s.DB.Model(&db.Dependent{}).Where("repository_id = ?", repo.ID).Count(&dependentsTotal)
-	s.DB.Where("repository_id = ?", repo.ID).Order("dependent_repos desc").
-		Limit(tabRowCap).Find(&dependents)
+func (s *Server) loadRepoInventoryView(repoID uint, deps []DepGroup) repoInventoryView {
+	var inv repoInventoryView
+	s.DB.Where("repository_id = ?", repoID).Order("dependent_repos desc, downloads desc").Find(&inv.Packages)
+	s.DB.Model(&db.Dependent{}).Where("repository_id = ?", repoID).Count(&inv.DependentsTotal)
+	s.DB.Where("repository_id = ?", repoID).Order("dependent_repos desc").
+		Limit(tabRowCap).Find(&inv.Dependents)
+	s.DB.Model(&db.Advisory{}).Where("repository_id = ?", repoID).Count(&inv.AdvisoriesTotal)
+	s.DB.Where("repository_id = ?", repoID).Order("cvss_score desc").
+		Limit(tabRowCap).Find(&inv.Advisories)
+	inv.KnownPURLs = s.lookupKnownPURLs(deps)
+	inv.KnownURLs = s.lookupKnownURLs(inv.Dependents)
+	return inv
+}
 
-	var advisories []db.Advisory
-	var advisoriesTotal int64
-	s.DB.Model(&db.Advisory{}).Where("repository_id = ?", repo.ID).Count(&advisoriesTotal)
-	s.DB.Where("repository_id = ?", repo.ID).Order("cvss_score desc").
-		Limit(tabRowCap).Find(&advisories)
+type repoSubprojectView struct {
+	Rows      []db.Subproject
+	ScanCount map[string]int
+}
 
-	knownPURLs := s.lookupKnownPURLs(deps)
-	knownURLs := s.lookupKnownURLs(dependents)
-
-	// Pass repo html_url and commit for location links in threat model
-	tmCommit := ""
-	if tmScan != nil {
-		tmCommit = tmScan.Commit
+func (s *Server) loadRepoSubprojectView(repoID uint) repoSubprojectView {
+	view := repoSubprojectView{ScanCount: map[string]int{}}
+	s.DB.Where("repository_id = ?", repoID).Order("path").Find(&view.Rows)
+	if len(view.Rows) == 0 {
+		return view
 	}
-
-	var activeSkills []db.Skill
-	s.DB.Where("active = ?", true).Order("name").Find(&activeSkills)
-
-	var subprojects []db.Subproject
-	s.DB.Where("repository_id = ?", repo.ID).Order("path").Find(&subprojects)
-	subScanCount := map[string]int{}
-	if len(subprojects) > 0 {
-		rows := make([]struct {
-			SubPath string
-			N       int
-		}, 0)
-		s.DB.Raw(`SELECT sub_path, COUNT(*) AS n FROM scans
-			WHERE repository_id = ? AND sub_path != '' GROUP BY sub_path`,
-			repo.ID).Scan(&rows)
-		for _, r := range rows {
-			subScanCount[r.SubPath] = r.N
-		}
+	rows := make([]struct {
+		SubPath string
+		N       int
+	}, 0)
+	s.DB.Raw(`SELECT sub_path, COUNT(*) AS n FROM scans
+		WHERE repository_id = ? AND sub_path != '' GROUP BY sub_path`,
+		repoID).Scan(&rows)
+	for _, r := range rows {
+		view.ScanCount[r.SubPath] = r.N
 	}
+	return view
+}
 
-	// Count failed scans in the latest-per-skill set: same scope as the
-	// retry-failed handler would act on for this repo. Drives the
-	// "Retry failed" button on the Scans tab.
-	var failedScans int
+func countFailedScans(scans []db.Scan) int {
+	total := 0
 	for _, sc := range scans {
 		if sc.Status == db.ScanFailed {
-			failedScans++
+			total++
 		}
 	}
-
-	// activeScans drives both the delete-confirm warning (a running scan keeps
-	// writing into the repo's clone/workspace until it returns) and the "Cancel
-	// all" button; pausedScans drives "Resume all". Both are counted over every
-	// scan, not the latest-per-skill set.
-	activeScans, pausedScans := s.repoScanActionCounts(repo.ID)
-
-	data := map[string]any{
-		"Repo": repo, "Scans": scans, "Latest": latest,
-		"Findings":              rf.DeepDive,
-		"FindingsTotal":         rf.DeepDiveTotal,
-		"ScannerFindings":       rf.Scanners,
-		"ScannerFindingsTotal":  rf.ScannersTotal,
-		"ScanSkill":             rf.ScanSkill,
-		"ScanCommit":            rf.ScanCommit,
-		"ExpectedFindings":      expectedView.Matches.Expected,
-		"ExpectedMatched":       expectedView.Matches.MatchedTotal,
-		"ExpectedFindingStatus": expectedView.FindingStatus,
-		"NewFindingCount":       int(newFindings),
-		"FailedScans":           failedScans,
-		"ActiveScans":           int(activeScans),
-		"PausedScans":           int(pausedScans),
-		"TotalCost":             totalCost,
-		// Cached on the row, refreshed by the worker after each scan (#126).
-		"DiskBytes":  repo.DiskBytes,
-		"TMCommit":   tmCommit,
-		"DepsCommit": depsCommit,
-		"Deps":       deps, "DepsTotal": depsTotal,
-		"Pkgs":       pkgs,
-		"Dependents": dependents, "DependentsTotal": dependentsTotal,
-		"Advisories": advisories, "AdvisoriesTotal": advisoriesTotal,
-		"Maintainers": maintainers, "ThreatModel": threatModel,
-		"KnownURLs": knownURLs, "KnownPURLs": knownPURLs,
-		"ShowAllDeps": showAllDeps, "HiddenDeps": hiddenDeps,
-		"Skills":        activeSkills,
-		"Subprojects":   subprojects,
-		"SubScanCount":  subScanCount,
-		"Workbench":     wb,
-		"Category":      category,
-		"Categories":    CWECategories(),
-		"Uncategorized": UncategorizedCWE,
-		"TabRowCap":     int64(tabRowCap),
-	}
-	s.render(w, r, "repo_show.html", data)
+	return total
 }
 
 // latestDepsCommit returns the commit of the latest successful dependencies

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -1996,17 +1996,7 @@ func (s *Server) repoShow(w http.ResponseWriter, r *http.Request) {
 
 	category := r.URL.Query().Get("category")
 	rf := loadRepoFindings(s.DB, repo.ID, category)
-	var expectedRows []db.ExpectedFinding
-	s.DB.Where("repository_id = ?", repo.ID).Order("file, cwe").Find(&expectedRows)
-	latestScanID := uint(0)
-	if latest != nil {
-		latestScanID = latest.ID
-	}
-	expectedMatches := expectedMatchesForRows(s.DB, repo.ID, latestScanID, expectedRows)
-	visibleFindings := make([]db.Finding, 0, len(rf.DeepDive)+len(rf.Scanners))
-	visibleFindings = append(visibleFindings, rf.DeepDive...)
-	visibleFindings = append(visibleFindings, rf.Scanners...)
-	expectedFindingStatus := expectedStatusForFindings(visibleFindings, expectedRows)
+	expectedView := loadRepoExpectedView(s.DB, repo.ID, latest, rf)
 
 	// Count deep-dive findings still awaiting verification, scoped to the
 	// same category filter as the visible list. Drives the "Verify all new"
@@ -2116,9 +2106,9 @@ func (s *Server) repoShow(w http.ResponseWriter, r *http.Request) {
 		"ScannerFindingsTotal":  rf.ScannersTotal,
 		"ScanSkill":             rf.ScanSkill,
 		"ScanCommit":            rf.ScanCommit,
-		"ExpectedFindings":      expectedMatches.Expected,
-		"ExpectedMatched":       expectedMatches.MatchedTotal,
-		"ExpectedFindingStatus": expectedFindingStatus,
+		"ExpectedFindings":      expectedView.Matches.Expected,
+		"ExpectedMatched":       expectedView.Matches.MatchedTotal,
+		"ExpectedFindingStatus": expectedView.FindingStatus,
 		"NewFindingCount":       int(newFindings),
 		"FailedScans":           failedScans,
 		"ActiveScans":           int(activeScans),

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -1977,6 +1977,10 @@ func (s *Server) loadRepoShowView(
 	category := query.Get("category")
 	findings := loadRepoFindings(s.DB, repo.ID, category)
 	deps := s.loadRepoDependencyView(repo.ID, query.Get("deps") == "all")
+	// activeScans drives both the delete-confirm warning (a running scan keeps
+	// writing into the repo's clone/workspace until it returns) and the "Cancel
+	// all" button; pausedScans drives "Resume all". Both are counted over every
+	// scan, not the latest-per-skill set.
 	activeScans, pausedScans := s.repoScanActionCounts(repo.ID)
 	return repoShowView{
 		Repo:            repo,
@@ -2020,30 +2024,31 @@ func (v repoShowView) renderData() map[string]any {
 		"ActiveScans":           v.ActiveScans,
 		"PausedScans":           v.PausedScans,
 		"TotalCost":             v.TotalCost,
-		"DiskBytes":             v.Repo.DiskBytes,
-		"TMCommit":              v.TMCommit,
-		"DepsCommit":            v.Dependencies.Commit,
-		"Deps":                  v.Dependencies.Groups,
-		"DepsTotal":             v.Dependencies.Total,
-		"Pkgs":                  v.Inventory.Packages,
-		"Dependents":            v.Inventory.Dependents,
-		"DependentsTotal":       v.Inventory.DependentsTotal,
-		"Advisories":            v.Inventory.Advisories,
-		"AdvisoriesTotal":       v.Inventory.AdvisoriesTotal,
-		"Maintainers":           v.Maintainers,
-		"ThreatModel":           v.ThreatModel,
-		"KnownURLs":             v.Inventory.KnownURLs,
-		"KnownPURLs":            v.Inventory.KnownPURLs,
-		"ShowAllDeps":           v.Dependencies.ShowAll,
-		"HiddenDeps":            v.Dependencies.Hidden,
-		"Skills":                v.Skills,
-		"Subprojects":           v.Subprojects.Rows,
-		"SubScanCount":          v.Subprojects.ScanCount,
-		"Workbench":             v.Workbench,
-		"Category":              v.Category,
-		"Categories":            CWECategories(),
-		"Uncategorized":         UncategorizedCWE,
-		"TabRowCap":             int64(tabRowCap),
+		// Cached on the row, refreshed by the worker after each scan (#126).
+		"DiskBytes":       v.Repo.DiskBytes,
+		"TMCommit":        v.TMCommit,
+		"DepsCommit":      v.Dependencies.Commit,
+		"Deps":            v.Dependencies.Groups,
+		"DepsTotal":       v.Dependencies.Total,
+		"Pkgs":            v.Inventory.Packages,
+		"Dependents":      v.Inventory.Dependents,
+		"DependentsTotal": v.Inventory.DependentsTotal,
+		"Advisories":      v.Inventory.Advisories,
+		"AdvisoriesTotal": v.Inventory.AdvisoriesTotal,
+		"Maintainers":     v.Maintainers,
+		"ThreatModel":     v.ThreatModel,
+		"KnownURLs":       v.Inventory.KnownURLs,
+		"KnownPURLs":      v.Inventory.KnownPURLs,
+		"ShowAllDeps":     v.Dependencies.ShowAll,
+		"HiddenDeps":      v.Dependencies.Hidden,
+		"Skills":          v.Skills,
+		"Subprojects":     v.Subprojects.Rows,
+		"SubScanCount":    v.Subprojects.ScanCount,
+		"Workbench":       v.Workbench,
+		"Category":        v.Category,
+		"Categories":      CWECategories(),
+		"Uncategorized":   UncategorizedCWE,
+		"TabRowCap":       int64(tabRowCap),
 	}
 }
 
@@ -2232,6 +2237,9 @@ func (s *Server) loadRepoSubprojectView(repoID uint) repoSubprojectView {
 }
 
 func countFailedScans(scans []db.Scan) int {
+	// Count failed scans in the latest-per-skill set: same scope as the
+	// retry-failed handler would act on for this repo. Drives the
+	// "Retry failed" button on the Scans tab.
 	total := 0
 	for _, sc := range scans {
 		if sc.Status == db.ScanFailed {

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -437,6 +437,7 @@ func TestNavKey(t *testing.T) {
 		"/repositories/7": "repos",
 		"/findings":       "findings",
 		"/findings/42":    "findings",
+		"/benchmark":      "benchmark",
 		"/scans/1":        "scans",
 		"/sboms":          "sboms",
 		"/usage":          "usage",
@@ -2429,7 +2430,7 @@ func TestEnqueueSkillWith_effort(t *testing.T) {
 	}
 }
 
-func TestEnqueueSkillWith_stampsSkillsRepoSHA(t *testing.T) {
+func TestEnqueueSkillWith_stampsBenchmarkVersionFields(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()
 	s.SkillsRepoSHA = "feedface0123456789abcdef0123456789abcdef"
@@ -2437,7 +2438,7 @@ func TestEnqueueSkillWith_stampsSkillsRepoSHA(t *testing.T) {
 	repo := db.Repository{URL: "https://github.com/foo/bar", Name: "bar"}
 	s.DB.Create(&repo)
 	skill := db.Skill{Name: "lite", Body: "b", OutputFile: "r.json", OutputKind: "freeform",
-		Version: 1, Active: true, Source: "ui"}
+		Version: 7, Metadata: `{"scrutineer.version":1}`, Active: true, Source: "ui"}
 	s.DB.Create(&skill)
 
 	scanID, err := s.enqueueSkillWith(context.Background(), repo.ID, skill.ID, ScanOpts{})
@@ -2448,6 +2449,12 @@ func TestEnqueueSkillWith_stampsSkillsRepoSHA(t *testing.T) {
 	s.DB.First(&sc, scanID)
 	if sc.SkillsRepoSHA != s.SkillsRepoSHA {
 		t.Errorf("scan.SkillsRepoSHA = %q, want %q", sc.SkillsRepoSHA, s.SkillsRepoSHA)
+	}
+	if sc.SkillVersion != skill.Version {
+		t.Errorf("scan.SkillVersion = %d, want %d", sc.SkillVersion, skill.Version)
+	}
+	if sc.SkillSchemaVersion != 1 {
+		t.Errorf("scan.SkillSchemaVersion = %d, want 1", sc.SkillSchemaVersion)
 	}
 }
 

--- a/internal/web/templates/benchmark.html
+++ b/internal/web/templates/benchmark.html
@@ -1,0 +1,61 @@
+{{template "head" .}}
+
+<div class="flex items-start justify-between gap-4 mb-6">
+  <div>
+    {{template "crumbs" (crumbs "Benchmark" "")}}
+    <h2 class="text-2xl font-semibold mt-1 flex items-center gap-2">
+      <i data-lucide="gauge"></i> Benchmark
+    </h2>
+  </div>
+</div>
+
+<form method="get" action="/benchmark" class="form grid grid-cols-1 md:grid-cols-[1fr_1fr_1fr_auto] gap-2 mb-4">
+  <input class="input" type="search" name="skill" value="{{.Skill}}" placeholder="Skill">
+  <input class="input" type="search" name="model" value="{{.Model}}" placeholder="Model">
+  <input class="input" type="search" name="harness" value="{{.Harness}}" placeholder="Harness SHA">
+  <button class="btn-outline" type="submit"><i data-lucide="filter"></i> Filter</button>
+</form>
+
+{{if .Rows}}
+<div class="flex flex-wrap gap-2 mb-4">
+  <span class="badge-outline">Recall {{pct .Totals.Recall}}</span>
+  <span class="badge-outline">Precision {{pct .Totals.Precision}}</span>
+  <span class="badge-outline">F1 {{pct .Totals.F1}}</span>
+  <span class="badge-outline">{{.Totals.Matched}} / {{.Totals.Expected}} expected matched</span>
+</div>
+
+<table class="table w-full">
+  <thead><tr>
+    <th>Repository</th>
+    <th class="w-24 text-right">Recall</th>
+    <th class="w-24 text-right">Precision</th>
+    <th class="w-20 text-right">F1</th>
+    <th class="w-36">Expected</th>
+    <th class="w-40">Scan</th>
+    <th>Skill</th>
+    <th>Model</th>
+    <th class="w-20">Schema</th>
+    <th>Harness</th>
+  </tr></thead>
+  <tbody>
+  {{range .Rows}}
+    <tr>
+      <td><a class="font-medium" href="/repositories/{{.Repo.ID}}#rt13">{{.Repo.Name}}</a></td>
+      <td class="text-right">{{pct .Recall}}</td>
+      <td class="text-right">{{pct .Precision}}</td>
+      <td class="text-right">{{pct .F1}}</td>
+      <td>{{.Matched}} / {{.Expected}}</td>
+      <td>{{if .Scan}}<a class="hover:underline" href="/scans/{{.Scan.ID}}">#{{.Scan.ID}}</a>{{else}}<span class="text-muted-foreground">none</span>{{end}}</td>
+      <td class="whitespace-normal">{{.Skill}}</td>
+      <td class="whitespace-normal">{{.Model}}</td>
+      <td>{{if .SkillSchemaVersion}}v{{.SkillSchemaVersion}}{{end}}</td>
+      <td>{{if .HarnessSHA}}<code class="text-xs">{{short .HarnessSHA}}</code>{{end}}</td>
+    </tr>
+  {{end}}
+  </tbody>
+</table>
+{{else}}
+  {{template "empty" (dict "Icon" "gauge" "Title" "No benchmark repositories" "Body" "Add expected findings on a repository to include it here.")}}
+{{end}}
+
+{{template "foot" .}}

--- a/internal/web/templates/layout.html
+++ b/internal/web/templates/layout.html
@@ -48,6 +48,7 @@
           <li><a href="/"{{if eq $nav "repos"}} aria-current="page"{{end}}><i data-lucide="folder-git-2"></i><span>Repositories</span></a></li>
           <li><a href="/orgs"{{if eq $nav "orgs"}} aria-current="page"{{end}}><i data-lucide="building"></i><span>Organizations</span></a></li>
           <li><a href="/findings"{{if eq $nav "findings"}} aria-current="page"{{end}}><i data-lucide="bug"></i><span>Findings</span></a></li>
+          <li><a href="/benchmark"{{if eq $nav "benchmark"}} aria-current="page"{{end}}><i data-lucide="gauge"></i><span>Benchmark</span></a></li>
           <li><a href="/packages"{{if eq $nav "packages"}} aria-current="page"{{end}}><i data-lucide="package"></i><span>Packages</span></a></li>
           <li><a href="/sboms"{{if eq $nav "sboms"}} aria-current="page"{{end}}><i data-lucide="file-box"></i><span>SBOMs</span></a></li>
           <li><a href="/advisories"{{if eq $nav "advisories"}} aria-current="page"{{end}}><i data-lucide="shield-alert"></i><span>Advisories</span></a></li>

--- a/internal/web/templates/repo_show.html
+++ b/internal/web/templates/repo_show.html
@@ -87,13 +87,13 @@
       Threat Model
     </button>
     {{end}}
-	    <button type="button" role="tab" id="rt12" aria-controls="rp12" aria-selected="false">
-	      Workbench
-	      {{if .Workbench.HasOverride}}<span class="badge-outline ml-1">override</span>{{end}}
-	    </button>
-	    <button type="button" role="tab" id="rt13" aria-controls="rp13" aria-selected="false">
-	      Benchmark{{if .ExpectedFindings}} <span class="badge-outline ml-1">{{.ExpectedMatched}}/{{len .ExpectedFindings}}</span>{{end}}
-	    </button>
+    <button type="button" role="tab" id="rt12" aria-controls="rp12" aria-selected="false">
+      Workbench
+      {{if .Workbench.HasOverride}}<span class="badge-outline ml-1">override</span>{{end}}
+    </button>
+    <button type="button" role="tab" id="rt13" aria-controls="rp13" aria-selected="false">
+      Benchmark{{if .ExpectedFindings}} <span class="badge-outline ml-1">{{.ExpectedMatched}}/{{len .ExpectedFindings}}</span>{{end}}
+    </button>
     {{if .Advisories}}
     <button type="button" role="tab" id="rt8" aria-controls="rp8" aria-selected="false">
       Advisories
@@ -212,14 +212,14 @@
           <tbody>
           {{range .Latest.Findings}}
             <tr id="finding-{{.ID}}">
-	              <td>{{template "severity-badge" .Severity}}</td>
-	              <td class="min-w-0 whitespace-normal"><a href="/findings/{{.ID}}">{{.Title}}</a></td>
-	              <td>
-	                {{template "finding-status" (fstatus .Status)}}
-	                {{if $.ExpectedFindings}}
-	                  {{if index $.ExpectedFindingStatus .ID}}<span class="badge-outline text-xs mt-1">expected</span>{{else}}<span class="badge-outline text-xs mt-1">unexpected</span>{{end}}
-	                {{end}}
-	              </td>
+              <td>{{template "severity-badge" .Severity}}</td>
+              <td class="min-w-0 whitespace-normal"><a href="/findings/{{.ID}}">{{.Title}}</a></td>
+              <td>
+                {{template "finding-status" (fstatus .Status)}}
+                {{if $.ExpectedFindings}}
+                  {{if index $.ExpectedFindingStatus .ID}}<span class="badge-outline text-xs mt-1">expected</span>{{else}}<span class="badge-outline text-xs mt-1">unexpected</span>{{end}}
+                {{end}}
+              </td>
               <td class="whitespace-normal">
                 {{template "loc-link" (dict "HTMLURL" $.Repo.HTMLURL "Commit" $.Latest.Commit "Location" .Location "Extra" .ExtraLocationCount)}}
               </td>
@@ -282,12 +282,12 @@
         <div id="finding-card-{{.ID}}" class="card">
           <header>
             <div class="flex items-center gap-2">
-	              {{template "severity-badge" .Severity}}
-	              {{template "finding-status" (fstatus .Status)}}
-	              {{if $.ExpectedFindings}}
-	                {{if index $.ExpectedFindingStatus .ID}}<span class="badge-outline text-xs">expected</span>{{else}}<span class="badge-outline text-xs">unexpected</span>{{end}}
-	              {{end}}
-	              <h3><a href="/findings/{{.ID}}">{{.Title}}</a></h3>
+              {{template "severity-badge" .Severity}}
+              {{template "finding-status" (fstatus .Status)}}
+              {{if $.ExpectedFindings}}
+                {{if index $.ExpectedFindingStatus .ID}}<span class="badge-outline text-xs">expected</span>{{else}}<span class="badge-outline text-xs">unexpected</span>{{end}}
+              {{end}}
+              <h3><a href="/findings/{{.ID}}">{{.Title}}</a></h3>
               {{if .CWE}}<span class="badge-outline ml-auto" data-tooltip="{{cwename .CWE}}">{{with cwecatid .CWE}}<span class="text-muted-foreground">{{.}} ›</span> {{end}}{{.CWE}}</span>{{end}}
             </div>
             <p>
@@ -318,12 +318,12 @@
         <div id="finding-card-{{.ID}}" class="card">
           <header>
             <div class="flex items-center gap-2">
-	              {{template "severity-badge" .Severity}}
-	              {{template "finding-status" (fstatus .Status)}}
-	              {{if $.ExpectedFindings}}
-	                {{if index $.ExpectedFindingStatus .ID}}<span class="badge-outline text-xs">expected</span>{{else}}<span class="badge-outline text-xs">unexpected</span>{{end}}
-	              {{end}}
-	              <h3><a href="/findings/{{.ID}}">{{.Title}}</a></h3>
+              {{template "severity-badge" .Severity}}
+              {{template "finding-status" (fstatus .Status)}}
+              {{if $.ExpectedFindings}}
+                {{if index $.ExpectedFindingStatus .ID}}<span class="badge-outline text-xs">expected</span>{{else}}<span class="badge-outline text-xs">unexpected</span>{{end}}
+              {{end}}
+              <h3><a href="/findings/{{.ID}}">{{.Title}}</a></h3>
               <span class="badge-outline ml-auto">{{index $skills .ScanID}}</span>
               {{if .CWE}}<span class="badge-outline" data-tooltip="{{cwename .CWE}}">{{with cwecatid .CWE}}<span class="text-muted-foreground">{{.}} ›</span> {{end}}{{.CWE}}</span>{{end}}
             </div>
@@ -415,63 +415,63 @@
   </div>
   {{end}}
 
-	  <div role="tabpanel" id="rp12" aria-labelledby="rt12" hidden>
-	    {{template "threat_workbench" .}}
-	  </div>
+  <div role="tabpanel" id="rp12" aria-labelledby="rt12" hidden>
+    {{template "threat_workbench" .}}
+  </div>
 
-	  <div role="tabpanel" id="rp13" aria-labelledby="rt13" hidden>
-	    <div class="grid gap-4">
-	      <form method="post" action="/repositories/{{.Repo.ID}}/expected" class="form grid grid-cols-1 md:grid-cols-[1fr_8rem_10rem_1fr_auto] gap-2 items-end">
-	        <label class="grid gap-1">
-	          <span class="text-xs text-muted-foreground">File</span>
-	          <input class="input" name="file" placeholder="src/parser.go" required>
-	        </label>
-	        <label class="grid gap-1">
-	          <span class="text-xs text-muted-foreground">CWE</span>
-	          <input class="input" name="cwe" placeholder="CWE-79" required>
-	        </label>
-	        <label class="grid gap-1">
-	          <span class="text-xs text-muted-foreground">CVE</span>
-	          <input class="input" name="cve" placeholder="CVE-2026-0001">
-	        </label>
-	        <label class="grid gap-1">
-	          <span class="text-xs text-muted-foreground">Note</span>
-	          <input class="input" name="note" placeholder="Known vulnerable sink">
-	        </label>
-	        <button type="submit" class="btn"><i data-lucide="plus"></i> Add</button>
-	      </form>
-	      {{if .ExpectedFindings}}
-	        <table class="table w-full">
-	          <thead><tr>
-	            <th class="w-24">Status</th><th>File</th><th class="w-28">CWE</th><th class="w-36">CVE</th><th>Note</th><th class="w-24"></th>
-	          </tr></thead>
-	          <tbody>
-	          {{range .ExpectedFindings}}
-	            <tr>
-	              <td>
-	                {{if .Matched}}<span class="badge-outline">matched</span>{{else}}<span class="badge-destructive">missed</span>{{end}}
-	              </td>
-	              <td class="whitespace-normal"><code class="text-xs break-all">{{.Expected.File}}</code></td>
-	              <td><span class="badge-outline">{{.Expected.CWE}}</span></td>
-	              <td class="text-muted-foreground">{{.Expected.CVE}}</td>
-	              <td class="whitespace-normal text-sm text-muted-foreground">{{.Expected.Note}}</td>
-	              <td class="text-right">
-	                {{if .FindingID}}<a href="/findings/{{.FindingID}}" class="btn-sm-ghost" aria-label="View matched finding" data-tooltip="View matched finding"><i data-lucide="external-link"></i></a>{{end}}
-	                <form method="post" action="/repositories/{{$.Repo.ID}}/expected/{{.Expected.ID}}/delete" class="inline">
-	                  <button type="submit" class="btn-sm-ghost" aria-label="Delete expected finding" data-tooltip="Delete expected finding"><i data-lucide="trash-2"></i></button>
-	                </form>
-	              </td>
-	            </tr>
-	          {{end}}
-	          </tbody>
-	        </table>
-	      {{else}}
-	        <p class="text-sm text-muted-foreground">No expected findings recorded for this repository.</p>
-	      {{end}}
-	    </div>
-	  </div>
+  <div role="tabpanel" id="rp13" aria-labelledby="rt13" hidden>
+    <div class="grid gap-4">
+      <form method="post" action="/repositories/{{.Repo.ID}}/expected" class="form grid grid-cols-1 md:grid-cols-[1fr_8rem_10rem_1fr_auto] gap-2 items-end">
+        <label class="grid gap-1">
+          <span class="text-xs text-muted-foreground">File</span>
+          <input class="input" name="file" placeholder="src/parser.go" required>
+        </label>
+        <label class="grid gap-1">
+          <span class="text-xs text-muted-foreground">CWE</span>
+          <input class="input" name="cwe" placeholder="CWE-79" required>
+        </label>
+        <label class="grid gap-1">
+          <span class="text-xs text-muted-foreground">CVE</span>
+          <input class="input" name="cve" placeholder="CVE-2026-0001">
+        </label>
+        <label class="grid gap-1">
+          <span class="text-xs text-muted-foreground">Note</span>
+          <input class="input" name="note" placeholder="Known vulnerable sink">
+        </label>
+        <button type="submit" class="btn"><i data-lucide="plus"></i> Add</button>
+      </form>
+      {{if .ExpectedFindings}}
+        <table class="table w-full">
+          <thead><tr>
+            <th class="w-24">Status</th><th>File</th><th class="w-28">CWE</th><th class="w-36">CVE</th><th>Note</th><th class="w-24"></th>
+          </tr></thead>
+          <tbody>
+          {{range .ExpectedFindings}}
+            <tr>
+              <td>
+                {{if .Matched}}<span class="badge-outline">matched</span>{{else}}<span class="badge-destructive">missed</span>{{end}}
+              </td>
+              <td class="whitespace-normal"><code class="text-xs break-all">{{.Expected.File}}</code></td>
+              <td><span class="badge-outline">{{.Expected.CWE}}</span></td>
+              <td class="text-muted-foreground">{{.Expected.CVE}}</td>
+              <td class="whitespace-normal text-sm text-muted-foreground">{{.Expected.Note}}</td>
+              <td class="text-right">
+                {{if .FindingID}}<a href="/findings/{{.FindingID}}" class="btn-sm-ghost" aria-label="View matched finding" data-tooltip="View matched finding"><i data-lucide="external-link"></i></a>{{end}}
+                <form method="post" action="/repositories/{{$.Repo.ID}}/expected/{{.Expected.ID}}/delete" class="inline">
+                  <button type="submit" class="btn-sm-ghost" aria-label="Delete expected finding" data-tooltip="Delete expected finding"><i data-lucide="trash-2"></i></button>
+                </form>
+              </td>
+            </tr>
+          {{end}}
+          </tbody>
+        </table>
+      {{else}}
+        <p class="text-sm text-muted-foreground">No expected findings recorded for this repository.</p>
+      {{end}}
+    </div>
+  </div>
 
-	  {{if .Advisories}}
+  {{if .Advisories}}
   <div role="tabpanel" id="rp8" aria-labelledby="rt8" hidden>
     <table class="table w-full">
       <thead><tr>

--- a/internal/web/templates/repo_show.html
+++ b/internal/web/templates/repo_show.html
@@ -87,10 +87,13 @@
       Threat Model
     </button>
     {{end}}
-    <button type="button" role="tab" id="rt12" aria-controls="rp12" aria-selected="false">
-      Workbench
-      {{if .Workbench.HasOverride}}<span class="badge-outline ml-1">override</span>{{end}}
-    </button>
+	    <button type="button" role="tab" id="rt12" aria-controls="rp12" aria-selected="false">
+	      Workbench
+	      {{if .Workbench.HasOverride}}<span class="badge-outline ml-1">override</span>{{end}}
+	    </button>
+	    <button type="button" role="tab" id="rt13" aria-controls="rp13" aria-selected="false">
+	      Benchmark{{if .ExpectedFindings}} <span class="badge-outline ml-1">{{.ExpectedMatched}}/{{len .ExpectedFindings}}</span>{{end}}
+	    </button>
     {{if .Advisories}}
     <button type="button" role="tab" id="rt8" aria-controls="rp8" aria-selected="false">
       Advisories
@@ -209,9 +212,14 @@
           <tbody>
           {{range .Latest.Findings}}
             <tr id="finding-{{.ID}}">
-              <td>{{template "severity-badge" .Severity}}</td>
-              <td class="min-w-0 whitespace-normal"><a href="/findings/{{.ID}}">{{.Title}}</a></td>
-              <td>{{template "finding-status" (fstatus .Status)}}</td>
+	              <td>{{template "severity-badge" .Severity}}</td>
+	              <td class="min-w-0 whitespace-normal"><a href="/findings/{{.ID}}">{{.Title}}</a></td>
+	              <td>
+	                {{template "finding-status" (fstatus .Status)}}
+	                {{if $.ExpectedFindings}}
+	                  {{if index $.ExpectedFindingStatus .ID}}<span class="badge-outline text-xs mt-1">expected</span>{{else}}<span class="badge-outline text-xs mt-1">unexpected</span>{{end}}
+	                {{end}}
+	              </td>
               <td class="whitespace-normal">
                 {{template "loc-link" (dict "HTMLURL" $.Repo.HTMLURL "Commit" $.Latest.Commit "Location" .Location "Extra" .ExtraLocationCount)}}
               </td>
@@ -274,9 +282,12 @@
         <div id="finding-card-{{.ID}}" class="card">
           <header>
             <div class="flex items-center gap-2">
-              {{template "severity-badge" .Severity}}
-              {{template "finding-status" (fstatus .Status)}}
-              <h3><a href="/findings/{{.ID}}">{{.Title}}</a></h3>
+	              {{template "severity-badge" .Severity}}
+	              {{template "finding-status" (fstatus .Status)}}
+	              {{if $.ExpectedFindings}}
+	                {{if index $.ExpectedFindingStatus .ID}}<span class="badge-outline text-xs">expected</span>{{else}}<span class="badge-outline text-xs">unexpected</span>{{end}}
+	              {{end}}
+	              <h3><a href="/findings/{{.ID}}">{{.Title}}</a></h3>
               {{if .CWE}}<span class="badge-outline ml-auto" data-tooltip="{{cwename .CWE}}">{{with cwecatid .CWE}}<span class="text-muted-foreground">{{.}} ›</span> {{end}}{{.CWE}}</span>{{end}}
             </div>
             <p>
@@ -307,9 +318,12 @@
         <div id="finding-card-{{.ID}}" class="card">
           <header>
             <div class="flex items-center gap-2">
-              {{template "severity-badge" .Severity}}
-              {{template "finding-status" (fstatus .Status)}}
-              <h3><a href="/findings/{{.ID}}">{{.Title}}</a></h3>
+	              {{template "severity-badge" .Severity}}
+	              {{template "finding-status" (fstatus .Status)}}
+	              {{if $.ExpectedFindings}}
+	                {{if index $.ExpectedFindingStatus .ID}}<span class="badge-outline text-xs">expected</span>{{else}}<span class="badge-outline text-xs">unexpected</span>{{end}}
+	              {{end}}
+	              <h3><a href="/findings/{{.ID}}">{{.Title}}</a></h3>
               <span class="badge-outline ml-auto">{{index $skills .ScanID}}</span>
               {{if .CWE}}<span class="badge-outline" data-tooltip="{{cwename .CWE}}">{{with cwecatid .CWE}}<span class="text-muted-foreground">{{.}} ›</span> {{end}}{{.CWE}}</span>{{end}}
             </div>
@@ -401,11 +415,63 @@
   </div>
   {{end}}
 
-  <div role="tabpanel" id="rp12" aria-labelledby="rt12" hidden>
-    {{template "threat_workbench" .}}
-  </div>
+	  <div role="tabpanel" id="rp12" aria-labelledby="rt12" hidden>
+	    {{template "threat_workbench" .}}
+	  </div>
 
-  {{if .Advisories}}
+	  <div role="tabpanel" id="rp13" aria-labelledby="rt13" hidden>
+	    <div class="grid gap-4">
+	      <form method="post" action="/repositories/{{.Repo.ID}}/expected" class="form grid grid-cols-1 md:grid-cols-[1fr_8rem_10rem_1fr_auto] gap-2 items-end">
+	        <label class="grid gap-1">
+	          <span class="text-xs text-muted-foreground">File</span>
+	          <input class="input" name="file" placeholder="src/parser.go" required>
+	        </label>
+	        <label class="grid gap-1">
+	          <span class="text-xs text-muted-foreground">CWE</span>
+	          <input class="input" name="cwe" placeholder="CWE-79" required>
+	        </label>
+	        <label class="grid gap-1">
+	          <span class="text-xs text-muted-foreground">CVE</span>
+	          <input class="input" name="cve" placeholder="CVE-2026-0001">
+	        </label>
+	        <label class="grid gap-1">
+	          <span class="text-xs text-muted-foreground">Note</span>
+	          <input class="input" name="note" placeholder="Known vulnerable sink">
+	        </label>
+	        <button type="submit" class="btn"><i data-lucide="plus"></i> Add</button>
+	      </form>
+	      {{if .ExpectedFindings}}
+	        <table class="table w-full">
+	          <thead><tr>
+	            <th class="w-24">Status</th><th>File</th><th class="w-28">CWE</th><th class="w-36">CVE</th><th>Note</th><th class="w-24"></th>
+	          </tr></thead>
+	          <tbody>
+	          {{range .ExpectedFindings}}
+	            <tr>
+	              <td>
+	                {{if .Matched}}<span class="badge-outline">matched</span>{{else}}<span class="badge-destructive">missed</span>{{end}}
+	              </td>
+	              <td class="whitespace-normal"><code class="text-xs break-all">{{.Expected.File}}</code></td>
+	              <td><span class="badge-outline">{{.Expected.CWE}}</span></td>
+	              <td class="text-muted-foreground">{{.Expected.CVE}}</td>
+	              <td class="whitespace-normal text-sm text-muted-foreground">{{.Expected.Note}}</td>
+	              <td class="text-right">
+	                {{if .FindingID}}<a href="/findings/{{.FindingID}}" class="btn-sm-ghost" aria-label="View matched finding" data-tooltip="View matched finding"><i data-lucide="external-link"></i></a>{{end}}
+	                <form method="post" action="/repositories/{{$.Repo.ID}}/expected/{{.Expected.ID}}/delete" class="inline">
+	                  <button type="submit" class="btn-sm-ghost" aria-label="Delete expected finding" data-tooltip="Delete expected finding"><i data-lucide="trash-2"></i></button>
+	                </form>
+	              </td>
+	            </tr>
+	          {{end}}
+	          </tbody>
+	        </table>
+	      {{else}}
+	        <p class="text-sm text-muted-foreground">No expected findings recorded for this repository.</p>
+	      {{end}}
+	    </div>
+	  </div>
+
+	  {{if .Advisories}}
   <div role="tabpanel" id="rp8" aria-labelledby="rt8" hidden>
     <table class="table w-full">
       <thead><tr>

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -169,46 +169,6 @@ paths:
                 type: array
                 items: { $ref: '#/components/schemas/ExpectedFinding' }
         '403': { $ref: '#/components/responses/Forbidden' }
-    post:
-      summary: Add an expected finding for benchmark comparison
-      operationId: addRepositoryExpectedFinding
-      parameters:
-        - $ref: '#/components/parameters/RepositoryID'
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema: { $ref: '#/components/schemas/ExpectedFindingInput' }
-      responses:
-        '201':
-          description: Created
-          content:
-            application/json:
-              schema: { $ref: '#/components/schemas/ExpectedFinding' }
-        '400':
-          description: Malformed JSON
-        '403': { $ref: '#/components/responses/Forbidden' }
-        '422':
-          description: Missing file/CWE or duplicate row
-
-  /repositories/{id}/expected/{expected_id}:
-    delete:
-      summary: Delete an expected finding
-      operationId: deleteRepositoryExpectedFinding
-      parameters:
-        - $ref: '#/components/parameters/RepositoryID'
-        - name: expected_id
-          in: path
-          required: true
-          schema: { type: integer, format: int64 }
-      responses:
-        '204':
-          description: Deleted
-        '400':
-          description: Invalid expected finding id
-        '403': { $ref: '#/components/responses/Forbidden' }
-        '404': { $ref: '#/components/responses/NotFound' }
-
   /repositories/{id}/dependencies:
     get:
       summary: List dependencies declared by this repository's manifests
@@ -1195,15 +1155,6 @@ components:
         cwe:           { type: string, description: CWE identifier, e.g. CWE-79. }
         cve:           { type: string }
         note:          { type: string }
-
-    ExpectedFindingInput:
-      type: object
-      required: [file, cwe]
-      properties:
-        file: { type: string, description: Path relative to the repository root, without line number. }
-        cwe:  { type: string, description: CWE identifier, e.g. CWE-79. }
-        cve:  { type: string }
-        note: { type: string }
 
     Scan:
       type: object

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -154,6 +154,61 @@ paths:
         '403': { $ref: '#/components/responses/Forbidden' }
         '404': { $ref: '#/components/responses/NotFound' }
 
+  /repositories/{id}/expected:
+    get:
+      summary: List expected findings for benchmark comparison
+      operationId: listRepositoryExpectedFindings
+      parameters:
+        - $ref: '#/components/parameters/RepositoryID'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: '#/components/schemas/ExpectedFinding' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+    post:
+      summary: Add an expected finding for benchmark comparison
+      operationId: addRepositoryExpectedFinding
+      parameters:
+        - $ref: '#/components/parameters/RepositoryID'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/ExpectedFindingInput' }
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ExpectedFinding' }
+        '400':
+          description: Malformed JSON
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '422':
+          description: Missing file/CWE or duplicate row
+
+  /repositories/{id}/expected/{expected_id}:
+    delete:
+      summary: Delete an expected finding
+      operationId: deleteRepositoryExpectedFinding
+      parameters:
+        - $ref: '#/components/parameters/RepositoryID'
+        - name: expected_id
+          in: path
+          required: true
+          schema: { type: integer, format: int64 }
+      responses:
+        '204':
+          description: Deleted
+        '400':
+          description: Invalid expected finding id
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/NotFound' }
+
   /repositories/{id}/dependencies:
     get:
       summary: List dependencies declared by this repository's manifests
@@ -1130,6 +1185,26 @@ components:
             created_at:  { type: string, format: date-time, nullable: true }
             finished_at: { type: string, format: date-time, nullable: true }
 
+    ExpectedFinding:
+      type: object
+      required: [id, repository_id, file, cwe]
+      properties:
+        id:            { type: integer, format: int64 }
+        repository_id: { type: integer, format: int64 }
+        file:          { type: string, description: Path relative to the repository root, without line number. }
+        cwe:           { type: string, description: CWE identifier, e.g. CWE-79. }
+        cve:           { type: string }
+        note:          { type: string }
+
+    ExpectedFindingInput:
+      type: object
+      required: [file, cwe]
+      properties:
+        file: { type: string, description: Path relative to the repository root, without line number. }
+        cwe:  { type: string, description: CWE identifier, e.g. CWE-79. }
+        cve:  { type: string }
+        note: { type: string }
+
     Scan:
       type: object
       required: [id, kind, status, repository_id]
@@ -1140,8 +1215,9 @@ components:
         status:        { type: string, enum: [queued, running, paused, done, failed, cancelled] }
         model:         { type: string }
         commit:        { type: string }
-        skill_name:    { type: string }
-        skill_version: { type: integer }
+        skill_name:           { type: string }
+        skill_version:        { type: integer, description: Snapshot of the Skill row version at enqueue time. }
+        skill_schema_version: { type: integer, description: Snapshot of metadata.scrutineer.version at enqueue time. }
         started_at:    { type: string, format: date-time, nullable: true }
         finished_at:   { type: string, format: date-time, nullable: true }
         max_turns_hit: { type: boolean, description: True when the scan completed with partial output after hitting the Claude max-turns cap; retry resumes the saved session when available. }


### PR DESCRIPTION
Fixes #568

## Summary

Adds expected findings support for benchmarking model-backed scan skills against known vulnerable repositories.

This introduces repository-scoped expected findings, matches them against scan findings by file path + CWE while ignoring line numbers and adds a benchmark rollup page for recall/precision tracking.

## Changes

- Add `expected_findings` storage via `db.ExpectedFinding`
- Add read-only API support to list expected findings
- Add operator UI routes to add and delete expected findings
- Add a Benchmark tab on repository pages
- Badge scan findings as expected or unexpected when benchmark rows exist
- Add `/benchmark` rollup with recall, precision, F1 and filters for skill/model/harness
- Snapshot `skill_schema_version` on scans for benchmark attribution
- Update OpenAPI docs
- Add focused tests for read-only API access, UI writes, matching, repo UI badges, benchmark rollup and scan version snapshots

## API scope

The scan-token API exposes expected findings as read-only. Creating and deleting expected findings is intentionally limited to the operator UI routes so running skills cannot mutate benchmark ground truth and inflate their own recall or precision.

## Tests

- `go test ./internal/web -run 'TestExpected|TestBenchmark|TestBuildExpected|TestRepoShowBenchmark|TestRepoShow'`
- `go test ./...`
- `go vet ./...`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run`
- `git diff --check`

Main fixes are:

- Change “Add API endpoints to list, add and delete expected findings” to “read-only API support”.
- Add the API scope section explaining why writes are UI/operator-only.
- Update tests to match what you actually ran.