### PR TITLE
Report partial exposure enqueue results

### DIFF
--- a/internal/web/finding_exposure.go
+++ b/internal/web/finding_exposure.go
@@ -3,6 +3,7 @@ package web
 import (
 	"fmt"
 	"net/http"
+	"strings"
 
 	"scrutineer/internal/db"
 )
@@ -48,13 +49,15 @@ func (s *Server) findingExposureRun(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	model := r.FormValue("model")
+	var queued, skipped, errored int
 	for i := range deps {
 		dep := deps[i]
 		if dep.RepositoryURL == "" {
 			if err := s.recordSkippedExposure(f.ID, dep.ID); err != nil {
-				http.Error(w, err.Error(), http.StatusInternalServerError)
-				return
+				errored++
+				continue
 			}
+			skipped++
 			continue
 		}
 		if _, err := s.enqueueSkillWith(r.Context(), scan.RepositoryID, skill.ID, ScanOpts{
@@ -62,11 +65,31 @@ func (s *Server) findingExposureRun(w http.ResponseWriter, r *http.Request) {
 			FindingID:   &f.ID,
 			DependentID: &dep.ID,
 		}); err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
+			errored++
+			continue
 		}
+		queued++
 	}
+	setFlash(w, exposureRunToast(queued, skipped, errored))
 	s.redirect(w, r, fmt.Sprintf("/findings/%d", f.ID))
+}
+
+func exposureRunToast(queued, skipped, errored int) Flash {
+	parts := []string{fmt.Sprintf("%d queued", queued)}
+	if skipped > 0 {
+		parts = append(parts, fmt.Sprintf("%d skipped (no repository URL)", skipped))
+	}
+	if errored > 0 {
+		parts = append(parts, fmt.Sprintf("%d errored", errored))
+	}
+	category := successKey
+	switch {
+	case errored > 0:
+		category = errorKey
+	case queued == 0:
+		category = warningKey
+	}
+	return Flash{Category: category, Title: "Exposure: " + strings.Join(parts, ", ")}
 }
 
 // recordSkippedExposure writes an under_investigation row for a

--- a/internal/web/finding_exposure_test.go
+++ b/internal/web/finding_exposure_test.go
@@ -1,12 +1,14 @@
 package web
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
+	"gorm.io/gorm"
 	"scrutineer/internal/db"
 	"scrutineer/internal/worker"
 )
