### PR TITLE
Add SBOM import confirmation

### DIFF
--- a/docs/database.md
+++ b/docs/database.md
@@ -448,6 +448,7 @@ User-uploaded CycloneDX or SPDX documents. Packages are replaced wholesale on re
 | spec_version | text | e.g. `1.5`. |
 | raw | blob | The original document bytes. |
 | package_count | integer | Denormalised count of components. |
+| import_pending | boolean | True for a newly parsed upload until the operator confirms repository resolution. Legacy and confirmed uploads are false. |
 | created_at | datetime | |
 | updated_at | datetime | |
 

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -1207,7 +1207,11 @@ type SBOMUpload struct {
 	Raw         []byte
 
 	PackageCount int
-	Packages     []SBOMPackage `gorm:"constraint:OnDelete:CASCADE"`
+	// ImportPending is true after a newly parsed upload and until the operator
+	// confirms repository resolution. False preserves the previous behaviour
+	// for uploads created before the confirmation step was introduced.
+	ImportPending bool          `gorm:"not null;default:false"`
+	Packages      []SBOMPackage `gorm:"constraint:OnDelete:CASCADE"`
 
 	CreatedAt time.Time
 	UpdatedAt time.Time

--- a/internal/web/sboms.go
+++ b/internal/web/sboms.go
@@ -25,6 +25,7 @@ func (s *Server) registerSBOMRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /sboms/new", s.sbomNew)
 	mux.HandleFunc("POST /sboms", s.sbomUpload)
 	mux.HandleFunc("GET /sboms/{id}", s.sbomShow)
+	mux.HandleFunc("POST /sboms/{id}/confirm", s.sbomConfirm)
 	mux.HandleFunc("POST /sboms/{id}/resolve", s.sbomResolve)
 	mux.HandleFunc("POST /sboms/{id}/delete", s.sbomDelete)
 }
@@ -81,12 +82,13 @@ func (s *Server) sbomUpload(w http.ResponseWriter, r *http.Request) {
 	}
 
 	up := db.SBOMUpload{
-		Name:         firstNonEmpty(doc.Document.Name, header.Filename),
-		Filename:     header.Filename,
-		Format:       string(doc.Type),
-		SpecVersion:  doc.SpecVersion,
-		Raw:          data,
-		PackageCount: len(doc.Packages),
+		Name:          firstNonEmpty(doc.Document.Name, header.Filename),
+		Filename:      header.Filename,
+		Format:        string(doc.Type),
+		SpecVersion:   doc.SpecVersion,
+		Raw:           data,
+		PackageCount:  len(doc.Packages),
+		ImportPending: true,
 	}
 	scope := doc.ClassifyScope()
 	for _, p := range doc.Packages {
@@ -104,9 +106,28 @@ func (s *Server) sbomUpload(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	s.goResolve(up.ID)
-
 	s.redirect(w, r, fmt.Sprintf("/sboms/%d", up.ID))
+}
+
+type sbomScopeCounts struct {
+	Direct     int
+	Transitive int
+	Unknown    int
+}
+
+func countSBOMScopes(pkgs []db.SBOMPackage) sbomScopeCounts {
+	var counts sbomScopeCounts
+	for _, p := range pkgs {
+		switch p.Scope {
+		case sbom.ScopeDirect:
+			counts.Direct++
+		case sbom.ScopeTransitive:
+			counts.Transitive++
+		default:
+			counts.Unknown++
+		}
+	}
+	return counts
 }
 
 // anyPackageHasScope reports whether at least one package carries a
@@ -134,6 +155,7 @@ func (s *Server) sbomShow(w http.ResponseWriter, r *http.Request) {
 	}
 
 	hasScope := anyPackageHasScope(up.Packages)
+	scopeCounts := countSBOMScopes(up.Packages)
 
 	scope := r.URL.Query().Get("scope")
 	pkgs := up.Packages
@@ -216,13 +238,39 @@ func (s *Server) sbomShow(w http.ResponseWriter, r *http.Request) {
 		"Severity": r.URL.Query().Get("severity"), "Sort": joinSort(sortCol, dir),
 		"Category":   r.URL.Query().Get("category"),
 		"Categories": CWECategories(), "Uncategorized": UncategorizedCWE,
-		"Scope": scope, "HasScope": hasScope,
+		"Scope": scope, "HasScope": hasScope, "ScopeCounts": scopeCounts,
 	})
