### PR TITLE
fix: retry only the newest failure per tuple in bulk retry-failed

### DIFF
--- a/internal/web/scans.go
+++ b/internal/web/scans.go
@@ -222,7 +222,10 @@ func (s *Server) scansRetryFailed(w http.ResponseWriter, r *http.Request) {
 
 	// Skip any failed scan that has a later scan with the same
 	// (repository, skill, sub_path, ref, finding_id) tuple already in
-	// queued/running/done.
+	// queued/running/done, or superseded by a newer failed/paused attempt,
+	// so repeated failures retry only the newest row per tuple. Cancelled is
+	// deliberately absent: a user-cancelled newer run shouldn't block
+	// retrying an older genuine failure.
 	var scans []db.Scan
 	err := q.Select("id, repository_id, skill_id, model, effort, finding_id, sub_path, ref, profile, rescan_mode, diff_base_scan_id, scan_group, backend, status, session_id, resumed_from_scan_id, import_payload").
 		Where(`NOT EXISTS (
@@ -234,7 +237,7 @@ func (s *Server) scansRetryFailed(w http.ResponseWriter, r *http.Request) {
 			  AND COALESCE(n.ref, '') = COALESCE(scans.ref, '')
 			  AND COALESCE(n.finding_id, 0) = COALESCE(scans.finding_id, 0)
 			  AND n.status IN ?
-		)`, []db.ScanStatus{db.ScanQueued, db.ScanRunning, db.ScanDone}).
+		)`, []db.ScanStatus{db.ScanQueued, db.ScanRunning, db.ScanDone, db.ScanFailed, db.ScanPaused}).
 		Find(&scans).Error
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/internal/web/scans_test.go
+++ b/internal/web/scans_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"scrutineer/internal/db"
+	"scrutineer/internal/worker"
 )
 
 func TestResumeOpts(t *testing.T) {
@@ -401,5 +402,56 @@ func TestScansCancelAll_requiresRepository(t *testing.T) {
 	s.scansCancelAll(w, localReq("POST", "/scans/cancel-all"))
 	if w.Code != http.StatusBadRequest {
 		t.Errorf("status = %d, want 400", w.Code)
+	}
+}
+
+// Repeated failures of one (repository, skill, sub_path, ref, finding_id)
+// tuple must retry only the newest failed row, and a failure superseded by a
+// newer paused attempt must not retry at all. Suppression by queued/running/
+// done — and cancelled deliberately not suppressing — is covered by
+// TestScansRetryFailed_skipsAlreadyRetried.
+func TestScansRetryFailed_dedupesRepeatedFailures(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	repo := db.Repository{URL: "https://example.com/r", Name: "r"}
+	s.DB.Create(&repo)
+	skill := db.Skill{Name: "hello", Description: "d", Body: "b",
+		OutputFile: "report.json", OutputKind: "freeform", Version: 1,
+		Active: true, Source: "ui"}
+	s.DB.Create(&skill)
+
+	mk := func(status db.ScanStatus, subPath string) {
+		sc := db.Scan{RepositoryID: repo.ID, Kind: worker.JobSkill, Status: status,
+			StatusPriority: db.StatusPriorityFor(status),
+			SkillID:        &skill.ID, SkillName: skill.Name, SubPath: subPath}
+		s.DB.Create(&sc)
+	}
+
+	// Three straight failures of the same tuple — only the newest retries.
+	mk(db.ScanFailed, "")
+	mk(db.ScanFailed, "")
+	mk(db.ScanFailed, "")
+
+	// A failure with a newer paused attempt for its tuple — superseded.
+	mk(db.ScanFailed, "parked")
+	mk(db.ScanPaused, "parked")
+
+	var maxID uint
+	s.DB.Model(&db.Scan{}).Select("MAX(id)").Scan(&maxID)
+
+	w := httptest.NewRecorder()
+	s.scansRetryFailed(w, localReq("POST", "/scans/retry-failed"))
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("status = %d, want 303; body=%s", w.Code, w.Body)
+	}
+
+	var queued []db.Scan
+	s.DB.Where("id > ? AND status = ?", maxID, db.ScanQueued).Find(&queued)
+	if len(queued) != 1 {
+		t.Fatalf("new queued scans = %d, want exactly 1", len(queued))
+	}
+	if queued[0].SubPath != "" {
+		t.Errorf("retried sub_path = %q, want the repeated-failure tuple (parked is superseded)", queued[0].SubPath)
 	}
 }

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -4149,17 +4149,19 @@ func TestScansRetryFailed_filtersBySkill(t *testing.T) {
 	s.DB.Create(&a)
 	s.DB.Create(&b)
 
-	mk := func(name string, sk uint) {
+	// Distinct sub_paths keep the two alpha failures in separate tuples, so
+	// both are eligible under the newest-failure-per-tuple dedup.
+	mk := func(name string, sk uint, subPath string) {
 		sc := db.Scan{
 			RepositoryID: repo.ID, Kind: "skill", Status: db.ScanFailed,
 			StatusPriority: db.StatusPriorityFor(db.ScanFailed),
-			SkillID:        &sk, SkillName: name,
+			SkillID:        &sk, SkillName: name, SubPath: subPath,
 		}
 		s.DB.Create(&sc)
 	}
-	mk("alpha", a.ID)
-	mk("alpha", a.ID)
-	mk("bravo", b.ID)
+	mk("alpha", a.ID, "one")
+	mk("alpha", a.ID, "two")
+	mk("bravo", b.ID, "")
 
 	req := httptest.NewRequest("POST", "/scans/retry-failed?skill=alpha", nil)
 	req.Host = testHost
@@ -4307,16 +4309,18 @@ func TestScansRetryFailed_repositoryScopeRedirects(t *testing.T) {
 	s.DB.Create(&rB)
 	skill := db.Skill{Name: "deep-dive", Description: "x", Body: "b", Active: true, Source: "ui", Version: 1}
 	s.DB.Create(&skill)
-	mk := func(repoID uint) {
+	// Distinct sub_paths keep rA's two failures in separate tuples, so both
+	// are eligible under the newest-failure-per-tuple dedup.
+	mk := func(repoID uint, subPath string) {
 		s.DB.Create(&db.Scan{
 			RepositoryID: repoID, Kind: "skill", Status: db.ScanFailed,
 			StatusPriority: db.StatusPriorityFor(db.ScanFailed),
-			SkillID:        &skill.ID, SkillName: "deep-dive",
+			SkillID:        &skill.ID, SkillName: "deep-dive", SubPath: subPath,
 		})
 	}
-	mk(rA.ID)
-	mk(rA.ID)
-	mk(rB.ID)
+	mk(rA.ID, "one")
+	mk(rA.ID, "two")
+	mk(rB.ID, "")
 
 	req := httptest.NewRequest("POST",
 		fmt.Sprintf("/scans/retry-failed?repository=%d", rA.ID), nil)


### PR DESCRIPTION
"Retry failed" enqueues one retry per historical failed row, not one per failing target: the `NOT EXISTS` filter in `scansRetryFailed` only treats a newer `queued`/`running`/`done` scan as superseding, so when the same (repository, skill, sub_path, ref, finding_id) tuple has failed several times, every old failure passes the filter and each one is re-enqueued — duplicate parallel retries for one target.

This adds `failed` and `paused` to the superseding-status list, as suggested in the issue thread:

- a newer **failed** attempt supersedes older failures, so only the newest failure per tuple is retried;
- a newer **paused** attempt also supersedes — an older failure shouldn't respawn work for a tuple that is deliberately parked;
- `cancelled` is deliberately left out: a user-cancelled newer run shouldn't block retrying an older genuine failure.

The new regression test covers the two gaps (three failures of one tuple → exactly one new queued scan; an older failure with a newer paused attempt → none), complementing `TestScansRetryFailed_skipsAlreadyRetried`, which already locks the queued/running/done suppression and the cancelled behavior. Two existing tests (`_filtersBySkill`, `_repositoryScopeRedirects`) seeded repeated failures of the same tuple and asserted every row was requeued — that expectation encoded this bug, so their fixtures now use distinct sub_paths, keeping what they actually test (skill filtering, repo scoping) unchanged.

Verified locally on macOS arm64 (go1.26.5):

- `go test ./internal/web/ -run TestScansRetryFailed_dedupesRepeatedFailures` fails against `main`'s unfixed `scans.go` (4 new queued scans instead of 1) and passes with this change;
- `go test -race ./...`, `go vet ./...`, and `go vet -tags podman ./...` pass.

Prepared with AI assistance (Claude Code); happy to adjust anything in review.

Fixes #574
