### PR TITLE
Match profiles against brief's full report; drop the ProfileMarker engine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN pip install --no-cache-dir semgrep==1.167.0 "setuptools<81"
 FROM golang:1.26.5-alpine@sha256:99e12cfb19b753915f9b9fdc5a99f1869a24a69d3a0955832d5702e7fa68f1be AS go-tools
 RUN apk add --no-cache git
 RUN GOBIN=/out go install github.com/git-pkgs/git-pkgs@v0.15.3 && \
-    GOBIN=/out go install github.com/git-pkgs/brief/cmd/brief@v0.6.0
+    GOBIN=/out go install github.com/git-pkgs/brief/cmd/brief@v0.9.3
 
 # vid links tree-sitter grammars (C), so unlike the main binary it needs
 # cgo; build-base provides gcc and musl headers, matching the musl-based

--- a/Dockerfile.runner
+++ b/Dockerfile.runner
@@ -10,7 +10,7 @@ ARG SEMGREP_VERSION=1.167.0
 
 FROM golang:1.26.5-trixie@sha256:8d5bf3ef8fd204fea2ea0dea4b46d4ecdabceb88b9b4cb86d2b323425add49c7 AS go-tools
 RUN GOBIN=/out go install github.com/git-pkgs/git-pkgs@v0.15.3 && \
-    GOBIN=/out go install github.com/git-pkgs/brief/cmd/brief@v0.6.0
+    GOBIN=/out go install github.com/git-pkgs/brief/cmd/brief@v0.9.3
 
 FROM rust:1.96-trixie@sha256:1f0dbad1df66647807e6952d1db85d0b2bda7606cb2139d82517e4f009967376 AS zizmor-build
 ENV CARGO_HTTP_MULTIPLEXING=false

