### PR TITLE
Harden Codex harness event parsing

### DIFF
--- a/internal/web/models.go
+++ b/internal/web/models.go
@@ -159,8 +159,8 @@ func builtinModelForTier(tier, fallback string) string {
 			return m.ID
 		}
 	}
-	// Otherwise the substring heuristic covers the built-in Anthropic list
-	// (which carries no tier tags): Mid → first sonnet, Max → latest opus.
+	// Otherwise the substring heuristic keeps older or minimally tagged
+	// model lists usable: Mid → first sonnet, Max → latest opus.
 	// A custom list that neither tags tiers nor matches these needles falls
 	// through to DefaultModel; set the tiers in /settings for that case.
 	switch tier {

--- a/internal/worker/harness_codex.go
+++ b/internal/worker/harness_codex.go
@@ -149,7 +149,7 @@ func parseCodexLine(raw []byte, emit func(Event)) {
 		return
 	}
 	switch {
-	case ev.SessionID != "" || ev.ThreadID != "":
+	case isCodexSessionEvent(ev) && (ev.SessionID != "" || ev.ThreadID != ""):
 		id := ev.SessionID
 		if id == "" {
 			id = ev.ThreadID
@@ -195,6 +195,15 @@ func parseCodexLine(raw []byte, emit func(Event)) {
 		emit(Event{Kind: KindText, Text: ev.Message})
 	default:
 		emit(Event{Kind: KindText, Text: line})
+	}
+}
+
+func isCodexSessionEvent(ev codexLine) bool {
+	switch ev.Type {
+	case "thread.started", "session.created", "init":
+		return true
+	default:
+		return false
 	}
 }
 
@@ -290,7 +299,6 @@ func (CodexHarness) AccountErrorText(s string) string {
 		"invalid_api_key",
 		"incorrect api key",
 		"account is not active",
-		"billing details",
 	} {
 		if strings.Contains(lower, phrase) {
 			return text

--- a/internal/worker/harness_codex_test.go
+++ b/internal/worker/harness_codex_test.go
@@ -146,6 +146,7 @@ func TestCodexHarness_AccountErrorText(t *testing.T) {
 		"429 Too Many Requests":               true,
 		"insufficient_quota for this account": true,
 		"invalid_api_key provided":            true,
+		"update your billing details later":   false,
 		"repo mentions billing integrations":  false,
 		"compiling skill":                     false,
 		"":                                    false,
@@ -185,6 +186,23 @@ func TestCodexHarness_ParseStream_live(t *testing.T) {
 		{Kind: KindTool, Tool: "command", Text: "/bin/bash -lc 'ls ./src'"},
 		{Kind: KindText, Text: "done"},
 		{Kind: KindResult, Turns: 1, Usage: Usage{InputTokens: 17339, OutputTokens: 92, CacheReadTokens: 11008}},
+	}
+	var got []Event
+	CodexHarness{}.ParseStream(strings.NewReader(in), func(e Event) { got = append(got, e) })
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("ParseStream mismatch\n got: %+v\nwant: %+v", got, want)
+	}
+}
+
+func TestCodexHarness_ParseStream_threadIDDoesNotMaskPayloads(t *testing.T) {
+	in := `{"type":"turn.completed","thread_id":"thr-1","usage":{"input_tokens":12,"cached_input_tokens":3,"output_tokens":4}}
+{"type":"item.completed","thread_id":"thr-1","item":{"id":"item_1","type":"agent_message","text":"done"}}
+{"type":"error","thread_id":"thr-1","error":"rate_limit_exceeded"}
+`
+	want := []Event{
+		{Kind: KindResult, Turns: 1, Usage: Usage{InputTokens: 12, OutputTokens: 4, CacheReadTokens: 3}},
+		{Kind: KindText, Text: "done"},
+		{Kind: KindError, Text: "rate_limit_exceeded"},
 	}
 	var got []Event
 	CodexHarness{}.ParseStream(strings.NewReader(in), func(e Event) { got = append(got, e) })


### PR DESCRIPTION
Fixes #583

## Summary

Applies the remaining Codex harness follow-ups from the #535 review.

This makes Codex JSONL parsing more defensive, reduces false-positive account error detection and updates a stale model-tier comment.

## Changes

- Gate Codex session events on explicit event types: `thread.started`, `session.created` and `init`
- Preserve usage, text and error payloads if future Codex events include `thread_id` or `session_id`
- Remove the loose `"billing details"` account-error substring
- Update the stale model-tier fallback comment in `internal/web/models.go`
- Add regression tests for session parsing and account-error false positives

## Tests

- `go test ./internal/worker -run 'TestCodexHarness'`
- `git diff --check`
- `go test ./...`
- `go vet ./...`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run`