### PR TITLE
Reject malformed JSON in skill run API

### DIFF
--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -61,6 +61,17 @@ func (s *Server) apiAuth(next http.Handler) http.Handler {
 
 const apiMaxBody = 1 << 20
 
+func decodeOptionalAPIBody(w http.ResponseWriter, r *http.Request, dst any) bool {
+	if err := json.NewDecoder(r.Body).Decode(dst); err != nil {
+		if errors.Is(err, io.EOF) {
+			return true
+		}
+		writeAPIError(w, http.StatusBadRequest, "invalid JSON request body")
+		return false
+	}
+	return true
+}
+
 func bearer(h string) string {
 	const prefix = "Bearer "
 	if strings.HasPrefix(h, prefix) {
@@ -315,7 +326,9 @@ func (s *Server) apiRunSkill(w http.ResponseWriter, r *http.Request) {
 		Ref     string `json:"ref"`
 		Profile string `json:"profile"`
 	}
-	_ = json.NewDecoder(r.Body).Decode(&body)
+	if !decodeOptionalAPIBody(w, r, &body) {
+		return
+	}
 	if body.Profile != "" && !worker.KnownProfile(body.Profile) {
 		writeAPIError(w, http.StatusBadRequest, "unknown profile")
 		return
@@ -369,7 +382,9 @@ func (s *Server) apiRunFindingSkill(w http.ResponseWriter, r *http.Request) {
 	var body struct {
 		Model string `json:"model"`
 	}
-	_ = json.NewDecoder(r.Body).Decode(&body)
+	if !decodeOptionalAPIBody(w, r, &body) {
+		return
+	}
 	scanID, err := s.enqueueSkillScoped(r.Context(), repoID, skill.ID, new(uint(id)), body.Model)
 	if err != nil {
 		if errors.Is(err, ErrSkillRequiresRemote) {

--- a/internal/web/api_test.go
+++ b/internal/web/api_test.go
@@ -381,6 +381,57 @@ func TestAPIRunSkill_profileOverridePersists(t *testing.T) {
 	}
 }
 
+func TestAPIRunSkill_rejectsMalformedJSON(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	repo, scan := seedRunningScan(t, s)
+
+	skill := db.Skill{Name: "metadata", Description: "m", Body: "b", OutputFile: "report.json", Version: 1, Active: true, Source: "ui"}
+	s.DB.Create(&skill)
+
+	path := "/api/repositories/" + strconv.FormatUint(uint64(repo.ID), 10) + "/skills/metadata/run"
+	r := httptest.NewRequest("POST", path, strings.NewReader(`{"profile":`))
+	r.Host = testHost
+	r.Header.Set("Authorization", "Bearer "+scan.APIToken)
+	r.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, r)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status %d, want 400. body=%s", w.Code, w.Body)
+	}
+	var count int64
+	s.DB.Model(&db.Scan{}).Where("skill_id = ?", skill.ID).Count(&count)
+	if count != 0 {
+		t.Errorf("malformed request still created %d scans, want 0", count)
+	}
+}
+
+func TestAPIRunSkill_emptyBodyStillEnqueues(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	repo, scan := seedRunningScan(t, s)
+
+	skill := db.Skill{Name: "metadata", Description: "m", Body: "b", OutputFile: "report.json", Version: 1, Active: true, Source: "ui"}
+	s.DB.Create(&skill)
+
+	path := "/api/repositories/" + strconv.FormatUint(uint64(repo.ID), 10) + "/skills/metadata/run"
+	r := httptest.NewRequest("POST", path, nil)
+	r.Host = testHost
+	r.Header.Set("Authorization", "Bearer "+scan.APIToken)
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, r)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("status %d, want 201. body=%s", w.Code, w.Body)
+	}
+	var row db.Scan
+	if err := s.DB.Where("skill_id = ?", skill.ID).First(&row).Error; err != nil {
+		t.Fatal(err)
+	}
+	if row.Ref != "" || row.Profile != "" {
+		t.Errorf("empty-body scan options = ref:%q profile:%q, want zero values", row.Ref, row.Profile)
+	}
+}
+
 func TestAPIRunSkill_unknownProfileRejected(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()
@@ -490,6 +541,65 @@ func TestAPIRunFindingSkill_scopesFindingID(t *testing.T) {
 	}
 	if row.APIToken == "" {
 		t.Error("enqueued scan missing api token")
+	}
+}
+
+func TestAPIRunFindingSkill_rejectsMalformedJSON(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	repo, scan := seedRunningScan(t, s)
+
+	prior := db.Scan{RepositoryID: repo.ID, Kind: worker.JobSkill, Status: db.ScanDone, SkillName: "security-deep-dive"}
+	s.DB.Create(&prior)
+	finding := db.Finding{ScanID: prior.ID, RepositoryID: repo.ID, FindingID: "F1", Title: "x", Severity: "High", Status: db.FindingNew}
+	s.DB.Create(&finding)
+	verify := db.Skill{Name: "verify", Description: "v", Body: "b", OutputFile: "report.json", OutputKind: "verify", Version: 1, Active: true, Source: "ui"}
+	s.DB.Create(&verify)
+
+	path := "/api/findings/" + strconv.FormatUint(uint64(finding.ID), 10) + "/skills/verify/run"
+	r := httptest.NewRequest("POST", path, strings.NewReader(`{"model":`))
+	r.Host = testHost
+	r.Header.Set("Authorization", "Bearer "+scan.APIToken)
+	r.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, r)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status %d, want 400. body=%s", w.Code, w.Body)
+	}
+	var count int64
+	s.DB.Model(&db.Scan{}).Where("skill_id = ?", verify.ID).Count(&count)
+	if count != 0 {
+		t.Errorf("malformed request still created %d scans, want 0", count)
+	}
+}
+
+func TestAPIRunFindingSkill_emptyBodyStillEnqueues(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	repo, scan := seedRunningScan(t, s)
+
+	prior := db.Scan{RepositoryID: repo.ID, Kind: worker.JobSkill, Status: db.ScanDone, SkillName: "security-deep-dive"}
+	s.DB.Create(&prior)
+	finding := db.Finding{ScanID: prior.ID, RepositoryID: repo.ID, FindingID: "F1", Title: "x", Severity: "High", Status: db.FindingNew}
+	s.DB.Create(&finding)
+	verify := db.Skill{Name: "verify", Description: "v", Body: "b", OutputFile: "report.json", OutputKind: "verify", Version: 1, Active: true, Source: "ui"}
+	s.DB.Create(&verify)
+
+	path := "/api/findings/" + strconv.FormatUint(uint64(finding.ID), 10) + "/skills/verify/run"
+	r := httptest.NewRequest("POST", path, nil)
+	r.Host = testHost
+	r.Header.Set("Authorization", "Bearer "+scan.APIToken)
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, r)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("status %d, want 201. body=%s", w.Code, w.Body)
+	}
+	var row db.Scan
+	if err := s.DB.Where("skill_id = ?", verify.ID).First(&row).Error; err != nil {
+		t.Fatal(err)
+	}
+	if row.FindingID == nil || *row.FindingID != finding.ID {
+		t.Errorf("enqueued scan has wrong finding_id: got=%v want=%d", row.FindingID, finding.ID)
 	}
 }
 


### PR DESCRIPTION
Fixes #560

## Summary

Reject malformed JSON request bodies in the skill execution API instead of silently continuing with zero-value options.

## Changes

- Add shared optional JSON body decoding for skill-run API handlers
- Return `400 Bad Request` when `apiRunSkill` receives malformed JSON
- Return `400 Bad Request` when `apiRunFindingSkill` receives malformed JSON
- Preserve existing empty-body behavior for both endpoints
- Add regression tests covering malformed JSON and empty bodies for repository-scoped and finding-scoped skill runs

## Tests

- `go test ./internal/web -run 'TestAPIRunSkill|TestAPIRunFindingSkill'`
- `git diff --check`
- `go test ./...`
- `go vet ./...`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run`