### PR TITLE
ci: adopt Renovate for dependency updates

### DIFF
--- a/.github/workflows/runner-image.yml
+++ b/.github/workflows/runner-image.yml
@@ -39,6 +39,9 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: verify Claude Code version pins
+        run: scripts/check-claude-version-pins.sh
+
       - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ARG COMMIT=""
 RUN CGO_ENABLED=0 go build -ldflags "-X main.commit=${COMMIT}" -o /scrutineer ./cmd/scrutineer
 
 FROM node:26-alpine@sha256:725aeba2364a9b16beae49e180d83bd597dbd0b15c47f1f28875c290bfd255b9 AS claude
-RUN npm install -g @anthropic-ai/claude-code@2.1.173
+RUN npm install -g @anthropic-ai/claude-code@2.1.210
 
 FROM python:3.15.0b3-alpine@sha256:c46e1b5012956890f42c4492c55cafde3ce675796854127cf93e9216f9f28f1a AS python-tools
 RUN pip install --no-cache-dir semgrep==1.167.0 "setuptools<81"

--- a/Dockerfile.runner
+++ b/Dockerfile.runner
@@ -3,7 +3,12 @@
 # works -- substitute the binary):
 #   docker build -t scrutineer-runner -f Dockerfile.runner .
 
-ARG CLAUDE_VERSION=2.1.173
+# Keep each release tag beside its architecture-specific digest so Renovate can
+# update the selected asset and checksum atomically. A mismatched tag/digest in
+# a Renovate PR fails sha256sum below and usually means asset identification
+# failed upstream.
+ARG CLAUDE_AMD64_LOCK=v2.1.210@sha256:3db32c13a1e16b2d867d096a9808f42d8678c5597d10799a1904fd897e043beb
+ARG CLAUDE_ARM64_LOCK=v2.1.210@sha256:83c01a39c3f785c6ae43c8923d5596e3246e7b87782b4cacc34259fbee5821d8
 ARG CODEX_VERSION=0.142.5
 ARG OPENCODE_VERSION=1.17.12
 ARG SEMGREP_VERSION=1.167.0
@@ -29,7 +34,8 @@ COPY . .
 RUN CGO_ENABLED=0 go build -o /out/scrutineer ./cmd/scrutineer
 
 FROM debian:trixie-slim@sha256:28de0877c2189802884ccd20f15ee41c203573bd87bb6b883f5f46362d24c5c2
-ARG CLAUDE_VERSION
+ARG CLAUDE_AMD64_LOCK
+ARG CLAUDE_ARM64_LOCK
 ARG CODEX_VERSION
 ARG OPENCODE_VERSION
 ARG SEMGREP_VERSION
@@ -65,12 +71,14 @@ RUN python3 -m venv /opt/semgrep && \
 ARG TARGETARCH
 RUN set -eux; \
     case "${TARGETARCH}" in \
-      amd64) arch=x64;   sha=b3d1afba5c02fa0fed43150e9470e556cf0cfc3a5c27d836a199d54051c96390 ;; \
-      arm64) arch=arm64; sha=2f0038e9f7b3ee049e7db202b4f10af7d2e62af542b7fd7d1f542ea04166a4fe ;; \
+      amd64) arch=x64;   lock="${CLAUDE_AMD64_LOCK}" ;; \
+      arm64) arch=arm64; lock="${CLAUDE_ARM64_LOCK}" ;; \
       *) echo "unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;; \
     esac; \
+    tag="${lock%@*}"; \
+    sha="${lock#*@sha256:}"; \
     curl -fsSL -o /tmp/claude.tgz \
-      "https://github.com/anthropics/claude-code/releases/download/v${CLAUDE_VERSION}/claude-linux-${arch}.tar.gz"; \
+      "https://github.com/anthropics/claude-code/releases/download/${tag}/claude-linux-${arch}.tar.gz"; \
     echo "${sha}  /tmp/claude.tgz" | sha256sum -c -; \
     tar -xzf /tmp/claude.tgz -C /usr/local/bin claude && rm /tmp/claude.tgz
 

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "enabledManagers": [
+    "gomod",
+    "github-actions",
+    "dockerfile",
+    "custom.regex"
+  ],
+  "dependencyDashboard": true,
+  "automerge": false,
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Update Claude Code release assets and SHA-256 pins",
+      "managerFilePatterns": ["/^Dockerfile\\.runner$/"],
+      "matchStrings": [
+        "ARG CLAUDE_(?:AMD64|ARM64)_LOCK=(?<currentValue>v\\d+\\.\\d+\\.\\d+)@sha256:(?<currentDigest>[a-f0-9]{64})"
+      ],
+      "packageNameTemplate": "anthropics/claude-code",
+      "depNameTemplate": "anthropics/claude-code",
+      "datasourceTemplate": "github-release-attachments",
+      "versioningTemplate": "semver-coerced"
+    },
+    {
+      "customType": "regex",
+      "description": "Update Claude Code image and documented versions from GitHub releases",
+      "managerFilePatterns": [
+        "/^Dockerfile$/",
+        "/^threatmodel\\.md$/"
+      ],
+      "matchStrings": [
+        "(?:@anthropic-ai/claude-code@|`claude-code@)(?<currentValue>\\d+\\.\\d+\\.\\d+)"
+      ],
+      "packageNameTemplate": "anthropics/claude-code",
+      "depNameTemplate": "anthropics/claude-code",
+      "datasourceTemplate": "github-release-attachments",
+      "versioningTemplate": "semver-coerced",
+      "extractVersionTemplate": "^v(?<version>.+)$"
+    }
+  ],
+  "packageRules": [
+    {
+      "matchManagers": ["gomod"],
+      "groupName": "Go modules",
+      "minimumReleaseAge": "7 days"
+    },
+    {
+      "matchManagers": ["gomod"],
+      "matchDepTypes": ["indirect"],
+      "enabled": true
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "groupName": "GitHub Actions",
+      "minimumReleaseAge": "7 days"
+    },
+    {
+      "matchManagers": ["dockerfile"],
+      "groupName": "Docker images",
+      "minimumReleaseAge": "7 days"
+    },
+    {
+      "description": "Keep all four Claude Code pins on one GitHub release; do not approve a partial group in the Dependency Dashboard",
+      "matchPackageNames": ["anthropics/claude-code"],
+      "groupName": "Claude Code",
+      "minimumGroupSize": 4,
+      "minimumReleaseAge": "7 days"
+    }
+  ],
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "automerge": false
+  }
+}

