### PR TITLE
Use atomic upserts for exposure result rows

### DIFF
--- a/internal/db/finding_helpers.go
+++ b/internal/db/finding_helpers.go
@@ -99,6 +99,16 @@ func UpsertFindingDependent(gdb *gorm.DB, row FindingDependent) error {
 	}).Create(&row).Error
 }
 
+// EnsureFindingDependent creates a finding/dependent row when it is missing,
+// but deliberately preserves any existing exposure verdict. Use this for
+// placeholder rows that only make a dependent visible in the finding view.
+func EnsureFindingDependent(gdb *gorm.DB, row FindingDependent) error {
+	return gdb.Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "finding_id"}, {Name: "dependent_id"}},
+		DoNothing: true,
+	}).Create(&row).Error
+}
+
 // WriteFindingTimeField is the time.Time twin of WriteFindingField for
 // timestamp columns the analyst (or a skill) can set. The closed set
 // of writable timestamp columns lives in findingTimeFieldAccessor, so

--- a/internal/db/finding_helpers.go
+++ b/internal/db/finding_helpers.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/git-pkgs/vulns"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 // GHSAIDPattern matches a GitHub Security Advisory id: the GHSA prefix
@@ -83,6 +84,19 @@ func WriteFindingField(gdb *gorm.DB, findingID uint, field, newValue string, sou
 		}
 		return nil
 	})
+}
+
+// UpsertFindingDependent records the current exposure verdict for one
+// finding/dependent pair. The pair has a database unique index, so using the
+// same conflict target as that index makes concurrent writers update the row
+// instead of racing between a lookup and insert.
+func UpsertFindingDependent(gdb *gorm.DB, row FindingDependent) error {
+	return gdb.Clauses(clause.OnConflict{
+		Columns: []clause.Column{{Name: "finding_id"}, {Name: "dependent_id"}},
+		DoUpdates: clause.AssignmentColumns([]string{
+			"status", "justification", "rationale", "scan_id", "scan_commit", "updated_at",
+		}),
+	}).Create(&row).Error
 }
 
 // WriteFindingTimeField is the time.Time twin of WriteFindingField for

