### PR TITLE
Add skill eval harness

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -25,4 +25,3 @@ Each scenario YAML names:
 The default judge matches findings by title substring plus optional severity,
 CWE, and path. Model-backed judging can be plugged in by implementing
 `evals.Judge`.
-

--- a/evals/README.md
+++ b/evals/README.md
@@ -1,0 +1,28 @@
+# Skill evals
+
+Fixture-driven skill evals live here. They are off by default in normal CI;
+run the harness explicitly with:
+
+```sh
+go test -tags evals ./internal/evals/...
+```
+
+That command validates scenario loading and the deterministic judge. To run the
+actual model-backed skills against every fixture, opt in:
+
+```sh
+SCRUTINEER_RUN_EVALS=1 SCRUTINEER_EVAL_MODEL=claude-sonnet-5 go test -tags evals ./internal/evals/... -run TestRunFixtures -v
+```
+
+Each scenario YAML names:
+
+- `given`: short description of the bug or non-bug.
+- `fixture`: directory under `evals/fixtures/`.
+- `skill`: bundled skill to execute.
+- `should_find`: required findings the report must include.
+- `should_not_find`: false positives the report must not include.
+
+The default judge matches findings by title substring plus optional severity,
+CWE, and path. Model-backed judging can be plugged in by implementing
+`evals.Judge`.
+

--- a/evals/fixtures/github-actions-basic/.github/workflows/ci.yml
+++ b/evals/fixtures/github-actions-basic/.github/workflows/ci.yml
@@ -11,4 +11,3 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: echo ok
-

--- a/evals/fixtures/github-actions-basic/.github/workflows/ci.yml
+++ b/evals/fixtures/github-actions-basic/.github/workflows/ci.yml
@@ -1,0 +1,14 @@
+name: ci
+
+on:
+  pull_request:
+
+permissions: write-all
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: echo ok
+

--- a/evals/fixtures/github-actions-basic/README.md
+++ b/evals/fixtures/github-actions-basic/README.md
@@ -2,4 +2,3 @@
 
 Tiny workflow fixture with intentionally broad write permissions for zizmor
 coverage.
-

--- a/evals/fixtures/github-actions-basic/README.md
+++ b/evals/fixtures/github-actions-basic/README.md
@@ -1,0 +1,5 @@
+# GitHub Actions fixture
+
+Tiny workflow fixture with intentionally broad write permissions for zizmor
+coverage.
+

--- a/evals/fixtures/sqli-basic/README.md
+++ b/evals/fixtures/sqli-basic/README.md
@@ -3,4 +3,3 @@
 Tiny Flask app with one intentionally vulnerable query builder and one harmless
 unused import. The eval expects the vulnerable query construction to be found
 and the unused import to be ignored.
-

--- a/evals/fixtures/sqli-basic/README.md
+++ b/evals/fixtures/sqli-basic/README.md
@@ -1,0 +1,6 @@
+# SQLi fixture
+
+Tiny Flask app with one intentionally vulnerable query builder and one harmless
+unused import. The eval expects the vulnerable query construction to be found
+and the unused import to be ignored.
+

--- a/evals/fixtures/sqli-basic/app.py
+++ b/evals/fixtures/sqli-basic/app.py
@@ -14,4 +14,3 @@ def users():
     name = flask.request.args.get("name", "")
     conn = sqlite3.connect(":memory:")
     return flask.jsonify(conn.execute(buildQuery(name)).fetchall())
-

--- a/evals/fixtures/sqli-basic/app.py
+++ b/evals/fixtures/sqli-basic/app.py
@@ -1,0 +1,17 @@
+import sqlite3
+import flask
+import math
+
+app = flask.Flask(__name__)
+
+
+def buildQuery(username):
+    return "SELECT * FROM users WHERE name = '" + username + "'"
+
+
+@app.get("/users")
+def users():
+    name = flask.request.args.get("name", "")
+    conn = sqlite3.connect(":memory:")
+    return flask.jsonify(conn.execute(buildQuery(name)).fetchall())
+

--- a/evals/security-deep-dive-sqli.yaml
+++ b/evals/security-deep-dive-sqli.yaml
@@ -8,5 +8,5 @@ should_find:
     path: app.py
     required: true
 should_not_find:
-  - the unused import on line 3
-
+  - finding: unused import
+    path: app.py

--- a/evals/security-deep-dive-sqli.yaml
+++ b/evals/security-deep-dive-sqli.yaml
@@ -1,0 +1,12 @@
+given: a Flask handler concatenates user input into a SQL string
+fixture: fixtures/sqli-basic
+skill: security-deep-dive
+should_find:
+  - finding: SQL injection in buildQuery
+    severity: High
+    cwe: CWE-89
+    path: app.py
+    required: true
+should_not_find:
+  - the unused import on line 3
+

--- a/evals/semgrep-sqli.yaml
+++ b/evals/semgrep-sqli.yaml
@@ -8,5 +8,6 @@ should_find:
     path: app.py
     required: true
 should_not_find:
-  - harmless string formatting in README examples
-
+  - finding: SQL injection
+    cwe: CWE-89
+    path: README.md

--- a/evals/semgrep-sqli.yaml
+++ b/evals/semgrep-sqli.yaml
@@ -1,0 +1,12 @@
+given: a Python route builds a SQL query from request input
+fixture: fixtures/sqli-basic
+skill: semgrep
+should_find:
+  - finding: SQL injection
+    severity: High
+    cwe: CWE-89
+    path: app.py
+    required: true
+should_not_find:
+  - harmless string formatting in README examples
+

--- a/evals/zizmor-permissions.yaml
+++ b/evals/zizmor-permissions.yaml
@@ -7,5 +7,5 @@ should_find:
     path: .github/workflows/ci.yml
     required: true
 should_not_find:
-  - missing workflow directory
-
+  - finding: missing workflow directory
+    path: .github/workflows/missing.yml

--- a/evals/zizmor-permissions.yaml
+++ b/evals/zizmor-permissions.yaml
@@ -1,0 +1,11 @@
+given: a GitHub Actions workflow grants broad write permissions
+fixture: fixtures/github-actions-basic
+skill: zizmor
+should_find:
+  - finding: permissions
+    severity: Medium
+    path: .github/workflows/ci.yml
+    required: true
+should_not_find:
+  - missing workflow directory
+

--- a/internal/evals/evals_test.go
+++ b/internal/evals/evals_test.go
@@ -218,7 +218,7 @@ func TestRunnerStagesSkillAndScoresReport(t *testing.T) {
 		t.Fatal(err)
 	}
 	r := Runner{
-		Runner:     fakeSkillRunner{report: `{"findings":[{"title":"SQL injection in buildQuery","severity":"High","cwe":"CWE-89","location":"app.py:7"}]}`},
+		Runner:     fakeSkillRunner{report: validDeepDiveReport()},
 		SkillsRoot: "../../skills",
 		EvalsRoot:  "../../evals",
 		WorkRoot:   t.TempDir(),
@@ -233,6 +233,23 @@ func TestRunnerStagesSkillAndScoresReport(t *testing.T) {
 	}
 	if res.Cost.USD != 0.01 || res.Cost.Turns != 1 || res.Cost.InputTokens != 10 {
 		t.Fatalf("cost not accumulated: %+v", res.Cost)
+	}
+}
+
+func TestRunnerRejectsSchemaInvalidReport(t *testing.T) {
+	sc, err := LoadScenario("../../evals/security-deep-dive-sqli.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := Runner{
+		Runner:     fakeSkillRunner{report: `{"findings":[{"title":"SQL injection in buildQuery","severity":"High","cwe":"CWE-89","location":"app.py:7"}]}`},
+		SkillsRoot: "../../skills",
+		EvalsRoot:  "../../evals",
+		WorkRoot:   t.TempDir(),
+	}
+	_, err = r.RunScenario(context.Background(), sc)
+	if err == nil || !strings.Contains(err.Error(), "failed schema validation") {
+		t.Fatalf("RunScenario error = %v, want schema validation failure", err)
 	}
 }
 
