### PR TITLE
Add deep-dive refusal audits

### DIFF
--- a/docs/database.md
+++ b/docs/database.md
@@ -94,6 +94,8 @@ One row per skill execution or external import. `skill_name` / `skill_version` p
 | max_turns_hit | boolean | True when the scan is `done` with partial output because Claude hit the configured max-turns cap. Such scans keep their session id so Retry can resume. |
 | prompt | text | Activation prompt sent to claude. The skill body lives in the Skill row, not here. |
 | report | text | The skill's primary output. JSON for parsed kinds, freeform for everything else. On a fix-validation anchor (`baseline_scan_id` set) it is replaced, once the scan finalises, by the JSON validation report: the resolved/surviving/new fingerprint diff against the baseline plus the finding-scoped verify verdicts. |
+| refusal_audit | text | Structured post-report `security-deep-dive` follow-up listing analysis the agent declined or skipped. Kept separate from the primary report. |
+| refusal_audit_warning | boolean | Denormalized flag set when `refusal_audit` reports a refusal or one or more skipped paths; used to flag incomplete coverage in scan lists. |
 | log | text | Line-by-line transcript of the scan. Streamed to the UI via SSE. |
 | error | text | Error message if the scan failed. |
 | findings_count | integer | Denormalised count of findings parsed from the report. |

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -292,8 +292,15 @@ type Scan struct {
 
 	Prompt string
 	Report string
-	Log    string
-	Error  string
+	// RefusalAudit is the structured follow-up from security-deep-dive after
+	// its primary report. It records analysis the agent declined or only
+	// partially completed, without changing the primary report artifact.
+	RefusalAudit string `gorm:"type:text"`
+	// RefusalAuditWarning is denormalized from RefusalAudit so scan lists can
+	// flag incomplete coverage without parsing JSON while rendering.
+	RefusalAuditWarning bool `gorm:"not null;default:false"`
+	Log                 string
+	Error               string
 	// PausedUntil is set for model-account pauses with a known reset time.
 	// Nil means a manual pause or an account pause without a reported reset.
 	PausedUntil *time.Time `gorm:"index"`

--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -265,6 +265,7 @@ func (s *Server) apiGetScan(w http.ResponseWriter, r *http.Request) {
 	}
 	summary := scanSummary(sc)
 	summary["report"] = sc.Report
+	summary["refusal_audit"] = sc.RefusalAudit
 	summary["log"] = sc.Log
 	writeJSON(w, http.StatusOK, summary)
 }
@@ -492,6 +493,7 @@ func scanSummary(sc db.Scan) map[string]any {
 		"max_turns_hit":        sc.MaxTurnsHit,
 		errorKey:               sc.Error,
 	}
+	m["refusal_audit_warning"] = sc.RefusalAuditWarning
 	if sc.Ref != "" {
 		m["ref"] = sc.Ref
 	}

