### PR TITLE
Fill small test gaps surfaced by coverage report

### DIFF
--- a/internal/httpx/retry_test.go
+++ b/internal/httpx/retry_test.go
@@ -13,24 +13,28 @@ import (
 
 func TestRetryAfterDelay(t *testing.T) {
 	const fallback = 3 * time.Second
-	const maxDelay = 30 * time.Second
-	future := time.Now().Add(10 * time.Second).UTC().Format(http.TimeFormat)
-	longFuture := time.Now().Add(90 * time.Second).UTC().Format(http.TimeFormat)
-	past := time.Now().Add(-10 * time.Second).UTC().Format(http.TimeFormat)
+	// The HTTP-date branch reads time.Now() internally, so those cases assert
+	// against a range rather than an exact value. The offsets are large and the
+	// window is 30s wide so a slow CI runner cannot flake the assertion; the
+	// point is which branch fired and whether the cap applied, not the precise
+	// remaining delay.
+	now := time.Now().UTC()
+	httpDate := func(d time.Duration) string { return now.Add(d).Format(http.TimeFormat) }
 	for _, tc := range []struct {
 		name, header string
+		maxDelay     time.Duration
 		wantMin      time.Duration
 		wantMax      time.Duration
 	}{
-		{"empty falls back", "", fallback, fallback},
-		{"integer seconds", "5", 5 * time.Second, 5 * time.Second},
-		{"integer seconds capped", "90", maxDelay, maxDelay},
-		{"http-date future", future, 8 * time.Second, 12 * time.Second},
-		{"http-date future capped", longFuture, maxDelay, maxDelay},
-		{"http-date past yields zero", past, 0, 0},
-		{"garbage falls back", "not-a-time", fallback, fallback},
+		{"empty falls back", "", time.Minute, fallback, fallback},
+		{"integer seconds", "5", time.Minute, 5 * time.Second, 5 * time.Second},
+		{"integer seconds capped", "90", 30 * time.Second, 30 * time.Second, 30 * time.Second},
+		{"http-date future", httpDate(5 * time.Minute), time.Hour, 270 * time.Second, 300 * time.Second},
+		{"http-date future capped", httpDate(5 * time.Minute), 30 * time.Second, 30 * time.Second, 30 * time.Second},
+		{"http-date past yields zero", httpDate(-time.Minute), time.Hour, 0, 0},
+		{"garbage falls back", "not-a-time", time.Minute, fallback, fallback},
 	} {
-		got := retryAfterDelay(tc.header, fallback, maxDelay)
+		got := retryAfterDelay(tc.header, fallback, tc.maxDelay)
 		if got < tc.wantMin || got > tc.wantMax {
 			t.Errorf("%s: retryAfterDelay(%q) = %v, want in [%v, %v]",
 				tc.name, tc.header, got, tc.wantMin, tc.wantMax)

--- a/internal/httpx/retry_test.go
+++ b/internal/httpx/retry_test.go
@@ -11,6 +11,33 @@ import (
 	"time"
 )
 
+func TestRetryAfterDelay(t *testing.T) {
+	const fallback = 3 * time.Second
+	const maxDelay = 30 * time.Second
+	future := time.Now().Add(10 * time.Second).UTC().Format(http.TimeFormat)
+	longFuture := time.Now().Add(90 * time.Second).UTC().Format(http.TimeFormat)
+	past := time.Now().Add(-10 * time.Second).UTC().Format(http.TimeFormat)
+	for _, tc := range []struct {
+		name, header string
+		wantMin      time.Duration
+		wantMax      time.Duration
+	}{
+		{"empty falls back", "", fallback, fallback},
+		{"integer seconds", "5", 5 * time.Second, 5 * time.Second},
+		{"integer seconds capped", "90", maxDelay, maxDelay},
+		{"http-date future", future, 8 * time.Second, 12 * time.Second},
+		{"http-date future capped", longFuture, maxDelay, maxDelay},
+		{"http-date past yields zero", past, 0, 0},
+		{"garbage falls back", "not-a-time", fallback, fallback},
+	} {
+		got := retryAfterDelay(tc.header, fallback, maxDelay)
+		if got < tc.wantMin || got > tc.wantMax {
+			t.Errorf("%s: retryAfterDelay(%q) = %v, want in [%v, %v]",
+				tc.name, tc.header, got, tc.wantMin, tc.wantMax)
+		}
+	}
+}
+
 func TestDoRetrySucceedsAfterTransientStatus(t *testing.T) {
 	hits := 0
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -4620,6 +4620,86 @@ func TestSettingsUpdateTheme_rejectsInvalid(t *testing.T) {
 	}
 }
 
+func TestSettingsUpdateColorScheme_setsCookie(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	form := url.Values{"color_scheme": {"dark"}}
+	req := httptest.NewRequest("POST", "/settings/color-scheme", strings.NewReader(form.Encode()))
+	req.Host = testHost
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+
+	var found bool
+	for _, sc := range w.Header().Values("Set-Cookie") {
+		if strings.HasPrefix(sc, "color_scheme=dark") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("color_scheme cookie not set; cookies: %v", w.Header().Values("Set-Cookie"))
+	}
+}
+
+func TestSettingsUpdateColorScheme_rejectsInvalid(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	form := url.Values{"color_scheme": {"sepia"}}
+	req := httptest.NewRequest("POST", "/settings/color-scheme", strings.NewReader(form.Encode()))
+	req.Host = testHost
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Sec-Fetch-Site", "same-origin")
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Errorf("want 422 for invalid color scheme, got %d", w.Code)
+	}
+}
+
+func TestHumanDuration(t *testing.T) {
+	for _, tc := range []struct {
+		d    time.Duration
+		want string
+	}{
+		{0, "0s"},
+		{999 * time.Millisecond, "0s"},
+		{45 * time.Second, "45s"},
+		{3 * time.Minute, "3m"},
+		{2 * time.Hour, "2h"},
+		{2*time.Hour + 30*time.Minute, "2h30m"},
+		{50 * time.Hour, "2d"},
+	} {
+		if got := humanDuration(tc.d); got != tc.want {
+			t.Errorf("humanDuration(%v) = %q, want %q", tc.d, got, tc.want)
+		}
+	}
+}
+
+func TestOrgActivityLess(t *testing.T) {
+	early := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	late := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	a := orgRow{LastActivity: &early}
+	b := orgRow{LastActivity: &late}
+	n := orgRow{LastActivity: nil}
+
+	if !orgActivityLess(a, b) || orgActivityLess(b, a) {
+		t.Errorf("earlier activity should sort before later")
+	}
+	// nil (never active) sorts oldest, so it comes before any real timestamp
+	// under the ascending comparator; dirLess flips this to newest-first.
+	if !orgActivityLess(n, a) || orgActivityLess(a, n) {
+		t.Errorf("nil LastActivity should sort before any real timestamp")
+	}
+	if orgActivityLess(n, orgRow{}) {
+		t.Errorf("nil vs nil should not sort strictly-before")
+	}
+}
+
 func TestSettingsUpdateEffort_setsDefault(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()

--- a/internal/worker/harness_codex_test.go
+++ b/internal/worker/harness_codex_test.go
@@ -33,18 +33,26 @@ func TestHarnessByName(t *testing.T) {
 }
 
 func TestHarnessName(t *testing.T) {
-	if got := HarnessName(ClaudeHarness{}); got != "claude" {
-		t.Errorf("HarnessName(ClaudeHarness) = %q, want claude", got)
-	}
-	if got := HarnessName(CodexHarness{}); got != "codex" {
-		t.Errorf("HarnessName(CodexHarness) = %q, want codex", got)
+	for _, tc := range []struct {
+		h    Harness
+		want string
+	}{
+		{ClaudeHarness{}, "claude"},
+		{CodexHarness{}, "codex"},
+		{OpencodeHarness{}, "opencode"},
+	} {
+		if got := HarnessName(tc.h); got != tc.want {
+			t.Errorf("HarnessName(%T) = %q, want %q", tc.h, got, tc.want)
+		}
 	}
 }
 
 func TestHarnessNames(t *testing.T) {
 	got := HarnessNames()
-	if !strings.Contains(got, "claude") || !strings.Contains(got, "codex") {
-		t.Errorf("HarnessNames() = %q, want both claude and codex listed", got)
+	for _, want := range []string{"claude", "codex", "opencode"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("HarnessNames() = %q, want %q listed", got, want)
+		}
 	}
 	if strings.HasPrefix(got, ",") || strings.Contains(got, ", ,") {
 		t.Errorf("HarnessNames() = %q, empty default alias should not appear", got)


### PR DESCRIPTION
Test-only additions covering functions that showed 0% or near-0% in `go tool cover -func`.

- `retryAfterDelay` (40% → 100%): direct table test covering the HTTP-date branch (future and past), the unparseable-header fallback, and the `maxDelay` cap on both integer and date forms. Previously only the integer-seconds path was hit via `TestDoRetryRespectsRetryAfter`.
- `humanDuration` (27% → 100%): seven cases over every arm of the switch. Previous coverage was incidental via template rendering.
- `settingsUpdateColorScheme` (0% → 100%): mirrors the existing `settingsUpdateTheme` tests — valid value sets the cookie and 303s, unknown value 422s.
- `orgActivityLess` (0% → 100%): direct comparator test covering nil-vs-nil, nil-vs-real, and real-vs-real. `TestOrgsList_sortOptions` never drives `?sort=newest`.
- `TestHarnessName` / `TestHarnessNames`: now assert `opencode` alongside `claude` and `codex`; missed when #536 landed.

No production code touched.