### PR TITLE
Return errors for failed JSONL export setup

### DIFF
--- a/internal/web/api_export.go
+++ b/internal/web/api_export.go
@@ -379,12 +379,13 @@ func applyFindingFilters(q *gorm.DB, r *http.Request) *gorm.DB {
 // preloads into memory. The body is partial on mid-stream errors: once
 // we have committed to 200, a truncated stream is the only honest signal.
 func streamJSONL[T any](w http.ResponseWriter, q *gorm.DB, project func(T) map[string]any) {
-	w.Header().Set("Content-Type", "application/x-ndjson; charset=utf-8")
 	rows, err := q.Rows()
 	if err != nil {
+		writeAPIError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
 	defer func() { _ = rows.Close() }()
+	w.Header().Set("Content-Type", "application/x-ndjson; charset=utf-8")
 	enc := json.NewEncoder(w)
 	flusher, _ := w.(http.Flusher)
 	for rows.Next() {

--- a/internal/web/api_export_test.go
+++ b/internal/web/api_export_test.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"io"
+	"net/http"
 	"net/http/httptest"
 	"strconv"
 	"strings"
@@ -84,6 +85,28 @@ func TestExportRepoFindings(t *testing.T) {
 				t.Errorf("export row missing %q", k)
 			}
 		}
+	}
+}
+
+func TestStreamJSONLRowsErrorReturns500(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	w := httptest.NewRecorder()
+	streamJSONL[db.Finding](w, s.DB.Raw("SELECT * FROM missing_export_table"), findingExport)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("status %d, want 500. body=%s", w.Code, w.Body)
+	}
+	if ct := w.Header().Get("Content-Type"); ct != "application/json; charset=utf-8" {
+		t.Errorf("content-type %q, want JSON API error", ct)
+	}
+	var body map[string]string
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatal(err)
+	}
+	if body[errorKey] == "" {
+		t.Fatalf("error response missing %q: %+v", errorKey, body)
 	}
 }
 


### PR DESCRIPTION
Fixes #561

## Summary

Return an explicit server error when an NDJSON export query fails before streaming starts.

Previously, `streamJSONL` set the NDJSON response header before opening query rows and returned silently if `q.Rows()` failed. That could produce an emptyvsuccessful response for a real database/query setup failure.

## Changes

- Open GORM rows before committing the NDJSON response headers
- Return `500 Internal Server Error` as a JSON API error when `q.Rows()` fails
- Preserve successful NDJSON export responses with `application/x-ndjson; charset=utf-8`
- Add regression coverage for row setup failures

## Tests

- `go test ./internal/web -run 'TestExportRepoFindings|TestStreamJSONLRowsErrorReturns500'`
- `git diff --check`
- `go test ./...`
- `go vet ./...`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run`