--- a/internal/web/api_export.go
+++ b/internal/web/api_export.go
@@ -548,7 +548,7 @@ func findingExport(f db.Finding) map[string]any {
 // running scan's auth credential and must never leak through an
 // unauthenticated channel.
 func scanExport(sc db.Scan) map[string]any {
-	return map[string]any{
+	out := map[string]any{
 		"id":                 sc.ID,
 		"repository_id":      sc.RepositoryID,
 		"kind":               sc.Kind,
@@ -577,4 +577,7 @@ func scanExport(sc db.Scan) map[string]any {
 		"created_at":         sc.CreatedAt,
 		"updated_at":         sc.UpdatedAt,
 	}
+	out["refusal_audit"] = sc.RefusalAudit
+	out["refusal_audit_warning"] = sc.RefusalAuditWarning
+	return out
 }

--- a/internal/web/refusal_audit_test.go
+++ b/internal/web/refusal_audit_test.go
@@ -1,0 +1,42 @@
+package web
+
+import (
+	"fmt"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"scrutineer/internal/db"
+)
+
+func TestRepoShow_refusalAuditWarning(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	repo := db.Repository{URL: "https://example.com/refusal-audit", Name: "refusal-audit"}
+	s.DB.Create(&repo)
+	scan := db.Scan{
+		RepositoryID:        repo.ID,
+		Kind:                "skill",
+		Status:              db.ScanDone,
+		SkillName:           deepDiveSkillName,
+		RefusalAudit:        `{"refused":false,"reason":null,"skipped":[{"path":"blob.bin","reason":"opaque"}]}`,
+		RefusalAuditWarning: true,
+	}
+	s.DB.Create(&scan)
+
+	body := getRepoPage(t, s, repo.ID)
+	if !strings.Contains(body, "analysis incomplete") {
+		t.Errorf("repo Scans tab missing refusal warning: %s", body)
+	}
+
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq("GET", fmt.Sprintf("/scans/%d", scan.ID)))
+	if w.Code != 200 {
+		t.Fatalf("scan page status %d: %s", w.Code, w.Body)
+	}
+	for _, want := range []string{"analysis incomplete", "Refusal audit", "blob.bin"} {
+		if !strings.Contains(w.Body.String(), want) {
+			t.Errorf("scan page missing %q: %s", want, w.Body)
+		}
+	}
+}

--- a/internal/web/templates/repo_show.html
+++ b/internal/web/templates/repo_show.html
@@ -618,7 +618,7 @@
   <tr id="scan-{{.ID}}"{{if $.OOB}} hx-swap-oob="true"{{end}}>
     <td><a href="/scans/{{.ID}}">{{.ID}}</a></td>
     <td>{{if .SkillName}}{{.SkillName}}{{else}}{{.Kind}}{{end}} {{template "branch-tag" .Ref}}{{if eq .RescanMode "diff"}} <span class="badge-outline text-xs">diff</span>{{end}}</td>
-    <td>{{template "status-badge" (status .Status)}} {{if .MaxTurnsHit}}<span class="badge-outline"><i data-lucide="timer-off"></i> max turns</span>{{end}}</td>
+    <td>{{template "status-badge" (status .Status)}} {{if .MaxTurnsHit}}<span class="badge-outline"><i data-lucide="timer-off"></i> max turns</span>{{end}}{{if .RefusalAuditWarning}} <span class="badge-outline" data-tooltip="The deep-dive reported refused or skipped analysis"><i data-lucide="triangle-alert"></i> analysis incomplete</span>{{end}}</td>
     <td>{{if gt .FindingsCount 0}}{{template "findings-badge" .FindingsCount}}{{end}}</td>
     <td class="text-muted-foreground">{{if .Model}}{{.Model}}{{else}}-{{end}}</td>
     <td class="text-muted-foreground">{{if gt .CostUSD 0.0}}{{usd .CostUSD}}{{else}}-{{end}}</td>

--- a/internal/web/templates/scan_show.html
+++ b/internal/web/templates/scan_show.html
@@ -10,6 +10,7 @@
     {{if .SkillName}}{{if .SkillID}}<a href="/skills/{{.SkillID}}">{{.SkillName}}</a>{{else}}{{.SkillName}}{{end}}{{else}}{{.Kind}}{{end}} / scan #{{.ID}}
     {{template "status-badge" (status .Status)}}
     {{if .MaxTurnsHit}}<span class="badge-outline"><i data-lucide="timer-off"></i> max turns</span>{{end}}
+    {{if .RefusalAuditWarning}}<span class="badge-outline"><i data-lucide="triangle-alert"></i> analysis incomplete</span>{{end}}
   </h2>
   {{if and (eq .Kind "skill") .SkillID}}
     <div class="flex items-center gap-2">
@@ -129,6 +130,13 @@
   </div>
 {{end}}
 
+{{if .RefusalAuditWarning}}
+  <div class="alert mb-6">
+    <i data-lucide="triangle-alert"></i>
+    <section>The deep-dive reported refused or skipped analysis. Review the refusal audit before treating coverage as complete.</section>
+  </div>
+{{end}}
+
 {{$live := and (not .Status.Terminal) (ne (status .Status) "paused")}}
 {{$default := 1}}{{if $live}}{{$default = 2}}{{end}}
 <div class="tabs w-full" id="scan-tabs">
@@ -191,6 +199,13 @@
   <div role="tabpanel" id="p3" aria-labelledby="t3" hidden>
     <pre class="log" tabindex="0" role="region" aria-label="Scan prompt">{{.Prompt}}</pre>
   </div>
+  {{end}}
+
+  {{if .RefusalAudit}}
+  <details class="mt-4">
+    <summary class="cursor-pointer text-sm text-muted-foreground">Refusal audit</summary>
+    <pre class="log mt-2" tabindex="0" role="region" aria-label="Refusal audit JSON">{{prettyjson .RefusalAudit}}</pre>
+  </details>
   {{end}}
 </div>
 {{end}}

--- a/internal/worker/refusal_audit.go
+++ b/internal/worker/refusal_audit.go
@@ -1,0 +1,94 @@
+package worker
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"scrutineer/internal/db"
+)
+
+// refusalAudit is a short, post-report account of code the deep-dive agent
+// declined to analyse or could analyse only partially. It deliberately lives
+// outside report.json so an audit cannot change the scan's primary artifact.
+type refusalAudit struct {
+	Refused bool                  `json:"refused"`
+	Reason  *string               `json:"reason"`
+	Skipped []refusalAuditSkipped `json:"skipped"`
+}
+
+type refusalAuditSkipped struct {
+	Path   string `json:"path"`
+	Reason string `json:"reason"`
+}
+
+func (a refusalAudit) warning() bool {
+	return a.Refused || len(a.Skipped) > 0
+}
+
+func (w *Worker) auditSkillRefusals(ctx context.Context, skill *db.Skill, scan *db.Scan, sj SkillJob, emit func(Event)) {
+	if skill.Name != refusalAuditSkillName || scan.SessionID == "" {
+		return
+	}
+
+	emit(Event{Kind: KindText, Text: "refusal audit: asking the agent to account for skipped analysis"})
+	auditJob := sj
+	auditJob.ResumeSessionID = scan.SessionID
+	auditJob.ResumePrompt = buildRefusalAuditPrompt()
+	auditJob.OutputFile = refusalAuditOutputFile
+	auditJob.MaxTurns = refusalAuditMaxTurns
+	res, err := w.Runner.RunSkill(ctx, auditJob, emit)
+	w.applySkillResult(scan, res)
+	if err != nil {
+		emit(Event{Kind: KindError, Text: fmt.Sprintf("refusal audit failed: %v; primary report retained", err)})
+		return
+	}
+	audit, err := parseRefusalAudit(res.Report)
+	if err != nil {
+		emit(Event{Kind: KindError, Text: fmt.Sprintf("refusal audit ignored: %v", err)})
+		return
+	}
+
+	scan.RefusalAudit = res.Report
+	scan.RefusalAuditWarning = audit.warning()
+	if scan.RefusalAuditWarning {
+		emit(Event{Kind: KindText, Text: "refusal audit: analysis was refused or skipped; see scan details"})
+	}
+}
+
+func buildRefusalAuditPrompt() string {
+	return `The primary security-deep-dive report is complete. Do not restart analysis and do not modify report.json.
+
+Audit only whether you declined, skipped, or could only partially analyse any security-relevant repository content. Write ./refusal_audit.json as exactly one JSON object:
+{"refused": false, "reason": null, "skipped": []}
+
+Set refused to true only when you declined analysis. Give its reason when true. For each skipped or partial area, add a repository-relative path and a concise reason. Use an empty skipped array when nothing was skipped. Do not write prose outside the JSON file.`
+}
+
+func parseRefusalAudit(raw string) (refusalAudit, error) {
+	var audit refusalAudit
+	raw = strings.TrimSpace(raw)
+	if !strings.HasPrefix(raw, "{") {
+		return refusalAudit{}, fmt.Errorf("%s must contain one JSON object", refusalAuditOutputFile)
+	}
+	dec := json.NewDecoder(strings.NewReader(raw))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&audit); err != nil {
+		return refusalAudit{}, fmt.Errorf("%s is not valid JSON: %w", refusalAuditOutputFile, err)
+	}
+	if err := dec.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		return refusalAudit{}, fmt.Errorf("%s must contain one JSON object", refusalAuditOutputFile)
+	}
+	if audit.Refused && (audit.Reason == nil || strings.TrimSpace(*audit.Reason) == "") {
+		return refusalAudit{}, fmt.Errorf("%s must include a reason when refused is true", refusalAuditOutputFile)
+	}
+	for i, skipped := range audit.Skipped {
+		if strings.TrimSpace(skipped.Path) == "" || strings.TrimSpace(skipped.Reason) == "" {
+			return refusalAudit{}, fmt.Errorf("%s skipped[%d] must include path and reason", refusalAuditOutputFile, i)
+		}
+	}
+	return audit, nil
+}

