### PR TITLE
Parse Link header by <...> delimiters, not commas

### DIFF
--- a/internal/worker/ecosystems.go
+++ b/internal/worker/ecosystems.go
@@ -402,19 +402,24 @@ func ecosystemsGetWithLink(ctx context.Context, endpoint string) ([]byte, string
 }
 
 // nextLink extracts the URL of the rel="next" entry from an RFC 8288 Link
-// header, or "" when absent.
+// header, or "" when absent. Links are located by their <...> URI-Reference
+// delimiters rather than by splitting on commas, so a comma inside the URL
+// (e.g. in a query parameter) does not truncate it (#543). RFC 3986 forbids a
+// literal '>' in a URI, so the first '>' after '<' is the terminator.
 func nextLink(header string) string {
-	for _, part := range strings.Split(header, ",") {
-		urlPart, params, found := strings.Cut(part, ";")
-		if !found {
-			continue
+	_, rest, found := strings.Cut(header, "<")
+	for found {
+		u, after, closed := strings.Cut(rest, ">")
+		if !closed {
+			return "" // unterminated <...>
 		}
-		if !strings.Contains(params, "rel=\"next\"") && !strings.Contains(params, "rel=next") {
-			continue
+		// The link's parameters run from '>' up to the next '<' (start of
+		// the following link-value) or the end of the header.
+		var params string
+		params, rest, found = strings.Cut(after, "<")
+		if strings.Contains(params, `rel="next"`) || strings.Contains(params, "rel=next") {
+			return u
 		}
-		u := strings.TrimSpace(urlPart)
-		u = strings.TrimPrefix(u, "<")
-		return strings.TrimSuffix(u, ">")
 	}
 	return ""
 }

--- a/internal/worker/ecosystems_test.go
+++ b/internal/worker/ecosystems_test.go
@@ -437,9 +437,16 @@ func TestNextLink(t *testing.T) {
 	}{
 		{`<https://x/api?page=2>; rel="next"`, "https://x/api?page=2"},
 		{`<https://x/api?page=3>; rel="last", <https://x/api?page=2>; rel="next"`, "https://x/api?page=2"},
+		{`<https://x/api?page=2>; rel=next`, "https://x/api?page=2"},
 		{`<https://x/api?page=9>; rel="last"`, ""},
+		// Commas inside the <...> URI-Reference (e.g. in a query param)
+		// must not be treated as link separators (#543).
+		{`<https://x/api?page=2&f=a,b,c>; rel="next"`, "https://x/api?page=2&f=a,b,c"},
+		{`<https://x/api?f=a,b>; rel="prev", <https://x/api?page=2>; rel="next"`, "https://x/api?page=2"},
+		{`<https://x/api?page=1>; rel="prev", <https://x/api?page=2&f=a,b>; rel="next"`, "https://x/api?page=2&f=a,b"},
 		{"", ""},
 		{"garbage", ""},
+		{`<https://x/api?page=2; rel="next"`, ""}, // unterminated <...>
 	}
 	for _, c := range cases {
 		if got := nextLink(c.header); got != c.want {


### PR DESCRIPTION
`nextLink` split the header on every comma, so a comma inside the `rel="next"` URL (e.g. a query parameter like `?filters=a,b,c`) truncated it and returned a garbage fragment — the old parser returned `"c"` for `<https://x/api?page=2&f=a,b,c>; rel="next"`.

Locate each link by its `<...>` URI-Reference instead. RFC 3986 forbids a literal `>` in a URI so the first `>` after `<` is the terminator; parameters run from there to the next `<` or end of header. Unterminated `<...` now returns `""` rather than the partial URL.

More relevant since #565 — `nextLink` now backs packages and dependents pagination as well as advisories.

Fixes #543