### PR TITLE
fix: handle repository lookup errors in OSV exports

### DIFF
--- a/internal/web/finding_osv.go
+++ b/internal/web/finding_osv.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"embed"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"regexp"
@@ -15,6 +16,7 @@ import (
 	"github.com/git-pkgs/purl"
 	"github.com/git-pkgs/vulns"
 	"github.com/santhosh-tekuri/jsonschema/v6"
+	"gorm.io/gorm"
 
 	"scrutineer/internal/db"
 )
@@ -84,7 +86,15 @@ func (s *Server) findingOSV(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	var repo db.Repository
-	s.DB.First(&repo, f.RepositoryID)
+	if err := s.DB.First(&repo, f.RepositoryID).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			http.NotFound(w, r)
+			return
+		}
+		s.Log.Error("osv repository", "finding", f.ID, "repository", f.RepositoryID, "err", err)
+		http.Error(w, "failed to load repository", http.StatusInternalServerError)
+		return
+	}
 	var refs []db.FindingReference
 	s.DB.Where("finding_id = ?", f.ID).Order("id desc").Find(&refs)
 	var pkgs []db.Package

--- a/internal/web/finding_osv_test.go
+++ b/internal/web/finding_osv_test.go
@@ -1,12 +1,15 @@
 package web
 
 import (
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"slices"
 	"strconv"
 	"strings"
 	"testing"
+
+	"gorm.io/gorm"
 
 	"scrutineer/internal/db"
 )
@@ -442,6 +445,36 @@ func TestFindingOSV_404ForMissingFinding(t *testing.T) {
 	w := getOSV(t, s, 99999)
 	if w.Code != http.StatusNotFound {
 		t.Fatalf("status %d, want 404", w.Code)
+	}
+}
+
+func TestFindingOSV_handlesRepositoryLookupErrors(t *testing.T) {
+	for _, tt := range []struct {
+		name       string
+		err        error
+		wantStatus int
+	}{
+		{name: "missing", err: gorm.ErrRecordNotFound, wantStatus: http.StatusNotFound},
+		{name: "database failure", err: errors.New("database unavailable"), wantStatus: http.StatusInternalServerError},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			s, done := newTestServer(t)
+			defer done()
+
+			f := seedCSAFFinding(t, s, nil)
+			if err := s.DB.Callback().Query().Before("gorm:query").Register("test:fail_repository_lookup", func(tx *gorm.DB) {
+				if tx.Statement.Table == "repositories" {
+					_ = tx.AddError(tt.err)
+				}
+			}); err != nil {
+				t.Fatal(err)
+			}
+
+			w := getOSV(t, s, f.ID)
+			if w.Code != tt.wantStatus {
+				t.Errorf("status = %d, want %d; body=%s", w.Code, tt.wantStatus, w.Body)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- stop OSV exports when their repository lookup fails
- return 404 for a missing repository and 500 for operational database errors
- cover both failure paths with handler regressions

## Why

The OSV handler ignored repository lookup errors and continued with a zero-value repository, allowing incomplete security data to be returned as a successful export.

Closes #597

## Validation

- `go test -race ./...` — passed
- `go vet ./...` — passed
- `go vet -tags podman ./...` — passed
- `golangci-lint run ./...` — passed
- `govulncheck ./...` — passed
- `go mod tidy -diff` — passed