### PR TITLE
Add evidence and negative assertions to skill evals

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -21,10 +21,24 @@ Each scenario YAML names:
 - `skill`: bundled skill to execute.
 - `should_find`: required findings the report must include.
 - `should_not_find`: false positives the report must not include.
-- `evidence_contains`: terms that must appear in the matched finding's title,
-  location, or narrative fields (`trace`, `boundary`, `validation`, `rating`).
 - `must_not_contain`: repo-level terms that must not appear anywhere in the
   report, such as an out-of-scope framework or nonexistent file.
+
+Each `should_find` or `should_not_find` assertion may include
+`evidence_contains`:
+
+```yaml
+should_find:
+  - finding: SQL injection
+    evidence_contains:
+      - buildQuery
+      - request.args
+```
+
+Every evidence term must appear in the matched finding's title, location,
+locations, or narrative fields: `trace`, `boundary`, `validation`, `rating`,
+`description`, `affected`, `prior_art`, or `reach`. CWE values are match
+criteria, not evidence.
 
 The default judge matches findings by title substring plus optional severity,
 CWE, path, and evidence. These assertions define a minimum bar: additional

--- a/evals/README.md
+++ b/evals/README.md
@@ -21,7 +21,13 @@ Each scenario YAML names:
 - `skill`: bundled skill to execute.
 - `should_find`: required findings the report must include.
 - `should_not_find`: false positives the report must not include.
+- `evidence_contains`: terms that must appear in the matched finding's title,
+  location, or narrative fields (`trace`, `boundary`, `validation`, `rating`).
+- `must_not_contain`: repo-level terms that must not appear anywhere in the
+  report, such as an out-of-scope framework or nonexistent file.
 
 The default judge matches findings by title substring plus optional severity,
-CWE, and path. Model-backed judging can be plugged in by implementing
-`evals.Judge`.
+CWE, path, and evidence. These assertions define a minimum bar: additional
+findings do not fail an eval unless they match `should_not_find` or the report
+contains a `must_not_contain` term. Model-backed judging can be plugged in by
+implementing `evals.Judge`.

--- a/evals/security-deep-dive-sqli.yaml
+++ b/evals/security-deep-dive-sqli.yaml
@@ -6,7 +6,11 @@ should_find:
     severity: High
     cwe: CWE-89
     path: app.py
+    evidence_contains:
+      - buildQuery
     required: true
 should_not_find:
   - finding: unused import
     path: app.py
+must_not_contain:
+  - Rails::ActiveRecord

--- a/internal/evals/evals_test.go
+++ b/internal/evals/evals_test.go
@@ -38,8 +38,12 @@ fixture: fixtures/x
 skill: security-deep-dive
 should_find:
   - finding: required by default
+    evidence_contains:
+      - buildQuery
   - finding: optional miss
     required: false
