### PR TITLE
fix: silence spurious record-not-found logs when persisting findings

### DIFF
--- a/internal/worker/findings_dedup_test.go
+++ b/internal/worker/findings_dedup_test.go
@@ -1,8 +1,10 @@
 package worker
 
 import (
+	"bytes"
 	"errors"
 	"io"
+	"log"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -10,6 +12,9 @@ import (
 	"testing"
 
 	"scrutineer/internal/db"
+
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
 )
 
 func TestParseFindingsOutput_capturesSnippetAndRefreshesOnReobserve(t *testing.T) {
@@ -347,6 +352,43 @@ func TestParseFindingsOutput_preservesAnalystStatusOnReobservation(t *testing.T)
 	}
 	if rows[0].SeenCount != 2 {
 		t.Errorf("seen count = %d, want 2", rows[0].SeenCount)
+	}
+}
+
+func TestParseFindingsOutput_rejectedWithoutStatusHistoryDoesNotLogRecordNotFound(t *testing.T) {
+	base, err := db.Open(filepath.Join(t.TempDir(), "p.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var logs bytes.Buffer
+	gdb := base.Session(&gorm.Session{
+		Logger: logger.New(log.New(&logs, "", 0), logger.Config{LogLevel: logger.Warn}),
+	})
+	repo := db.Repository{URL: "https://x/r", Name: "r"}
+	gdb.Create(&repo)
+	w := &Worker{DB: gdb, Log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+
+	report := `{"findings":[{"id":"F1","title":"noise","severity":"Low","cwe":"CWE-200","location":"x.go:1"}]}`
+	s1 := &db.Scan{RepositoryID: repo.ID, Kind: JobSkill, SkillName: "semgrep", Status: db.ScanDone, Commit: "abc"}
+	gdb.Create(s1)
+	if err := w.parseFindingsOutput(&db.Skill{}, s1, report, func(Event) {}); err != nil {
+		t.Fatal(err)
+	}
+	gdb.Model(&db.Finding{}).Where("repository_id = ?", repo.ID).Update("status", db.FindingRejected)
+	logs.Reset()
+
+	s2 := &db.Scan{RepositoryID: repo.ID, Kind: JobSkill, SkillName: "semgrep", Status: db.ScanDone, Commit: "def"}
+	gdb.Create(s2)
+	if err := w.parseFindingsOutput(&db.Skill{}, s2, report, func(Event) {}); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(logs.String(), "record not found") {
+		t.Fatalf("expected rejected finding without status history to avoid noisy GORM miss log, got:\n%s", logs.String())
+	}
+	var got db.Finding
+	gdb.First(&got)
+	if got.Status != db.FindingRejected {
+		t.Errorf("finding without status history should remain rejected, got %s", got.Status)
 	}
 }
 

--- a/internal/worker/findings_stream_test.go
+++ b/internal/worker/findings_stream_test.go
@@ -1,13 +1,19 @@
 package worker
 
 import (
+	"bytes"
 	"errors"
 	"io"
+	"log"
 	"log/slog"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"scrutineer/internal/db"
+
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
 )
 
 func newStreamWorker(t *testing.T) (*Worker, db.Repository) {
@@ -43,6 +49,30 @@ func TestPersistStreamedFinding_createsRowFromBody(t *testing.T) {
 	}
 	if f.Fingerprint == "" {
 		t.Error("streamed finding has no fingerprint, final report cannot reconcile against it")
+	}
+}
+
+func TestPersistStreamedFinding_newFindingDoesNotLogRecordNotFound(t *testing.T) {
+	base, err := db.Open(filepath.Join(t.TempDir(), "p.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var logs bytes.Buffer
+	gdb := base.Session(&gorm.Session{
+		Logger: logger.New(log.New(&logs, "", 0), logger.Config{LogLevel: logger.Warn}),
+	})
+	repo := db.Repository{URL: "https://x/r", Name: "r"}
+	gdb.Create(&repo)
+	scan := &db.Scan{RepositoryID: repo.ID, Kind: JobSkill, SkillName: "sd", Status: db.ScanRunning, Commit: "aaa"}
+	gdb.Create(scan)
+	w := &Worker{DB: gdb, DataDir: t.TempDir(), Log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+
+	_, err = w.PersistStreamedFinding(scan, []byte(`{"id":"F1","title":"t","severity":"High","location":"main.go:10"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(logs.String(), "record not found") {
+		t.Fatalf("expected new streamed finding to avoid noisy GORM miss log, got:\n%s", logs.String())
 	}
 }
 

--- a/internal/worker/skill.go
+++ b/internal/worker/skill.go
@@ -440,8 +440,11 @@ func (w *Worker) persistFinding(scan *db.Scan, f *db.Finding) (created bool, err
 
 	var existing db.Finding
 	lookup := w.DB.Where("repository_id = ? AND fingerprint = ?", scan.RepositoryID, f.Fingerprint).
-		Order("id").First(&existing).Error
-	if lookup == nil {
+		Order("id").Limit(1).Find(&existing)
+	if lookup.Error != nil {
+		return false, fmt.Errorf("lookup existing finding: %w", lookup.Error)
+	}
+	if lookup.RowsAffected > 0 {
 		if uerr := w.reobserveFinding(&existing, f, scan); uerr != nil {
 			return false, uerr
 		}
@@ -513,8 +516,11 @@ func (w *Worker) reobserveFinding(existing, f *db.Finding, scan *db.Scan) error 
 	var statusRestore string
 	if existing.Status == db.FindingRejected {
 		var lastStatus db.FindingHistory
-		if err := w.DB.Where("finding_id = ? AND field = ?", existing.ID, "status").
-			Order("id desc").First(&lastStatus).Error; err == nil {
+		lastStatusLookup := w.DB.Where("finding_id = ? AND field = ?", existing.ID, "status").
+			Order("id desc").Limit(1).Find(&lastStatus)
+		if lastStatusLookup.Error != nil {
+			w.Log.Warn("lookup finding status history", "finding", existing.ID, "scan", scan.ID, "err", lastStatusLookup.Error)
+		} else if lastStatusLookup.RowsAffected > 0 {
 			if lastStatus.Source == db.SourceSystem {
 				statusRestore = lastStatus.OldValue
 				updates["status"] = statusRestore


### PR DESCRIPTION
GORM's `First` emits a warn-level `record not found` trace on every miss. Two lookups in the worker miss routinely and spammed the log:

- the existence lookup in `persistFinding` misses for **every brand-new finding**, and
- the status-history lookup in `reobserveFinding` misses for **every rejected finding with no prior history row**.

Both switch to `Order(...).Limit(1).Find(...)`, which returns no error on a miss (so GORM's tracer logs nothing) while still surfacing real DB errors in `Error`. The explicit `Order("id").Limit(1)` preserves `First`'s deterministic lowest-id selection.

In `persistFinding` this also un-masks a latent bug: the old `if lookup == nil` path treated *any* error — including a genuine DB failure — as "not found" and fell through to `Create`, silently swallowing it. Real lookup errors now propagate. The status-history miss stays non-fatal and is logged at warn only on a real error, matching the surrounding "history failures are logged but not fatal" behavior.

## Testing

- `TestPersistStreamedFinding_newFindingDoesNotLogRecordNotFound` — asserts a new streamed finding produces no `record not found` in the GORM logger.
- `TestParseFindingsOutput_rejectedWithoutStatusHistoryDoesNotLogRecordNotFound` — asserts a re-observed rejected finding with no status history stays quiet and remains rejected.
- Full `internal/worker` suite, `go vet`, and `go build ./...` pass.
