### PR TITLE
Render diff-rescan coverage on the scan page

### DIFF
--- a/docs/diff-based-rescans.md
+++ b/docs/diff-based-rescans.md
@@ -69,10 +69,12 @@ other files that affect how untrusted input reaches security-sensitive code.
 
 ## Coverage Metadata
 
-Diff scans record structured coverage metadata. The UI and later automation use
-that metadata to explain which changed files were covered, which were skipped,
-and why stale-finding updates were disabled or scoped.
+Diff scans record structured coverage metadata on the scan row. The scan page
+shows the requested and actual mode, the fallback reason when the run degraded
+to a full scan, the changed-file count and patch size, and a collapsible list
+of every changed file linked into the in-app code browser at the head commit.
 
-Deterministic tools that cannot soundly limit themselves to the diff should say
-so in their coverage metadata. They may run as a full scan or skip themselves,
-depending on the tool and repository.
+Per-file covered/skipped reporting depends on skills emitting that detail and
+is not surfaced yet. Deterministic tools that cannot soundly limit themselves
+to the diff should say so in their coverage metadata; they may run as a full
+scan or skip themselves depending on the tool and repository.

--- a/internal/web/scans.go
+++ b/internal/web/scans.go
@@ -2,6 +2,7 @@ package web
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -132,7 +133,93 @@ func (s *Server) scanShow(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 		return
 	}
-	s.render(w, r, "scan_show.html", map[string]any{"Scan": scan})
+	s.render(w, r, "scan_show.html", map[string]any{
+		"Scan": scan,
+		"Diff": parseScanDiffView(scan),
+	})
+}
+
+// scanDiffView is the parsed diff-rescan metadata for the scan page,
+// merged from the two JSON blobs the worker writes: Coverage (requested vs
+// actual mode plus a fallback reason) and DiffStats (changed-file list and
+// patch size). Nil when the scan carried neither.
+type scanDiffView struct {
+	RequestedMode  string
+	ActualMode     string
+	FallbackReason string
+	ChangedFiles   int
+	PatchBytes     int64
+	Files          []scanDiffFile
+}
+
+type scanDiffFile struct {
+	Status string `json:"status"`
+	Path   string `json:"path"`
+	Old    string `json:"old"`
+}
+
+// StatusName expands the git --name-status letter to a word so the
+// changed-files table reads without a legend. Rename/copy carry a
+// similarity score suffix (R100, C075) which is dropped here; the
+// old→new path already conveys the rename.
+func (f scanDiffFile) StatusName() string {
+	if f.Status == "" {
+		return ""
+	}
+	switch f.Status[0] {
+	case 'A':
+		return "added"
+	case 'M':
+		return "modified"
+	case 'D':
+		return "deleted"
+	case 'R':
+		return "renamed"
+	case 'C':
+		return "copied"
+	case 'T':
+		return "type change"
+	}
+	return f.Status
+}
+
+// Linkable reports whether the file exists at the head commit and so can
+// be linked through the in-app blob route. Deleted files only existed at
+// the base commit.
+func (f scanDiffFile) Linkable() bool {
+	return f.Status != "" && f.Status[0] != 'D'
+}
+
+func parseScanDiffView(scan db.Scan) *scanDiffView {
+	if scan.Coverage == "" && scan.DiffStats == "" {
+		return nil
+	}
+	var v scanDiffView
+	if scan.Coverage != "" {
+		var cov struct {
+			RequestedMode  string `json:"requested_mode"`
+			ActualMode     string `json:"actual_mode"`
+			FallbackReason string `json:"fallback_reason"`
+		}
+		if json.Unmarshal([]byte(scan.Coverage), &cov) == nil {
+			v.RequestedMode = cov.RequestedMode
+			v.ActualMode = cov.ActualMode
+			v.FallbackReason = cov.FallbackReason
+		}
+	}
+	if scan.DiffStats != "" {
+		var stats struct {
+			ChangedFiles int            `json:"changed_files"`
+			PatchBytes   int64          `json:"patch_bytes"`
+			Files        []scanDiffFile `json:"files"`
+		}
+		if json.Unmarshal([]byte(scan.DiffStats), &stats) == nil {
+			v.ChangedFiles = stats.ChangedFiles
+			v.PatchBytes = stats.PatchBytes
+			v.Files = stats.Files
+		}
+	}
+	return &v
 }
 
 func (s *Server) scanRetry(w http.ResponseWriter, r *http.Request) {

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -4836,6 +4836,118 @@ func TestScanShowSkillLink(t *testing.T) {
 	}
 }
 