+}
+
+// sbomConfirm starts repository resolution for a newly parsed SBOM. The
+// conditional update makes a repeated click harmless: only the first request
+// changes the pending state and launches the background resolver.
+func (s *Server) sbomConfirm(w http.ResponseWriter, r *http.Request) {
+	up, ok := loadByID[db.SBOMUpload](s, w, r)
+	if !ok {
+		return
+	}
+	result := s.DB.Model(&db.SBOMUpload{}).
+		Where("id = ? AND import_pending = ?", up.ID, true).
+		Update("import_pending", false)
+	if result.Error != nil {
+		http.Error(w, result.Error.Error(), http.StatusInternalServerError)
+		return
+	}
+	if result.RowsAffected > 0 {
+		s.goResolve(up.ID)
+		setFlash(w, Flash{Category: successKey, Title: fmt.Sprintf("Importing %d SBOM packages", up.PackageCount)})
+	}
+	s.redirect(w, r, fmt.Sprintf("/sboms/%d", up.ID))
 }
 
 func (s *Server) sbomResolve(w http.ResponseWriter, r *http.Request) {
 	up, ok := loadByID[db.SBOMUpload](s, w, r)
 	if !ok {
+		return
+	}
+	if up.ImportPending {
+		http.Error(w, "confirm SBOM import before resolving repositories", http.StatusConflict)
 		return
 	}
 	s.goResolve(up.ID)
@@ -266,7 +314,7 @@ func (s *Server) sbomDelete(w http.ResponseWriter, r *http.Request) {
 // resolveSBOMPackages walks every unresolved package in the upload, looks up
 // its source repository via packages.ecosyste.ms, FirstOrCreates the repo,
 // enqueues the default triage skill if the repo is new, and links the
-// package row. Runs in the background after upload so the page can render
+// package row. Runs in the background after the operator confirms import so the page can render
 // immediately.
 func (s *Server) resolveSBOMPackages(uploadID uint) {
 	ctx, cancel := context.WithTimeout(context.Background(), sbomResolveTimeout)

--- a/internal/web/sboms_test.go
+++ b/internal/web/sboms_test.go
@@ -71,6 +71,15 @@ func TestSBOMUpload_parsesAndStores(t *testing.T) {
 	if up.PackageCount != 2 || len(up.Packages) != 2 {
 		t.Fatalf("packages = %d (%d rows)", up.PackageCount, len(up.Packages))
 	}
+	if !up.ImportPending {
+		t.Error("new upload should wait for import confirmation")
+	}
+	var repos, scans int64
+	s.DB.Model(&db.Repository{}).Count(&repos)
+	s.DB.Model(&db.Scan{}).Count(&scans)
+	if repos != 0 || scans != 0 {
+		t.Errorf("upload created repos=%d scans=%d before confirmation", repos, scans)
+	}
 	var lodash db.SBOMPackage
 	for _, p := range up.Packages {
 		if p.Name == "lodash" {
@@ -140,6 +149,113 @@ func TestSBOMResolveHandler(t *testing.T) {
 	s.Handler().ServeHTTP(w, r)
 	if w.Code != http.StatusNotFound {
 		t.Errorf("missing upload: status = %d, want 404", w.Code)
+	}
+}
+
+func TestSBOMConfirm_resolvesAfterOperatorConfirmation(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	s.resolveSync = true
+	s.resolvePURL = func(_ context.Context, purl string) string {
+		switch {
+		case strings.Contains(purl, "direct"):
+			return "https://github.com/acme/direct"
+		case strings.Contains(purl, "transitive"):
+			return "https://github.com/acme/transitive"
+		default:
+			return ""
+		}
+	}
+	s.DB.Create(&db.Skill{Name: defaultSkillName, Body: "b", Active: true})
+	up := db.SBOMUpload{Name: "pending", ImportPending: true, Packages: []db.SBOMPackage{
+		{Name: "direct", PURL: "pkg:npm/direct@1", Scope: sbom.ScopeDirect},
+		{Name: "transitive", PURL: "pkg:npm/transitive@1", Scope: sbom.ScopeTransitive},
+	}}
+	s.DB.Create(&up)
+
+	req := localReq("POST", fmt.Sprintf("/sboms/%d/resolve", up.ID))
+	req.Header.Set("Sec-Fetch-Site", "same-origin")
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusConflict {
+		t.Fatalf("unconfirmed resolve status = %d, want 409", w.Code)
+	}
+	var repos, scans int64
+	s.DB.Model(&db.Repository{}).Count(&repos)
+	s.DB.Model(&db.Scan{}).Count(&scans)
+	if repos != 0 || scans != 0 {
+		t.Fatalf("unconfirmed resolve created repos=%d scans=%d", repos, scans)
+	}
+
+	req = localReq("POST", fmt.Sprintf("/sboms/%d/confirm", up.ID))
+	req.Header.Set("Sec-Fetch-Site", "same-origin")
+	w = httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("confirm status = %d: %s", w.Code, w.Body)
+	}
+	var confirmed db.SBOMUpload
+	if err := s.DB.Preload("Packages").First(&confirmed, up.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if confirmed.ImportPending {
+		t.Fatal("confirmation did not clear ImportPending")
+	}
+	for _, p := range confirmed.Packages {
+		if p.RepositoryID == nil {
+			t.Fatalf("package %s was not resolved", p.Name)
+		}
+		var count int64
+		s.DB.Model(&db.Scan{}).Where("repository_id = ?", *p.RepositoryID).Count(&count)
+		want := int64(0)
+		if p.Scope == sbom.ScopeDirect {
+			want = 1
+		}
+		if count != want {
+			t.Errorf("%s scans = %d, want %d", p.Name, count, want)
+		}
+	}
+
+	// A second confirmation must not enqueue another direct-dependency scan.
+	req = localReq("POST", fmt.Sprintf("/sboms/%d/confirm", up.ID))
+	req.Header.Set("Sec-Fetch-Site", "same-origin")
+	w = httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("repeat confirm status = %d", w.Code)
+	}
+	s.DB.Model(&db.Scan{}).Count(&scans)
+	if scans != 1 {
+		t.Errorf("repeat confirmation scans = %d, want 1", scans)
+	}
+}
+
+func TestSBOMShow_pendingImportSummary(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	up := db.SBOMUpload{Name: "pending", PackageCount: 3, ImportPending: true, Packages: []db.SBOMPackage{
+		{Name: "direct", Scope: sbom.ScopeDirect},
+		{Name: "transitive", Scope: sbom.ScopeTransitive},
+		{Name: "unknown"},
+	}}
+	s.DB.Create(&up)
+
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq("GET", fmt.Sprintf("/sboms/%d", up.ID)))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d: %s", w.Code, w.Body)
+	}
+	body := w.Body.String()
+	for _, want := range []string{
+		"Import 3 packages", "This SBOM contains 3 packages", "1 direct dependencies are eligible for triage scans",
+		"1 transitive dependencies will be linked without scans", "Awaiting import confirmation", "awaiting import",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("pending SBOM page missing %q: %s", want, body)
+		}
+	}
+	if strings.Contains(body, "Re-resolve") {
+		t.Error("pending SBOM should not render the re-resolve action")
 	}
 }
 

--- a/internal/web/templates/sbom_show.html
+++ b/internal/web/templates/sbom_show.html
@@ -12,10 +12,17 @@
     </p>
   </div>
   <div class="flex items-center gap-2">
+    {{if .SBOM.ImportPending}}
+    <form method="post" action="/sboms/{{.SBOM.ID}}/confirm"
+          hx-post="/sboms/{{.SBOM.ID}}/confirm" hx-swap="none">
+      <button class="btn" type="submit"><i data-lucide="check"></i> Import {{.SBOM.PackageCount}} packages</button>
+    </form>
+    {{else}}
     <form method="post" action="/sboms/{{.SBOM.ID}}/resolve"
           hx-post="/sboms/{{.SBOM.ID}}/resolve" hx-swap="none">
       <button class="btn-outline" type="submit"><i data-lucide="refresh-cw"></i> Re-resolve</button>
     </form>
+    {{end}}
     <form method="post" action="/sboms/{{.SBOM.ID}}/delete"
           hx-post="/sboms/{{.SBOM.ID}}/delete" hx-swap="none"
           hx-confirm="Delete this SBOM and its package list?">
@@ -23,6 +30,20 @@
     </form>
   </div>
 </div>
+
+{{if .SBOM.ImportPending}}
+  <div class="alert mb-6">
+    <i data-lucide="triangle-alert"></i>
+    <section>
+      This SBOM contains {{.SBOM.PackageCount}} packages. Confirm import to resolve repository rows.
+      {{if .HasScope}}
+        {{.ScopeCounts.Direct}} direct dependencies are eligible for triage scans; {{.ScopeCounts.Transitive}} transitive dependencies will be linked without scans.
+      {{else}}
+        This SBOM has no dependency graph, so all packages are eligible for triage scans.
+      {{end}}
+    </section>
+  </div>
+{{end}}
 
 <div class="tabs w-full" id="sbom-tabs">
   <nav role="tablist" aria-orientation="horizontal">
@@ -44,8 +65,12 @@
   <div role="tabpanel" id="sp1" aria-labelledby="st1">
     <div class="flex items-center justify-between mb-3">
       <p class="text-sm text-muted-foreground">
-        {{.Resolved}} of {{len .Packages}} resolved &middot; {{.WithRepo}} linked to a repository.
-        {{if lt .Resolved (len .Packages)}}Resolution runs in the background; refresh to see progress.{{end}}
+        {{if .SBOM.ImportPending}}
+          Awaiting import confirmation. No repositories have been resolved or scans queued.
+        {{else}}
+          {{.Resolved}} of {{len .Packages}} resolved &middot; {{.WithRepo}} linked to a repository.
+          {{if lt .Resolved (len .Packages)}}Resolution runs in the background; refresh to see progress.{{end}}
+        {{end}}
       </p>
       {{if .HasScope}}
       <div class="dropdown-menu">
@@ -94,6 +119,8 @@
               <a href="/repositories/{{.Repository.ID}}" class="hover:underline">{{.Repository.Name}}</a>
             {{else if .ResolveError}}
               <span class="text-xs text-muted-foreground">{{.ResolveError}}</span>
+            {{else if $.SBOM.ImportPending}}
+              <span class="text-xs text-muted-foreground">awaiting import</span>
             {{else}}
               <span class="text-xs text-muted-foreground">resolving&hellip;</span>
             {{end}}


### PR DESCRIPTION
Part of #464

## Summary

Adds an explicit confirmation step between uploading an SBOM and resolving its package repositories.

SBOM uploads are now parsed and stored first. The upload page shows the package count and dependency-scope summary, allowing the operator to review the expected import before any repository rows are created or scans are queued.

## Changes

- Add `import_pending` state for newly uploaded SBOMs
- Show an import confirmation action and scope-aware package summary
- Defer repository resolution and triage enqueueing until confirmation
- Keep transitive dependencies linked without automatically queuing scans
- Treat flat SBOMs without a dependency graph as eligible for the existing triage behavior
- Make confirmation idempotent to prevent duplicate resolver runs
- Block the re-resolve endpoint while an upload is still awaiting confirmation
- Document the new database field

## Tests

- Verify upload alone creates no repository rows or scans
- Verify confirmation resolves packages and queues only eligible dependencies
- Verify repeated confirmation does not enqueue duplicate scans
- Verify unconfirmed imports cannot bypass the confirmation gate
- Verify the pending-import UI summary

## Verification

- `go test ./...`
- `go test -tags evals ./...`
- `go vet ./...`
- `go vet -tags evals ./...`
- `golangci-lint run ./cmd/... ./internal/...`
- `golangci-lint run --build-tags evals ./cmd/... ./internal/...`
- `git diff --check`