@@ -58,6 +60,141 @@ func TestFindingExposureRun_enqueuesScanPerDependent(t *testing.T) {
 	if len(rows) != 1 || rows[0].DependentID != skipped.ID || rows[0].Status != db.ExposureUnderInvestigation {
 		t.Fatalf("expected one under_investigation row for the URL-less dependent, got %+v", rows)
 	}
+	if flash := flashFrom(t, w); !strings.Contains(flash.Title, "3 queued") || !strings.Contains(flash.Title, "1 skipped") {
+		t.Errorf("flash = %q, want 3 queued / 1 skipped", flash.Title)
+	}
+}
+
+func TestFindingExposureRun_reportsPartialSuccess(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	f, skill := seedExposureFinding(t, s)
+	first := db.Dependent{RepositoryID: f.RepositoryID, Name: "first", Ecosystem: "npm", RepositoryURL: "https://github.com/example/first", DependentRepos: 400}
+	failed := db.Dependent{RepositoryID: f.RepositoryID, Name: "failed", Ecosystem: "npm", RepositoryURL: "https://github.com/example/failed", DependentRepos: 300}
+	last := db.Dependent{RepositoryID: f.RepositoryID, Name: "last", Ecosystem: "npm", RepositoryURL: "https://github.com/example/last", DependentRepos: 200}
+	skipped := db.Dependent{RepositoryID: f.RepositoryID, Name: "no-url", Ecosystem: "npm", DependentRepos: 100}
+	for _, dep := range []*db.Dependent{&first, &failed, &last, &skipped} {
+		if err := s.DB.Create(dep).Error; err != nil {
+			t.Fatalf("seed dependent: %v", err)
+		}
+	}
+	failExposureScanCreate(t, s, failed.ID)
+
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq(http.MethodPost, fmt.Sprintf("/findings/%d/exposure", f.ID)))
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("status %d, want redirect: %s", w.Code, w.Body)
+	}
+	if w.Header().Get("Location") != fmt.Sprintf("/findings/%d", f.ID) {
+		t.Errorf("location = %q", w.Header().Get("Location"))
+	}
+	flash := flashFrom(t, w)
+	if flash.Category != errorKey || !strings.Contains(flash.Title, "2 queued") || !strings.Contains(flash.Title, "1 skipped") || !strings.Contains(flash.Title, "1 errored") {
+		t.Errorf("flash = %+v, want partial-success counts", flash)
+	}
+
+	var scans []db.Scan
+	if err := s.DB.Where("kind = ? AND skill_id = ?", worker.JobExposure, skill.ID).Find(&scans).Error; err != nil {
+		t.Fatalf("load exposure scans: %v", err)
+	}
+	if len(scans) != 2 {
+		t.Fatalf("exposure scans = %d, want 2", len(scans))
+	}
+	queued := map[uint]bool{}
+	for _, scan := range scans {
+		if scan.DependentID != nil {
+			queued[*scan.DependentID] = true
+		}
+	}
+	if !queued[first.ID] || !queued[last.ID] || queued[failed.ID] {
+		t.Errorf("queued dependents = %v, want first and last only", queued)
+	}
+	var rows []db.FindingDependent
+	if err := s.DB.Where("finding_id = ? AND dependent_id = ?", f.ID, skipped.ID).Find(&rows).Error; err != nil {
+		t.Fatalf("load skipped exposure: %v", err)
+	}
+	if len(rows) != 1 || rows[0].Status != db.ExposureUnderInvestigation {
+		t.Errorf("skipped exposure rows = %+v", rows)
+	}
+}
+
+func TestFindingExposureRun_continuesAfterSkippedExposureWriteFailure(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	f, skill := seedExposureFinding(t, s)
+	skipped := db.Dependent{RepositoryID: f.RepositoryID, Name: "no-url", Ecosystem: "npm", DependentRepos: 200}
+	queued := db.Dependent{RepositoryID: f.RepositoryID, Name: "queued", Ecosystem: "npm", RepositoryURL: "https://github.com/example/queued", DependentRepos: 100}
+	for _, dep := range []*db.Dependent{&skipped, &queued} {
+		if err := s.DB.Create(dep).Error; err != nil {
+			t.Fatalf("seed dependent: %v", err)
+		}
+	}
+	failSkippedExposureCreate(t, s, skipped.ID)
+
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq(http.MethodPost, fmt.Sprintf("/findings/%d/exposure", f.ID)))
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("status %d, want redirect: %s", w.Code, w.Body)
+	}
+	flash := flashFrom(t, w)
+	if flash.Category != errorKey || !strings.Contains(flash.Title, "1 queued") || strings.Contains(flash.Title, "skipped") || !strings.Contains(flash.Title, "1 errored") {
+		t.Errorf("flash = %+v, want 1 queued / 1 errored with no skipped count", flash)
+	}
+
+	var scans []db.Scan
+	if err := s.DB.Where("kind = ? AND skill_id = ?", worker.JobExposure, skill.ID).Find(&scans).Error; err != nil {
+		t.Fatalf("load exposure scans: %v", err)
+	}
+	if len(scans) != 1 || scans[0].DependentID == nil || *scans[0].DependentID != queued.ID {
+		t.Fatalf("exposure scans = %+v, want queued dependent only", scans)
+	}
+	var rows []db.FindingDependent
+	if err := s.DB.Where("finding_id = ? AND dependent_id = ?", f.ID, skipped.ID).Find(&rows).Error; err != nil {
+		t.Fatalf("load skipped exposure: %v", err)
+	}
+	if len(rows) != 0 {
+		t.Errorf("skipped exposure rows = %+v, want none after failed write", rows)
+	}
+}
+
+func failExposureScanCreate(t *testing.T, s *Server, dependentID uint) {
+	t.Helper()
+	const callback = "test:fail-exposure-scan-create"
+	if err := s.DB.Callback().Create().Before("gorm:create").Register(callback, func(tx *gorm.DB) {
+		scan, ok := tx.Statement.Dest.(*db.Scan)
+		if !ok || scan.DependentID == nil || *scan.DependentID != dependentID {
+			return
+		}
+		_ = tx.AddError(errors.New("injected exposure enqueue failure"))
+	}); err != nil {
+		t.Fatalf("register callback: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := s.DB.Callback().Create().Remove(callback); err != nil {
+			t.Errorf("remove callback: %v", err)
+		}
+	})
+}
+
+func failSkippedExposureCreate(t *testing.T, s *Server, dependentID uint) {
+	t.Helper()
+	const callback = "test:fail-skipped-exposure-create"
+	if err := s.DB.Callback().Create().Before("gorm:create").Register(callback, func(tx *gorm.DB) {
+		row, ok := tx.Statement.Dest.(*db.FindingDependent)
+		if !ok || row.DependentID != dependentID {
+			return
+		}
+		_ = tx.AddError(errors.New("injected skipped exposure write failure"))
+	}); err != nil {
+		t.Fatalf("register callback: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := s.DB.Callback().Create().Remove(callback); err != nil {
+			t.Errorf("remove callback: %v", err)
+		}
+	})
 }
 
 func TestRecordSkippedExposure_preservesExistingRow(t *testing.T) {

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -2637,7 +2637,17 @@ func (s *Server) enqueueSkillWith(ctx context.Context, repoID, skillID uint, opt
 		prio = worker.PrioFinding
 	}
 	if err := s.Queue.Enqueue(ctx, kind, scan.ID, prio); err != nil {
-		return 0, err
+		enqueueErr := fmt.Errorf("enqueue scan %d: %w", scan.ID, err)
+		now := time.Now()
+		if markErr := s.DB.Model(&db.Scan{}).Where("id = ?", scan.ID).Updates(map[string]any{
+			"status":          db.ScanFailed,
+			"status_priority": db.StatusPriorityFor(db.ScanFailed),
+			"error":           enqueueErr.Error(),
+			"finished_at":     &now,
+		}).Error; markErr != nil {
+			return 0, errors.Join(enqueueErr, fmt.Errorf("mark scan failed: %w", markErr))
+		}
+		return 0, enqueueErr
 	}
 	s.DB.Model(&db.Repository{}).Where("id = ?", repoID).Update("updated_at", time.Now())
 	return scan.ID, nil

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -2535,6 +2535,33 @@ func TestEnqueueSkillWith_profileMismatch(t *testing.T) {
 	}
 }
 
