### PR TITLE
Fix --version flag handling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -170,7 +170,7 @@ jobs:
           VERSION: ${{ needs.preflight.outputs.version }}
           RUNNER_IMAGE: ${{ needs.preflight.outputs.runner_image }}
         run: |
-          OUTPUT=$(dist/scrutineer version)
+          OUTPUT=$(dist/scrutineer --version)
           grep -F "scrutineer ${VERSION}" <<< "${OUTPUT}"
           grep -F "runner: ${RUNNER_IMAGE}" <<< "${OUTPUT}"
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ You can also build a checkout-independent executable and run it from another dir
     install -m 0755 scrutineer ~/.local/bin/scrutineer
     scrutineer
 
-Precompiled binaries cover Linux and macOS on `amd64` and `arm64`. Run `scrutineer version` to see the application version, source commit, build timestamp, and exact runner-image digest paired with that release.
+Precompiled binaries cover Linux and macOS on `amd64` and `arm64`. Run `scrutineer --version` (or `scrutineer version`) to see the application version, source commit, build timestamp, and exact runner-image digest paired with that release.
 
 The executable does not bundle Docker, Podman, or Apple's `container` CLI. Scrutineer remains a host application that asks the selected external runtime to launch an ephemeral runner container for each scan; it materialises the embedded profile Dockerfiles under the data directory when `docker/profiles` is not available from a source checkout. Content-addressed skill and profile bundles from older versions are retained because existing skill records may still reference their auxiliary files; incomplete extraction directories older than 24 hours are removed automatically. To run under codex or opencode instead, see the [Codex backend](#codex-backend) and [Opencode backend](#opencode-backend) sections; only the credential and `-backend` flag change.
 

--- a/cmd/scrutineer/backup.go
+++ b/cmd/scrutineer/backup.go
@@ -23,9 +23,10 @@ const (
 )
 
 // dispatch routes a subcommand when args[0] names one, returning handled=true.
-// Server flags start with "-" and an empty argv both fall through with
-// handled=false, so scrutineer's default behaviour (boot the server) is
-// preserved for everything that is not a known subcommand.
+// Server flags and an empty argv fall through with handled=false, except for
+// the conventional --version/-version aliases. This preserves scrutineer's
+// default behaviour (boot the server) for everything that is not a known
+// command.
 func dispatch(args []string, out io.Writer) (handled bool, err error) {
 	if len(args) == 0 {
 		return false, nil
@@ -37,7 +38,7 @@ func dispatch(args []string, out io.Writer) (handled bool, err error) {
 		return true, runRestore(args[1:], out)
 	case "proxy":
 		return true, runProxy(args[1:])
-	case "version":
+	case "version", "--version", "-version":
 		return true, runVersion(out)
 	default:
 		return false, nil

--- a/cmd/scrutineer/version_test.go
+++ b/cmd/scrutineer/version_test.go
@@ -17,23 +17,27 @@ func TestDispatchVersion(t *testing.T) {
 		version, commit, buildDate, defaultRunnerImage = oldVersion, oldCommit, oldBuildDate, oldRunner
 	})
 
-	var out bytes.Buffer
-	handled, err := dispatch([]string{"version"}, &out)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !handled {
-		t.Fatal("version command was not handled")
-	}
-	for _, want := range []string{
-		"scrutineer 2026.07.12.1",
-		"commit: 0123456789abcdef",
-		"built: 2026-07-11T20:00:00Z",
-		"runner: ghcr.io/example/runner@sha256:abc",
-	} {
-		if !strings.Contains(out.String(), want) {
-			t.Errorf("version output %q missing %q", out.String(), want)
-		}
+	for _, arg := range []string{"version", "--version", "-version"} {
+		t.Run(arg, func(t *testing.T) {
+			var out bytes.Buffer
+			handled, err := dispatch([]string{arg}, &out)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !handled {
+				t.Fatalf("%s was not handled", arg)
+			}
+			for _, want := range []string{
+				"scrutineer 2026.07.12.1",
+				"commit: 0123456789abcdef",
+				"built: 2026-07-11T20:00:00Z",
+				"runner: ghcr.io/example/runner@sha256:abc",
+			} {
+				if !strings.Contains(out.String(), want) {
+					t.Errorf("version output %q missing %q", out.String(), want)
+				}
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- recognize --version and -version as aliases for the existing version command
- keep the detailed version, commit, build date, and runner image output
- exercise --version in release validation and document it as the primary spelling

## Testing

- go test ./...
- env GOCACHE=/tmp/scrutineer-gocache go vet ./...
- verified a release-like build with injected Homebrew version metadata