### PR TITLE
Make finding API patches atomic

### DIFF
--- a/internal/web/api_finding_writes.go
+++ b/internal/web/api_finding_writes.go
@@ -3,10 +3,13 @@ package web
 import (
 	"encoding/json"
 	"net/http"
+	"sort"
 	"strconv"
 	"time"
 
 	"scrutineer/internal/db"
+
+	"gorm.io/gorm"
 )
 
 // The handlers below let skills (and the browser UI) mutate a finding:
@@ -34,11 +37,21 @@ func (s *Server) apiPatchFinding(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	source := sourceFromRequest(r)
-	for field, value := range body.Fields {
-		if err := db.WriteFindingField(s.DB, uint(id), field, value, source, body.By); err != nil {
-			writeAPIError(w, http.StatusUnprocessableEntity, err.Error())
-			return
+	fields := make([]string, 0, len(body.Fields))
+	for field := range body.Fields {
+		fields = append(fields, field)
+	}
+	sort.Strings(fields)
+	if err := s.DB.Transaction(func(tx *gorm.DB) error {
+		for _, field := range fields {
+			if err := db.WriteFindingField(tx, uint(id), field, body.Fields[field], source, body.By); err != nil {
+				return err
+			}
 		}
+		return nil
+	}); err != nil {
+		writeAPIError(w, http.StatusUnprocessableEntity, err.Error())
+		return
 	}
 	w.WriteHeader(http.StatusNoContent)
 }

--- a/internal/web/api_finding_writes_test.go
+++ b/internal/web/api_finding_writes_test.go
@@ -98,6 +98,60 @@ func TestAPIPatchFinding(t *testing.T) {
 	}
 }
 
+func TestAPIPatchFindingAtomicRollback(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	f, tok, _ := seedFindingForAPI(t, s)
+	path := fmt.Sprintf("/api/findings/%d", f.ID)
+
+	w := apiReq(t, s, "PATCH", path, tok,
+		`{"fields":{"cve_id":"CVE-2026-12345","ghsa_id":"not-a-ghsa"},"by":"disclose"}`)
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d, want 422; body=%s", w.Code, w.Body)
+	}
+
+	var got db.Finding
+	s.DB.First(&got, f.ID)
+	if got.CVEID != "" || got.GHSAID != "" {
+		t.Fatalf("finding fields committed despite failed patch: cve=%q ghsa=%q", got.CVEID, got.GHSAID)
+	}
+	var hist []db.FindingHistory
+	s.DB.Where("finding_id = ?", f.ID).Find(&hist)
+	if len(hist) != 0 {
+		t.Fatalf("history rows = %d, want 0 after rollback: %+v", len(hist), hist)
+	}
+}
+
+func TestAPIPatchFindingCVSSSyncsInsideTransaction(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	f, tok, _ := seedFindingForAPI(t, s)
+	path := fmt.Sprintf("/api/findings/%d", f.ID)
+	const vec = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+
+	w := apiReq(t, s, "PATCH", path, tok,
+		`{"fields":{"cvss_vector":"`+vec+`","severity":"Critical"},"by":"disclose"}`)
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204; body=%s", w.Code, w.Body)
+	}
+
+	var got db.Finding
+	s.DB.First(&got, f.ID)
+	if got.CVSSVector != vec || got.CVSSScore != 9.8 || got.Severity != "Critical" {
+		t.Fatalf("finding after patch: vector=%q score=%v severity=%q", got.CVSSVector, got.CVSSScore, got.Severity)
+	}
+	var hist []db.FindingHistory
+	s.DB.Where("finding_id = ?", f.ID).Order("field").Find(&hist)
+	fields := make([]string, 0, len(hist))
+	for _, h := range hist {
+		fields = append(fields, h.Field)
+	}
+	want := []string{"cvss_score", "cvss_vector", "severity"}
+	if fmt.Sprint(fields) != fmt.Sprint(want) {
+		t.Fatalf("history fields = %v, want %v", fields, want)
+	}
+}
+
 // TestAPIFindingChildCollections covers the POST-then-GET round trip for the
 // three sibling child collections (notes, communications, references). They
 // share findingScoped and the same JSON-body shape, so a table keeps the


### PR DESCRIPTION
Fixes #563
## Summary

Wraps multi-field `PATCH /api/findings/{id}` updates in a single database transaction so partial updates cannot be committed when a later field fails validation.

## Changes

- Run all finding field writes from one API PATCH request inside one transaction
- Keep existing `db.WriteFindingField` validation, history logging, and CVSS score synchronization behavior
- Apply fields in deterministic sorted order
- Add regression coverage for rollback behavior
- Add coverage that CVSS score synchronization still works inside the transaction

## Tests

- `go test ./internal/web -run 'TestAPIPatchFinding|TestAPIListFindingHistory|TestSourceFromRequest'`
- `go test ./...`
- `go vet ./...`
- `git diff --check`
- `golangci-lint run`