### PR TITLE
Add auxiliary structured model calls

### DIFF
--- a/internal/llm/messages.go
+++ b/internal/llm/messages.go
@@ -10,8 +10,6 @@ import (
 	"io"
 	"net/http"
 	"strings"
-
-	"github.com/santhosh-tekuri/jsonschema/v6"
 )
 
 const (
@@ -44,9 +42,19 @@ type Usage struct {
 }
 
 type messageRequest struct {
-	Model     string    `json:"model"`
-	MaxTokens int       `json:"max_tokens"`
-	Messages  []message `json:"messages"`
+	Model        string       `json:"model"`
+	MaxTokens    int          `json:"max_tokens"`
+	Messages     []message    `json:"messages"`
+	OutputConfig outputConfig `json:"output_config"`
+}
+
+type outputConfig struct {
+	Format structuredOutputFormat `json:"format"`
+}
+
+type structuredOutputFormat struct {
+	Type   string          `json:"type"`
+	Schema json.RawMessage `json:"schema"`
 }
 
 type message struct {
@@ -71,17 +79,16 @@ type apiError struct {
 	} `json:"error"`
 }
 
-// Call sends prompt as one user turn and asks the API to continue an assistant
-// JSON value. The response is extracted tolerantly, then validated against
-// schema before being returned. Usage is returned even when extraction or
-// schema validation fails, so callers can still record billable requests.
+// Call sends prompt as one user turn and requests a response constrained to
+// schema through Anthropic structured outputs. Usage is returned even when a
+// provider response is malformed, so callers can still record billable
+// requests.
 //
 // POST calls are intentionally not retried: the provider may have accepted a
 // timed-out request, and retrying would risk paying for duplicate inference.
 func Call(ctx context.Context, prompt string, schema json.RawMessage, opts Options) (json.RawMessage, Usage, error) {
-	prefix, err := schemaPrefix(schema)
-	if err != nil {
-		return nil, Usage{}, err
+	if !json.Valid(schema) {
+		return nil, Usage{}, fmt.Errorf("llm: schema is not valid JSON")
 	}
 	if strings.TrimSpace(opts.APIKey) == "" {
 		return nil, Usage{}, fmt.Errorf("llm: API key is required")
@@ -102,8 +109,10 @@ func Call(ctx context.Context, prompt string, schema json.RawMessage, opts Optio
 		MaxTokens: opts.MaxTokens,
 		Messages: []message{
 			{Role: "user", Content: prompt},
-			{Role: "assistant", Content: prefix},
 		},
+		OutputConfig: outputConfig{Format: structuredOutputFormat{
+			Type: "json_schema", Schema: schema,
+		}},
 	})
 	if err != nil {
 		return nil, Usage{}, fmt.Errorf("llm: marshal request: %w", err)
@@ -137,35 +146,11 @@ func Call(ctx context.Context, prompt string, schema json.RawMessage, opts Optio
 	if err := json.Unmarshal(data, &decoded); err != nil {
 		return nil, Usage{}, fmt.Errorf("llm: decode response: %w", err)
 	}
-	text := responseText(decoded.Content)
-	result, err := ExtractJSON(text)
-	if err != nil {
-		result, err = ExtractJSON(prefix + text)
-	}
-	if err != nil {
-		return nil, decoded.Usage, err
-	}
-	if err := validateSchema(schema, result); err != nil {
-		return nil, decoded.Usage, err
+	result := json.RawMessage(strings.TrimSpace(responseText(decoded.Content)))
+	if !json.Valid(result) {
+		return nil, decoded.Usage, fmt.Errorf("llm: structured response is not valid JSON")
 	}
 	return result, decoded.Usage, nil
-}
-
-func schemaPrefix(schema json.RawMessage) (string, error) {
-	var root struct {
-		Type string `json:"type"`
-	}
-	if err := json.Unmarshal(schema, &root); err != nil {
-		return "", fmt.Errorf("llm: schema is not valid JSON: %w", err)
-	}
-	switch root.Type {
-	case "object":
-		return "{", nil
-	case "array":
-		return "[", nil
-	default:
-		return "", fmt.Errorf("llm: schema root type must be object or array, got %q", root.Type)
-	}
 }
 
 func responseText(blocks []contentBlock) string {
@@ -176,45 +161,6 @@ func responseText(blocks []contentBlock) string {
 		}
 	}
 	return text.String()
-}
-
-// ExtractJSON finds the first complete object or array embedded in text. It
-// accepts bare JSON, fenced JSON, and model prose surrounding the value.
-func ExtractJSON(text string) (json.RawMessage, error) {
-	for i := range text {
-		if text[i] != '{' && text[i] != '[' {
-			continue
-		}
-		dec := json.NewDecoder(strings.NewReader(text[i:]))
-		var value json.RawMessage
-		if err := dec.Decode(&value); err == nil {
-			return value, nil
-		}
-	}
-	return nil, fmt.Errorf("llm: response does not contain a JSON object or array")
-}
-
-func validateSchema(schema, value json.RawMessage) error {
-	compiler := jsonschema.NewCompiler()
-	doc, err := jsonschema.UnmarshalJSON(bytes.NewReader(schema))
-	if err != nil {
-		return fmt.Errorf("llm: schema is not valid JSON: %w", err)
-	}
-	if err := compiler.AddResource("schema.json", doc); err != nil {
-		return fmt.Errorf("llm: load schema: %w", err)
-	}
-	compiled, err := compiler.Compile("schema.json")
-	if err != nil {
-		return fmt.Errorf("llm: compile schema: %w", err)
-	}
-	instance, err := jsonschema.UnmarshalJSON(bytes.NewReader(value))
-	if err != nil {
-		return fmt.Errorf("llm: extracted response is not valid JSON: %w", err)
-	}
-	if err := compiled.Validate(instance); err != nil {
-		return fmt.Errorf("llm: response does not match schema: %w", err)
-	}
-	return nil
 }
 
 func responseError(resp *http.Response) error {

--- a/internal/llm/messages.go
+++ b/internal/llm/messages.go
@@ -1,0 +1,244 @@
+// Package llm provides small, structured one-shot model calls for work that
+// does not need a full agent workspace or tool loop.
+package llm
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/santhosh-tekuri/jsonschema/v6"
+)
+
+const (
+	DefaultEndpoint = "https://api.anthropic.com/v1/messages"
+	apiVersion      = "2023-06-01"
+	maxResponseSize = 10 << 20
+	maxErrorSize    = 32 << 10
+)
+
+// Options configures one Anthropic Messages API request. Endpoint is the full
+// Messages endpoint, which lets deployments use a compatible proxy. APIKey,
+// Model, and MaxTokens are required so each call's billing and output budget
+// are explicit at the call site.
+type Options struct {
+	Endpoint   string
+	APIKey     string
+	Model      string
+	MaxTokens  int
+	HTTPClient *http.Client
+}
+
+// Usage is the token accounting reported by the Messages API. Cache creation
+// maps to CacheWriteTokens so worker scan accounting uses the same fields as
+// harness result events.
+type Usage struct {
+	InputTokens      int `json:"input_tokens"`
+	OutputTokens     int `json:"output_tokens"`
+	CacheReadTokens  int `json:"cache_read_input_tokens"`
+	CacheWriteTokens int `json:"cache_creation_input_tokens"`
+}
+
+type messageRequest struct {
+	Model     string    `json:"model"`
+	MaxTokens int       `json:"max_tokens"`
+	Messages  []message `json:"messages"`
+}
+
+type message struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type messageResponse struct {
+	Content []contentBlock `json:"content"`
+	Usage   Usage          `json:"usage"`
+}
+
+type contentBlock struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+type apiError struct {
+	Error struct {
+		Type    string `json:"type"`
+		Message string `json:"message"`
+	} `json:"error"`
+}
+
+// Call sends prompt as one user turn and asks the API to continue an assistant
+// JSON value. The response is extracted tolerantly, then validated against
+// schema before being returned. Usage is returned even when extraction or
+// schema validation fails, so callers can still record billable requests.
+//
+// POST calls are intentionally not retried: the provider may have accepted a
+// timed-out request, and retrying would risk paying for duplicate inference.
+func Call(ctx context.Context, prompt string, schema json.RawMessage, opts Options) (json.RawMessage, Usage, error) {
+	prefix, err := schemaPrefix(schema)
+	if err != nil {
+		return nil, Usage{}, err
+	}
+	if strings.TrimSpace(opts.APIKey) == "" {
+		return nil, Usage{}, fmt.Errorf("llm: API key is required")
+	}
+	if strings.TrimSpace(opts.Model) == "" {
+		return nil, Usage{}, fmt.Errorf("llm: model is required")
+	}
+	if opts.MaxTokens <= 0 {
+		return nil, Usage{}, fmt.Errorf("llm: max tokens must be positive")
+	}
+
+	endpoint := opts.Endpoint
+	if endpoint == "" {
+		endpoint = DefaultEndpoint
+	}
+	body, err := json.Marshal(messageRequest{
+		Model:     opts.Model,
+		MaxTokens: opts.MaxTokens,
+		Messages: []message{
+			{Role: "user", Content: prompt},
+			{Role: "assistant", Content: prefix},
+		},
+	})
+	if err != nil {
+		return nil, Usage{}, fmt.Errorf("llm: marshal request: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return nil, Usage{}, fmt.Errorf("llm: create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("x-api-key", opts.APIKey)
+	req.Header.Set("anthropic-version", apiVersion)
+
+	client := opts.HTTPClient
+	if client == nil {
+		client = http.DefaultClient
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, Usage{}, fmt.Errorf("llm: messages request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return nil, Usage{}, responseError(resp)
+	}
+
+	data, err := readLimited(resp.Body, maxResponseSize)
+	if err != nil {
+		return nil, Usage{}, fmt.Errorf("llm: read response: %w", err)
+	}
+	var decoded messageResponse
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return nil, Usage{}, fmt.Errorf("llm: decode response: %w", err)
+	}
+	text := responseText(decoded.Content)
+	result, err := ExtractJSON(text)
+	if err != nil {
+		result, err = ExtractJSON(prefix + text)
+	}
+	if err != nil {
+		return nil, decoded.Usage, err
+	}
+	if err := validateSchema(schema, result); err != nil {
+		return nil, decoded.Usage, err
+	}
+	return result, decoded.Usage, nil
+}
+
+func schemaPrefix(schema json.RawMessage) (string, error) {
+	var root struct {
+		Type string `json:"type"`
+	}
+	if err := json.Unmarshal(schema, &root); err != nil {
+		return "", fmt.Errorf("llm: schema is not valid JSON: %w", err)
+	}
+	switch root.Type {
+	case "object":
+		return "{", nil
+	case "array":
+		return "[", nil
+	default:
+		return "", fmt.Errorf("llm: schema root type must be object or array, got %q", root.Type)
+	}
+}
+
+func responseText(blocks []contentBlock) string {
+	var text strings.Builder
+	for _, block := range blocks {
+		if block.Type == "text" {
+			text.WriteString(block.Text)
+		}
+	}
+	return text.String()
+}
+
+// ExtractJSON finds the first complete object or array embedded in text. It
+// accepts bare JSON, fenced JSON, and model prose surrounding the value.
+func ExtractJSON(text string) (json.RawMessage, error) {
+	for i := range text {
+		if text[i] != '{' && text[i] != '[' {
+			continue
+		}
+		dec := json.NewDecoder(strings.NewReader(text[i:]))
+		var value json.RawMessage
+		if err := dec.Decode(&value); err == nil {
+			return value, nil
+		}
+	}
+	return nil, fmt.Errorf("llm: response does not contain a JSON object or array")
+}
+
+func validateSchema(schema, value json.RawMessage) error {
+	compiler := jsonschema.NewCompiler()
+	doc, err := jsonschema.UnmarshalJSON(bytes.NewReader(schema))
+	if err != nil {
+		return fmt.Errorf("llm: schema is not valid JSON: %w", err)
+	}
+	if err := compiler.AddResource("schema.json", doc); err != nil {
+		return fmt.Errorf("llm: load schema: %w", err)
+	}
+	compiled, err := compiler.Compile("schema.json")
+	if err != nil {
+		return fmt.Errorf("llm: compile schema: %w", err)
+	}
+	instance, err := jsonschema.UnmarshalJSON(bytes.NewReader(value))
+	if err != nil {
+		return fmt.Errorf("llm: extracted response is not valid JSON: %w", err)
+	}
+	if err := compiled.Validate(instance); err != nil {
+		return fmt.Errorf("llm: response does not match schema: %w", err)
+	}
+	return nil
+}
+
+func responseError(resp *http.Response) error {
+	body, err := readLimited(resp.Body, maxErrorSize)
+	if err != nil {
+		return fmt.Errorf("llm: messages API returned %s", resp.Status)
+	}
+	var apiErr apiError
+	if json.Unmarshal(body, &apiErr) == nil && apiErr.Error.Message != "" {
+		if apiErr.Error.Type != "" {
+			return fmt.Errorf("llm: messages API %s: %s: %s", resp.Status, apiErr.Error.Type, apiErr.Error.Message)
+		}
+		return fmt.Errorf("llm: messages API %s: %s", resp.Status, apiErr.Error.Message)
+	}
+	return fmt.Errorf("llm: messages API returned %s: %s", resp.Status, strings.TrimSpace(string(body)))
+}
+
+func readLimited(r io.Reader, limit int64) ([]byte, error) {
+	data, err := io.ReadAll(io.LimitReader(r, limit+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(data)) > limit {
+		return nil, fmt.Errorf("response exceeds %d byte limit", limit)
+	}
+	return data, nil
+}

--- a/internal/llm/messages.go
+++ b/internal/llm/messages.go
@@ -80,9 +80,9 @@ type apiError struct {
 }
 
 // Call sends prompt as one user turn and requests a response constrained to
-// schema through Anthropic structured outputs. Usage is returned even when a
-// provider response is malformed, so callers can still record billable
-// requests.
+// schema through Anthropic structured outputs. Usage is returned when the API
+// response itself is valid but its structured text is malformed, so callers can
+// still record billable requests.
 //
 // POST calls are intentionally not retried: the provider may have accepted a
 // timed-out request, and retrying would risk paying for duplicate inference.

--- a/internal/llm/messages_test.go
+++ b/internal/llm/messages_test.go
@@ -1,0 +1,124 @@
+package llm
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+const objectSchema = `{"type":"object","required":["answer"],"additionalProperties":false,"properties":{"answer":{"type":"string"}}}`
+
+func TestCall_objectContinuationAndUsage(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/v1/messages" {
+			t.Fatalf("request = %s %s", r.Method, r.URL.Path)
+		}
+		if got := r.Header.Get("x-api-key"); got != "key" {
+			t.Errorf("x-api-key = %q", got)
+		}
+		if got := r.Header.Get("anthropic-version"); got != apiVersion {
+			t.Errorf("anthropic-version = %q", got)
+		}
+		var request messageRequest
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			t.Fatal(err)
+		}
+		if request.Model != "claude-sonnet-4-6" || request.MaxTokens != 64 {
+			t.Errorf("request = %+v", request)
+		}
+		if len(request.Messages) != 2 || request.Messages[1] != (message{Role: "assistant", Content: "{"}) {
+			t.Errorf("messages = %+v", request.Messages)
+		}
+		_, _ = io.WriteString(w, `{"content":[{"type":"text","text":"\"answer\":\"ok\"}"}],"usage":{"input_tokens":100,"output_tokens":12,"cache_read_input_tokens":30,"cache_creation_input_tokens":7}}`)
+	}))
+	defer server.Close()
+
+	got, usage, err := Call(context.Background(), "reply as JSON", json.RawMessage(objectSchema), Options{
+		Endpoint: server.URL + "/v1/messages", APIKey: "key", Model: "claude-sonnet-4-6", MaxTokens: 64, HTTPClient: server.Client(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != `{"answer":"ok"}` {
+		t.Errorf("result = %s", got)
+	}
+	if usage != (Usage{InputTokens: 100, OutputTokens: 12, CacheReadTokens: 30, CacheWriteTokens: 7}) {
+		t.Errorf("usage = %+v", usage)
+	}
+}
+
+func TestCall_arrayContinuation(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"content":[{"type":"text","text":"1,2]"}],"usage":{}}`)
+	}))
+	defer server.Close()
+
+	got, _, err := Call(context.Background(), "array", json.RawMessage(`{"type":"array","items":{"type":"integer"}}`), Options{
+		Endpoint: server.URL, APIKey: "key", Model: "claude-sonnet-4-6", MaxTokens: 32, HTTPClient: server.Client(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != `[1,2]` {
+		t.Errorf("result = %s", got)
+	}
+}
+
+func TestExtractJSON(t *testing.T) {
+	for _, tc := range []struct {
+		text string
+		want string
+	}{
+		{`{"answer":"bare"}`, `{"answer":"bare"}`},
+		{"Here is the result:\n```json\n{\"answer\":\"fenced\"}\n```", `{"answer":"fenced"}`},
+		{"analysis first [1, 2] trailing prose", `[1, 2]`},
+	} {
+		got, err := ExtractJSON(tc.text)
+		if err != nil {
+			t.Fatalf("ExtractJSON(%q): %v", tc.text, err)
+		}
+		if string(got) != tc.want {
+			t.Errorf("ExtractJSON(%q) = %s, want %s", tc.text, got, tc.want)
+		}
+	}
+}
+
+func TestCall_validationFailureStillReturnsUsage(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"content":[{"type":"text","text":"\"wrong\":true}"}],"usage":{"input_tokens":9,"output_tokens":3}}`)
+	}))
+	defer server.Close()
+
+	_, usage, err := Call(context.Background(), "object", json.RawMessage(objectSchema), Options{
+		Endpoint: server.URL, APIKey: "key", Model: "claude-sonnet-4-6", MaxTokens: 32, HTTPClient: server.Client(),
+	})
+	if err == nil || !strings.Contains(err.Error(), "does not match schema") {
+		t.Fatalf("Call error = %v", err)
+	}
+	if usage.InputTokens != 9 || usage.OutputTokens != 3 {
+		t.Errorf("usage = %+v, want returned despite validation failure", usage)
+	}
+}
+
+func TestCall_rejectsAPIErrorsAndInvalidOptions(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = io.WriteString(w, `{"error":{"type":"authentication_error","message":"bad key"}}`)
+	}))
+	defer server.Close()
+
+	_, _, err := Call(context.Background(), "object", json.RawMessage(objectSchema), Options{
+		Endpoint: server.URL, APIKey: "key", Model: "claude-sonnet-4-6", MaxTokens: 32, HTTPClient: server.Client(),
+	})
+	if err == nil || !strings.Contains(err.Error(), "authentication_error") {
+		t.Fatalf("API error = %v", err)
+	}
+	_, _, err = Call(context.Background(), "object", json.RawMessage(objectSchema), Options{APIKey: "key", Model: "m"})
+	if err == nil || !strings.Contains(err.Error(), "max tokens") {
+		t.Fatalf("option error = %v", err)
+	}
+}

--- a/internal/llm/messages_test.go
+++ b/internal/llm/messages_test.go
@@ -12,7 +12,7 @@ import (
 
 const objectSchema = `{"type":"object","required":["answer"],"additionalProperties":false,"properties":{"answer":{"type":"string"}}}`
 
-func TestCall_objectContinuationAndUsage(t *testing.T) {
+func TestCall_requestsStructuredOutputAndReturnsUsage(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost || r.URL.Path != "/v1/messages" {
 			t.Fatalf("request = %s %s", r.Method, r.URL.Path)
@@ -30,10 +30,13 @@ func TestCall_objectContinuationAndUsage(t *testing.T) {
 		if request.Model != "claude-sonnet-4-6" || request.MaxTokens != 64 {
 			t.Errorf("request = %+v", request)
 		}
-		if len(request.Messages) != 2 || request.Messages[1] != (message{Role: "assistant", Content: "{"}) {
+		if len(request.Messages) != 1 || request.Messages[0] != (message{Role: "user", Content: "reply as JSON"}) {
 			t.Errorf("messages = %+v", request.Messages)
 		}
-		_, _ = io.WriteString(w, `{"content":[{"type":"text","text":"\"answer\":\"ok\"}"}],"usage":{"input_tokens":100,"output_tokens":12,"cache_read_input_tokens":30,"cache_creation_input_tokens":7}}`)
+		if request.OutputConfig.Format.Type != "json_schema" || string(request.OutputConfig.Format.Schema) != objectSchema {
+			t.Errorf("output_config = %+v", request.OutputConfig)
+		}
+		_, _ = io.WriteString(w, `{"content":[{"type":"text","text":"{\"answer\":\"ok\"}"}],"usage":{"input_tokens":100,"output_tokens":12,"cache_read_input_tokens":30,"cache_creation_input_tokens":7}}`)
 	}))
 	defer server.Close()
 
@@ -51,9 +54,9 @@ func TestCall_objectContinuationAndUsage(t *testing.T) {
 	}
 }
 
-func TestCall_arrayContinuation(t *testing.T) {
+func TestCall_arrayStructuredOutput(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		_, _ = io.WriteString(w, `{"content":[{"type":"text","text":"1,2]"}],"usage":{}}`)
+		_, _ = io.WriteString(w, `{"content":[{"type":"text","text":"[1,2]"}],"usage":{}}`)
 	}))
 	defer server.Close()
 
@@ -68,35 +71,16 @@ func TestCall_arrayContinuation(t *testing.T) {
 	}
 }
 
-func TestExtractJSON(t *testing.T) {
-	for _, tc := range []struct {
-		text string
-		want string
-	}{
-		{`{"answer":"bare"}`, `{"answer":"bare"}`},
-		{"Here is the result:\n```json\n{\"answer\":\"fenced\"}\n```", `{"answer":"fenced"}`},
-		{"analysis first [1, 2] trailing prose", `[1, 2]`},
-	} {
-		got, err := ExtractJSON(tc.text)
-		if err != nil {
-			t.Fatalf("ExtractJSON(%q): %v", tc.text, err)
-		}
-		if string(got) != tc.want {
-			t.Errorf("ExtractJSON(%q) = %s, want %s", tc.text, got, tc.want)
-		}
-	}
-}
-
-func TestCall_validationFailureStillReturnsUsage(t *testing.T) {
+func TestCall_malformedStructuredResponseStillReturnsUsage(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		_, _ = io.WriteString(w, `{"content":[{"type":"text","text":"\"wrong\":true}"}],"usage":{"input_tokens":9,"output_tokens":3}}`)
+		_, _ = io.WriteString(w, `{"content":[{"type":"text","text":"not JSON"}],"usage":{"input_tokens":9,"output_tokens":3}}`)
 	}))
 	defer server.Close()
 
 	_, usage, err := Call(context.Background(), "object", json.RawMessage(objectSchema), Options{
 		Endpoint: server.URL, APIKey: "key", Model: "claude-sonnet-4-6", MaxTokens: 32, HTTPClient: server.Client(),
 	})
