### PR TITLE
Add repository scan configuration

### DIFF
--- a/docs/database.md
+++ b/docs/database.md
@@ -46,6 +46,7 @@ The central entity. One row per git URL.
 | clone_error | text | Last clone/fetch failure message; non-empty means the repo is currently unreachable. Cleared on next successful clone. |
 | disk_bytes | integer | Cached on-disk size of the persistent clone cache, so the repo list renders the disk badge from a column instead of walking each repo's cache per row. Refreshed by the worker after each scan and backfilled once at startup; 0 for local repos and remote repos not scanned since the column was added. |
 | threat_model | text | Operator's working-copy threat-model JSON. When set, the worker writes it to `./threat_model.json` in every skill workspace and `security-deep-dive` loads it instead of fetching the latest `threat-model` scan. Edited via the threat-model workbench tab. Empty = no override. |
+| scan_config | text | Analyst-authored YAML with `focus_areas`, `known_bugs`, `attack_surface`, and `skip` patterns. Validated by the repository editor, staged as `scrutineer.scan_config` in every skill workspace, and its `skip` patterns layer onto each skill's path-filter deny list. Empty = no repository-specific guidance. |
 | created_at | datetime | |
 | updated_at | datetime | |
 

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -199,12 +199,18 @@ The worker then runs `claude -p "Use the {name} skill in this workspace"` with t
       "coverage_metadata_key": "coverage"
     },
     "fork_org": "your-security-forks",
