### PR TITLE
Wrap report imports in a transaction and batch fingerprint lookup

### DIFF
--- a/internal/web/import.go
+++ b/internal/web/import.go
@@ -196,15 +196,42 @@ func (s *Server) importResult(res ingest.Result, repoOverride string, revalidate
 		FindingsCount: len(res.Findings),
 	}
 	scan.StatusPriority = db.StatusPriorityFor(scan.Status)
-	if err := s.DB.Create(&scan).Error; err != nil {
+
+	var created []db.Finding
+	var observed int
+	err = s.DB.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Create(&scan).Error; err != nil {
+			return err
+		}
+		created, observed, err = s.importFindings(tx, &scan, res)
+		return err
+	})
+	if err != nil {
 		return nil, err
 	}
-
-	created, observed := s.importFindings(&scan, res, revalidate)
+	// Imported findings carry an external tool's unvalidated severity
+	// claim, so revalidate runs over every newly-imported finding
+	// regardless of severity (not just High/Critical, as it does for
+	// security-deep-dive output). ?revalidate=false skips this — and the
+	// verify it chains into — for callers importing already-audited
+	// findings such as a trusted sharing bundle. Enqueued after commit so
+	// a rolled-back import never queues work against phantom findings.
+	if revalidate {
+		for i := range created {
+			// Imports have no parent scan and hence no resolved profile to carry;
+			// revalidate detects fresh, and its resolved profile then carries into
+			// the chained verify (autoChainVerifyAfterRevalidate). See #548.
+			s.enqueueRevalidateForFinding(context.Background(), &created[i], "")
+		}
+	}
 	s.Log.Info("import",
 		"repo", repo.URL, "tool", res.Tool, "scan", scan.ID,
 		"created", len(created), "observed", observed)
 
+	ids := make([]uint, len(created))
+	for i, f := range created {
+		ids[i] = f.ID
+	}
 	return map[string]any{
 		"repository_id": repo.ID,
 		"repository":    repo.URL,
@@ -212,15 +239,74 @@ func (s *Server) importResult(res ingest.Result, repoOverride string, revalidate
 		"tool":          res.Tool,
 		"created":       len(created),
 		"observed":      observed,
-		"finding_ids":   created,
+		"finding_ids":   ids,
 	}, nil
 }
 
+const importBatchSize = 50
+
 // importFindings mirrors the worker's fingerprint-then-upsert loop so an
 // import behaves like a scan: re-importing the same report bumps
