### PR TITLE
feat(findings): add Repo ID column to the findings table

### DIFF
--- a/internal/web/templates/findings.html
+++ b/internal/web/templates/findings.html
@@ -121,6 +121,7 @@
     <thead><tr>
       <th class="w-24">Severity</th><th>Title</th><th class="w-24">Status</th>
       <th class="w-32">Repository</th>
+      <th class="w-20">Repo ID</th>
       {{if .AnySubPath}}<th class="w-32">Sub-path</th>{{end}}
       <th class="w-44">CWE</th>
       <th class="w-56">Location</th><th class="w-16">Scan</th>
@@ -144,6 +145,7 @@
         </td>
         <td>{{template "finding-status" (fstatus .Status)}}</td>
         <td class="truncate">{{$repo.Name}}</td>
+        <td class="text-muted-foreground">{{$repo.ID}}</td>
         {{if $showSub}}
           <td class="text-muted-foreground text-xs">{{if .SubPath}}<code>{{.SubPath}}</code>{{else}}<span class="text-muted-foreground">root</span>{{end}}</td>
         {{end}}


### PR DESCRIPTION
feat(findings): add Repo ID column to the findings table

Surface the repository's primary key next to the Repository name on the
/findings page. It's the same value the JSON API emits as repository_id,
so having it visible in the list makes finding-level exports easier to
cross-reference without opening each repo.

Pure template change: the repo record (and its ID) was already in scope
in findings.html via the Repos map, so no handler, model, or serializer
change is needed. The cell reuses the existing "#<id>" muted style used
for the adjacent Scan column and on the repository page.
