### PR TITLE
finding-dedup: record subsumed and chain relations alongside duplicates

### DIFF
--- a/internal/worker/skill_parsers.go
+++ b/internal/worker/skill_parsers.go
@@ -1004,6 +1004,16 @@ func (w *Worker) parseRevalidateOutput(scan *db.Scan, report string, emit func(E
 	return nil
 }
 
+// dedupGroup is one head-plus-members relation from a finding-dedup report.
+// Duplicates and subsumed both fit this shape (canonical/parent + children);
+// chains have no head, so HeadID is 0 there and applyDedupChain reads
+// MemberIDs only.
+type dedupGroup struct {
+	HeadID    uint
+	MemberIDs []uint
+	Reason    string
+}
+
 func (w *Worker) parseFindingDedupOutput(scan *db.Scan, report string, emit func(Event)) error {
 	var result struct {
 		Duplicates []struct {
@@ -1011,44 +1021,151 @@ func (w *Worker) parseFindingDedupOutput(scan *db.Scan, report string, emit func
 			DuplicateIDs []uint `json:"duplicate_ids"`
 			Reason       string `json:"reason"`
 		} `json:"duplicates"`
+		Subsumed []struct {
+			ParentID    uint   `json:"parent_id"`
+			SubsumedIDs []uint `json:"subsumed_ids"`
+			Reason      string `json:"reason"`
+		} `json:"subsumed"`
+		Chains []struct {
+			FindingIDs []uint `json:"finding_ids"`
+			Reason     string `json:"reason"`
+		} `json:"chains"`
 	}
 	if err := json.Unmarshal([]byte(report), &result); err != nil {
 		return fmt.Errorf("parse finding_dedup report: %w", err)
 	}
-	if len(result.Duplicates) == 0 {
-		emit(Event{Kind: KindText, Text: "finding-dedup: no duplicates reported"})
+	if len(result.Duplicates)+len(result.Subsumed)+len(result.Chains) == 0 {
+		emit(Event{Kind: KindText, Text: "finding-dedup: no relations reported"})
 		return nil
 	}
 
-	marked, skipped := 0, 0
-	for _, group := range result.Duplicates {
-		canonical, ok := w.dedupFinding(scan.RepositoryID, group.CanonicalID)
-		if !ok || !dedupCandidateOpen(canonical.Status) {
-			skipped += len(group.DuplicateIDs)
-			continue
-		}
-		for _, duplicateID := range group.DuplicateIDs {
-			if duplicateID == 0 || duplicateID == canonical.ID {
-				skipped++
-				continue
-			}
-			duplicate, ok := w.dedupFinding(scan.RepositoryID, duplicateID)
-			if !ok || !dedupCandidateOpen(duplicate.Status) {
-				skipped++
-				continue
-			}
-			if err := db.WriteFindingField(w.DB, duplicate.ID, "status", string(db.FindingDuplicate), db.SourceModel, findingDedupSkill); err != nil {
-				return fmt.Errorf("mark finding %d duplicate: %w", duplicate.ID, err)
-			}
-			if err := w.addDedupNote(duplicate.ID, canonical.ID, group.Reason); err != nil {
-				return err
-			}
-			marked++
-		}
+	skipped := 0
+	marked, err := w.applyDedupHeaded(scan.RepositoryID, dedupHeaderDuplicate, true,
+		mapDedupGroups(result.Duplicates, func(g struct {
+			CanonicalID  uint   `json:"canonical_id"`
+			DuplicateIDs []uint `json:"duplicate_ids"`
+			Reason       string `json:"reason"`
+		}) dedupGroup {
+			return dedupGroup{HeadID: g.CanonicalID, MemberIDs: g.DuplicateIDs, Reason: g.Reason}
+		}), &skipped)
+	if err != nil {
+		return err
 	}
 
-	emit(Event{Kind: KindText, Text: fmt.Sprintf("finding-dedup: marked %d duplicate(s), skipped %d", marked, skipped)})
+	// Subsumed findings do not change status: the bug is real and stays in
+	// the database, but disclose and report-upstream read the note marker
+	// and refuse to file it separately (the parent is what the maintainer
+	// should see). Same repo-and-open guards as duplicates apply.
+	subsumed, err := w.applyDedupHeaded(scan.RepositoryID, dedupHeaderSubsumed, false,
+		mapDedupGroups(result.Subsumed, func(g struct {
+			ParentID    uint   `json:"parent_id"`
+			SubsumedIDs []uint `json:"subsumed_ids"`
+			Reason      string `json:"reason"`
+		}) dedupGroup {
+			return dedupGroup{HeadID: g.ParentID, MemberIDs: g.SubsumedIDs, Reason: g.Reason}
+		}), &skipped)
+	if err != nil {
+		return err
+	}
+
+	chained, err := w.applyDedupChains(scan.RepositoryID,
+		mapDedupGroups(result.Chains, func(g struct {
+			FindingIDs []uint `json:"finding_ids"`
+			Reason     string `json:"reason"`
+		}) dedupGroup {
+			return dedupGroup{MemberIDs: g.FindingIDs, Reason: g.Reason}
+		}), &skipped)
+	if err != nil {
+		return err
+	}
+
+	emit(Event{Kind: KindText, Text: fmt.Sprintf(
+		"finding-dedup: marked %d duplicate(s), noted %d subsumed, noted %d chain member(s), skipped %d",
+		marked, subsumed, chained, skipped)})
 	return nil
+}
+
+func mapDedupGroups[T any](in []T, f func(T) dedupGroup) []dedupGroup {
+	out := make([]dedupGroup, len(in))
+	for i, g := range in {
+		out[i] = f(g)
+	}
+	return out
+}
+
+// applyDedupHeaded handles the duplicate and subsumed shapes: one head
+// (canonical or parent) plus a list of members that each get a note
+// pointing at the head. When flipStatus is set the member's lifecycle
+// moves to duplicate; otherwise (subsumed) only the note lands.
+func (w *Worker) applyDedupHeaded(repoID uint, verb string, flipStatus bool, groups []dedupGroup, skipped *int) (int, error) {
+	n := 0
+	for _, g := range groups {
+		head, ok := w.dedupFinding(repoID, g.HeadID)
+		if !ok || !dedupCandidateOpen(head.Status) {
+			*skipped += len(g.MemberIDs)
+			continue
+		}
+		for _, id := range g.MemberIDs {
+			if id == 0 || id == head.ID {
+				*skipped++
+				continue
+			}
+			member, ok := w.dedupFinding(repoID, id)
+			if !ok || !dedupCandidateOpen(member.Status) {
+				*skipped++
+				continue
+			}
+			if flipStatus {
+				if err := db.WriteFindingField(w.DB, member.ID, "status", string(db.FindingDuplicate), db.SourceModel, findingDedupSkill); err != nil {
+					return n, fmt.Errorf("mark finding %d duplicate: %w", member.ID, err)
+				}
+			}
+			if err := w.addRelationNote(member.ID, verb, []uint{head.ID}, g.Reason); err != nil {
+				return n, err
+			}
+			n++
+		}
+	}
+	return n, nil
+}
+
+// minChainMembers is the smallest chain worth recording after the
+// repo-and-open filter has run: a chain with one surviving member has
+// nothing to compose with.
+const minChainMembers = 2
+
+// applyDedupChains handles the chain shape: every member stays open and
+// each gets a note listing the OTHER members so disclose on any one of
+// them can fetch exactly the ids it needs to compose.
+func (w *Worker) applyDedupChains(repoID uint, groups []dedupGroup, skipped *int) (int, error) {
+	n := 0
+	for _, g := range groups {
+		var members []uint
+		for _, id := range g.MemberIDs {
+			f, ok := w.dedupFinding(repoID, id)
+			if !ok || !dedupCandidateOpen(f.Status) {
+				*skipped++
+				continue
+			}
+			members = append(members, f.ID)
+		}
+		if len(members) < minChainMembers {
+			continue
+		}
+		for _, m := range members {
+			others := make([]uint, 0, len(members)-1)
+			for _, o := range members {
+				if o != m {
+					others = append(others, o)
+				}
+			}
+			if err := w.addRelationNote(m, dedupHeaderChains, others, g.Reason); err != nil {
+				return n, err
+			}
+			n++
+		}
+	}
+	return n, nil
 }
 
 func (w *Worker) dedupFinding(repoID, findingID uint) (db.Finding, bool) {
@@ -1072,14 +1189,36 @@ func dedupCandidateOpen(status db.FindingLifecycle) bool {
 	return !status.Closed()
 }
 
-func (w *Worker) addDedupNote(duplicateID, canonicalID uint, reason string) error {
+// dedupHeader* are the fixed first-line markers written to FindingNote by
+// finding-dedup, in the form "finding-dedup: <verb> finding #N[, #M...]".
+// disclose and report-upstream fetch GET /findings/{id}/notes and match on
+// these prefixes, so changing them is a coordinated change with those two
+// skills. The values are the human-readable verb, not an enum; the "#N"
+// suffix is what the reader parses.
+const (
+	dedupHeaderDuplicate = "duplicates"
+	dedupHeaderSubsumed  = "subsumed by"
+	dedupHeaderChains    = "chains with"
+)
+
+// addRelationNote records a finding-dedup relation on findingID as a note
+// whose first line is a fixed marker (see dedupHeader* above) followed by
+// the related ids, then a blank line and the reason. The marker line is
+// what downstream skills grep for; the reason is for the analyst.
+func (w *Worker) addRelationNote(findingID uint, verb string, relatedIDs []uint, reason string) error {
 	var b strings.Builder
-	fmt.Fprintf(&b, "finding-dedup: duplicates finding #%d", canonicalID)
-	if strings.TrimSpace(reason) != "" {
-		fmt.Fprintf(&b, "\n\n%s", strings.TrimSpace(reason))
+	fmt.Fprintf(&b, "finding-dedup: %s finding ", verb)
+	for i, id := range relatedIDs {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		fmt.Fprintf(&b, "#%d", id)
 	}
-	if _, err := db.AddFindingNote(w.DB, duplicateID, b.String(), findingDedupSkill); err != nil {
-		return fmt.Errorf("record dedup note for finding %d: %w", duplicateID, err)
+	if r := strings.TrimSpace(reason); r != "" {
+		fmt.Fprintf(&b, "\n\n%s", r)
+	}
+	if _, err := db.AddFindingNote(w.DB, findingID, b.String(), findingDedupSkill); err != nil {
+		return fmt.Errorf("record %s note for finding %d: %w", verb, findingID, err)
 	}
 	return nil
 }

--- a/internal/worker/skill_parsers.go
+++ b/internal/worker/skill_parsers.go
@@ -1006,7 +1006,7 @@ func (w *Worker) parseRevalidateOutput(scan *db.Scan, report string, emit func(E
 
 // dedupGroup is one head-plus-members relation from a finding-dedup report.
 // Duplicates and subsumed both fit this shape (canonical/parent + children);
-// chains have no head, so HeadID is 0 there and applyDedupChain reads
+// chains have no head, so HeadID is 0 there and applyDedupChains reads
 // MemberIDs only.
 type dedupGroup struct {
 	HeadID    uint

--- a/internal/worker/skill_parsers_test.go
+++ b/internal/worker/skill_parsers_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"os"
@@ -998,6 +999,138 @@ func TestParseFindingDedup_marksDuplicatesWithHistoryAndNote(t *testing.T) {
 	notes := findingNotes(gdb, duplicate.ID)
 	if len(notes) == 0 || !strings.Contains(notes[0].Body, "duplicates finding #") {
 		t.Fatalf("missing dedup note: %+v", notes)
+	}
+}
+
+// setupDedupRepo creates a repo, a scan, and n open findings, returning the
+// scan and the findings in creation order. Cuts the boilerplate the
+// duplicate/subsumed/chain tests each repeat.
+func setupDedupRepo(t *testing.T, gdb *gorm.DB, n int) (db.Scan, []db.Finding) {
+	t.Helper()
+	repo := db.Repository{URL: "https://example.com/x", Name: "x"}
+	gdb.Create(&repo)
+	scan := db.Scan{RepositoryID: repo.ID, Kind: JobSkill, Status: db.ScanDone, SkillName: "finding-dedup"}
+	gdb.Create(&scan)
+	fs := make([]db.Finding, n)
+	for i := range fs {
+		fs[i] = db.Finding{ScanID: scan.ID, RepositoryID: repo.ID, FindingID: "F" + strconv.Itoa(i+1),
+			Title: "f" + strconv.Itoa(i+1), Severity: "High", Status: db.FindingNew}
+		gdb.Create(&fs[i])
+	}
+	return scan, fs
+}
+
+func TestParseFindingDedup_subsumedNotesWithoutStatusChange(t *testing.T) {
+	gdb, _ := db.Open(filepath.Join(t.TempDir(), "sub.db"))
+	scan, fs := setupDedupRepo(t, gdb, 3)
+	parent, childA, childB := fs[0], fs[1], fs[2]
+
+	w := &Worker{DB: gdb, Log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	report := fmt.Sprintf(`{"duplicates":[],"subsumed":[{"parent_id":%d,"subsumed_ids":[%d,%d],"reason":"only reachable via the unauth admin route in the parent"}]}`,
+		parent.ID, childA.ID, childB.ID)
+	if err := w.parseFindingDedupOutput(&scan, report, func(Event) {}); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, child := range []db.Finding{childA, childB} {
+		var got db.Finding
+		gdb.First(&got, child.ID)
+		if got.Status != db.FindingNew {
+			t.Errorf("child %d status = %s; subsumed must not change lifecycle", child.ID, got.Status)
+		}
+		notes := findingNotes(gdb, child.ID)
+		if len(notes) == 0 {
+			t.Fatalf("child %d: no note", child.ID)
+		}
+		wantHeader := fmt.Sprintf("finding-dedup: subsumed by finding #%d", parent.ID)
+		if !strings.HasPrefix(notes[0].Body, wantHeader) {
+			t.Errorf("child %d note header = %q, want prefix %q", child.ID, firstLine(notes[0].Body), wantHeader)
+		}
+		if !strings.Contains(notes[0].Body, "unauth admin route") {
+			t.Errorf("child %d note missing reason", child.ID)
+		}
+	}
+	if len(findingNotes(gdb, parent.ID)) != 0 {
+		t.Error("parent should not get a subsumed note; only children carry the marker")
+	}
+}
+
+func TestParseFindingDedup_chainsNotesEachMemberWithOthers(t *testing.T) {
+	gdb, _ := db.Open(filepath.Join(t.TempDir(), "chain.db"))
+	scan, fs := setupDedupRepo(t, gdb, 3)
+	a, b, c := fs[0], fs[1], fs[2]
+
+	w := &Worker{DB: gdb, Log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	report := fmt.Sprintf(`{"duplicates":[],"chains":[{"finding_ids":[%d,%d,%d],"reason":"traversal + predictable secret path = credential disclosure"}]}`,
+		a.ID, b.ID, c.ID)
+	if err := w.parseFindingDedupOutput(&scan, report, func(Event) {}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Each member's note lists the OTHER members, not itself, so disclose on
+	// any one of them can fetch exactly the ids it needs to compose.
+	cases := []struct {
+		on     db.Finding
+		others []uint
+	}{
+		{a, []uint{b.ID, c.ID}},
+		{b, []uint{a.ID, c.ID}},
+		{c, []uint{a.ID, b.ID}},
+	}
+	for _, tc := range cases {
+		var got db.Finding
+		gdb.First(&got, tc.on.ID)
+		if got.Status != db.FindingNew {
+			t.Errorf("chain member %d status = %s; chains must not change lifecycle", tc.on.ID, got.Status)
+		}
+		notes := findingNotes(gdb, tc.on.ID)
+		if len(notes) == 0 {
+			t.Fatalf("member %d: no note", tc.on.ID)
+		}
+		header := firstLine(notes[0].Body)
+		if !strings.HasPrefix(header, "finding-dedup: chains with finding #") {
+			t.Errorf("member %d header = %q", tc.on.ID, header)
+		}
+		for _, other := range tc.others {
+			if !strings.Contains(header, fmt.Sprintf("#%d", other)) {
+				t.Errorf("member %d header missing #%d: %q", tc.on.ID, other, header)
+			}
+		}
+		if strings.Contains(header, fmt.Sprintf("#%d", tc.on.ID)) {
+			t.Errorf("member %d header should not reference itself: %q", tc.on.ID, header)
+		}
+	}
+}
+
+func TestParseFindingDedup_chainOfOneAfterFilterIsNoop(t *testing.T) {
+	gdb, _ := db.Open(filepath.Join(t.TempDir(), "chain1.db"))
+	scan, fs := setupDedupRepo(t, gdb, 2)
+	// Close the second so only one open member survives the repo/open filter.
+	gdb.Model(&fs[1]).Update("status", db.FindingRejected)
+
+	w := &Worker{DB: gdb, Log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	report := fmt.Sprintf(`{"duplicates":[],"chains":[{"finding_ids":[%d,%d],"reason":"x"}]}`, fs[0].ID, fs[1].ID)
+	if err := w.parseFindingDedupOutput(&scan, report, func(Event) {}); err != nil {
+		t.Fatal(err)
+	}
+	if len(findingNotes(gdb, fs[0].ID)) != 0 {
+		t.Error("chain with a single surviving member should write no notes")
+	}
+}
+
+func TestParseFindingDedup_subsumedSkipsClosedParentAndSelfRef(t *testing.T) {
+	gdb, _ := db.Open(filepath.Join(t.TempDir(), "subskip.db"))
+	scan, fs := setupDedupRepo(t, gdb, 2)
+	gdb.Model(&fs[0]).Update("status", db.FindingFixed) // closed parent
+
+	w := &Worker{DB: gdb, Log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	report := fmt.Sprintf(`{"duplicates":[],"subsumed":[{"parent_id":%d,"subsumed_ids":[%d],"reason":"x"},{"parent_id":%d,"subsumed_ids":[%d],"reason":"self"}]}`,
+		fs[0].ID, fs[1].ID, fs[1].ID, fs[1].ID)
+	if err := w.parseFindingDedupOutput(&scan, report, func(Event) {}); err != nil {
+		t.Fatal(err)
+	}
+	if len(findingNotes(gdb, fs[1].ID)) != 0 {
+		t.Error("closed parent and self-reference should both be skipped")
 	}
 }
 

--- a/internal/worker/skill_parsers_test.go
+++ b/internal/worker/skill_parsers_test.go
@@ -1021,7 +1021,10 @@ func setupDedupRepo(t *testing.T, gdb *gorm.DB, n int) (db.Scan, []db.Finding) {
 }
 
 func TestParseFindingDedup_subsumedNotesWithoutStatusChange(t *testing.T) {
-	gdb, _ := db.Open(filepath.Join(t.TempDir(), "sub.db"))
+	gdb, err := db.Open(filepath.Join(t.TempDir(), "sub.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
 	scan, fs := setupDedupRepo(t, gdb, 3)
 	parent, childA, childB := fs[0], fs[1], fs[2]
 
@@ -1056,7 +1059,10 @@ func TestParseFindingDedup_subsumedNotesWithoutStatusChange(t *testing.T) {
 }
 
 func TestParseFindingDedup_chainsNotesEachMemberWithOthers(t *testing.T) {
-	gdb, _ := db.Open(filepath.Join(t.TempDir(), "chain.db"))
+	gdb, err := db.Open(filepath.Join(t.TempDir(), "chain.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
 	scan, fs := setupDedupRepo(t, gdb, 3)
 	a, b, c := fs[0], fs[1], fs[2]
 
@@ -1103,7 +1109,10 @@ func TestParseFindingDedup_chainsNotesEachMemberWithOthers(t *testing.T) {
 }
 
 func TestParseFindingDedup_chainOfOneAfterFilterIsNoop(t *testing.T) {
-	gdb, _ := db.Open(filepath.Join(t.TempDir(), "chain1.db"))
+	gdb, err := db.Open(filepath.Join(t.TempDir(), "chain1.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
 	scan, fs := setupDedupRepo(t, gdb, 2)
 	// Close the second so only one open member survives the repo/open filter.
 	gdb.Model(&fs[1]).Update("status", db.FindingRejected)
@@ -1119,7 +1128,10 @@ func TestParseFindingDedup_chainOfOneAfterFilterIsNoop(t *testing.T) {
 }
 
 func TestParseFindingDedup_subsumedSkipsClosedParentAndSelfRef(t *testing.T) {
-	gdb, _ := db.Open(filepath.Join(t.TempDir(), "subskip.db"))
+	gdb, err := db.Open(filepath.Join(t.TempDir(), "subskip.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
 	scan, fs := setupDedupRepo(t, gdb, 2)
 	gdb.Model(&fs[0]).Update("status", db.FindingFixed) // closed parent
 

--- a/skills/disclose/SKILL.md
+++ b/skills/disclose/SKILL.md
@@ -27,6 +27,11 @@ Draft disclosure content for an existing finding in a shape that maps one-to-one
 2. Fetch the finding: `GET {api_base}/findings/{finding_id}` with `Authorization: Bearer {token}`. You get title, severity, cwe (comma-joined), location, affected, cvss_vector, cve_id, fix_version, fix_commit, and the six-step prose (trace, boundary, validation, prior_art, reach, rating). Also fetch:
    - `GET {api_base}/repositories/{repository_id}` for the upstream URL and default branch
    - `GET {api_base}/repositories/{repository_id}/packages` for the list of published packages; you need this to fill GHSA's affected-package block
+   - `GET {api_base}/findings/{finding_id}/notes` for relation markers written by `finding-dedup`
+
+   Scan the notes for a body whose first line starts with `finding-dedup: subsumed by finding #`. If one exists, this finding is only reachable through the parent named after the `#`, and any correct fix for the parent closes it. Write `{"error": "finding {id} is subsumed by finding #{parent}; disclose the parent instead"}` and exit 0.
+
+   Scan the notes for a body whose first line starts with `finding-dedup: chains with finding #`. If one exists, extract every `#N` on that line and fetch each with `GET {api_base}/findings/{N}`. These are the chain members whose traces the Composed section below pulls in.
 
 3. Compose the GHSA fields below. Every field names the GHSA REST key (`summary`, `description`, `vulnerabilities`, etc.) so the mapping is explicit. Keep each one factual and derived from the finding — do not invent details the audit did not establish.
 
@@ -56,9 +61,13 @@ Draft disclosure content for an existing finding in a shape that maps one-to-one
 
    Reuse the Validation prose, formatted as a short runnable recipe. Include the minimum needed to trigger the bug. A fenced code block when a script exists.
 
+   ## Composed with
+
+   Only when step 2 found chain members. One short paragraph per chained finding: its title, its location, and one sentence from its Trace naming the sink. Then one paragraph explaining how the chain works and why the combined severity is higher than any member alone (reuse the reason from the `finding-dedup: chains with` note). Close with "Each chained issue is tracked as scrutineer finding #{N}." so the maintainer knows the others exist as separate records but are being reported together here. Omit the whole section when there are no chain members.
+
    ## Fix suggestion
 
-   One or two sentences on where the guard belongs (sanitise here, validate there, remove the sink). Do not claim a specific patch unless the Trace identifies the exact line.
+   One or two sentences on where the guard belongs (sanitise here, validate there, remove the sink). Do not claim a specific patch unless the Trace identifies the exact line. When the finding chains, name which link the fix breaks.
 
    ## References
 

--- a/skills/finding-dedup/SKILL.md
+++ b/skills/finding-dedup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: finding-dedup
-description: Compare open findings in one repository and mark findings that describe the same underlying vulnerability as duplicates.
+description: Compare open findings in one repository and record how they relate. Marks same-vulnerability findings as duplicates, findings that another finding's fix will close as subsumed, and findings that combine into a higher-severity attack as a chain.
 license: MIT
 compatibility: Needs network access to the scrutineer API (http://host:port/api). Repository-scoped; compares existing finding rows and does not create new findings.
 metadata:
@@ -42,9 +42,15 @@ Find duplicate findings that fingerprinting missed because their line ranges, si
 
    Weigh each finding's `dup_check` field: when several deep-dives run in parallel, the audit agent records there which siblings it already compared this finding against and why it judged it distinct. Treat that as the agent's own argument, not a verdict — if its reasoning holds against the pair in front of you, it is evidence against merging; if it compared against the wrong finding or got the root cause wrong, override it.
 
-4. Mark a duplicate only when the findings are the same underlying vulnerability. Do not group findings that merely share a CWE, sink type, file, or helper function but have different attacker-controlled inputs, different exploit paths, or different impacts.
+4. Classify each related pair into exactly one of:
 
-5. Choose one canonical finding for each duplicate group. Prefer the lowest database `id` among the open findings unless a later finding has materially better evidence. Never choose a finding with status `fixed`, `published`, `rejected`, or `duplicate` as canonical.
+   - **duplicate** — same underlying vulnerability: same root cause, same vulnerable code path, same security impact. Do not group findings that merely share a CWE, sink type, file, or helper function but have different attacker-controlled inputs, different exploit paths, or different impacts.
+   - **subsumed** — different bugs, but one is only reachable through the other, and any correct fix for the parent closes the child too. Example: finding A is "unauthenticated user can reach the admin router"; finding B is "admin router path X lacks input validation". B is real on its own terms but a maintainer who fixes A has closed B's only unauthenticated path. B is subsumed by A. Do not use this when the child has an independent path the parent's fix leaves open; that is two findings.
+   - **chain** — two or more findings that combine into a higher-severity attack than any of them alone. Example: finding A is a low-severity path traversal that reads arbitrary files under the app root; finding B is a medium-severity secret written to a predictable path under the app root. Separately each is what it is; together they are credential disclosure. Both stay open; the chain is what `disclose` reports.
+
+   A pair that is none of these is unrelated; do not record it.
+
+5. For duplicate groups, choose one canonical finding. Prefer the lowest database `id` among the open findings unless a later finding has materially better evidence. Never choose a finding with status `fixed`, `published`, `rejected`, or `duplicate` as canonical. For subsumed groups, the parent is the finding whose fix closes the others; it is not chosen by id. For chains there is no canonical; list members in exploit order when the order matters.
 
 ## Output
 
@@ -58,10 +64,23 @@ Write `./report.json`:
       "duplicate_ids": [124, 125],
       "reason": "Same vulnerable parser branch and same untrusted field reaches the same allocation without a bounds check; the reports differ only by line range."
     }
+  ],
+  "subsumed": [
+    {
+      "parent_id": 130,
+      "subsumed_ids": [131],
+      "reason": "131 is only reachable via the unauthenticated admin route in 130; any fix that gates that route closes 131's only untrusted path."
+    }
+  ],
+  "chains": [
+    {
+      "finding_ids": [140, 141],
+      "reason": "140 reads arbitrary files under the app root; 141 writes a session token to a predictable path under the app root. Together: unauthenticated session takeover."
+    }
   ]
 }
 ```
 
-Use database `id` values, not per-scan `finding_id` values like `F1`. If there are no duplicates, write `{"duplicates":[]}`.
+Use database `id` values, not per-scan `finding_id` values like `F1`. `duplicates` is required; write `[]` when there are none. `subsumed` and `chains` are optional; omit them when empty.
 
-Scrutineer validates that every id belongs to this repository and only changes open findings. Accepted duplicate findings are moved to lifecycle status `duplicate`, and a note is appended explaining which canonical finding they duplicate.
+Scrutineer validates that every id belongs to this repository and only touches open findings. Accepted duplicates are moved to lifecycle status `duplicate` with a note naming the canonical. Subsumed findings and chain members do not change status; each gets a note whose first line is `finding-dedup: subsumed by finding #N` or `finding-dedup: chains with finding #N[, #M...]`. `disclose` and `report-upstream` read those notes: a subsumed finding is refused (file the parent instead), and a chain member's disclosure pulls the other members' traces into a Composed section.

--- a/skills/finding-dedup/schema.json
+++ b/skills/finding-dedup/schema.json
@@ -35,6 +35,57 @@
           }
         }
       }
+    },
+    "subsumed": {
+      "type": "array",
+      "description": "Findings that are only reachable through another finding, such that any correct fix for the parent closes them too. Distinct from duplicates: the bugs are different, but the child does not need its own disclosure.",
+      "items": {
+        "type": "object",
+        "required": ["parent_id", "subsumed_ids", "reason"],
+        "additionalProperties": false,
+        "properties": {
+          "parent_id": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Database id of the finding whose fix closes the subsumed ones."
+          },
+          "subsumed_ids": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true,
+            "items": { "type": "integer", "minimum": 1 },
+            "description": "Database ids of open findings to mark subsumed by the parent."
+          },
+          "reason": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Why the parent's fix necessarily closes these."
+          }
+        }
+      }
+    },
+    "chains": {
+      "type": "array",
+      "description": "Groups of two or more findings that combine into a higher-severity attack than any of them alone. All members stay open; disclose reports them together.",
+      "items": {
+        "type": "object",
+        "required": ["finding_ids", "reason"],
+        "additionalProperties": false,
+        "properties": {
+          "finding_ids": {
+            "type": "array",
+            "minItems": 2,
+            "uniqueItems": true,
+            "items": { "type": "integer", "minimum": 1 },
+            "description": "Database ids of open findings that chain together. Order is the exploit order when it matters."
+          },
+          "reason": {
+            "type": "string",
+            "minLength": 1,
+            "description": "How the chain works and why the combined severity is higher."
+          }
+        }
+      }
     }
   }
 }

--- a/skills/report-upstream/SKILL.md
+++ b/skills/report-upstream/SKILL.md
@@ -31,6 +31,7 @@ Read `./context.json`, then `GET {api_base}/repositories/{repository_id}` and `G
 - `repository.url` host is not `github.com`
 - `gh auth status` fails — the runner has no GitHub credentials
 - the finding's `status` is `reported`, `acknowledged`, `fixed`, `published`, `rejected`, or `duplicate` — already past the reporting step or closed
+- `GET {api_base}/findings/{finding_id}/notes` returns any note whose body starts with `finding-dedup: subsumed by finding #` — this finding is only reachable through the parent named after the `#`, and any correct fix for the parent closes it; file the parent instead
 - the finding's `disclosure_draft` is empty — run `disclose` first
 - the finding already has a reference tagged `ghsa-upstream` (`GET {api_base}/findings/{finding_id}/references`) — a previous run of this skill already filed it
 - PVR is not enabled on the upstream: `gh api repos/{owner}/{repo}/private-vulnerability-reporting` does not return `{"enabled": true}`. Include `repository.posture` and `posture_summary` (from the repository fetch) in the error so the operator sees why


### PR DESCRIPTION
A maintainer with a three-link exploit chain currently gets three PVR reports that each tell a third of the story, and a finding that is only reachable through another finding's bug gets filed separately even though fixing the parent closes it.

`finding-dedup` now classifies each related pair into exactly one of `duplicate` (same vulnerability), `subsumed` (different bug, but any correct fix for the parent closes it), or `chain` (combines into higher severity than any member alone). The report carries `subsumed[]` and `chains[]` alongside `duplicates[]`.

The parser writes fixed-first-line note markers on the affected findings: `finding-dedup: subsumed by finding #N` on each subsumed child, and `finding-dedup: chains with finding #N, #M` on each chain member listing the other members. Neither changes lifecycle status; the bug stays in the database and the analyst can still see it. Duplicates and subsumed share one `applyDedupHeaded` helper (head + members, same repo-and-open guards, self-ref skipped; `flipStatus` decides whether status moves); chains go through `applyDedupChains` (each member notes the others; a chain that filters to one open member is a no-op). `addDedupNote` generalises to `addRelationNote` with the three verbs as named constants and a comment that changing them is a coordinated change with `disclose`/`report-upstream`.

`disclose` fetches `GET /findings/{id}/notes`: a subsumed marker is a refusal (disclose the parent instead); a chains marker triggers fetching each `#N` and pulling title, location, and one-line trace into a new `## Composed with` section of the description body. `report-upstream` gains the same subsumed refusal as a precondition.

No db schema change: duplicates were always status-plus-note (there is no relation table), and the two new relations follow the same pattern. Touches `skill_parsers.go` in a different function than #605/#606 so any merge is non-overlapping hunks.

Method lifted from OSTIF's internal report-breakout skill (shared privately, with permission).