### PR TITLE
Remove dead code surfaced by post-#569/#571 sweep

### DIFF
--- a/internal/web/expected_findings.go
+++ b/internal/web/expected_findings.go
@@ -99,20 +99,16 @@ func buildExpectedFinding(repoID uint, file, cwe, cve, note string) (db.Expected
 func expectedFindingResponses(rows []db.ExpectedFinding) []expectedFindingResponse {
 	out := make([]expectedFindingResponse, 0, len(rows))
 	for _, row := range rows {
-		out = append(out, expectedFindingResponseFrom(row))
+		out = append(out, expectedFindingResponse{
+			ID:           row.ID,
+			RepositoryID: row.RepositoryID,
+			File:         row.File,
+			CWE:          row.CWE,
+			CVE:          row.CVE,
+			Note:         row.Note,
+		})
 	}
 	return out
-}
-
-func expectedFindingResponseFrom(row db.ExpectedFinding) expectedFindingResponse {
-	return expectedFindingResponse{
-		ID:           row.ID,
-		RepositoryID: row.RepositoryID,
-		File:         row.File,
-		CWE:          row.CWE,
-		CVE:          row.CVE,
-		Note:         row.Note,
-	}
 }
 
 func skillSchemaVersion(skill db.Skill) int {
@@ -139,7 +135,6 @@ type expectedFindingStatus struct {
 
 type expectedMatchSet struct {
 	Expected             []expectedFindingStatus
-	FindingStatus        map[uint]bool
 	MatchedTotal         int
 	FindingTotal         int
 	TruePositiveFindings int
@@ -173,16 +168,9 @@ func loadRepoExpectedView(gdb *gorm.DB, repoID uint, latest *db.Scan, rf repoFin
 	}
 }
 
-func expectedMatchesForScan(gdb *gorm.DB, repoID, scanID uint) expectedMatchSet {
-	var expected []db.ExpectedFinding
-	gdb.Where("repository_id = ?", repoID).Order("file, cwe").Find(&expected)
-	return expectedMatchesForRows(gdb, repoID, scanID, expected)
-}
-
 func expectedMatchesForRows(gdb *gorm.DB, repoID, scanID uint, expected []db.ExpectedFinding) expectedMatchSet {
 	out := expectedMatchSet{
-		Expected:      make([]expectedFindingStatus, 0, len(expected)),
-		FindingStatus: map[uint]bool{},
+		Expected: make([]expectedFindingStatus, 0, len(expected)),
 	}
 	for _, row := range expected {
 		out.Expected = append(out.Expected, expectedFindingStatus{Expected: row})
@@ -200,7 +188,6 @@ func expectedMatchesForRows(gdb *gorm.DB, repoID, scanID uint, expected []db.Exp
 		findingMatched := false
 		for i := range out.Expected {
 			if findingMatchesExpected(f, out.Expected[i].Expected) {
-				out.FindingStatus[f.ID] = true
 				findingMatched = true
 				if !out.Expected[i].Matched {
 					out.Expected[i].Matched = true
@@ -233,7 +220,7 @@ func findingMatchesExpected(f db.Finding, expected db.ExpectedFinding) bool {
 	if normalizeCWE(f.CWE) != normalizeCWE(expected.CWE) {
 		return false
 	}
-	want := normalizeExpectedFile(expected.File)
+	want := cleanRepoPath(expected.File)
 	for _, loc := range findingLocations(f) {
 		if normalizeLocationFile(loc) == want {
 			return true
@@ -251,10 +238,6 @@ func findingLocations(f db.Finding) []string {
 		return nil
 	}
 	return []string{f.Location}
-}
-
-func normalizeExpectedFile(file string) string {
-	return cleanRepoPath(file)
 }
 
 func cleanExpectedFileInput(file string) (string, error) {

--- a/internal/web/expected_findings_test.go
+++ b/internal/web/expected_findings_test.go
@@ -118,12 +118,9 @@ func TestExpectedFindingMatchingIgnoresLineNumbers(t *testing.T) {
 	s.DB.Create(&matched)
 	s.DB.Create(&unexpected)
 
-	got := expectedMatchesForScan(s.DB, repo.ID, scan.ID)
+	got := expectedMatchesForRows(s.DB, repo.ID, scan.ID, []db.ExpectedFinding{expected})
 	if got.MatchedTotal != 1 || got.FindingTotal != 2 || got.TruePositiveFindings != 1 {
 		t.Fatalf("matches = %+v", got)
-	}
-	if !got.FindingStatus[matched.ID] || got.FindingStatus[unexpected.ID] {
-		t.Fatalf("finding status = %+v", got.FindingStatus)
 	}
 	if len(got.Expected) != 1 || !got.Expected[0].Matched || got.Expected[0].FindingID != matched.ID {
 		t.Fatalf("expected status = %+v", got.Expected)
@@ -137,8 +134,11 @@ func TestExpectedFindingPrecisionUsesTruePositiveFindings(t *testing.T) {
 	s.DB.Create(&repo)
 	scan := db.Scan{RepositoryID: repo.ID, Kind: "skill", SkillName: "vuln-scan", Status: db.ScanDone}
 	s.DB.Create(&scan)
-	s.DB.Create(&db.ExpectedFinding{RepositoryID: repo.ID, File: "src/a.go", CWE: "CWE-79"})
-	s.DB.Create(&db.ExpectedFinding{RepositoryID: repo.ID, File: "src/b.go", CWE: "CWE-79"})
+	expected := []db.ExpectedFinding{
+		{RepositoryID: repo.ID, File: "src/a.go", CWE: "CWE-79"},
+		{RepositoryID: repo.ID, File: "src/b.go", CWE: "CWE-79"},
+	}
+	s.DB.Create(&expected)
 	finding := db.Finding{
 		RepositoryID: repo.ID,
 		ScanID:       scan.ID,
@@ -150,7 +150,7 @@ func TestExpectedFindingPrecisionUsesTruePositiveFindings(t *testing.T) {
 	}
 	s.DB.Create(&finding)
 
-	got := expectedMatchesForScan(s.DB, repo.ID, scan.ID)
+	got := expectedMatchesForRows(s.DB, repo.ID, scan.ID, expected)
 	if got.MatchedTotal != 2 || got.FindingTotal != 1 || got.TruePositiveFindings != 1 {
 		t.Fatalf("matches = %+v", got)
 	}
@@ -173,13 +173,17 @@ func TestExpectedFindingMatchingIgnoresLowSeverityForBenchmarkTotals(t *testing.
 	s.DB.Create(&repo)
 	scan := db.Scan{RepositoryID: repo.ID, Kind: "skill", SkillName: "vuln-scan", Status: db.ScanDone}
 	s.DB.Create(&scan)
-	s.DB.Create(&db.ExpectedFinding{RepositoryID: repo.ID, File: "src/app.go", CWE: "CWE-79"})
+	expected := []db.ExpectedFinding{{RepositoryID: repo.ID, File: "src/app.go", CWE: "CWE-79"}}
+	s.DB.Create(&expected)
 	low := db.Finding{RepositoryID: repo.ID, ScanID: scan.ID, Title: "low xss", Severity: "Low", CWE: "CWE-79", Location: "src/app.go:77"}
 	s.DB.Create(&low)
 
-	got := expectedMatchesForScan(s.DB, repo.ID, scan.ID)
-	if got.MatchedTotal != 0 || got.FindingTotal != 0 || got.TruePositiveFindings != 0 || got.FindingStatus[low.ID] {
-		t.Fatalf("low severity finding affected benchmark totals/status: %+v", got)
+	got := expectedMatchesForRows(s.DB, repo.ID, scan.ID, expected)
+	if got.MatchedTotal != 0 || got.FindingTotal != 0 || got.TruePositiveFindings != 0 {
+		t.Fatalf("low severity finding affected benchmark totals: %+v", got)
+	}
+	if got.Expected[0].Matched {
+		t.Fatalf("low severity finding matched expected: %+v", got.Expected)
 	}
 }
 

--- a/internal/web/maintainers.go
+++ b/internal/web/maintainers.go
@@ -23,7 +23,7 @@ func (s *Server) maintainersList(w http.ResponseWriter, r *http.Request) {
 	}
 
 	const nameSort = "name"
-	sortCol, dir := splitSort(r.URL.Query().Get("sort"), "")
+	sortCol, dir := splitSort(r.URL.Query().Get("sort"))
 	switch sortCol {
 	case "login":
 		q = q.Order(orderByExpr("login", dir, false))

--- a/internal/web/orgs.go
+++ b/internal/web/orgs.go
@@ -106,7 +106,7 @@ func (s *Server) orgsList(w http.ResponseWriter, r *http.Request) {
 	// columns), so unlike the SQL indexes this sorts the slice and flips the
 	// comparator for direction via dirLess rather than an ORDER BY.
 	const nameSort = "name"
-	sortCol, dir := splitSort(r.URL.Query().Get("sort"), "")
+	sortCol, dir := splitSort(r.URL.Query().Get("sort"))
 	switch sortCol {
 	case "findings":
 		sortSlice(rows, dirLess(dir, "desc", func(a, b orgRow) bool { return a.FindingsTotal < b.FindingsTotal }))

--- a/internal/web/sboms.go
+++ b/internal/web/sboms.go
@@ -31,7 +31,7 @@ func (s *Server) registerSBOMRoutes(mux *http.ServeMux) {
 
 func (s *Server) sbomList(w http.ResponseWriter, r *http.Request) {
 	q := s.DB.Model(&db.SBOMUpload{})
-	sortCol, dir := splitSort(r.URL.Query().Get("sort"), "")
+	sortCol, dir := splitSort(r.URL.Query().Get("sort"))
 	switch sortCol {
 	case "name":
 		q = q.Order(orderByExpr("name", dir, false)).Order("id desc")

--- a/internal/web/scans.go
+++ b/internal/web/scans.go
@@ -24,7 +24,7 @@ func (s *Server) jobs(w http.ResponseWriter, r *http.Request) {
 		q = q.Where("status = ?", status)
 	}
 
-	sortCol, dir := splitSort(r.URL.Query().Get("sort"), "")
+	sortCol, dir := splitSort(r.URL.Query().Get("sort"))
 	switch sortCol {
 	case "id":
 		q = q.Order(orderByExpr("scans.id", dir, true))

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -629,7 +629,7 @@ func (s *Server) repoList(w http.ResponseWriter, r *http.Request) {
 			like, like, like, like)
 	}
 
-	sortCol, dir := splitSort(r.URL.Query().Get("sort"), "")
+	sortCol, dir := splitSort(r.URL.Query().Get("sort"))
 	const nameSort = "name"
 	switch sortCol {
 	case nameSort:
@@ -944,7 +944,7 @@ func (s *Server) findings(w http.ResponseWriter, r *http.Request) {
 	missed := r.URL.Query().Get("missed") == "1"
 	search := strings.TrimSpace(r.URL.Query().Get("q"))
 
-	sortCol, dir := splitSort(r.URL.Query().Get("sort"), "")
+	sortCol, dir := splitSort(r.URL.Query().Get("sort"))
 	switch sortCol {
 	case sortSeverity:
 		// severityOrder ranks the most severe LOWEST, so the intuitive default
@@ -1114,16 +1114,12 @@ func (s *Server) depScan(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	repoURL := resolveDepRepoURL(r.Context(), dep)
+	repoURL := resolvePURLRepo(r.Context(), dep.PURL)
 	if repoURL == "" {
 		http.Error(w, "could not resolve repository URL for "+dep.Name, http.StatusUnprocessableEntity)
 		return
 	}
 	s.addRepoAndScan(w, r, repoURL)
-}
-
-func resolveDepRepoURL(ctx context.Context, dep db.Dependency) string {
-	return resolvePURLRepo(ctx, dep.PURL)
 }
 
 // resolvePURLRepo asks packages.ecosyste.ms for the repository_url behind a
@@ -1510,7 +1506,7 @@ func (s *Server) packages(w http.ResponseWriter, r *http.Request) {
 		q = q.Where("name LIKE ? OR p_url LIKE ? OR licenses LIKE ?", like, like, like)
 	}
 
-	sortCol, dir := splitSort(r.URL.Query().Get("sort"), "")
+	sortCol, dir := splitSort(r.URL.Query().Get("sort"))
 	switch sortCol {
 	case "name":
 		q = q.Order(orderByExpr("name", dir, false))
@@ -1580,7 +1576,7 @@ func (s *Server) advisoriesList(w http.ResponseWriter, r *http.Request) {
 			like, like, like, like)
 	}
 
-	sortCol, dir := splitSort(r.URL.Query().Get("sort"), "")
+	sortCol, dir := splitSort(r.URL.Query().Get("sort"))
 	switch sortCol {
 	case "newest":
 		q = q.Order(orderByExpr("published_at", dir, true)).Order("id desc")

--- a/internal/web/sortable.go
+++ b/internal/web/sortable.go
@@ -22,14 +22,15 @@ type sortCtx struct {
 }
 
 // splitSort parses a "key.dir" sort token. The direction suffix is only
-// honoured when it is exactly "asc" or "desc"; otherwise defDir is returned,
-// so callers can pass a per-column default (or "" to detect "unset").
-func splitSort(token, defDir string) (key, dir string) {
+// honoured when it is exactly "asc" or "desc"; anything else returns the whole
+// token as the key with an empty direction, leaving the handler to apply its
+// own per-column default via wantDesc.
+func splitSort(token string) (key, dir string) {
 	key, rest, ok := strings.Cut(token, ".")
 	if ok && (rest == "asc" || rest == "desc") {
 		return key, rest
 	}
-	return token, defDir
+	return token, ""
 }
 
 // dirOr returns dir when it is a valid direction ("asc"/"desc"), else def. It
@@ -87,7 +88,7 @@ func orderByExpr(expr, dir string, defaultDesc bool) string {
 // natural default. Every other query param (filters, search) is preserved and
 // pagination resets to page 1.
 func (c sortCtx) URL(key, def string) string {
-	curKey, curDir := splitSort(c.query.Get("sort"), "")
+	curKey, curDir := splitSort(c.query.Get("sort"))
 	next := def
 	if curKey == key {
 		eff := curDir
@@ -114,7 +115,7 @@ func (c sortCtx) URL(key, def string) string {
 // Dir reports the active direction for key ("asc"/"desc") so a header can draw
 // its arrow, or "" when key is not the current sort.
 func (c sortCtx) Dir(key, def string) string {
-	curKey, curDir := splitSort(c.query.Get("sort"), "")
+	curKey, curDir := splitSort(c.query.Get("sort"))
 	if curKey != key {
 		return ""
 	}
@@ -125,6 +126,6 @@ func (c sortCtx) Dir(key, def string) string {
 // suffix. Templates use it to keep a sort dropdown's label and active-item
 // highlight in sync with a compound token like "severity.asc".
 func sortKey(token string) string {
-	key, _ := splitSort(token, "")
+	key, _ := splitSort(token)
 	return key
 }

--- a/internal/web/sortable_test.go
+++ b/internal/web/sortable_test.go
@@ -11,23 +11,22 @@ import (
 
 func TestSplitSort(t *testing.T) {
 	for _, tc := range []struct {
-		token, defDir string
-		wantKey       string
-		wantDir       string
+		token   string
+		wantKey string
+		wantDir string
 	}{
-		{"severity.asc", "", "severity", "asc"},
-		{"severity.desc", "", "severity", "desc"},
-		{"severity", "", "severity", ""},
-		{"severity", "desc", "severity", "desc"},
-		{"", "asc", "", "asc"},
+		{"severity.asc", "severity", "asc"},
+		{"severity.desc", "severity", "desc"},
+		{"severity", "severity", ""},
+		{"", "", ""},
 		// An unrecognised direction suffix is not a direction: the whole token
 		// is treated as the key, so it falls through to a handler's default.
-		{"severity.bogus", "", "severity.bogus", ""},
+		{"severity.bogus", "severity.bogus", ""},
 	} {
-		key, dir := splitSort(tc.token, tc.defDir)
+		key, dir := splitSort(tc.token)
 		if key != tc.wantKey || dir != tc.wantDir {
-			t.Errorf("splitSort(%q,%q) = (%q,%q), want (%q,%q)",
-				tc.token, tc.defDir, key, dir, tc.wantKey, tc.wantDir)
+			t.Errorf("splitSort(%q) = (%q,%q), want (%q,%q)",
+				tc.token, key, dir, tc.wantKey, tc.wantDir)
 		}
 	}
 }

--- a/internal/worker/stream.go
+++ b/internal/worker/stream.go
@@ -81,7 +81,6 @@ type streamMessage struct {
 	Message       *assistantMsg   `json:"message"`
 	Result        json.RawMessage `json:"result"`
 	CostUSD       *float64        `json:"total_cost_usd"`
-	Duration      *int64          `json:"duration_ms"`
 	NumTurns      *int            `json:"num_turns"`
 	Usage         *Usage          `json:"usage"`
 	Error         json.RawMessage `json:"error"`


### PR DESCRIPTION
Mechanical dead-code cleanup from a whole-codebase review after the past week's merges.

- `expectedMatchesForScan` — only callers were tests; those now drive `expectedMatchesForRows` directly, which is the production path used by `loadRepoExpectedView` and `benchmark.go`
- `expectedMatchSet.FindingStatus` — written but never read; the template's `ExpectedFindingStatus` comes from `repoExpectedView.FindingStatus` (via `expectedStatusForFindings`), not this map
- `expectedFindingResponseFrom`, `normalizeExpectedFile` — single-caller one-liners, inlined
- `streamMessage.Duration` — decoded from claude stream-json but never read after decode
- `splitSort` `defDir` param — all 11 callers pass `""`; per-column direction defaults are applied downstream via `wantDesc`, not here
- `resolveDepRepoURL` — one-line wrapper around `resolvePURLRepo`, inlined at its sole caller

`deadcode ./...` is now clean.