+func TestEnqueueSkillWith_queueFailureMarksScanFailed(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	repo := db.Repository{URL: "https://github.com/foo/bar", Name: "bar"}
+	s.DB.Create(&repo)
+	skill := db.Skill{Name: "audit", Body: "b", OutputFile: "r.json", OutputKind: "freeform", Version: 1, Active: true, Source: "ui"}
+	s.DB.Create(&skill)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if _, err := s.enqueueSkillWith(ctx, repo.ID, skill.ID, ScanOpts{}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("enqueue error = %v, want context canceled", err)
+	}
+
+	var scan db.Scan
+	if err := s.DB.Where("repository_id = ? AND skill_id = ?", repo.ID, skill.ID).First(&scan).Error; err != nil {
+		t.Fatal(err)
+	}
+	if scan.Status != db.ScanFailed || scan.StatusPriority != db.StatusPriorityFor(db.ScanFailed) {
+		t.Errorf("scan status = %q priority = %d, want failed/%d", scan.Status, scan.StatusPriority, db.StatusPriorityFor(db.ScanFailed))
+	}
+	if scan.FinishedAt == nil || !strings.Contains(scan.Error, "context canceled") {
+		t.Errorf("scan failure fields = %+v", scan)
+	}
+}
+
 func TestEnqueueSkillWith_findingScopedJumpsQueue(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()


### PR DESCRIPTION
Fixes #599

## Summary

Updates the “Run exposure” action to report partial success accurately when one or more dependent exposure scans cannot be enqueued.

Previously, the handler returned HTTP 500 at the first enqueue error even though earlier scans were already queued. It now continues processing the remaining dependents and redirects back to the finding with a summary flash.

## Changes

- Track queued, skipped, and errored dependents during exposure fan-out.
- Continue enqueueing after an individual exposure enqueue failure.
- Show a flash with the final outcome counts.
- Mark flashes as errors when any enqueue fails and warnings when nothing queues.
- Keep URL-less dependents recorded as `under_investigation`.
- Add coverage for both full success and a failed middle enqueue with later dependents still queued.

## Tests

- `go test ./...`
- `go test -tags evals ./...`
- `go vet ./...`
- `go vet -tags evals ./...`
- `golangci-lint run ./cmd/... ./internal/...`
- `golangci-lint run --build-tags evals ./cmd/... ./internal/...`
- `git diff --check`