### PR TITLE
Replace backtick-quoted identifiers with dialect-aware GORM conditions

### DIFF
--- a/internal/db/audit.go
+++ b/internal/db/audit.go
@@ -161,7 +161,9 @@ func ComputeAuditMetrics(gdb *gorm.DB) (AuditMetrics, error) {
 // after later revalidate runs change the model's mind.
 func LatestRevalidateVerdict(gdb *gorm.DB, findingID uint) string {
 	var note FindingNote
-	if err := gdb.Where("finding_id = ? AND `by` = ?", findingID, "revalidate").
+	// Map condition so GORM's dialector quotes the reserved-word column
+	// (`by` on SQLite, "by" on Postgres) instead of hardcoding one style.
+	if err := gdb.Where(map[string]any{"finding_id": findingID, "by": "revalidate"}).
 		Order("created_at desc").First(&note).Error; err != nil {
 		return ""
 	}

--- a/internal/db/audit_test.go
+++ b/internal/db/audit_test.go
@@ -2,8 +2,11 @@ package db
 
 import (
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
+
+	"gorm.io/gorm"
 )
 
 func TestAddFindingReview_rejectsUnknownVerdict(t *testing.T) {
@@ -215,5 +218,28 @@ func TestLatestRevalidateVerdict(t *testing.T) {
 	_, _ = AddFindingNote(gdb, f.ID, "revalidate: true_positive\n\nsink reachable", "revalidate")
 	if got := LatestRevalidateVerdict(gdb, f.ID); got != "true_positive" {
 		t.Errorf("latest: got %q, want true_positive", got)
+	}
+}
+
+// TestReservedWordColumnsUseDialectorQuoting guards against reintroducing
+// hardcoded identifier quoting (#629). Map conditions emit a
+// table-qualified, dialector-quoted column (`finding_notes`.`by` on SQLite,
+// "finding_notes"."by" on Postgres); a raw string with an inline `by` would
+// not be table-qualified and would break under a Postgres dialector.
+func TestReservedWordColumnsUseDialectorQuoting(t *testing.T) {
+	gdb, err := Open(filepath.Join(t.TempDir(), "quote.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	dry := gdb.Session(&gorm.Session{DryRun: true})
+
+	stmt := dry.Where(map[string]any{"finding_id": 1, "by": "revalidate"}).Find(&FindingNote{}).Statement
+	if !strings.Contains(stmt.SQL.String(), "`finding_notes`.`by`") {
+		t.Errorf("map condition did not emit dialector-quoted table.column: %s", stmt.SQL.String())
+	}
+
+	stmt = dry.Model(&Scan{}).Not(map[string]any{"commit": ""}).Find(&Scan{}).Statement
+	if !strings.Contains(stmt.SQL.String(), "`scans`.`commit`") {
+		t.Errorf("Not(map) did not emit dialector-quoted table.column: %s", stmt.SQL.String())
 	}
 }

--- a/internal/db/audit_test.go
+++ b/internal/db/audit_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 func TestAddFindingReview_rejectsUnknownVerdict(t *testing.T) {
@@ -222,24 +223,28 @@ func TestLatestRevalidateVerdict(t *testing.T) {
 }
 
 // TestReservedWordColumnsUseDialectorQuoting guards against reintroducing
-// hardcoded identifier quoting (#629). Map conditions emit a
-// table-qualified, dialector-quoted column (`finding_notes`.`by` on SQLite,
-// "finding_notes"."by" on Postgres); a raw string with an inline `by` would
-// not be table-qualified and would break under a Postgres dialector.
+// hardcoded identifier quoting (#629). Map conditions emit a table-qualified,
+// dialector-quoted column; a raw string with an inline `by` would not be
+// table-qualified and would break under a Postgres dialector. The expected
+// fragment is built via Statement.Quote so the assertion holds under any
+// dialector rather than assuming SQLite backticks.
 func TestReservedWordColumnsUseDialectorQuoting(t *testing.T) {
 	gdb, err := Open(filepath.Join(t.TempDir(), "quote.db"))
 	if err != nil {
 		t.Fatal(err)
 	}
 	dry := gdb.Session(&gorm.Session{DryRun: true})
+	quote := func(table, col string) string {
+		return dry.Statement.Quote(clause.Column{Table: table, Name: col})
+	}
 
 	stmt := dry.Where(map[string]any{"finding_id": 1, "by": "revalidate"}).Find(&FindingNote{}).Statement
-	if !strings.Contains(stmt.SQL.String(), "`finding_notes`.`by`") {
-		t.Errorf("map condition did not emit dialector-quoted table.column: %s", stmt.SQL.String())
+	if want := quote("finding_notes", "by"); !strings.Contains(stmt.SQL.String(), want) {
+		t.Errorf("map condition did not emit dialector-quoted %s: %s", want, stmt.SQL.String())
 	}
 
 	stmt = dry.Model(&Scan{}).Not(map[string]any{"commit": ""}).Find(&Scan{}).Statement
-	if !strings.Contains(stmt.SQL.String(), "`scans`.`commit`") {
-		t.Errorf("Not(map) did not emit dialector-quoted table.column: %s", stmt.SQL.String())
+	if want := quote("scans", "commit"); !strings.Contains(stmt.SQL.String(), want) {
+		t.Errorf("Not(map) did not emit dialector-quoted %s: %s", want, stmt.SQL.String())
 	}
 }

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -909,12 +909,11 @@ func loadRepoFindings(gdb *gorm.DB, repoID uint, category string) repoFindings {
 			scanIDs = append(scanIDs, f.ScanID)
 		}
 	}
-	var rows []struct {
-		ID        uint
-		SkillName string
-		Commit    string
-	}
-	gdb.Raw("SELECT id, COALESCE(skill_name, '') AS skill_name, COALESCE(`commit`, '') AS `commit` FROM scans WHERE id IN ?", scanIDs).Scan(&rows)
+	// Typed Find so GORM's dialector quotes the reserved-word column
+	// (`commit` on SQLite, "commit" on Postgres) and coerces NULL text to
+	// the Go zero value, replacing the previous Raw + COALESCE.
+	var rows []db.Scan
+	gdb.Select("id", "skill_name", "commit").Where("id IN ?", scanIDs).Find(&rows)
 	for _, row := range rows {
 		rf.ScanSkill[row.ID] = row.SkillName
 		rf.ScanCommit[row.ID] = row.Commit
@@ -2257,8 +2256,11 @@ func (s *Server) latestDepsCommit(repoID uint) string {
 	var commits []string
 	s.DB.Model(&db.Scan{}).
 		Joins("JOIN skills ON skills.id = scans.skill_id").
-		Where("scans.repository_id = ? AND skills.output_kind = ? AND scans.status = ? AND scans.`commit` <> ''",
+		Where("scans.repository_id = ? AND skills.output_kind = ? AND scans.status = ?",
 			repoID, "dependencies", db.ScanDone).
+		// Not(map) lets GORM's dialector quote the reserved-word column
+		// against the model's table instead of hardcoding scans.`commit`.
+		Not(map[string]any{"commit": ""}).
 		Order("scans.id DESC").
 		Limit(1).
 		Pluck("scans.commit", &commits)

--- a/internal/worker/diff_rescan.go
+++ b/internal/worker/diff_rescan.go
@@ -151,7 +151,10 @@ func (w *Worker) prepareDiffRescan(ctx context.Context, scan *db.Scan, workRoot 
 }
 
 func (w *Worker) diffBaseline(scan *db.Scan) (db.Scan, bool) {
-	q := w.DB.Where("repository_id = ? AND status = ? AND `commit` <> ''", scan.RepositoryID, db.ScanDone)
+	// Not(map) lets GORM's dialector quote the reserved-word column
+	// (`commit` on SQLite, "commit" on Postgres) instead of hardcoding one style.
+	q := w.DB.Where("repository_id = ? AND status = ?", scan.RepositoryID, db.ScanDone).
+		Not(map[string]any{"commit": ""})
 	if scan.DiffBaseScanID != nil {
 		q = q.Where("id = ?", *scan.DiffBaseScanID)
 	} else {

--- a/internal/worker/skill_parsers_test.go
+++ b/internal/worker/skill_parsers_test.go
@@ -1009,7 +1009,7 @@ func TestParseReleaseWatch_notReleasedAddsNote(t *testing.T) {
 		t.Errorf("ReleaseTag should remain empty: %q", f.ReleaseTag)
 	}
 	var notes []db.FindingNote
-	gdb.Where("finding_id = ? AND `by` = ?", f.ID, "release-watch").Find(&notes)
+	gdb.Where(map[string]any{"finding_id": f.ID, "by": "release-watch"}).Find(&notes)
 	if len(notes) != 1 || !strings.Contains(notes[0].Body, "not released") {
 		t.Errorf("notes = %+v, want one release-watch note", notes)
 	}
@@ -1041,7 +1041,7 @@ func TestParseDisclose_postsSummaryNote(t *testing.T) {
 	f, gdb := runSkillWithFinding(t, "disclose", report, db.FindingTriaged)
 
 	var notes []db.FindingNote
-	gdb.Where("finding_id = ? AND `by` = ?", f.ID, "disclose").Find(&notes)
+	gdb.Where(map[string]any{"finding_id": f.ID, "by": "disclose"}).Find(&notes)
 	if len(notes) != 1 {
 		t.Fatalf("want one disclose note, got %d: %+v", len(notes), notes)
 	}
@@ -1064,7 +1064,7 @@ func TestParseDisclose_errorReportRecordsRefusal(t *testing.T) {
 	f, gdb := runSkillWithFinding(t, "disclose", report, db.FindingNew)
 
 	var notes []db.FindingNote
-	gdb.Where("finding_id = ? AND `by` = ?", f.ID, "disclose").Find(&notes)
+	gdb.Where(map[string]any{"finding_id": f.ID, "by": "disclose"}).Find(&notes)
 	if len(notes) != 1 {
 		t.Fatalf("want one disclose note, got %d", len(notes))
 	}


### PR DESCRIPTION
Part of #629.

Replaces the seven hardcoded backtick-quoted identifiers (`` `by` ``, `` `commit` ``) in raw GORM condition strings with map conditions and typed queries so the active dialector emits the right quote character (`` ` `` on SQLite, `"` on Postgres). No schema or behaviour change.

`internal/web/server.go`'s `Raw("SELECT ... COALESCE(...) ...")` becomes a typed `Select(...).Find(&[]db.Scan{})`; GORM coerces NULL text to the Go zero value so the `COALESCE` is no longer needed. The `` <> '' `` predicates become `Not(map[string]any{"commit": ""})`, which the dialector table-qualifies and quotes.

Adds `TestReservedWordColumnsUseDialectorQuoting` as a DryRun guard that map/`Not(map)` conditions emit the dialector-quoted `table.column` form.

Not in scope here (remaining blockers for Postgres, will open a tracking issue): renaming the `commit`/`by` columns so quoting isn't needed at all, DSN-based driver selection in `db.Open` with the `_pragma` string skipped for Postgres, `VACUUM INTO` backup path, goqite's Postgres story, and the 18 `LIKE` search predicates that go case-sensitive on Postgres.
