### PR TITLE
Follow up #571: joinSort helper, sbomShow direction, wider sort guard

### DIFF
--- a/internal/web/maintainers.go
+++ b/internal/web/maintainers.go
@@ -43,10 +43,7 @@ func (s *Server) maintainersList(w http.ResponseWriter, r *http.Request) {
 		sortCol, dir = nameSort, ""
 		q = q.Order("CASE WHEN name = '' THEN 1 ELSE 0 END, name, login")
 	}
-	sort := sortCol
-	if dir != "" {
-		sort = sortCol + "." + dir
-	}
+	sort := joinSort(sortCol, dir)
 
 	var total int64
 	q.Count(&total)

--- a/internal/web/orgs.go
+++ b/internal/web/orgs.go
@@ -120,10 +120,7 @@ func (s *Server) orgsList(w http.ResponseWriter, r *http.Request) {
 		sortCol, dir = nameSort, ""
 		sortSlice(rows, orgNameLess)
 	}
-	sort := sortCol
-	if dir != "" {
-		sort = sortCol + "." + dir
-	}
+	sort := joinSort(sortCol, dir)
 
 	s.render(w, r, "orgs.html", map[string]any{
 		"Orgs": rows, "Q": search, "Sort": sort,

--- a/internal/web/sboms.go
+++ b/internal/web/sboms.go
@@ -45,10 +45,7 @@ func (s *Server) sbomList(w http.ResponseWriter, r *http.Request) {
 		sortCol, dir = defaultSort, ""
 		q = q.Order("id desc")
 	}
-	sort := sortCol
-	if dir != "" {
-		sort = sortCol + "." + dir
-	}
+	sort := joinSort(sortCol, dir)
 
 	var total int64
 	q.Count(&total)
@@ -163,7 +160,7 @@ func (s *Server) sbomShow(w http.ResponseWriter, r *http.Request) {
 		repoIDs = append(repoIDs, id)
 	}
 
-	sort := r.URL.Query().Get("sort")
+	sortCol, dir := splitSort(r.URL.Query().Get("sort"))
 	var findings []db.Finding
 	var findingsTotal int64
 	var advisories []db.Advisory
@@ -180,14 +177,16 @@ func (s *Server) sbomShow(w http.ResponseWriter, r *http.Request) {
 		if category := r.URL.Query().Get("category"); category != "" {
 			q = applyCWECategoryFilter(q, category)
 		}
-		switch sort {
+		switch sortCol {
 		case sortSeverity:
-			q = q.Order(severityOrder).Order("id desc")
+			// severityOrder ranks the most severe LOWEST, so the "desc" logical
+			// default is ascending on the expression; !wantDesc flips it.
+			q = q.Order(orderBySuffix("("+severityOrder+")", !wantDesc(dir, true))).Order("findings.id desc")
 		case sortRepository:
 			q = q.Joins("JOIN repositories r ON r.id = findings.repository_id").
-				Order("r.name").Order("findings.id desc")
+				Order(orderByExpr("r.name", dir, false)).Order("findings.id desc")
 		default:
-			sort = defaultSort
+			sortCol, dir = defaultSort, ""
 			q = q.Order("id desc")
 		}
 		q.Model(&db.Finding{}).Count(&findingsTotal)
@@ -214,7 +213,7 @@ func (s *Server) sbomShow(w http.ResponseWriter, r *http.Request) {
 		"Advisories": advisories, "AdvisoriesTotal": advisoriesTotal,
 		"Repos":    reposByID,
 		"Resolved": resolved, "WithRepo": withRepo,
-		"Severity": r.URL.Query().Get("severity"), "Sort": sort,
+		"Severity": r.URL.Query().Get("severity"), "Sort": joinSort(sortCol, dir),
 		"Category":   r.URL.Query().Get("category"),
 		"Categories": CWECategories(), "Uncategorized": UncategorizedCWE,
 		"Scope": scope, "HasScope": hasScope,

--- a/internal/web/scans.go
+++ b/internal/web/scans.go
@@ -41,10 +41,7 @@ func (s *Server) jobs(w http.ResponseWriter, r *http.Request) {
 		sortCol, dir = defaultSort, ""
 		q = q.Order("status_priority, scans.id desc")
 	}
-	sort := sortCol
-	if dir != "" {
-		sort = sortCol + "." + dir
-	}
+	sort := joinSort(sortCol, dir)
 
 	var total int64
 	q.Count(&total)

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -664,10 +664,7 @@ func (s *Server) repoList(w http.ResponseWriter, r *http.Request) {
 		sortCol, dir = defaultSort, ""
 		q = q.Order("updated_at desc")
 	}
-	sort := sortCol
-	if dir != "" {
-		sort = sortCol + "." + dir
-	}
+	sort := joinSort(sortCol, dir)
 
 	var total int64
 	q.Count(&total)
@@ -968,10 +965,7 @@ func (s *Server) findings(w http.ResponseWriter, r *http.Request) {
 		sortCol, dir = defaultSort, ""
 		q = q.Order("id desc")
 	}
-	sort := sortCol
-	if dir != "" {
-		sort = sortCol + "." + dir
-	}
+	sort := joinSort(sortCol, dir)
 
 	var total int64
 	q.Count(&total)
@@ -1524,10 +1518,7 @@ func (s *Server) packages(w http.ResponseWriter, r *http.Request) {
 		sortCol, dir = "name", ""
 		q = q.Order("name")
 	}
-	sort := sortCol
-	if dir != "" {
-		sort = sortCol + "." + dir
-	}
+	sort := joinSort(sortCol, dir)
 
 	var total int64
 	q.Count(&total)
@@ -1591,10 +1582,7 @@ func (s *Server) advisoriesList(w http.ResponseWriter, r *http.Request) {
 		sortCol, dir = sortSeverity, ""
 		q = q.Order("cvss_score desc, id desc")
 	}
-	sort := sortCol
-	if dir != "" {
-		sort = sortCol + "." + dir
-	}
+	sort := joinSort(sortCol, dir)
 
 	var total int64
 	q.Count(&total)

--- a/internal/web/sortable.go
+++ b/internal/web/sortable.go
@@ -33,6 +33,17 @@ func splitSort(token string) (key, dir string) {
 	return token, ""
 }
 
+// joinSort is the inverse of splitSort: it rebuilds a "key" or "key.dir" token
+// from the (allowlisted key, validated dir) a handler resolved. Handlers pass
+// this back to templates as .Sort so filter and pagination links preserve the
+// active sort — the same value sortCtx reads via c.query.Get("sort").
+func joinSort(key, dir string) string {
+	if dir == "" {
+		return key
+	}
+	return key + "." + dir
+}
+
 // dirOr returns dir when it is a valid direction ("asc"/"desc"), else def. It
 // resolves the request direction for the NON-SQL callers — the template arrow
 // (sortCtx.Dir) and the in-memory org comparator (dirLess). SQL ORDER BY

--- a/internal/web/sortable_test.go
+++ b/internal/web/sortable_test.go
@@ -31,6 +31,45 @@ func TestSplitSort(t *testing.T) {
 	}
 }
 
+func TestJoinSort(t *testing.T) {
+	for _, tc := range []struct{ key, dir, want string }{
+		{"severity", "", "severity"},
+		{"severity", "asc", "severity.asc"},
+		{"severity", "desc", "severity.desc"},
+		{"", "", ""},
+	} {
+		if got := joinSort(tc.key, tc.dir); got != tc.want {
+			t.Errorf("joinSort(%q,%q) = %q, want %q", tc.key, tc.dir, got, tc.want)
+		}
+	}
+	// Round-trip: joinSort is the inverse of splitSort for every valid token.
+	for _, token := range []string{"severity", "severity.asc", "severity.desc", ""} {
+		key, dir := splitSort(token)
+		if got := joinSort(key, dir); got != token {
+			t.Errorf("joinSort(splitSort(%q)) = %q", token, got)
+		}
+	}
+}
+
+func TestWantDesc(t *testing.T) {
+	for _, tc := range []struct {
+		dir  string
+		def  bool
+		want bool
+	}{
+		{"asc", true, false},
+		{"asc", false, false},
+		{"desc", true, true},
+		{"desc", false, true},
+		{"", true, true},
+		{"", false, false},
+	} {
+		if got := wantDesc(tc.dir, tc.def); got != tc.want {
+			t.Errorf("wantDesc(%q, %v) = %v, want %v", tc.dir, tc.def, got, tc.want)
+		}
+	}
+}
+
 func TestSortCtxURL(t *testing.T) {
 	c := sortCtx{path: "/findings", query: url.Values{
 		"sort": {"severity"}, "status": {"all"}, "page": {"3"},
@@ -227,7 +266,7 @@ func TestSort_maliciousParamFallsBackSafely(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()
 
-	repo := db.Repository{URL: "https://x/keep", Name: "keep"}
+	repo := db.Repository{URL: "https://x/keep", Name: "keep", Owner: "keep-org"}
 	s.DB.Create(&repo)
 	s.DB.Create(&db.Scan{RepositoryID: repo.ID, Kind: "skill", Status: db.ScanDone,
 		StatusPriority: db.StatusPriorityFor(db.ScanDone), FindingsCount: 1})
@@ -242,9 +281,11 @@ func TestSort_maliciousParamFallsBackSafely(t *testing.T) {
 		"' OR '1'='1",
 		"(SELECT 1)",
 	}
-	// Both the repo index (/) and the scans index (/scans) go through the same
-	// allowlists, so exercise both with every payload.
-	for _, base := range []string{"/", "/scans"} {
+	// Every sortable index has its own switch dispatch, so exercise each with
+	// every payload — a regression on any one of them would let request text
+	// reach an ORDER BY.
+	bases := []string{"/", "/scans", "/findings", "/packages", "/advisories", "/maintainers", "/orgs", "/sboms"}
+	for _, base := range bases {
 		for _, p := range payloads {
 			w := httptest.NewRecorder()
 			s.Handler().ServeHTTP(w, localReq("GET", base+"?sort="+url.QueryEscape(p)))


### PR DESCRIPTION
Cleanups and coverage on the column-sort path introduced in #571.

- `joinSort` is the inverse of `splitSort`; eight handlers rebuilt the `key.dir` token by hand after their sort switch, now one call each
- `sbomShow`'s findings tab was the one sort left reading `?sort=` raw and hardcoding direction; route it through `splitSort` + `orderByExpr` so `?sort=severity.asc` actually reverses, matching the `/findings` index
- `TestWantDesc` covers the explicit `"desc"` branch (was 0%); every function in `sortable.go` is now at 100%
- `TestJoinSort` covers the new helper and round-trips through `splitSort`
- `TestSort_maliciousParamFallsBackSafely` now hits all eight sortable indexes (`/`, `/scans`, `/findings`, `/packages`, `/advisories`, `/maintainers`, `/orgs`, `/sboms`); each has its own switch dispatch and would regress independently