### PR TITLE
perf(worker): buffer scan log accumulation

### DIFF
--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -405,18 +405,23 @@ func (w *Worker) applyResume(scan *db.Scan, sj *SkillJob, emit func(Event)) {
 	}
 }
 
-// scanEmitter returns the emit callback handed to a job handler. It appends
-// each event to scan.Log in memory and streams it live to subscribers via
-// publish(); DB persistence is batched to logFlushInterval so a token-heavy
-// scan does not rewrite the whole log TEXT column on every event. wrap's
-// final Save(&scan) flushes the tail along with every other column, so a
+// scanEmitter returns the emit callback handed to a job handler and a snapshot
+// callback that materializes its buffered log into scan.Log. Event accumulation
+// stays linear, live publication remains immediate, and DB persistence is
+// batched to logFlushInterval. wrap snapshots before final persistence so a
 // scan that finishes between flushes still lands its full log. Session
 // events bypass batching: a session id is small, terminal-only changes,
 // and must hit the DB the moment it appears so a crash mid-run leaves the
 // scan resumable.
-func (w *Worker) scanEmitter(scan *db.Scan) func(Event) {
+func (w *Worker) scanEmitter(scan *db.Scan) (func(Event), func()) {
 	interval := w.logFlushInterval()
 	lastFlush := time.Now()
+	var logBuilder strings.Builder
+	logBuilder.Grow(len(scan.Log))
+	logBuilder.WriteString(scan.Log)
+	snapshot := func() {
+		scan.Log = logBuilder.String()
+	}
 	return func(e Event) {
 		if e.Kind == KindSession {
 			if e.SessionID != "" && e.SessionID != scan.SessionID {
@@ -429,8 +434,10 @@ func (w *Worker) scanEmitter(scan *db.Scan) func(Event) {
 			w.recordRateLimit(*e.RateLimit)
 		}
 		line := FormatEvent(e)
-		scan.Log += line + "\n"
+		logBuilder.WriteString(line)
+		logBuilder.WriteByte('\n')
 		if time.Since(lastFlush) >= interval {
+			snapshot()
 			w.DB.Model(&db.Scan{}).Where("id = ?", scan.ID).Update("log", scan.Log)
 			lastFlush = time.Now()
 		}
@@ -450,7 +457,7 @@ func (w *Worker) scanEmitter(scan *db.Scan) func(Event) {
 			scan.CacheWriteTokens += e.Usage.CacheWriteTokens
 		}
 		w.publish(scan.ID, scan.RepositoryID, "scan-log", line+"\n")
-	}
+	}, snapshot
 }
 
 // clearSessionStore wipes a finished scan's resume state so its next
@@ -581,10 +588,10 @@ func (w *Worker) wrap(h handler) func(context.Context, []byte) error {
 			}
 		}
 
-		emit := w.scanEmitter(&scan)
+		emit, snapshotLog := w.scanEmitter(&scan)
 
 		report, err := h(ctx, &scan, emit)
-		return w.finalizeScan(ctx, &scan, report, err, timeout, emit)
+		return w.finalizeScan(ctx, &scan, report, err, timeout, emit, snapshotLog)
 	}
 }
 
