### PR TITLE
feat: sortable table columns

### DIFF
--- a/internal/web/maintainers.go
+++ b/internal/web/maintainers.go
@@ -26,19 +26,19 @@ func (s *Server) maintainersList(w http.ResponseWriter, r *http.Request) {
 	sortCol, dir := splitSort(r.URL.Query().Get("sort"), "")
 	switch sortCol {
 	case "login":
-		q = q.Order("login " + dirOr(dir, "asc"))
+		q = q.Order(orderByExpr("login", dir, false))
 	case statusKey:
-		q = q.Order("status " + dirOr(dir, "asc")).Order("name")
+		q = q.Order(orderByExpr("status", dir, false)).Order("name")
 	case "email":
-		q = q.Order("email " + dirOr(dir, "asc")).Order("name")
+		q = q.Order(orderByExpr("email", dir, false)).Order("name")
 	case "company":
-		q = q.Order("company " + dirOr(dir, "asc")).Order("name")
+		q = q.Order(orderByExpr("company", dir, false)).Order("name")
 	case "newest":
-		q = q.Order("id " + dirOr(dir, "desc"))
+		q = q.Order(orderByExpr("id", dir, true))
 	case nameSort:
 		// Push empty names to the end regardless of direction.
 		q = q.Order("CASE WHEN name = '' THEN 1 ELSE 0 END").
-			Order("name " + dirOr(dir, "asc")).Order("login")
+			Order(orderByExpr("name", dir, false)).Order("login")
 	default:
 		sortCol, dir = nameSort, ""
 		q = q.Order("CASE WHEN name = '' THEN 1 ELSE 0 END, name, login")

--- a/internal/web/maintainers.go
+++ b/internal/web/maintainers.go
@@ -23,18 +23,29 @@ func (s *Server) maintainersList(w http.ResponseWriter, r *http.Request) {
 	}
 
 	const nameSort = "name"
-	sort := r.URL.Query().Get("sort")
-	switch sort {
+	sortCol, dir := splitSort(r.URL.Query().Get("sort"), "")
+	switch sortCol {
 	case "login":
-		q = q.Order("login")
+		q = q.Order("login " + dirOr(dir, "asc"))
 	case statusKey:
-		q = q.Order("status, name")
+		q = q.Order("status " + dirOr(dir, "asc")).Order("name")
+	case "email":
+		q = q.Order("email " + dirOr(dir, "asc")).Order("name")
+	case "company":
+		q = q.Order("company " + dirOr(dir, "asc")).Order("name")
 	case "newest":
-		q = q.Order("id desc")
+		q = q.Order("id " + dirOr(dir, "desc"))
+	case nameSort:
+		// Push empty names to the end regardless of direction.
+		q = q.Order("CASE WHEN name = '' THEN 1 ELSE 0 END").
+			Order("name " + dirOr(dir, "asc")).Order("login")
 	default:
-		sort = nameSort
-		// Push empty names to the end instead of the front.
+		sortCol, dir = nameSort, ""
 		q = q.Order("CASE WHEN name = '' THEN 1 ELSE 0 END, name, login")
+	}
+	sort := sortCol
+	if dir != "" {
+		sort = sortCol + "." + dir
 	}
 
 	var total int64

--- a/internal/web/orgs.go
+++ b/internal/web/orgs.go
@@ -102,32 +102,31 @@ func (s *Server) orgsList(w http.ResponseWriter, r *http.Request) {
 		rows = append(rows, row)
 	}
 
+	// Org rows are aggregated in memory (Repos/FindingsTotal are computed, not
+	// columns), so unlike the SQL indexes this sorts the slice and flips the
+	// comparator for direction via dirLess rather than an ORDER BY.
 	const nameSort = "name"
-	sortBy := r.URL.Query().Get("sort")
-	switch sortBy {
+	sortCol, dir := splitSort(r.URL.Query().Get("sort"), "")
+	switch sortCol {
 	case "findings":
-		sortSlice(rows, func(a, b orgRow) bool { return a.FindingsTotal > b.FindingsTotal })
+		sortSlice(rows, dirLess(dir, "desc", func(a, b orgRow) bool { return a.FindingsTotal < b.FindingsTotal }))
 	case "repos":
-		sortSlice(rows, func(a, b orgRow) bool { return a.Repos > b.Repos })
-	case defaultSort:
-		sortSlice(rows, func(a, b orgRow) bool {
-			if a.LastActivity == nil {
-				return false
-			}
-			if b.LastActivity == nil {
-				return true
-			}
-			return a.LastActivity.After(*b.LastActivity)
-		})
+		sortSlice(rows, dirLess(dir, "desc", func(a, b orgRow) bool { return a.Repos < b.Repos }))
+	case "newest":
+		sortSlice(rows, dirLess(dir, "desc", orgActivityLess))
+	case nameSort:
+		sortSlice(rows, dirLess(dir, "asc", orgNameLess))
 	default:
-		sortBy = nameSort
-		sortSlice(rows, func(a, b orgRow) bool {
-			return strings.ToLower(a.Owner) < strings.ToLower(b.Owner)
-		})
+		sortCol, dir = nameSort, ""
+		sortSlice(rows, orgNameLess)
+	}
+	sort := sortCol
+	if dir != "" {
+		sort = sortCol + "." + dir
 	}
 
 	s.render(w, r, "orgs.html", map[string]any{
-		"Orgs": rows, "Q": search, "Sort": sortBy,
+		"Orgs": rows, "Q": search, "Sort": sort,
 	})
 }
 
@@ -135,6 +134,34 @@ func (s *Server) orgsList(w http.ResponseWriter, r *http.Request) {
 // less)` without pulling sort.Slice's (i, j int) idiom into each case.
 func sortSlice[T any](s []T, less func(a, b T) bool) {
 	sort.Slice(s, func(i, j int) bool { return less(s[i], s[j]) })
+}
+
+// dirLess adapts an ascending comparator to the requested direction, applying
+// def when dir is unset. It is the in-memory counterpart to dirOr, which does
+// the same job for the SQL indexes' ORDER BY.
+func dirLess[T any](dir, def string, lessAsc func(a, b T) bool) func(a, b T) bool {
+	if dirOr(dir, def) == "desc" {
+		return func(a, b T) bool { return lessAsc(b, a) }
+	}
+	return lessAsc
+}
+
+// orgNameLess orders owners case-insensitively, ascending.
+func orgNameLess(a, b orgRow) bool {
+	return strings.ToLower(a.Owner) < strings.ToLower(b.Owner)
+}
+
+// orgActivityLess orders by last activity ascending (oldest first), with
+// never-active orgs sorting oldest. dirLess flips it to the newest-first
+// default the Last activity column and the "newest" preset show.
+func orgActivityLess(a, b orgRow) bool {
+	if a.LastActivity == nil {
+		return b.LastActivity != nil
+	}
+	if b.LastActivity == nil {
+		return false
+	}
+	return a.LastActivity.Before(*b.LastActivity)
 }
 
 func (s *Server) orgShow(w http.ResponseWriter, r *http.Request) {

--- a/internal/web/sboms.go
+++ b/internal/web/sboms.go
@@ -34,13 +34,13 @@ func (s *Server) sbomList(w http.ResponseWriter, r *http.Request) {
 	sortCol, dir := splitSort(r.URL.Query().Get("sort"), "")
 	switch sortCol {
 	case "name":
-		q = q.Order("name " + dirOr(dir, "asc")).Order("id desc")
+		q = q.Order(orderByExpr("name", dir, false)).Order("id desc")
 	case "format":
-		q = q.Order("format " + dirOr(dir, "asc")).Order("id desc")
+		q = q.Order(orderByExpr("format", dir, false)).Order("id desc")
 	case "packages":
-		q = q.Order("package_count " + dirOr(dir, "desc")).Order("id desc")
+		q = q.Order(orderByExpr("package_count", dir, true)).Order("id desc")
 	case "uploaded":
-		q = q.Order("created_at " + dirOr(dir, "desc")).Order("id desc")
+		q = q.Order(orderByExpr("created_at", dir, true)).Order("id desc")
 	default:
 		sortCol, dir = defaultSort, ""
 		q = q.Order("id desc")

--- a/internal/web/sboms.go
+++ b/internal/web/sboms.go
@@ -30,12 +30,32 @@ func (s *Server) registerSBOMRoutes(mux *http.ServeMux) {
 }
 
 func (s *Server) sbomList(w http.ResponseWriter, r *http.Request) {
+	q := s.DB.Model(&db.SBOMUpload{})
+	sortCol, dir := splitSort(r.URL.Query().Get("sort"), "")
+	switch sortCol {
+	case "name":
+		q = q.Order("name " + dirOr(dir, "asc")).Order("id desc")
+	case "format":
+		q = q.Order("format " + dirOr(dir, "asc")).Order("id desc")
+	case "packages":
+		q = q.Order("package_count " + dirOr(dir, "desc")).Order("id desc")
+	case "uploaded":
+		q = q.Order("created_at " + dirOr(dir, "desc")).Order("id desc")
+	default:
+		sortCol, dir = defaultSort, ""
+		q = q.Order("id desc")
+	}
+	sort := sortCol
+	if dir != "" {
+		sort = sortCol + "." + dir
+	}
+
 	var total int64
-	s.DB.Model(&db.SBOMUpload{}).Count(&total)
+	q.Count(&total)
 	page := paginate(r, total)
 	var rows []db.SBOMUpload
-	s.DB.Order("id desc").Limit(perPage).Offset((page.N - 1) * perPage).Find(&rows)
-	s.render(w, r, "sboms.html", map[string]any{"SBOMs": rows, "Page": page})
+	q.Limit(perPage).Offset((page.N - 1) * perPage).Find(&rows)
+	s.render(w, r, "sboms.html", map[string]any{"SBOMs": rows, "Page": page, "Sort": sort})
 }
 
 func (s *Server) sbomNew(w http.ResponseWriter, r *http.Request) {

--- a/internal/web/scans.go
+++ b/internal/web/scans.go
@@ -27,16 +27,16 @@ func (s *Server) jobs(w http.ResponseWriter, r *http.Request) {
 	sortCol, dir := splitSort(r.URL.Query().Get("sort"), "")
 	switch sortCol {
 	case "id":
-		q = q.Order("scans.id " + dirOr(dir, "desc"))
+		q = q.Order(orderByExpr("scans.id", dir, true))
 	case "skill":
-		q = q.Order("skill_name " + dirOr(dir, "asc")).Order("scans.id desc")
+		q = q.Order(orderByExpr("skill_name", dir, false)).Order("scans.id desc")
 	case statusKey:
-		q = q.Order("status " + dirOr(dir, "asc")).Order("scans.id desc")
+		q = q.Order(orderByExpr("status", dir, false)).Order("scans.id desc")
 	case sortRepository:
-		q = q.Joins("Repository").Order("`Repository`.name " + dirOr(dir, "asc")).Order("scans.id desc")
+		q = q.Joins("Repository").Order(orderByExpr("`Repository`.name", dir, false)).Order("scans.id desc")
 	case "findings":
 		// findings_count is a denormalised column on the scan row.
-		q = q.Order("findings_count " + dirOr(dir, "desc")).Order("scans.id desc")
+		q = q.Order(orderByExpr("findings_count", dir, true)).Order("scans.id desc")
 	default:
 		sortCol, dir = defaultSort, ""
 		q = q.Order("status_priority, scans.id desc")

--- a/internal/web/scans.go
+++ b/internal/web/scans.go
@@ -24,17 +24,23 @@ func (s *Server) jobs(w http.ResponseWriter, r *http.Request) {
 		q = q.Where("status = ?", status)
 	}
 
-	sort := r.URL.Query().Get("sort")
-	switch sort {
+	sortCol, dir := splitSort(r.URL.Query().Get("sort"), "")
+	switch sortCol {
+	case "id":
+		q = q.Order("scans.id " + dirOr(dir, "desc"))
 	case "skill":
-		q = q.Order("skill_name, id desc")
+		q = q.Order("skill_name " + dirOr(dir, "asc")).Order("scans.id desc")
 	case statusKey:
-		q = q.Order("status, id desc")
+		q = q.Order("status " + dirOr(dir, "asc")).Order("scans.id desc")
 	case sortRepository:
-		q = q.Joins("Repository").Order("`Repository`.name, scans.id desc")
+		q = q.Joins("Repository").Order("`Repository`.name " + dirOr(dir, "asc")).Order("scans.id desc")
 	default:
-		sort = defaultSort
+		sortCol, dir = defaultSort, ""
 		q = q.Order("status_priority, scans.id desc")
+	}
+	sort := sortCol
+	if dir != "" {
+		sort = sortCol + "." + dir
 	}
 
 	var total int64

--- a/internal/web/scans.go
+++ b/internal/web/scans.go
@@ -34,6 +34,9 @@ func (s *Server) jobs(w http.ResponseWriter, r *http.Request) {
 		q = q.Order("status " + dirOr(dir, "asc")).Order("scans.id desc")
 	case sortRepository:
 		q = q.Joins("Repository").Order("`Repository`.name " + dirOr(dir, "asc")).Order("scans.id desc")
+	case "findings":
+		// findings_count is a denormalised column on the scan row.
+		q = q.Order("findings_count " + dirOr(dir, "desc")).Order("scans.id desc")
 	default:
 		sortCol, dir = defaultSort, ""
 		q = q.Order("status_priority, scans.id desc")

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -416,7 +416,18 @@ func (s *Server) render(w http.ResponseWriter, r *http.Request, name string, dat
 	data["Theme"] = resolveTheme(r)
 	data["ColorScheme"] = resolveColorScheme(r)
 	data["Flash"] = popFlash(w, r)
-	data["Sorter"] = sortCtx{path: r.URL.Path, query: r.URL.Query()}
+	// Seed the sorter with the handler's EFFECTIVE sort (data["Sort"]) rather
+	// than the raw ?sort param. That token is already the sanitized, defaulted
+	// sort the ORDER BY actually used, so folding it in makes a default or
+	// sanitized sort mark its column active (aria-sort + arrow) and makes the
+	// first header click flip direction instead of silently repeating the
+	// default. When ?sort is a valid explicit token the two agree, so this is a
+	// no-op there; non-index pages set no "Sort" and keep the raw query.
+	sorterQuery := r.URL.Query()
+	if eff, ok := data["Sort"].(string); ok && eff != "" {
+		sorterQuery.Set("sort", eff)
+	}
+	data["Sorter"] = sortCtx{path: r.URL.Path, query: sorterQuery}
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	if err := s.tmpl.ExecuteTemplate(w, name, data); err != nil {
 		s.Log.Error("render", "tmpl", name, "err", err)

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -613,13 +613,13 @@ func (s *Server) repoList(w http.ResponseWriter, r *http.Request) {
 	const nameSort = "name"
 	switch sortCol {
 	case nameSort:
-		q = q.Order(nameSort + " " + dirOr(dir, "asc"))
+		q = q.Order(orderByExpr(nameSort, dir, false))
 	case "stars":
-		q = q.Order("stars " + dirOr(dir, "desc"))
+		q = q.Order(orderByExpr("stars", dir, true))
 	case "language":
-		q = q.Order("languages " + dirOr(dir, "asc")).Order("name")
+		q = q.Order(orderByExpr("languages", dir, false)).Order("name")
 	case "size":
-		q = q.Order("disk_bytes " + dirOr(dir, "desc")).Order("updated_at desc")
+		q = q.Order(orderByExpr("disk_bytes", dir, true)).Order("updated_at desc")
 	case "findings":
 		// Correlated subquery keeps the existing Count/Find chain intact
 		// (a JOIN+GROUP BY would change what Count(&total) returns). Low-
@@ -929,21 +929,21 @@ func (s *Server) findings(w http.ResponseWriter, r *http.Request) {
 	case sortSeverity:
 		// severityOrder ranks the most severe LOWEST, so the intuitive default
 		// (most severe first, shown as "desc") is ascending on the expression;
-		// flip the SQL direction relative to the logical one.
-		q = q.Order("(" + severityOrder + ") " + flipSQLDir(dirOr(dir, "desc"))).Order("findings.id desc")
+		// !wantDesc flips the SQL direction relative to the logical one.
+		q = q.Order(orderBySuffix("("+severityOrder+")", !wantDesc(dir, true))).Order("findings.id desc")
 	case sortRepository:
 		q = q.Joins("JOIN repositories r ON r.id = findings.repository_id").
-			Order("r.name " + dirOr(dir, "asc")).Order("findings.id desc")
+			Order(orderByExpr("r.name", dir, false)).Order("findings.id desc")
 	case "title":
-		q = q.Order("findings.title " + dirOr(dir, "asc")).Order("findings.id desc")
+		q = q.Order(orderByExpr("findings.title", dir, false)).Order("findings.id desc")
 	case statusKey:
-		q = q.Order("findings.status " + dirOr(dir, "asc")).Order("findings.id desc")
+		q = q.Order(orderByExpr("findings.status", dir, false)).Order("findings.id desc")
 	case "repo_id":
-		q = q.Order("findings.repository_id " + dirOr(dir, "asc")).Order("findings.id desc")
+		q = q.Order(orderByExpr("findings.repository_id", dir, false)).Order("findings.id desc")
 	case "cwe":
-		q = q.Order("findings.cwe " + dirOr(dir, "asc")).Order("findings.id desc")
+		q = q.Order(orderByExpr("findings.cwe", dir, false)).Order("findings.id desc")
 	case "scan":
-		q = q.Order("findings.scan_id " + dirOr(dir, "desc")).Order("findings.id desc")
+		q = q.Order(orderByExpr("findings.scan_id", dir, true)).Order("findings.id desc")
 	default:
 		sortCol, dir = defaultSort, ""
 		q = q.Order("id desc")
@@ -1482,17 +1482,17 @@ func (s *Server) packages(w http.ResponseWriter, r *http.Request) {
 	sortCol, dir := splitSort(r.URL.Query().Get("sort"), "")
 	switch sortCol {
 	case "name":
-		q = q.Order("name " + dirOr(dir, "asc"))
+		q = q.Order(orderByExpr("name", dir, false))
 	case "downloads":
-		q = q.Order("downloads " + dirOr(dir, "desc"))
+		q = q.Order(orderByExpr("downloads", dir, true))
 	case "dependents":
-		q = q.Order("dependent_repos " + dirOr(dir, "desc"))
+		q = q.Order(orderByExpr("dependent_repos", dir, true))
 	case "ecosystem":
-		q = q.Order("ecosystem " + dirOr(dir, "asc")).Order("name")
+		q = q.Order(orderByExpr("ecosystem", dir, false)).Order("name")
 	case "registry":
-		q = q.Order("registry_url " + dirOr(dir, "asc")).Order("name")
+		q = q.Order(orderByExpr("registry_url", dir, false)).Order("name")
 	case "latest":
-		q = q.Order("latest_release_at " + dirOr(dir, "desc")).Order("name")
+		q = q.Order(orderByExpr("latest_release_at", dir, true)).Order("name")
 	default:
 		sortCol, dir = "name", ""
 		q = q.Order("name")
@@ -1552,14 +1552,14 @@ func (s *Server) advisoriesList(w http.ResponseWriter, r *http.Request) {
 	sortCol, dir := splitSort(r.URL.Query().Get("sort"), "")
 	switch sortCol {
 	case "newest":
-		q = q.Order("published_at " + dirOr(dir, "desc")).Order("id desc")
+		q = q.Order(orderByExpr("published_at", dir, true)).Order("id desc")
 	case sortRepository:
 		q = q.Joins("JOIN repositories r ON r.id = advisories.repository_id").
-			Order("r.name " + dirOr(dir, "asc")).Order("advisories.cvss_score desc")
+			Order(orderByExpr("r.name", dir, false)).Order("advisories.cvss_score desc")
 	case "title":
-		q = q.Order("title " + dirOr(dir, "asc")).Order("id desc")
+		q = q.Order(orderByExpr("title", dir, false)).Order("id desc")
 	case sortSeverity:
-		q = q.Order("cvss_score " + dirOr(dir, "desc")).Order("id desc")
+		q = q.Order(orderByExpr("cvss_score", dir, true)).Order("id desc")
 	default:
 		sortCol, dir = sortSeverity, ""
 		q = q.Order("cvss_score desc, id desc")

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -200,8 +200,9 @@ func New(gdb *gorm.DB, q *queue.Queue, log *slog.Logger, broker *Broker, w *work
 			}
 			return m
 		},
-		"list":  func(xs ...string) []string { return xs },
-		"len64": tmplLen64,
+		"list":    func(xs ...string) []string { return xs },
+		"len64":   tmplLen64,
+		"sortkey": sortKey,
 		"cwename": func(id string) string {
 			if _, c, ok := LookupCWE(id); ok {
 				return c.Name
@@ -415,6 +416,7 @@ func (s *Server) render(w http.ResponseWriter, r *http.Request, name string, dat
 	data["Theme"] = resolveTheme(r)
 	data["ColorScheme"] = resolveColorScheme(r)
 	data["Flash"] = popFlash(w, r)
+	data["Sorter"] = sortCtx{path: r.URL.Path, query: r.URL.Query()}
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	if err := s.tmpl.ExecuteTemplate(w, name, data); err != nil {
 		s.Log.Error("render", "tmpl", name, "err", err)
@@ -607,25 +609,31 @@ func (s *Server) repoList(w http.ResponseWriter, r *http.Request) {
 			like, like, like, like)
 	}
 
-	sort := r.URL.Query().Get("sort")
+	sortCol, dir := splitSort(r.URL.Query().Get("sort"), "")
 	const nameSort = "name"
-	switch sort {
+	switch sortCol {
 	case nameSort:
-		q = q.Order(nameSort)
+		q = q.Order(nameSort + " " + dirOr(dir, "asc"))
 	case "stars":
-		q = q.Order("stars desc")
+		q = q.Order("stars " + dirOr(dir, "desc"))
 	case "language":
-		q = q.Order("languages, name")
+		q = q.Order("languages " + dirOr(dir, "asc")).Order("name")
+	case "size":
+		q = q.Order("disk_bytes " + dirOr(dir, "desc")).Order("updated_at desc")
 	case "findings":
 		// Correlated subquery keeps the existing Count/Find chain intact
 		// (a JOIN+GROUP BY would change what Count(&total) returns). Low-
 		// thousands of repos so the per-row subselect is fine on sqlite.
 		// Scanner-skill findings (zizmor, semgrep, …) are excluded so the
 		// list reflects curated audit output, matching the repo Findings tab.
-		q = q.Order("(" + deepDiveFindingsCountSQL + ") desc, updated_at desc")
+		q = q.Order("(" + deepDiveFindingsCountSQL + ") " + dirOr(dir, "desc")).Order("updated_at desc")
 	default:
-		sort = defaultSort
+		sortCol, dir = defaultSort, ""
 		q = q.Order("updated_at desc")
+	}
+	sort := sortCol
+	if dir != "" {
+		sort = sortCol + "." + dir
 	}
 
 	var total int64
@@ -903,16 +911,33 @@ func (s *Server) findings(w http.ResponseWriter, r *http.Request) {
 	missed := r.URL.Query().Get("missed") == "1"
 	search := strings.TrimSpace(r.URL.Query().Get("q"))
 
-	sort := r.URL.Query().Get("sort")
-	switch sort {
+	sortCol, dir := splitSort(r.URL.Query().Get("sort"), "")
+	switch sortCol {
 	case sortSeverity:
-		q = q.Order(severityOrder).Order("id desc")
+		// severityOrder ranks the most severe LOWEST, so the intuitive default
+		// (most severe first, shown as "desc") is ascending on the expression;
+		// flip the SQL direction relative to the logical one.
+		q = q.Order("(" + severityOrder + ") " + flipSQLDir(dirOr(dir, "desc"))).Order("findings.id desc")
 	case sortRepository:
 		q = q.Joins("JOIN repositories r ON r.id = findings.repository_id").
-			Order("r.name").Order("findings.id desc")
+			Order("r.name " + dirOr(dir, "asc")).Order("findings.id desc")
+	case "title":
+		q = q.Order("findings.title " + dirOr(dir, "asc")).Order("findings.id desc")
+	case statusKey:
+		q = q.Order("findings.status " + dirOr(dir, "asc")).Order("findings.id desc")
+	case "repo_id":
+		q = q.Order("findings.repository_id " + dirOr(dir, "asc")).Order("findings.id desc")
+	case "cwe":
+		q = q.Order("findings.cwe " + dirOr(dir, "asc")).Order("findings.id desc")
+	case "scan":
+		q = q.Order("findings.scan_id " + dirOr(dir, "desc")).Order("findings.id desc")
 	default:
-		sort = defaultSort
+		sortCol, dir = defaultSort, ""
 		q = q.Order("id desc")
+	}
+	sort := sortCol
+	if dir != "" {
+		sort = sortCol + "." + dir
 	}
 
 	var total int64
@@ -1441,19 +1466,27 @@ func (s *Server) packages(w http.ResponseWriter, r *http.Request) {
 		q = q.Where("name LIKE ? OR p_url LIKE ? OR licenses LIKE ?", like, like, like)
 	}
 
-	sort := r.URL.Query().Get("sort")
-	switch sort {
+	sortCol, dir := splitSort(r.URL.Query().Get("sort"), "")
+	switch sortCol {
 	case "name":
-		q = q.Order("name")
+		q = q.Order("name " + dirOr(dir, "asc"))
 	case "downloads":
-		q = q.Order("downloads desc")
+		q = q.Order("downloads " + dirOr(dir, "desc"))
 	case "dependents":
-		q = q.Order("dependent_repos desc")
+		q = q.Order("dependent_repos " + dirOr(dir, "desc"))
 	case "ecosystem":
-		q = q.Order("ecosystem, name")
+		q = q.Order("ecosystem " + dirOr(dir, "asc")).Order("name")
+	case "registry":
+		q = q.Order("registry_url " + dirOr(dir, "asc")).Order("name")
+	case "latest":
+		q = q.Order("latest_release_at " + dirOr(dir, "desc")).Order("name")
 	default:
-		sort = "name"
+		sortCol, dir = "name", ""
 		q = q.Order("name")
+	}
+	sort := sortCol
+	if dir != "" {
+		sort = sortCol + "." + dir
 	}
 
 	var total int64
@@ -1503,16 +1536,24 @@ func (s *Server) advisoriesList(w http.ResponseWriter, r *http.Request) {
 			like, like, like, like)
 	}
 
-	sort := r.URL.Query().Get("sort")
-	switch sort {
+	sortCol, dir := splitSort(r.URL.Query().Get("sort"), "")
+	switch sortCol {
 	case "newest":
-		q = q.Order("published_at desc, id desc")
+		q = q.Order("published_at " + dirOr(dir, "desc")).Order("id desc")
 	case sortRepository:
 		q = q.Joins("JOIN repositories r ON r.id = advisories.repository_id").
-			Order("r.name").Order("advisories.cvss_score desc")
+			Order("r.name " + dirOr(dir, "asc")).Order("advisories.cvss_score desc")
+	case "title":
+		q = q.Order("title " + dirOr(dir, "asc")).Order("id desc")
+	case sortSeverity:
+		q = q.Order("cvss_score " + dirOr(dir, "desc")).Order("id desc")
 	default:
-		sort = "severity"
+		sortCol, dir = sortSeverity, ""
 		q = q.Order("cvss_score desc, id desc")
+	}
+	sort := sortCol
+	if dir != "" {
+		sort = sortCol + "." + dir
 	}
 
 	var total int64

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -626,7 +626,20 @@ func (s *Server) repoList(w http.ResponseWriter, r *http.Request) {
 		// thousands of repos so the per-row subselect is fine on sqlite.
 		// Scanner-skill findings (zizmor, semgrep, …) are excluded so the
 		// list reflects curated audit output, matching the repo Findings tab.
-		q = q.Order("(" + deepDiveFindingsCountSQL + ") " + dirOr(dir, "desc")).Order("updated_at desc")
+		// orderByExpr keeps the request out of the raw-subquery clause.
+		q = q.Order(orderByExpr("("+deepDiveFindingsCountSQL+")", dir, true)).Order("updated_at desc")
+	case "scanned":
+		// Order by each repo's latest scan id (the row the Last scan column
+		// renders), most-recent first by default; never-scanned repos (NULL)
+		// sort last under DESC. Correlated subquery, like the findings case.
+		q = q.Order(orderByExpr("(SELECT MAX(id) FROM scans WHERE scans.repository_id = repositories.id)", dir, true)).Order("updated_at desc")
+	case statusKey:
+		// Order by the same rank the scans index uses: the denormalised
+		// status_priority column (0=running .. 3=terminal), lowest-first by
+		// default so active repos surface. COALESCE pushes never-scanned repos
+		// last. The Status badge is computed live for display, but sorting can
+		// use the indexed column, exactly as /scans does.
+		q = q.Order(orderByExpr("COALESCE((SELECT MIN(status_priority) FROM scans WHERE scans.repository_id = repositories.id), 99)", dir, false)).Order("updated_at desc")
 	default:
 		sortCol, dir = defaultSort, ""
 		q = q.Order("updated_at desc")

--- a/internal/web/sortable.go
+++ b/internal/web/sortable.go
@@ -32,9 +32,11 @@ func splitSort(token, defDir string) (key, dir string) {
 	return token, defDir
 }
 
-// dirOr returns dir when it is a valid direction, else def. Its result is only
-// ever the literals "asc"/"desc" (or the trusted def), so it is safe to splice
-// into an ORDER BY clause; raw request input never reaches the query this way.
+// dirOr returns dir when it is a valid direction ("asc"/"desc"), else def. It
+// resolves the request direction for the NON-SQL callers — the template arrow
+// (sortCtx.Dir) and the in-memory org comparator (dirLess). SQL ORDER BY
+// clauses do not use this: they go through orderByExpr, which carries the
+// direction as a boolean so the request never reaches the query at all.
 func dirOr(dir, def string) string {
 	if dir == "asc" || dir == "desc" {
 		return dir
@@ -42,38 +44,42 @@ func dirOr(dir, def string) string {
 	return def
 }
 
-// orderByExpr renders an ORDER BY term for a TRUSTED, constant SQL expression
-// with a validated direction. Unlike expr+" "+dirOr(dir,…), the direction is
-// resolved to a boolean here and the ASC/DESC suffix comes from a code literal,
-// so the request never contributes a single byte to the clause — the result is
-// provably one of two fixed strings. Defence in depth over the switch/dirOr
-// allowlists, used for the sorts whose expression is a raw subquery.
+// wantDesc resolves a validated direction to a boolean; defaultDesc applies
+// when dir is unset. It is the single point that turns the (allowlisted)
+// request direction into a bool, so callers build an ORDER BY without ever
+// concatenating the request's own bytes into SQL.
+func wantDesc(dir string, defaultDesc bool) bool {
+	switch dir {
+	case "asc":
+		return false
+	case "desc":
+		return true
+	default:
+		return defaultDesc
+	}
+}
+
+// orderBySuffix appends ASC or DESC — a code literal, chosen by a boolean — to
+// a TRUSTED, constant SQL expression. Because the direction is a bool and the
+// suffix is literal, the request contributes no bytes to the clause; the result
+// is provably one of two fixed strings.
 //
 // expr MUST be a compile-time constant; never pass request-derived text (a SQL
 // ORDER BY direction cannot be a bind parameter, so a raw expression here is
 // the boundary — keep it constant).
-func orderByExpr(expr, dir string, defaultDesc bool) string {
-	desc := defaultDesc
-	switch dir {
-	case "asc":
-		desc = false
-	case "desc":
-		desc = true
-	}
+func orderBySuffix(expr string, desc bool) string {
 	if desc {
 		return expr + " DESC"
 	}
 	return expr + " ASC"
 }
 
-// flipSQLDir returns the opposite SQL direction. It is used for columns whose
-// ORDER BY expression inverts the logical sense — e.g. severityOrder ranks the
-// most severe lowest, so "most severe first" is an ascending sort on it.
-func flipSQLDir(dir string) string {
-	if dir == "asc" {
-		return "desc"
-	}
-	return "asc"
+// orderByExpr is the common case: resolve dir against defaultDesc, then suffix
+// the trusted expr. Every index sort builds its ORDER BY through this (or
+// orderBySuffix directly, for the severity rank whose expression inverts the
+// logical direction), so no sort concatenates the request direction into SQL.
+func orderByExpr(expr, dir string, defaultDesc bool) string {
+	return orderBySuffix(expr, wantDesc(dir, defaultDesc))
 }
 
 // URL returns the current index URL re-sorted by key. When key is already the

--- a/internal/web/sortable.go
+++ b/internal/web/sortable.go
@@ -1,0 +1,100 @@
+package web
+
+import (
+	"maps"
+	"net/url"
+	"strings"
+)
+
+// sortCtx builds column-sort URLs and reports the active sort direction for
+// the index tables. render() injects one, built from the current request, as
+// ".Sorter" in every template so the th-sort partial can drive header links
+// without each handler threading path/query through by hand.
+//
+// Direction is folded into the sort token rather than carried in a separate
+// query param: "severity" means the column's natural default direction and
+// "severity.asc"/"severity.desc" pin it. Because that one `sort` value is
+// already propagated by every filter and pagination link, direction survives
+// filtering and paging with no extra plumbing.
+type sortCtx struct {
+	path  string
+	query url.Values
+}
+
+// splitSort parses a "key.dir" sort token. The direction suffix is only
+// honoured when it is exactly "asc" or "desc"; otherwise defDir is returned,
+// so callers can pass a per-column default (or "" to detect "unset").
+func splitSort(token, defDir string) (key, dir string) {
+	key, rest, ok := strings.Cut(token, ".")
+	if ok && (rest == "asc" || rest == "desc") {
+		return key, rest
+	}
+	return token, defDir
+}
+
+// dirOr returns dir when it is a valid direction, else def. Its result is only
+// ever the literals "asc"/"desc" (or the trusted def), so it is safe to splice
+// into an ORDER BY clause; raw request input never reaches the query this way.
+func dirOr(dir, def string) string {
+	if dir == "asc" || dir == "desc" {
+		return dir
+	}
+	return def
+}
+
+// flipSQLDir returns the opposite SQL direction. It is used for columns whose
+// ORDER BY expression inverts the logical sense — e.g. severityOrder ranks the
+// most severe lowest, so "most severe first" is an ascending sort on it.
+func flipSQLDir(dir string) string {
+	if dir == "asc" {
+		return "desc"
+	}
+	return "asc"
+}
+
+// URL returns the current index URL re-sorted by key. When key is already the
+// active sort it flips direction; otherwise it applies def, the column's
+// natural default. Every other query param (filters, search) is preserved and
+// pagination resets to page 1.
+func (c sortCtx) URL(key, def string) string {
+	curKey, curDir := splitSort(c.query.Get("sort"), "")
+	next := def
+	if curKey == key {
+		eff := curDir
+		if eff == "" {
+			eff = def
+		}
+		if eff == "asc" {
+			next = "desc"
+		} else {
+			next = "asc"
+		}
+	}
+	token := key
+	if next != def {
+		token = key + "." + next
+	}
+	q := url.Values{}
+	maps.Copy(q, c.query)
+	q.Set("sort", token)
+	q.Del("page") // re-sorting starts on page 1
+	return c.path + "?" + q.Encode()
+}
+
+// Dir reports the active direction for key ("asc"/"desc") so a header can draw
+// its arrow, or "" when key is not the current sort.
+func (c sortCtx) Dir(key, def string) string {
+	curKey, curDir := splitSort(c.query.Get("sort"), "")
+	if curKey != key {
+		return ""
+	}
+	return dirOr(curDir, def)
+}
+
+// sortKey returns just the column key of a sort token, dropping any direction
+// suffix. Templates use it to keep a sort dropdown's label and active-item
+// highlight in sync with a compound token like "severity.asc".
+func sortKey(token string) string {
+	key, _ := splitSort(token, "")
+	return key
+}

--- a/internal/web/sortable.go
+++ b/internal/web/sortable.go
@@ -42,6 +42,30 @@ func dirOr(dir, def string) string {
 	return def
 }
 
+// orderByExpr renders an ORDER BY term for a TRUSTED, constant SQL expression
+// with a validated direction. Unlike expr+" "+dirOr(dir,…), the direction is
+// resolved to a boolean here and the ASC/DESC suffix comes from a code literal,
+// so the request never contributes a single byte to the clause — the result is
+// provably one of two fixed strings. Defence in depth over the switch/dirOr
+// allowlists, used for the sorts whose expression is a raw subquery.
+//
+// expr MUST be a compile-time constant; never pass request-derived text (a SQL
+// ORDER BY direction cannot be a bind parameter, so a raw expression here is
+// the boundary — keep it constant).
+func orderByExpr(expr, dir string, defaultDesc bool) string {
+	desc := defaultDesc
+	switch dir {
+	case "asc":
+		desc = false
+	case "desc":
+		desc = true
+	}
+	if desc {
+		return expr + " DESC"
+	}
+	return expr + " ASC"
+}
+
 // flipSQLDir returns the opposite SQL direction. It is used for columns whose
 // ORDER BY expression inverts the logical sense — e.g. severityOrder ranks the
 // most severe lowest, so "most severe first" is an ascending sort on it.

--- a/internal/web/sortable_test.go
+++ b/internal/web/sortable_test.go
@@ -71,6 +71,24 @@ func TestSortCtxDir(t *testing.T) {
 	}
 }
 
+// assertOrder fails fatally when either marker is missing from body, then
+// checks first appears before second. A bare strings.Index comparison passes
+// silently when a row is absent (Index returns -1), which would mask a
+// rendering regression; this makes "both present, and in order" the claim.
+func assertOrder(t *testing.T, body, first, second string) {
+	t.Helper()
+	i, j := strings.Index(body, first), strings.Index(body, second)
+	if i < 0 {
+		t.Fatalf("%q not found in response", first)
+	}
+	if j < 0 {
+		t.Fatalf("%q not found in response", second)
+	}
+	if i > j {
+		t.Errorf("%q should appear before %q", first, second)
+	}
+}
+
 // TestFindings_sortDirection proves the folded-token direction actually
 // reaches the ORDER BY: the same column reverses between .asc and its default.
 func TestFindings_sortDirection(t *testing.T) {
@@ -95,9 +113,7 @@ func TestFindings_sortDirection(t *testing.T) {
 
 	// Default severity direction is desc: Critical before Low.
 	body := get("?sort=severity")
-	if strings.Index(body, "crit-one") > strings.Index(body, "low-one") {
-		t.Errorf("sort=severity should put Critical before Low")
-	}
+	assertOrder(t, body, "crit-one", "low-one")
 	// The active header must offer the flip to ascending.
 	if !strings.Contains(body, "sort=severity.asc") {
 		t.Errorf("active severity header should link to the ascending flip")
@@ -118,8 +134,51 @@ func TestFindings_sortDirection(t *testing.T) {
 
 	// Explicit ascending reverses it: Low before Critical.
 	body = get("?sort=severity.asc")
-	if strings.Index(body, "low-one") > strings.Index(body, "crit-one") {
-		t.Errorf("sort=severity.asc should put Low before Critical")
+	assertOrder(t, body, "low-one", "crit-one")
+}
+
+// TestSort_defaultColumnActiveWithoutParam guards the landing page with no
+// ?sort — the primary nav entry path. render() seeds the sorter from each
+// handler's effective sort, so every index whose default IS a real column must
+// render that header active: aria-sort set and the first click linking to the
+// direction FLIP, not an idle header whose first click silently re-applies the
+// default order. Sweeps all four affected tables and both default directions
+// (name asc; advisories severity desc).
+func TestSort_defaultColumnActiveWithoutParam(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	// One row per table — the index templates only draw the sortable header row
+	// when the result set is non-empty. The repo's Owner seeds the orgs index.
+	repo := db.Repository{URL: "https://x/def-repo", Name: "def-repo", Owner: "anorg"}
+	s.DB.Create(&repo)
+	s.DB.Create(&db.Maintainer{Login: "amaint", Name: "amaint", Status: db.MaintainerActive})
+	s.DB.Create(&db.Package{RepositoryID: repo.ID, Name: "apkg", Ecosystem: "rubygems"})
+	s.DB.Create(&db.Advisory{RepositoryID: repo.ID, UUID: "u1", Title: "adv", Severity: "HIGH", CVSSScore: 7.5})
+
+	for _, tc := range []struct {
+		path, ariaSort, flip string
+	}{
+		{"/maintainers", "ascending", "sort=name.desc"},
+		{"/orgs", "ascending", "sort=name.desc"},
+		{"/packages", "ascending", "sort=name.desc"},
+		{"/advisories", "descending", "sort=severity.asc"},
+	} {
+		w := httptest.NewRecorder()
+		s.Handler().ServeHTTP(w, localReq("GET", tc.path))
+		if w.Code != 200 {
+			t.Fatalf("GET %s status %d", tc.path, w.Code)
+		}
+		body := w.Body.String()
+		// The default column announces its direction even with no ?sort.
+		if want := `aria-sort="` + tc.ariaSort + `"`; !strings.Contains(body, want) {
+			t.Errorf("GET %s: default column should set %s without ?sort", tc.path, want)
+		}
+		// Its header links to the flip, so the first click reverses direction
+		// instead of re-applying the order the page already shows.
+		if !strings.Contains(body, tc.flip) {
+			t.Errorf("GET %s: default header should link to the flip (%s)", tc.path, tc.flip)
+		}
 	}
 }
 
@@ -149,23 +208,13 @@ func TestSort_derivedColumns(t *testing.T) {
 		}
 		return w.Body.String()
 	}
-	before := func(body, a, b string) bool { return strings.Index(body, a) < strings.Index(body, b) }
-
 	// Last scan: most-recently-scanned repo first, reversed under .asc.
-	if b := get("/?sort=scanned"); !before(b, "repo-new", "repo-old") {
-		t.Errorf("sort=scanned should put the most-recently-scanned repo first")
-	}
-	if b := get("/?sort=scanned.asc"); !before(b, "repo-old", "repo-new") {
-		t.Errorf("sort=scanned.asc should reverse")
-	}
+	assertOrder(t, get("/?sort=scanned"), "repo-new", "repo-old")
+	assertOrder(t, get("/?sort=scanned.asc"), "repo-old", "repo-new")
 	// Status: running (rank 0) before done (rank 3) under the asc default.
-	if b := get("/?sort=status"); !before(b, "repo-new", "repo-old") {
-		t.Errorf("sort=status should rank the running repo before the done repo")
-	}
+	assertOrder(t, get("/?sort=status"), "repo-new", "repo-old")
 	// Scans Findings: the higher findings_count first under the desc default.
-	if b := get("/scans?sort=findings"); !before(b, "repo-new", "repo-old") {
-		t.Errorf("/scans?sort=findings should rank the 9-finding scan before the 2-finding scan")
-	}
+	assertOrder(t, get("/scans?sort=findings"), "repo-new", "repo-old")
 }
 
 // TestSort_maliciousParamFallsBackSafely feeds hostile ?sort= values (unknown

--- a/internal/web/sortable_test.go
+++ b/internal/web/sortable_test.go
@@ -110,6 +110,11 @@ func TestFindings_sortDirection(t *testing.T) {
 	if !strings.Contains(body, `aria-sort="descending"`) {
 		t.Errorf("active severity header should set aria-sort=descending")
 	}
+	// Inactive sortable columns (e.g. Title) show the idle affordance so the
+	// header reads as sortable before any click.
+	if !strings.Contains(body, `data-lucide="chevrons-up-down"`) {
+		t.Errorf("inactive sortable headers should show the idle chevron")
+	}
 
 	// Explicit ascending reverses it: Low before Critical.
 	body = get("?sort=severity.asc")

--- a/internal/web/sortable_test.go
+++ b/internal/web/sortable_test.go
@@ -122,3 +122,96 @@ func TestFindings_sortDirection(t *testing.T) {
 		t.Errorf("sort=severity.asc should put Low before Critical")
 	}
 }
+
+// TestSort_derivedColumns covers the columns that sort via a correlated
+// subquery or denormalised key rather than a plain column: repo Last scan /
+// Status and the scans Findings count.
+func TestSort_derivedColumns(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	repoOld := db.Repository{URL: "https://x/repo-old", Name: "repo-old"}
+	repoNew := db.Repository{URL: "https://x/repo-new", Name: "repo-new"}
+	s.DB.Create(&repoOld)
+	s.DB.Create(&repoNew)
+	// repoOld scanned first (lower id) and finished; repoNew scanned later
+	// (higher id) and still running, with more findings.
+	s.DB.Create(&db.Scan{RepositoryID: repoOld.ID, Kind: "skill", Status: db.ScanDone,
+		StatusPriority: db.StatusPriorityFor(db.ScanDone), FindingsCount: 2})
+	s.DB.Create(&db.Scan{RepositoryID: repoNew.ID, Kind: "skill", Status: db.ScanRunning,
+		StatusPriority: db.StatusPriorityFor(db.ScanRunning), FindingsCount: 9})
+
+	get := func(path string) string {
+		w := httptest.NewRecorder()
+		s.Handler().ServeHTTP(w, localReq("GET", path))
+		if w.Code != 200 {
+			t.Fatalf("GET %s status %d", path, w.Code)
+		}
+		return w.Body.String()
+	}
+	before := func(body, a, b string) bool { return strings.Index(body, a) < strings.Index(body, b) }
+
+	// Last scan: most-recently-scanned repo first, reversed under .asc.
+	if b := get("/?sort=scanned"); !before(b, "repo-new", "repo-old") {
+		t.Errorf("sort=scanned should put the most-recently-scanned repo first")
+	}
+	if b := get("/?sort=scanned.asc"); !before(b, "repo-old", "repo-new") {
+		t.Errorf("sort=scanned.asc should reverse")
+	}
+	// Status: running (rank 0) before done (rank 3) under the asc default.
+	if b := get("/?sort=status"); !before(b, "repo-new", "repo-old") {
+		t.Errorf("sort=status should rank the running repo before the done repo")
+	}
+	// Scans Findings: the higher findings_count first under the desc default.
+	if b := get("/scans?sort=findings"); !before(b, "repo-new", "repo-old") {
+		t.Errorf("/scans?sort=findings should rank the 9-finding scan before the 2-finding scan")
+	}
+}
+
+// TestSort_maliciousParamFallsBackSafely feeds hostile ?sort= values (unknown
+// keys, SQLi payloads, bad directions) to the index handlers and asserts they
+// fall back to the default order — HTTP 200, no error — and that no injected
+// statement executed (the tables survive with their row counts intact). This
+// is the regression guard for the switch/dirOr/orderByExpr allowlists: if a
+// later refactor lets request text reach an ORDER BY, a DROP/DELETE payload
+// would drop a table and fail these assertions loudly.
+func TestSort_maliciousParamFallsBackSafely(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	repo := db.Repository{URL: "https://x/keep", Name: "keep"}
+	s.DB.Create(&repo)
+	s.DB.Create(&db.Scan{RepositoryID: repo.ID, Kind: "skill", Status: db.ScanDone,
+		StatusPriority: db.StatusPriorityFor(db.ScanDone), FindingsCount: 1})
+
+	payloads := []string{
+		"name); DROP TABLE repositories;--",
+		"scanned; DROP TABLE scans",
+		"status.asc'); DROP TABLE repositories;--",
+		"scanned.desc; DELETE FROM scans",
+		"findings) UNION SELECT 1--",
+		"status.evil",
+		"' OR '1'='1",
+		"(SELECT 1)",
+	}
+	// Both the repo index (/) and the scans index (/scans) go through the same
+	// allowlists, so exercise both with every payload.
+	for _, base := range []string{"/", "/scans"} {
+		for _, p := range payloads {
+			w := httptest.NewRecorder()
+			s.Handler().ServeHTTP(w, localReq("GET", base+"?sort="+url.QueryEscape(p)))
+			if w.Code != 200 {
+				t.Errorf("GET %s?sort=%q: status %d, want 200 (should fall back, not error)", base, p, w.Code)
+			}
+			// If any payload had been executed, a table would be gone and these
+			// counts would error or read zero.
+			var repos, scans int64
+			if err := s.DB.Model(&db.Repository{}).Count(&repos).Error; err != nil || repos != 1 {
+				t.Fatalf("after %s?sort=%q: repositories table harmed (count=%d err=%v)", base, p, repos, err)
+			}
+			if err := s.DB.Model(&db.Scan{}).Count(&scans).Error; err != nil || scans != 1 {
+				t.Fatalf("after %s?sort=%q: scans table harmed (count=%d err=%v)", base, p, scans, err)
+			}
+		}
+	}
+}

--- a/internal/web/sortable_test.go
+++ b/internal/web/sortable_test.go
@@ -1,0 +1,115 @@
+package web
+
+import (
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"scrutineer/internal/db"
+)
+
+func TestSplitSort(t *testing.T) {
+	for _, tc := range []struct {
+		token, defDir string
+		wantKey       string
+		wantDir       string
+	}{
+		{"severity.asc", "", "severity", "asc"},
+		{"severity.desc", "", "severity", "desc"},
+		{"severity", "", "severity", ""},
+		{"severity", "desc", "severity", "desc"},
+		{"", "asc", "", "asc"},
+		// An unrecognised direction suffix is not a direction: the whole token
+		// is treated as the key, so it falls through to a handler's default.
+		{"severity.bogus", "", "severity.bogus", ""},
+	} {
+		key, dir := splitSort(tc.token, tc.defDir)
+		if key != tc.wantKey || dir != tc.wantDir {
+			t.Errorf("splitSort(%q,%q) = (%q,%q), want (%q,%q)",
+				tc.token, tc.defDir, key, dir, tc.wantKey, tc.wantDir)
+		}
+	}
+}
+
+func TestSortCtxURL(t *testing.T) {
+	c := sortCtx{path: "/findings", query: url.Values{
+		"sort": {"severity"}, "status": {"all"}, "page": {"3"},
+	}}
+
+	// The active column (default desc) flips to asc, drops the page so
+	// re-sorting starts at page 1, and preserves other filters.
+	got := c.URL("severity", "desc")
+	if !strings.Contains(got, "sort=severity.asc") {
+		t.Errorf("active column should flip to asc: %s", got)
+	}
+	if strings.Contains(got, "page=") {
+		t.Errorf("re-sort should drop page: %s", got)
+	}
+	if !strings.Contains(got, "status=all") {
+		t.Errorf("filters should be preserved: %s", got)
+	}
+
+	// An inactive column applies its own default direction as a bare token.
+	got = c.URL("title", "asc")
+	if !strings.Contains(got, "sort=title") || strings.Contains(got, "title.") {
+		t.Errorf("inactive column should use bare default token: %s", got)
+	}
+}
+
+func TestSortCtxDir(t *testing.T) {
+	active := sortCtx{query: url.Values{"sort": {"severity"}}}
+	if got := active.Dir("severity", "desc"); got != "desc" {
+		t.Errorf("active-at-default dir = %q, want desc", got)
+	}
+	if got := active.Dir("title", "asc"); got != "" {
+		t.Errorf("inactive column dir = %q, want empty", got)
+	}
+	pinned := sortCtx{query: url.Values{"sort": {"severity.asc"}}}
+	if got := pinned.Dir("severity", "desc"); got != "asc" {
+		t.Errorf("pinned dir = %q, want asc", got)
+	}
+}
+
+// TestFindings_sortDirection proves the folded-token direction actually
+// reaches the ORDER BY: the same column reverses between .asc and its default.
+func TestFindings_sortDirection(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	repo := db.Repository{URL: "https://example.com/dir", Name: "dir"}
+	s.DB.Create(&repo)
+	scan := db.Scan{RepositoryID: repo.ID, Kind: "skill", Status: db.ScanDone, SkillName: "security-deep-dive"}
+	s.DB.Create(&scan)
+	s.DB.Create(&db.Finding{ScanID: scan.ID, RepositoryID: repo.ID, Title: "crit-one", Severity: "Critical", Status: db.FindingNew})
+	s.DB.Create(&db.Finding{ScanID: scan.ID, RepositoryID: repo.ID, Title: "low-one", Severity: "Low", Status: db.FindingNew})
+
+	get := func(q string) string {
+		w := httptest.NewRecorder()
+		s.Handler().ServeHTTP(w, localReq("GET", "/findings"+q))
+		if w.Code != 200 {
+			t.Fatalf("GET /findings%s status %d", q, w.Code)
+		}
+		return w.Body.String()
+	}
+
+	// Default severity direction is desc: Critical before Low.
+	body := get("?sort=severity")
+	if strings.Index(body, "crit-one") > strings.Index(body, "low-one") {
+		t.Errorf("sort=severity should put Critical before Low")
+	}
+	// The active header must offer the flip to ascending.
+	if !strings.Contains(body, "sort=severity.asc") {
+		t.Errorf("active severity header should link to the ascending flip")
+	}
+	// Columns are clickable via the shared partial.
+	if !strings.Contains(body, `class="th-sort"`) {
+		t.Errorf("headers should render as th-sort links")
+	}
+
+	// Explicit ascending reverses it: Low before Critical.
+	body = get("?sort=severity.asc")
+	if strings.Index(body, "low-one") > strings.Index(body, "crit-one") {
+		t.Errorf("sort=severity.asc should put Low before Critical")
+	}
+}

--- a/internal/web/sortable_test.go
+++ b/internal/web/sortable_test.go
@@ -106,6 +106,10 @@ func TestFindings_sortDirection(t *testing.T) {
 	if !strings.Contains(body, `class="th-sort"`) {
 		t.Errorf("headers should render as th-sort links")
 	}
+	// The active column exposes its direction to assistive tech.
+	if !strings.Contains(body, `aria-sort="descending"`) {
+		t.Errorf("active severity header should set aria-sort=descending")
+	}
 
 	// Explicit ascending reverses it: Low before Critical.
 	body = get("?sort=severity.asc")

--- a/internal/web/sortable_test.go
+++ b/internal/web/sortable_test.go
@@ -172,9 +172,9 @@ func TestSort_derivedColumns(t *testing.T) {
 // keys, SQLi payloads, bad directions) to the index handlers and asserts they
 // fall back to the default order — HTTP 200, no error — and that no injected
 // statement executed (the tables survive with their row counts intact). This
-// is the regression guard for the switch/dirOr/orderByExpr allowlists: if a
-// later refactor lets request text reach an ORDER BY, a DROP/DELETE payload
-// would drop a table and fail these assertions loudly.
+// is the regression guard for the switch dispatch + orderByExpr: if a later
+// refactor lets request text reach an ORDER BY, a DROP/DELETE payload would
+// drop a table and fail these assertions loudly.
 func TestSort_maliciousParamFallsBackSafely(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()

--- a/internal/web/static/theme.css
+++ b/internal/web/static/theme.css
@@ -378,6 +378,10 @@ pre.log { background: var(--muted); padding: 1rem; border-radius: var(--radius);
 .table th a.th-sort:hover { color: var(--foreground); text-decoration: underline;
                             text-underline-offset: 2px; }
 .th-sort-arrow { width: 0.9em; height: 0.9em; }
+/* Idle (unsorted) columns show a faded double chevron as a sort affordance;
+   it firms up on hover. The active column's solid chevron is full-strength. */
+.th-sort-idle { opacity: 0.4; }
+.table th a.th-sort:hover .th-sort-idle { opacity: 0.75; }
 
 /* ── prose (rendered markdown in finding fields) ── */
 .prose { font-size: 0.875rem; line-height: 1.625; max-width: 80ch; }

--- a/internal/web/static/theme.css
+++ b/internal/web/static/theme.css
@@ -373,6 +373,11 @@ pre.log { background: var(--muted); padding: 1rem; border-radius: var(--radius);
           max-height: 60vh; overflow: auto; font-size: 0.8rem; white-space: pre-wrap; }
 .lucide:not([class*="size-"]) { width: 1em; height: 1em; vertical-align: -0.15em; }
 .table tbody tr:has(a) { cursor: pointer; }
+.table th a.th-sort { display: inline-flex; align-items: center; gap: 0.15rem;
+                      white-space: nowrap; color: inherit; }
+.table th a.th-sort:hover { color: var(--foreground); text-decoration: underline;
+                            text-underline-offset: 2px; }
+.th-sort-arrow { width: 0.9em; height: 0.9em; }
 
 /* ── prose (rendered markdown in finding fields) ── */
 .prose { font-size: 0.875rem; line-height: 1.625; max-width: 80ch; }

--- a/internal/web/templates/advisories.html
+++ b/internal/web/templates/advisories.html
@@ -30,14 +30,14 @@
     <div class="dropdown-menu">
       <button type="button" class="btn-outline" aria-haspopup="menu" aria-expanded="false">
         <i data-lucide="arrow-down-wide-narrow"></i>
-        {{if eq .Sort "newest"}}Newest{{else if eq .Sort "repository"}}Repository{{else}}Severity{{end}}
+        {{$sk := sortkey .Sort}}{{if eq $sk "newest"}}Newest{{else if eq $sk "repository"}}Repository{{else}}Severity{{end}}
         <i data-lucide="chevron-down"></i>
       </button>
       <div data-popover aria-hidden="true" data-align="end">
         <div role="menu">
           {{range (list "severity" "newest" "repository")}}
             <a role="menuitem" href="/advisories?q={{$.Q}}&severity={{$.Severity}}&sort={{.}}"
-               {{if eq . $.Sort}}aria-current="true"{{end}}>{{.}}</a>
+               {{if eq . (sortkey $.Sort)}}aria-current="true"{{end}}>{{.}}</a>
           {{end}}
         </div>
       </div>
@@ -48,12 +48,12 @@
 {{if .Advisories}}
   <table class="table w-full">
     <thead><tr>
-      <th class="w-24">Severity</th>
+      {{template "th-sort" (dict "Sorter" .Sorter "Key" "severity" "Def" "desc" "Label" "Severity" "Class" "w-24")}}
       <th class="w-16">CVSS</th>
-      <th>Title</th>
-      <th class="w-40">Repository</th>
+      {{template "th-sort" (dict "Sorter" .Sorter "Key" "title" "Def" "asc" "Label" "Title" "Class" "")}}
+      {{template "th-sort" (dict "Sorter" .Sorter "Key" "repository" "Def" "asc" "Label" "Repository" "Class" "w-40")}}
       <th class="w-56">Packages</th>
-      <th class="w-32">Published</th>
+      {{template "th-sort" (dict "Sorter" .Sorter "Key" "newest" "Def" "desc" "Label" "Published" "Class" "w-32")}}
     </tr></thead>
     <tbody>
     {{$repos := .Repos}}

--- a/internal/web/templates/findings.html
+++ b/internal/web/templates/findings.html
@@ -99,7 +99,7 @@
       </div>
     </div>
     <div class="dropdown-menu">
-      <button type="button" class="btn-outline" aria-hashpopup="menu" aria-expanded="false">
+      <button type="button" class="btn-outline" aria-haspopup="menu" aria-expanded="false">
         <i data-lucide="arrow-down-wide-narrow"></i>
         {{if eq (sortkey .Sort) "severity"}}Severity{{else if eq (sortkey .Sort) "repository"}}Repository{{else}}Newest{{end}}
         <i data-lucide="chevron-down"></i>

--- a/internal/web/templates/findings.html
+++ b/internal/web/templates/findings.html
@@ -101,14 +101,14 @@
     <div class="dropdown-menu">
       <button type="button" class="btn-outline" aria-hashpopup="menu" aria-expanded="false">
         <i data-lucide="arrow-down-wide-narrow"></i>
-        {{if eq .Sort "severity"}}Severity{{else if eq .Sort "repository"}}Repository{{else}}Newest{{end}}
+        {{if eq (sortkey .Sort) "severity"}}Severity{{else if eq (sortkey .Sort) "repository"}}Repository{{else}}Newest{{end}}
         <i data-lucide="chevron-down"></i>
       </button>
       <div data-popover aria-hidden="true" data-align="end">
         <div role="menu">
           {{range (list "newest" "severity" "repository")}}
             <a role="menuitem" href="/findings?q={{$.Q}}&severity={{$.Severity}}&status={{$st}}&category={{$.Category}}&sort={{.}}&missed={{$mp}}&scanners={{$sc}}"
-               {{if eq . $.Sort}}aria-current="true"{{end}}>{{.}}</a>
+               {{if eq . (sortkey $.Sort)}}aria-current="true"{{end}}>{{.}}</a>
           {{end}}
         </div>
       </div>
@@ -119,12 +119,15 @@
 {{if .Findings}}
   <table class="table table-fixed w-full">
     <thead><tr>
-      <th class="w-24">Severity</th><th>Title</th><th class="w-24">Status</th>
-      <th class="w-32">Repository</th>
-      <th class="w-20">Repo ID</th>
+      {{template "th-sort" (dict "Sorter" .Sorter "Key" "severity" "Def" "desc" "Label" "Severity" "Class" "w-24")}}
+      {{template "th-sort" (dict "Sorter" .Sorter "Key" "title" "Def" "asc" "Label" "Title" "Class" "")}}
+      {{template "th-sort" (dict "Sorter" .Sorter "Key" "status" "Def" "asc" "Label" "Status" "Class" "w-24")}}
+      {{template "th-sort" (dict "Sorter" .Sorter "Key" "repository" "Def" "asc" "Label" "Repository" "Class" "w-32")}}
+      {{template "th-sort" (dict "Sorter" .Sorter "Key" "repo_id" "Def" "asc" "Label" "Repo ID" "Class" "w-20")}}
       {{if .AnySubPath}}<th class="w-32">Sub-path</th>{{end}}
-      <th class="w-44">CWE</th>
-      <th class="w-56">Location</th><th class="w-16">Scan</th>
+      {{template "th-sort" (dict "Sorter" .Sorter "Key" "cwe" "Def" "asc" "Label" "CWE" "Class" "w-44")}}
+      <th class="w-56">Location</th>
+      {{template "th-sort" (dict "Sorter" .Sorter "Key" "scan" "Def" "desc" "Label" "Scan" "Class" "w-16")}}
     </tr></thead>
     <tbody>
     {{$repos := .Repos}}

--- a/internal/web/templates/jobs.html
+++ b/internal/web/templates/jobs.html
@@ -61,14 +61,14 @@
     <div class="dropdown-menu">
       <button type="button" class="btn-outline" aria-haspopup="menu" aria-expanded="false">
         <i data-lucide="arrow-down-wide-narrow"></i>
-        {{if eq .Sort "skill"}}Skill{{else if eq .Sort "status"}}Status{{else if eq .Sort "repository"}}Repository{{else}}Newest{{end}}
+        {{$sk := sortkey .Sort}}{{if eq $sk "skill"}}Skill{{else if eq $sk "status"}}Status{{else if eq $sk "repository"}}Repository{{else}}Newest{{end}}
         <i data-lucide="chevron-down"></i>
       </button>
       <div data-popover aria-hidden="true" data-align="end">
         <div role="menu">
           {{range (list "newest" "skill" "status" "repository")}}
             <a role="menuitem" href="/scans?skill={{$.Skill}}&status={{$.Status}}&sort={{.}}"
-               {{if eq . $.Sort}}aria-current="true"{{end}}>{{.}}</a>
+               {{if eq . (sortkey $.Sort)}}aria-current="true"{{end}}>{{.}}</a>
           {{end}}
         </div>
       </div>
@@ -101,9 +101,12 @@
   <table class="table">
     <thead>
       <tr>
-        <th>#</th><th>Repository</th>
+        {{template "th-sort" (dict "Sorter" .Sorter "Key" "id" "Def" "desc" "Label" "#" "Class" "")}}
+        {{template "th-sort" (dict "Sorter" .Sorter "Key" "repository" "Def" "asc" "Label" "Repository" "Class" "")}}
         {{if .AnySubPath}}<th>Sub-path</th>{{end}}
-        <th>Skill</th><th>Status</th><th>Findings</th><th>Model</th><th>Cost</th><th>Started</th><th>Duration</th><th class="w-12"></th>
+        {{template "th-sort" (dict "Sorter" .Sorter "Key" "skill" "Def" "asc" "Label" "Skill" "Class" "")}}
+        {{template "th-sort" (dict "Sorter" .Sorter "Key" "status" "Def" "asc" "Label" "Status" "Class" "")}}
+        <th>Findings</th><th>Model</th><th>Cost</th><th>Started</th><th>Duration</th><th class="w-12"></th>
       </tr>
     </thead>
     <tbody>

--- a/internal/web/templates/jobs.html
+++ b/internal/web/templates/jobs.html
@@ -106,7 +106,8 @@
         {{if .AnySubPath}}<th>Sub-path</th>{{end}}
         {{template "th-sort" (dict "Sorter" .Sorter "Key" "skill" "Def" "asc" "Label" "Skill" "Class" "")}}
         {{template "th-sort" (dict "Sorter" .Sorter "Key" "status" "Def" "asc" "Label" "Status" "Class" "")}}
-        <th>Findings</th><th>Model</th><th>Cost</th><th>Started</th><th>Duration</th><th class="w-12"></th>
+        {{template "th-sort" (dict "Sorter" .Sorter "Key" "findings" "Def" "desc" "Label" "Findings" "Class" "")}}
+        <th>Model</th><th>Cost</th><th>Started</th><th>Duration</th><th class="w-12"></th>
       </tr>
     </thead>
     <tbody>

--- a/internal/web/templates/maintainers.html
+++ b/internal/web/templates/maintainers.html
@@ -30,14 +30,14 @@
     <div class="dropdown-menu">
       <button type="button" class="btn-outline" aria-haspopup="menu" aria-expanded="false">
         <i data-lucide="arrow-down-wide-narrow"></i>
-        {{if eq .Sort "login"}}Login{{else if eq .Sort "status"}}Status{{else if eq .Sort "newest"}}Newest{{else}}Name{{end}}
+        {{$sk := sortkey .Sort}}{{if eq $sk "login"}}Login{{else if eq $sk "status"}}Status{{else if eq $sk "newest"}}Newest{{else}}Name{{end}}
         <i data-lucide="chevron-down"></i>
       </button>
       <div data-popover aria-hidden="true" data-align="end">
         <div role="menu">
           {{range (list "name" "login" "status" "newest")}}
             <a role="menuitem" href="/maintainers?q={{$.Q}}&status={{$.Status}}&sort={{.}}"
-               {{if eq . $.Sort}}aria-current="true"{{end}}>{{.}}</a>
+               {{if eq . (sortkey $.Sort)}}aria-current="true"{{end}}>{{.}}</a>
           {{end}}
         </div>
       </div>
@@ -48,7 +48,12 @@
 {{if .Maintainers}}
   <table class="table w-full">
     <thead><tr>
-      <th>Name</th><th>Login</th><th>Email</th><th>Company</th><th>Repos</th><th>Findings</th><th>Status</th>
+      {{template "th-sort" (dict "Sorter" .Sorter "Key" "name" "Def" "asc" "Label" "Name" "Class" "")}}
+      {{template "th-sort" (dict "Sorter" .Sorter "Key" "login" "Def" "asc" "Label" "Login" "Class" "")}}
+      {{template "th-sort" (dict "Sorter" .Sorter "Key" "email" "Def" "asc" "Label" "Email" "Class" "")}}
+      {{template "th-sort" (dict "Sorter" .Sorter "Key" "company" "Def" "asc" "Label" "Company" "Class" "")}}
+      <th>Repos</th><th>Findings</th>
+      {{template "th-sort" (dict "Sorter" .Sorter "Key" "status" "Def" "asc" "Label" "Status" "Class" "")}}
     </tr></thead>
     <tbody>
     {{$counts := .FindingCounts}}

--- a/internal/web/templates/orgs.html
+++ b/internal/web/templates/orgs.html
@@ -13,14 +13,14 @@
     <div class="dropdown-menu">
       <button type="button" class="btn-outline" aria-haspopup="menu" aria-expanded="false">
         <i data-lucide="arrow-down-wide-narrow"></i>
-        {{if eq .Sort "findings"}}Findings{{else if eq .Sort "repos"}}Repos{{else if eq .Sort "newest"}}Newest{{else}}Name{{end}}
+        {{$sk := sortkey .Sort}}{{if eq $sk "findings"}}Findings{{else if eq $sk "repos"}}Repos{{else if eq $sk "newest"}}Newest{{else}}Name{{end}}
         <i data-lucide="chevron-down"></i>
       </button>
       <div data-popover aria-hidden="true" data-align="end">
         <div role="menu">
           {{range (list "name" "findings" "repos" "newest")}}
             <a role="menuitem" href="/orgs?q={{$.Q}}&sort={{.}}"
-               {{if eq . $.Sort}}aria-current="true"{{end}}>{{.}}</a>
+               {{if eq . (sortkey $.Sort)}}aria-current="true"{{end}}>{{.}}</a>
           {{end}}
         </div>
       </div>
@@ -31,10 +31,10 @@
 {{if .Orgs}}
   <table class="table w-full">
     <thead><tr>
-      <th>Owner</th>
-      <th class="w-24 text-right">Repos</th>
-      <th class="w-24 text-right">Findings</th>
-      <th class="w-40">Last activity</th>
+      {{template "th-sort" (dict "Sorter" .Sorter "Key" "name" "Def" "asc" "Label" "Owner" "Class" "")}}
+      {{template "th-sort" (dict "Sorter" .Sorter "Key" "repos" "Def" "desc" "Label" "Repos" "Class" "w-24 text-right")}}
+      {{template "th-sort" (dict "Sorter" .Sorter "Key" "findings" "Def" "desc" "Label" "Findings" "Class" "w-24 text-right")}}
+      {{template "th-sort" (dict "Sorter" .Sorter "Key" "newest" "Def" "desc" "Label" "Last activity" "Class" "w-40")}}
     </tr></thead>
     <tbody>
     {{range .Orgs}}

--- a/internal/web/templates/packages.html
+++ b/internal/web/templates/packages.html
@@ -30,14 +30,14 @@
     <div class="dropdown-menu">
       <button type="button" class="btn-outline" aria-haspopup="menu" aria-expanded="false">
         <i data-lucide="arrow-down-wide-narrow"></i>
-        {{if eq .Sort "downloads"}}Downloads{{else if eq .Sort "dependents"}}Dependents{{else if eq .Sort "ecosystem"}}Ecosystem{{else}}Name{{end}}
+        {{$sk := sortkey .Sort}}{{if eq $sk "downloads"}}Downloads{{else if eq $sk "dependents"}}Dependents{{else if eq $sk "ecosystem"}}Ecosystem{{else}}Name{{end}}
         <i data-lucide="chevron-down"></i>
       </button>
       <div data-popover aria-hidden="true" data-align="end">
         <div role="menu">
           {{range (list "name" "downloads" "dependents" "ecosystem")}}
             <a role="menuitem" href="/packages?q={{$.Q}}&ecosystem={{$.Ecosystem}}&sort={{.}}"
-               {{if eq . $.Sort}}aria-current="true"{{end}}>{{.}}</a>
+               {{if eq . (sortkey $.Sort)}}aria-current="true"{{end}}>{{.}}</a>
           {{end}}
         </div>
       </div>
@@ -48,9 +48,12 @@
 {{if .Pkgs}}
   <table class="table w-full">
     <thead><tr>
-      <th>Name</th><th>Ecosystem</th><th>Registry</th>
-      <th>Latest</th><th>Downloads</th>
-      <th>Dependents</th>
+      {{template "th-sort" (dict "Sorter" .Sorter "Key" "name" "Def" "asc" "Label" "Name" "Class" "")}}
+      {{template "th-sort" (dict "Sorter" .Sorter "Key" "ecosystem" "Def" "asc" "Label" "Ecosystem" "Class" "")}}
+      {{template "th-sort" (dict "Sorter" .Sorter "Key" "registry" "Def" "asc" "Label" "Registry" "Class" "")}}
+      {{template "th-sort" (dict "Sorter" .Sorter "Key" "latest" "Def" "desc" "Label" "Latest" "Class" "")}}
+      {{template "th-sort" (dict "Sorter" .Sorter "Key" "downloads" "Def" "desc" "Label" "Downloads" "Class" "")}}
+      {{template "th-sort" (dict "Sorter" .Sorter "Key" "dependents" "Def" "desc" "Label" "Dependents" "Class" "")}}
     </tr></thead>
     <tbody>
     {{range .Pkgs}}

--- a/internal/web/templates/partials.html
+++ b/internal/web/templates/partials.html
@@ -31,12 +31,13 @@
 
 {{/* th-sort renders a sortable column header. Args (dict): Sorter (from
      render), Key (sort token), Def ("asc"/"desc" natural direction), Label,
-     Class (th classes). The active column shows a direction chevron; the rest
-     are plain links that a hover cursor marks as clickable. */}}
+     Class (th classes). The active column shows a direction chevron and
+     aria-sort for assistive tech; the rest are plain links that a hover cursor
+     marks as clickable. */}}
 {{define "th-sort"}}
-<th class="{{.Class}}"><a class="th-sort" href="{{.Sorter.URL .Key .Def}}">{{.Label}}
-  {{- $d := .Sorter.Dir .Key .Def -}}
-  {{if eq $d "asc"}} <i data-lucide="chevron-up" class="th-sort-arrow"></i>
+{{- $d := .Sorter.Dir .Key .Def -}}
+<th class="{{.Class}}"{{if eq $d "asc"}} aria-sort="ascending"{{else if eq $d "desc"}} aria-sort="descending"{{end}}><a class="th-sort" href="{{.Sorter.URL .Key .Def}}">{{.Label}}
+  {{- if eq $d "asc"}} <i data-lucide="chevron-up" class="th-sort-arrow"></i>
   {{- else if eq $d "desc"}} <i data-lucide="chevron-down" class="th-sort-arrow"></i>{{end -}}
 </a></th>
 {{end}}

--- a/internal/web/templates/partials.html
+++ b/internal/web/templates/partials.html
@@ -29,6 +29,18 @@
 {{end}}
 {{end}}
 
+{{/* th-sort renders a sortable column header. Args (dict): Sorter (from
+     render), Key (sort token), Def ("asc"/"desc" natural direction), Label,
+     Class (th classes). The active column shows a direction chevron; the rest
+     are plain links that a hover cursor marks as clickable. */}}
+{{define "th-sort"}}
+<th class="{{.Class}}"><a class="th-sort" href="{{.Sorter.URL .Key .Def}}">{{.Label}}
+  {{- $d := .Sorter.Dir .Key .Def -}}
+  {{if eq $d "asc"}} <i data-lucide="chevron-up" class="th-sort-arrow"></i>
+  {{- else if eq $d "desc"}} <i data-lucide="chevron-down" class="th-sort-arrow"></i>{{end -}}
+</a></th>
+{{end}}
+
 {{define "row-cap"}}{{- if gt .Total (len64 .Shown) -}}
 <p class="text-sm text-muted-foreground mt-3">
   Showing {{len .Shown}} of {{.Total}}.{{if .Href}} <a class="hover:underline" href="{{.Href}}">View all</a>.{{end}}

--- a/internal/web/templates/partials.html
+++ b/internal/web/templates/partials.html
@@ -31,14 +31,15 @@
 
 {{/* th-sort renders a sortable column header. Args (dict): Sorter (from
      render), Key (sort token), Def ("asc"/"desc" natural direction), Label,
-     Class (th classes). The active column shows a direction chevron and
-     aria-sort for assistive tech; the rest are plain links that a hover cursor
-     marks as clickable. */}}
+     Class (th classes). The active column shows a solid direction chevron and
+     aria-sort for assistive tech; every other sortable column shows a faded
+     up/down chevron so the affordance is visible before any click. */}}
 {{define "th-sort"}}
 {{- $d := .Sorter.Dir .Key .Def -}}
 <th class="{{.Class}}"{{if eq $d "asc"}} aria-sort="ascending"{{else if eq $d "desc"}} aria-sort="descending"{{end}}><a class="th-sort" href="{{.Sorter.URL .Key .Def}}">{{.Label}}
   {{- if eq $d "asc"}} <i data-lucide="chevron-up" class="th-sort-arrow"></i>
-  {{- else if eq $d "desc"}} <i data-lucide="chevron-down" class="th-sort-arrow"></i>{{end -}}
+  {{- else if eq $d "desc"}} <i data-lucide="chevron-down" class="th-sort-arrow"></i>
+  {{- else}} <i data-lucide="chevrons-up-down" class="th-sort-arrow th-sort-idle"></i>{{end -}}
 </a></th>
 {{end}}
 

--- a/internal/web/templates/repo_list.html
+++ b/internal/web/templates/repo_list.html
@@ -44,7 +44,8 @@
       <tr>
         {{template "th-sort" (dict "Sorter" .Sorter "Key" "name" "Def" "asc" "Label" "Repository" "Class" "")}}
         {{template "th-sort" (dict "Sorter" .Sorter "Key" "language" "Def" "asc" "Label" "Language" "Class" "")}}
-        <th>Last scan</th><th>Status</th>
+        {{template "th-sort" (dict "Sorter" .Sorter "Key" "scanned" "Def" "desc" "Label" "Last scan" "Class" "")}}
+        {{template "th-sort" (dict "Sorter" .Sorter "Key" "status" "Def" "asc" "Label" "Status" "Class" "")}}
         {{template "th-sort" (dict "Sorter" .Sorter "Key" "findings" "Def" "desc" "Label" "Findings" "Class" "")}}
         {{template "th-sort" (dict "Sorter" .Sorter "Key" "size" "Def" "desc" "Label" "Size" "Class" "")}}
         <th></th>

--- a/internal/web/templates/repo_list.html
+++ b/internal/web/templates/repo_list.html
@@ -25,14 +25,14 @@
   <div class="dropdown-menu">
     <button type="button" class="btn-outline" aria-haspopup="menu" aria-expanded="false">
       <i data-lucide="arrow-down-wide-narrow"></i>
-      {{if eq .Sort "name"}}Name{{else if eq .Sort "stars"}}Stars{{else if eq .Sort "language"}}Language{{else if eq .Sort "findings"}}Findings{{else}}Newest{{end}}
+      {{$sk := sortkey .Sort}}{{if eq $sk "name"}}Name{{else if eq $sk "stars"}}Stars{{else if eq $sk "language"}}Language{{else if eq $sk "findings"}}Findings{{else}}Newest{{end}}
       <i data-lucide="chevron-down"></i>
     </button>
     <div data-popover aria-hidden="true" data-align="end">
       <div role="menu">
         {{range (list "newest" "findings" "name" "stars" "language")}}
           <a role="menuitem" href="/?q={{$.Q}}&language={{$.Language}}&sort={{.}}"
-             {{if eq . $.Sort}}aria-current="true"{{end}}>{{.}}</a>
+             {{if eq . (sortkey $.Sort)}}aria-current="true"{{end}}>{{.}}</a>
         {{end}}
       </div>
     </div>
@@ -41,7 +41,14 @@
 {{if .Rows}}
   <table class="table">
     <thead>
-      <tr><th>Repository</th><th>Language</th><th>Last scan</th><th>Status</th><th>Findings</th><th>Size</th><th></th></tr>
+      <tr>
+        {{template "th-sort" (dict "Sorter" .Sorter "Key" "name" "Def" "asc" "Label" "Repository" "Class" "")}}
+        {{template "th-sort" (dict "Sorter" .Sorter "Key" "language" "Def" "asc" "Label" "Language" "Class" "")}}
+        <th>Last scan</th><th>Status</th>
+        {{template "th-sort" (dict "Sorter" .Sorter "Key" "findings" "Def" "desc" "Label" "Findings" "Class" "")}}
+        {{template "th-sort" (dict "Sorter" .Sorter "Key" "size" "Def" "desc" "Label" "Size" "Class" "")}}
+        <th></th>
+      </tr>
     </thead>
     <tbody>
     {{range .Rows}}

--- a/internal/web/templates/sboms.html
+++ b/internal/web/templates/sboms.html
@@ -29,8 +29,10 @@
 {{if .SBOMs}}
   <table class="table w-full">
     <thead><tr>
-      <th>Name</th><th class="w-28">Format</th><th class="w-24 text-right">Packages</th>
-      <th class="w-40">Uploaded</th>
+      {{template "th-sort" (dict "Sorter" .Sorter "Key" "name" "Def" "asc" "Label" "Name" "Class" "")}}
+      {{template "th-sort" (dict "Sorter" .Sorter "Key" "format" "Def" "asc" "Label" "Format" "Class" "w-28")}}
+      {{template "th-sort" (dict "Sorter" .Sorter "Key" "packages" "Def" "desc" "Label" "Packages" "Class" "w-24 text-right")}}
+      {{template "th-sort" (dict "Sorter" .Sorter "Key" "uploaded" "Def" "desc" "Label" "Uploaded" "Class" "w-40")}}
     </tr></thead>
     <tbody>
     {{range .SBOMs}}


### PR DESCRIPTION
Click a column header on any index table (Repositories, Findings, Packages,
SBOMs, Advisories, Maintainers, Scans, Organizations) to sort; click again to
flip ascending/descending. Reuses the existing server-side `?sort` +
pagination, so sorting survives filtering and paging.

- Direction is folded into the `sort` token — no new query params. The active
  column shows a direction arrow + `aria-sort`; other sortable columns show a
  faded chevron affordance.
- ORDER BY direction is carried as a boolean (`orderByExpr`), so no request
  text ever reaches a query — includes an injection regression test.
