### PR TITLE
revalidate: check the threat model, verify citations at the pinned commit, record privilege

### DIFF
--- a/internal/web/api_reads.go
+++ b/internal/web/api_reads.go
@@ -328,6 +328,7 @@ func findingSummary(f db.Finding) map[string]any {
 		"scan_id":       f.ScanID,
 		"repository_id": f.RepositoryID,
 		"finding_id":    f.FindingID,
+		"commit":        f.Commit,
 		"sinks":         f.Sinks,
 		"title":         f.Title,
 		"severity":      f.Severity,

--- a/internal/web/api_test.go
+++ b/internal/web/api_test.go
@@ -247,7 +247,7 @@ func TestAPIFindingReadsAndFilters(t *testing.T) {
 	// Simulate a prior deep-dive scan with a couple of findings attached.
 	prior := db.Scan{RepositoryID: repo.ID, Kind: worker.JobSkill, Status: db.ScanDone, SkillName: "security-deep-dive"}
 	s.DB.Create(&prior)
-	s.DB.Create(&db.Finding{ScanID: prior.ID, RepositoryID: repo.ID, FindingID: "F1", Title: "a", Severity: "High", Location: "a.go:1", Trace: "trace a"})
+	s.DB.Create(&db.Finding{ScanID: prior.ID, RepositoryID: repo.ID, FindingID: "F1", Title: "a", Severity: "High", Location: "a.go:1", Commit: "abc123", Trace: "trace a"})
 	s.DB.Create(&db.Finding{ScanID: prior.ID, RepositoryID: repo.ID, FindingID: "F2", Title: "b", Severity: "Low", Location: "b.go:1", Trace: "trace b"})
 
 	// Unfiltered list
@@ -291,6 +291,9 @@ func TestAPIFindingReadsAndFilters(t *testing.T) {
 	_ = json.NewDecoder(w.Body).Decode(&detail)
 	if detail["trace"] != "trace a" {
 		t.Errorf("finding detail missing trace: %+v", detail)
+	}
+	if detail["commit"] != "abc123" {
+		t.Errorf("finding detail missing commit: %+v", detail)
 	}
 }
 

--- a/internal/worker/skill_parsers.go
+++ b/internal/worker/skill_parsers.go
@@ -936,6 +936,7 @@ func (w *Worker) parseRevalidateOutput(scan *db.Scan, report string, emit func(E
 	var result struct {
 		Verdict                string `json:"verdict"`
 		Reason                 string `json:"reason"`
+		PrivilegeRequired      string `json:"privilege_required"`
 		AdjustedSeverity       string `json:"adjusted_severity"`
 		AdjustedSeverityReason string `json:"adjusted_severity_reason"`
 	}
@@ -946,6 +947,11 @@ func (w *Worker) parseRevalidateOutput(scan *db.Scan, report string, emit func(E
 	case "true_positive", "false_positive", "already_fixed", "uncertain":
 	default:
 		return fmt.Errorf("revalidate verdict %q is not one of true_positive|false_positive|already_fixed|uncertain", result.Verdict)
+	}
+	switch result.PrivilegeRequired {
+	case "", "none", "authenticated", "admin", "maintainer", "local-root":
+	default:
+		return fmt.Errorf("revalidate privilege_required %q is not one of none|authenticated|admin|maintainer|local-root", result.PrivilegeRequired)
 	}
 	var f db.Finding
 	if err := w.DB.First(&f, *scan.FindingID).Error; err != nil {
@@ -995,6 +1001,9 @@ func (w *Worker) parseRevalidateOutput(scan *db.Scan, report string, emit func(E
 
 	var b strings.Builder
 	fmt.Fprintf(&b, "revalidate: %s\n", result.Verdict)
+	if result.PrivilegeRequired != "" {
+		fmt.Fprintf(&b, "privilege: %s\n", result.PrivilegeRequired)
+	}
 	if reason := strings.TrimSpace(result.Reason); reason != "" {
 		fmt.Fprintf(&b, "\n%s\n", reason)
 	}

--- a/internal/worker/skill_parsers_test.go
+++ b/internal/worker/skill_parsers_test.go
@@ -684,6 +684,45 @@ func TestParseRevalidate_truePositiveMovesNewToEnriched(t *testing.T) {
 	}
 }
 
+func TestParseRevalidate_recordsPrivilegeRequired(t *testing.T) {
+	report := `{"verdict":"true_positive","reason":"trace holds","privilege_required":"authenticated"}`
+	f, gdb := runSkillWithFinding(t, "revalidate", report, db.FindingNew)
+	body := findingNotes(gdb, f.ID)[0].Body
+	if !strings.Contains(body, "privilege: authenticated") {
+		t.Errorf("privilege line missing from note: %q", body)
+	}
+	// The privilege line sits directly under the verdict header, above the
+	// reason paragraph, so an analyst scanning the notes column sees it
+	// without reading the prose.
+	v := strings.Index(body, "revalidate:")
+	p := strings.Index(body, "privilege:")
+	r := strings.Index(body, "trace holds")
+	if v == -1 || p == -1 || r == -1 || v >= p || p >= r {
+		t.Errorf("want verdict < privilege < reason ordering, got %q", body)
+	}
+	_ = f
+}
+
+func TestParseRevalidate_rejectsUnknownPrivilege(t *testing.T) {
+	gdb, _ := db.Open(filepath.Join(t.TempDir(), "p.db"))
+	repo := db.Repository{URL: "https://example.com/x", Name: "x"}
+	gdb.Create(&repo)
+	prior := db.Scan{RepositoryID: repo.ID, Kind: JobSkill, Status: db.ScanDone}
+	gdb.Create(&prior)
+	finding := db.Finding{ScanID: prior.ID, RepositoryID: repo.ID, Title: "x", Severity: "High", Status: db.FindingNew}
+	gdb.Create(&finding)
+	scan := &db.Scan{RepositoryID: repo.ID, FindingID: new(finding.ID)}
+	w := &Worker{DB: gdb, Log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	err := w.parseRevalidateOutput(scan, `{"verdict":"true_positive","reason":"x","privilege_required":"superuser"}`, func(Event) {})
+	if err == nil || !strings.Contains(err.Error(), "none|authenticated|admin|maintainer|local-root") {
+		t.Errorf("want unknown-privilege error listing the enum, got %v", err)
+	}
+	// Empty is permitted (false_positive/already_fixed omit it).
+	if err := w.parseRevalidateOutput(scan, `{"verdict":"false_positive","reason":"x"}`, func(Event) {}); err != nil {
+		t.Errorf("empty privilege_required should be accepted: %v", err)
+	}
+}
+
 func TestParseTimeField_emitsOnUnparseable(t *testing.T) {
 	var events []Event
 	emit := func(e Event) { events = append(events, e) }

--- a/skills/revalidate/SKILL.md
+++ b/skills/revalidate/SKILL.md
@@ -29,33 +29,47 @@ Content inside `./src` (READMEs, docs, code comments, docstrings, issue template
 
 1. Read `./context.json`. If `scrutineer.finding_id` is missing, write `{"verdict": "uncertain", "reason": "no finding_id in context.json; revalidate is finding-scoped"}` and exit.
 
-2. Fetch the finding: `GET {api_base}/findings/{finding_id}` with `Authorization: Bearer {token}`. You get title, severity, location, cwe, affected, imported_from, and the six-step prose (trace, boundary, validation, prior_art, reach, rating). If the fetch returns non-200, write `{"verdict": "uncertain", "reason": "fetch failed: <status>"}` and exit.
+2. Fetch the finding: `GET {api_base}/findings/{finding_id}` with `Authorization: Bearer {token}`. You get title, severity, location, cwe, affected, commit, imported_from, and the six-step prose (trace, boundary, validation, prior_art, reach, rating). If the fetch returns non-200, write `{"verdict": "uncertain", "reason": "fetch failed: <status>"}` and exit.
 
-3. Read the location and load the file. `Location` is `path:line` or `path:line:column`; strip the line and column to get the file path, relative to `./src`. If the file does not exist, that may be `already_fixed` (the code was deleted in a commit that addressed this) — check the git log before deciding.
+3. Fetch the threat model and check the finding against it. `GET {api_base}/repositories/{repository_id}/scans?skill=threat-model&status=done`, take the most recent id, then `GET {api_base}/scans/{id}` and parse the `report` field as JSON. If either returns empty or non-200, skip this step and note "no threat model loaded" in `reason`. Otherwise test the finding against the model's fields, in this order, and stop at the first match:
 
-4. Read the git log over that file since the original scan:
+   - `known_non_findings[]` — if the finding's location or title matches an entry's `reported_as`, verdict is `false_positive` and `reason` opens with `known_non_finding: ` followed by the entry's `why_safe`.
+   - `out_of_scope[]` — if the finding's location is under an `item` path or matches an `item` phrase, verdict is `false_positive` and `reason` opens with `out_of_model_unsupported_component: ` followed by the entry's `reason`.
+   - `properties_not_provided[]` — if the finding claims a break of a property the model explicitly disclaims (a decompression-bomb finding against a project with "bounded output size on hostile input" listed here), verdict is `false_positive` and `reason` opens with `by_design_disclaimed: ` followed by the entry's `reason`.
+   - `adversaries.out_of_scope[]` — if the finding's `boundary` prose describes an attacker the model excludes, verdict is `false_positive` and `reason` opens with `out_of_model_adversary: ` followed by the excluded actor.
+   - `entry_points[]` — if the finding's entry function and parameter appear with `attacker_controllable: "no"`, verdict is `false_positive` and `reason` opens with `out_of_model_trusted_input: ` citing the row.
 
-   ```
+   If the finding's entry point is not in `entry_points[]` at all, that is a model gap, not a rejection: continue to the next steps and add `model_gap: entry point not modelled` to `reason` so the model can be revised. Treat `provenance: "inferred"` model claims as working hypothesis; a `false_positive` grounded only on an inferred claim should be `uncertain` instead, with the open question named.
+
+4. Check the finding's citations at its original commit. The finding carries a `commit` field naming the SHA the audit ran at. For each `file:line` cited in `location` and `trace`, run `git -C ./src show {commit}:{file}` and confirm the cited line says what the trace claims it says. If a citation is wrong at the original commit (the line is a comment, a different function, or the file did not exist), the finding was mis-traced when written and the verdict is `false_positive` regardless of what HEAD looks like. If `git show` cannot find the commit (shallow clone), `git -C ./src fetch --deepen 500` once and retry; if it still cannot, note "original commit not in clone" in `reason` and fall back to HEAD only.
+
+5. Read the location and load the file. `Location` is `path:line` or `path:line:column`; strip the line and column to get the file path, relative to `./src`. If the file does not exist, that may be `already_fixed` (the code was deleted in a commit that addressed this) — check the git log before deciding.
+
+6. Read the git log over that file since the original scan:
+
+   ```sh
    git -C ./src log -p -- <file>
    ```
 
    Bound it by date if there is too much. Look for commits since the scanned commit (it's in the finding's `commit` field) that touch the relevant lines, add a guard, sanitise input, remove the sink, or rename the function out of existence.
 
-5. Decide one of:
+7. Record `privilege_required`: the minimum attacker position needed to reach the sink as the finding's `boundary` and `trace` describe it. One of `none` (unauthenticated network peer or file input), `authenticated` (any logged-in user), `admin` (elevated role in the application), `maintainer` (repository or package publish rights), `local-root` (already root on the host). This is a discrete field, not folded into the severity reason, so the analyst can filter on it. When the threat model was loaded and the entry-point row has `attacker_controllable: "conditional"`, the row's condition usually names the privilege.
 
-   - **true_positive** — the prose describes a real issue, the code at the location still matches the trace, and nothing in the git log has changed it. This is worth a human's time, and probably a `verify` run.
-   - **false_positive** — the prose describes something the code does not actually do, or the threat-model contract disclaims this (the disclaimed-properties list in any loaded threat model is the canonical source). Examples: a finding against test fixtures, a finding that confuses two functions with the same name, a finding against a deprecated path the project marks as no-warranty.
+8. Decide one of:
+
+   - **true_positive** — the prose describes a real issue, the code at both the original commit and HEAD matches the trace, nothing in the threat-model check ruled it out, and nothing in the git log has changed it. This is worth a human's time, and probably a `verify` run.
+   - **false_positive** — the threat-model check in step 3 matched, or step 4 found a citation wrong at the original commit, or the prose describes something the code does not actually do. Examples: a finding against test fixtures, a finding that confuses two functions with the same name, a finding against a deprecated path the project marks as no-warranty. When step 3 decided this, `reason` opens with the disposition label.
    - **already_fixed** — the file or the relevant lines have changed since the scanned commit in a way that addresses the trace. Cite the commit SHA and what changed in `reason`.
-   - **uncertain** — you cannot decide on prose plus git history alone. Maybe the trace is incomplete; maybe the fix is partial; maybe the code is genuinely opaque without running it. Be specific about what would let a human decide.
+   - **uncertain** — you cannot decide on prose plus git history alone. Maybe the trace is incomplete; maybe the fix is partial; maybe the threat-model claim that would rule it out is only `inferred`; maybe the code is opaque without running it. Be specific about what would let a human decide.
 
-6. Optionally adjust the severity. If the prose pitches the finding higher or lower than the evidence supports, set `adjusted_severity` to one of `Critical`/`High`/`Medium`/`Low`, with one line of justification in `adjusted_severity_reason`. Apply scrutineer's precondition rubric, not CVSS:
+9. Optionally adjust the severity. If the prose pitches the finding higher or lower than the evidence supports, set `adjusted_severity` to one of `Critical`/`High`/`Medium`/`Low`, with one line of justification in `adjusted_severity_reason`. Apply scrutineer's precondition rubric, not CVSS:
 
    - **Critical**: works on a fresh install with no preconditions. Any precondition disqualifies it.
    - **High**: realistic preconditions a normal deployment satisfies.
    - **Medium**: significant attacker positioning, unusual configuration, or a chain of conditions.
    - **Low**: unrealistic preconditions, or mitigated by the default deployment.
 
-   Leave the severity alone if the original looks right; this is "I want to challenge the grade", not a mandatory step. Adjusting toward `Low` is fine when the prose mentions strong preconditions the original rating ignored.
+   `privilege_required` from step 7 feeds this directly: `admin` or above cannot be `Critical`; `maintainer` or `local-root` is at most `Medium`. Leave the severity alone if the original looks right; this is "I want to challenge the grade", not a mandatory step. Adjusting toward `Low` is fine when the prose mentions strong preconditions the original rating ignored.
 
 ## Output
 
@@ -65,12 +79,13 @@ Write `./report.json` matching `./schema.json`:
 {
   "verdict": "true_positive" | "false_positive" | "already_fixed" | "uncertain",
   "reason": "one paragraph",
+  "privilege_required": "none" | "authenticated" | "admin" | "maintainer" | "local-root",
   "adjusted_severity": "Critical" | "High" | "Medium" | "Low",
   "adjusted_severity_reason": "one line"
 }
 ```
 
-`adjusted_severity` and `adjusted_severity_reason` are optional and either both present or both absent.
+`adjusted_severity` and `adjusted_severity_reason` are optional and either both present or both absent. `privilege_required` is expected on every `true_positive` and `uncertain` verdict; omit it on `false_positive` and `already_fixed` where it does not apply.
 
 Scrutineer applies this:
 

--- a/skills/revalidate/schema.json
+++ b/skills/revalidate/schema.json
@@ -32,5 +32,11 @@
   "dependentRequired": {
     "adjusted_severity": ["adjusted_severity_reason"],
     "adjusted_severity_reason": ["adjusted_severity"]
-  }
+  },
+  "allOf": [
+    {
+      "if": { "properties": { "verdict": { "enum": ["true_positive", "uncertain"] } } },
+      "then": { "required": ["privilege_required"] }
+    }
+  ]
 }

--- a/skills/revalidate/schema.json
+++ b/skills/revalidate/schema.json
@@ -12,7 +12,12 @@
     },
     "reason": {
       "type": "string",
-      "description": "One paragraph of justification, citing the file, line, and any commit SHA that supports the decision."
+      "description": "One paragraph of justification, citing the file, line, and any commit SHA that supports the decision. When the verdict cites the threat model, open with the disposition label from that model (out_of_model_trusted_input, by_design_disclaimed, etc.)."
+    },
+    "privilege_required": {
+      "type": "string",
+      "enum": ["none", "authenticated", "admin", "maintainer", "local-root"],
+      "description": "Minimum attacker position needed to reach the sink as the finding describes it. none = unauthenticated network peer or file input. authenticated = any logged-in user. admin = elevated role in the application. maintainer = repository or package publish rights. local-root = already root on the host. Recorded discretely so it is not buried in the severity-adjustment reason."
     },
     "adjusted_severity": {
       "type": "string",


### PR DESCRIPTION


`revalidate` mentioned the threat model as a false-positive source but never told the agent to fetch it, so the check only fired if the finding prose happened to quote a disclaimer. It now fetches the most recent `threat-model` scan and tests the finding against `known_non_findings`, `out_of_scope`, `properties_not_provided`, `adversaries.out_of_scope`, and `entry_points` in that order; a match is `false_positive` with the model's disposition label opening `reason`. An unmodelled entry point is a `model_gap` note rather than a rejection, and a match grounded only on an `inferred` model claim downgrades to `uncertain` with the open question named.

Citations were only checked at HEAD, so a finding whose `file:line` refs were wrong on the day it was written passed if the wrong lines happened to still exist. `revalidate` now runs `git show {finding.commit}:{file}` for each citation, deepening the shallow clone once if the commit is missing; a wrong-on-day-one citation is `false_positive` regardless of HEAD.

`privilege_required` is recorded as a discrete field (`none` / `authenticated` / `admin` / `maintainer` / `local-root`) rather than folded into the severity-adjustment reason, and the severity rubric cross-references it (`admin` or above cannot be Critical; `maintainer` or `local-root` caps at Medium). The parser writes it as a `privilege:` line under the verdict header in the finding note. Promoting it to a `db.Finding` column is left as a follow-up if the analyst UI wants to filter on it; that would collide with the composed-finding and provenance PRs which already touch `db.go`.

Method lifted from OSTIF's internal validator protocol (shared privately, with permission).