@@ -593,8 +600,9 @@ func (w *Worker) wrap(h handler) func(context.Context, []byte) error {
 // hit an account-level Claude problem, cleans up the workspace, and publishes
 // the status. It returns an error only when the terminal save fails, which
 // wrap propagates to goqite.
-func (w *Worker) finalizeScan(ctx context.Context, scan *db.Scan, report string, err error, timeout time.Duration, emit func(Event)) error {
+func (w *Worker) finalizeScan(ctx context.Context, scan *db.Scan, report string, err error, timeout time.Duration, emit func(Event), snapshotLog func()) error {
 	finishScan(ctx, scan, report, err, timeout, emit)
+	snapshotLog()
 	if scan.Status == db.ScanDone && !scan.MaxTurnsHit {
 		w.clearSessionStore(scan)
 	}
@@ -616,6 +624,7 @@ func (w *Worker) finalizeScan(ctx context.Context, scan *db.Scan, report string,
 			}
 		}
 		// resolveAccountReset emitted after the Save above; persist that log tail.
+		snapshotLog()
 		if logErr := w.DB.Model(&db.Scan{}).Where("id = ?", scan.ID).Update("log", scan.Log).Error; logErr != nil {
 			w.Log.Warn("account-pause log update failed", "scan", scan.ID, "err", logErr)
 		}

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"os"
@@ -866,11 +867,10 @@ func TestWorker_workspaceCleanup(t *testing.T) {
 }
 
 // TestScanEmitter_batchesDBWrites pins the batching behaviour: with a long
-// flush interval, in-memory scan.Log grows on every event but the DB log
-// column stays at the value from the most recent flush. SSE publish fires
-// on every event regardless of the flush cadence so the live UI stays
-// real-time. wrap()'s final Save persists scan.Log along with every other
-// column, so a scan that finishes mid-batch still lands its full log.
+// flush interval, the append buffer grows while scan.Log and the DB log column
+// stay at the value from the most recent snapshot. SSE publish fires on every
+// event regardless of the flush cadence so the live UI stays real-time. The
+// explicit snapshot models wrap()'s final persistence boundary.
 func TestScanEmitter_batchesDBWrites(t *testing.T) {
 	gdb, err := db.Open(filepath.Join(t.TempDir(), "emit.db"))
 	if err != nil {
@@ -888,11 +888,12 @@ func TestScanEmitter_batchesDBWrites(t *testing.T) {
 		LogFlushInterval: time.Hour,
 		OnEvent:          func(_, _ uint, _, _ string) { published++ },
 	}
-	emit := w.scanEmitter(&scan)
+	emit, snapshot := w.scanEmitter(&scan)
 
 	for i := 0; i < 5; i++ {
 		emit(Event{Kind: "text", Text: "line"})
 	}
+	snapshot()
 
 	if strings.Count(scan.Log, "line") != 5 {
 		t.Errorf("in-memory scan.Log should hold all 5 events, got %q", scan.Log)
@@ -904,6 +905,42 @@ func TestScanEmitter_batchesDBWrites(t *testing.T) {
 	gdb.First(&row, scan.ID)
 	if row.Log != "" {
 		t.Errorf("DB log should be empty until interval elapses, got %q", row.Log)
+	}
+}
+
+func TestScanEmitter_preservesManyEventsAcrossFlushes(t *testing.T) {
+	gdb, err := db.Open(filepath.Join(t.TempDir(), "emit_many.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo := db.Repository{URL: "https://example.com/x", Name: "x"}
+	gdb.Create(&repo)
+	scan := db.Scan{RepositoryID: repo.ID, Kind: JobSkill, Status: db.ScanRunning}
+	gdb.Create(&scan)
+
+	w := &Worker{
+		DB:               gdb,
+		Log:              slog.New(slog.NewTextHandler(io.Discard, nil)),
+		LogFlushInterval: time.Nanosecond,
+	}
+	emit, snapshot := w.scanEmitter(&scan)
+
+	var want strings.Builder
+	for i := 0; i < 256; i++ {
+		e := Event{Kind: KindText, Text: fmt.Sprintf("line-%03d", i)}
+		emit(e)
+		want.WriteString(FormatEvent(e))
+		want.WriteByte('\n')
+	}
+	snapshot()
+
+	if scan.Log != want.String() {
+		t.Fatalf("in-memory log does not contain every event in order")
+	}
+	var row db.Scan
+	gdb.First(&row, scan.ID)
+	if row.Log != want.String() {
+		t.Fatalf("persisted log does not contain every event in order")
 	}
 }
 
@@ -925,7 +962,7 @@ func TestScanEmitter_flushesWhenIntervalElapses(t *testing.T) {
 		Log:              slog.New(slog.NewTextHandler(io.Discard, nil)),
 		LogFlushInterval: time.Nanosecond,
 	}
-	emit := w.scanEmitter(&scan)
+	emit, _ := w.scanEmitter(&scan)
 	// Sleep past the interval so the very first event triggers a flush.
 	time.Sleep(time.Microsecond)
 	emit(Event{Kind: "text", Text: "first"})
@@ -956,7 +993,7 @@ func TestScanEmitter_sessionWritesBypassBatching(t *testing.T) {
 		Log:              slog.New(slog.NewTextHandler(io.Discard, nil)),
 		LogFlushInterval: time.Hour,
 	}
-	emit := w.scanEmitter(&scan)
+	emit, _ := w.scanEmitter(&scan)
 	emit(Event{Kind: KindSession, SessionID: "sess-123"})
 
 	var row db.Scan
@@ -999,6 +1036,41 @@ func TestScanEmitter_finalSaveCoversUnflushedTail(t *testing.T) {
 	gdb.First(&got, scan.ID)
 	if !strings.Contains(got.Log, "running skill fast") {
 		t.Errorf("final Save should persist the buffered log tail; got %q", got.Log)
+	}
+}
+
+func TestScanEmitter_failedFinalSaveCoversUnflushedTail(t *testing.T) {
+	gdb, err := db.Open(filepath.Join(t.TempDir(), "failed_tail.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo := db.Repository{URL: "https://example.com/x", Name: "x"}
+	gdb.Create(&repo)
+	skill := db.Skill{Name: "fast", Description: "x", Body: "b", Active: true, Source: "ui", Version: 1}
+	gdb.Create(&skill)
+	scan := db.Scan{RepositoryID: repo.ID, Kind: JobSkill, Status: db.ScanQueued, SkillID: &skill.ID}
+	gdb.Create(&scan)
+
+	w := &Worker{
+		DB:               gdb,
+		Log:              slog.New(slog.NewTextHandler(io.Discard, nil)),
+		DataDir:          t.TempDir(),
+		Runner:           fakeRunner{skillErr: errors.New("boom")},
+		PrepareRepoSrc:   stubPrepareRepoSrc,
+		LogFlushInterval: time.Hour,
+	}
+	body, _ := json.Marshal(queue.Payload{ScanID: scan.ID})
+	if err := w.wrap(w.doSkill)(context.Background(), body); err != nil {
+		t.Fatalf("wrap: %v", err)
+	}
+
+	var got db.Scan
+	gdb.First(&got, scan.ID)
+	if got.Status != db.ScanFailed {
+		t.Errorf("status = %s, want failed", got.Status)
+	}
+	if !strings.Contains(got.Log, "running skill fast") {
+		t.Errorf("failed final Save should persist the buffered log tail; got %q", got.Log)
 	}
 }
 


### PR DESCRIPTION
## Summary
- replace per-event scan.Log concatenation with a builder-backed accumulator
- snapshot the complete log at periodic, final, and post-account-reset persistence boundaries while keeping live publications immediate
- cover ordered many-event flushes plus successful and failed final-save tails

## Validation
- go test ./internal/worker -count=1
- go test -race ./internal/worker -count=1
- go mod tidy -diff
- go vet ./...
- go vet -tags podman ./...
- golangci-lint run --timeout=10m (0 issues)
- govulncheck ./... (0 reachable vulnerabilities)

Fixes #628