--- a/scripts/check-claude-version-pins.sh
+++ b/scripts/check-claude-version-pins.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Ensures Renovate or a manual edit cannot leave the runner, main image, and
+# threat-model documentation on different Claude Code releases. Keep this
+# compatible with macOS bash 3.2 and BSD userland so it also runs locally.
+
+set -euo pipefail
+
+root=$(cd "$(dirname "$0")/.." && pwd)
+
+runner_amd64=$(sed -E -n \
+  's/^ARG CLAUDE_AMD64_LOCK=v([0-9]+\.[0-9]+\.[0-9]+)@sha256:[0-9a-f]{64}$/\1/p' \
+  "$root/Dockerfile.runner")
+runner_arm64=$(sed -E -n \
+  's/^ARG CLAUDE_ARM64_LOCK=v([0-9]+\.[0-9]+\.[0-9]+)@sha256:[0-9a-f]{64}$/\1/p' \
+  "$root/Dockerfile.runner")
+main_image=$(sed -E -n \
+  's|^RUN npm install -g @anthropic-ai/claude-code@([0-9]+\.[0-9]+\.[0-9]+)$|\1|p' \
+  "$root/Dockerfile")
+# Backticks in this pattern are literal Markdown delimiters, not shell syntax.
+# shellcheck disable=SC2016
+documented=$(sed -E -n \
+  's/.*`claude-code@([0-9]+\.[0-9]+\.[0-9]+)`.*/\1/p' \
+  "$root/threatmodel.md")
+
+require_single() {
+  local label=$1
+  local value=$2
+  local count
+  count=$(printf '%s\n' "$value" | awk 'NF { count++ } END { print count + 0 }')
+  if [ "$count" -ne 1 ]; then
+    printf 'expected exactly one Claude Code version in %s, found %s\n' "$label" "$count" >&2
+    return 1
+  fi
+}
+
+require_single 'Dockerfile.runner amd64 lock' "$runner_amd64"
+require_single 'Dockerfile.runner arm64 lock' "$runner_arm64"
+require_single 'Dockerfile npm install' "$main_image"
+require_single 'threatmodel.md tool list' "$documented"
+
+if [ "$runner_amd64" != "$runner_arm64" ] || \
+   [ "$runner_amd64" != "$main_image" ] || \
+   [ "$runner_amd64" != "$documented" ]; then
+  printf '%s\n' \
+    'Claude Code version pins disagree:' \
+    "  Dockerfile.runner amd64: $runner_amd64" \
+    "  Dockerfile.runner arm64: $runner_arm64" \
+    "  Dockerfile npm install:  $main_image" \
+    "  threatmodel.md:          $documented" >&2
+  exit 1
+fi
+
+printf 'Claude Code version pins agree: %s\n' "$runner_amd64"

--- a/threatmodel.md
+++ b/threatmodel.md
@@ -120,11 +120,11 @@ No rate limiting on `POST /repositories`, no cap on clone size, no timeout on th
 
 ### T11: Image supply chain (partially mitigated)
 
