### PR TITLE
Use purl.PURLTypeToOSV instead of a local ecosystem map

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,6 +41,3 @@ require (
 	modernc.org/memory v1.11.0 // indirect
 	modernc.org/sqlite v1.50.0 // indirect
 )
-
-// TODO: remove once git-pkgs/purl v0.1.14 is tagged (PR git-pkgs/purl#19).
-replace github.com/git-pkgs/purl => ../../git-pkgs/purl

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.26.5
 require (
 	filippo.io/age v1.3.1
 	github.com/git-pkgs/pom v0.1.4
-	github.com/git-pkgs/purl v0.1.13
+	github.com/git-pkgs/purl v0.1.14
 	github.com/git-pkgs/sbom v0.1.3
 	github.com/glebarez/sqlite v1.11.0
 	github.com/google/uuid v1.6.0
@@ -41,3 +41,6 @@ require (
 	modernc.org/memory v1.11.0 // indirect
 	modernc.org/sqlite v1.50.0 // indirect
 )
+
+// TODO: remove once git-pkgs/purl v0.1.14 is tagged (PR git-pkgs/purl#19).
+replace github.com/git-pkgs/purl => ../../git-pkgs/purl

--- a/go.sum
+++ b/go.sum
@@ -15,8 +15,6 @@ github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkp
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/git-pkgs/pom v0.1.4 h1:C6st+XSbF75eKuwfdkDZZtYHoTcaWRIEQYar5VtszUo=
 github.com/git-pkgs/pom v0.1.4/go.mod h1:ufdMBe1lKzqOeP9IUb9NPZ458xKV8E8NvuyBMxOfwIk=
-github.com/git-pkgs/purl v0.1.13 h1:at8BU6vnP5oonHFHAPA064BzgRqij+SZcOUDgNT2DC8=
-github.com/git-pkgs/purl v0.1.13/go.mod h1:8oCcdcYZA/e1B33e7Ylju6azboTKjdqf3ybcbQj6I/o=
 github.com/git-pkgs/sbom v0.1.3 h1:HNZabAgUSu4qel9tVtAedZTjMmml2JRaFYNuipBCGjs=
 github.com/git-pkgs/sbom v0.1.3/go.mod h1:42YiJ+W9jBsPZnYJQs6tUlOtWlC0vDBOtND8TMwE8ek=
 github.com/git-pkgs/vers v0.2.6 h1:IelZd7BP/JhzTloUTDY67nehUgoYva3g9viqAMCHJg8=

--- a/go.sum
+++ b/go.sum
@@ -15,6 +15,8 @@ github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkp
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/git-pkgs/pom v0.1.4 h1:C6st+XSbF75eKuwfdkDZZtYHoTcaWRIEQYar5VtszUo=
 github.com/git-pkgs/pom v0.1.4/go.mod h1:ufdMBe1lKzqOeP9IUb9NPZ458xKV8E8NvuyBMxOfwIk=
+github.com/git-pkgs/purl v0.1.14 h1:GgqwiBNS0eKJqJ/gabUBEC10Xhpj6UX12kfNzujaeYc=
+github.com/git-pkgs/purl v0.1.14/go.mod h1:8oCcdcYZA/e1B33e7Ylju6azboTKjdqf3ybcbQj6I/o=
 github.com/git-pkgs/sbom v0.1.3 h1:HNZabAgUSu4qel9tVtAedZTjMmml2JRaFYNuipBCGjs=
 github.com/git-pkgs/sbom v0.1.3/go.mod h1:42YiJ+W9jBsPZnYJQs6tUlOtWlC0vDBOtND8TMwE8ek=
 github.com/git-pkgs/vers v0.2.6 h1:IelZd7BP/JhzTloUTDY67nehUgoYva3g9viqAMCHJg8=

--- a/internal/web/finding_osv.go
+++ b/internal/web/finding_osv.go
@@ -301,24 +301,12 @@ func osvSeverityList(f db.Finding) []osvSeverity {
 	return out
 }
 
-// osvEcosystemByPURLType maps a canonical PURL type to its OSV ecosystem name.
-// It mirrors git-pkgs' osvEcosystemNames but (a) carries the ok flag the
-// library's EcosystemToOSV lacks -- that helper returns its input unchanged on
-// a miss, which would then fail the schema's ecosystem pattern -- and (b) omits
-// entries the embedded schema does not list (e.g. cocoapods), so a lookup miss
-// always routes the finding to a GIT range instead of an invalid package.
-var osvEcosystemByPURLType = map[string]string{
-	"gem":           "RubyGems",
-	"npm":           "npm",
-	"pypi":          "PyPI",
-	"cargo":         "crates.io",
-	"golang":        "Go",
-	"maven":         "Maven",
-	"nuget":         "NuGet",
-	"composer":      "Packagist",
-	"hex":           "Hex",
-	"pub":           "Pub",
-	"githubactions": "GitHub Actions",
+// osvSchemaMissing lists OSV ecosystem names purl.PURLTypeToOSV knows but the
+// embedded schema at osv_schemas/ does not accept in its ecosystem pattern.
+// Packages in these ecosystems route to a GIT range instead so the exported
+// record still validates. Re-check when bumping the embedded schema.
+var osvSchemaMissing = map[string]bool{
+	"CocoaPods": true,
 }
 
 func osvEcosystem(pkg db.Package) (string, bool) {
@@ -326,8 +314,11 @@ func osvEcosystem(pkg db.Package) (string, bool) {
 	if err != nil {
 		return "", false
 	}
-	eco, ok := osvEcosystemByPURLType[p.Type]
-	return eco, ok
+	eco, ok := purl.PURLTypeToOSV(p.Type)
+	if !ok || osvSchemaMissing[eco] {
+		return "", false
+	}
+	return eco, true
 }
 
 // osvAffectedList anchors the finding. Registry packages whose ecosystem the


### PR DESCRIPTION
Drops the `osvEcosystemByPURLType` map in `finding_osv.go` that mirrored `git-pkgs/purl`'s internal `osvEcosystemNames`. purl v0.1.14 exports `PURLTypeToOSV(purlType) (string, bool)` with the ok flag that was the reason for the local copy.

The one intentional divergence (CocoaPods, which purl maps but the embedded OSV schema's ecosystem pattern does not accept) becomes an explicit `osvSchemaMissing` denylist so it's clear the exclusion is schema-driven rather than an oversight in the map. Existing tests at `finding_osv_test.go:283` and `:482` cover that path.

Upstream: git-pkgs/purl#19.