--- a/internal/web/finding_exposure.go
+++ b/internal/web/finding_exposure.go
@@ -51,7 +51,10 @@ func (s *Server) findingExposureRun(w http.ResponseWriter, r *http.Request) {
 	for i := range deps {
 		dep := deps[i]
 		if dep.RepositoryURL == "" {
-			s.recordSkippedExposure(f.ID, dep.ID)
+			if err := s.recordSkippedExposure(f.ID, dep.ID); err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
 			continue
 		}
 		if _, err := s.enqueueSkillWith(r.Context(), scan.RepositoryID, skill.ID, ScanOpts{
@@ -69,16 +72,12 @@ func (s *Server) findingExposureRun(w http.ResponseWriter, r *http.Request) {
 // recordSkippedExposure writes an under_investigation row for a
 // dependent we cannot audit (no upstream repo URL) so the per-dependent
 // table on the finding page stays complete.
-func (s *Server) recordSkippedExposure(findingID, dependentID uint) {
+func (s *Server) recordSkippedExposure(findingID, dependentID uint) error {
 	row := db.FindingDependent{
 		FindingID:   findingID,
 		DependentID: dependentID,
 		Status:      db.ExposureUnderInvestigation,
 		Rationale:   "skipped: dependent has no repository URL",
 	}
-	var existing db.FindingDependent
-	if err := s.DB.Where("finding_id = ? AND dependent_id = ?", findingID, dependentID).First(&existing).Error; err == nil {
-		return
-	}
-	s.DB.Create(&row)
+	return db.UpsertFindingDependent(s.DB, row)
 }

--- a/internal/web/finding_exposure.go
+++ b/internal/web/finding_exposure.go
@@ -79,5 +79,5 @@ func (s *Server) recordSkippedExposure(findingID, dependentID uint) error {
 		Status:      db.ExposureUnderInvestigation,
 		Rationale:   "skipped: dependent has no repository URL",
 	}
-	return db.UpsertFindingDependent(s.DB, row)
+	return db.EnsureFindingDependent(s.DB, row)
 }

--- a/internal/web/finding_exposure_test.go
+++ b/internal/web/finding_exposure_test.go
@@ -60,7 +60,7 @@ func TestFindingExposureRun_enqueuesScanPerDependent(t *testing.T) {
 	}
 }
 
-func TestRecordSkippedExposure_upsertsExistingRow(t *testing.T) {
+func TestRecordSkippedExposure_preservesExistingRow(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()
 
@@ -93,10 +93,10 @@ func TestRecordSkippedExposure_upsertsExistingRow(t *testing.T) {
 		t.Fatalf("finding dependent rows = %d, want 1", len(rows))
 	}
 	row := rows[0]
-	if row.Status != db.ExposureUnderInvestigation || row.Justification != "" || row.Rationale != "skipped: dependent has no repository URL" {
+	if row.Status != db.ExposureKnownAffected || row.Justification != "old justification" || row.Rationale != "old rationale" {
 		t.Errorf("verdict fields = %+v", row)
 	}
-	if row.ScanID != nil || row.ScanCommit != "" {
+	if row.ScanID == nil || *row.ScanID != f.ScanID || row.ScanCommit != "old-commit" {
 		t.Errorf("scan fields = %+v", row)
 	}
 }

--- a/internal/web/finding_exposure_test.go
+++ b/internal/web/finding_exposure_test.go
@@ -60,6 +60,47 @@ func TestFindingExposureRun_enqueuesScanPerDependent(t *testing.T) {
 	}
 }
 
+func TestRecordSkippedExposure_upsertsExistingRow(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	f, _ := seedExposureFinding(t, s)
+	dep := db.Dependent{RepositoryID: f.RepositoryID, Name: "no-url", Ecosystem: "npm"}
+	if err := s.DB.Create(&dep).Error; err != nil {
+		t.Fatalf("seed dependent: %v", err)
+	}
+	if err := s.DB.Create(&db.FindingDependent{
+		FindingID:     f.ID,
+		DependentID:   dep.ID,
+		Status:        db.ExposureKnownAffected,
+		Justification: "old justification",
+		Rationale:     "old rationale",
+		ScanID:        &f.ScanID,
+		ScanCommit:    "old-commit",
+	}).Error; err != nil {
+		t.Fatalf("seed finding dependent: %v", err)
+	}
+
+	if err := s.recordSkippedExposure(f.ID, dep.ID); err != nil {
+		t.Fatalf("record skipped exposure: %v", err)
+	}
+
+	var rows []db.FindingDependent
+	if err := s.DB.Where("finding_id = ? AND dependent_id = ?", f.ID, dep.ID).Find(&rows).Error; err != nil {
+		t.Fatalf("load finding dependent: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("finding dependent rows = %d, want 1", len(rows))
+	}
+	row := rows[0]
+	if row.Status != db.ExposureUnderInvestigation || row.Justification != "" || row.Rationale != "skipped: dependent has no repository URL" {
+		t.Errorf("verdict fields = %+v", row)
+	}
+	if row.ScanID != nil || row.ScanCommit != "" {
+		t.Errorf("scan fields = %+v", row)
+	}
+}
+
 func TestFindingExposureRun_noDependents422(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()

--- a/internal/worker/exposure.go
+++ b/internal/worker/exposure.go
@@ -125,7 +125,9 @@ func (w *Worker) doExposure(ctx context.Context, scan *db.Scan, emit func(Event)
 		return "", fmt.Errorf("load dependent %d: %w", *scan.DependentID, err)
 	}
 	if dep.RepositoryURL == "" {
-		w.upsertExposure(scan, dep.ID, db.ExposureUnderInvestigation, "", "dependent has no repository URL", "")
+		if err := w.upsertExposure(scan, dep.ID, db.ExposureUnderInvestigation, "", "dependent has no repository URL", ""); err != nil {
+			return "", fmt.Errorf("record exposure: %w", err)
+		}
 		emit(Event{Kind: KindText, Text: "dependent has no repository URL; marked under_investigation"})
 		return "", nil
 	}
@@ -150,7 +152,9 @@ func (w *Worker) doExposure(ctx context.Context, scan *db.Scan, emit func(Event)
 	cacheCommit, err := w.prepareDependentSrc(ctx, dep.RepositoryURL, scan.Ref, workRoot, emit)
 	if err != nil {
 		if _, ok := errors.AsType[*RepoUnreachableError](err); ok {
-			w.upsertExposure(scan, dep.ID, db.ExposureUnderInvestigation, "", "dependent repository unreachable", "")
+			if upsertErr := w.upsertExposure(scan, dep.ID, db.ExposureUnderInvestigation, "", "dependent repository unreachable", ""); upsertErr != nil {
+				return "", fmt.Errorf("record unreachable dependent exposure: %w", upsertErr)
+			}
 			emit(Event{Kind: KindError, Text: err.Error()})
 			return "", nil
 		}
@@ -205,14 +209,17 @@ func (w *Worker) doExposure(ctx context.Context, scan *db.Scan, emit func(Event)
 		}
 		return res.Report, err
 	}
-	if res.Report != "" {
-		if perr := w.parseExposureOutput(&skill, scan, dep.ID, res.Report, emit); perr != nil {
-			return res.Report, perr
-		}
-	} else {
-		w.upsertExposure(scan, dep.ID, db.ExposureUnderInvestigation, "", "skill produced no report", res.Commit)
+	return res.Report, w.recordExposureResult(&skill, scan, dep.ID, res.Report, res.Commit, emit)
+}
+
+func (w *Worker) recordExposureResult(skill *db.Skill, scan *db.Scan, depID uint, report, commit string, emit func(Event)) error {
+	if report != "" {
+		return w.parseExposureOutput(skill, scan, depID, report, emit)
 	}
-	return res.Report, nil
+	if err := w.upsertExposure(scan, depID, db.ExposureUnderInvestigation, "", "skill produced no report", commit); err != nil {
+		return fmt.Errorf("record missing exposure report: %w", err)
+	}
+	return nil
 }
 
 // parseExposureOutput reads the one-shot verdict produced by the exposure
@@ -241,12 +248,17 @@ func (w *Worker) parseExposureOutput(skill *db.Skill, scan *db.Scan, depID uint,
 	if r.Status != db.ExposureKnownNotAffected || !db.ValidExposureJustification(r.Justification) {
 		r.Justification = ""
 	}
-	w.upsertExposure(scan, depID, r.Status, r.Justification, r.Rationale, scan.Commit)
+	if err := w.upsertExposure(scan, depID, r.Status, r.Justification, r.Rationale, scan.Commit); err != nil {
+		return fmt.Errorf("record exposure: %w", err)
+	}
 	emit(Event{Kind: KindText, Text: fmt.Sprintf("recorded exposure: %s", r.Status)})
 	return nil
 }
 
-func (w *Worker) upsertExposure(scan *db.Scan, depID uint, status, justification, rationale, commit string) {
+func (w *Worker) upsertExposure(scan *db.Scan, depID uint, status, justification, rationale, commit string) error {
+	if scan.FindingID == nil {
+		return errors.New("exposure scan missing finding_id")
+	}
 	row := db.FindingDependent{
 		FindingID:     *scan.FindingID,
 		DependentID:   depID,
@@ -256,17 +268,5 @@ func (w *Worker) upsertExposure(scan *db.Scan, depID uint, status, justification
 		ScanID:        &scan.ID,
 		ScanCommit:    commit,
 	}
-	var existing db.FindingDependent
-	err := w.DB.Where("finding_id = ? AND dependent_id = ?", row.FindingID, row.DependentID).First(&existing).Error
-	if err != nil {
-		_ = w.DB.Create(&row).Error
-		return
-	}
-	w.DB.Model(&existing).Updates(map[string]any{
-		"status":        row.Status,
-		"justification": row.Justification,
-		"rationale":     row.Rationale,
-		"scan_id":       row.ScanID,
-		"scan_commit":   row.ScanCommit,
-	})
+	return db.UpsertFindingDependent(w.DB, row)
 }

--- a/internal/worker/exposure_test.go
+++ b/internal/worker/exposure_test.go
@@ -111,12 +111,19 @@ func TestParseExposureOutput_upsertsExistingRow(t *testing.T) {
 	w := newExposureWorker(t)
 	scan, skill, dep := seedExposureFixtures(t, w)
 
-	first := `{"status":"under_investigation","spec_version":1}`
-	if err := w.parseExposureOutput(&skill, &scan, dep.ID, first, func(Event) {}); err != nil {
-		t.Fatal(err)
+	if err := w.DB.Create(&db.FindingDependent{
+		FindingID:     *scan.FindingID,
+		DependentID:   dep.ID,
+		Status:        db.ExposureUnderInvestigation,
+		Justification: "old justification",
+		Rationale:     "old rationale",
+		ScanCommit:    "old-commit",
+	}).Error; err != nil {
+		t.Fatalf("seed finding dependent: %v", err)
 	}
-	second := `{"status":"known_affected","spec_version":1}`
-	if err := w.parseExposureOutput(&skill, &scan, dep.ID, second, func(Event) {}); err != nil {
+	scan.Commit = "new-commit"
+	report := `{"status":"known_not_affected","justification":"vulnerable_code_not_in_execute_path","rationale":"new rationale","spec_version":1}`
+	if err := w.parseExposureOutput(&skill, &scan, dep.ID, report, func(Event) {}); err != nil {
 		t.Fatal(err)
 	}
 	var rows []db.FindingDependent
@@ -124,8 +131,15 @@ func TestParseExposureOutput_upsertsExistingRow(t *testing.T) {
 	if len(rows) != 1 {
 		t.Fatalf("expected upsert, got %d rows", len(rows))
 	}
-	if rows[0].Status != db.ExposureKnownAffected {
-		t.Errorf("status = %q", rows[0].Status)
+	row := rows[0]
+	if row.Status != db.ExposureKnownNotAffected {
+		t.Errorf("status = %q", row.Status)
+	}
+	if row.Justification != db.JustifVulnerableCodeNotInPath || row.Rationale != "new rationale" {
+		t.Errorf("verdict fields = %+v", row)
+	}
+	if row.ScanID == nil || *row.ScanID != scan.ID || row.ScanCommit != scan.Commit {
+		t.Errorf("scan fields = %+v", row)
 	}
 }
 


### PR DESCRIPTION
Fixes #598

## Summary

Makes exposure-result writes atomic so concurrent worker and UI updates cannot race between a lookup and insert, then silently lose state on the unique `(finding_id, dependent_id)` constraint.

## Changes

- Add shared `db.UpsertFindingDependent` using GORM `ON CONFLICT`.
- Update mutable exposure fields on conflict:
  - `status`
  - `justification`
  - `rationale`
  - `scan_id`
  - `scan_commit`
  - `updated_at`
- Route worker-recorded exposure verdicts through the shared helper.
- Route URL-less dependent skipped-exposure rows through the same helper.
- Surface persistence errors to the worker or HTTP handler instead of ignoring them.
- Add coverage for updating existing rows through both paths.

## Tests

- `go test ./...`
- `go test -tags evals ./...`
- `go vet ./...`
- `go vet -tags evals ./...`
- `golangci-lint run ./cmd/... ./internal/...`
- `golangci-lint run --build-tags evals ./cmd/... ./internal/...`
- `git diff --check`