-Tool versions are pinned: `claude-code@2.1.173`, `semgrep==1.167.0`, `git-pkgs@v0.15.3`, `brief@v0.9.3`, `zizmor@1.26.1`. The final stage is `debian:trixie-slim`; the `golang:1.26.5-trixie` and `rust:1.96-trixie` builder stages are pinned by sha256 digest. The container runs as non-root user `runner`. The runner image is built in CI, smoke-tested, and published to GHCR; users pull a known-good artifact rather than rebuilding against live registries.
+Tool versions are pinned: `claude-code@2.1.210`, `semgrep==1.167.0`, `git-pkgs@v0.15.3`, `brief@v0.9.3`, `zizmor@1.26.1`. The final stage is `debian:trixie-slim`; the `golang:1.26.5-trixie` and `rust:1.96-trixie` builder stages are pinned by sha256 digest. The container runs as non-root user `runner`. The runner image is built in CI, smoke-tested, and published to GHCR; users pull a known-good artifact rather than rebuilding against live registries.
 
 Supply-chain surface in the final stage:
 - `apt` pulls from Debian's official mirrors plus the GitHub CLI repo at `cli.github.com/packages` (signed-by keyring under `/etc/apt/keyrings/`). `gh` is used at scan time by the `fork` and `report-upstream` skills.
-- `claude` is the glibc tarball from `github.com/anthropics/claude-code` releases, SHA256-pinned per architecture. The hashes are computed locally and reviewed on version bumps because the un-suffixed assets are not in upstream `SHASUMS256.txt`.
+- `claude` is the glibc tarball from `github.com/anthropics/claude-code` releases, SHA256-pinned per architecture. Renovate maps each current digest to its architecture-specific filename using upstream's `SHASUMS256.txt`, then copies the corresponding digest from the new release's manifest. This pipeline does not verify the manifest's accompanying signature, so the pin detects tarball bytes that differ from the digest selected at update time but does not protect against a compromised upstream release at selection time. CI asserts that all four version pins agree, verifies each downloaded tarball against its selected digest, and smoke-tests that the installed binary runs.
 - `semgrep` is installed via `pip` into a venv at `/opt/semgrep` (PEP 668 dodge without `--break-system-packages`). `pip` is therefore present, scoped to that venv.
 - `curl` remains on PATH; used at build time to fetch the claude tarball and apt keyrings, and at scan time inside the egress-proxied container. `npm` is not installed.
 


### PR DESCRIPTION
Dependabot keeps Go modules, Actions and Docker images current, but it cannot touch the Claude Code pins: the release tag and per-architecture SHA256 in `Dockerfile.runner`, the npm pin in `Dockerfile`, and the version documented in `threatmodel.md`. Those four sites are bumped by hand today and can drift apart without anything noticing. This adds a Renovate config using the built-in `gomod`, `github-actions` and `dockerfile` managers plus two custom regex managers for the Claude pins, with a seven day minimum release age on everything, indirect Go dependencies enabled, and automerge left off. Coverage is a superset of the current Dependabot jobs: Renovate also reaches indirect Go dependencies (Dependabot bumps those only for security) and the `composer` pins under `docker/profiles`, which `directory: /` never scanned, so the first Docker images PR will be larger than usual.

`Dockerfile.runner` now keeps each release tag beside its architecture-specific digest so the `github-release-attachments` datasource can update a tag and its checksum atomically. All four pins resolve through that same datasource and package, so they always select the same release. Routing the bare versions through the `npm` datasource instead would let them skew: GitHub publishes each release a few hours after npm (+0.4h to +12.3h across the last twelve releases) and the age filter independently picks the newest release older than seven days per datasource, so at every release boundary there is a window where npm resolves to one version while GitHub is still on the previous one. That pairs one version's tag with another version's digests, and `minimumGroupSize` cannot catch it, since it counts updates rather than versions.

That skew would build and smoke-test cleanly, because the tag and digest stay internally consistent and the smoke test only checks that `claude` runs, so `scripts/check-claude-version-pins.sh` hard-fails when the four sites disagree or one goes missing, and runs in the runner-image build ahead of both architecture builds. Claude Code moves from 2.1.173 to 2.1.210 for the recent socket and connection reliability fixes. The threat model now describes what the pin actually guarantees: Renovate maps each digest to its filename through upstream's `SHASUMS256.txt` and copies the replacement from that manifest, whose signature nothing here verifies, so the pin detects a tarball that differs from the digest chosen at update time but not a compromised release at selection time.

`.github/dependabot.yml` is intentionally unchanged and comes out once Renovate's first run is confirmed; until then both may open a PR for the same update, which duplicates rather than misses. One follow-up before the new check can be relied on: `main` currently has no branch protection and no rulesets, so the check fails correctly but nothing prevents a merge through a failure. The two runner-image builds should be configured as required checks.