-// SeenCount on existing rows instead of inserting duplicates.
-func (s *Server) importFindings(scan *db.Scan, res ingest.Result, revalidate bool) (created []uint, observed int) {
+// SeenCount on existing rows instead of inserting duplicates. Runs inside
+// the caller's transaction so a mid-import failure leaves no partial state.
+func (s *Server) importFindings(tx *gorm.DB, scan *db.Scan, res ingest.Result) (created []db.Finding, observed int, err error) {
+	incoming, fingerprints := buildImportFindings(scan, res)
+	if len(incoming) == 0 {
+		return nil, 0, nil
+	}
+
+	existing, err := existingByFingerprint(tx, scan.RepositoryID, fingerprints)
+	if err != nil {
+		return nil, 0, fmt.Errorf("lookup existing findings: %w", err)
+	}
+
+	var observedIDs []uint
+	var history []db.FindingHistory
+	for _, f := range incoming {
+		if prev, ok := existing[f.Fingerprint]; ok {
+			observedIDs = append(observedIDs, prev.ID)
+			history = append(history, db.FindingHistory{
+				FindingID: prev.ID,
+				Field:     "observed",
+				NewValue:  fmt.Sprintf("import scan %d (%s)", scan.ID, res.Tool),
+				Source:    db.SourceTool,
+				By:        res.Tool,
+			})
+			continue
+		}
+		created = append(created, f)
+	}
+
+	if len(created) > 0 {
+		if err := tx.CreateInBatches(&created, importBatchSize).Error; err != nil {
+			return nil, 0, fmt.Errorf("create findings: %w", err)
+		}
+	}
+	if len(observedIDs) > 0 {
+		err := tx.Model(&db.Finding{}).Where("id IN ?", observedIDs).Updates(map[string]any{
+			"last_seen_scan_id":   scan.ID,
+			"last_seen_commit":    scan.Commit,
+			"seen_count":          gorm.Expr("seen_count + 1"),
+			"missed_count":        0,
+			"last_missed_scan_id": 0,
+		}).Error
+		if err != nil {
+			return nil, 0, fmt.Errorf("update observed findings: %w", err)
+		}
+		if err := tx.CreateInBatches(&history, importBatchSize).Error; err != nil {
+			return nil, 0, fmt.Errorf("create finding history: %w", err)
+		}
+	}
+	return created, len(observedIDs), nil
+}
+
+// buildImportFindings maps ingest.Finding rows onto db.Finding and
+// fingerprints them, dropping in-batch duplicates. Returned fingerprints
+// preserves input order for the existing-row lookup.
+func buildImportFindings(scan *db.Scan, res ingest.Result) ([]db.Finding, []string) {
 	seen := map[string]bool{}
+	incoming := make([]db.Finding, 0, len(res.Findings))
+	fingerprints := make([]string, 0, len(res.Findings))
 	for _, in := range res.Findings {
 		// A bundle may carry a per-finding commit (findings from scans at
 		// different revisions); fall back to the scan/bundle commit, which is
@@ -255,57 +341,35 @@ func (s *Server) importFindings(scan *db.Scan, res ingest.Result, revalidate boo
 		// in different monorepo sub-projects do not collide on one fingerprint.
 		// Other formats leave SubPath empty, so their fingerprint is unchanged.
 		f.Fingerprint = db.FingerprintFinding(res.Tool, f.SubPath, f.CWE, f.Location, f.Title)
-
 		if seen[f.Fingerprint] {
 			continue
 		}
 		seen[f.Fingerprint] = true
+		incoming = append(incoming, f)
+		fingerprints = append(fingerprints, f.Fingerprint)
+	}
+	return incoming, fingerprints
+}
 
-		var existing db.Finding
-		err := s.DB.Where("repository_id = ? AND fingerprint = ?", scan.RepositoryID, f.Fingerprint).
-			Order("id").First(&existing).Error
-		if err == nil {
-			s.DB.Model(&db.Finding{}).Where("id = ?", existing.ID).Updates(map[string]any{
-				"last_seen_scan_id":   scan.ID,
-				"last_seen_commit":    scan.Commit,
-				"seen_count":          existing.SeenCount + 1,
-				"missed_count":        0,
-				"last_missed_scan_id": 0,
-			})
-			s.DB.Create(&db.FindingHistory{
-				FindingID: existing.ID,
-				Field:     "observed",
-				NewValue:  fmt.Sprintf("import scan %d (%s)", scan.ID, res.Tool),
-				Source:    db.SourceTool,
-				By:        res.Tool,
-			})
-			observed++
-			continue
-		}
-		if !errors.Is(err, gorm.ErrRecordNotFound) {
-			s.Log.Error("import: lookup existing finding", "err", err)
-			continue
-		}
-		if err := s.DB.Create(&f).Error; err != nil {
-			s.Log.Error("import: create finding", "err", err)
-			continue
-		}
-		created = append(created, f.ID)
-		// Imported findings carry an external tool's unvalidated severity
-		// claim, so revalidate runs over every newly-imported finding
-		// regardless of severity (not just High/Critical, as it does for
-		// security-deep-dive output). ?revalidate=false skips this — and the
-		// verify it chains into — for callers importing already-audited
-		// findings such as a trusted sharing bundle.
-		if revalidate {
-			fcopy := f
-			// Imports have no parent scan and hence no resolved profile to carry;
-			// revalidate detects fresh, and its resolved profile then carries into
-			// the chained verify (autoChainVerifyAfterRevalidate). See #548.
-			s.enqueueRevalidateForFinding(context.Background(), &fcopy, "")
+// existingByFingerprint fetches all findings for the repository whose
+// fingerprint is in the incoming set, keyed by fingerprint. When legacy
+// duplicate rows share a fingerprint the lowest-id row wins, matching the
+// previous per-row `Order("id").First` behaviour.
+func existingByFingerprint(tx *gorm.DB, repoID uint, fingerprints []string) (map[string]db.Finding, error) {
+	var rows []db.Finding
+	err := tx.Select("id", "fingerprint").
+		Where("repository_id = ? AND fingerprint IN ?", repoID, fingerprints).
+		Order("id").Find(&rows).Error
+	if err != nil {
+		return nil, err
+	}
+	out := make(map[string]db.Finding, len(rows))
+	for _, r := range rows {
+		if _, ok := out[r.Fingerprint]; !ok {
+			out[r.Fingerprint] = r
 		}
 	}
-	return created, observed
+	return out, nil
 }
 
 // maybeDecrypt transparently decrypts an age-encrypted body. If the body

--- a/internal/web/import.go
+++ b/internal/web/import.go
@@ -301,8 +301,7 @@ func (s *Server) importFindings(tx *gorm.DB, scan *db.Scan, res ingest.Result) (
 }
 
 // buildImportFindings maps ingest.Finding rows onto db.Finding and
-// fingerprints them, dropping in-batch duplicates. Returned fingerprints
-// preserves input order for the existing-row lookup.
+// fingerprints them, dropping in-batch duplicates.
 func buildImportFindings(scan *db.Scan, res ingest.Result) ([]db.Finding, []string) {
 	seen := map[string]bool{}
 	incoming := make([]db.Finding, 0, len(res.Findings))

--- a/internal/web/import_test.go
+++ b/internal/web/import_test.go
@@ -1,8 +1,11 @@
 package web
 
 import (
+	"errors"
 	"strings"
 	"testing"
+
+	"gorm.io/gorm"
 
 	"scrutineer/internal/db"
 	"scrutineer/internal/ingest"
@@ -110,6 +113,105 @@ func TestAppendFixDescription(t *testing.T) {
 	}
 }
 
+func TestImportFindings_reimportBumpsSeenCount(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	res := ingest.Result{
+		RepoURL: "https://example.com/r",
+		Tool:    "external-scanner",
+		Commit:  "abc",
+		Findings: []ingest.Finding{
+			{Title: "one", Severity: "High", Location: "a.go:1", CWE: "CWE-79"},
+			{Title: "two", Severity: "Low", Location: "b.go:1", CWE: "CWE-89"},
+		},
+	}
+	first, err := s.importResult(res, "", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first["created"] != 2 || first["observed"] != 0 {
+		t.Fatalf("first import created=%v observed=%v, want 2/0", first["created"], first["observed"])
+	}
+
+	// Second import: one finding matches, one is new.
+	res.Commit = "def"
+	res.Findings = []ingest.Finding{
+		{Title: "one", Severity: "High", Location: "a.go:1", CWE: "CWE-79"},
+		{Title: "three", Severity: "Medium", Location: "c.go:1", CWE: "CWE-22"},
+	}
+	second, err := s.importResult(res, "", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if second["created"] != 1 || second["observed"] != 1 {
+		t.Fatalf("second import created=%v observed=%v, want 1/1", second["created"], second["observed"])
+	}
+
+	var total int64
+	s.DB.Model(&db.Finding{}).Count(&total)
+	if total != 3 {
+		t.Fatalf("total findings = %d, want 3 (no duplicate for re-observed)", total)
+	}
+
+	var reobserved db.Finding
+	s.DB.Where("title = ?", "one").First(&reobserved)
+	if reobserved.SeenCount != 2 {
+		t.Errorf("SeenCount = %d, want 2", reobserved.SeenCount)
+	}
+	if reobserved.LastSeenCommit != "def" {
+		t.Errorf("LastSeenCommit = %q, want def", reobserved.LastSeenCommit)
+	}
+	if reobserved.LastSeenScanID != uint(second["scan_id"].(uint)) {
+		t.Errorf("LastSeenScanID = %d, want %d", reobserved.LastSeenScanID, second["scan_id"])
+	}
+	if reobserved.MissedCount != 0 {
+		t.Errorf("MissedCount = %d, want 0 (reset on re-observation)", reobserved.MissedCount)
+	}
+	var hist int64
+	s.DB.Model(&db.FindingHistory{}).
+		Where("finding_id = ? AND field = ?", reobserved.ID, "observed").Count(&hist)
+	if hist != 1 {
+		t.Errorf("history rows = %d, want 1", hist)
+	}
+}
+
+func TestImportFindings_rollbackLeavesNoScanOrFindings(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	repo := db.Repository{URL: "https://example.com/r", Name: "r"}
+	s.DB.Create(&repo)
+	scan := db.Scan{RepositoryID: repo.ID, Status: db.ScanDone, Commit: "abc"}
+
+	// Run the same tx shape as importResult but force an error after the
+	// scan and findings have been written, so we can assert both roll back.
+	res := ingest.Result{
+		Tool: "external-scanner",
+		Findings: []ingest.Finding{
+			{Title: "ok", Severity: "High", Location: "a.go:1"},
+		},
+	}
+	err := s.DB.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Create(&scan).Error; err != nil {
+			return err
+		}
+		if _, _, err := s.importFindings(tx, &scan, res); err != nil {
+			return err
+		}
+		return errors.New("simulated post-write failure")
+	})
+	if err == nil {
+		t.Fatal("expected transaction to roll back")
+	}
+
+	var scans, findings int64
+	s.DB.Model(&db.Scan{}).Count(&scans)
+	s.DB.Model(&db.Finding{}).Count(&findings)
+	if scans != 0 || findings != 0 {
+		t.Fatalf("after rollback: scans=%d findings=%d, want 0/0", scans, findings)
+	}
+}
+
 func TestImportFindings_keepsSuggestedFixGated(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()
@@ -128,12 +230,15 @@ func TestImportFindings_keepsSuggestedFixGated(t *testing.T) {
 			SuggestedFix: "validate input before use",
 		}},
 	}
-	created, _ := s.importFindings(&scan, res, true)
+	created, _, err := s.importFindings(s.DB, &scan, res)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if len(created) != 1 {
 		t.Fatalf("created %d findings, want 1", len(created))
 	}
 	var f db.Finding
-	s.DB.First(&f, created[0])
+	s.DB.First(&f, created[0].ID)
 	if f.SuggestedFix != "" {
 		t.Errorf("SuggestedFix = %q, want empty (gated column)", f.SuggestedFix)
 	}
@@ -164,22 +269,23 @@ func TestImportFindings_revalidateToggle(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			s, done := newTestServer(t)
 			defer done()
-			repo := db.Repository{URL: "https://example.com/r", Name: "r"}
-			s.DB.Create(&repo)
-			scan := db.Scan{RepositoryID: repo.ID, Status: db.ScanDone, Commit: "abc"}
-			s.DB.Create(&scan)
 			revalidate := db.Skill{Name: "revalidate", OutputFile: "report.json", OutputKind: "revalidate", Version: 1, Active: true}
 			s.DB.Create(&revalidate)
 
 			res := ingest.Result{
-				Tool: "external-scanner",
+				RepoURL: "https://example.com/r",
+				Tool:    "external-scanner",
 				Findings: []ingest.Finding{
 					{Title: "high", Severity: "High", Location: "a.go:1"},
 					{Title: "low", Severity: "Low", Location: "b.go:1"},
 				},
 			}
-			if created, _ := s.importFindings(&scan, res, tc.revalidate); len(created) != 2 {
-				t.Fatalf("created %d findings, want 2", len(created))
+			out, err := s.importResult(res, "", tc.revalidate)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if out["created"] != 2 {
+				t.Fatalf("created %v findings, want 2", out["created"])
 			}
 			var queued int64
 			s.DB.Model(&db.Scan{}).
@@ -195,14 +301,14 @@ func TestImportFindings_revalidateToggle(t *testing.T) {
 func TestImportFindings_skipsRevalidateWhenSkillAbsent(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()
-	repo := db.Repository{URL: "https://example.com/r", Name: "r"}
-	s.DB.Create(&repo)
-	scan := db.Scan{RepositoryID: repo.ID, Status: db.ScanDone, Commit: "abc"}
-	s.DB.Create(&scan)
 	// No revalidate skill registered. Import must still succeed.
-	res := ingest.Result{Tool: "x", Findings: []ingest.Finding{{Title: "t", Severity: "High", Location: "a.go:1"}}}
-	if created, _ := s.importFindings(&scan, res, true); len(created) != 1 {
-		t.Fatalf("created = %d, want 1", len(created))
+	res := ingest.Result{RepoURL: "https://example.com/r", Tool: "x", Findings: []ingest.Finding{{Title: "t", Severity: "High", Location: "a.go:1"}}}
+	out, err := s.importResult(res, "", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out["created"] != 1 {
+		t.Fatalf("created = %v, want 1", out["created"])
 	}
 }
 


### PR DESCRIPTION
Fixes #579

`importResult` now creates the `Scan` row and runs `importFindings` inside one transaction, so a mid-import failure leaves neither a dangling scan nor partial findings. Revalidate is enqueued after commit so a rollback never queues work against phantom finding IDs.

`importFindings` replaces the per-row `(repository_id, fingerprint)` lookup with a single `IN` query against `idx_findings_repo_fp`, batches new findings and history rows via `CreateInBatches`, and updates all observed rows in one statement using `seen_count = seen_count + 1`. Errors now propagate to roll back the transaction instead of being logged and skipped. Legacy duplicate-fingerprint rows still resolve to the lowest id, matching the previous `Order("id").First` behaviour.

Added `TestImportFindings_reimportBumpsSeenCount` (written against the old code first) covering the observed path, and `TestImportFindings_rollbackLeavesNoScanOrFindings` for the atomicity guarantee. The two revalidate tests moved to `importResult` since that is where the enqueue now lives.