### PR TITLE
Use bulk updates for scan status actions

### DIFF
--- a/internal/web/scans.go
+++ b/internal/web/scans.go
@@ -2,6 +2,7 @@ package web
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -11,6 +12,9 @@ import (
 
 	"scrutineer/internal/db"
 	"scrutineer/internal/worker"
+
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 func (s *Server) jobs(w http.ResponseWriter, r *http.Request) {
@@ -271,38 +275,88 @@ func (s *Server) scansRetryFailed(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) scansPauseQueued(w http.ResponseWriter, r *http.Request) {
-	var scans []db.Scan
-	if err := s.DB.Where("status = ?", db.ScanQueued).Find(&scans).Error; err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+	now := time.Now()
+	res := s.DB.Model(&db.Scan{}).Where("status = ?", db.ScanQueued).Updates(scanStatusUpdates(
+		db.ScanPaused,
+		"paused by user",
+		&now,
+		nil,
+	))
+	if res.Error != nil {
+		http.Error(w, res.Error.Error(), http.StatusInternalServerError)
 		return
 	}
-	now := time.Now()
-	for _, sc := range scans {
-		s.DB.Model(&db.Scan{}).Where("id = ? AND status = ?", sc.ID, db.ScanQueued).Updates(map[string]any{
-			statusKey:         db.ScanPaused,
-			"status_priority": db.StatusPriorityFor(db.ScanPaused),
-			errorKey:          "paused by user",
-			"finished_at":     &now,
-		})
-	}
-	setFlash(w, Flash{Category: successKey, Title: fmt.Sprintf("%d queued scans paused", len(scans))})
+	setFlash(w, Flash{Category: successKey, Title: fmt.Sprintf("%d queued scans paused", res.RowsAffected)})
 	s.redirect(w, r, "/scans?status=paused")
+}
+
+func scanStatusUpdates(status db.ScanStatus, msg string, finishedAt *time.Time, pausedUntil *time.Time) map[string]any {
+	return map[string]any{
+		statusKey:         status,
+		"status_priority": db.StatusPriorityFor(status),
+		errorKey:          msg,
+		"finished_at":     finishedAt,
+		"paused_until":    pausedUntil,
+	}
+}
+
+func (s *Server) bulkResumePaused(base *gorm.DB) ([]db.Scan, error) {
+	var scans []db.Scan
+	res := base.Model(&scans).Clauses(clause.Returning{
+		Columns: []clause.Column{
+			{Name: "id"},
+			{Name: "kind"},
+			{Name: "finding_id"},
+			{Name: "error"},
+			{Name: "paused_until"},
+		},
+	}).Where("status = ?", db.ScanPaused).Updates(scanStatusUpdates(
+		db.ScanQueued,
+		"",
+		nil,
+		nil,
+	))
+	if res.Error != nil {
+		return nil, res.Error
+	}
+	return scans, nil
+}
+
+func (s *Server) restorePausedAfterResumeEnqueueFailure(scan db.Scan, err error) error {
+	now := time.Now()
+	return s.DB.Model(&db.Scan{}).Where("id = ? AND status = ?", scan.ID, db.ScanQueued).Updates(scanStatusUpdates(
+		db.ScanPaused,
+		"resume failed: "+err.Error(),
+		&now,
+		scan.PausedUntil,
+	)).Error
+}
+
+func (s *Server) enqueueResumedScan(ctx context.Context, scan db.Scan) error {
+	priority := worker.PrioScan
+	if scan.FindingID != nil {
+		priority = worker.PrioFinding
+	}
+	if err := s.Queue.Enqueue(ctx, scan.Kind, scan.ID, priority); err != nil {
+		return errors.Join(err, s.restorePausedAfterResumeEnqueueFailure(scan, err))
+	}
+	return nil
 }
 
 func (s *Server) scansResumePaused(w http.ResponseWriter, r *http.Request) {
 	repoID, _ := strconv.Atoi(r.URL.Query().Get("repository"))
-	q := s.DB.Where("status = ?", db.ScanPaused)
+	q := s.DB
 	if repoID > 0 {
 		q = q.Where("repository_id = ?", repoID)
 	}
-	var scans []db.Scan
-	if err := q.Find(&scans).Error; err != nil {
+	scans, err := s.bulkResumePaused(q)
+	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 	var resumed, errored int
 	for _, sc := range scans {
-		if err := s.resumeScan(r.Context(), &sc); err != nil {
+		if err := s.enqueueResumedScan(r.Context(), sc); err != nil {
 			errored++
 			continue
 		}
@@ -463,13 +517,21 @@ func (s *Server) scansCancelAll(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "missing repository", http.StatusBadRequest)
 		return
 	}
+	now := time.Now()
+	queued := s.DB.Model(&db.Scan{}).
+		Where("repository_id = ? AND status = ?", repoID, db.ScanQueued).
+		Updates(scanStatusUpdates(db.ScanCancelled, "cancelled by user", &now, nil))
+	if queued.Error != nil {
+		http.Error(w, queued.Error.Error(), http.StatusInternalServerError)
+		return
+	}
 	var scans []db.Scan
 	if err := s.DB.Where("repository_id = ? AND status IN ?",
-		repoID, []db.ScanStatus{db.ScanQueued, db.ScanRunning}).Find(&scans).Error; err != nil {
+		repoID, []db.ScanStatus{db.ScanRunning}).Find(&scans).Error; err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	var cancelled int
+	cancelled := int(queued.RowsAffected)
 	for i := range scans {
 		s.cancelScan(&scans[i])
 		cancelled++

--- a/internal/web/scans_test.go
+++ b/internal/web/scans_test.go
@@ -242,6 +242,62 @@ func TestScansCancelAll_cancelsRepoQueuedAndRunning(t *testing.T) {
 	if got := statusOf(otherQueued.ID); got != db.ScanQueued {
 		t.Errorf("other repo queued -> %q, want queued (untouched)", got)
 	}
+	var queuedGot db.Scan
+	s.DB.First(&queuedGot, queued.ID)
+	if queuedGot.Error != "cancelled by user" || queuedGot.FinishedAt == nil {
+		t.Errorf("queued cancel fields: error=%q finished_at=%v", queuedGot.Error, queuedGot.FinishedAt)
+	}
+	if queuedGot.StatusPriority != db.StatusPriorityFor(db.ScanCancelled) {
+		t.Errorf("queued status_priority = %d, want cancelled priority", queuedGot.StatusPriority)
+	}
+}
+
+func TestScansPauseQueued_bulkUpdatesQueuedOnly(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	repo := db.Repository{URL: "https://example.com/pause", Name: "pause"}
+	s.DB.Create(&repo)
+
+	mk := func(st db.ScanStatus) db.Scan {
+		sc := db.Scan{RepositoryID: repo.ID, Kind: "skill", Status: st, StatusPriority: db.StatusPriorityFor(st)}
+		s.DB.Create(&sc)
+		return sc
+	}
+	q1 := mk(db.ScanQueued)
+	q2 := mk(db.ScanQueued)
+	running := mk(db.ScanRunning)
+	doneScan := mk(db.ScanDone)
+
+	r := localReq("POST", "/scans/pause-queued")
+	r.Header.Set("Sec-Fetch-Site", "same-origin")
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, r)
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("status = %d, want 303; body=%s", w.Code, w.Body)
+	}
+	if loc := w.Header().Get("Location"); loc != "/scans?status=paused" {
+		t.Errorf("Location = %q, want /scans?status=paused", loc)
+	}
+
+	var q1got, q2got, runningGot, doneGot db.Scan
+	s.DB.First(&q1got, q1.ID)
+	s.DB.First(&q2got, q2.ID)
+	s.DB.First(&runningGot, running.ID)
+	s.DB.First(&doneGot, doneScan.ID)
+	for _, got := range []db.Scan{q1got, q2got} {
+		if got.Status != db.ScanPaused || got.StatusPriority != db.StatusPriorityFor(db.ScanPaused) {
+			t.Errorf("queued scan %d -> status=%s priority=%d, want paused", got.ID, got.Status, got.StatusPriority)
+		}
+		if got.Error != "paused by user" || got.FinishedAt == nil {
+			t.Errorf("queued scan %d pause fields: error=%q finished_at=%v", got.ID, got.Error, got.FinishedAt)
+		}
+	}
+	if runningGot.Status != db.ScanRunning {
+		t.Errorf("running -> %q, want running", runningGot.Status)
+	}
+	if doneGot.Status != db.ScanDone {
+		t.Errorf("done -> %q, want done", doneGot.Status)
+	}
 }
 
 func TestScansResumePaused(t *testing.T) {


### PR DESCRIPTION
Fixes #575
## Summary

Replaces safe per-row scan status updates with bulk updates while preserving worker-aware behavior for running scans.

## Changes

- Bulk-pause queued scans in one database update
- Use `RowsAffected` for the pause flash count
- Bulk-resume paused scan rows before enqueueing the returned scans
- Restore a scan back to paused if resume enqueue fails
- Bulk-cancel queued scans in `scansCancelAll`
- Keep running scan cancellation on the existing worker-aware per-row path
- Add/expand tests for pause, resume and cancel behavior

## Tests

- `go test ./internal/web -run 'TestScans(PauseQueued|ResumePaused|CancelAll)|TestScanCancel'`
- `go test ./...`
- `go vet ./...`
- `git diff --check`
- `golangci-lint run`