+must_not_contain:
+  - Rails::ActiveRecord
 `), 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -52,6 +56,12 @@ should_find:
 	}
 	if sc.ShouldFind[1].Required {
 		t.Fatal("explicit required:false should stay optional")
+	}
+	if got := sc.ShouldFind[0].Evidence; len(got) != 1 || got[0] != "buildQuery" {
+		t.Fatalf("evidence_contains = %#v, want [buildQuery]", got)
+	}
+	if got := sc.MustNotContain; len(got) != 1 || got[0] != "Rails::ActiveRecord" {
+		t.Fatalf("must_not_contain = %#v, want [Rails::ActiveRecord]", got)
 	}
 }
 
@@ -116,6 +126,30 @@ func TestScenarioValidate(t *testing.T) {
 				ShouldNotFind: []Assertion{{}},
 			},
 		},
+		{
+			name: "blank evidence term",
+			sc: Scenario{
+				Path:    "case.yaml",
+				Given:   "x",
+				Fixture: "fixtures/x",
+				Skill:   "security-deep-dive",
+				ShouldFind: []Assertion{{
+					Finding:  "x",
+					Evidence: []string{""},
+				}},
+			},
+		},
+		{
+			name: "blank must_not_contain term",
+			sc: Scenario{
+				Path:           "case.yaml",
+				Given:          "x",
+				Fixture:        "fixtures/x",
+				Skill:          "security-deep-dive",
+				ShouldFind:     []Assertion{{Finding: "x"}},
+				MustNotContain: []string{""},
+			},
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -133,11 +167,12 @@ func TestHeuristicJudge(t *testing.T) {
 			Severity: "High",
 			CWE:      "CWE-89",
 			Path:     "app.py",
+			Evidence: []string{"buildQuery", "username parameter"},
 			Required: true,
 		}},
 		ShouldNotFind: []Assertion{{Finding: "unused import"}},
 	}
-	report := `{"findings":[{"title":"SQL injection in build_query","severity":"High","cwe":"CWE-89","location":"app.py:8"}]}`
+	report := `{"findings":[{"title":"SQL injection in buildQuery","severity":"High","cwe":"CWE-89","location":"app.py:8","trace":"The username parameter reaches buildQuery."}]}`
 	got, err := (HeuristicJudge{}).Judge(sc, report)
 	if err != nil {
 		t.Fatal(err)
@@ -165,6 +200,8 @@ func TestAssertionMatchesFinding(t *testing.T) {
 		{name: "severity mismatch", a: Assertion{Severity: "Low"}, want: false},
 		{name: "cwe mismatch", a: Assertion{CWE: "CWE-78"}, want: false},
 		{name: "path mismatch", a: Assertion{Path: "other.py"}, want: false},
+		{name: "evidence match", a: Assertion{Evidence: []string{"buildQuery"}}, want: true},
+		{name: "evidence mismatch", a: Assertion{Evidence: []string{"missing function"}}, want: false},
 		{
 			name: "path avoids file prefix false positive",
 			a:    Assertion{Path: "app.py"},
@@ -188,6 +225,27 @@ func TestAssertionMatchesFinding(t *testing.T) {
 				t.Fatalf("assertionMatchesFinding() = %v, want %v", got, tc.want)
 			}
 		})
+	}
+}
+
+func TestHeuristicJudgeMustNotContain(t *testing.T) {
+	sc := Scenario{MustNotContain: []string{"Rails::ActiveRecord", "ghost.py"}}
+	passingReport := `{"findings":[{"title":"SQL injection","location":"app.py:7"}]}`
+	got, err := (HeuristicJudge{}).Judge(sc, passingReport)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 || !got[0].Matched || !got[1].Matched {
+		t.Fatalf("must_not_contain should pass: %+v", got)
+	}
+
+	failingReport := `{"findings":[],"summary":"Rails::ActiveRecord is in scope"}`
+	got, err = (HeuristicJudge{}).Judge(sc, failingReport)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got[0].Matched || !strings.Contains(got[0].Reason, "unexpectedly contains") {
+		t.Fatalf("must_not_contain should fail: %+v", got[0])
 	}
 }
 
@@ -250,6 +308,27 @@ func TestRunnerRejectsSchemaInvalidReport(t *testing.T) {
 	_, err = r.RunScenario(context.Background(), sc)
 	if err == nil || !strings.Contains(err.Error(), "failed schema validation") {
 		t.Fatalf("RunScenario error = %v, want schema validation failure", err)
+	}
+}
+
+func TestRunnerCountsMustNotContainFailure(t *testing.T) {
+	sc, err := LoadScenario("../../evals/security-deep-dive-sqli.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	sc.MustNotContain = []string{"username parameter"}
+	r := Runner{
+		Runner:     fakeSkillRunner{report: validDeepDiveReport()},
+		SkillsRoot: "../../skills",
+		EvalsRoot:  "../../evals",
+		WorkRoot:   t.TempDir(),
+	}
+	res, err := r.RunScenario(context.Background(), sc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Unexpected != 1 {
+		t.Fatalf("unexpected = %d, want 1: %+v", res.Unexpected, res.Matches)
 	}
 }
 

--- a/internal/evals/evals_test.go
+++ b/internal/evals/evals_test.go
@@ -160,6 +160,36 @@ func TestScenarioValidate(t *testing.T) {
 	}
 }
 
+func TestScenarioValidateAllowsMustNotContainOnly(t *testing.T) {
+	sc := Scenario{
+		Path:           "case.yaml",
+		Given:          "x",
+		Fixture:        "fixtures/x",
+		Skill:          "security-deep-dive",
+		MustNotContain: []string{"Rails::ActiveRecord"},
+	}
+	if err := sc.validate(); err != nil {
+		t.Fatalf("validate() = %v, want nil", err)
+	}
+}
+
+func TestScenarioValidateNamesInvalidAssertion(t *testing.T) {
+	sc := Scenario{
+		Path:    "case.yaml",
+		Given:   "x",
+		Fixture: "fixtures/x",
+		Skill:   "security-deep-dive",
+		ShouldFind: []Assertion{{
+			Finding:  "SQL injection",
+			Evidence: []string{""},
+		}},
+	}
+	err := sc.validate()
+	if err == nil || !strings.Contains(err.Error(), "should_find[0] (SQL injection)") {
+		t.Fatalf("validate() = %v, want assertion index and label", err)
+	}
+}
+
 func TestHeuristicJudge(t *testing.T) {
 	sc := Scenario{
 		ShouldFind: []Assertion{{
@@ -202,6 +232,7 @@ func TestAssertionMatchesFinding(t *testing.T) {
 		{name: "path mismatch", a: Assertion{Path: "other.py"}, want: false},
 		{name: "evidence match", a: Assertion{Evidence: []string{"buildQuery"}}, want: true},
 		{name: "evidence mismatch", a: Assertion{Evidence: []string{"missing function"}}, want: false},
+		{name: "CWE is not evidence", a: Assertion{Evidence: []string{"CWE-89"}}, want: false},
 		{
 			name: "path avoids file prefix false positive",
 			a:    Assertion{Path: "app.py"},

--- a/internal/evals/judge.go
+++ b/internal/evals/judge.go
@@ -103,7 +103,7 @@ func findingHasEvidence(f Finding, terms []string) bool {
 		return true
 	}
 	evidence := strings.Join([]string{
-		f.Title, f.CWE, f.Location, strings.Join(f.Locations, "\n"),
+		f.Title, f.Location, strings.Join(f.Locations, "\n"),
 		f.Trace, f.Boundary, f.Validation, f.Rating, f.Description,
 		f.Affected, f.PriorArt, f.Reach,
 	}, "\n")

--- a/internal/evals/judge.go
+++ b/internal/evals/judge.go
@@ -11,8 +11,9 @@ import (
 )
 
 const (
-	assertionShouldFind    = "should_find"
-	assertionShouldNotFind = "should_not_find"
+	assertionShouldFind     = "should_find"
+	assertionShouldNotFind  = "should_not_find"
+	assertionMustNotContain = "must_not_contain"
 )
 
 // Judge scores a skill report against one scenario. Model-backed judges can
@@ -28,7 +29,7 @@ func (HeuristicJudge) Judge(sc Scenario, raw string) ([]AssertionResult, error) 
 	if err != nil {
 		return nil, err
 	}
-	results := make([]AssertionResult, 0, len(sc.ShouldFind)+len(sc.ShouldNotFind))
+	results := make([]AssertionResult, 0, len(sc.ShouldFind)+len(sc.ShouldNotFind)+len(sc.MustNotContain))
 	for _, a := range sc.ShouldFind {
 		match := matchingFinding(a, findings)
 		results = append(results, AssertionResult{
@@ -47,6 +48,15 @@ func (HeuristicJudge) Judge(sc Scenario, raw string) ([]AssertionResult, error) 
 			Matched:   match == nil,
 			Required:  true,
 			Reason:    notFindReason(match),
+		})
+	}
+	for _, term := range sc.MustNotContain {
+		results = append(results, AssertionResult{
+			Assertion: Assertion{Finding: term},
+			Kind:      assertionMustNotContain,
+			Matched:   !containsFold(raw, term),
+			Required:  true,
+			Reason:    mustNotContainReason(raw, term),
 		})
 	}
 	return results, nil
@@ -82,6 +92,26 @@ func assertionMatchesFinding(a Assertion, f Finding) bool {
 	if a.Path != "" && !findingHasPath(f, a.Path) {
 		return false
 	}
+	if !findingHasEvidence(f, a.Evidence) {
+		return false
+	}
+	return true
+}
+
+func findingHasEvidence(f Finding, terms []string) bool {
+	if len(terms) == 0 {
+		return true
+	}
+	evidence := strings.Join([]string{
+		f.Title, f.CWE, f.Location, strings.Join(f.Locations, "\n"),
+		f.Trace, f.Boundary, f.Validation, f.Rating, f.Description,
+		f.Affected, f.PriorArt, f.Reach,
+	}, "\n")
+	for _, term := range terms {
+		if !containsFold(evidence, term) {
+			return false
+		}
+	}
 	return true
 }
 
@@ -112,4 +142,11 @@ func notFindReason(f *Finding) string {
 		return "no matching finding emitted"
 	}
 	return fmt.Sprintf("unexpected finding %q at %s", f.Title, f.Location)
+}
+
+func mustNotContainReason(report, term string) string {
+	if !containsFold(report, term) {
+		return fmt.Sprintf("report does not contain %q", term)
+	}
+	return fmt.Sprintf("report unexpectedly contains %q", term)
 }

--- a/internal/evals/runner.go
+++ b/internal/evals/runner.go
@@ -123,7 +123,7 @@ func (r Runner) RunScenario(ctx context.Context, sc Scenario) (Result, error) {
 			result.FailedRequired++
 		case !m.Matched && m.Kind == assertionShouldFind:
 			result.OptionalMisses++
-		case !m.Matched && m.Kind == assertionShouldNotFind:
+		case !m.Matched && (m.Kind == assertionShouldNotFind || m.Kind == assertionMustNotContain):
 			result.Unexpected++
 		}
 	}

--- a/internal/evals/types.go
+++ b/internal/evals/types.go
@@ -12,22 +12,24 @@ import (
 // Scenario is one YAML eval file under evals/. It points at a fixture
 // repository and names the skill whose output should be judged.
 type Scenario struct {
-	Path          string      `yaml:"-"`
-	Given         string      `yaml:"given"`
-	Fixture       string      `yaml:"fixture"`
-	Skill         string      `yaml:"skill"`
-	ShouldFind    []Assertion `yaml:"should_find"`
-	ShouldNotFind []Assertion `yaml:"should_not_find"`
+	Path           string      `yaml:"-"`
+	Given          string      `yaml:"given"`
+	Fixture        string      `yaml:"fixture"`
+	Skill          string      `yaml:"skill"`
+	ShouldFind     []Assertion `yaml:"should_find"`
+	ShouldNotFind  []Assertion `yaml:"should_not_find"`
+	MustNotContain []string    `yaml:"must_not_contain"`
 }
 
 // Assertion describes one expected positive or negative condition. Negative
 // assertions may be a scalar string in YAML; positives usually use fields.
 type Assertion struct {
-	Finding     string `yaml:"finding"`
-	Severity    string `yaml:"severity"`
-	CWE         string `yaml:"cwe"`
-	Path        string `yaml:"path"`
-	Required    bool   `yaml:"required"`
+	Finding     string   `yaml:"finding"`
+	Severity    string   `yaml:"severity"`
+	CWE         string   `yaml:"cwe"`
+	Path        string   `yaml:"path"`
+	Evidence    []string `yaml:"evidence_contains"`
+	Required    bool     `yaml:"required"`
 	requiredSet bool
 }
 
@@ -38,17 +40,18 @@ func (a *Assertion) UnmarshalYAML(value *yaml.Node) error {
 	}
 	for i := 0; i+1 < len(value.Content); i += 2 {
 		switch value.Content[i].Value {
-		case "finding", "severity", "cwe", "path", "required":
+		case "finding", "severity", "cwe", "path", "evidence_contains", "required":
 		default:
 			return fmt.Errorf("unknown assertion field %q", value.Content[i].Value)
 		}
 	}
 	var out struct {
-		Finding  string `yaml:"finding"`
-		Severity string `yaml:"severity"`
-		CWE      string `yaml:"cwe"`
-		Path     string `yaml:"path"`
-		Required *bool  `yaml:"required"`
+		Finding  string   `yaml:"finding"`
+		Severity string   `yaml:"severity"`
+		CWE      string   `yaml:"cwe"`
+		Path     string   `yaml:"path"`
+		Evidence []string `yaml:"evidence_contains"`
+		Required *bool    `yaml:"required"`
 	}
 	if err := value.Decode(&out); err != nil {
 		return err
@@ -57,6 +60,7 @@ func (a *Assertion) UnmarshalYAML(value *yaml.Node) error {
 	a.Severity = out.Severity
 	a.CWE = out.CWE
 	a.Path = out.Path
+	a.Evidence = out.Evidence
 	if out.Required != nil {
 		a.Required = *out.Required
 		a.requiredSet = true
@@ -99,6 +103,19 @@ func (s Scenario) validate() error {
 		if a.empty() {
 			return fmt.Errorf("%s has an empty should_not_find assertion", s.Path)
 		}
+		if err := a.validateEvidence(); err != nil {
+			return fmt.Errorf("%s has invalid should_not_find evidence_contains: %w", s.Path, err)
+		}
+	}
+	for _, a := range s.ShouldFind {
+		if err := a.validateEvidence(); err != nil {
+			return fmt.Errorf("%s has invalid should_find evidence_contains: %w", s.Path, err)
+		}
+	}
+	for _, term := range s.MustNotContain {
+		if strings.TrimSpace(term) == "" {
+			return fmt.Errorf("%s has an empty must_not_contain term", s.Path)
+		}
 	}
 	return nil
 }
@@ -107,16 +124,34 @@ func (a Assertion) empty() bool {
 	return strings.TrimSpace(a.Finding) == "" &&
 		strings.TrimSpace(a.Severity) == "" &&
 		strings.TrimSpace(a.CWE) == "" &&
-		strings.TrimSpace(a.Path) == ""
+		strings.TrimSpace(a.Path) == "" &&
+		len(a.Evidence) == 0
+}
+
+func (a Assertion) validateEvidence() error {
+	for _, term := range a.Evidence {
+		if strings.TrimSpace(term) == "" {
+			return fmt.Errorf("empty term")
+		}
+	}
+	return nil
 }
 
 // Finding is the subset of report.json finding fields the eval judge needs.
 type Finding struct {
-	Title     string   `json:"title"`
-	Severity  string   `json:"severity"`
-	CWE       string   `json:"cwe"`
-	Location  string   `json:"location"`
-	Locations []string `json:"locations"`
+	Title       string   `json:"title"`
+	Severity    string   `json:"severity"`
+	CWE         string   `json:"cwe"`
+	Location    string   `json:"location"`
+	Locations   []string `json:"locations"`
+	Trace       string   `json:"trace"`
+	Boundary    string   `json:"boundary"`
+	Validation  string   `json:"validation"`
+	Rating      string   `json:"rating"`
+	Description string   `json:"description"`
+	Affected    string   `json:"affected"`
+	PriorArt    string   `json:"prior_art"`
+	Reach       string   `json:"reach"`
 }
 
 type report struct {

--- a/internal/evals/types.go
+++ b/internal/evals/types.go
@@ -74,6 +74,11 @@ func (a Assertion) label() string {
 			return strings.TrimSpace(v)
 		}
 	}
+	for _, term := range a.Evidence {
+		if strings.TrimSpace(term) != "" {
+			return strings.TrimSpace(term)
+		}
+	}
 	return "<empty assertion>"
 }
 
@@ -91,30 +96,30 @@ func (s Scenario) validate() error {
 	if len(missing) > 0 {
 		return fmt.Errorf("%s missing %s", s.Path, strings.Join(missing, ", "))
 	}
-	if len(s.ShouldFind) == 0 && len(s.ShouldNotFind) == 0 {
+	if len(s.ShouldFind) == 0 && len(s.ShouldNotFind) == 0 && len(s.MustNotContain) == 0 {
 		return fmt.Errorf("%s has no assertions", s.Path)
 	}
-	for _, a := range s.ShouldFind {
-		if a.empty() {
-			return fmt.Errorf("%s has an empty should_find assertion", s.Path)
-		}
+	if err := validateAssertions(s.Path, assertionShouldFind, s.ShouldFind); err != nil {
+		return err
 	}
-	for _, a := range s.ShouldNotFind {
-		if a.empty() {
-			return fmt.Errorf("%s has an empty should_not_find assertion", s.Path)
-		}
-		if err := a.validateEvidence(); err != nil {
-			return fmt.Errorf("%s has invalid should_not_find evidence_contains: %w", s.Path, err)
-		}
+	if err := validateAssertions(s.Path, assertionShouldNotFind, s.ShouldNotFind); err != nil {
+		return err
 	}
-	for _, a := range s.ShouldFind {
-		if err := a.validateEvidence(); err != nil {
-			return fmt.Errorf("%s has invalid should_find evidence_contains: %w", s.Path, err)
-		}
-	}
-	for _, term := range s.MustNotContain {
+	for i, term := range s.MustNotContain {
 		if strings.TrimSpace(term) == "" {
-			return fmt.Errorf("%s has an empty must_not_contain term", s.Path)
+			return fmt.Errorf("%s must_not_contain[%d]: empty term", s.Path, i)
+		}
+	}
+	return nil
+}
+
+func validateAssertions(path, kind string, assertions []Assertion) error {
+	for i, a := range assertions {
+		if a.empty() {
+			return fmt.Errorf("%s %s[%d] (%s): empty assertion", path, kind, i, a.label())
+		}
+		if err := a.validateEvidence(); err != nil {
+			return fmt.Errorf("%s %s[%d] (%s): invalid evidence_contains: %w", path, kind, i, a.label(), err)
 		}
 	}
 	return nil


### PR DESCRIPTION
Fixes #114

## Summary

Strengthens the fixture-driven skill eval rubric so expected findings require concrete supporting evidence and reports can be rejected for repo-level hallucinations.

## Changes

- Add `evidence_contains` to `should_find` and `should_not_find` assertions
- Require every evidence term to appear in the matched finding's title, location, or narrative fields
- Add scenario-level `must_not_contain` terms checked against the complete report
- Reject blank evidence and forbidden-term entries during scenario validation
- Update the SQLi seed scenario with evidence and an out-of-scope framework guard
- Document the new YAML fields and clarify that evals define a minimum recall floor: additional findings remain allowed unless explicitly prohibited
- Add focused loader, judge and runner tests for passing and failing evidence/forbidden-term cases

## Tests

- `go test ./...`
- `go test -tags evals ./...`
- `go vet ./...`
- `go vet -tags evals ./...`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run ./cmd/... ./internal/...`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --build-tags evals ./cmd/... ./internal/...`
- `git diff --check`