-	if err == nil || !strings.Contains(err.Error(), "does not match schema") {
+	if err == nil || !strings.Contains(err.Error(), "not valid JSON") {
 		t.Fatalf("Call error = %v", err)
 	}
 	if usage.InputTokens != 9 || usage.OutputTokens != 3 {
@@ -120,5 +104,9 @@ func TestCall_rejectsAPIErrorsAndInvalidOptions(t *testing.T) {
 	_, _, err = Call(context.Background(), "object", json.RawMessage(objectSchema), Options{APIKey: "key", Model: "m"})
 	if err == nil || !strings.Contains(err.Error(), "max tokens") {
 		t.Fatalf("option error = %v", err)
+	}
+	_, _, err = Call(context.Background(), "object", json.RawMessage(`{`), Options{APIKey: "key", Model: "m", MaxTokens: 1})
+	if err == nil || !strings.Contains(err.Error(), "schema is not valid JSON") {
+		t.Fatalf("schema error = %v", err)
 	}
 }

--- a/internal/worker/auxiliary.go
+++ b/internal/worker/auxiliary.go
@@ -1,0 +1,66 @@
+package worker
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"gorm.io/gorm"
+
+	"scrutineer/internal/db"
+	"scrutineer/internal/llm"
+)
+
+// CallAuxiliary performs a direct structured model call and records its usage
+// on scan. It is for small worker-side decisions that do not need an agent
+// workspace. Usage is persisted even when the provider returned JSON that
+// failed schema validation, because the request was still billable.
+func (w *Worker) CallAuxiliary(ctx context.Context, scan *db.Scan, prompt string, schema json.RawMessage, opts llm.Options) (json.RawMessage, error) {
+	if w == nil || w.DB == nil {
+		return nil, fmt.Errorf("auxiliary model call requires a worker database")
+	}
+	if scan == nil || scan.ID == 0 {
+		return nil, fmt.Errorf("auxiliary model call requires a persisted scan")
+	}
+	result, usage, callErr := llm.Call(ctx, prompt, schema, opts)
+	if err := recordAuxiliaryUsage(w.DB, scan, opts.Model, usage); err != nil {
+		if callErr != nil {
+			return nil, fmt.Errorf("%w; record auxiliary usage: %v", callErr, err)
+		}
+		return nil, fmt.Errorf("record auxiliary usage: %w", err)
+	}
+	return result, callErr
+}
+
+func recordAuxiliaryUsage(gdb *gorm.DB, scan *db.Scan, model string, usage llm.Usage) error {
+	if usage == (llm.Usage{}) {
+		return nil
+	}
+	workerUsage := Usage{
+		InputTokens:      usage.InputTokens,
+		OutputTokens:     usage.OutputTokens,
+		CacheReadTokens:  usage.CacheReadTokens,
+		CacheWriteTokens: usage.CacheWriteTokens,
+	}
+	cost := CostFromUsage(model, workerUsage)
+	updates := map[string]any{
+		"cost_usd":           gorm.Expr("cost_usd + ?", cost),
+		"input_tokens":       gorm.Expr("input_tokens + ?", workerUsage.InputTokens),
+		"output_tokens":      gorm.Expr("output_tokens + ?", workerUsage.OutputTokens),
+		"cache_read_tokens":  gorm.Expr("cache_read_tokens + ?", workerUsage.CacheReadTokens),
+		"cache_write_tokens": gorm.Expr("cache_write_tokens + ?", workerUsage.CacheWriteTokens),
+	}
+	result := gdb.Model(&db.Scan{}).Where("id = ?", scan.ID).Updates(updates)
+	if result.Error != nil {
+		return result.Error
+	}
+	if result.RowsAffected == 0 {
+		return fmt.Errorf("scan %d no longer exists", scan.ID)
+	}
+	scan.CostUSD += cost
+	scan.InputTokens += workerUsage.InputTokens
+	scan.OutputTokens += workerUsage.OutputTokens
+	scan.CacheReadTokens += workerUsage.CacheReadTokens
+	scan.CacheWriteTokens += workerUsage.CacheWriteTokens
+	return nil
+}

--- a/internal/worker/auxiliary.go
+++ b/internal/worker/auxiliary.go
@@ -13,8 +13,8 @@ import (
 
 // CallAuxiliary performs a direct structured model call and records its usage
 // on scan. It is for small worker-side decisions that do not need an agent
-// workspace. Usage is persisted even when the provider returned JSON that
-// failed schema validation, because the request was still billable.
+// workspace. Usage is persisted even when the provider response is malformed,
+// because the request was still billable.
 func (w *Worker) CallAuxiliary(ctx context.Context, scan *db.Scan, prompt string, schema json.RawMessage, opts llm.Options) (json.RawMessage, error) {
 	if w == nil || w.DB == nil {
 		return nil, fmt.Errorf("auxiliary model call requires a worker database")
@@ -37,7 +37,10 @@ func recordAuxiliaryUsage(gdb *gorm.DB, scan *db.Scan, model string, usage llm.U
 		return nil
 	}
 	workerUsage := Usage{
-		InputTokens:      usage.InputTokens,
+		// Anthropic reports uncached input separately from cache-read and
+		// cache-write input. Worker Usage records total prompt input, with
+		// the cache values as subsets, matching harness usage semantics.
+		InputTokens:      usage.InputTokens + usage.CacheReadTokens + usage.CacheWriteTokens,
 		OutputTokens:     usage.OutputTokens,
 		CacheReadTokens:  usage.CacheReadTokens,
 		CacheWriteTokens: usage.CacheWriteTokens,

--- a/internal/worker/auxiliary.go
+++ b/internal/worker/auxiliary.go
@@ -13,14 +13,21 @@ import (
 
 // CallAuxiliary performs a direct structured model call and records its usage
 // on scan. It is for small worker-side decisions that do not need an agent
-// workspace. Usage is persisted even when the provider response is malformed,
-// because the request was still billable.
+// workspace. Usage is persisted when the provider returns a decodable response,
+// even when its structured text is malformed, because the request was still
+// billable.
 func (w *Worker) CallAuxiliary(ctx context.Context, scan *db.Scan, prompt string, schema json.RawMessage, opts llm.Options) (json.RawMessage, error) {
 	if w == nil || w.DB == nil {
 		return nil, fmt.Errorf("auxiliary model call requires a worker database")
 	}
 	if scan == nil || scan.ID == 0 {
 		return nil, fmt.Errorf("auxiliary model call requires a persisted scan")
+	}
+	if opts.Model == "" {
+		opts.Model = scan.Model
+	}
+	if scan.Model != "" && opts.Model != scan.Model {
+		return nil, fmt.Errorf("auxiliary model %q does not match scan model %q", opts.Model, scan.Model)
 	}
 	result, usage, callErr := llm.Call(ctx, prompt, schema, opts)
 	if err := recordAuxiliaryUsage(w.DB, scan, opts.Model, usage); err != nil {
@@ -36,22 +43,25 @@ func recordAuxiliaryUsage(gdb *gorm.DB, scan *db.Scan, model string, usage llm.U
 	if usage == (llm.Usage{}) {
 		return nil
 	}
-	workerUsage := Usage{
-		// Anthropic reports uncached input separately from cache-read and
-		// cache-write input. Worker Usage records total prompt input, with
-		// the cache values as subsets, matching harness usage semantics.
-		InputTokens:      usage.InputTokens + usage.CacheReadTokens + usage.CacheWriteTokens,
+	storedUsage := Usage{
+		// Anthropic's input_tokens is fresh input. Scan stores that separately
+		// from cache categories so TotalInputTokens can add each exactly once.
+		InputTokens:      usage.InputTokens,
 		OutputTokens:     usage.OutputTokens,
 		CacheReadTokens:  usage.CacheReadTokens,
 		CacheWriteTokens: usage.CacheWriteTokens,
 	}
-	cost := CostFromUsage(model, workerUsage)
+	pricingUsage := storedUsage
+	// CostFromUsage takes the harness representation, where input_tokens is
+	// the total prompt size and cache categories are subsets of that total.
+	pricingUsage.InputTokens += pricingUsage.CacheReadTokens + pricingUsage.CacheWriteTokens
+	cost := CostFromUsage(model, pricingUsage)
 	updates := map[string]any{
 		"cost_usd":           gorm.Expr("cost_usd + ?", cost),
-		"input_tokens":       gorm.Expr("input_tokens + ?", workerUsage.InputTokens),
-		"output_tokens":      gorm.Expr("output_tokens + ?", workerUsage.OutputTokens),
-		"cache_read_tokens":  gorm.Expr("cache_read_tokens + ?", workerUsage.CacheReadTokens),
-		"cache_write_tokens": gorm.Expr("cache_write_tokens + ?", workerUsage.CacheWriteTokens),
+		"input_tokens":       gorm.Expr("input_tokens + ?", storedUsage.InputTokens),
+		"output_tokens":      gorm.Expr("output_tokens + ?", storedUsage.OutputTokens),
+		"cache_read_tokens":  gorm.Expr("cache_read_tokens + ?", storedUsage.CacheReadTokens),
+		"cache_write_tokens": gorm.Expr("cache_write_tokens + ?", storedUsage.CacheWriteTokens),
 	}
 	result := gdb.Model(&db.Scan{}).Where("id = ?", scan.ID).Updates(updates)
 	if result.Error != nil {
@@ -61,9 +71,9 @@ func recordAuxiliaryUsage(gdb *gorm.DB, scan *db.Scan, model string, usage llm.U
 		return fmt.Errorf("scan %d no longer exists", scan.ID)
 	}
 	scan.CostUSD += cost
-	scan.InputTokens += workerUsage.InputTokens
-	scan.OutputTokens += workerUsage.OutputTokens
-	scan.CacheReadTokens += workerUsage.CacheReadTokens
-	scan.CacheWriteTokens += workerUsage.CacheWriteTokens
+	scan.InputTokens += storedUsage.InputTokens
+	scan.OutputTokens += storedUsage.OutputTokens
+	scan.CacheReadTokens += storedUsage.CacheReadTokens
+	scan.CacheWriteTokens += storedUsage.CacheWriteTokens
 	return nil
 }

--- a/internal/worker/auxiliary_test.go
+++ b/internal/worker/auxiliary_test.go
@@ -15,7 +15,7 @@ import (
 	"scrutineer/internal/llm"
 )
 
-func TestCallAuxiliary_recordsUsageOnSchemaFailure(t *testing.T) {
+func TestCallAuxiliary_recordsUsageOnMalformedResponse(t *testing.T) {
 	gdb, err := db.Open(filepath.Join(t.TempDir(), "auxiliary.db"))
 	if err != nil {
 		t.Fatal(err)
@@ -29,7 +29,7 @@ func TestCallAuxiliary_recordsUsageOnSchemaFailure(t *testing.T) {
 		t.Fatal(err)
 	}
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		_, _ = io.WriteString(w, `{"content":[{"type":"text","text":"\"wrong\":true}"}],"usage":{"input_tokens":100,"output_tokens":10,"cache_read_input_tokens":20,"cache_creation_input_tokens":30}}`)
+		_, _ = io.WriteString(w, `{"content":[{"type":"text","text":"not JSON"}],"usage":{"input_tokens":100,"output_tokens":10,"cache_read_input_tokens":20,"cache_creation_input_tokens":30}}`)
 	}))
 	defer server.Close()
 
@@ -38,17 +38,17 @@ func TestCallAuxiliary_recordsUsageOnSchemaFailure(t *testing.T) {
 		Endpoint: server.URL, APIKey: "key", Model: scan.Model, MaxTokens: 32, HTTPClient: server.Client(),
 	})
 	if err == nil {
-		t.Fatal("CallAuxiliary succeeded, want schema error")
+		t.Fatal("CallAuxiliary succeeded, want malformed-response error")
 	}
 
 	var got db.Scan
 	if err := gdb.First(&got, scan.ID).Error; err != nil {
 		t.Fatal(err)
 	}
-	if got.InputTokens != 100 || got.OutputTokens != 10 || got.CacheReadTokens != 20 || got.CacheWriteTokens != 30 {
+	if got.InputTokens != 150 || got.OutputTokens != 10 || got.CacheReadTokens != 20 || got.CacheWriteTokens != 30 {
 		t.Errorf("usage = in:%d out:%d read:%d write:%d", got.InputTokens, got.OutputTokens, got.CacheReadTokens, got.CacheWriteTokens)
 	}
-	if want := 0.0005085; math.Abs(got.CostUSD-want) > 1e-12 {
+	if want := 0.0005685; math.Abs(got.CostUSD-want) > 1e-12 {
 		t.Errorf("cost = %.7f, want %.7f", got.CostUSD, want)
 	}
 	if scan.InputTokens != got.InputTokens || scan.CostUSD != got.CostUSD {

--- a/internal/worker/auxiliary_test.go
+++ b/internal/worker/auxiliary_test.go
@@ -1,0 +1,68 @@
+package worker
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"math"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"scrutineer/internal/db"
+	"scrutineer/internal/llm"
+)
+
+func TestCallAuxiliary_recordsUsageOnSchemaFailure(t *testing.T) {
+	gdb, err := db.Open(filepath.Join(t.TempDir(), "auxiliary.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo := db.Repository{URL: "https://example.com/auxiliary", Name: "auxiliary"}
+	if err := gdb.Create(&repo).Error; err != nil {
+		t.Fatal(err)
+	}
+	scan := db.Scan{RepositoryID: repo.ID, Kind: JobSkill, Status: db.ScanRunning, Model: "claude-sonnet-4-6"}
+	if err := gdb.Create(&scan).Error; err != nil {
+		t.Fatal(err)
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"content":[{"type":"text","text":"\"wrong\":true}"}],"usage":{"input_tokens":100,"output_tokens":10,"cache_read_input_tokens":20,"cache_creation_input_tokens":30}}`)
+	}))
+	defer server.Close()
+
+	w := &Worker{DB: gdb, Log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	_, err = w.CallAuxiliary(context.Background(), &scan, "answer", json.RawMessage(`{"type":"object","required":["answer"],"properties":{"answer":{"type":"string"}}}`), llm.Options{
+		Endpoint: server.URL, APIKey: "key", Model: scan.Model, MaxTokens: 32, HTTPClient: server.Client(),
+	})
+	if err == nil {
+		t.Fatal("CallAuxiliary succeeded, want schema error")
+	}
+
+	var got db.Scan
+	if err := gdb.First(&got, scan.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if got.InputTokens != 100 || got.OutputTokens != 10 || got.CacheReadTokens != 20 || got.CacheWriteTokens != 30 {
+		t.Errorf("usage = in:%d out:%d read:%d write:%d", got.InputTokens, got.OutputTokens, got.CacheReadTokens, got.CacheWriteTokens)
+	}
+	if want := 0.0005085; math.Abs(got.CostUSD-want) > 1e-12 {
+		t.Errorf("cost = %.7f, want %.7f", got.CostUSD, want)
+	}
+	if scan.InputTokens != got.InputTokens || scan.CostUSD != got.CostUSD {
+		t.Errorf("in-memory scan was not updated: %+v", scan)
+	}
+}
+
+func TestRecordAuxiliaryUsage_rejectsMissingScan(t *testing.T) {
+	gdb, err := db.Open(filepath.Join(t.TempDir(), "missing-scan.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = recordAuxiliaryUsage(gdb, &db.Scan{ID: 999}, "claude-sonnet-4-6", llm.Usage{InputTokens: 1})
+	if err == nil || err.Error() != "scan 999 no longer exists" {
+		t.Fatalf("recordAuxiliaryUsage() error = %v", err)
+	}
+}

--- a/internal/worker/auxiliary_test.go
+++ b/internal/worker/auxiliary_test.go
@@ -11,6 +11,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	"gorm.io/gorm"
+
 	"scrutineer/internal/db"
 	"scrutineer/internal/llm"
 )
@@ -28,14 +30,23 @@ func TestCallAuxiliary_recordsUsageOnMalformedResponse(t *testing.T) {
 	if err := gdb.Create(&scan).Error; err != nil {
 		t.Fatal(err)
 	}
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var request struct {
+			Model string `json:"model"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			t.Fatal(err)
+		}
+		if request.Model != scan.Model {
+			t.Errorf("model = %q, want %q", request.Model, scan.Model)
+		}
 		_, _ = io.WriteString(w, `{"content":[{"type":"text","text":"not JSON"}],"usage":{"input_tokens":100,"output_tokens":10,"cache_read_input_tokens":20,"cache_creation_input_tokens":30}}`)
 	}))
 	defer server.Close()
 
 	w := &Worker{DB: gdb, Log: slog.New(slog.NewTextHandler(io.Discard, nil))}
 	_, err = w.CallAuxiliary(context.Background(), &scan, "answer", json.RawMessage(`{"type":"object","required":["answer"],"properties":{"answer":{"type":"string"}}}`), llm.Options{
-		Endpoint: server.URL, APIKey: "key", Model: scan.Model, MaxTokens: 32, HTTPClient: server.Client(),
+		Endpoint: server.URL, APIKey: "key", MaxTokens: 32, HTTPClient: server.Client(),
 	})
 	if err == nil {
 		t.Fatal("CallAuxiliary succeeded, want malformed-response error")
@@ -45,7 +56,7 @@ func TestCallAuxiliary_recordsUsageOnMalformedResponse(t *testing.T) {
 	if err := gdb.First(&got, scan.ID).Error; err != nil {
 		t.Fatal(err)
 	}
-	if got.InputTokens != 150 || got.OutputTokens != 10 || got.CacheReadTokens != 20 || got.CacheWriteTokens != 30 {
+	if got.InputTokens != 100 || got.OutputTokens != 10 || got.CacheReadTokens != 20 || got.CacheWriteTokens != 30 {
 		t.Errorf("usage = in:%d out:%d read:%d write:%d", got.InputTokens, got.OutputTokens, got.CacheReadTokens, got.CacheWriteTokens)
 	}
 	if want := 0.0005685; math.Abs(got.CostUSD-want) > 1e-12 {
@@ -53,6 +64,16 @@ func TestCallAuxiliary_recordsUsageOnMalformedResponse(t *testing.T) {
 	}
 	if scan.InputTokens != got.InputTokens || scan.CostUSD != got.CostUSD {
 		t.Errorf("in-memory scan was not updated: %+v", scan)
+	}
+}
+
+func TestCallAuxiliary_rejectsDifferentModel(t *testing.T) {
+	w := &Worker{DB: &gorm.DB{}}
+	_, err := w.CallAuxiliary(context.Background(), &db.Scan{ID: 1, Model: "claude-haiku-4-5"}, "answer", json.RawMessage(`{"type":"object"}`), llm.Options{
+		Model: "claude-sonnet-4-6",
+	})
+	if err == nil || err.Error() != `auxiliary model "claude-sonnet-4-6" does not match scan model "claude-haiku-4-5"` {
+		t.Fatalf("CallAuxiliary() error = %v", err)
 	}
 }
 

--- a/internal/worker/pricing.go
+++ b/internal/worker/pricing.go
@@ -4,9 +4,9 @@ import "strings"
 
 // modelPrice is the USD list price per 1M tokens for one model. In is
 // the uncached-input rate, Out the output rate, CachedIn the discounted
-// cache-read rate.
+// cache-read rate, and CacheWrite the cache-creation rate.
 type modelPrice struct {
-	In, Out, CachedIn float64
+	In, Out, CachedIn, CacheWrite float64
 }
 
 // modelPricing maps model ids to their per-1M-token USD list prices. It
@@ -24,15 +24,15 @@ type modelPrice struct {
 //nolint:mnd // a pricing table is a table of numbers; naming each rate would obscure it
 var modelPricing = map[string]modelPrice{
 	// Anthropic
-	"claude-opus-4-6":   {In: 5.00, Out: 25.00, CachedIn: 0.50},
-	"claude-opus-4-7":   {In: 5.00, Out: 25.00, CachedIn: 0.50},
-	"claude-opus-4-8":   {In: 5.00, Out: 25.00, CachedIn: 0.50},
-	"claude-sonnet-4-6": {In: 3.00, Out: 15.00, CachedIn: 0.30},
+	"claude-opus-4-6":   {In: 5.00, Out: 25.00, CachedIn: 0.50, CacheWrite: 6.25},
+	"claude-opus-4-7":   {In: 5.00, Out: 25.00, CachedIn: 0.50, CacheWrite: 6.25},
+	"claude-opus-4-8":   {In: 5.00, Out: 25.00, CachedIn: 0.50, CacheWrite: 6.25},
+	"claude-sonnet-4-6": {In: 3.00, Out: 15.00, CachedIn: 0.30, CacheWrite: 3.75},
 	// Sonnet 5 is not on any published price sheet as of 2026-07;
 	// priced at Sonnet 4.6's rate. Claude reports cost in-stream so
 	// this row is only reached by the coverage tripwire, not billing.
-	"claude-sonnet-5": {In: 3.00, Out: 15.00, CachedIn: 0.30},
-	"claude-fable-5":  {In: 10.00, Out: 50.00, CachedIn: 1.00},
+	"claude-sonnet-5": {In: 3.00, Out: 15.00, CachedIn: 0.30, CacheWrite: 3.75},
+	"claude-fable-5":  {In: 10.00, Out: 50.00, CachedIn: 1.00, CacheWrite: 12.50},
 
 	// OpenAI (codex catalog at the pinned Dockerfile.runner version)
 	"gpt-5.5":       {In: 5.00, Out: 30.00, CachedIn: 0.50},
@@ -55,7 +55,9 @@ const perMillion = 1e6
 // total prompt token count and CacheReadTokens is the cached subset of
 // it, so uncached = InputTokens - CacheReadTokens. That is what codex's
 // turn.completed usage reports. CacheWriteTokens is not billed
-// separately by OpenAI and codex does not report it, so it is ignored.
+// separately by OpenAI and codex does not report it, so those pricing rows
+// leave CacheWrite at zero. Anthropic's Messages API does bill cache creation,
+// and auxiliary calls report it in CacheWriteTokens.
 func costFromUsage(model string, u Usage) float64 {
 	p, ok := modelPricing[normalizeModelID(model)]
 	if !ok {
@@ -67,7 +69,14 @@ func costFromUsage(model string, u Usage) float64 {
 	}
 	return (float64(uncached)*p.In +
 		float64(u.CacheReadTokens)*p.CachedIn +
+		float64(u.CacheWriteTokens)*p.CacheWrite +
 		float64(u.OutputTokens)*p.Out) / perMillion
+}
+
+// CostFromUsage exposes the scan pricing calculation to worker helpers that
+// account for direct model calls outside the harness event stream.
+func CostFromUsage(model string, u Usage) float64 {
+	return costFromUsage(model, u)
 }
 
 // normalizeModelID strips a leading provider/ prefix (opencode's

--- a/internal/worker/pricing.go
+++ b/internal/worker/pricing.go
@@ -10,7 +10,7 @@ type modelPrice struct {
 }
 
 // modelPricing maps model ids to their per-1M-token USD list prices. It
-// backs costFromUsage, which the event loop consults when a harness's
+// backs CostFromUsage, which the event loop consults when a harness's
 // stream reports token usage but no dollar figure (codex). Claude
 // reports total_cost_usd in-stream so its entries here are not used to
 // compute cost; they exist so the coverage tripwire in pricing_test.go
@@ -28,6 +28,7 @@ var modelPricing = map[string]modelPrice{
 	"claude-opus-4-7":   {In: 5.00, Out: 25.00, CachedIn: 0.50, CacheWrite: 6.25},
 	"claude-opus-4-8":   {In: 5.00, Out: 25.00, CachedIn: 0.50, CacheWrite: 6.25},
 	"claude-sonnet-4-6": {In: 3.00, Out: 15.00, CachedIn: 0.30, CacheWrite: 3.75},
+	"claude-haiku-4-5":  {In: 1.00, Out: 5.00, CachedIn: 0.10, CacheWrite: 1.25},
 	// Sonnet 5 is not on any published price sheet as of 2026-07;
 	// priced at Sonnet 4.6's rate. Claude reports cost in-stream so
 	// this row is only reached by the coverage tripwire, not billing.
@@ -44,26 +45,27 @@ var modelPricing = map[string]modelPrice{
 
 const perMillion = 1e6
 
-// costFromUsage computes the dollar cost of one result event's token
-// usage against the given model's list price. Called by the event loop
+// CostFromUsage computes the dollar cost of one result event's token usage
+// against the given model's list price. Called by the event loop
 // only when the harness's stream event reported Usage but no CostUSD
 // (codex); claude reports CostUSD directly so this is never reached
 // for it. Returns 0 for an unpriced model so an unknown id degrades to
 // "cost not shown" rather than a wrong number.
 //
-// The arithmetic assumes OpenAI usage semantics: InputTokens is the
-// total prompt token count and CacheReadTokens is the cached subset of
-// it, so uncached = InputTokens - CacheReadTokens. That is what codex's
-// turn.completed usage reports. CacheWriteTokens is not billed
-// separately by OpenAI and codex does not report it, so those pricing rows
-// leave CacheWrite at zero. Anthropic's Messages API does bill cache creation,
-// and auxiliary calls report it in CacheWriteTokens.
-func costFromUsage(model string, u Usage) float64 {
+// InputTokens is the total prompt token count. CacheReadTokens is a discounted
+// subset. CacheWriteTokens is a separate subset only for models with a
+// dedicated cache-write rate; on OpenAI rows where CacheWrite is zero, it
+// remains ordinary input. The auxiliary Anthropic path normalizes its separate
+// input counters into this shared representation.
+func CostFromUsage(model string, u Usage) float64 {
 	p, ok := modelPricing[normalizeModelID(model)]
 	if !ok {
 		return 0
 	}
 	uncached := u.InputTokens - u.CacheReadTokens
+	if p.CacheWrite > 0 {
+		uncached -= u.CacheWriteTokens
+	}
 	if uncached < 0 {
 		uncached = 0
 	}
@@ -71,12 +73,6 @@ func costFromUsage(model string, u Usage) float64 {
 		float64(u.CacheReadTokens)*p.CachedIn +
 		float64(u.CacheWriteTokens)*p.CacheWrite +
 		float64(u.OutputTokens)*p.Out) / perMillion
-}
-
-// CostFromUsage exposes the scan pricing calculation to worker helpers that
-// account for direct model calls outside the harness event stream.
-func CostFromUsage(model string, u Usage) float64 {
-	return costFromUsage(model, u)
 }
 
 // normalizeModelID strips a leading provider/ prefix (opencode's

--- a/internal/worker/pricing_test.go
+++ b/internal/worker/pricing_test.go
@@ -36,6 +36,19 @@ func TestCostFromUsage(t *testing.T) {
 	}
 }
 
+func TestCostFromUsage_anthropicCacheWrite(t *testing.T) {
+	// claude-sonnet-4-6: $3 in / $15 out / $0.30 cache read / $3.75 cache write, per 1M.
+	got := costFromUsage("claude-sonnet-4-6", Usage{
+		InputTokens:      2_000_000,
+		CacheReadTokens:  1_000_000,
+		CacheWriteTokens: 1_000_000,
+		OutputTokens:     1_000_000,
+	})
+	if want := 22.05; math.Abs(got-want) > 1e-9 {
+		t.Errorf("costFromUsage = %.4f, want %.4f", got, want)
+	}
+}
+
 func TestCostFromUsage_unknownModelIsZero(t *testing.T) {
 	if got := costFromUsage("no-such-model", Usage{InputTokens: 1_000_000, OutputTokens: 1_000_000}); got != 0 {
 		t.Errorf("unknown model cost = %.4f, want 0", got)

--- a/internal/worker/pricing_test.go
+++ b/internal/worker/pricing_test.go
@@ -8,7 +8,7 @@ import (
 // TestPricingCoversEveryDefaultModel is the staleness tripwire: every
 // model any registered harness offers by default must have a price
 // entry, so a new harness (or a new model added to an existing one)
-// fails here until pricing.go is updated. That keeps costFromUsage from
+// fails here until pricing.go is updated. That keeps CostFromUsage from
 // silently returning $0 for a model in the pick list.
 func TestPricingCoversEveryDefaultModel(t *testing.T) {
 	for name, h := range harnesses {
@@ -26,31 +26,43 @@ func TestPricingCoversEveryDefaultModel(t *testing.T) {
 func TestCostFromUsage(t *testing.T) {
 	// gpt-5.4: $2.50 in / $15 out / $0.25 cached, per 1M.
 	// 1M uncached in + 1M cached in + 1M out = 2.50 + 0.25 + 15.00.
-	got := costFromUsage("gpt-5.4", Usage{
+	got := CostFromUsage("gpt-5.4", Usage{
 		InputTokens:     2_000_000, // total, of which 1M cached
 		CacheReadTokens: 1_000_000,
 		OutputTokens:    1_000_000,
 	})
 	if want := 17.75; math.Abs(got-want) > 1e-9 {
-		t.Errorf("costFromUsage = %.4f, want %.4f", got, want)
+		t.Errorf("CostFromUsage = %.4f, want %.4f", got, want)
 	}
 }
 
 func TestCostFromUsage_anthropicCacheWrite(t *testing.T) {
 	// claude-sonnet-4-6: $3 in / $15 out / $0.30 cache read / $3.75 cache write, per 1M.
-	got := costFromUsage("claude-sonnet-4-6", Usage{
-		InputTokens:      2_000_000,
+	got := CostFromUsage("claude-sonnet-4-6", Usage{
+		InputTokens:      3_000_000, // 1M uncached, 1M cache read, 1M cache write
 		CacheReadTokens:  1_000_000,
 		CacheWriteTokens: 1_000_000,
 		OutputTokens:     1_000_000,
 	})
 	if want := 22.05; math.Abs(got-want) > 1e-9 {
-		t.Errorf("costFromUsage = %.4f, want %.4f", got, want)
+		t.Errorf("CostFromUsage = %.4f, want %.4f", got, want)
+	}
+}
+
+func TestCostFromUsage_haiku(t *testing.T) {
+	if got := CostFromUsage("claude-haiku-4-5", Usage{InputTokens: 1_000_000, OutputTokens: 1_000_000}); got != 6 {
+		t.Errorf("CostFromUsage = %.4f, want 6", got)
+	}
+}
+
+func TestCostFromUsage_openAICacheWriteIsOrdinaryInput(t *testing.T) {
+	if got := CostFromUsage("gpt-5.4", Usage{InputTokens: 1_000_000, CacheWriteTokens: 1_000_000}); got != 2.5 {
+		t.Errorf("CostFromUsage = %.4f, want 2.5", got)
 	}
 }
 
 func TestCostFromUsage_unknownModelIsZero(t *testing.T) {
-	if got := costFromUsage("no-such-model", Usage{InputTokens: 1_000_000, OutputTokens: 1_000_000}); got != 0 {
+	if got := CostFromUsage("no-such-model", Usage{InputTokens: 1_000_000, OutputTokens: 1_000_000}); got != 0 {
 		t.Errorf("unknown model cost = %.4f, want 0", got)
 	}
 }
@@ -59,7 +71,7 @@ func TestCostFromUsage_zeroUsageIsZero(t *testing.T) {
 	// A result event with no token usage (e.g. a claude run where the
 	// stream reported CostUSD elsewhere) must not synthesize a nonzero
 	// cost.
-	if got := costFromUsage("gpt-5.4", Usage{}); got != 0 {
+	if got := CostFromUsage("gpt-5.4", Usage{}); got != 0 {
 		t.Errorf("zero-usage cost = %.4f, want 0", got)
 	}
 }

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -440,7 +440,7 @@ func (w *Worker) scanEmitter(scan *db.Scan) func(Event) {
 			// from list prices so /usage and the scan row show a real
 			// figure instead of $0.
 			if e.CostUSD == 0 {
-				e.CostUSD = costFromUsage(scan.Model, e.Usage)
+				e.CostUSD = CostFromUsage(scan.Model, e.Usage)
 			}
 			scan.CostUSD += e.CostUSD
 			scan.Turns += e.Turns


### PR DESCRIPTION
Fixes #63

## Summary

Adds a lightweight direct Anthropic Messages API helper for structured one-shot model calls that do not need a full agent workspace or tool loop.

## Changes

- Add `internal/llm` with `Call(ctx, prompt, schema, opts)`.
- Request schema-constrained JSON with Anthropic structured outputs using `output_config.format.type: json_schema`.
- Send a single user prompt without unsupported assistant-turn prefilling.
- Return the structured JSON response after confirming it is valid JSON.
- Preserve usage when the API response decodes successfully but its structured text is invalid, so billable requests remain accounted for.
- Add `Worker.CallAuxiliary` to persist auxiliary-call usage and cost on the active `Scan` row.
- Keep Anthropic fresh input, cache-read input, and cache-write input separate in scan usage accounting while normalizing a copy for pricing.
- Default an auxiliary call to the scan model and reject explicit model mismatches.
- Add Anthropic cache-creation pricing, including Haiku, while preserving zero cache-write cost for OpenAI models.
- Reject accounting updates when the target scan no longer exists.

## Tests

- `go test ./...`
- `go test -tags evals ./...`
- `go vet ./...`
- `go vet -tags evals ./...`
- `golangci-lint run ./cmd/... ./internal/...`
- `golangci-lint run --build-tags evals ./cmd/... ./internal/...`
- `git diff --check`