-    "metadata_dir": ".scrutineer/"
+    "metadata_dir": ".scrutineer/",
+    "scan_config": {
+      "focus_areas": [{"name": "parser", "paths": ["src/parse/**"], "surface": "accepts arbitrary bytes"}],
+      "known_bugs": ["GHSA-xxxx-yyyy"],
+      "attack_surface": "stdin is attacker controlled",
+      "skip": ["tests/**"]
+    }
   }
 }
 ```
 
-`finding_id` is only present for finding-scoped skills (`verify`, `revalidate`, `breaking-change`, `disclose`, `patch`, `mitigate`, `public-issue`, `release-watch`, `exposure`). `dependent_id` is only set on `exposure` runs and points to the dependent whose code is under audit; `./src` is then a copy of that dependent's clone, not of the finding's repository. `scan_ref` is empty when the scan is on the default branch. `scan_subpath` is set when the operator scoped the scan to a monorepo sub-folder; skills that walk source honour it, skills that query external APIs by repository URL ignore it. `scan_group` is set when the scan is one of a parallel batch (Scan-all-subprojects, a single New-scan run, or a Diff rescan group); an audit skill passes it to `/repositories/{id}/findings?scan_group=...` to read what its siblings have already filed before reporting its own, and is absent otherwise. `rescan` is present only for diff rescans; the worker stages `diff.patch`, `changed_files.json`, and, when available, `old_threat_model.json` in the workspace root. `fork_org` is absent unless `-fork-org` is configured. `metadata_dir` is the directory inside a staging repo where scrutineer keeps its per-project metadata (`.scrutineer/` by default); operators with a different consortium-flavoured convention set `metadata_dir` in scrutineer.yaml. `packages` is a convenience copy of the package rows when the `packages` skill has already run; otherwise it is omitted.
+`finding_id` is only present for finding-scoped skills (`verify`, `revalidate`, `breaking-change`, `disclose`, `patch`, `mitigate`, `public-issue`, `release-watch`, `exposure`). `dependent_id` is only set on `exposure` runs and points to the dependent whose code is under audit; `./src` is then a copy of that dependent's clone, not of the finding's repository. `scan_ref` is empty when the scan is on the default branch. `scan_subpath` is set when the operator scoped the scan to a monorepo sub-folder; skills that walk source honour it, skills that query external APIs by repository URL ignore it. `scan_group` is set when the scan is one of a parallel batch (Scan-all-subprojects, a single New-scan run, or a Diff rescan group); an audit skill passes it to `/repositories/{id}/findings?scan_group=...` to read what its siblings have already filed before reporting its own, and is absent otherwise. `rescan` is present only for diff rescans; the worker stages `diff.patch`, `changed_files.json`, and, when available, `old_threat_model.json` in the workspace root. `fork_org` is absent unless `-fork-org` is configured. `metadata_dir` is the directory inside a staging repo where scrutineer keeps its per-project metadata (`.scrutineer/` by default); operators with a different consortium-flavoured convention set `metadata_dir` in scrutineer.yaml. `scan_config` is present only when an analyst saved repository guidance; `skip` patterns are already removed from `./src`, and audit skills use its focus areas, known bugs, and attack-surface statement as review context. `packages` is a convenience copy of the package rows when the `packages` skill has already run; otherwise it is omitted.
 
 ## schema.json
 

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -103,6 +103,11 @@ type Repository struct {
 	// workbench tab; empty means no override.
 	ThreatModel string `gorm:"type:text"`
 
+	// ScanConfig is analyst-authored YAML that narrows and explains the
+	// repository's security review. The worker validates and stages it as
+	// scrutineer.scan_config in every skill workspace.
+	ScanConfig string `gorm:"type:text"`
+
 	CreatedAt time.Time
 	UpdatedAt time.Time
 

--- a/internal/repoconfig/config.go
+++ b/internal/repoconfig/config.go
@@ -4,6 +4,7 @@ package repoconfig
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"path"
@@ -44,7 +45,7 @@ func Parse(raw string) (Config, error) {
 		return Config{}, err
 	}
 	var extra any
-	if err := dec.Decode(&extra); err != io.EOF {
+	if err := dec.Decode(&extra); !errors.Is(err, io.EOF) {
 		if err == nil {
 			return Config{}, fmt.Errorf("multiple YAML documents are not supported")
 		}

--- a/internal/repoconfig/config.go
+++ b/internal/repoconfig/config.go
@@ -1,0 +1,129 @@
+// Package repoconfig parses the analyst-authored scan configuration attached
+// to a repository.
+package repoconfig
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"path"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	"scrutineer/internal/skills"
+)
+
+// Config is the durable, repository-specific input to model-backed scans.
+// It is stored as YAML on db.Repository and staged as JSON in context.json.
+type Config struct {
+	FocusAreas    []FocusArea `yaml:"focus_areas,omitempty" json:"focus_areas,omitempty"`
+	KnownBugs     []string    `yaml:"known_bugs,omitempty" json:"known_bugs,omitempty"`
+	AttackSurface string      `yaml:"attack_surface,omitempty" json:"attack_surface,omitempty"`
+	Skip          []string    `yaml:"skip,omitempty" json:"skip,omitempty"`
+}
+
+// FocusArea is an analyst-defined code region and the security property worth
+// investigating there.
+type FocusArea struct {
+	Name    string   `yaml:"name" json:"name"`
+	Paths   []string `yaml:"paths" json:"paths"`
+	Surface string   `yaml:"surface" json:"surface"`
+}
+
+// Parse decodes and validates the YAML stored on a repository. Empty input is
+// an intentionally unconfigured repository.
+func Parse(raw string) (Config, error) {
+	if strings.TrimSpace(raw) == "" {
+		return Config{}, nil
+	}
+	dec := yaml.NewDecoder(bytes.NewBufferString(raw))
+	dec.KnownFields(true)
+	var cfg Config
+	if err := dec.Decode(&cfg); err != nil {
+		return Config{}, err
+	}
+	var extra any
+	if err := dec.Decode(&extra); err != io.EOF {
+		if err == nil {
+			return Config{}, fmt.Errorf("multiple YAML documents are not supported")
+		}
+		return Config{}, err
+	}
+	if err := cfg.validate(); err != nil {
+		return Config{}, err
+	}
+	return cfg, nil
+}
+
+// Normalise validates YAML and returns its stable, readable representation
+// together with the parsed value. Empty input clears the configuration.
+func Normalise(raw string) (string, Config, error) {
+	cfg, err := Parse(raw)
+	if err != nil {
+		return "", Config{}, err
+	}
+	if cfg.Empty() {
+		return "", cfg, nil
+	}
+	b, err := yaml.Marshal(cfg)
+	if err != nil {
+		return "", Config{}, err
+	}
+	return string(b), cfg, nil
+}
+
+// Empty reports whether no repository-specific scan guidance is configured.
+func (c Config) Empty() bool {
+	return len(c.FocusAreas) == 0 && len(c.KnownBugs) == 0 &&
+		strings.TrimSpace(c.AttackSurface) == "" && len(c.Skip) == 0
+}
+
+func (c Config) validate() error {
+	for i, area := range c.FocusAreas {
+		if strings.TrimSpace(area.Name) == "" {
+			return fmt.Errorf("focus_areas[%d].name is required", i)
+		}
+		if len(area.Paths) == 0 {
+			return fmt.Errorf("focus_areas[%d].paths is required", i)
+		}
+		if strings.TrimSpace(area.Surface) == "" {
+			return fmt.Errorf("focus_areas[%d].surface is required", i)
+		}
+		if err := validatePatterns(fmt.Sprintf("focus_areas[%d].paths", i), area.Paths); err != nil {
+			return err
+		}
+	}
+	for i, bug := range c.KnownBugs {
+		if strings.TrimSpace(bug) == "" {
+			return fmt.Errorf("known_bugs[%d] is empty", i)
+		}
+	}
+	return validatePatterns("skip", c.Skip)
+}
+
+func validatePatterns(field string, patterns []string) error {
+	for i := range patterns {
+		pattern := patterns[i]
+		pattern = strings.TrimSpace(strings.ReplaceAll(pattern, "\\", "/"))
+		patterns[i] = pattern
+		if pattern == "" {
+			return fmt.Errorf("%s[%d] is empty", field, i)
+		}
+		if path.IsAbs(pattern) || hasWindowsVolume(pattern) || hasParentPathSegment(pattern) {
+			return fmt.Errorf("%s[%d] must be relative to the repository root", field, i)
+		}
+		if err := skills.ValidateGlob(pattern); err != nil {
+			return fmt.Errorf("%s[%d] is not a valid glob: %w", field, i, err)
+		}
+	}
+	return nil
+}
+
+func hasWindowsVolume(p string) bool {
+	return len(p) >= 2 && p[1] == ':'
+}
+
+func hasParentPathSegment(p string) bool {
+	return strings.Contains("/"+p+"/", "/../") || p == ".."
+}

--- a/internal/repoconfig/config_test.go
+++ b/internal/repoconfig/config_test.go
@@ -1,0 +1,69 @@
+package repoconfig
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNormalise(t *testing.T) {
+	raw := `focus_areas:
+  - name: parser
+    paths: [src/parse/**]
+    surface: accepts arbitrary bytes
+known_bugs:
+  - GHSA-xxxx-yyyy
+attack_surface: stdin is attacker controlled
+skip: [tests/**]
+`
+	normalised, cfg, err := Normalise(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(normalised, "focus_areas:") || cfg.FocusAreas[0].Name != "parser" {
+		t.Fatalf("normalised=%q config=%+v", normalised, cfg)
+	}
+	if cfg.Skip[0] != "tests/**" || cfg.AttackSurface == "" || cfg.KnownBugs[0] != "GHSA-xxxx-yyyy" {
+		t.Fatalf("config=%+v", cfg)
+	}
+}
+
+func TestParseRejectsInvalidConfig(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{"unknown field", "unknown: value", "field unknown"},
+		{"focus missing paths", "focus_areas:\n  - name: parser\n    surface: bytes", "paths is required"},
+		{"absolute skip", "skip: [/tmp/**]", "relative"},
+		{"windows volume", "skip: ['C:/tmp/**']", "relative"},
+		{"parent skip", "skip: [../vendor/**]", "relative"},
+		{"bad glob", "skip: ['[broken']", "valid glob"},
+		{"blank known bug", "known_bugs: [' ']", "is empty"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := Parse(tc.raw)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("Parse() error = %v, want %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestParseNormalisesBackslashPatterns(t *testing.T) {
+	cfg, err := Parse(`skip: ['tests\**']`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := cfg.Skip[0]; got != "tests/**" {
+		t.Fatalf("skip = %q, want tests/**", got)
+	}
+}
+
+func TestParseEmpty(t *testing.T) {
+	cfg, err := Parse(" \n")
+	if err != nil || !cfg.Empty() {
+		t.Fatalf("Parse empty = %+v, %v", cfg, err)
+	}
+}

--- a/internal/web/repo_scan_config.go
+++ b/internal/web/repo_scan_config.go
@@ -1,0 +1,46 @@
+package web
+
+import (
+	"fmt"
+	"net/http"
+
+	"scrutineer/internal/db"
+	"scrutineer/internal/repoconfig"
+)
+
+const scanConfigTab = "#rt14"
+
+// repoScanConfigSave validates and persists the analyst-authored repository
+// guidance. Empty input deliberately clears the configuration.
+func (s *Server) repoScanConfigSave(w http.ResponseWriter, r *http.Request) {
+	repo, ok := loadByID[db.Repository](s, w, r)
+	if !ok {
+		return
+	}
+	config, _, err := repoconfig.Normalise(r.FormValue("scan_config"))
+	if err != nil {
+		http.Error(w, "scan config is not valid YAML: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	if err := s.DB.Model(&db.Repository{}).Where("id = ?", repo.ID).
+		Update("scan_config", config).Error; err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	setFlash(w, Flash{Category: "success", Title: "Scan config saved"})
+	s.redirect(w, r, fmt.Sprintf("/repositories/%d%s", repo.ID, scanConfigTab))
+}
+
+func (s *Server) repoScanConfigClear(w http.ResponseWriter, r *http.Request) {
+	repo, ok := loadByID[db.Repository](s, w, r)
+	if !ok {
+		return
+	}
+	if err := s.DB.Model(&db.Repository{}).Where("id = ?", repo.ID).
+		Update("scan_config", "").Error; err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	setFlash(w, Flash{Category: "success", Title: "Scan config cleared"})
+	s.redirect(w, r, fmt.Sprintf("/repositories/%d%s", repo.ID, scanConfigTab))
+}

--- a/internal/web/repo_scan_config_seed.go
+++ b/internal/web/repo_scan_config_seed.go
@@ -1,0 +1,38 @@
+package web
+
+import (
+	"encoding/json"
+	"strings"
+
+	"scrutineer/internal/db"
+	"scrutineer/internal/repoconfig"
+)
+
+// autoSeedRepoScanConfig accepts a threat-model proposal only for an
+// unconfigured root/default-branch repository. The conditional update keeps a
+// concurrent analyst edit authoritative.
+func (s *Server) autoSeedRepoScanConfig(scan *db.Scan) {
+	if scan == nil || scan.Status != db.ScanDone || scan.SkillName != threatModelSkillName ||
+		scan.SubPath != "" || scan.Ref != "" || strings.TrimSpace(scan.Report) == "" {
+		return
+	}
+	var report struct {
+		ScanConfig json.RawMessage `json:"scan_config"`
+	}
+	if err := json.Unmarshal([]byte(scan.Report), &report); err != nil || len(report.ScanConfig) == 0 {
+		return
+	}
+	config, parsed, err := repoconfig.Normalise(string(report.ScanConfig))
+	if err != nil {
+		s.Log.Warn("scan config proposal invalid", "scan", scan.ID, "err", err)
+		return
+	}
+	if parsed.Empty() {
+		return
+	}
+	if err := s.DB.Model(&db.Repository{}).
+		Where("id = ? AND scan_config = ''", scan.RepositoryID).
+		Update("scan_config", config).Error; err != nil {
+		s.Log.Warn("save scan config proposal", "scan", scan.ID, "err", err)
+	}
+}

--- a/internal/web/repo_scan_config_seed.go
+++ b/internal/web/repo_scan_config_seed.go
@@ -31,7 +31,7 @@ func (s *Server) autoSeedRepoScanConfig(scan *db.Scan) {
 		return
 	}
 	if err := s.DB.Model(&db.Repository{}).
-		Where("id = ? AND scan_config = ''", scan.RepositoryID).
+		Where("id = ? AND (scan_config = '' OR scan_config IS NULL)", scan.RepositoryID).
 		Update("scan_config", config).Error; err != nil {
 		s.Log.Warn("save scan config proposal", "scan", scan.ID, "err", err)
 	}

--- a/internal/web/repo_scan_config_seed_test.go
+++ b/internal/web/repo_scan_config_seed_test.go
@@ -26,6 +26,28 @@ func TestAutoSeedRepoScanConfig(t *testing.T) {
 	}
 }
 
+func TestAutoSeedRepoScanConfigSeedsLegacyNull(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	repo := db.Repository{URL: "https://example.com/seed-null", Name: "seed-null"}
+	s.DB.Create(&repo)
+	if err := s.DB.Model(&db.Repository{}).Where("id = ?", repo.ID).Update("scan_config", nil).Error; err != nil {
+		t.Fatal(err)
+	}
+	scan := &db.Scan{
+		RepositoryID: repo.ID,
+		Status:       db.ScanDone,
+		SkillName:    threatModelSkillName,
+		Report:       `{"scan_config":{"skip":["tests/**"]}}`,
+	}
+	s.autoSeedRepoScanConfig(scan)
+	var got db.Repository
+	s.DB.First(&got, repo.ID)
+	if !strings.Contains(got.ScanConfig, "tests/**") {
+		t.Fatalf("ScanConfig = %q, want seeded value", got.ScanConfig)
+	}
+}
+
 func TestAutoSeedRepoScanConfigPreservesAnalystConfig(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()

--- a/internal/web/repo_scan_config_seed_test.go
+++ b/internal/web/repo_scan_config_seed_test.go
@@ -1,0 +1,46 @@
+package web
+
+import (
+	"strings"
+	"testing"
+
+	"scrutineer/internal/db"
+)
+
+func TestAutoSeedRepoScanConfig(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	repo := db.Repository{URL: "https://example.com/seed", Name: "seed"}
+	s.DB.Create(&repo)
+	scan := &db.Scan{
+		RepositoryID: repo.ID,
+		Status:       db.ScanDone,
+		SkillName:    threatModelSkillName,
+		Report:       `{"scan_config":{"focus_areas":[{"name":"parser","paths":["src/parse/**"],"surface":"accepts bytes"}],"skip":["tests/**"]}}`,
+	}
+	s.autoSeedRepoScanConfig(scan)
+	var got db.Repository
+	s.DB.First(&got, repo.ID)
+	if got.ScanConfig == "" || !strings.Contains(got.ScanConfig, "focus_areas:") || !strings.Contains(got.ScanConfig, "tests/**") {
+		t.Fatalf("ScanConfig = %q", got.ScanConfig)
+	}
+}
+
+func TestAutoSeedRepoScanConfigPreservesAnalystConfig(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	repo := db.Repository{URL: "https://example.com/seed-existing", Name: "seed-existing", ScanConfig: "skip: [vendor/**]\n"}
+	s.DB.Create(&repo)
+	scan := &db.Scan{
+		RepositoryID: repo.ID,
+		Status:       db.ScanDone,
+		SkillName:    threatModelSkillName,
+		Report:       `{"scan_config":{"skip":["tests/**"]}}`,
+	}
+	s.autoSeedRepoScanConfig(scan)
+	var got db.Repository
+	s.DB.First(&got, repo.ID)
+	if got.ScanConfig != repo.ScanConfig {
+		t.Fatalf("ScanConfig = %q, want %q", got.ScanConfig, repo.ScanConfig)
+	}
+}

--- a/internal/web/repo_scan_config_test.go
+++ b/internal/web/repo_scan_config_test.go
@@ -1,0 +1,78 @@
+package web
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"scrutineer/internal/db"
+)
+
+func TestRepoScanConfigSave(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	repo := db.Repository{URL: "https://example.com/config", Name: "config"}
+	s.DB.Create(&repo)
+	config := `focus_areas:
+  - name: parser
+    paths: [src/parse/**]
+    surface: accepts bytes
+skip: [tests/**]`
+	w := postForm(t, s, fmt.Sprintf("/repositories/%d/scan-config", repo.ID), url.Values{"scan_config": {config}})
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("code = %d body=%s", w.Code, w.Body.String())
+	}
+	var got db.Repository
+	s.DB.First(&got, repo.ID)
+	if !strings.Contains(got.ScanConfig, "focus_areas:") || !strings.Contains(got.ScanConfig, "tests/**") {
+		t.Fatalf("ScanConfig = %q", got.ScanConfig)
+	}
+}
+
+func TestRepoScanConfigSaveRejectsInvalidYAML(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	repo := db.Repository{URL: "https://example.com/config-invalid", Name: "config-invalid"}
+	s.DB.Create(&repo)
+	w := postForm(t, s, fmt.Sprintf("/repositories/%d/scan-config", repo.ID), url.Values{"scan_config": {"skip: [../private/**]"}})
+	if w.Code != http.StatusBadRequest || !strings.Contains(w.Body.String(), "relative") {
+		t.Fatalf("code=%d body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestRepoScanConfigClear(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	repo := db.Repository{URL: "https://example.com/config-clear", Name: "config-clear", ScanConfig: "skip: [tests/**]\n"}
+	s.DB.Create(&repo)
+	w := postForm(t, s, fmt.Sprintf("/repositories/%d/scan-config/clear", repo.ID), url.Values{})
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("code = %d body=%s", w.Code, w.Body.String())
+	}
+	var got db.Repository
+	s.DB.First(&got, repo.ID)
+	if got.ScanConfig != "" {
+		t.Fatalf("ScanConfig = %q, want empty", got.ScanConfig)
+	}
+}
+
+func TestRepoShowScanConfigTab(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	repo := db.Repository{URL: "https://example.com/config-tab", Name: "config-tab", ScanConfig: "skip:\n  - tests/**\n"}
+	s.DB.Create(&repo)
+	rw := httptest.NewRecorder()
+	s.Handler().ServeHTTP(rw, localReq(http.MethodGet, fmt.Sprintf("/repositories/%d", repo.ID)))
+	if rw.Code != http.StatusOK {
+		t.Fatalf("code=%d body=%s", rw.Code, rw.Body.String())
+	}
+	body := rw.Body.String()
+	for _, want := range []string{"Scan config", "scan-config", "scrutineer.scan_config", "tests/**"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("repo page missing %q", want)
+		}
+	}
+}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -345,6 +345,8 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("POST /repositories/{id}/threat-model", s.repoThreatModelSave)
 	mux.HandleFunc("POST /repositories/{id}/threat-model/run", s.repoThreatModelRun)
 	mux.HandleFunc("POST /repositories/{id}/threat-model/clear", s.repoThreatModelClear)
+	mux.HandleFunc("POST /repositories/{id}/scan-config", s.repoScanConfigSave)
+	mux.HandleFunc("POST /repositories/{id}/scan-config/clear", s.repoScanConfigClear)
 	mux.HandleFunc("GET /scans", s.jobs)
 	mux.HandleFunc("GET /orgs", s.orgsList)
 	mux.HandleFunc("GET /orgs/{login}", s.orgShow)

--- a/internal/web/templates/repo_scan_config.html
+++ b/internal/web/templates/repo_scan_config.html
@@ -1,0 +1,48 @@
+{{define "repo_scan_config"}}
+<p class="text-sm text-muted-foreground mb-4 max-w-3xl">
+  Repository-specific security guidance is staged in every skill workspace as
+  <code>scrutineer.scan_config</code>. <code>skip</code> patterns also remove
+  matching files before a skill runs.
+</p>
+
+<form method="post" action="/repositories/{{.Repo.ID}}/scan-config" class="form grid gap-3 max-w-4xl">
+  <textarea name="scan_config" rows="20" spellcheck="false"
+            class="input w-full font-mono text-xs"
+            placeholder="focus_areas:
+  - name: parser
+    paths: [src/parse/**]
+    surface: accepts arbitrary bytes from the network
+known_bugs:
+  - GHSA-xxxx-yyyy
+attack_surface: |
+  Single-tenant CLI. Config files are operator-trusted.
+skip:
+  - tests/**">{{.Repo.ScanConfig}}</textarea>
+  <div class="flex items-center gap-2">
+    <button type="submit" class="btn"><i data-lucide="save"></i> Save</button>
+    {{if .Repo.ScanConfig}}
+      <button type="submit" class="btn-outline"
+              formaction="/repositories/{{.Repo.ID}}/scan-config/clear"
+              formnovalidate
+              hx-confirm="Clear this repository's scan config? Future skills will no longer receive it.">
+        <i data-lucide="eraser"></i> Clear
+      </button>
+    {{end}}
+  </div>
+</form>
+
+<details class="mt-4 max-w-4xl">
+  <summary class="text-sm text-muted-foreground cursor-pointer hover:underline">Config format</summary>
+  <pre class="text-xs mt-2 overflow-x-auto"><code>focus_areas:
+  - name: parser
+    paths: [src/parse/**]
+    surface: accepts arbitrary bytes from network
+known_bugs:
+  - GHSA-xxxx-yyyy
+  - null deref in foo() with empty input, wontfix per #432
+attack_surface: &gt;
+  Single-tenant CLI tool. Config files are operator-trusted.
+skip:
+  - tests/**</code></pre>
+</details>
+{{end}}

--- a/internal/web/templates/repo_show.html
+++ b/internal/web/templates/repo_show.html
@@ -99,6 +99,9 @@
       Workbench
       {{if .Workbench.HasOverride}}<span class="badge-outline ml-1">override</span>{{end}}
     </button>
+    <button type="button" role="tab" id="rt14" aria-controls="rp14" aria-selected="false">
+      Scan config{{if .Repo.ScanConfig}} <span class="badge-outline ml-1">set</span>{{end}}
+    </button>
     <button type="button" role="tab" id="rt13" aria-controls="rp13" aria-selected="false">
       Benchmark{{if .ExpectedFindings}} <span class="badge-outline ml-1">{{.ExpectedMatched}}/{{len .ExpectedFindings}}</span>{{end}}
     </button>
@@ -425,6 +428,10 @@
 
   <div role="tabpanel" id="rp12" aria-labelledby="rt12" hidden>
     {{template "threat_workbench" .}}
+  </div>
+
+  <div role="tabpanel" id="rp14" aria-labelledby="rt14" hidden>
+    {{template "repo_scan_config" .}}
   </div>
 
   <div role="tabpanel" id="rp13" aria-labelledby="rt13" hidden>

--- a/internal/web/validate_fix_enqueue.go
+++ b/internal/web/validate_fix_enqueue.go
@@ -159,6 +159,7 @@ func parseFindingIDs(r *http.Request) ([]uint, error) {
 // not matter; autoEnqueueFindingDedup already skips anchor scans.
 func (s *Server) onScanFinalized(scan *db.Scan) {
 	s.autoUpdateThreatModel(scan)
+	s.autoSeedRepoScanConfig(scan)
 	s.autoComputeFixValidation(scan)
 	s.autoEnqueueFindingDedup(scan)
 }

--- a/internal/worker/exposure.go
+++ b/internal/worker/exposure.go
@@ -158,7 +158,7 @@ func (w *Worker) doExposure(ctx context.Context, scan *db.Scan, emit func(Event)
 	}
 	scan.Commit = cacheCommit
 
-	if err := applyPathFilters(workRoot, &skill, emit); err != nil {
+	if err := applyRepositoryPathFilters(workRoot, &skill, scan.Repository.ScanConfig, emit); err != nil {
 		return "", fmt.Errorf("apply path filters: %w", err)
 	}
 

--- a/internal/worker/skill.go
+++ b/internal/worker/skill.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"scrutineer/internal/db"
+	"scrutineer/internal/repoconfig"
 	"scrutineer/internal/skills"
 )
 
@@ -65,6 +66,9 @@ type skillContextScrutineer struct {
 	// Rescan is present for diff-based rescans. It names the baseline and
 	// staged files a diff-aware skill should read.
 	Rescan *skillContextRescan `json:"rescan,omitempty"`
+	// ScanConfig is the operator-authored repository guidance. It is omitted
+	// entirely for repositories without a saved configuration.
+	ScanConfig *repoconfig.Config `json:"scan_config,omitempty"`
 }
 
 type skillContextRescan struct {
@@ -157,7 +161,7 @@ func (w *Worker) doSkill(ctx context.Context, scan *db.Scan, emit func(Event)) (
 	if err := w.prepareDiffRescan(ctx, scan, workRoot, emit); err != nil {
 		return "", err
 	}
-	if err := applyPathFilters(workRoot, &skill, emit); err != nil {
+	if err := applyRepositoryPathFilters(workRoot, &skill, scan.Repository.ScanConfig, emit); err != nil {
 		return "", fmt.Errorf("apply path filters: %w", err)
 	}
 
@@ -863,8 +867,24 @@ func (w *Worker) parseMaintainersOutput(scan *db.Scan, report string, emit func(
 // Emits a one-line scan-log entry with the count when at least one file
 // is removed.
 func applyPathFilters(workRoot string, skill *db.Skill, emit func(Event)) error {
+	return applyPathFiltersWithSkips(workRoot, skill, nil, emit)
+}
+
+// applyRepositoryPathFilters layers the repository's configured skip patterns
+// on top of the skill's filters. A repository cannot use this setting to bring
+// files back that a skill or the builtin skip list has excluded.
+func applyRepositoryPathFilters(workRoot string, skill *db.Skill, rawConfig string, emit func(Event)) error {
+	cfg, err := repoconfig.Parse(rawConfig)
+	if err != nil {
+		return fmt.Errorf("parse repository scan config: %w", err)
+	}
+	return applyPathFiltersWithSkips(workRoot, skill, cfg.Skip, emit)
+}
+
+func applyPathFiltersWithSkips(workRoot string, skill *db.Skill, repositorySkips []string, emit func(Event)) error {
 	paths := skills.SplitPatterns(skill.Paths)
 	ignorePaths := skills.SplitPatterns(skill.IgnorePaths)
+	ignorePaths = append(ignorePaths, repositorySkips...)
 	src := filepath.Join(workRoot, "src")
 	if _, err := os.Stat(src); err != nil {
 		if os.IsNotExist(err) {
@@ -1119,6 +1139,13 @@ func stageContext(workRoot, apiBase, forkOrg, metadataDir string, scan *db.Scan,
 			ForkOrg:     forkOrg,
 			MetadataDir: metadataDir,
 		},
+	}
+	config, err := repoconfig.Parse(repo.ScanConfig)
+	if err != nil {
+		return fmt.Errorf("parse repository scan config: %w", err)
+	}
+	if !config.Empty() {
+		ctx.Scrutineer.ScanConfig = &config
 	}
 	if scan.SkillID != nil {
 		ctx.Scrutineer.SkillID = *scan.SkillID

--- a/internal/worker/skill_test.go
+++ b/internal/worker/skill_test.go
@@ -303,6 +303,39 @@ func TestStageContext_writesRepoFacts(t *testing.T) {
 	}
 }
 
+func TestStageContext_includesRepositoryScanConfig(t *testing.T) {
+	dir := t.TempDir()
+	repo := &db.Repository{
+		URL:  "https://example.com/config",
+		Name: "config",
+		ScanConfig: `focus_areas:
+  - name: parser
+    paths: [src/parse/**]
+    surface: accepts arbitrary bytes
+known_bugs: [GHSA-xxxx-yyyy]
+attack_surface: stdin is attacker controlled
+skip: [tests/**]`,
+	}
+	scan := &db.Scan{ID: 7, RepositoryID: 3, APIToken: "tok"}
+	if err := stageContext(dir, "http://127.0.0.1:8080/api", "", "", scan, repo); err != nil {
+		t.Fatal(err)
+	}
+	b, err := os.ReadFile(filepath.Join(dir, "context.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got skillContext
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Scrutineer.ScanConfig == nil || got.Scrutineer.ScanConfig.FocusAreas[0].Name != "parser" {
+		t.Fatalf("scan_config = %+v", got.Scrutineer.ScanConfig)
+	}
+	if got.Scrutineer.ScanConfig.Skip[0] != "tests/**" || got.Scrutineer.ScanConfig.KnownBugs[0] != "GHSA-xxxx-yyyy" {
+		t.Fatalf("scan_config = %+v", got.Scrutineer.ScanConfig)
+	}
+}
+
 func TestStageImportPayload(t *testing.T) {
 	dir := t.TempDir()
 	if err := stageImportPayload(dir, []byte("scanner output")); err != nil {
@@ -641,6 +674,22 @@ func TestApplyPathFilters_ignorePathsCumulative(t *testing.T) {
 	}
 	assertExists(t, src, "src/foo.go", "src/bar.go")
 	assertGone(t, src, "src/foo_test.go")
+}
+
+func TestApplyRepositoryPathFilters_layersRepositorySkip(t *testing.T) {
+	work := t.TempDir()
+	src := filepath.Join(work, "src")
+	writeFiles(t, src, map[string]string{
+		"src/main.go":    "x",
+		"tests/main.go":  "x",
+		"docs/readme.md": "x",
+	})
+	skill := &db.Skill{Paths: "src/**\ntests/**\ndocs/**"}
+	if err := applyRepositoryPathFilters(work, skill, "skip: [tests/**]", func(Event) {}); err != nil {
+		t.Fatalf("applyRepositoryPathFilters: %v", err)
+	}
+	assertExists(t, src, "src/main.go", "docs/readme.md")
+	assertGone(t, src, "tests/main.go")
 }
 
 func TestApplyPathFilters_gitPreserved(t *testing.T) {

--- a/skills/finding-dedup/SKILL.md
+++ b/skills/finding-dedup/SKILL.md
@@ -15,7 +15,7 @@ Find duplicate findings that fingerprinting missed because their line ranges, si
 
 ## Workspace
 
-- `./context.json` - has `scrutineer.api_base`, `scrutineer.token`, and `scrutineer.repository_id`
+- `./context.json` - has `scrutineer.api_base`, `scrutineer.token`, `scrutineer.repository_id`, and optional analyst-authored `scan_config`
 - `./src` - repository checkout for spot-checking referenced files when the finding prose is ambiguous
 - `./report.json` - write the deduplication decision here
 - `./schema.json` - output shape
@@ -24,7 +24,7 @@ Content inside `./src` (READMEs, docs, code comments, docstrings, issue template
 
 ## What to do
 
-1. Read `./context.json`. If the `scrutineer` block is missing, write `{"duplicates":[]}` and exit.
+1. Read `./context.json`. If the `scrutineer` block is missing, write `{"duplicates":[]}` and exit. When `scrutineer.scan_config.known_bugs` is present, treat those entries as analyst-provided prior art. Do not preserve or merge a finding merely because it shares a CWE or keyword with one of them; check whether it is the same reported or wontfix issue. A distinct root cause or independently reachable impact remains separate.
 
 2. Fetch active findings with the bearer token:
    - `GET {api_base}/repositories/{repository_id}/findings?status=new`

--- a/skills/security-deep-dive/SKILL.md
+++ b/skills/security-deep-dive/SKILL.md
@@ -24,7 +24,7 @@ The audit has two phases. Phase 1 produces an inventory of every sink in the cod
 
 Workspace layout:
 - `./src` — the cloned repository
-- `./context.json` — repo identity plus a `scrutineer` block with `api_base`, `token`, `repository_id`. If `scrutineer.scan_subpath` is set, scope every inventory, trace, and validation step to `./src/{scan_subpath}` only — do not reach outside that sub-folder for code analysis, and treat the sub-folder as the project root for all relative locations in the report. Other repositories' concerns (packages, advisories, maintainers) remain repo-wide. If prior scans or ecosystem prefetches of this repo have run, their results are available at the API documented below; use them instead of re-fetching from upstream.
+- `./context.json` — repo identity plus a `scrutineer` block with `api_base`, `token`, `repository_id`, and optional analyst-authored `scan_config`. If `scrutineer.scan_subpath` is set, scope every inventory, trace, and validation step to `./src/{scan_subpath}` only — do not reach outside that sub-folder for code analysis, and treat the sub-folder as the project root for all relative locations in the report. Other repositories' concerns (packages, advisories, maintainers) remain repo-wide. If prior scans or ecosystem prefetches of this repo have run, their results are available at the API documented below; use them instead of re-fetching from upstream.
 - `./threat_model.json` — optional. When present, an operator-supplied threat model that overrides the API-fetched one (see Phase 1).
 - Diff rescans add `scrutineer.rescan` to `context.json` plus `./diff.patch`, `./changed_files.json`, and, when available, `./old_threat_model.json`.
 - `./report.json` — write your final report here
@@ -53,6 +53,14 @@ Inventory only sinks that are new, modified, or whose reachability/security boun
 Do not mark untouched historical findings as gone just because they are outside the diff. Use `findings: []` only to mean "no new or materially changed findings in this diff." Put ruled-out entries in the report for changed sinks you actually inspected; do not fill the ruled-out list with old inventory from untouched code.
 
 ## Phase 1: Inventory
+
+If `scrutineer.scan_config` is present, use its `attack_surface` as the
+operator's ground truth when naming trust boundaries. Start the inventory with
+each listed `focus_areas` path and surface, then expand only when the code
+reveals a distinct boundary. Treat `known_bugs` as prior art: do not file a
+known, wontfix issue again unless the code demonstrates a distinct root cause
+or an independently reachable impact. The worker has already removed paths in
+`scan_config.skip` from `./src`.
 
 If `./threat_model.json` exists in the workdir, parse it and use it as the threat model; do not fetch one from the API. The operator placed it there to test how this audit behaves under an edited model, so the file takes precedence even if a `threat-model` scan has already run. Otherwise fetch the threat-model scan: `GET {api_base}/repositories/{repository_id}/scans?skill=threat-model&status=done`, take the most recent id, then `GET {api_base}/scans/{id}` and parse the `report` field as JSON. Either way, if you get one it already holds the trust map: `components` and `out_of_scope` say which code is in the model, `adversaries` names the actors, `trust_boundaries` describes the line per component, and `entry_points` is the per-parameter table Step 2 looks up. Fill this report's `boundaries[]` from those fields instead of deriving from scratch — one row per actor (callers and adversaries), with `trusted` set from whether the actor appears in `adversaries.in_scope` and `source` set from the threat model's `provenance`/`source` — then skip to listing sinks. Treat threat-model entries with `provenance: "inferred"` as working hypotheses you may overturn during Phase 2; `"documented"` entries cite a file:line you can re-read. An empty list or a non-200 means the threat-model skill has not run on this repository yet, in which case derive the boundaries yourself as below.
 

--- a/skills/threat-model/SKILL.md
+++ b/skills/threat-model/SKILL.md
@@ -18,7 +18,7 @@ You are running headless with no maintainer to consult. Every claim you write is
 ## Workspace
 
 - `./src` is the cloned repository.
-- `./context.json` has `repository.url`, `repository.full_name`, and a `scrutineer` block with `api_base`, `token`, `repository_id`. If `scrutineer.scan_subpath` is set, scope the model to that subtree and say so in the header.
+- `./context.json` has `repository.url`, `repository.full_name`, and a `scrutineer` block with `api_base`, `token`, `repository_id`, and optional analyst-authored `scan_config`. If `scrutineer.scan_subpath` is set, scope the model to that subtree and say so in the header.
 - Diff rescans add `scrutineer.rescan` to `context.json` plus `./diff.patch`, `./changed_files.json`, and, when available, `./old_threat_model.json`.
 - `./report.json` is the structured contract; write it to match `./schema.json`. This is the only file the worker keeps.
 
@@ -42,6 +42,17 @@ Diff mode is still a threat-model run, not a vulnerability scan. Do not report c
 ## Orient
 
 Spend minutes, not hours. You are forming hypotheses, not findings.
+
+When `scrutineer.scan_config` is present, its `attack_surface` is operator
+ground truth: preserve it in the model instead of inferring a contradictory
+scope. Use `focus_areas` to seed component families and entry points, record
+`known_bugs` as maintainer-provided prior art or known non-findings when their
+text supports that conclusion, and do not inspect paths removed by `skip`.
+When the block is absent, derive these inputs normally from the repository and
+include a proposed `scan_config` object in `report.json` with the focus areas,
+known bugs, attack-surface statement, and skip paths worth carrying into later
+scans. Scrutineer saves a valid proposal only when the analyst has not already
+configured the repository.
 
 Read `README*`, `SECURITY*`, `THREAT*`, anything under `docs/` or `doc/` with security in the name, header-file commentary, `FAQ`, `NOTES`, `CAVEATS`, `LIMITATIONS`, `CHANGELOG` entries that explain why behaviour is the way it is. Search the issue tracker references in the repo (issue numbers in comments and commit messages) for "wontfix", "by design", "not a bug", "out of scope", "won't fix". These are maintainer positions already on record; they are `documented` sources, the highest authority you have. A claim you find here is not `inferred` even if you would have guessed the same thing.
 

--- a/skills/threat-model/schema.json
+++ b/skills/threat-model/schema.json
@@ -63,7 +63,8 @@
       "uniqueItems": true,
       "minItems": 9, "maxItems": 9
     },
-    "open_questions": { "type": "array", "items": { "$ref": "#/$defs/open_question" } }
+    "open_questions": { "type": "array", "items": { "$ref": "#/$defs/open_question" } },
+    "scan_config": { "$ref": "#/$defs/scan_config" }
   },
 
   "$defs": {
@@ -265,6 +266,29 @@
         "claim":    { "type": "string" },
         "field":    { "type": "string" },
         "proposed": { "type": "string" }
+      }
+    },
+
+    "scan_config": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "focus_areas": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["name", "paths", "surface"],
+            "additionalProperties": false,
+            "properties": {
+              "name": { "type": "string" },
+              "paths": { "type": "array", "items": { "type": "string" }, "minItems": 1 },
+              "surface": { "type": "string" }
+            }
+          }
+        },
+        "known_bugs": { "type": "array", "items": { "type": "string" } },
+        "attack_surface": { "type": "string" },
+        "skip": { "type": "array", "items": { "type": "string" } }
       }
     }
   }

--- a/skills/vuln-scan/SKILL.md
+++ b/skills/vuln-scan/SKILL.md
@@ -20,7 +20,7 @@ The target is first-party source code. Do not report vulnerabilities that exist 
 ## Workspace
 
 - `./src` - cloned repository
-- `./context.json` - repository identity plus a `scrutineer` block with `api_base`, `token`, `repository_id`, and optional `scan_subpath`
+- `./context.json` - repository identity plus a `scrutineer` block with `api_base`, `token`, `repository_id`, optional `scan_subpath`, and optional analyst-authored `scan_config`
 - `./report.json` - write the findings report here
 - `./schema.json` - output schema
 
@@ -41,7 +41,7 @@ This scan is read-only:
 
 First, build a compact map of the target:
 
-1. Read `context.json` and determine the scoped source root.
+1. Read `context.json` and determine the scoped source root. When `scrutineer.scan_config` is present, treat its `attack_surface` as operator ground truth, seed the focus list with every `focus_areas` entry, and treat each `known_bugs` item as prior art rather than a new finding. The worker has already removed `scan_config.skip` paths from `./src`.
 2. List files with `rg --files` or equivalent.
 3. Identify languages, package layout, public entry points, handlers, parsers, CLIs, unsafe/FFI areas, deserializers, archive/file/network operations, authz boundaries, and agent/model/tool integrations.
 4. If available, fetch prior local reports from Scrutineer's API and use them as context:
@@ -53,7 +53,7 @@ If any API request fails or returns no data, continue with source-only review.
 
 ## Focus Areas
 
-Create three to ten focus areas. Prefer focus areas from the threat model if one exists; otherwise derive them from recon. Useful focus areas include:
+Create three to ten focus areas. Start with any `scrutineer.scan_config.focus_areas` entries, preserving their names, paths, and stated surface; add more only where recon finds a distinct security surface. Then prefer focus areas from the threat model if one exists; otherwise derive the remaining areas from recon. Useful focus areas include:
 
 - Memory safety: C/C++, unsafe Rust, raw pointers, unchecked indexes, allocation sizes, integer arithmetic that feeds buffers, FFI, lifetime hazards.
 - Injection and execution: eval, shell/process execution, dynamic imports, templates, SQL/NoSQL/query construction, regex construction, format strings.


### PR DESCRIPTION
Part of #115

## Summary

Adds analyst-managed repository scan configuration that carries persistent security-review guidance into skill workspaces and applies repository-specific path exclusions before scans run.

## Changes

- Add `Repository.ScanConfig` for validated YAML configuration
- Add a repository-page Scan config tab with save and clear actions
- Support:
  - `focus_areas`
  - `known_bugs`
  - `attack_surface`
  - `skip`
- Stage parsed config in every workspace as `scrutineer.scan_config`
- Layer repository `skip` patterns onto existing per-skill path filters
- Update `vuln-scan`, `threat-model`, `security-deep-dive`, and `finding-dedup` to use the new guidance
- Let completed root `threat-model` scans seed a valid config only when no analyst config exists
- Preserve analyst configuration with a conditional database update
- Document the repository column and `context.json` contract

## Tests

- `go test ./...`
- `go test -tags evals ./...`
- `go vet ./...`
- `go vet -tags evals ./...`
- `go test ./internal/worker -run 'TestBundledSchemas_(compileAndAcceptSamples|rejectBadShapes)' -count=1`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run ./cmd/... ./internal/...`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --build-tags evals ./cmd/... ./internal/...`
- `git diff --check`