### PR TITLE
Correct repo cache history docs

### DIFF
--- a/docs/skills.md
+++ b/docs/skills.md
@@ -157,7 +157,7 @@ When a scan starts, the worker creates `./data/work/scan-{id}/` with:
     ./scripts/                   copy of the skill's scripts/, so `bash scripts/foo.sh` resolves from cwd
     ./report.json                the skill writes its output here
 
-`./src/` is copied from a per-URL persistent clone under `./data/work/repo-cache/<sha256(url)>/src/` so the second scan of the same repository only fetches the delta. The cache is always full-history; the code browser at `/repositories/{id}/blob/{commit}/{path}` resolves historical commits against it via `git show`.
+`./src/` is copied from a per-URL persistent clone under `./data/work/repo-cache/<sha256(url)>/src/` so the second scan of the same repository only fetches the delta. The cache is shallow by default and is deepened on demand when the code browser needs to resolve a historical commit for `/repositories/{id}/blob/{commit}/{path}`.
 
 The worker then runs `claude -p "Use the {name} skill in this workspace"` with the working directory set to the workspace root. Anything the skill writes outside `./report.json` is discarded when the workspace is cleaned. Write intermediate files under `./` rather than `/tmp`; concurrent scans share `/tmp` in the container runner.
 


### PR DESCRIPTION
## Summary
- correct docs/skills.md to say the repo cache is shallow by default
- note that historical commits are resolved by deepening the cache on demand

## Tests
- not run; docs-only change