+func TestScanShowRendersDiffCoverage(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	repo := db.Repository{URL: "u", Name: "n"}
+	s.DB.Create(&repo)
+	scan := db.Scan{
+		RepositoryID:   repo.ID,
+		Kind:           "skill",
+		Status:         db.ScanDone,
+		SkillName:      "security-deep-dive",
+		RescanMode:     db.ScanRescanModeDiff,
+		Commit:         "def456def456def456",
+		DiffBaseCommit: "abc123abc123abc123",
+		Coverage:       `{"requested_mode":"diff","actual_mode":"diff"}`,
+		DiffStats: `{"base_commit":"abc123abc123abc123","head_commit":"def456def456def456","changed_files":3,"patch_bytes":2048,` +
+			`"files":[{"status":"M","path":"lib/xmlparse.c"},{"status":"R100","path":"lib/xmlrole.c","old":"lib/oldrole.c"},{"status":"D","path":"lib/gone.c"}]}`,
+	}
+	s.DB.Create(&scan)
+
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq("GET", fmt.Sprintf("/scans/%d", scan.ID)))
+	if w.Code != 200 {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+	body := w.Body.String()
+	for _, want := range []string{
+		"3 files changed",
+		"2.0 KB patch",
+		"modified",
+		"renamed",
+		"deleted",
+		"lib/oldrole.c",
+		fmt.Sprintf("/repositories/%d/blob/def456def456def456/lib/xmlparse.c", repo.ID),
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("scan show diff coverage missing %q", want)
+		}
+	}
+	if strings.Contains(body, fmt.Sprintf("/blob/%s/lib/gone.c", scan.Commit)) {
+		t.Errorf("deleted file should not link to head-commit blob")
+	}
+	if strings.Contains(body, `"requested_mode"`) {
+		t.Errorf("scan show should not dump raw Coverage JSON")
+	}
+}
+
+func TestScanShowRendersDiffFallback(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	repo := db.Repository{URL: "u", Name: "n"}
+	s.DB.Create(&repo)
+	scan := db.Scan{
+		RepositoryID: repo.ID,
+		Kind:         "skill",
+		Status:       db.ScanDone,
+		SkillName:    "security-deep-dive",
+		RescanMode:   db.ScanRescanModeFull,
+		Coverage:     `{"requested_mode":"diff","actual_mode":"full","fallback_reason":"no compatible baseline scan with a commit"}`,
+	}
+	s.DB.Create(&scan)
+
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq("GET", fmt.Sprintf("/scans/%d", scan.ID)))
+	if w.Code != 200 {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+	body := w.Body.String()
+	for _, want := range []string{
+		"ran as a full scan",
+		"no compatible baseline scan with a commit",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("scan show fallback missing %q", want)
+		}
+	}
+	if strings.Contains(body, "files changed") {
+		t.Errorf("fallback should not render a changed-files header")
+	}
+}
+
+func TestParseScanDiffView(t *testing.T) {
+	if got := parseScanDiffView(db.Scan{}); got != nil {
+		t.Errorf("empty scan = %+v, want nil", got)
+	}
+	v := parseScanDiffView(db.Scan{
+		Coverage:  `{"requested_mode":"diff","actual_mode":"diff"}`,
+		DiffStats: `{"changed_files":1,"patch_bytes":10,"files":[{"status":"A","path":"x"}]}`,
+	})
+	if v == nil || v.ActualMode != "diff" || v.ChangedFiles != 1 || v.PatchBytes != 10 || len(v.Files) != 1 {
+		t.Fatalf("parsed = %+v", v)
+	}
+	if v.Files[0].StatusName() != "added" || !v.Files[0].Linkable() {
+		t.Errorf("added file: name=%q linkable=%v", v.Files[0].StatusName(), v.Files[0].Linkable())
+	}
+	if got := (scanDiffFile{Status: "D"}).Linkable(); got {
+		t.Errorf("deleted file linkable = %v, want false", got)
+	}
+	if got := (scanDiffFile{Status: "R100"}).StatusName(); got != "renamed" {
+		t.Errorf("R100 status name = %q, want renamed", got)
+	}
+	if got := (scanDiffFile{Status: "X"}).StatusName(); got != "X" {
+		t.Errorf("unknown status name = %q, want passthrough", got)
+	}
+	// Malformed JSON in one blob should not lose the other.
+	v = parseScanDiffView(db.Scan{Coverage: `{bad`, DiffStats: `{"changed_files":2}`})
+	if v == nil || v.ChangedFiles != 2 || v.ActualMode != "" {
+		t.Errorf("partial parse = %+v", v)
+	}
+}
+
 func TestScanShowSkillNameWithoutID(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()

--- a/internal/web/templates/scan_show.html
+++ b/internal/web/templates/scan_show.html
@@ -116,11 +116,44 @@
   </div>
 {{end}}
 
-{{if .Coverage}}
-  <details class="mb-6">
-    <summary class="text-sm text-muted-foreground cursor-pointer hover:underline">Coverage metadata</summary>
-    <pre class="mt-2 overflow-auto rounded border bg-muted/40 p-3 text-xs">{{.Coverage}}</pre>
-  </details>
+{{with $.Diff}}
+  {{if .FallbackReason}}
+    <div class="alert mb-6">
+      <i data-lucide="info"></i>
+      <section>Diff rescan requested; ran as a full scan. {{.FallbackReason}}.</section>
+    </div>
+  {{else if eq .ActualMode "diff"}}
+    {{$scan := $.Scan}}
+    <div class="mb-6 rounded border">
+      <div class="flex items-center justify-between gap-4 px-3 py-2 text-sm">
+        <div class="flex items-center gap-2">
+          <i data-lucide="diff"></i>
+          <span>Diff rescan · {{.ChangedFiles}} file{{if ne .ChangedFiles 1}}s{{end}} changed · {{bytes .PatchBytes}} patch</span>
+        </div>
+        <span class="text-muted-foreground text-xs">
+          <code>{{short $scan.DiffBaseCommit}}</code> → <code>{{short $scan.Commit}}</code>
+        </span>
+      </div>
+      {{if .Files}}
+        <details>
+          <summary class="cursor-pointer px-3 py-2 text-xs text-muted-foreground hover:underline border-t">Changed files</summary>
+          <table class="table w-full text-xs">
+            <tbody>
+              {{range .Files}}
+                <tr>
+                  <td class="text-muted-foreground w-24">{{.StatusName}}</td>
+                  <td class="font-mono">
+                    {{if .Old}}<span class="text-muted-foreground">{{.Old}} → </span>{{end}}
+                    {{if and .Linkable $scan.Commit}}<a class="hover:underline" href="/repositories/{{$scan.RepositoryID}}/blob/{{$scan.Commit}}/{{.Path}}">{{.Path}}</a>{{else}}{{.Path}}{{end}}
+                  </td>
+                </tr>
+              {{end}}
+            </tbody>
+          </table>
+        </details>
+      {{end}}
+    </div>
+  {{end}}
 {{end}}
 
 {{if .MaxTurnsHit}}


### PR DESCRIPTION
Part of #594.

Replaces the raw `<pre>{{.Coverage}}</pre>` dump on the scan page with a rendered view of the diff-rescan metadata #602 already records.

`scanShow` now parses the two JSON blobs on `db.Scan` (`Coverage` for requested/actual mode and fallback reason, `DiffStats` for the changed-file list and patch size) into a `scanDiffView` and passes it to the template. The template renders one of:

- an alert when a requested diff fell back to a full scan, with the reason
- a header line (`Diff rescan · N files changed · X KB patch · <base> → <head>`) plus a collapsible changed-files table with git status letters expanded to words and paths linked through the existing `/repositories/{id}/blob/{commit}/{path}` route (deleted files aren't linked since they only exist at the base commit)

`docs/diff-based-rescans.md` updated to describe what the page actually shows; per-file covered/skipped reporting still depends on skills emitting it and stays a follow-up.