@@ -280,7 +297,7 @@ func TestRunAllContinuesAfterScenarioError(t *testing.T) {
 		mustLoadScenario(t, "../../evals/security-deep-dive-sqli.yaml"),
 	}
 	r := Runner{
-		Runner:     fakeSkillRunner{report: `{"findings":[{"title":"SQL injection in buildQuery","severity":"High","cwe":"CWE-89","location":"app.py:7"}]}`},
+		Runner:     fakeSkillRunner{report: validDeepDiveReport()},
 		SkillsRoot: "../../skills",
 		EvalsRoot:  "../../evals",
 		WorkRoot:   t.TempDir(),
@@ -309,12 +326,54 @@ func mustLoadScenario(t *testing.T, path string) Scenario {
 	return sc
 }
 
+func validDeepDiveReport() string {
+	return `{
+  "repository": "https://example.com/eval",
+  "commit": "abcdef1",
+  "spec_version": 1,
+  "model": "test-model",
+  "date": "2026-07-09",
+  "languages": ["Python"],
+  "boundaries": [{
+    "actor": "HTTP client",
+    "trusted": "no",
+    "controls": "No input validation before query construction",
+    "source": "app.py"
+  }],
+  "inventory": [{
+    "id": "S1",
+    "location": "app.py:7",
+    "class": "Validation",
+    "consumes": "username query parameter"
+  }],
+  "findings": [{
+    "id": "F1",
+    "sinks": ["S1"],
+    "title": "SQL injection in buildQuery",
+    "severity": "High",
+    "cwe": "CWE-89",
+    "location": "app.py:7",
+    "reachability": "reachable",
+    "quality_tier": "high",
+    "trace": "The username parameter is concatenated into SQL.",
+    "boundary": "Untrusted HTTP input crosses into SQL execution.",
+    "validation": "Manual review of app.py shows string concatenation in buildQuery.",
+    "rating": "High impact and directly reachable."
+  }],
+  "ruled_out": [{
+    "sinks": ["S1"],
+    "step": 6,
+    "reason": "No additional sinks were present in the fixture."
+  }]
+}`
+}
+
 type fakeSkillRunner struct {
 	report string
 	err    error
 }
 
-func (f fakeSkillRunner) RunSkill(_ context.Context, sj worker.SkillJob, emit func(worker.Event)) (worker.SkillResult, error) {
+func (f fakeSkillRunner) RunSkill(ctx context.Context, sj worker.SkillJob, emit func(worker.Event)) (worker.SkillResult, error) {
 	if f.err != nil {
 		return worker.SkillResult{}, f.err
 	}
@@ -325,6 +384,9 @@ func (f fakeSkillRunner) RunSkill(_ context.Context, sj worker.SkillJob, emit fu
 		return worker.SkillResult{}, err
 	}
 	if _, err := os.Stat(filepath.Join(sj.SkillDir, "SKILL.md")); err != nil {
+		return worker.SkillResult{}, err
+	}
+	if err := runGit(ctx, filepath.Join(sj.WorkRoot, "src"), "rev-parse", "--verify", "HEAD"); err != nil {
 		return worker.SkillResult{}, err
 	}
 	emit(worker.Event{

--- a/internal/evals/evals_test.go
+++ b/internal/evals/evals_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"scrutineer/internal/worker"
@@ -54,6 +55,77 @@ should_find:
 	}
 }
 
+func TestLoadScenarioRejectsUnknownAssertionField(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "scenario.yaml")
+	if err := os.WriteFile(path, []byte(`given: typo case
+fixture: fixtures/x
+skill: security-deep-dive
+should_find:
+  - finding: typo
+    severty: High
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := LoadScenario(path)
+	if err == nil || !strings.Contains(err.Error(), "severty") {
+		t.Fatalf("LoadScenario error = %v, want unknown severty field", err)
+	}
+}
+
+func TestScenarioValidate(t *testing.T) {
+	tests := []struct {
+		name string
+		sc   Scenario
+	}{
+		{
+			name: "missing fixture",
+			sc: Scenario{
+				Path:       "case.yaml",
+				Given:      "x",
+				Skill:      "security-deep-dive",
+				ShouldFind: []Assertion{{Finding: "x"}},
+			},
+		},
+		{
+			name: "no assertions",
+			sc: Scenario{
+				Path:    "case.yaml",
+				Given:   "x",
+				Fixture: "fixtures/x",
+				Skill:   "security-deep-dive",
+			},
+		},
+		{
+			name: "blank should_find",
+			sc: Scenario{
+				Path:       "case.yaml",
+				Given:      "x",
+				Fixture:    "fixtures/x",
+				Skill:      "security-deep-dive",
+				ShouldFind: []Assertion{{}},
+			},
+		},
+		{
+			name: "blank should_not_find",
+			sc: Scenario{
+				Path:          "case.yaml",
+				Given:         "x",
+				Fixture:       "fixtures/x",
+				Skill:         "security-deep-dive",
+				ShouldNotFind: []Assertion{{}},
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := tc.sc.validate(); err == nil {
+				t.Fatal("validate succeeded, want error")
+			}
+		})
+	}
+}
+
 func TestHeuristicJudge(t *testing.T) {
 	sc := Scenario{
 		ShouldFind: []Assertion{{
@@ -80,6 +152,66 @@ func TestHeuristicJudge(t *testing.T) {
 	}
 }
 
+func TestAssertionMatchesFinding(t *testing.T) {
+	baseFinding := Finding{Title: "SQL injection in buildQuery", Severity: "high", CWE: "cwe-89", Location: "app.py:12:3"}
+	tests := []struct {
+		name string
+		a    Assertion
+		f    Finding
+		want bool
+	}{
+		{name: "full match", a: Assertion{Finding: "sql injection", Severity: "High", CWE: "CWE-89", Path: "app.py"}, want: true},
+		{name: "title mismatch", a: Assertion{Finding: "command injection"}, want: false},
+		{name: "severity mismatch", a: Assertion{Severity: "Low"}, want: false},
+		{name: "cwe mismatch", a: Assertion{CWE: "CWE-78"}, want: false},
+		{name: "path mismatch", a: Assertion{Path: "other.py"}, want: false},
+		{
+			name: "path avoids file prefix false positive",
+			a:    Assertion{Path: "app.py"},
+			f:    Finding{Title: "backup", Location: "app.py.bak:1"},
+			want: false,
+		},
+		{
+			name: "directory prefix match",
+			a:    Assertion{Path: "pkg"},
+			f:    Finding{Title: "nested", Location: "pkg/app.py:1"},
+			want: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			f := tc.f
+			if f.Title == "" && f.Location == "" {
+				f = baseFinding
+			}
+			if got := assertionMatchesFinding(tc.a, f); got != tc.want {
+				t.Fatalf("assertionMatchesFinding() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestHeuristicJudgeFailures(t *testing.T) {
+	sc := Scenario{
+		ShouldFind:    []Assertion{{Finding: "SQL injection", Required: true}},
+		ShouldNotFind: []Assertion{{Finding: "debug endpoint"}},
+	}
+	report := `{"findings":[{"title":"debug endpoint exposed","severity":"Medium","location":"debug.py:1"}]}`
+	got, err := (HeuristicJudge{}).Judge(sc, report)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("results = %d, want 2", len(got))
+	}
+	if got[0].Matched {
+		t.Fatalf("should_find unexpectedly matched: %+v", got[0])
+	}
+	if got[1].Matched {
+		t.Fatalf("should_not_find hit should fail the assertion: %+v", got[1])
+	}
+}
+
 func TestRunnerStagesSkillAndScoresReport(t *testing.T) {
 	sc, err := LoadScenario("../../evals/security-deep-dive-sqli.yaml")
 	if err != nil {
@@ -101,31 +233,6 @@ func TestRunnerStagesSkillAndScoresReport(t *testing.T) {
 	}
 	if res.Cost.USD != 0.01 || res.Cost.Turns != 1 || res.Cost.InputTokens != 10 {
 		t.Fatalf("cost not accumulated: %+v", res.Cost)
-	}
-}
-
-func TestCopyDirNestedSymlink(t *testing.T) {
-	src := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(src, "nested"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(src, "target.txt"), []byte("ok"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.Symlink("../target.txt", filepath.Join(src, "nested", "link.txt")); err != nil {
-		t.Fatal(err)
-	}
-
-	dst := filepath.Join(t.TempDir(), "copy")
-	if err := copyDir(src, dst); err != nil {
-		t.Fatal(err)
-	}
-	link, err := os.Readlink(filepath.Join(dst, "nested", "link.txt"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if link != "../target.txt" {
-		t.Fatalf("symlink target = %q, want ../target.txt", link)
 	}
 }
 
@@ -157,11 +264,60 @@ func TestRunFixtures(t *testing.T) {
 	}
 }
 
+func TestRunnerRejectsFixtureTraversal(t *testing.T) {
+	r := Runner{EvalsRoot: "../../evals"}
+	for _, fixture := range []string{"../outside", "/tmp/repo", "C:/repo"} {
+		_, err := r.fixturePath(Scenario{Path: "case.yaml", Fixture: fixture})
+		if err == nil {
+			t.Fatalf("fixturePath(%q) succeeded, want error", fixture)
+		}
+	}
+}
+
+func TestRunAllContinuesAfterScenarioError(t *testing.T) {
+	scenarios := []Scenario{
+		{Path: "bad.yaml", Fixture: "../bad", Skill: "security-deep-dive"},
+		mustLoadScenario(t, "../../evals/security-deep-dive-sqli.yaml"),
+	}
+	r := Runner{
+		Runner:     fakeSkillRunner{report: `{"findings":[{"title":"SQL injection in buildQuery","severity":"High","cwe":"CWE-89","location":"app.py:7"}]}`},
+		SkillsRoot: "../../skills",
+		EvalsRoot:  "../../evals",
+		WorkRoot:   t.TempDir(),
+	}
+	results, err := r.RunAll(context.Background(), scenarios)
+	if err == nil {
+		t.Fatal("RunAll error = nil, want joined error")
+	}
+	if len(results) != 2 {
+		t.Fatalf("results = %d, want 2", len(results))
+	}
+	if results[0].Error == "" {
+		t.Fatalf("first result missing error: %+v", results[0])
+	}
+	if results[1].Error != "" || results[1].FailedRequired != 0 {
+		t.Fatalf("second scenario should still run successfully: %+v", results[1])
+	}
+}
+
+func mustLoadScenario(t *testing.T, path string) Scenario {
+	t.Helper()
+	sc, err := LoadScenario(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return sc
+}
+
 type fakeSkillRunner struct {
 	report string
+	err    error
 }
 
 func (f fakeSkillRunner) RunSkill(_ context.Context, sj worker.SkillJob, emit func(worker.Event)) (worker.SkillResult, error) {
+	if f.err != nil {
+		return worker.SkillResult{}, f.err
+	}
 	if sj.Name == "" || sj.SkillDir == "" || sj.OutputFile == "" {
 		return worker.SkillResult{}, os.ErrInvalid
 	}

--- a/internal/evals/evals_test.go
+++ b/internal/evals/evals_test.go
@@ -104,6 +104,31 @@ func TestRunnerStagesSkillAndScoresReport(t *testing.T) {
 	}
 }
 
+func TestCopyDirNestedSymlink(t *testing.T) {
+	src := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(src, "nested"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "target.txt"), []byte("ok"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("../target.txt", filepath.Join(src, "nested", "link.txt")); err != nil {
+		t.Fatal(err)
+	}
+
+	dst := filepath.Join(t.TempDir(), "copy")
+	if err := copyDir(src, dst); err != nil {
+		t.Fatal(err)
+	}
+	link, err := os.Readlink(filepath.Join(dst, "nested", "link.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if link != "../target.txt" {
+		t.Fatalf("symlink target = %q, want ../target.txt", link)
+	}
+}
+
 func TestRunFixtures(t *testing.T) {
 	if os.Getenv("SCRUTINEER_RUN_EVALS") != "1" {
 		t.Skip("set SCRUTINEER_RUN_EVALS=1 to execute model-backed skill evals")

--- a/internal/evals/evals_test.go
+++ b/internal/evals/evals_test.go
@@ -1,0 +1,162 @@
+//go:build evals
+
+package evals
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"scrutineer/internal/worker"
+)
+
+func TestLoadScenarios(t *testing.T) {
+	scenarios, err := LoadScenarios("../../evals")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(scenarios) < 3 {
+		t.Fatalf("scenarios = %d, want at least 3", len(scenarios))
+	}
+	for _, sc := range scenarios {
+		if sc.Skill == "" || sc.Fixture == "" {
+			t.Fatalf("invalid scenario: %+v", sc)
+		}
+		if _, err := os.Stat(filepath.Join("../../evals", sc.Fixture)); err != nil {
+			t.Fatalf("%s fixture %q missing: %v", sc.Path, sc.Fixture, err)
+		}
+	}
+}
+
+func TestLoadScenarioDefaultsRequiredButAllowsOptional(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "scenario.yaml")
+	if err := os.WriteFile(path, []byte(`given: optional case
+fixture: fixtures/x
+skill: security-deep-dive
+should_find:
+  - finding: required by default
+  - finding: optional miss
+    required: false
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	sc, err := LoadScenario(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !sc.ShouldFind[0].Required {
+		t.Fatal("first should_find should default to required")
+	}
+	if sc.ShouldFind[1].Required {
+		t.Fatal("explicit required:false should stay optional")
+	}
+}
+
+func TestHeuristicJudge(t *testing.T) {
+	sc := Scenario{
+		ShouldFind: []Assertion{{
+			Finding:  "SQL injection",
+			Severity: "High",
+			CWE:      "CWE-89",
+			Path:     "app.py",
+			Required: true,
+		}},
+		ShouldNotFind: []Assertion{{Finding: "unused import"}},
+	}
+	report := `{"findings":[{"title":"SQL injection in build_query","severity":"High","cwe":"CWE-89","location":"app.py:8"}]}`
+	got, err := (HeuristicJudge{}).Judge(sc, report)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("results = %d, want 2", len(got))
+	}
+	for _, r := range got {
+		if !r.Matched {
+			t.Fatalf("assertion did not pass: %+v", r)
+		}
+	}
+}
+
+func TestRunnerStagesSkillAndScoresReport(t *testing.T) {
+	sc, err := LoadScenario("../../evals/security-deep-dive-sqli.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := Runner{
+		Runner:     fakeSkillRunner{report: `{"findings":[{"title":"SQL injection in buildQuery","severity":"High","cwe":"CWE-89","location":"app.py:7"}]}`},
+		SkillsRoot: "../../skills",
+		EvalsRoot:  "../../evals",
+		WorkRoot:   t.TempDir(),
+		Model:      "test-model",
+	}
+	res, err := r.RunScenario(context.Background(), sc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.FailedRequired != 0 || res.Unexpected != 0 {
+		t.Fatalf("unexpected failures: %+v", res)
+	}
+	if res.Cost.USD != 0.01 || res.Cost.Turns != 1 || res.Cost.InputTokens != 10 {
+		t.Fatalf("cost not accumulated: %+v", res.Cost)
+	}
+}
+
+func TestRunFixtures(t *testing.T) {
+	if os.Getenv("SCRUTINEER_RUN_EVALS") != "1" {
+		t.Skip("set SCRUTINEER_RUN_EVALS=1 to execute model-backed skill evals")
+	}
+	scenarios, err := LoadScenarios("../../evals")
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := Runner{
+		Runner:     worker.LocalClaude{},
+		SkillsRoot: "../../skills",
+		EvalsRoot:  "../../evals",
+		WorkRoot:   t.TempDir(),
+		Model:      os.Getenv("SCRUTINEER_EVAL_MODEL"),
+	}
+	results, err := r.RunAll(context.Background(), scenarios)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, res := range results {
+		t.Logf("%s: assertions=%d required_misses=%d optional_misses=%d unexpected=%d cost=$%.4f turns=%d",
+			res.Scenario.Path, res.AssertionTotal, res.FailedRequired, res.OptionalMisses, res.Unexpected, res.Cost.USD, res.Cost.Turns)
+		if res.FailedRequired > 0 || res.Unexpected > 0 {
+			t.Fail()
+		}
+	}
+}
+
+type fakeSkillRunner struct {
+	report string
+}
+
+func (f fakeSkillRunner) RunSkill(_ context.Context, sj worker.SkillJob, emit func(worker.Event)) (worker.SkillResult, error) {
+	if sj.Name == "" || sj.SkillDir == "" || sj.OutputFile == "" {
+		return worker.SkillResult{}, os.ErrInvalid
+	}
+	if _, err := os.Stat(filepath.Join(sj.WorkRoot, "src")); err != nil {
+		return worker.SkillResult{}, err
+	}
+	if _, err := os.Stat(filepath.Join(sj.SkillDir, "SKILL.md")); err != nil {
+		return worker.SkillResult{}, err
+	}
+	emit(worker.Event{
+		Kind:    worker.KindResult,
+		CostUSD: 0.01,
+		Turns:   1,
+		Usage:   worker.Usage{InputTokens: 10, OutputTokens: 2},
+	})
+	return worker.SkillResult{Commit: "abc", Report: f.report}, nil
+}
+
+func (fakeSkillRunner) SkillDir(workRoot, name string) string {
+	return filepath.Join(workRoot, ".claude", "skills", name)
+}
+
+var _ worker.SkillRunner = fakeSkillRunner{}

--- a/internal/evals/judge.go
+++ b/internal/evals/judge.go
@@ -5,8 +5,9 @@ package evals
 import (
 	"encoding/json"
 	"fmt"
-	"path/filepath"
 	"strings"
+
+	"scrutineer/internal/findingnorm"
 )
 
 const (
@@ -75,7 +76,7 @@ func assertionMatchesFinding(a Assertion, f Finding) bool {
 	if a.Severity != "" && !strings.EqualFold(strings.TrimSpace(f.Severity), strings.TrimSpace(a.Severity)) {
 		return false
 	}
-	if a.CWE != "" && !strings.EqualFold(strings.TrimSpace(f.CWE), strings.TrimSpace(a.CWE)) {
+	if a.CWE != "" && findingnorm.CWE(f.CWE) != findingnorm.CWE(a.CWE) {
 		return false
 	}
 	if a.Path != "" && !findingHasPath(f, a.Path) {
@@ -85,21 +86,14 @@ func assertionMatchesFinding(a Assertion, f Finding) bool {
 }
 
 func findingHasPath(f Finding, want string) bool {
-	want = cleanReportPath(want)
+	want = findingnorm.RepoPath(want)
 	for _, loc := range append([]string{f.Location}, f.Locations...) {
-		if strings.HasPrefix(cleanReportPath(loc), want) {
+		got := findingnorm.LocationFile(loc)
+		if got == want || strings.HasPrefix(got, want+"/") {
 			return true
 		}
 	}
 	return false
-}
-
-func cleanReportPath(s string) string {
-	s = strings.TrimSpace(s)
-	if before, _, ok := strings.Cut(s, ":"); ok {
-		s = before
-	}
-	return filepath.ToSlash(filepath.Clean(s))
 }
 
 func containsFold(haystack, needle string) bool {

--- a/internal/evals/judge.go
+++ b/internal/evals/judge.go
@@ -1,0 +1,121 @@
+//go:build evals
+
+package evals
+
+import (
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	assertionShouldFind    = "should_find"
+	assertionShouldNotFind = "should_not_find"
+)
+
+// Judge scores a skill report against one scenario. Model-backed judges can
+// implement this interface; the default judge is deterministic and local.
+type Judge interface {
+	Judge(sc Scenario, report string) ([]AssertionResult, error)
+}
+
+type HeuristicJudge struct{}
+
+func (HeuristicJudge) Judge(sc Scenario, raw string) ([]AssertionResult, error) {
+	findings, err := parseFindings(raw)
+	if err != nil {
+		return nil, err
+	}
+	results := make([]AssertionResult, 0, len(sc.ShouldFind)+len(sc.ShouldNotFind))
+	for _, a := range sc.ShouldFind {
+		match := matchingFinding(a, findings)
+		results = append(results, AssertionResult{
+			Assertion: a,
+			Kind:      assertionShouldFind,
+			Matched:   match != nil,
+			Required:  a.Required,
+			Reason:    matchReason(a, match),
+		})
+	}
+	for _, a := range sc.ShouldNotFind {
+		match := matchingFinding(a, findings)
+		results = append(results, AssertionResult{
+			Assertion: a,
+			Kind:      assertionShouldNotFind,
+			Matched:   match == nil,
+			Required:  true,
+			Reason:    notFindReason(match),
+		})
+	}
+	return results, nil
+}
+
+func parseFindings(raw string) ([]Finding, error) {
+	var r report
+	if err := json.Unmarshal([]byte(raw), &r); err != nil {
+		return nil, fmt.Errorf("parse report.json: %w", err)
+	}
+	return r.Findings, nil
+}
+
+func matchingFinding(a Assertion, findings []Finding) *Finding {
+	for i := range findings {
+		if assertionMatchesFinding(a, findings[i]) {
+			return &findings[i]
+		}
+	}
+	return nil
+}
+
+func assertionMatchesFinding(a Assertion, f Finding) bool {
+	if a.Finding != "" && !containsFold(f.Title, a.Finding) {
+		return false
+	}
+	if a.Severity != "" && !strings.EqualFold(strings.TrimSpace(f.Severity), strings.TrimSpace(a.Severity)) {
+		return false
+	}
+	if a.CWE != "" && !strings.EqualFold(strings.TrimSpace(f.CWE), strings.TrimSpace(a.CWE)) {
+		return false
+	}
+	if a.Path != "" && !findingHasPath(f, a.Path) {
+		return false
+	}
+	return true
+}
+
+func findingHasPath(f Finding, want string) bool {
+	want = cleanReportPath(want)
+	for _, loc := range append([]string{f.Location}, f.Locations...) {
+		if strings.HasPrefix(cleanReportPath(loc), want) {
+			return true
+		}
+	}
+	return false
+}
+
+func cleanReportPath(s string) string {
+	s = strings.TrimSpace(s)
+	if before, _, ok := strings.Cut(s, ":"); ok {
+		s = before
+	}
+	return filepath.ToSlash(filepath.Clean(s))
+}
+
+func containsFold(haystack, needle string) bool {
+	return strings.Contains(strings.ToLower(haystack), strings.ToLower(strings.TrimSpace(needle)))
+}
+
+func matchReason(a Assertion, f *Finding) string {
+	if f == nil {
+		return "no finding matched " + a.label()
+	}
+	return fmt.Sprintf("matched %q at %s", f.Title, f.Location)
+}
+
+func notFindReason(f *Finding) string {
+	if f == nil {
+		return "no matching finding emitted"
+	}
+	return fmt.Sprintf("unexpected finding %q at %s", f.Title, f.Location)
+}

--- a/internal/evals/load.go
+++ b/internal/evals/load.go
@@ -3,6 +3,7 @@
 package evals
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -45,7 +46,9 @@ func LoadScenario(path string) (Scenario, error) {
 		return Scenario{}, fmt.Errorf("read scenario %s: %w", path, err)
 	}
 	var sc Scenario
-	if err := yaml.Unmarshal(raw, &sc); err != nil {
+	dec := yaml.NewDecoder(bytes.NewReader(raw))
+	dec.KnownFields(true)
+	if err := dec.Decode(&sc); err != nil {
 		return Scenario{}, fmt.Errorf("parse scenario %s: %w", path, err)
 	}
 	sc.Path = path

--- a/internal/evals/load.go
+++ b/internal/evals/load.go
@@ -1,0 +1,61 @@
+//go:build evals
+
+package evals
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// LoadScenarios reads every top-level .yaml/.yml file under root.
+func LoadScenarios(root string) ([]Scenario, error) {
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return nil, fmt.Errorf("read evals dir: %w", err)
+	}
+	var scenarios []Scenario
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if !strings.HasSuffix(name, ".yaml") && !strings.HasSuffix(name, ".yml") {
+			continue
+		}
+		path := filepath.Join(root, name)
+		sc, err := LoadScenario(path)
+		if err != nil {
+			return nil, err
+		}
+		scenarios = append(scenarios, sc)
+	}
+	sort.Slice(scenarios, func(i, j int) bool { return scenarios[i].Path < scenarios[j].Path })
+	return scenarios, nil
+}
+
+// LoadScenario parses one scenario YAML file.
+func LoadScenario(path string) (Scenario, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return Scenario{}, fmt.Errorf("read scenario %s: %w", path, err)
+	}
+	var sc Scenario
+	if err := yaml.Unmarshal(raw, &sc); err != nil {
+		return Scenario{}, fmt.Errorf("parse scenario %s: %w", path, err)
+	}
+	sc.Path = path
+	if err := sc.validate(); err != nil {
+		return Scenario{}, err
+	}
+	for i := range sc.ShouldFind {
+		if !sc.ShouldFind[i].requiredSet {
+			sc.ShouldFind[i].Required = true
+		}
+	}
+	return sc, nil
+}

--- a/internal/evals/runner.go
+++ b/internal/evals/runner.go
@@ -4,21 +4,17 @@ package evals
 
 import (
 	"context"
-	"encoding/json"
+	"errors"
 	"fmt"
-	"io"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 
 	"scrutineer/internal/db"
+	"scrutineer/internal/findingnorm"
 	"scrutineer/internal/skills"
 	"scrutineer/internal/worker"
-)
-
-const (
-	dirPerm  = 0o755
-	filePerm = 0o644
 )
 
 // Runner executes scenarios with a real worker.SkillRunner. It prepares the
@@ -35,14 +31,16 @@ type Runner struct {
 
 func (r Runner) RunAll(ctx context.Context, scenarios []Scenario) ([]Result, error) {
 	results := make([]Result, 0, len(scenarios))
+	var errs []error
 	for _, sc := range scenarios {
 		res, err := r.RunScenario(ctx, sc)
 		if err != nil {
-			return results, err
+			res = Result{Scenario: sc, Error: err.Error()}
+			errs = append(errs, err)
 		}
 		results = append(results, res)
 	}
-	return results, nil
+	return results, errors.Join(errs...)
 }
 
 func (r Runner) RunScenario(ctx context.Context, sc Scenario) (Result, error) {
@@ -63,11 +61,15 @@ func (r Runner) RunScenario(ctx context.Context, sc Scenario) (Result, error) {
 	if err != nil {
 		return Result{}, err
 	}
-	fixture := r.fixturePath(sc)
-	if err := copyDir(fixture, filepath.Join(work, "src")); err != nil {
+	fixture, err := r.fixturePath(sc)
+	if err != nil {
+		return Result{}, err
+	}
+	if err := worker.CopyTree(fixture, filepath.Join(work, "src")); err != nil {
 		return Result{}, fmt.Errorf("stage fixture %s: %w", fixture, err)
 	}
-	if err := r.stageWorkspace(work, skill); err != nil {
+	repo := evalRepository(sc, fixture)
+	if err := r.stageWorkspace(work, skill, repo); err != nil {
 		return Result{}, err
 	}
 
@@ -83,7 +85,7 @@ func (r Runner) RunScenario(ctx context.Context, sc Scenario) (Result, error) {
 		}
 	}
 	res, err := r.Runner.RunSkill(ctx, worker.SkillJob{
-		Repo:       evalRepository(sc, fixture),
+		Repo:       repo,
 		WorkRoot:   work,
 		Model:      r.Model,
 		Name:       skill.Name,
@@ -135,63 +137,42 @@ func (r Runner) loadSkill(name string) (*db.Skill, error) {
 	}
 	model.Active = true
 	model.Version = 1
+	if err := worker.ValidateSkillPaths(model.Name, model.OutputFile); err != nil {
+		return nil, err
+	}
 	return model, nil
 }
 
-func (r Runner) fixturePath(sc Scenario) string {
-	if filepath.IsAbs(sc.Fixture) {
-		return sc.Fixture
+func (r Runner) fixturePath(sc Scenario) (string, error) {
+	raw := strings.TrimSpace(strings.ReplaceAll(sc.Fixture, "\\", "/"))
+	if path.IsAbs(raw) || hasWindowsVolume(raw) || findingnorm.HasParentPathSegment(raw) {
+		return "", fmt.Errorf("%s: fixture must be relative to evals root", sc.Path)
 	}
 	root := r.EvalsRoot
 	if root == "" {
 		root = "evals"
 	}
-	return filepath.Join(root, sc.Fixture)
+	return filepath.Join(root, filepath.FromSlash(raw)), nil
 }
 
-func (r Runner) stageWorkspace(work string, skill *db.Skill) error {
-	ctx := map[string]any{
-		"repository": map[string]any{
-			"url":  "file://" + filepath.Join(work, "src"),
-			"name": filepath.Base(filepath.Join(work, "src")),
-		},
-		"scrutineer": map[string]any{
-			"api_base":      "http://127.0.0.1:0/api",
-			"scan_id":       0,
-			"token":         "eval-token",
-			"repository_id": 0,
-			"metadata_dir":  ".scrutineer/",
-		},
-	}
-	b, err := json.MarshalIndent(ctx, "", "  ")
-	if err != nil {
-		return err
-	}
-	if err := os.WriteFile(filepath.Join(work, "context.json"), b, filePerm); err != nil {
-		return err
-	}
+func hasWindowsVolume(p string) bool {
+	return len(p) >= 2 && p[1] == ':'
+}
 
-	dst := r.Runner.SkillDir(work, skill.Name)
-	if err := os.RemoveAll(dst); err != nil {
-		return err
+func (r Runner) stageWorkspace(work string, skill *db.Skill, repo db.Repository) error {
+	scan := db.Scan{
+		Repository: repo,
+		APIToken:   "eval-token",
 	}
-	if err := copyDir(skill.SourcePath, dst); err != nil {
-		return fmt.Errorf("stage skill dir: %w", err)
-	}
-	if skill.SchemaJSON != "" {
-		if err := os.WriteFile(filepath.Join(work, "schema.json"), []byte(skill.SchemaJSON), filePerm); err != nil {
-			return err
-		}
-	}
-	if err := os.WriteFile(filepath.Join(dst, "context.json"), b, filePerm); err != nil {
-		return err
-	}
-	if _, err := os.Stat(filepath.Join(skill.SourcePath, "scripts")); err == nil {
-		if err := copyDir(filepath.Join(skill.SourcePath, "scripts"), filepath.Join(work, "scripts")); err != nil {
-			return fmt.Errorf("stage skill scripts: %w", err)
-		}
-	}
-	return nil
+	return worker.StageWorkspace(
+		work,
+		r.Runner.SkillDir(work, skill.Name),
+		"http://127.0.0.1:0/api",
+		"",
+		worker.DefaultMetadataDir,
+		&scan,
+		skill,
+	)
 }
 
 func evalRepository(sc Scenario, fixture string) db.Repository {
@@ -203,66 +184,4 @@ func evalRepository(sc Scenario, fixture string) db.Repository {
 		URL:  "file://" + fixture,
 		Name: name,
 	}
-}
-
-func copyDir(src, dst string) error {
-	info, err := os.Stat(src)
-	if err != nil {
-		return err
-	}
-	if !info.IsDir() {
-		return fmt.Errorf("%s is not a directory", src)
-	}
-	return filepath.WalkDir(src, func(path string, d os.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		rel, err := filepath.Rel(src, path)
-		if err != nil {
-			return err
-		}
-		if rel == "." {
-			return os.MkdirAll(dst, dirPerm)
-		}
-		target := filepath.Join(dst, rel)
-		if d.IsDir() {
-			return os.MkdirAll(target, dirPerm)
-		}
-		return copyFile(path, target)
-	})
-}
-
-func copyFile(src, dst string) error {
-	info, err := os.Lstat(src)
-	if err != nil {
-		return err
-	}
-	if info.Mode()&os.ModeSymlink != 0 {
-		link, err := os.Readlink(src)
-		if err != nil {
-			return err
-		}
-		if err := os.MkdirAll(filepath.Dir(dst), dirPerm); err != nil {
-			return err
-		}
-		return os.Symlink(link, dst)
-	}
-	if !info.Mode().IsRegular() {
-		return nil
-	}
-	if err := os.MkdirAll(filepath.Dir(dst), dirPerm); err != nil {
-		return err
-	}
-	in, err := os.Open(src)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = in.Close() }()
-	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, info.Mode().Perm())
-	if err != nil {
-		return err
-	}
-	defer func() { _ = out.Close() }()
-	_, err = io.Copy(out, in)
-	return err
 }

--- a/internal/evals/runner.go
+++ b/internal/evals/runner.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path"
 	"path/filepath"
 	"strings"
@@ -65,8 +66,12 @@ func (r Runner) RunScenario(ctx context.Context, sc Scenario) (Result, error) {
 	if err != nil {
 		return Result{}, err
 	}
-	if err := worker.CopyTree(fixture, filepath.Join(work, "src")); err != nil {
+	src := filepath.Join(work, "src")
+	if err := worker.CopyTree(fixture, src); err != nil {
 		return Result{}, fmt.Errorf("stage fixture %s: %w", fixture, err)
+	}
+	if err := ensureFixtureGitRepo(ctx, src); err != nil {
+		return Result{}, fmt.Errorf("stage fixture git repo: %w", err)
 	}
 	repo := evalRepository(sc, fixture)
 	if err := r.stageWorkspace(work, skill, repo); err != nil {
@@ -96,6 +101,9 @@ func (r Runner) RunScenario(ctx context.Context, sc Scenario) (Result, error) {
 	}, emit)
 	if err != nil {
 		return Result{}, fmt.Errorf("%s: run %s: %w", sc.Path, sc.Skill, err)
+	}
+	if detail := worker.ValidateReportSchema(skill.SchemaJSON, res.Report); detail != "" {
+		return Result{}, fmt.Errorf("%s: %s failed schema validation: %s", sc.Path, skill.OutputFile, detail)
 	}
 	matches, err := judge.Judge(sc, res.Report)
 	if err != nil {
@@ -157,6 +165,35 @@ func (r Runner) fixturePath(sc Scenario) (string, error) {
 
 func hasWindowsVolume(p string) bool {
 	return len(p) >= 2 && p[1] == ':'
+}
+
+func ensureFixtureGitRepo(ctx context.Context, src string) error {
+	if err := runGit(ctx, src, "rev-parse", "--verify", "HEAD"); err == nil {
+		return nil
+	}
+	if err := runGit(ctx, src, "init"); err != nil {
+		return err
+	}
+	if err := runGit(ctx, src, "add", "-A"); err != nil {
+		return err
+	}
+	return runGit(ctx, src,
+		"-c", "commit.gpgsign=false",
+		"-c", "gpg.format=openpgp",
+		"-c", "user.name=Scrutineer Eval",
+		"-c", "user.email=evals@scrutineer.local",
+		"commit", "-m", "eval fixture",
+	)
+}
+
+func runGit(ctx context.Context, dir string, args ...string) error {
+	cmdArgs := append([]string{"-C", dir}, args...)
+	cmd := exec.CommandContext(ctx, "git", cmdArgs...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("git %s: %w: %s", strings.Join(args, " "), err, strings.TrimSpace(string(out)))
+	}
+	return nil
 }
 
 func (r Runner) stageWorkspace(work string, skill *db.Skill, repo db.Repository) error {

--- a/internal/evals/runner.go
+++ b/internal/evals/runner.go
@@ -242,6 +242,9 @@ func copyFile(src, dst string) error {
 		if err != nil {
 			return err
 		}
+		if err := os.MkdirAll(filepath.Dir(dst), dirPerm); err != nil {
+			return err
+		}
 		return os.Symlink(link, dst)
 	}
 	if !info.Mode().IsRegular() {

--- a/internal/evals/runner.go
+++ b/internal/evals/runner.go
@@ -1,0 +1,265 @@
+//go:build evals
+
+package evals
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"scrutineer/internal/db"
+	"scrutineer/internal/skills"
+	"scrutineer/internal/worker"
+)
+
+const (
+	dirPerm  = 0o755
+	filePerm = 0o644
+)
+
+// Runner executes scenarios with a real worker.SkillRunner. It prepares the
+// same workspace shape as a skill scan, but keeps database and queue state out
+// of the eval loop so prompt changes can be measured quickly.
+type Runner struct {
+	Runner     worker.SkillRunner
+	SkillsRoot string
+	EvalsRoot  string
+	WorkRoot   string
+	Model      string
+	Judge      Judge
+}
+
+func (r Runner) RunAll(ctx context.Context, scenarios []Scenario) ([]Result, error) {
+	results := make([]Result, 0, len(scenarios))
+	for _, sc := range scenarios {
+		res, err := r.RunScenario(ctx, sc)
+		if err != nil {
+			return results, err
+		}
+		results = append(results, res)
+	}
+	return results, nil
+}
+
+func (r Runner) RunScenario(ctx context.Context, sc Scenario) (Result, error) {
+	if r.Runner == nil {
+		return Result{}, fmt.Errorf("eval runner requires a worker.SkillRunner")
+	}
+	judge := r.Judge
+	if judge == nil {
+		judge = HeuristicJudge{}
+	}
+	work, err := os.MkdirTemp(r.WorkRoot, "scrutineer-eval-*")
+	if err != nil {
+		return Result{}, fmt.Errorf("create eval workdir: %w", err)
+	}
+	defer func() { _ = os.RemoveAll(work) }()
+
+	skill, err := r.loadSkill(sc.Skill)
+	if err != nil {
+		return Result{}, err
+	}
+	fixture := r.fixturePath(sc)
+	if err := copyDir(fixture, filepath.Join(work, "src")); err != nil {
+		return Result{}, fmt.Errorf("stage fixture %s: %w", fixture, err)
+	}
+	if err := r.stageWorkspace(work, skill); err != nil {
+		return Result{}, err
+	}
+
+	var cost Cost
+	emit := func(e worker.Event) {
+		if e.Kind == worker.KindResult {
+			cost.USD += e.CostUSD
+			cost.Turns += e.Turns
+			cost.InputTokens += e.Usage.InputTokens
+			cost.OutputTokens += e.Usage.OutputTokens
+			cost.CacheReadTokens += e.Usage.CacheReadTokens
+			cost.CacheWriteTokens += e.Usage.CacheWriteTokens
+		}
+	}
+	res, err := r.Runner.RunSkill(ctx, worker.SkillJob{
+		Repo:       evalRepository(sc, fixture),
+		WorkRoot:   work,
+		Model:      r.Model,
+		Name:       skill.Name,
+		SkillDir:   r.Runner.SkillDir(work, skill.Name),
+		OutputFile: skill.OutputFile,
+		MaxTurns:   skill.MaxTurns,
+		SrcReady:   true,
+	}, emit)
+	if err != nil {
+		return Result{}, fmt.Errorf("%s: run %s: %w", sc.Path, sc.Skill, err)
+	}
+	matches, err := judge.Judge(sc, res.Report)
+	if err != nil {
+		return Result{}, fmt.Errorf("%s: judge: %w", sc.Path, err)
+	}
+	result := Result{
+		Scenario:       sc,
+		Commit:         res.Commit,
+		Report:         res.Report,
+		AssertionTotal: len(matches),
+		Matches:        matches,
+		Cost:           cost,
+	}
+	for _, m := range matches {
+		switch {
+		case !m.Matched && m.Kind == assertionShouldFind && m.Required:
+			result.FailedRequired++
+		case !m.Matched && m.Kind == assertionShouldFind:
+			result.OptionalMisses++
+		case !m.Matched && m.Kind == assertionShouldNotFind:
+			result.Unexpected++
+		}
+	}
+	return result, nil
+}
+
+func (r Runner) loadSkill(name string) (*db.Skill, error) {
+	root := r.SkillsRoot
+	if root == "" {
+		root = "skills"
+	}
+	parsed, err := skills.ParseFile(filepath.Join(root, name, "SKILL.md"))
+	if err != nil {
+		return nil, err
+	}
+	model, err := parsed.ToModel("eval")
+	if err != nil {
+		return nil, err
+	}
+	model.Active = true
+	model.Version = 1
+	return model, nil
+}
+
+func (r Runner) fixturePath(sc Scenario) string {
+	if filepath.IsAbs(sc.Fixture) {
+		return sc.Fixture
+	}
+	root := r.EvalsRoot
+	if root == "" {
+		root = "evals"
+	}
+	return filepath.Join(root, sc.Fixture)
+}
+
+func (r Runner) stageWorkspace(work string, skill *db.Skill) error {
+	ctx := map[string]any{
+		"repository": map[string]any{
+			"url":  "file://" + filepath.Join(work, "src"),
+			"name": filepath.Base(filepath.Join(work, "src")),
+		},
+		"scrutineer": map[string]any{
+			"api_base":      "http://127.0.0.1:0/api",
+			"scan_id":       0,
+			"token":         "eval-token",
+			"repository_id": 0,
+			"metadata_dir":  ".scrutineer/",
+		},
+	}
+	b, err := json.MarshalIndent(ctx, "", "  ")
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(filepath.Join(work, "context.json"), b, filePerm); err != nil {
+		return err
+	}
+
+	dst := r.Runner.SkillDir(work, skill.Name)
+	if err := os.RemoveAll(dst); err != nil {
+		return err
+	}
+	if err := copyDir(skill.SourcePath, dst); err != nil {
+		return fmt.Errorf("stage skill dir: %w", err)
+	}
+	if skill.SchemaJSON != "" {
+		if err := os.WriteFile(filepath.Join(work, "schema.json"), []byte(skill.SchemaJSON), filePerm); err != nil {
+			return err
+		}
+	}
+	if err := os.WriteFile(filepath.Join(dst, "context.json"), b, filePerm); err != nil {
+		return err
+	}
+	if _, err := os.Stat(filepath.Join(skill.SourcePath, "scripts")); err == nil {
+		if err := copyDir(filepath.Join(skill.SourcePath, "scripts"), filepath.Join(work, "scripts")); err != nil {
+			return fmt.Errorf("stage skill scripts: %w", err)
+		}
+	}
+	return nil
+}
+
+func evalRepository(sc Scenario, fixture string) db.Repository {
+	name := strings.TrimSuffix(filepath.Base(sc.Fixture), string(filepath.Separator))
+	if name == "." || name == "" {
+		name = filepath.Base(fixture)
+	}
+	return db.Repository{
+		URL:  "file://" + fixture,
+		Name: name,
+	}
+}
+
+func copyDir(src, dst string) error {
+	info, err := os.Stat(src)
+	if err != nil {
+		return err
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("%s is not a directory", src)
+	}
+	return filepath.WalkDir(src, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		if rel == "." {
+			return os.MkdirAll(dst, dirPerm)
+		}
+		target := filepath.Join(dst, rel)
+		if d.IsDir() {
+			return os.MkdirAll(target, dirPerm)
+		}
+		return copyFile(path, target)
+	})
+}
+
+func copyFile(src, dst string) error {
+	info, err := os.Lstat(src)
+	if err != nil {
+		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		link, err := os.Readlink(src)
+		if err != nil {
+			return err
+		}
+		return os.Symlink(link, dst)
+	}
+	if !info.Mode().IsRegular() {
+		return nil
+	}
+	if err := os.MkdirAll(filepath.Dir(dst), dirPerm); err != nil {
+		return err
+	}
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = in.Close() }()
+	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, info.Mode().Perm())
+	if err != nil {
+		return err
+	}
+	defer func() { _ = out.Close() }()
+	_, err = io.Copy(out, in)
+	return err
+}

--- a/internal/evals/types.go
+++ b/internal/evals/types.go
@@ -36,6 +36,13 @@ func (a *Assertion) UnmarshalYAML(value *yaml.Node) error {
 		a.Finding = strings.TrimSpace(value.Value)
 		return nil
 	}
+	for i := 0; i+1 < len(value.Content); i += 2 {
+		switch value.Content[i].Value {
+		case "finding", "severity", "cwe", "path", "required":
+		default:
+			return fmt.Errorf("unknown assertion field %q", value.Content[i].Value)
+		}
+	}
 	var out struct {
 		Finding  string `yaml:"finding"`
 		Severity string `yaml:"severity"`
@@ -83,7 +90,24 @@ func (s Scenario) validate() error {
 	if len(s.ShouldFind) == 0 && len(s.ShouldNotFind) == 0 {
 		return fmt.Errorf("%s has no assertions", s.Path)
 	}
+	for _, a := range s.ShouldFind {
+		if a.empty() {
+			return fmt.Errorf("%s has an empty should_find assertion", s.Path)
+		}
+	}
+	for _, a := range s.ShouldNotFind {
+		if a.empty() {
+			return fmt.Errorf("%s has an empty should_not_find assertion", s.Path)
+		}
+	}
 	return nil
+}
+
+func (a Assertion) empty() bool {
+	return strings.TrimSpace(a.Finding) == "" &&
+		strings.TrimSpace(a.Severity) == "" &&
+		strings.TrimSpace(a.CWE) == "" &&
+		strings.TrimSpace(a.Path) == ""
 }
 
 // Finding is the subset of report.json finding fields the eval judge needs.
@@ -110,6 +134,7 @@ type Result struct {
 	Unexpected     int
 	Matches        []AssertionResult
 	Cost           Cost
+	Error          string
 }
 
 // AssertionResult is one judged assertion.

--- a/internal/evals/types.go
+++ b/internal/evals/types.go
@@ -1,0 +1,132 @@
+//go:build evals
+
+package evals
+
+import (
+	"fmt"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Scenario is one YAML eval file under evals/. It points at a fixture
+// repository and names the skill whose output should be judged.
+type Scenario struct {
+	Path          string      `yaml:"-"`
+	Given         string      `yaml:"given"`
+	Fixture       string      `yaml:"fixture"`
+	Skill         string      `yaml:"skill"`
+	ShouldFind    []Assertion `yaml:"should_find"`
+	ShouldNotFind []Assertion `yaml:"should_not_find"`
+}
+
+// Assertion describes one expected positive or negative condition. Negative
+// assertions may be a scalar string in YAML; positives usually use fields.
+type Assertion struct {
+	Finding     string `yaml:"finding"`
+	Severity    string `yaml:"severity"`
+	CWE         string `yaml:"cwe"`
+	Path        string `yaml:"path"`
+	Required    bool   `yaml:"required"`
+	requiredSet bool
+}
+
+func (a *Assertion) UnmarshalYAML(value *yaml.Node) error {
+	if value.Kind == yaml.ScalarNode {
+		a.Finding = strings.TrimSpace(value.Value)
+		return nil
+	}
+	var out struct {
+		Finding  string `yaml:"finding"`
+		Severity string `yaml:"severity"`
+		CWE      string `yaml:"cwe"`
+		Path     string `yaml:"path"`
+		Required *bool  `yaml:"required"`
+	}
+	if err := value.Decode(&out); err != nil {
+		return err
+	}
+	a.Finding = out.Finding
+	a.Severity = out.Severity
+	a.CWE = out.CWE
+	a.Path = out.Path
+	if out.Required != nil {
+		a.Required = *out.Required
+		a.requiredSet = true
+	}
+	return nil
+}
+
+func (a Assertion) label() string {
+	for _, v := range []string{a.Finding, a.CWE, a.Path, a.Severity} {
+		if strings.TrimSpace(v) != "" {
+			return strings.TrimSpace(v)
+		}
+	}
+	return "<empty assertion>"
+}
+
+func (s Scenario) validate() error {
+	var missing []string
+	if strings.TrimSpace(s.Given) == "" {
+		missing = append(missing, "given")
+	}
+	if strings.TrimSpace(s.Fixture) == "" {
+		missing = append(missing, "fixture")
+	}
+	if strings.TrimSpace(s.Skill) == "" {
+		missing = append(missing, "skill")
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("%s missing %s", s.Path, strings.Join(missing, ", "))
+	}
+	if len(s.ShouldFind) == 0 && len(s.ShouldNotFind) == 0 {
+		return fmt.Errorf("%s has no assertions", s.Path)
+	}
+	return nil
+}
+
+// Finding is the subset of report.json finding fields the eval judge needs.
+type Finding struct {
+	Title     string   `json:"title"`
+	Severity  string   `json:"severity"`
+	CWE       string   `json:"cwe"`
+	Location  string   `json:"location"`
+	Locations []string `json:"locations"`
+}
+
+type report struct {
+	Findings []Finding `json:"findings"`
+}
+
+// Result is the per-scenario output from Runner.
+type Result struct {
+	Scenario       Scenario
+	Commit         string
+	Report         string
+	AssertionTotal int
+	FailedRequired int
+	OptionalMisses int
+	Unexpected     int
+	Matches        []AssertionResult
+	Cost           Cost
+}
+
+// AssertionResult is one judged assertion.
+type AssertionResult struct {
+	Assertion Assertion
+	Kind      string
+	Matched   bool
+	Required  bool
+	Reason    string
+}
+
+// Cost captures the model usage emitted by the skill runner.
+type Cost struct {
+	USD              float64
+	Turns            int
+	InputTokens      int
+	OutputTokens     int
+	CacheReadTokens  int
+	CacheWriteTokens int
+}

--- a/internal/findingnorm/normalize.go
+++ b/internal/findingnorm/normalize.go
@@ -1,0 +1,54 @@
+package findingnorm
+
+import (
+	"path"
+	"strings"
+)
+
+func CWE(cwe string) string {
+	return strings.ToUpper(strings.TrimSpace(cwe))
+}
+
+func LocationFile(loc string) string {
+	loc = strings.TrimSpace(strings.Split(strings.TrimSpace(loc), "\n")[0])
+	for {
+		i := strings.LastIndexByte(loc, ':')
+		if i < 0 || !allDigits(loc[i+1:]) {
+			break
+		}
+		loc = loc[:i]
+	}
+	return RepoPath(loc)
+}
+
+func RepoPath(p string) string {
+	p = strings.TrimSpace(strings.ReplaceAll(p, "\\", "/"))
+	for strings.HasPrefix(p, "./") {
+		p = strings.TrimPrefix(p, "./")
+	}
+	if p == "" {
+		return ""
+	}
+	return path.Clean(p)
+}
+
+func HasParentPathSegment(p string) bool {
+	for _, part := range strings.Split(p, "/") {
+		if part == ".." {
+			return true
+		}
+	}
+	return false
+}
+
+func allDigits(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/web/expected_findings.go
+++ b/internal/web/expected_findings.go
@@ -11,6 +11,7 @@ import (
 	"gorm.io/gorm"
 
 	"scrutineer/internal/db"
+	"scrutineer/internal/findingnorm"
 )
 
 type expectedFindingResponse struct {
@@ -86,7 +87,7 @@ func buildExpectedFinding(repoID uint, file, cwe, cve, note string) (db.Expected
 	row := db.ExpectedFinding{
 		RepositoryID: repoID,
 		File:         cleanFile,
-		CWE:          normalizeCWE(cwe),
+		CWE:          findingnorm.CWE(cwe),
 		CVE:          strings.TrimSpace(cve),
 		Note:         strings.TrimSpace(note),
 	}
@@ -217,12 +218,12 @@ func expectedStatusForFindings(findings []db.Finding, expected []db.ExpectedFind
 }
 
 func findingMatchesExpected(f db.Finding, expected db.ExpectedFinding) bool {
-	if normalizeCWE(f.CWE) != normalizeCWE(expected.CWE) {
+	if findingnorm.CWE(f.CWE) != findingnorm.CWE(expected.CWE) {
 		return false
 	}
-	want := cleanRepoPath(expected.File)
+	want := findingnorm.RepoPath(expected.File)
 	for _, loc := range findingLocations(f) {
-		if normalizeLocationFile(loc) == want {
+		if findingnorm.LocationFile(loc) == want {
 			return true
 		}
 	}
@@ -245,60 +246,12 @@ func cleanExpectedFileInput(file string) (string, error) {
 	if raw == "" {
 		return "", fmt.Errorf("file is required")
 	}
-	if path.IsAbs(raw) || hasParentPathSegment(raw) {
+	if path.IsAbs(raw) || findingnorm.HasParentPathSegment(raw) {
 		return "", fmt.Errorf("file must be relative to the repository root")
 	}
-	clean := cleanRepoPath(raw)
-	if clean == "" || clean == "." || path.IsAbs(clean) || hasParentPathSegment(clean) {
+	clean := findingnorm.RepoPath(raw)
+	if clean == "" || clean == "." || path.IsAbs(clean) || findingnorm.HasParentPathSegment(clean) {
 		return "", fmt.Errorf("file must be relative to the repository root")
 	}
 	return clean, nil
-}
-
-func normalizeCWE(cwe string) string {
-	return strings.ToUpper(strings.TrimSpace(cwe))
-}
-
-func normalizeLocationFile(loc string) string {
-	loc = strings.TrimSpace(strings.Split(strings.TrimSpace(loc), "\n")[0])
-	for {
-		i := strings.LastIndexByte(loc, ':')
-		if i < 0 || !allDigits(loc[i+1:]) {
-			break
-		}
-		loc = loc[:i]
-	}
-	return cleanRepoPath(loc)
-}
-
-func cleanRepoPath(p string) string {
-	p = strings.TrimSpace(strings.ReplaceAll(p, "\\", "/"))
-	for strings.HasPrefix(p, "./") {
-		p = strings.TrimPrefix(p, "./")
-	}
-	if p == "" {
-		return ""
-	}
-	return path.Clean(p)
-}
-
-func hasParentPathSegment(p string) bool {
-	for _, part := range strings.Split(p, "/") {
-		if part == ".." {
-			return true
-		}
-	}
-	return false
-}
-
-func allDigits(s string) bool {
-	if s == "" {
-		return false
-	}
-	for _, r := range s {
-		if r < '0' || r > '9' {
-			return false
-		}
-	}
-	return true
 }

--- a/internal/worker/clone.go
+++ b/internal/worker/clone.go
@@ -54,7 +54,7 @@ func prepareLocalSrc(localPath, workRoot string, emit func(Event)) error {
 		return err
 	}
 	emit(Event{Kind: KindText, Text: "$ cp -r " + localPath + " ./src"})
-	return copyTree(resolved, dst)
+	return CopyTree(resolved, dst)
 }
 
 // ensureClone returns the path to an up-to-date clone of repo.URL under

--- a/internal/worker/exposure.go
+++ b/internal/worker/exposure.go
@@ -55,16 +55,16 @@ func (w *Worker) prepareDependentSrc(ctx context.Context, url, ref, workRoot str
 	if err := os.RemoveAll(dst); err != nil {
 		return "", err
 	}
-	if err := copyTree(cacheSrc, dst); err != nil {
+	if err := CopyTree(cacheSrc, dst); err != nil {
 		return "", fmt.Errorf("copy dependent cache: %w", err)
 	}
 	return commit, nil
 }
 
-// copyTree recursively copies src to dst, preserving permissions but not
+// CopyTree recursively copies src to dst, preserving permissions but not
 // ownership or timestamps. Symlinks are recreated; everything else is
 // copied byte-for-byte. Fast enough for git trees up to a few hundred MB.
-func copyTree(src, dst string) error {
+func CopyTree(src, dst string) error {
 	return filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err

--- a/internal/worker/repo_cache.go
+++ b/internal/worker/repo_cache.go
@@ -97,7 +97,7 @@ func (w *Worker) prepareRepoSrc(ctx context.Context, url, ref, workRoot string, 
 	if err := os.RemoveAll(dst); err != nil {
 		return "", err
 	}
-	if err := copyTree(cacheSrc, dst); err != nil {
+	if err := CopyTree(cacheSrc, dst); err != nil {
 		return "", fmt.Errorf("copy repo cache: %w", err)
 	}
 	return commit, nil

--- a/internal/worker/skill.go
+++ b/internal/worker/skill.go
@@ -921,6 +921,12 @@ func validateSkillPaths(name, outputFile string) error {
 	return nil
 }
 
+// ValidateSkillPaths exposes the same path checks production scans apply before
+// staging a skill. Eval harnesses call this before invoking StageWorkspace.
+func ValidateSkillPaths(name, outputFile string) error {
+	return validateSkillPaths(name, outputFile)
+}
+
 // stageSkill writes the skill's files into dst so claude-code discovers them
 // at ./.claude/skills/{name}. SKILL.md and schema.json are reconstructed from
 // the DB; supplementary files (scripts/, references/, assets/) are copied
@@ -993,7 +999,7 @@ func mirrorScripts(src, workRoot string) error {
 	if err := os.RemoveAll(dst); err != nil {
 		return err
 	}
-	return copyTree(srcScripts, dst)
+	return CopyTree(srcScripts, dst)
 }
 
 // renderSkillMD rebuilds a SKILL.md from the stored fields. The frontmatter
@@ -1112,7 +1118,14 @@ func stageContext(workRoot, apiBase, forkOrg, metadataDir string, scan *db.Scan,
 // threshold; the error wrapping stays here so failures still name the
 // staging step.
 func (w *Worker) stageWorkspace(workRoot, skillDir string, scan *db.Scan, skill *db.Skill) error {
-	if err := stageContext(workRoot, w.APIBase, w.ForkOrg, w.metadataDir(), scan, &scan.Repository); err != nil {
+	return StageWorkspace(workRoot, skillDir, w.APIBase, w.ForkOrg, w.metadataDir(), scan, skill)
+}
+
+// StageWorkspace writes the same workspace side files as a production skill
+// scan: context.json, an optional threat-model override, the rendered skill
+// bundle, and optional import payloads.
+func StageWorkspace(workRoot, skillDir, apiBase, forkOrg, metadataDir string, scan *db.Scan, skill *db.Skill) error {
+	if err := stageContext(workRoot, apiBase, forkOrg, metadataDir, scan, &scan.Repository); err != nil {
 		return fmt.Errorf("stage context: %w", err)
 	}
 	if err := stageThreatModel(workRoot, scan.SubPath, scan.Repository.ThreatModel); err != nil {
@@ -1156,7 +1169,7 @@ func copyAux(src, dst string) error {
 		if name == "SKILL.md" || name == "schema.json" {
 			continue
 		}
-		if err := copyTree(filepath.Join(src, name), filepath.Join(dst, name)); err != nil {
+		if err := CopyTree(filepath.Join(src, name), filepath.Join(dst, name)); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Part of #65

## Summary

Adds an off-by-default, fixture-driven eval harness for measuring skill prompt changes against known scenarios.

The harness loads YAML scenarios from `evals/`, stages fixture repositories and bundled skills, runs the selected skill through the existing `worker.SkillRunner` interface and judges the emitted `report.json` against `should_find` / `should_not_find` assertions.

## Changes

- Add `internal/evals` behind the `evals` build tag
- Add scenario loading for YAML files under `evals/`
- Add deterministic local judging for finding title, severity, CWE and path matches
- Add runner support for staging fixture repos and skill workspaces
- Track per-scenario cost, turns and token usage from runner events
- Add explicit eval entrypoint: `go test -tags evals ./internal/evals/...`
- Add seed scenarios for:
  - `security-deep-dive`
  - `semgrep`
  - `zizmor`
- Add mini fixture repositories under `evals/fixtures/`
- Document how to run normal harness checks and opt-in live model-backed evals

## Notes

This PR keeps evals out of normal CI by using the `evals` build tag.

The default tests validate loading, staging and deterministic judging. Live model-backed skill execution remains opt-in via:

```sh
SCRUTINEER_RUN_EVALS=1 SCRUTINEER_EVAL_MODEL=claude-sonnet-5 go test -tags evals ./internal/evals/... -run TestRunFixtures -v
```
## Tests

- go test -tags evals ./internal/evals/...
- go test -tags evals ./...
- go vet -tags evals ./internal/evals/...
- go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --build-tags evals
- git diff --check
- go test ./...
- go vet ./...
- go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run