--- a/README.md
+++ b/README.md
@@ -231,22 +231,23 @@ For deployments that treat skill prompts as untrusted, pass `--hardened` (or `ha
 
 ## Runner profiles
 
-When the container runner is active, scrutineer auto-detects a per-ecosystem **profile** for each scan: it runs `brief` against the clone to read the package managers, falling back to file markers for ecosystems `brief` doesn't cover. The matched profile selects a runner image (built on demand from `docker/profiles/<name>/Dockerfile`, cached content-addressed by the Dockerfile's hash) and injects that profile's `PROFILE.md` as the agent's orientation. The most specific profile wins, so a native-extension repo resolves to its `*-ext` profile ahead of the plain language profile. Force one with `?profile=<name>` on the scan API (validated against the skill's `requires_profile`); `default` forces the base runner image.
+When the container runner is active, scrutineer auto-detects a per-ecosystem **profile** for each scan: it runs `brief` against the clone and matches its structured package-manager, language, and tool detections. If `brief` fails or no selector matches, the scan uses the default runner image. The matched profile selects a runner image (built on demand from `docker/profiles/<name>/Dockerfile`, cached content-addressed by the Dockerfile's hash) and injects that profile's `PROFILE.md` as the agent's orientation. The most specific profile wins, so a native-extension repo resolves to its `*-ext` profile ahead of the plain language profile. Force one with `?profile=<name>` on the scan API (validated against the skill's `requires_profile`); `default` forces the base runner image.
 
 | Profile | Selected when | Adds |
 |---------|---------------|------|
-| `php` / `php-ext` | Composer / a `config.m4` with `PHP_ARG_` | PHP; `php-ext` builds PHP debug + ASan/UBSan for C extensions |
-| `python` / `python-ext` | pip/Poetry/uv/PDM / a `setup.py` declaring a C `Extension(` | CPython; `python-ext` builds CPython debug + ASan/UBSan |
+| `php` / `php-ext` | `package_manager:Composer` / `tools.native_extension:phpize` | PHP; `php-ext` builds PHP debug + ASan/UBSan for C extensions |
+| `python` / `python-ext` | `package_manager:pip` / `Pipenv` / `Poetry` / `uv` / `PDM` / `setuptools`; `python-ext` when `tools.native_extension:setuptools Extension` is present | CPython; `python-ext` builds CPython debug + ASan/UBSan |
 | `ruby` | Bundler | Ruby 3.4 + Bundler; metaprogramming / dynamic-dispatch guidance, plus a tripwire that flags an un-instrumented native extension |
-| `ruby-ext` | a gemspec with `spec.extensions`, or `ext/**/extconf.rb` / `ext/**/Cargo.toml` | A **superset** of `ruby`: adds an ASan/UBSan Ruby (the default interpreter), valgrind on the stock interpreter, and Rust nightly for rb-sys gems -- memory-safety coverage for C/C++/Rust native gems |
-| `ruby-rails` | `config/application.rb` | A superset of `ruby` plus **Brakeman**, Rails-specific SAST |
-| `node` | npm | Node.js |
+| `ruby-ext` | `tools.native_extension:mkmf` | A **superset** of `ruby`: adds an ASan/UBSan Ruby (the default interpreter), valgrind on the stock interpreter, Rust nightly for rb-sys gems, and Brakeman |
+| `ruby-rails` | `tools.build:Rails` | A superset of `ruby` plus **Brakeman**, Rails-specific SAST |
+| `node` | npm/pnpm/Yarn/Bun | Node.js |
 | `go` | Go Modules | Go toolchain |
 | `java` | Maven/Gradle | JDK |
-| `dotnet` | NuGet | .NET SDK |
+| `dotnet` | NuGet/dotnet CLI | .NET SDK |
 | `beam` | Mix/rebar3 | Erlang/Elixir |
 | `rust` | Cargo | Rust stable + nightly, Miri, sanitizers |
-| `c-cpp` | a CMake/Make/autotools/meson build file and no language ecosystem | C/C++ build toolchain |
+| `perl` | cpanm or Perl language detection | Perl toolchain |
+| `c-cpp` | `tools.build:CMake` / `Make` / `Autotools` / `Meson`, or C/C++ language detection, after language ecosystems have had a chance to match | C/C++ build toolchain |
 
 The three Ruby profiles are mutually exclusive at selection time, but `ruby-ext` and `ruby-rails` are deliberate *supersets* of `ruby` (the same Ruby-level audit, plus their extra coverage), so a detection that errs toward `ruby-ext` costs only build time, never coverage. A native gem that slips through to the plain `ruby` profile is caught by that profile's tripwire, which records that memory-safety scanning needs `ruby-ext`. Add a profile by registering it in `internal/worker/profile.go` and adding `docker/profiles/<name>/{Dockerfile,PROFILE.md}`.
 

--- a/internal/worker/container.go
+++ b/internal/worker/container.go
@@ -83,6 +83,9 @@ type ContainerRunner struct {
 	// zero value keeps the host-proxy path (docker, rootful podman, and all
 	// non-hardened scans). See usesEgressSidecar.
 	Egress EgressSidecarConfig
+	// detectProfile lets tests stub profile auto-detection without a container
+	// runtime. nil means DetectProfile.
+	detectProfile func(ctx context.Context, rt ContainerRuntime, runnerImage, srcDir string, relabel bool) Profile
 }
 
 // EgressSidecarConfig carries what setupHardenedNetwork needs to launch the
@@ -488,7 +491,11 @@ func (d ContainerRunner) resolveProfile(ctx context.Context, requested, src, sub
 		if subPath != "" {
 			srcDir = filepath.Join(src, subPath)
 		}
-		p = DetectProfile(ctx, d.Runtime, defaultImg, srcDir, d.SELinuxRelabel)
+		detect := d.detectProfile
+		if detect == nil {
+			detect = DetectProfile
+		}
+		p = detect(ctx, d.Runtime, defaultImg, srcDir, d.SELinuxRelabel)
 		if p.IsDefault() {
 			return "", defaultImg
 		}

--- a/internal/worker/container_test.go
+++ b/internal/worker/container_test.go
@@ -483,47 +483,35 @@ func TestRedactURLUserinfo(t *testing.T) {
 }
 
 func TestResolveProfile_SubPath(t *testing.T) {
-	d := ContainerRunner{ProfilesDir: t.TempDir()} // Provide a ProfilesDir so it doesn't short-circuit
-
+	// Detection runs against work/subPath, not work: stub detectProfile to
+	// record the srcDir it was handed and assert the join happened.
 	work := t.TempDir()
-	sub := filepath.Join(work, "nested", "php-ext")
-	if err := os.MkdirAll(sub, 0o700); err != nil {
-		t.Fatal(err)
+	var seenSrc string
+	d := ContainerRunner{
+		ProfilesDir: t.TempDir(), // present so resolveProfile doesn't short-circuit
+		detectProfile: func(_ context.Context, _ ContainerRuntime, _, srcDir string, _ bool) Profile {
+			seenSrc = srcDir
+			return Profile{}
+		},
 	}
-	// The php-ext profile detects config.m4 containing PHP_ARG_
-	if err := os.WriteFile(filepath.Join(sub, "config.m4"), []byte("PHP_ARG_"), 0o600); err != nil {
-		t.Fatal(err)
-	}
+	emit := func(Event) {}
 
-	var events []Event
-	emit := func(e Event) { events = append(events, e) }
-
-	// 1. Root path should NOT match php-ext (will default or fallback)
 	d.resolveProfile(context.Background(), "", work, "", emit)
-
-	matchedPhpExtAtRoot := false
-	for _, e := range events {
-		if strings.Contains(e.Text, "profile: php-ext") {
-			matchedPhpExtAtRoot = true
-		}
-	}
-	if matchedPhpExtAtRoot {
-		t.Errorf("expected no php-ext profile match at root")
+	if seenSrc != work {
+		t.Errorf("no subPath: srcDir = %q, want %q", seenSrc, work)
 	}
 
-	events = nil // clear
-
-	// 2. SubPath should match php-ext
 	d.resolveProfile(context.Background(), "", work, "nested/php-ext", emit)
-
-	matchedPhpExtInSubPath := false
-	for _, e := range events {
-		if strings.Contains(e.Text, "profile: php-ext") {
-			matchedPhpExtInSubPath = true
-		}
+	want := filepath.Join(work, "nested", "php-ext")
+	if seenSrc != want {
+		t.Errorf("with subPath: srcDir = %q, want %q", seenSrc, want)
 	}
-	if !matchedPhpExtInSubPath {
-		t.Errorf("expected php-ext profile match using subPath")
+
+	// A requested profile bypasses detection entirely.
+	seenSrc = ""
+	d.resolveProfile(context.Background(), "php-ext", work, "nested", emit)
+	if seenSrc != "" {
+		t.Errorf("requested profile should not call detectProfile, but srcDir = %q", seenSrc)
 	}
 }
 

--- a/internal/worker/profile.go
+++ b/internal/worker/profile.go
@@ -15,9 +15,9 @@ import (
 	"time"
 )
 
-// Category names in brief's JSON output that BriefMatch.Category can
-// reference. package_manager and language are top-level arrays in the
-// report; everything else is a key under tools.
+// Internal selector category names that BriefMatch.Category can reference.
+// package_manager and language map to brief's top-level package_managers and
+// languages arrays; everything else is a key under brief's tools object.
 const (
 	briefPackageManager  = "package_manager"
 	briefLanguage        = "language"
@@ -45,7 +45,7 @@ type Profile struct {
 	// profile matches when any BriefMatch is satisfied; a BriefMatch is
 	// satisfied when brief detected any of its Names in its Category.
 	// Every profile must carry at least one entry: an empty Detect would
-	// match every repo, and the registry sanity test rejects that.
+	// never match, and the registry sanity test rejects dead profiles.
 	Detect []BriefMatch
 	// BaseProfile, when set, names another registered profile whose built
 	// image this profile builds FROM instead of the runner image. EnsureImage

--- a/internal/worker/profile.go
+++ b/internal/worker/profile.go
@@ -1,15 +1,12 @@
 package worker
 
 import (
-	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
-	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -18,33 +15,22 @@ import (
 	"time"
 )
 
-// ProfileMarker refines profile selection beyond what brief reports.
-type ProfileMarker struct {
-	// Path is the marker location relative to the cloned source root.
-	// Its interpretation depends on Glob/Walk:
-	//   - default: an exact path, tested with os.Stat.
-	//   - Glob:    a filepath.Glob pattern (single-segment wildcards),
-	//              e.g. "*.gemspec".
-	//   - Walk:    "<root>/<basename>"; <basename> is searched for anywhere
-	//              under <root> by a depth- and count-bounded walk, e.g.
-	//              "ext/extconf.rb" finds an extconf.rb at any depth under
-	//              ext/.
-	Path string
-	// Contains, when set, must also appear inside the matched file — used
-	// e.g. to distinguish a phpize config.m4 from any unrelated autoconf
-	// file, or a gemspec that declares spec.extensions from one that merely
-	// mentions the word. Bounded by markerReadCap.
-	Contains string
-	// Glob makes Path a filepath.Glob pattern instead of an exact path.
-	// filepath.Glob expands * ? [..] within a single path segment, which
-	// covers root-level fan-outs like "*.gemspec".
-	Glob bool
-	// Walk makes Path a "<root>/<basename>" pair: <basename> (the last
-	// segment) is searched for anywhere beneath <root> (the rest) by a
-	// bounded directory walk. filepath.Glob cannot express "**", so this
-	// covers native-extension layouts like ext/<name>/extconf.rb and the
-	// deeper ext/<name>/<sub>/extconf.rb some gems use.
-	Walk bool
+// Category names in brief's JSON output that BriefMatch.Category can
+// reference. package_manager and language are top-level arrays in the
+// report; everything else is a key under tools.
+const (
+	briefPackageManager  = "package_manager"
+	briefLanguage        = "language"
+	briefBuild           = "build"
+	briefNativeExtension = "native_extension"
+)
+
+// BriefMatch selects a profile when brief detected any of Names in the
+// given Category. Names are matched case-insensitively against
+// Detection.Name in brief's JSON output.
+type BriefMatch struct {
+	Category string
+	Names    []string
 }
 
 // Profile selects a per-ecosystem runner image. The default profile
@@ -55,28 +41,12 @@ type Profile struct {
 	// Name matches the directory under docker/profiles/. Empty means
 	// "use the default runner image, no per-profile build".
 	Name string
-	// Ecosystem is a `brief` package_managers[].name, matched
-	// case-insensitively, for runtimes brief can see. A profile needs at
-	// least one of Ecosystem/Ecosystems, Markers, or AnyMarkers: each
-	// matcher treats an empty constraint as "no constraint", so an entry
-	// with all of them empty would match every repo. The registry sanity
-	// test rejects that. Markers/AnyMarkers cover ecosystems brief cannot
-	// see (e.g. a PECL C extension repo without composer.json).
-	Ecosystem string
-	// Ecosystems lists additional `brief` package_managers[].name values
-	// the profile also matches, for ecosystems one runtime serves under
-	// several names (e.g. Python's pip / Poetry / Pipenv / uv / PDM, or the
-	// JVM's Maven and Gradle). The profile matches if any of Ecosystem or
-	// Ecosystems matches.
-	Ecosystems []string
-	// Markers must ALL be present (AND) for the profile to match. Use for a
-	// precise signal, e.g. a config.m4 that contains PHP_ARG_.
-	Markers []ProfileMarker
-	// AnyMarkers match if at least ONE is present (OR). Use when a single
-	// ecosystem has several equally-valid build-file signals and brief
-	// reports no package manager for it — e.g. C/C++ projects built with
-	// CMake, Make, autotools, or meson.
-	AnyMarkers []ProfileMarker
+	// Detect selects the profile from brief's structured output. The
+	// profile matches when any BriefMatch is satisfied; a BriefMatch is
+	// satisfied when brief detected any of its Names in its Category.
+	// Every profile must carry at least one entry: an empty Detect would
+	// match every repo, and the registry sanity test rejects that.
+	Detect []BriefMatch
 	// BaseProfile, when set, names another registered profile whose built
 	// image this profile builds FROM instead of the runner image. EnsureImage
 	// builds that base first and passes its content-addressed tag as the
@@ -100,15 +70,10 @@ type Profile struct {
 // instead of a profile-specific built one.
 func (p Profile) IsDefault() bool { return p.Name == "" }
 
-// allEcosystems returns every brief package-manager name the profile
-// matches: the singular Ecosystem (if set) plus any in Ecosystems.
-func (p Profile) allEcosystems() []string {
-	out := make([]string, 0, len(p.Ecosystems)+1)
-	if p.Ecosystem != "" {
-		out = append(out, p.Ecosystem)
-	}
-	out = append(out, p.Ecosystems...)
-	return out
+// pm returns a Detect list matching any of the given brief
+// package_manager names. Shorthand for the common single-category case.
+func pm(names ...string) []BriefMatch {
+	return []BriefMatch{{Category: briefPackageManager, Names: names}}
 }
 
 // builtinProfiles is the v1 registry. Order matters: first match wins,
@@ -117,12 +82,12 @@ func (p Profile) allEcosystems() []string {
 // docker/profiles/<name>/ to expose a profile.
 var builtinProfiles = []Profile{
 	{
-		Name: "php-ext",
-		Markers: []ProfileMarker{
-			{Path: "config.m4", Contains: "PHP_ARG_"},
-		},
+		// brief's phpize detector looks for PHP_ARG_/PHP_NEW_EXTENSION in
+		// config.m4, so an unrelated autoconf file doesn't route here.
+		Name:   "php-ext",
+		Detect: []BriefMatch{{briefNativeExtension, []string{"phpize"}}},
 	},
-	{Name: "php", Ecosystem: "Composer"},
+	{Name: "php", Detect: pm("Composer")},
 	{
 		// Before ruby: a gem that ships a native extension (C/C++, or Rust
 		// via rb-sys/Cargo) routes to the sanitizer-instrumented interpreter.
@@ -138,93 +103,65 @@ var builtinProfiles = []Profile{
 		// fresh.
 		//
 		// It is NOT a superset of the rust profile (no Miri, only a minimal
-		// rustc for rb-sys shims), so the Cargo.toml marker below is gated on
-		// an rb-sys mention: an unqualified ext/**/Cargo.toml would pull a
-		// pure-Rust crate in here — ruby-ext precedes rust — and strip its
-		// Rust-specific coverage.
-		//
-		// Markers (OR): the gemspec's spec.extensions is RubyGems' own
-		// definition of "has native code" and is authoritative; the bounded
-		// ext/ walks catch the conventional ext/<name>/extconf.rb (mkmf, also
-		// used by rb-sys Rust) and a Cargo-native gem's ext/<name>/Cargo.toml
-		// that names rb-sys (magnus builds on it); the root extconf.rb covers
-		// the older single-dir style. A real Cargo-native gem also ships an
-		// extconf.rb or spec.extensions, so the sibling markers still catch it
-		// if the rb-sys needle is ever absent.
+		// rustc for rb-sys shims). brief's mkmf detector keys on extconf.rb,
+		// which rb-sys/magnus gems also ship, so a Rust-backed gem still
+		// lands here without a separate Cargo.toml check; a pure-Rust crate
+		// with no extconf.rb falls through to the rust profile below.
 		Name:            "ruby-ext",
 		FallbackProfile: "ruby",
-		AnyMarkers: []ProfileMarker{
-			{Path: "*.gemspec", Glob: true, Contains: ".extensions"},
-			{Path: "ext/extconf.rb", Walk: true},
-			{Path: "ext/Cargo.toml", Walk: true, Contains: "rb-sys"},
-			{Path: "extconf.rb"},
-		},
+		Detect:          []BriefMatch{{briefNativeExtension, []string{"mkmf"}}},
 	},
 	{
-		// Before ruby: a Rails app (config/application.rb is the canonical
-		// boot file) also gets Brakeman, the Rails-specific SAST, on top of
-		// the ruby runtime. Like ruby-ext this is a superset of the ruby
-		// profile — it builds FROM the ruby profile image (BaseProfile) and
-		// adds Brakeman, so the interpreter is byte-identical with no second
-		// from-source compile. Marker-only so it does not collide with ruby's
-		// Bundler ecosystem in the registry-sanity test. The marker requires
-		// the file to name Rails::Application (the base class every app's
-		// Application subclasses) so a coincidental config/application.rb in a
-		// non-Rails repo — of any language — does not route here.
+		// Before ruby: a Rails app also gets Brakeman, the Rails-specific
+		// SAST, on top of the ruby runtime. Like ruby-ext this is a superset
+		// of the ruby profile — it builds FROM the ruby profile image
+		// (BaseProfile) and adds Brakeman, so the interpreter is
+		// byte-identical with no second from-source compile. brief detects
+		// Rails via config/routes.rb, bin/rails, or a `rails` dependency in
+		// the Gemfile, so a coincidental config/application.rb in a non-Rails
+		// repo does not route here.
 		Name:            "ruby-rails",
 		BaseProfile:     "ruby",
 		FallbackProfile: "ruby",
-		Markers: []ProfileMarker{
-			{Path: "config/application.rb", Contains: "Rails::Application"},
-		},
+		Detect:          []BriefMatch{{briefBuild, []string{"Rails"}}},
 	},
-	{Name: "ruby", Ecosystem: "Bundler"},
-	{Name: "node", Ecosystem: "npm"},
+	{Name: "ruby", Detect: pm("Bundler")},
+	{Name: "node", Detect: pm("npm", "pnpm", "Yarn", "Bun")},
 	{
-		// Before python: a repo whose setup.py declares a C Extension is
-		// shipping native code, so route it to the ASan/UBSan interpreter.
-		Name: "python-ext",
-		Markers: []ProfileMarker{
-			{Path: "setup.py", Contains: "Extension("},
-		},
+		// Before python: brief's setuptools-Extension detector keys on
+		// setup.py declaring Extension()/ext_modules or a .pyx file, so
+		// route it to the ASan/UBSan interpreter.
+		Name:            "python-ext",
+		FallbackProfile: "python",
+		Detect:          []BriefMatch{{briefNativeExtension, []string{"setuptools Extension"}}},
 	},
-	{Name: "python", Ecosystems: []string{"pip", "Pipenv", "Poetry", "uv", "PDM"}},
-	{Name: "go", Ecosystem: "Go Modules"},
-	{Name: "java", Ecosystems: []string{"Maven", "Gradle"}},
-	{Name: "dotnet", Ecosystem: "NuGet"},
-	{Name: "beam", Ecosystems: []string{"Mix", "rebar3"}},
-	{Name: "rust", Ecosystem: "Cargo"},
+	{Name: "python", Detect: pm("pip", "Pipenv", "Poetry", "uv", "PDM", "setuptools")},
+	{Name: "go", Detect: pm("Go Modules")},
+	{Name: "java", Detect: pm("Maven", "Gradle")},
+	{Name: "dotnet", Detect: pm("NuGet", "dotnet CLI")},
+	{Name: "beam", Detect: pm("Mix", "rebar3")},
+	{Name: "rust", Detect: pm("Cargo")},
 	{
-		// brief reports no package manager for Perl (it parses cpanfile /
-		// META.json into purls but leaves package_managers null), so the
-		// profile matches on the dist's build files instead. Before c-cpp so
-		// a CPAN dist that also commits a generated Makefile, or whose
-		// Makefile.PL has already been run, routes here rather than to the
-		// native toolchain.
+		// Before c-cpp so a CPAN dist that also commits a generated Makefile,
+		// or whose Makefile.PL has already been run, routes here rather than
+		// to the native toolchain. brief reports cpanm in package_managers
+		// for a repo with cpanfile/Makefile.PL/Build.PL/META.*; the language
+		// match is a belt-and-braces for a dist with only *.pl/*.pm.
 		Name: "perl",
-		AnyMarkers: []ProfileMarker{
-			{Path: "Makefile.PL"},
-			{Path: "Build.PL"},
-			{Path: "cpanfile"},
-			{Path: "dist.ini"},
-			{Path: "META.json"},
-			{Path: "META.yml"},
+		Detect: []BriefMatch{
+			{briefPackageManager, []string{"cpanm"}},
+			{briefLanguage, []string{"Perl"}},
 		},
 	},
 	{
-		// Last: brief reports no package manager for C/C++, so this is a
-		// fallback for repos that match no language ecosystem above but
-		// carry a native build file. Language repos (which also often have
-		// a Makefile) match their ecosystem first, so this only catches
-		// repos that are actually native.
+		// Last: brief reports no package manager for plain C/C++, so match
+		// on the build tool instead. Language repos that also carry a
+		// Makefile match their own package-manager profile first, so this
+		// only catches repos that are actually native.
 		Name: "c-cpp",
-		AnyMarkers: []ProfileMarker{
-			{Path: "CMakeLists.txt"},
-			{Path: "Makefile"},
-			{Path: "GNUmakefile"},
-			{Path: "configure.ac"},
-			{Path: "configure.in"},
-			{Path: "meson.build"},
+		Detect: []BriefMatch{
+			{briefBuild, []string{"CMake", "Make", "Autotools", "Meson"}},
+			{briefLanguage, []string{"C", "C++"}},
 		},
 	},
 }
@@ -267,173 +204,70 @@ func IsNamedProfile(name string) bool {
 	return false
 }
 
-func matchProfile(briefOut []byte, srcDir string) Profile {
-	var brief struct {
-		PackageManagers []struct {
-			Name string `json:"name"`
-		} `json:"package_managers"`
+// briefDetections flattens brief's JSON output into category -> lower(name)
+// -> true. package_managers and languages become the briefPackageManager /
+// briefLanguage categories; every key under tools becomes its own category.
+// Unknown JSON is tolerated: an unmarshal error or an absent field yields an
+// empty (never nil) map so profile matching degrades to "no match" rather
+// than failing the scan.
+func briefDetections(out []byte) map[string]map[string]bool {
+	type detection struct {
+		Name string `json:"name"`
 	}
-	_ = json.Unmarshal(briefOut, &brief)
-	pms := make([]string, 0, len(brief.PackageManagers))
-	for _, pm := range brief.PackageManagers {
-		pms = append(pms, pm.Name)
+	var r struct {
+		PackageManagers []detection            `json:"package_managers"`
+		Languages       []detection            `json:"languages"`
+		Tools           map[string][]detection `json:"tools"`
 	}
+	_ = json.Unmarshal(out, &r)
+	det := map[string]map[string]bool{}
+	add := func(cat, name string) {
+		if name == "" {
+			return
+		}
+		if det[cat] == nil {
+			det[cat] = map[string]bool{}
+		}
+		det[cat][strings.ToLower(name)] = true
+	}
+	for _, d := range r.PackageManagers {
+		add(briefPackageManager, d.Name)
+	}
+	for _, d := range r.Languages {
+		add(briefLanguage, d.Name)
+	}
+	for cat, ds := range r.Tools {
+		for _, d := range ds {
+			add(cat, d.Name)
+		}
+	}
+	return det
+}
+
+// matchProfile returns the first builtinProfiles entry whose Detect list
+// is satisfied by the brief output, or the zero Profile if none match.
+func matchProfile(briefOut []byte) Profile {
+	det := briefDetections(briefOut)
 	for _, p := range builtinProfiles {
-		if !ecosystemMatch(p.allEcosystems(), pms) {
-			continue
+		if p.matches(det) {
+			return p
 		}
-		if !markersMatch(p.Markers, srcDir) {
-			continue
-		}
-		if !anyMarkersMatch(p.AnyMarkers, srcDir) {
-			continue
-		}
-		return p
 	}
 	return Profile{}
 }
 
-func ecosystemMatch(ecosystems, pms []string) bool {
-	if len(ecosystems) == 0 {
-		return true
-	}
-	for _, e := range ecosystems {
-		for _, pm := range pms {
-			if strings.EqualFold(pm, e) {
+// matches reports whether any of p.Detect is satisfied by det. Names are
+// compared case-insensitively (det keys are already lowercased).
+func (p Profile) matches(det map[string]map[string]bool) bool {
+	for _, m := range p.Detect {
+		names := det[m.Category]
+		for _, want := range m.Names {
+			if names[strings.ToLower(want)] {
 				return true
 			}
 		}
 	}
 	return false
-}
-
-func markersMatch(markers []ProfileMarker, srcDir string) bool {
-	if len(markers) == 0 {
-		return true
-	}
-	if srcDir == "" {
-		return false
-	}
-	for _, m := range markers {
-		if !markerPresent(m, srcDir) {
-			return false
-		}
-	}
-	return true
-}
-
-// anyMarkersMatch reports whether at least one marker is present (OR). An
-// empty list matches (the profile imposes no AnyMarkers constraint); a
-// non-empty list with no srcDir cannot match.
-func anyMarkersMatch(markers []ProfileMarker, srcDir string) bool {
-	if len(markers) == 0 {
-		return true
-	}
-	if srcDir == "" {
-		return false
-	}
-	for _, m := range markers {
-		if markerPresent(m, srcDir) {
-			return true
-		}
-	}
-	return false
-}
-
-// markerWalkMaxDepth and markerWalkMaxFiles bound the Walk matcher so a
-// deep or hostile tree can't stall detection. The depth is generous enough
-// for real ext/ layouts (ext/<name>/<sub>/extconf.rb) while the file cap is
-// a backstop against a pathological repo.
-const (
-	markerWalkMaxDepth = 6
-	markerWalkMaxFiles = 50_000
-)
-
-// markerPresent reports whether a single marker is satisfied under srcDir,
-// dispatching on the marker's mode (exact path, Glob pattern, or bounded
-// Walk). Contains, when set, additionally requires the matched file to hold
-// the substring.
-func markerPresent(m ProfileMarker, srcDir string) bool {
-	switch {
-	case m.Glob:
-		matches, err := filepath.Glob(filepath.Join(srcDir, m.Path))
-		if err != nil {
-			return false
-		}
-		for _, f := range matches {
-			if m.Contains == "" || fileContains(f, m.Contains) {
-				return true
-			}
-		}
-		return false
-	case m.Walk:
-		return walkMarkerPresent(m, srcDir)
-	default:
-		full := filepath.Join(srcDir, m.Path)
-		if m.Contains == "" {
-			_, err := os.Stat(full)
-			return err == nil
-		}
-		return fileContains(full, m.Contains)
-	}
-}
-
-// walkMarkerPresent searches for a file named filepath.Base(m.Path) anywhere
-// under filepath.Dir(m.Path) (relative to srcDir), bounded by
-// markerWalkMaxDepth and markerWalkMaxFiles. A missing or unreadable root is
-// simply "not present" — detection never fails a scan. When Contains is set
-// the matched file must also hold the substring.
-func walkMarkerPresent(m ProfileMarker, srcDir string) bool {
-	return walkMarkerPresentBounded(m, srcDir, markerWalkMaxDepth, markerWalkMaxFiles)
-}
-
-// walkMarkerPresentBounded is walkMarkerPresent with the depth and file bounds
-// injected, so both caps are unit-testable without materialising a
-// markerWalkMaxDepth-deep tree or markerWalkMaxFiles of files.
-func walkMarkerPresentBounded(m ProfileMarker, srcDir string, maxDepth, maxFiles int) bool {
-	root := filepath.Join(srcDir, filepath.Dir(m.Path))
-	target := filepath.Base(m.Path)
-	rootDepth := strings.Count(filepath.Clean(root), string(os.PathSeparator))
-	files := 0
-	found := false
-	_ = filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return nil // unreadable entry: skip it, don't abort the walk
-		}
-		if d.IsDir() {
-			if strings.Count(filepath.Clean(path), string(os.PathSeparator))-rootDepth > maxDepth {
-				return fs.SkipDir
-			}
-			return nil
-		}
-		files++
-		if files > maxFiles {
-			return fs.SkipAll
-		}
-		if d.Name() == target && (m.Contains == "" || fileContains(path, m.Contains)) {
-			found = true
-			return fs.SkipAll
-		}
-		return nil
-	})
-	return found
-}
-
-// markerReadCap bounds Contains-substring scans so a hostile or
-// runaway file can't stall detection.
-const markerReadCap = 1 << 20
-
-func fileContains(path, needle string) bool {
-	f, err := os.Open(path)
-	if err != nil {
-		return false
-	}
-	defer func() { _ = f.Close() }()
-	b, err := io.ReadAll(io.LimitReader(f, markerReadCap))
-	if err != nil {
-		return false
-	}
-	return bytes.Contains(b, []byte(needle))
 }
 
 // DetectProfile runs `brief` against the cloned source inside the
@@ -457,10 +291,11 @@ func DetectProfile(ctx context.Context, rt ContainerRuntime, runnerImage, srcDir
 	cmd := exec.CommandContext(ctx, rt.bin(), args...)
 	out, err := cmd.Output()
 	if err != nil {
-		// Marker-only profiles can still match when brief is unavailable.
-		out = nil
+		// A brief failure degrades to the default runner image; the scan
+		// still runs, without profile-specific tooling.
+		return Profile{}
 	}
-	return matchProfile(out, absSrc)
+	return matchProfile(out)
 }
 
 // ErrNoProfilesDir is returned by EnsureImage when the worker has no

--- a/internal/worker/profile_test.go
+++ b/internal/worker/profile_test.go
@@ -118,7 +118,6 @@ func TestMatchProfile(t *testing.T) {
 		{"composer + bundler picks php (registry order)", briefJSON("package_manager:Composer", "package_manager:Bundler"), "php"},
 		{"bundler + composer still picks php (registry order, not brief order)", briefJSON("package_manager:Bundler", "package_manager:Composer"), "php"},
 		{"composer before node when both present", briefJSON("package_manager:npm", "package_manager:Composer"), "php"},
-		{"composer present even if not first in brief output", briefJSON("package_manager:npm", "package_manager:Composer"), "php"},
 
 		// native_extension category (from brief v0.9.3)
 		{"phpize selects php-ext", briefJSON("native_extension:phpize"), "php-ext"},

--- a/internal/worker/profile_test.go
+++ b/internal/worker/profile_test.go
@@ -2,7 +2,7 @@ package worker
 
 import (
 	"context"
-	"fmt"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -48,606 +48,166 @@ func TestProfileByName(t *testing.T) {
 	}
 }
 
-const configM4Body = `dnl Minimal extension config
-PHP_ARG_ENABLE([example], [whether to enable example], [--enable-example])
-if test "$PHP_EXAMPLE" != "no"; then
-  PHP_NEW_EXTENSION(example, example.c, $ext_shared)
-fi
-`
-
-const configM4WithoutPHPArg = `dnl just a stray autoconf file
-AC_INIT([thing], [1.0])
-`
-
-func writeConfigM4(t *testing.T, dir, contents string) {
-	t.Helper()
-	const configM4FileMode = 0o644
-	path := filepath.Join(dir, "config.m4")
-	if err := os.WriteFile(path, []byte(contents), configM4FileMode); err != nil {
-		t.Fatalf("write %s: %v", path, err)
+// briefJSON builds a minimal brief output for TestMatchProfile. Each entry
+// is "category:name"; briefPackageManager and briefLanguage go into the
+// top-level arrays, everything else under tools[category].
+func briefJSON(entries ...string) string {
+	type det struct {
+		Name string `json:"name"`
 	}
+	var out struct {
+		PackageManagers []det            `json:"package_managers"`
+		Languages       []det            `json:"languages"`
+		Tools           map[string][]det `json:"tools"`
+	}
+	out.Tools = map[string][]det{}
+	for _, e := range entries {
+		cat, name, _ := strings.Cut(e, ":")
+		switch cat {
+		case briefPackageManager:
+			out.PackageManagers = append(out.PackageManagers, det{name})
+		case briefLanguage:
+			out.Languages = append(out.Languages, det{name})
+		default:
+			out.Tools[cat] = append(out.Tools[cat], det{name})
+		}
+	}
+	b, err := json.Marshal(out)
+	if err != nil {
+		panic(err)
+	}
+	return string(b)
 }
 
-const setupPyWithExtension = `from setuptools import setup, Extension
-setup(ext_modules=[Extension("pkg._speedups", ["src/speedups.c"])])
-`
-
-const setupPyPurePython = `from setuptools import setup
-setup(name="pkg", version="1.0", packages=["pkg"])
-`
-
-func writeSetupPy(t *testing.T, dir, contents string) {
-	t.Helper()
-	const setupPyFileMode = 0o644
-	path := filepath.Join(dir, "setup.py")
-	if err := os.WriteFile(path, []byte(contents), setupPyFileMode); err != nil {
-		t.Fatalf("write %s: %v", path, err)
-	}
-}
-
-func writeMarkerFile(t *testing.T, dir, name string) {
-	t.Helper()
-	const markerFileMode = 0o644
-	path := filepath.Join(dir, name)
-	if err := os.WriteFile(path, []byte("x\n"), markerFileMode); err != nil {
-		t.Fatalf("write %s: %v", path, err)
-	}
-}
-
-// writeFileAt writes contents to a slash-separated path relative to dir,
-// creating intermediate directories. Used for the ruby-ext markers, which
-// live under ext/<name>/ rather than at the repo root.
-func writeFileAt(t *testing.T, dir, rel, contents string) {
-	t.Helper()
-	const (
-		fileMode = 0o644
-		dirMode  = 0o755
-	)
-	path := filepath.Join(dir, filepath.FromSlash(rel))
-	if err := os.MkdirAll(filepath.Dir(path), dirMode); err != nil {
-		t.Fatalf("mkdir for %s: %v", path, err)
-	}
-	if err := os.WriteFile(path, []byte(contents), fileMode); err != nil {
-		t.Fatalf("write %s: %v", path, err)
-	}
-}
-
-// gemspecWithExtensions declares spec.extensions — RubyGems' own marker that
-// the gem builds native code. gemspecPureRuby mentions the word "extensions"
-// only in prose, so the ".extensions" Contains check must NOT match it.
-const gemspecWithExtensions = `Gem::Specification.new do |spec|
-  spec.name = "example"
-  spec.version = "1.0.0"
-  spec.extensions = ["ext/example/extconf.rb"]
-end
-`
-
-const gemspecPureRuby = `Gem::Specification.new do |spec|
-  spec.name = "example"
-  spec.version = "1.0.0"
-  spec.summary = "adds some useful extensions to core classes"
-end
-`
-
-//nolint:maintidx // exhaustive table: one case per builtinProfiles entry plus precedence/fallback edges; splitting would scatter the coverage.
 func TestMatchProfile(t *testing.T) {
 	tests := []struct {
-		name    string
-		json    string
-		setup   func(t *testing.T, dir string)
-		want    string
-		noSrcOK bool // if true, srcDir is "" for this case
+		name string
+		json string
+		want string
 	}{
-		{
-			name: "composer matches php",
-			json: `{"package_managers":[{"name":"Composer"}]}`,
-			want: "php",
-		},
-		{
-			name: "composer case-insensitive",
-			json: `{"package_managers":[{"name":"composer"}]}`,
-			want: "php",
-		},
-		{
-			name: "bundler matches ruby",
-			json: `{"package_managers":[{"name":"Bundler"}]}`,
-			want: "ruby",
-		},
-		{
-			name: "bundler case-insensitive",
-			json: `{"package_managers":[{"name":"bundler"}]}`,
-			want: "ruby",
-		},
-		{
-			name: "first composer match wins",
-			json: `{"package_managers":[{"name":"Composer"},{"name":"npm"}]}`,
-			want: "php",
-		},
-		{
-			name: "composer present even if not first",
-			json: `{"package_managers":[{"name":"npm"},{"name":"Composer"}]}`,
-			want: "php",
-		},
-		{
-			name: "composer + bundler picks php (registry order)",
-			json: `{"package_managers":[{"name":"Composer"},{"name":"Bundler"}]}`,
-			want: "php",
-		},
-		{
-			name: "bundler + composer still picks php (registry order, not brief order)",
-			json: `{"package_managers":[{"name":"Bundler"},{"name":"Composer"}]}`,
-			want: "php",
-		},
-		{
-			name: "npm matches node",
-			json: `{"package_managers":[{"name":"npm"}]}`,
-			want: "node",
-		},
-		{
-			name: "npm case-insensitive",
-			json: `{"package_managers":[{"name":"NPM"}]}`,
-			want: "node",
-		},
-		{
-			name: "composer before node when both present (registry order)",
-			json: `{"package_managers":[{"name":"npm"},{"name":"Composer"}]}`,
-			want: "php",
-		},
-		{
-			name: "pip matches python",
-			json: `{"package_managers":[{"name":"pip"}]}`,
-			want: "python",
-		},
-		{
-			name: "poetry matches python (secondary ecosystem)",
-			json: `{"package_managers":[{"name":"Poetry"}]}`,
-			want: "python",
-		},
-		{
-			name: "uv matches python case-insensitive",
-			json: `{"package_managers":[{"name":"UV"}]}`,
-			want: "python",
-		},
-		{
-			name: "pdm matches python",
-			json: `{"package_managers":[{"name":"PDM"}]}`,
-			want: "python",
-		},
-		{
-			name: "setup.py with Extension selects python-ext",
-			json: `{"package_managers":[{"name":"pip"}]}`,
-			setup: func(t *testing.T, dir string) {
-				writeSetupPy(t, dir, setupPyWithExtension)
-			},
-			want: "python-ext",
-		},
-		{
-			name: "setup.py with Extension matches python-ext even without a manager",
-			json: `{"package_managers":[]}`,
-			setup: func(t *testing.T, dir string) {
-				writeSetupPy(t, dir, setupPyWithExtension)
-			},
-			want: "python-ext",
-		},
-		{
-			name: "pure-python setup.py does not match python-ext, pip picks python",
-			json: `{"package_managers":[{"name":"pip"}]}`,
-			setup: func(t *testing.T, dir string) {
-				writeSetupPy(t, dir, setupPyPurePython)
-			},
-			want: "python",
-		},
-		{
-			name: "go modules matches go",
-			json: `{"package_managers":[{"name":"Go Modules"}]}`,
-			want: "go",
-		},
-		{
-			name: "go modules case-insensitive",
-			json: `{"package_managers":[{"name":"go modules"}]}`,
-			want: "go",
-		},
-		{
-			name: "maven matches java",
-			json: `{"package_managers":[{"name":"Maven"}]}`,
-			want: "java",
-		},
-		{
-			name: "gradle matches java (secondary ecosystem)",
-			json: `{"package_managers":[{"name":"Gradle"}]}`,
-			want: "java",
-		},
-		{
-			name: "gradle case-insensitive",
-			json: `{"package_managers":[{"name":"gradle"}]}`,
-			want: "java",
-		},
-		{
-			name: "nuget matches dotnet",
-			json: `{"package_managers":[{"name":"NuGet"}]}`,
-			want: "dotnet",
-		},
-		{
-			name: "nuget case-insensitive",
-			json: `{"package_managers":[{"name":"nuget"}]}`,
-			want: "dotnet",
-		},
-		{
-			name: "mix matches beam",
-			json: `{"package_managers":[{"name":"Mix"}]}`,
-			want: "beam",
-		},
-		{
-			name: "rebar3 matches beam (secondary ecosystem)",
-			json: `{"package_managers":[{"name":"rebar3"}]}`,
-			want: "beam",
-		},
-		{
-			name: "mix case-insensitive",
-			json: `{"package_managers":[{"name":"mix"}]}`,
-			want: "beam",
-		},
-		{
-			// brief reports package_managers:null for Perl, so the profile
-			// is marker-only and the json carries no signal here.
-			name: "Makefile.PL selects perl",
-			json: `{"package_managers":[]}`,
-			setup: func(t *testing.T, dir string) {
-				writeMarkerFile(t, dir, "Makefile.PL")
-			},
-			want: "perl",
-		},
-		{
-			name: "Build.PL selects perl",
-			json: `{"package_managers":[]}`,
-			setup: func(t *testing.T, dir string) {
-				writeMarkerFile(t, dir, "Build.PL")
-			},
-			want: "perl",
-		},
-		{
-			name: "cpanfile selects perl",
-			json: `{"package_managers":[]}`,
-			setup: func(t *testing.T, dir string) {
-				writeMarkerFile(t, dir, "cpanfile")
-			},
-			want: "perl",
-		},
-		{
-			name: "dist.ini selects perl",
-			json: `{"package_managers":[]}`,
-			setup: func(t *testing.T, dir string) {
-				writeMarkerFile(t, dir, "dist.ini")
-			},
-			want: "perl",
-		},
-		{
-			name: "META.json selects perl",
-			json: `{"package_managers":[]}`,
-			setup: func(t *testing.T, dir string) {
-				writeMarkerFile(t, dir, "META.json")
-			},
-			want: "perl",
-		},
-		{
-			name: "META.yml selects perl",
-			json: `{"package_managers":[]}`,
-			setup: func(t *testing.T, dir string) {
-				writeMarkerFile(t, dir, "META.yml")
-			},
-			want: "perl",
-		},
-		{
-			// A CPAN dist that also commits a generated Makefile must still
-			// route to perl, not c-cpp -- registry order guarantees this.
-			name: "Makefile.PL wins over a c-cpp build file",
-			json: `{"package_managers":[]}`,
-			setup: func(t *testing.T, dir string) {
-				writeMarkerFile(t, dir, "Makefile.PL")
-				writeMarkerFile(t, dir, "Makefile")
-			},
-			want: "perl",
-		},
-		{
-			// brief returns null (not []) for Perl projects; matchProfile
-			// must tolerate the absent key and still match on markers.
-			name: "perl marker matches when package_managers is null",
-			json: `{"package_managers":null}`,
-			setup: func(t *testing.T, dir string) {
-				writeMarkerFile(t, dir, "cpanfile")
-			},
-			want: "perl",
-		},
-		{
-			name: "CMakeLists.txt selects c-cpp (no package manager)",
-			json: `{"package_managers":[]}`,
-			setup: func(t *testing.T, dir string) {
-				writeMarkerFile(t, dir, "CMakeLists.txt")
-			},
-			want: "c-cpp",
-		},
-		{
-			name: "Makefile selects c-cpp",
-			json: `{"package_managers":[]}`,
-			setup: func(t *testing.T, dir string) {
-				writeMarkerFile(t, dir, "Makefile")
-			},
-			want: "c-cpp",
-		},
-		{
-			name: "meson.build selects c-cpp",
-			json: `{"package_managers":[]}`,
-			setup: func(t *testing.T, dir string) {
-				writeMarkerFile(t, dir, "meson.build")
-			},
-			want: "c-cpp",
-		},
-		{
-			name: "language ecosystem wins over a c-cpp build file",
-			json: `{"package_managers":[{"name":"Composer"}]}`,
-			setup: func(t *testing.T, dir string) {
-				writeMarkerFile(t, dir, "Makefile")
-			},
-			want: "php",
-		},
-		{
-			// rust is registered before the c-cpp fallback, so a Cargo
-			// crate that also ships a Makefile (common for -sys crates and
-			// build.rs-driven C builds) still routes to the rust profile.
-			name: "cargo wins over a c-cpp build file",
-			json: `{"package_managers":[{"name":"Cargo"}]}`,
-			setup: func(t *testing.T, dir string) {
-				writeMarkerFile(t, dir, "Makefile")
-			},
-			want: "rust",
-		},
-		{
-			name: "cargo matches rust",
-			json: `{"package_managers":[{"name":"Cargo"}]}`,
-			want: "rust",
-		},
-		{
-			name: "cargo case-insensitive",
-			json: `{"package_managers":[{"name":"cargo"}]}`,
-			want: "rust",
-		},
-		{
-			name: "truly unknown manager falls back",
-			json: `{"package_managers":[{"name":"Conan"}]}`,
-			want: "",
-		},
-		{
-			name: "empty manager list falls back",
-			json: `{"package_managers":[]}`,
-			want: "",
-		},
-		{
-			name: "missing field falls back",
-			json: `{}`,
-			want: "",
-		},
-		{
-			name: "invalid json falls back",
-			json: `not json`,
-			want: "",
-		},
-		{
-			name: "config.m4 with PHP_ARG selects php-ext",
-			json: `{"package_managers":[]}`,
-			setup: func(t *testing.T, dir string) {
-				writeConfigM4(t, dir, configM4Body)
-			},
-			want: "php-ext",
-		},
-		{
-			name: "php-ext wins over php when both signals present",
-			json: `{"package_managers":[{"name":"Composer"}]}`,
-			setup: func(t *testing.T, dir string) {
-				writeConfigM4(t, dir, configM4Body)
-			},
-			want: "php-ext",
-		},
-		{
-			name: "config.m4 without PHP_ARG does not match php-ext",
-			json: `{"package_managers":[{"name":"Composer"}]}`,
-			setup: func(t *testing.T, dir string) {
-				writeConfigM4(t, dir, configM4WithoutPHPArg)
-			},
-			want: "php", // composer marker still picks php
-		},
-		{
-			name: "config.m4 without PHP_ARG and no composer falls back",
-			json: `{"package_managers":[]}`,
-			setup: func(t *testing.T, dir string) {
-				writeConfigM4(t, dir, configM4WithoutPHPArg)
-			},
-			want: "",
-		},
-		{
-			name: "gemspec with spec.extensions selects ruby-ext",
-			json: `{"package_managers":[{"name":"Bundler"}]}`,
-			setup: func(t *testing.T, dir string) {
-				writeFileAt(t, dir, "example.gemspec", gemspecWithExtensions)
-			},
-			want: "ruby-ext",
-		},
-		{
-			name: "ext/<name>/extconf.rb selects ruby-ext",
-			json: `{"package_managers":[{"name":"Bundler"}]}`,
-			setup: func(t *testing.T, dir string) {
-				writeFileAt(t, dir, "ext/example/extconf.rb", "require 'mkmf'\ncreate_makefile('example')\n")
-			},
-			want: "ruby-ext",
-		},
-		{
-			name: "nested ext/<name>/<sub>/extconf.rb selects ruby-ext (bounded walk)",
-			json: `{"package_managers":[{"name":"Bundler"}]}`,
-			setup: func(t *testing.T, dir string) {
-				writeFileAt(t, dir, "ext/example/native/extconf.rb", "require 'mkmf'\n")
-			},
-			want: "ruby-ext",
-		},
-		{
-			name: "root extconf.rb selects ruby-ext (older single-dir gems)",
-			json: `{"package_managers":[{"name":"Bundler"}]}`,
-			setup: func(t *testing.T, dir string) {
-				writeFileAt(t, dir, "extconf.rb", "require 'mkmf'\n")
-			},
-			want: "ruby-ext",
-		},
-		{
-			name: "ext/<name>/Cargo.toml naming rb-sys selects ruby-ext (Cargo-native)",
-			json: `{"package_managers":[{"name":"Bundler"}]}`,
-			setup: func(t *testing.T, dir string) {
-				writeFileAt(t, dir, "ext/example/Cargo.toml", "[package]\nname = \"example\"\n\n[dependencies]\nrb-sys = \"0.9\"\n")
-			},
-			want: "ruby-ext",
-		},
-		{
-			// A Cargo-native gem (ext/**/Cargo.toml names rb-sys) still beats
-			// the rust profile even when brief only reports Cargo, because
-			// ruby-ext precedes rust in the registry.
-			name: "cargo-native gem naming rb-sys matches ruby-ext over rust",
-			json: `{"package_managers":[{"name":"Cargo"}]}`,
-			setup: func(t *testing.T, dir string) {
-				writeFileAt(t, dir, "ext/example/Cargo.toml", "[dependencies]\nrb-sys = \"0.9\"\n")
-			},
-			want: "ruby-ext",
-		},
-		{
-			// A pure-Rust crate that merely has an ext/ dir with a nested
-			// Cargo.toml (no rb-sys) must route to rust, not ruby-ext: ruby-ext
-			// is not a superset of rust (no Miri), so the Cargo.toml marker is
-			// gated on an rb-sys mention.
-			name: "pure-rust ext/**/Cargo.toml does not match ruby-ext, cargo picks rust",
-			json: `{"package_managers":[{"name":"Cargo"}]}`,
-			setup: func(t *testing.T, dir string) {
-				writeFileAt(t, dir, "ext/vendored/Cargo.toml", "[package]\nname = \"vendored\"\n")
-			},
-			want: "rust",
-		},
-		{
-			name: "ruby-ext matches without a package manager (brief unavailable)",
-			json: `{"package_managers":[]}`,
-			setup: func(t *testing.T, dir string) {
-				writeFileAt(t, dir, "ext/example/extconf.rb", "require 'mkmf'\n")
-			},
-			want: "ruby-ext",
-		},
-		{
-			name: "pure-ruby gemspec mentioning 'extensions' in prose does not match ruby-ext",
-			json: `{"package_managers":[{"name":"Bundler"}]}`,
-			setup: func(t *testing.T, dir string) {
-				writeFileAt(t, dir, "example.gemspec", gemspecPureRuby)
-			},
-			want: "ruby",
-		},
-		{
-			name: "pure-ruby Bundler repo selects ruby",
-			json: `{"package_managers":[{"name":"Bundler"}]}`,
-			setup: func(t *testing.T, dir string) {
-				writeFileAt(t, dir, "Gemfile", "source 'https://rubygems.org'\n")
-			},
-			want: "ruby",
-		},
-		{
-			name: "config/application.rb selects ruby-rails",
-			json: `{"package_managers":[{"name":"Bundler"}]}`,
-			setup: func(t *testing.T, dir string) {
-				writeFileAt(t, dir, "config/application.rb", "module App\n  class Application < Rails::Application\n  end\nend\n")
-			},
-			want: "ruby-rails",
-		},
-		{
-			// A config/application.rb that doesn't name Rails::Application (a
-			// coincidental path, any language) must not route to ruby-rails.
-			name: "config/application.rb without Rails::Application does not match ruby-rails",
-			json: `{"package_managers":[{"name":"Bundler"}]}`,
-			setup: func(t *testing.T, dir string) {
-				writeFileAt(t, dir, "config/application.rb", "# app config\nAPP_ROOT = __dir__\n")
-			},
-			want: "ruby", // Bundler still picks ruby; ruby-rails needs the Rails marker
-		},
+		// package_manager routes
+		{"composer matches php", briefJSON("package_manager:Composer"), "php"},
+		{"composer case-insensitive", briefJSON("package_manager:composer"), "php"},
+		{"bundler matches ruby", briefJSON("package_manager:Bundler"), "ruby"},
+		{"bundler case-insensitive", briefJSON("package_manager:bundler"), "ruby"},
+		{"npm matches node", briefJSON("package_manager:npm"), "node"},
+		{"pnpm matches node", briefJSON("package_manager:pnpm"), "node"},
+		{"yarn matches node", briefJSON("package_manager:Yarn"), "node"},
+		{"bun matches node", briefJSON("package_manager:Bun"), "node"},
+		{"npm case-insensitive", briefJSON("package_manager:NPM"), "node"},
+		{"pip matches python", briefJSON("package_manager:pip"), "python"},
+		{"poetry matches python", briefJSON("package_manager:Poetry"), "python"},
+		{"uv matches python case-insensitive", briefJSON("package_manager:UV"), "python"},
+		{"pdm matches python", briefJSON("package_manager:PDM"), "python"},
+		{"setuptools matches python", briefJSON("package_manager:setuptools"), "python"},
+		{"go modules matches go", briefJSON("package_manager:Go Modules"), "go"},
+		{"go modules case-insensitive", briefJSON("package_manager:go modules"), "go"},
+		{"maven matches java", briefJSON("package_manager:Maven"), "java"},
+		{"gradle matches java", briefJSON("package_manager:Gradle"), "java"},
+		{"gradle case-insensitive", briefJSON("package_manager:gradle"), "java"},
+		{"nuget matches dotnet", briefJSON("package_manager:NuGet"), "dotnet"},
+		{"dotnet CLI matches dotnet", briefJSON("package_manager:dotnet CLI"), "dotnet"},
+		{"nuget case-insensitive", briefJSON("package_manager:nuget"), "dotnet"},
+		{"mix matches beam", briefJSON("package_manager:Mix"), "beam"},
+		{"rebar3 matches beam", briefJSON("package_manager:rebar3"), "beam"},
+		{"mix case-insensitive", briefJSON("package_manager:mix"), "beam"},
+		{"cargo matches rust", briefJSON("package_manager:Cargo"), "rust"},
+		{"cpanm matches perl", briefJSON("package_manager:cpanm"), "perl"},
+
+		// registry order: first match in builtinProfiles wins, not brief order
+		{"composer + bundler picks php (registry order)", briefJSON("package_manager:Composer", "package_manager:Bundler"), "php"},
+		{"bundler + composer still picks php (registry order, not brief order)", briefJSON("package_manager:Bundler", "package_manager:Composer"), "php"},
+		{"composer before node when both present", briefJSON("package_manager:npm", "package_manager:Composer"), "php"},
+		{"composer present even if not first in brief output", briefJSON("package_manager:npm", "package_manager:Composer"), "php"},
+
+		// native_extension category (from brief v0.9.3)
+		{"phpize selects php-ext", briefJSON("native_extension:phpize"), "php-ext"},
+		{"phpize wins over composer (registry order)", briefJSON("package_manager:Composer", "native_extension:phpize"), "php-ext"},
+		{"mkmf selects ruby-ext", briefJSON("native_extension:mkmf"), "ruby-ext"},
+		{"mkmf wins over bundler (registry order)", briefJSON("package_manager:Bundler", "native_extension:mkmf"), "ruby-ext"},
+		{"setuptools Extension selects python-ext", briefJSON("native_extension:setuptools Extension"), "python-ext"},
+		{"setuptools Extension wins over pip", briefJSON("package_manager:pip", "native_extension:setuptools Extension"), "python-ext"},
+		{"setuptools Extension case-insensitive", briefJSON("native_extension:SETUPTOOLS EXTENSION"), "python-ext"},
+		// node-gyp is detected by brief but there is no node-ext profile yet;
+		// falls through to node via the package manager.
+		{"node-gyp with npm falls through to node", briefJSON("package_manager:npm", "native_extension:node-gyp"), "node"},
+
+		// build category
+		{"Rails selects ruby-rails", briefJSON("package_manager:Bundler", "build:Rails"), "ruby-rails"},
+		{"Rails without bundler still selects ruby-rails", briefJSON("build:Rails"), "ruby-rails"},
 		{
 			// A Rails app that also ships a native extension matches both
 			// ruby-rails and ruby-ext; ruby-ext wins on registry order, and
-			// since ruby-ext now also carries Brakeman (a superset of
-			// ruby-rails) that no longer drops Rails SAST.
-			name: "ruby-ext beats ruby-rails when a Rails app also ships a native ext (registry order)",
-			json: `{"package_managers":[{"name":"Bundler"}]}`,
-			setup: func(t *testing.T, dir string) {
-				writeFileAt(t, dir, "config/application.rb", "class Application < Rails::Application; end\n")
-				writeFileAt(t, dir, "ext/example/extconf.rb", "require 'mkmf'\n")
-			},
-			want: "ruby-ext",
+			// since ruby-ext also carries Brakeman (a superset of ruby-rails)
+			// that no longer drops Rails SAST.
+			"ruby-ext beats ruby-rails when both match (registry order)",
+			briefJSON("package_manager:Bundler", "build:Rails", "native_extension:mkmf"),
+			"ruby-ext",
+		},
+		{"Rake alone does not select ruby-rails", briefJSON("package_manager:Bundler", "build:Rake"), "ruby"},
+		{"CMake selects c-cpp", briefJSON("build:CMake"), "c-cpp"},
+		{"Make selects c-cpp", briefJSON("build:Make"), "c-cpp"},
+		{"Autotools selects c-cpp", briefJSON("build:Autotools"), "c-cpp"},
+		{"Meson selects c-cpp", briefJSON("build:Meson"), "c-cpp"},
+
+		// language fallbacks
+		{"Perl language matches perl (belt-and-braces for a *.pl-only dist)", briefJSON("language:Perl"), "perl"},
+		{"C language matches c-cpp", briefJSON("language:C"), "c-cpp"},
+		{"C++ language matches c-cpp", briefJSON("language:C++"), "c-cpp"},
+		{
+			// A CPAN dist that also commits a generated Makefile must still
+			// route to perl, not c-cpp: registry order and the cpanm/Perl
+			// selectors both come first.
+			"cpanm + Make picks perl over c-cpp (registry order)",
+			briefJSON("package_manager:cpanm", "language:Perl", "build:Make"),
+			"perl",
 		},
 		{
-			name:    "marker profile cannot match without srcDir",
-			json:    `{"package_managers":[]}`,
-			noSrcOK: true,
-			want:    "",
+			// A Bundler repo that also has a Makefile (common for gem
+			// build tasks) must not fall through to c-cpp.
+			"bundler + Make picks ruby over c-cpp",
+			briefJSON("package_manager:Bundler", "build:Make", "language:Ruby"),
+			"ruby",
 		},
+
+		// no-match cases
+		{"unknown ecosystem falls back to default", briefJSON("package_manager:CocoaPods"), ""},
+		{"empty brief output falls back to default", briefJSON(), ""},
+		{"unrelated tool category is ignored", briefJSON("test:RSpec"), ""},
+
+		// malformed / degraded input
+		{"invalid json is tolerated", `not json`, ""},
+		{"null package_managers is tolerated (perl via language)", `{"package_managers":null,"languages":[{"name":"Perl"}]}`, "perl"},
+		{"null tools is tolerated", `{"package_managers":[{"name":"Bundler"}],"tools":null}`, "ruby"},
+		{"nil brief output falls back to default", "", ""},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			dir := ""
-			if !tt.noSrcOK {
-				dir = t.TempDir()
-			}
-			if tt.setup != nil {
-				tt.setup(t, dir)
-			}
-			got := matchProfile([]byte(tt.json), dir)
+			got := matchProfile([]byte(tt.json))
 			if got.Name != tt.want {
-				t.Errorf("matchProfile = %q, want %q", got.Name, tt.want)
+				t.Errorf("matchProfile = %q, want %q (json=%s)", got.Name, tt.want, tt.json)
 			}
 		})
 	}
 }
 
-// TestWalkMarkerPresent_bounded locks the Walk matcher's depth bound: an
-// extconf.rb buried below markerWalkMaxDepth must not match (so a pathological
-// tree can't turn every repo into a ruby-ext candidate), while one within the
-// bound does.
-func TestWalkMarkerPresent_bounded(t *testing.T) {
-	m := ProfileMarker{Path: "ext/extconf.rb", Walk: true}
-
-	deep := t.TempDir()
-	rel := "ext/" + strings.Repeat("a/", markerWalkMaxDepth+2) + "extconf.rb"
-	writeFileAt(t, deep, rel, "require 'mkmf'\n")
-	if markerPresent(m, deep) {
-		t.Errorf("extconf.rb below depth %d should not match", markerWalkMaxDepth)
-	}
-
-	shallow := t.TempDir()
-	writeFileAt(t, shallow, "ext/example/extconf.rb", "require 'mkmf'\n")
-	if !markerPresent(m, shallow) {
-		t.Errorf("extconf.rb within depth bound should match")
-	}
-}
-
-// TestWalkMarkerPresent_fileCapAborts locks the file-count bound: once more
-// than maxFiles entries have been visited the walk aborts via SkipAll, so a
-// target sorted after the filler (only reached past the cap) is not found;
-// raising the cap by one finds it. Exercised through walkMarkerPresentBounded
-// so it needs a handful of files, not markerWalkMaxFiles of them.
-func TestWalkMarkerPresent_fileCapAborts(t *testing.T) {
-	m := ProfileMarker{Path: "ext/extconf.rb", Walk: true}
-	dir := t.TempDir()
-	// Filler files ("a00.txt"..) sort before the target ("extconf.rb"), so the
-	// target is visited only after all of them; WalkDir walks entries in
-	// lexical order, so a cap at the filler count trips before the match.
-	const filler = 5
-	for i := 0; i < filler; i++ {
-		writeFileAt(t, dir, fmt.Sprintf("ext/a%02d.txt", i), "x\n")
-	}
-	writeFileAt(t, dir, "ext/extconf.rb", "require 'mkmf'\n")
-
-	if walkMarkerPresentBounded(m, dir, markerWalkMaxDepth, filler) {
-		t.Errorf("walk should abort at the %d-file cap before reaching the target", filler)
-	}
-	if !walkMarkerPresentBounded(m, dir, markerWalkMaxDepth, filler+1) {
-		t.Errorf("with the cap above the file count the target should be found")
+// TestMatchProfile_everyProfileReachable derives one positive case per
+// registered profile from its own Detect entry, so a new profile is
+// exercised without a hand-added table row.
+func TestMatchProfile_everyProfileReachable(t *testing.T) {
+	for _, p := range builtinProfiles {
+		if len(p.Detect) == 0 || len(p.Detect[0].Names) == 0 {
+			t.Fatalf("profile %q has empty Detect (registrySanity should have caught this)", p.Name)
+		}
+		d := p.Detect[0]
+		got := matchProfile([]byte(briefJSON(d.Category + ":" + d.Names[0])))
+		// The match may be a more-specific earlier profile (e.g. asking for
+		// package_manager:Bundler when ruby-ext precedes ruby is impossible
+		// since ruby-ext keys on native_extension), so this asserts the
+		// input reaches p or something before it, never the default.
+		if got.Name == "" {
+			t.Errorf("profile %q: %s:%s matched nothing", p.Name, d.Category, d.Names[0])
+		}
 	}
 }
 
@@ -770,37 +330,26 @@ func TestEnsureImage_unknownBaseProfile(t *testing.T) {
 }
 
 // TestBuiltinProfiles_registrySanity guards the invariants matchProfile
-// and the validators rely on: every entry must have a name and either an
-// Ecosystem or at least one Marker, names must be unique, and ecosystems
-// must be unique case-insensitively (a duplicate would silently make
-// auto-detection resolve the wrong profile, with no other test failing).
-// Marker-only profiles legitimately have no Ecosystem and are excluded
-// from the ecosystem-uniqueness check. A profile that matches several
-// ecosystems (e.g. python, java) lists them via Ecosystems; every one is
-// checked for uniqueness against every other profile's.
+// and the validators rely on: every entry has a Name and a non-empty
+// Detect (an empty Detect would never match, making the profile dead
+// code), Names are unique, and no (category, name) selector appears in
+// two profiles where the later one could never win. BaseProfile /
+// FallbackProfile chains must resolve and be acyclic.
 func TestBuiltinProfiles_registrySanity(t *testing.T) {
 	names := map[string]bool{}
-	ecosystems := map[string]bool{}
 	for _, p := range builtinProfiles {
 		if p.Name == "" {
 			t.Error("profile with empty Name")
 		}
-		ecos := p.allEcosystems()
-		if len(ecos) == 0 && len(p.Markers) == 0 && len(p.AnyMarkers) == 0 {
-			t.Errorf("profile %q has no Ecosystem, Markers, or AnyMarkers", p.Name)
+		if len(p.Detect) == 0 {
+			t.Errorf("profile %q has empty Detect", p.Name)
 		}
 		if names[p.Name] {
 			t.Errorf("duplicate profile Name %q", p.Name)
 		}
 		names[p.Name] = true
-		for _, e := range ecos {
-			eco := strings.ToLower(e)
-			if ecosystems[eco] {
-				t.Errorf("duplicate profile Ecosystem %q (case-insensitive)", e)
-			}
-			ecosystems[eco] = true
-		}
 	}
+	assertProfileSelectorsUnique(t)
 	// Every BaseProfile must name another registered profile, so the FROM
 	// chain in EnsureImage resolves; a typo would otherwise silently build
 	// FROM the runner via ProfileByName's default fallback.
@@ -834,6 +383,31 @@ func TestBuiltinProfiles_registrySanity(t *testing.T) {
 	// slip through.
 	assertProfileChainAcyclic(t, "BaseProfile", func(p Profile) string { return p.BaseProfile })
 	assertProfileChainAcyclic(t, "FallbackProfile", func(p Profile) string { return p.FallbackProfile })
+}
+
+// assertProfileSelectorsUnique checks every BriefMatch is well-formed and no
+// (category, name) selector is claimed by more than one profile: a later
+// profile listing a selector an earlier one already owns can never win on
+// that selector alone (first-match-wins), so a duplicate is either a typo or
+// dead code. Kept out of TestBuiltinProfiles_registrySanity so its cognitive
+// complexity stays under the linter's cap.
+func assertProfileSelectorsUnique(t *testing.T) {
+	t.Helper()
+	selectors := map[[2]string]string{}
+	for _, p := range builtinProfiles {
+		for _, m := range p.Detect {
+			if m.Category == "" || len(m.Names) == 0 {
+				t.Errorf("profile %q has a BriefMatch with empty Category or Names", p.Name)
+			}
+			for _, n := range m.Names {
+				key := [2]string{m.Category, strings.ToLower(n)}
+				if prev, ok := selectors[key]; ok {
+					t.Errorf("profile %q: selector %s:%s already claimed by %q (later profile unreachable via this selector)", p.Name, m.Category, n, prev)
+				}
+				selectors[key] = p.Name
+			}
+		}
+	}
 }
 
 // assertProfileChainAcyclic walks the chain reached by next() from every

--- a/threatmodel.md
+++ b/threatmodel.md
@@ -94,7 +94,7 @@ Mitigation remaining: tag finding rows with their source job; render claude-sour
 
 Go's `html/template` auto-escapes all finding fields. `internal/web/jsontree.go` returns `template.HTML` but escapes every leaf through `html.EscapeString`. `internal/web/location.go` builds hrefs from `HTMLURL`, which is scheme-validated at the write site by `safeURL` (see T7).
 
-The two `html/template` XSS vulnerabilities (`GO-2026-4865`, `GO-2026-4603`) are fixed by `toolchain go1.26.2` in go.mod.
+The two `html/template` XSS vulnerabilities (`GO-2026-4865`, `GO-2026-4603`) are fixed by `toolchain go1.26.5` in go.mod.
 
 ### T7: Untrusted upstream metadata (mitigated)
 
@@ -114,11 +114,11 @@ No rate limiting on `POST /repositories`, no cap on clone size, no timeout on th
 
 ### T10: Stale Go toolchain (resolved)
 
-`go.mod` specifies `toolchain go1.26.2`. The Dockerfile builds with `golang:1.26.2-alpine`. All nine stdlib vulnerabilities are fixed.
+`go.mod` specifies `toolchain go1.26.5`. The Dockerfile builds with `golang:1.26.5-alpine`. All nine stdlib vulnerabilities are fixed.
 
 ### T11: Image supply chain (partially mitigated)
 
-Tool versions are pinned: `claude-code@2.1.173`, `semgrep==1.167.0`, `git-pkgs@v0.15.3`, `brief@v0.6.0`, `zizmor@1.26.1`. The final stage is `debian:trixie-slim`; the `golang:1.26-trixie` and `rust:1.96-trixie` builder stages are pinned by sha256 digest. The container runs as non-root user `runner`. The runner image is built in CI, smoke-tested, and published to GHCR; users pull a known-good artifact rather than rebuilding against live registries.
+Tool versions are pinned: `claude-code@2.1.173`, `semgrep==1.167.0`, `git-pkgs@v0.15.3`, `brief@v0.9.3`, `zizmor@1.26.1`. The final stage is `debian:trixie-slim`; the `golang:1.26.5-trixie` and `rust:1.96-trixie` builder stages are pinned by sha256 digest. The container runs as non-root user `runner`. The runner image is built in CI, smoke-tested, and published to GHCR; users pull a known-good artifact rather than rebuilding against live registries.
 
 Supply-chain surface in the final stage:
 - `apt` pulls from Debian's official mirrors plus the GitHub CLI repo at `cli.github.com/packages` (signed-by keyring under `/etc/apt/keyrings/`). `gh` is used at scan time by the `fork` and `report-upstream` skills.
@@ -183,7 +183,7 @@ GORM usage is consistently parameterised; no `Raw`, no string-built `Where`, and
 - [x] `io.LimitReader` (10 MB cap) on all ecosyste.ms response bodies (T7).
 - [x] `safeURL` validation on HTMLURL and IconURL before storing (T7).
 - [x] `0700` on the data directory at startup (T8).
-- [x] `toolchain go1.26.2` in go.mod so host builds match the image (T10).
+- [x] `toolchain go1.26.5` in go.mod so host builds match the image (T10).
 - [x] Pin tool versions in Dockerfile: claude-code, semgrep, git-pkgs, brief, zizmor (T11).
 - [x] Non-root `USER runner` in Dockerfile (T11).
 - [x] Trim final Docker stage: `npm` absent, `pip` scoped to the `/opt/semgrep` venv, `curl` retained for build- and scan-time fetches (T11).


### PR DESCRIPTION
Profile selection now matches against brief's `package_managers`, `languages`, and `tools[category]` output instead of only `package_managers[].name` plus a local file-marker engine. brief v0.9.3 (bumped in both Dockerfiles from v0.6.0) reports Rails under `tools.build`, CMake/Make/Autotools/Meson under `tools.build`, cpanm under `package_managers`, and mkmf/phpize/node-gyp/setuptools-Extension under the new `tools.native_extension` category, so the six profiles that previously carried `ProfileMarker` checks now key on brief detections like the other nine.

`Profile.Ecosystem`/`Ecosystems`/`Markers`/`AnyMarkers` are replaced by `Detect []BriefMatch{Category, Names}`. `matchProfile` drops its `srcDir` parameter. The `ProfileMarker` type and its matching engine (`markersMatch`, `anyMarkersMatch`, `markerPresent`, `walkMarkerPresent*`, `fileContains`, walk-bound constants) are deleted.

Alongside the mechanism swap:
- `node` now also matches pnpm/Yarn/Bun; `python` also setuptools; `dotnet` also `dotnet CLI` (brief reports these as distinct managers so the single-name match was missing repos)
- `python-ext` gains `FallbackProfile: "python"` for parity with `ruby-ext`
- `perl` matches via `cpanm` or the Perl language; `c-cpp` via the four build tools or the C/C++ language
- a brief exec failure degrades to the default runner rather than a partial host-side marker match

`TestMatchProfile` is rewritten as a pure table over brief JSON (63 cases); `TestMatchProfile_everyProfileReachable` derives one case per registered profile; `TestBuiltinProfiles_registrySanity` checks non-empty `Detect` and unique `(category, name)` selectors. `TestResolveProfile_SubPath` now stubs detection via a new unexported `ContainerRunner.detectProfile` field since the host-side marker fallback it relied on is gone.

Not done: importing `github.com/git-pkgs/brief/detect` in-process. brief's `go.mod` carries golangci-lint as a `tool` directive plus outline/forge/registries, which would add ~180 indirect modules including protobuf and cobra; keeping the container exec avoids that.

Net -596 lines. Upstream: git-pkgs/brief#108 (v0.9.3), ecosyste-ms/oss-taxonomy#19.