### PR TITLE
Add bounded retries for external API fetches

### DIFF
--- a/internal/httpx/retry.go
+++ b/internal/httpx/retry.go
@@ -1,0 +1,150 @@
+package httpx
+
+import (
+	"context"
+	"fmt"
+	"math/rand/v2"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+const (
+	defaultAttempts  = 3
+	defaultBaseDelay = 200 * time.Millisecond
+	defaultMaxDelay  = 2 * time.Second
+	backoffFactor    = 2
+	jitterDivisor    = 4
+)
+
+// RetryOptions configures DoRetry. Zero values use small bounded defaults.
+type RetryOptions struct {
+	Attempts  int
+	BaseDelay time.Duration
+	MaxDelay  time.Duration
+	Sleep     func(context.Context, time.Duration) error
+}
+
+// DoRetry performs an idempotent HTTP request with a small retry budget for
+// transient upstream failures. It retries network errors and 429/502/503/504
+// responses, respects Retry-After when present, and always honors req.Context().
+func DoRetry(req *http.Request, opts RetryOptions) (*http.Response, error) {
+	if req.Method != http.MethodGet {
+		return nil, fmt.Errorf("retry helper only supports GET, got %s", req.Method)
+	}
+	attempts := defaultedAttempts(opts.Attempts)
+	baseDelay := defaultedDuration(opts.BaseDelay, defaultBaseDelay)
+	maxDelay := defaultedDuration(opts.MaxDelay, defaultMaxDelay)
+	sleep := opts.Sleep
+	if sleep == nil {
+		sleep = sleepContext
+	}
+
+	var lastErr error
+	for attempt := 1; attempt <= attempts; attempt++ {
+		if err := req.Context().Err(); err != nil {
+			if lastErr != nil {
+				return nil, lastErr
+			}
+			return nil, err
+		}
+		resp, err := http.DefaultClient.Do(req.Clone(req.Context()))
+		if err == nil && !retryableStatus(resp.StatusCode) {
+			return resp, nil
+		}
+		if attempt == attempts {
+			if err != nil {
+				return nil, err
+			}
+			return resp, nil
+		}
+
+		delay := backoffDelay(attempt, baseDelay, maxDelay)
+		if err != nil {
+			lastErr = err
+		} else {
+			delay = retryAfterDelay(resp.Header.Get("Retry-After"), delay)
+			_ = resp.Body.Close()
+		}
+		if err := sleep(req.Context(), delay); err != nil {
+			return nil, err
+		}
+	}
+	return nil, lastErr
+}
+
+func defaultedAttempts(attempts int) int {
+	if attempts > 0 {
+		return attempts
+	}
+	return defaultAttempts
+}
+
+func defaultedDuration(v, fallback time.Duration) time.Duration {
+	if v > 0 {
+		return v
+	}
+	return fallback
+}
+
+func retryableStatus(status int) bool {
+	switch status {
+	case http.StatusTooManyRequests, http.StatusBadGateway, http.StatusServiceUnavailable, http.StatusGatewayTimeout:
+		return true
+	default:
+		return false
+	}
+}
+
+func retryAfterDelay(header string, fallback time.Duration) time.Duration {
+	if header == "" {
+		return fallback
+	}
+	if seconds, err := strconv.Atoi(header); err == nil {
+		return time.Duration(seconds) * time.Second
+	}
+	if at, err := http.ParseTime(header); err == nil {
+		delay := time.Until(at)
+		if delay > 0 {
+			return delay
+		}
+		return 0
+	}
+	return fallback
+}
+
+func backoffDelay(attempt int, baseDelay, maxDelay time.Duration) time.Duration {
+	delay := baseDelay
+	for range attempt - 1 {
+		delay *= backoffFactor
+		if delay >= maxDelay {
+			return jitter(maxDelay)
+		}
+	}
+	return jitter(delay)
+}
+
+func jitter(delay time.Duration) time.Duration {
+	if delay <= 0 {
+		return 0
+	}
+	spread := delay / jitterDivisor
+	if spread <= 0 {
+		return delay
+	}
+	return delay + time.Duration(rand.Int64N(int64(spread)))
+}
+
+func sleepContext(ctx context.Context, delay time.Duration) error {
+	if delay <= 0 {
+		return ctx.Err()
+	}
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}

--- a/internal/httpx/retry.go
+++ b/internal/httpx/retry.go
@@ -3,6 +3,7 @@ package httpx
 import (
 	"context"
 	"fmt"
+	"io"
 	"math/rand/v2"
 	"net/http"
 	"strconv"
@@ -63,7 +64,8 @@ func DoRetry(req *http.Request, opts RetryOptions) (*http.Response, error) {
 		if err != nil {
 			lastErr = err
 		} else {
-			delay = retryAfterDelay(resp.Header.Get("Retry-After"), delay)
+			delay = retryAfterDelay(resp.Header.Get("Retry-After"), delay, maxDelay)
+			_, _ = io.Copy(io.Discard, resp.Body)
 			_ = resp.Body.Close()
 		}
 		if err := sleep(req.Context(), delay); err != nil {
@@ -96,21 +98,28 @@ func retryableStatus(status int) bool {
 	}
 }
 
-func retryAfterDelay(header string, fallback time.Duration) time.Duration {
+func retryAfterDelay(header string, fallback, maxDelay time.Duration) time.Duration {
 	if header == "" {
 		return fallback
 	}
 	if seconds, err := strconv.Atoi(header); err == nil {
-		return time.Duration(seconds) * time.Second
+		return capDelay(time.Duration(seconds)*time.Second, maxDelay)
 	}
 	if at, err := http.ParseTime(header); err == nil {
 		delay := time.Until(at)
 		if delay > 0 {
-			return delay
+			return capDelay(delay, maxDelay)
 		}
 		return 0
 	}
 	return fallback
+}
+
+func capDelay(delay, maxDelay time.Duration) time.Duration {
+	if maxDelay > 0 && delay > maxDelay {
+		return maxDelay
+	}
+	return delay
 }
 
 func backoffDelay(attempt int, baseDelay, maxDelay time.Duration) time.Duration {

--- a/internal/httpx/retry_test.go
+++ b/internal/httpx/retry_test.go
@@ -83,6 +83,39 @@ func TestDoRetryRespectsRetryAfter(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	opts := testRetryOptions(func(_ context.Context, delay time.Duration) error {
+		delays = append(delays, delay)
+		return nil
+	})
+	opts.MaxDelay = 5 * time.Second
+	resp, err := DoRetry(req, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if len(delays) != 1 || delays[0] != 2*time.Second {
+		t.Fatalf("delays = %v, want [2s]", delays)
+	}
+}
+
+func TestDoRetryCapsRetryAfter(t *testing.T) {
+	hits := 0
+	var delays []time.Duration
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits++
+		if hits == 1 {
+			w.Header().Set("Retry-After", "3600")
+			http.Error(w, "rate limited", http.StatusTooManyRequests)
+			return
+		}
+		_, _ = io.WriteString(w, "ok")
+	}))
+	t.Cleanup(srv.Close)
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 	resp, err := DoRetry(req, testRetryOptions(func(_ context.Context, delay time.Duration) error {
 		delays = append(delays, delay)
 		return nil
@@ -91,8 +124,8 @@ func TestDoRetryRespectsRetryAfter(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer func() { _ = resp.Body.Close() }()
-	if len(delays) != 1 || delays[0] != 2*time.Second {
-		t.Fatalf("delays = %v, want [2s]", delays)
+	if len(delays) != 1 || delays[0] != time.Millisecond {
+		t.Fatalf("delays = %v, want [1ms]", delays)
 	}
 }
 

--- a/internal/httpx/retry_test.go
+++ b/internal/httpx/retry_test.go
@@ -1,0 +1,143 @@
+package httpx
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestDoRetrySucceedsAfterTransientStatus(t *testing.T) {
+	hits := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits++
+		if hits == 1 {
+			http.Error(w, "temporary", http.StatusBadGateway)
+			return
+		}
+		_, _ = io.WriteString(w, "ok")
+	}))
+	t.Cleanup(srv.Close)
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := DoRetry(req, testRetryOptions(nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if hits != 2 {
+		t.Fatalf("hits = %d, want 2", hits)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+}
+
+func TestDoRetryDoesNotRetryNonTransientClientError(t *testing.T) {
+	hits := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits++
+		http.Error(w, "bad request", http.StatusBadRequest)
+	}))
+	t.Cleanup(srv.Close)
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := DoRetry(req, testRetryOptions(nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if hits != 1 {
+		t.Fatalf("hits = %d, want 1", hits)
+	}
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", resp.StatusCode)
+	}
+}
+
+func TestDoRetryRespectsRetryAfter(t *testing.T) {
+	hits := 0
+	var delays []time.Duration
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits++
+		if hits == 1 {
+			w.Header().Set("Retry-After", "2")
+			http.Error(w, "rate limited", http.StatusTooManyRequests)
+			return
+		}
+		_, _ = io.WriteString(w, "ok")
+	}))
+	t.Cleanup(srv.Close)
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := DoRetry(req, testRetryOptions(func(_ context.Context, delay time.Duration) error {
+		delays = append(delays, delay)
+		return nil
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if len(delays) != 1 || delays[0] != 2*time.Second {
+		t.Fatalf("delays = %v, want [2s]", delays)
+	}
+}
+
+func TestDoRetryHonorsContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://127.0.0.1/", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := DoRetry(req, testRetryOptions(nil)); !errors.Is(err, context.Canceled) {
+		t.Fatalf("err = %v, want context.Canceled", err)
+	}
+}
+
+func TestDoRetryRetriesNetworkErrors(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	addr := ln.Addr().String()
+	_ = ln.Close()
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://"+addr, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	attempts := 0
+	_, err = DoRetry(req, testRetryOptions(func(_ context.Context, _ time.Duration) error {
+		attempts++
+		return nil
+	}))
+	if err == nil {
+		t.Fatal("expected network error")
+	}
+	if attempts != 2 {
+		t.Fatalf("sleep attempts = %d, want 2", attempts)
+	}
+}
+
+func testRetryOptions(sleep func(context.Context, time.Duration) error) RetryOptions {
+	return RetryOptions{
+		Attempts:  3,
+		BaseDelay: time.Millisecond,
+		MaxDelay:  time.Millisecond,
+		Sleep:     sleep,
+	}
+}

--- a/internal/web/org_import.go
+++ b/internal/web/org_import.go
@@ -10,6 +10,8 @@ import (
 	"os"
 	"strings"
 	"time"
+
+	"scrutineer/internal/httpx"
 )
 
 // OrgRepo is the slim view of a forge repository the org-import path needs:
@@ -98,7 +100,7 @@ func fetchGitHubRepos(ctx context.Context, kind, owner string) ([]OrgRepo, error
 			req.Header.Set("Authorization", "Bearer "+token)
 		}
 
-		resp, err := http.DefaultClient.Do(req)
+		resp, err := httpx.DoRetry(req, httpx.RetryOptions{})
 		if err != nil {
 			return nil, err
 		}

--- a/internal/worker/cna.go
+++ b/internal/worker/cna.go
@@ -13,6 +13,7 @@ import (
 	"gorm.io/gorm/clause"
 
 	"scrutineer/internal/db"
+	"scrutineer/internal/httpx"
 )
 
 // CNAListURL is the public CVE Program partner list. Served as a static
@@ -35,7 +36,7 @@ func SyncCNAs(ctx context.Context, gdb *gorm.DB, url string) (int, error) {
 		return 0, err
 	}
 	req.Header.Set("User-Agent", userAgent)
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := httpx.DoRetry(req, httpx.RetryOptions{})
 	if err != nil {
 		return 0, err
 	}

--- a/internal/worker/ecosystems.go
+++ b/internal/worker/ecosystems.go
@@ -15,6 +15,7 @@ import (
 	"gorm.io/gorm"
 
 	"scrutineer/internal/db"
+	"scrutineer/internal/httpx"
 )
 
 // ecosystemsEndpoints are the upstream ecosyste.ms lookup roots. Held as a
@@ -327,7 +328,7 @@ func ecosystemsGetWithLink(ctx context.Context, endpoint string) ([]byte, string
 	}
 	req.Header.Set("User-Agent", userAgent)
 	req.Header.Set("Accept", "application/json")
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := httpx.DoRetry(req, httpx.RetryOptions{})
 	if err != nil {
 		return nil, "", err
 	}

--- a/internal/worker/metadata.go
+++ b/internal/worker/metadata.go
@@ -11,6 +11,8 @@ import (
 	"net/http"
 	"net/url"
 	"time"
+
+	"scrutineer/internal/httpx"
 )
 
 var packagesLookup = "https://packages.ecosyste.ms/api/v1/packages/lookup"
@@ -38,7 +40,7 @@ func FetchPackagesByPURL(ctx context.Context, purl string) ([]json.RawMessage, [
 	req.Header.Set("User-Agent", userAgent)
 	req.Header.Set("Accept", "application/json")
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := httpx.DoRetry(req, httpx.RetryOptions{})
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
closes #544
## Summary

Adds a shared retry helper for idempotent external `GET` requests and applies it to metadata/API fetch paths used during repository ingestion and cache hydration.

## Changes

- Add `internal/httpx.DoRetry` with bounded retry/backoff behavior.
- Retry transient network errors and `429`, `502`, `503`, `504`.
- Respect `Retry-After` when upstream sends it.
- Honor caller context cancellation/deadlines.
- Use the helper for:
  - ecosyste.ms prefetches
  - packages.ecosyste.ms PURL lookup
  - CNA sync
  - GitHub organization import

## Testing

- `go test ./internal/httpx ./internal/worker -run 'TestDoRetry|TestRefreshEcosystems|TestFetchDependentsPaginationStopsAtCaps|TestAppendEcosystemsPagesStopsWhenInitialBodyHitsCap|TestSyncCNAs'`
- `go test ./internal/web -run 'TestOrgImport'`
- `go test ./...`
- `go vet ./...`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run`