--- a/internal/worker/refusal_audit.go
+++ b/internal/worker/refusal_audit.go
@@ -86,9 +86,38 @@ func parseRefusalAudit(raw string) (refusalAudit, error) {
 		return refusalAudit{}, fmt.Errorf("%s must include a reason when refused is true", refusalAuditOutputFile)
 	}
 	for i, skipped := range audit.Skipped {
-		if strings.TrimSpace(skipped.Path) == "" || strings.TrimSpace(skipped.Reason) == "" {
-			return refusalAudit{}, fmt.Errorf("%s skipped[%d] must include path and reason", refusalAuditOutputFile, i)
+		if !isRepositoryRelativePath(skipped.Path) {
+			return refusalAudit{}, fmt.Errorf("%s skipped[%d] path must be repository-relative", refusalAuditOutputFile, i)
+		}
+		if strings.TrimSpace(skipped.Reason) == "" {
+			return refusalAudit{}, fmt.Errorf("%s skipped[%d] must include a reason", refusalAuditOutputFile, i)
 		}
 	}
 	return audit, nil
+}
+
+// isRepositoryRelativePath accepts slash-separated repository paths without
+// normalising them, so malformed agent output cannot escape or ambiguously
+// describe the repository root.
+func isRepositoryRelativePath(path string) bool {
+	if path == "" || strings.ContainsRune(path, '\\') || strings.ContainsRune(path, 0) || strings.HasPrefix(path, "/") {
+		return false
+	}
+	segments := strings.Split(path, "/")
+	if isWindowsDrivePrefix(segments[0]) {
+		return false
+	}
+	for _, segment := range segments {
+		if segment == "" || segment == "." || segment == ".." {
+			return false
+		}
+	}
+	return true
+}
+
+func isWindowsDrivePrefix(segment string) bool {
+	if len(segment) < 2 || segment[1] != ':' {
+		return false
+	}
+	return (segment[0] >= 'a' && segment[0] <= 'z') || (segment[0] >= 'A' && segment[0] <= 'Z')
 }

--- a/internal/worker/refusal_audit_test.go
+++ b/internal/worker/refusal_audit_test.go
@@ -1,0 +1,158 @@
+package worker
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"scrutineer/internal/db"
+)
+
+func TestParseRefusalAudit(t *testing.T) {
+	valid := `{"refused":false,"reason":null,"skipped":[{"path":"src/parser.c","reason":"obfuscated generated code"}]}`
+	audit, err := parseRefusalAudit(valid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !audit.warning() {
+		t.Error("audit with skipped paths should warn")
+	}
+
+	for _, tc := range []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{"refusal without reason", `{"refused":true,"reason":"","skipped":[]}`, "reason"},
+		{"skipped without path", `{"refused":false,"reason":"","skipped":[{"reason":"partial"}]}`, "path"},
+		{"unknown field", `{"refused":false,"reason":"","skipped":[],"extra":true}`, "valid JSON"},
+		{"null", `null`, "one JSON object"},
+		{"two documents", `{"refused":false,"reason":"","skipped":[]} {}`, "one JSON object"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := parseRefusalAudit(tc.raw); err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("parseRefusalAudit() error = %v, want %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestDoSkill_recordsRefusalAudit(t *testing.T) {
+	runner := &sequenceRunner{results: []SkillResult{
+		{SessionID: "session-1", Report: `{"findings":[]}`},
+		{SessionID: "session-1", Report: `{"refused":false,"reason":null,"skipped":[{"path":"vendor/blob.bin","reason":"opaque generated data"}]}`},
+	}}
+	w, scanID := newRefusalAuditWorker(t, runner, refusalAuditSkillName)
+	runRefusalAuditScan(t, w, scanID)
+
+	if len(runner.jobs) != 2 {
+		t.Fatalf("RunSkill calls = %d, want primary run plus audit", len(runner.jobs))
+	}
+	auditJob := runner.jobs[1]
+	if auditJob.ResumeSessionID != "session-1" {
+		t.Errorf("audit ResumeSessionID = %q, want session-1", auditJob.ResumeSessionID)
+	}
+	if auditJob.OutputFile != refusalAuditOutputFile {
+		t.Errorf("audit OutputFile = %q, want %q", auditJob.OutputFile, refusalAuditOutputFile)
+	}
+	if auditJob.MaxTurns != refusalAuditMaxTurns {
+		t.Errorf("audit MaxTurns = %d, want %d", auditJob.MaxTurns, refusalAuditMaxTurns)
+	}
+	if !strings.Contains(auditJob.ResumePrompt, "Do not restart analysis") {
+		t.Errorf("audit prompt = %q, want focused follow-up", auditJob.ResumePrompt)
+	}
+
+	var scan db.Scan
+	if err := w.DB.First(&scan, scanID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if scan.Report != `{"findings":[]}` {
+		t.Errorf("primary report = %q, want unchanged", scan.Report)
+	}
+	if !scan.RefusalAuditWarning || !strings.Contains(scan.RefusalAudit, "vendor/blob.bin") {
+		t.Errorf("audit fields = warning:%t report:%q", scan.RefusalAuditWarning, scan.RefusalAudit)
+	}
+}
+
+func TestDoSkill_refusalAuditIsBestEffort(t *testing.T) {
+	runner := &sequenceRunner{results: []SkillResult{{SessionID: "session-1", Report: `{"findings":[]}`}, {}}, errs: []error{nil, errors.New("expired session")}}
+	w, scanID := newRefusalAuditWorker(t, runner, refusalAuditSkillName)
+	runRefusalAuditScan(t, w, scanID)
+
+	var scan db.Scan
+	if err := w.DB.First(&scan, scanID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if scan.Status != db.ScanDone || scan.Report != `{"findings":[]}` {
+		t.Errorf("scan = status:%s report:%q, want completed primary report", scan.Status, scan.Report)
+	}
+	if scan.RefusalAudit != "" || scan.RefusalAuditWarning {
+		t.Errorf("audit fields should stay empty after failure: %+v", scan)
+	}
+	if !strings.Contains(scan.Log, "refusal audit failed") {
+		t.Errorf("log = %q, want audit failure", scan.Log)
+	}
+}
+
+func TestDoSkill_skipsRefusalAuditWithoutSession(t *testing.T) {
+	runner := &sequenceRunner{results: []SkillResult{{Report: `{"findings":[]}`}}}
+	w, scanID := newRefusalAuditWorker(t, runner, refusalAuditSkillName)
+	runRefusalAuditScan(t, w, scanID)
+	if len(runner.jobs) != 1 {
+		t.Errorf("RunSkill calls = %d, want primary run only without a session", len(runner.jobs))
+	}
+}
+
+func TestDoSkill_refusalAuditIsDeepDiveOnly(t *testing.T) {
+	runner := &sequenceRunner{results: []SkillResult{{SessionID: "session-1", Report: `{"findings":[]}`}}}
+	w, scanID := newRefusalAuditWorker(t, runner, "vuln-scan")
+	runRefusalAuditScan(t, w, scanID)
+	if len(runner.jobs) != 1 {
+		t.Errorf("RunSkill calls = %d, want primary run only for a non-deep-dive skill", len(runner.jobs))
+	}
+}
+
+func newRefusalAuditWorker(t *testing.T, runner SkillRunner, skillName string) (*Worker, uint) {
+	t.Helper()
+	gdb, err := db.Open(filepath.Join(t.TempDir(), "refusal-audit.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo := db.Repository{URL: "https://example.com/refusal-audit", Name: "refusal-audit"}
+	if err := gdb.Create(&repo).Error; err != nil {
+		t.Fatal(err)
+	}
+	skill := db.Skill{Name: skillName, Description: "d", Body: "b", OutputFile: "report.json", OutputKind: "findings", Version: 1, Active: true, Source: "ui"}
+	if err := gdb.Create(&skill).Error; err != nil {
+		t.Fatal(err)
+	}
+	scan := db.Scan{RepositoryID: repo.ID, Kind: JobSkill, Status: db.ScanQueued, SkillID: &skill.ID, Model: "fake"}
+	if err := gdb.Create(&scan).Error; err != nil {
+		t.Fatal(err)
+	}
+	return &Worker{
+		DB:             gdb,
+		DataDir:        t.TempDir(),
+		Log:            slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Runner:         runner,
+		PrepareRepoSrc: stubPrepareRepoSrc,
+	}, scan.ID
+}
+
+func runRefusalAuditScan(t *testing.T, w *Worker, scanID uint) {
+	t.Helper()
+	body, err := json.Marshal(struct {
+		ScanID uint `json:"scan_id"`
+	}{ScanID: scanID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := w.wrap(w.doSkill)(context.Background(), body); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/worker/refusal_audit_test.go
+++ b/internal/worker/refusal_audit_test.go
@@ -29,10 +29,15 @@ func TestParseRefusalAudit(t *testing.T) {
 		want string
 	}{
 		{"refusal without reason", `{"refused":true,"reason":"","skipped":[]}`, "reason"},
-		{"skipped without path", `{"refused":false,"reason":"","skipped":[{"reason":"partial"}]}`, "path"},
+		{"skipped without path", `{"refused":false,"reason":"","skipped":[{"reason":"partial"}]}`, "repository-relative"},
 		{"unknown field", `{"refused":false,"reason":"","skipped":[],"extra":true}`, "valid JSON"},
 		{"null", `null`, "one JSON object"},
 		{"two documents", `{"refused":false,"reason":"","skipped":[]} {}`, "one JSON object"},
+		{"absolute skipped path", `{"refused":false,"reason":null,"skipped":[{"path":"/etc/passwd","reason":"outside repo"}]}`, "repository-relative"},
+		{"backslash skipped path", `{"refused":false,"reason":null,"skipped":[{"path":"src\\parser.c","reason":"outside repo"}]}`, "repository-relative"},
+		{"windows drive skipped path", `{"refused":false,"reason":null,"skipped":[{"path":"C:/temp/file","reason":"outside repo"}]}`, "repository-relative"},
+		{"parent skipped path", `{"refused":false,"reason":null,"skipped":[{"path":"src/../secret","reason":"outside repo"}]}`, "repository-relative"},
+		{"empty skipped segment", `{"refused":false,"reason":null,"skipped":[{"path":"src//parser.c","reason":"outside repo"}]}`, "repository-relative"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			if _, err := parseRefusalAudit(tc.raw); err == nil || !strings.Contains(err.Error(), tc.want) {

--- a/internal/worker/skill.go
+++ b/internal/worker/skill.go
@@ -20,6 +20,9 @@ const (
 	skillSchemaFile           = "schema.json"
 	schemaRepairMaxTurns      = 4
 	schemaRepairReportMaxSize = 4000
+	refusalAuditSkillName     = "security-deep-dive"
+	refusalAuditOutputFile    = "refusal_audit.json"
+	refusalAuditMaxTurns      = 3
 )
 
 // skillContext is the JSON document scrutineer writes to ./context.json in
@@ -204,6 +207,7 @@ func (w *Worker) doSkill(ctx context.Context, scan *db.Scan, emit func(Event)) (
 		if err != nil {
 			return report, err
 		}
+		w.auditSkillRefusals(ctx, &skill, scan, sj, emit)
 	}
 	return report, nil
 }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1207,6 +1207,7 @@ components:
         started_at:    { type: string, format: date-time, nullable: true }
         finished_at:   { type: string, format: date-time, nullable: true }
         max_turns_hit: { type: boolean, description: True when the scan completed with partial output after hitting the Claude max-turns cap; retry resumes the saved session when available. }
+        refusal_audit_warning: { type: boolean, description: True when a security-deep-dive refusal audit reports declined or skipped analysis. }
         error:         { type: string }
 
     ScanDetail:
@@ -1215,6 +1216,7 @@ components:
         - type: object
           properties:
             report: { type: string, description: Raw output report (may be JSON text). }
+            refusal_audit: { type: string, description: Structured post-report security-deep-dive refusal audit. }
             log:    { type: string }
 
     Maintainer:


### PR DESCRIPTION
Fixes #157

## Summary

Adds a short, best-effort refusal audit after successful `security-deep-dive` runs. The audit resumes the completed agent session and captures any security-relevant content it declined, skipped, or only partially analysed.

## Changes

- Resume the completed deep-dive session with a capped follow-up prompt.
- Require a separate `refusal_audit.json` artifact, leaving the primary `report.json` unchanged.
- Store the structured audit on `Scan` and persist a warning flag for refused or skipped analysis.
- Keep successful scans successful if the follow-up session is unavailable, fails or emits invalid audit JSON.
- Show an `analysis incomplete` warning in repository scan rows and scan details.
- Show the captured refusal audit on the scan page.
- Expose audit state through the scan API, JSONL export, OpenAPI schema, and database documentation.
- Add focused parser, worker-flow, failure-path, scope and UI tests.

## Tests

- `go test ./...`
- `go test -tags evals ./...`
- `go vet ./...`
- `go vet -tags evals ./...`
- `golangci-lint run ./cmd/... ./internal/...`
- `golangci-lint run --build-tags evals ./cmd/... ./internal/...`
- `git diff --check`