### PR TITLE
Postgres support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 /data/
 /data-*/
 /scrutineer
+# Compiled helper binaries (build from source under scripts/ instead).
+/migrate-sqlite-to-postgres
 *.db
 *.db-shm
 *.db-wal

--- a/cmd/scrutineer/backup.go
+++ b/cmd/scrutineer/backup.go
@@ -65,6 +65,9 @@ func runBackup(args []string, out io.Writer) error {
 	if err != nil {
 		return err
 	}
+	if err := errPostgresManaged(cfg); err != nil {
+		return err
+	}
 	dbPath := filepath.Join(resolveDataDir(cfg, dataDir), dbFileName)
 	if _, err := os.Stat(dbPath); err != nil {
 		return fmt.Errorf("no database at %s: %w", dbPath, err)
@@ -111,6 +114,9 @@ func runRestore(args []string, out io.Writer) error {
 
 	cfg, err := config.Load(configPath)
 	if err != nil {
+		return err
+	}
+	if err := errPostgresManaged(cfg); err != nil {
 		return err
 	}
 	if ok, err := isSQLiteFile(from); err != nil {
@@ -212,6 +218,18 @@ func serverRunning(addr string) bool {
 	}
 	_ = conn.Close()
 	return true
+}
+
+// errPostgresManaged returns a non-nil error when the config selects the
+// postgres backend. The backup/restore subcommands are SQLite-only (they use
+// VACUUM INTO and file swaps); PostgreSQL deployments back up through the
+// operator's own tooling (pg_dump/pg_restore, managed snapshots), so scrutineer
+// declines rather than pretending to.
+func errPostgresManaged(cfg *config.Config) error {
+	if cfg != nil && cfg.Database.Driver == "postgres" {
+		return errors.New("backup/restore is SQLite-only; PostgreSQL backups are operator-managed (use pg_dump/pg_restore or your provider's snapshots)")
+	}
+	return nil
 }
 
 // resolveDataDir mirrors the server's precedence: an explicit flag wins over

--- a/cmd/scrutineer/main.go
+++ b/cmd/scrutineer/main.go
@@ -118,9 +118,16 @@ type flags struct {
 	recipientsFile        string
 	identityFile          string
 	autoRejectMissedCount int
-	federationSalt        string
-	federationContact     string
-	skillLocal            skillDirs
+	// dbDriver selects the database backend ("" or "sqlite" for the embedded
+	// file, "postgres" for an external server). dbDSN is the connection
+	// string for postgres; sqlite ignores it and uses dataDir/scrutineer.db.
+	// These are config-only (no CLI flag) — a DSN on the command line would
+	// land in shell history and process listings.
+	dbDriver          string
+	dbDSN             string
+	federationSalt    string
+	federationContact string
+	skillLocal        skillDirs
 
 	// set records which flags were passed on the command line so merge
 	// knows not to let the config file override them.
@@ -272,6 +279,10 @@ func (f *flags) merge(cfg *config.Config) {
 	if cfg.AutoRejectMissedCount > 0 && !f.set["auto-reject-missed-count"] {
 		f.autoRejectMissedCount = cfg.AutoRejectMissedCount
 	}
+	// Database backend is config-only, so no f.set guard.
+	f.dbDriver = cfg.Database.Driver
+	f.dbDSN = cfg.Database.DSN
+
 	if cfg.FederationSalt != "" {
 		f.federationSalt = cfg.FederationSalt
 	}
@@ -305,6 +316,26 @@ func (f *flags) merge(cfg *config.Config) {
 	if cfg.Theme != "" {
 		web.SetTheme(cfg.Theme)
 	}
+}
+
+// databaseOptions maps the merged config onto db.OpenBackend's Options. For
+// postgres the DSN comes from config verbatim; for sqlite (the default) the
+// DSN is the database file inside the data directory, matching the historical
+// db.Open(dataDir/scrutineer.db) call.
+func (f *flags) databaseOptions() db.Options {
+	if f.dbDriver == "postgres" {
+		return db.Options{Dialect: db.DialectPostgres, DSN: f.dbDSN}
+	}
+	return db.Options{Dialect: db.DialectSQLite, DSN: filepath.Join(f.dataDir, dbFileName)}
+}
+
+// queueDialect selects the goqite backend to match databaseOptions so the
+// queue table lives in the same database as everything else.
+func (f *flags) queueDialect() queue.Dialect {
+	if f.dbDriver == "postgres" {
+		return queue.Postgres
+	}
+	return queue.SQLite
 }
 
 func (f *flags) fullClone() bool { return f.cloneMode == "full" }
@@ -470,7 +501,7 @@ func run(log *slog.Logger) error {
 	// walks into cloned scan workspaces under data/work/.
 	_ = os.WriteFile(filepath.Join(f.dataDir, "go.mod"), []byte("module scrutineer/data\n"), dataPermSecure)
 
-	gdb, err := db.Open(filepath.Join(f.dataDir, "scrutineer.db"))
+	gdb, err := db.OpenBackend(f.databaseOptions())
 	if err != nil {
 		return fmt.Errorf("open db: %w", err)
 	}
@@ -499,7 +530,7 @@ func run(log *slog.Logger) error {
 		}
 	}
 
-	q, err := queue.New(sqldb, log, f.concurrency)
+	q, err := queue.New(sqldb, log, f.concurrency, f.queueDialect())
 	if err != nil {
 		return fmt.Errorf("queue: %w", err)
 	}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,37 @@
+# Local PostgreSQL for scrutineer's postgres backend. This brings up only the
+# database service; scrutineer itself runs separately (go run ./cmd/scrutineer
+# or the container image) and is pointed at this server via the database block
+# in scrutineer.yaml. The schema is created automatically by scrutineer on
+# first connect (GORM AutoMigrate) — nothing is pre-provisioned here.
+#
+#   docker compose up -d
+#   # then, in scrutineer.yaml:
+#   #   database:
+#   #     driver: postgres
+#   #     dsn: postgres://scrutineer:scrutineer@127.0.0.1:5432/scrutineer?sslmode=disable
+name: scrutineer-postgres
+
+services:
+  db:
+    image: postgres:16-alpine
+    # Bound to loopback so the database is not reachable from other hosts with
+    # its dev-default password. Override POSTGRES_PASSWORD (and this binding)
+    # before exposing the stack anywhere real.
+    ports:
+      - "127.0.0.1:5432:5432"
+    environment:
+      POSTGRES_USER: scrutineer
+      POSTGRES_DB: scrutineer
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-scrutineer}
+    volumes:
+      - scrutineer-pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U scrutineer -d scrutineer"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 10s
+    restart: unless-stopped
+
+volumes:
+  scrutineer-pgdata:

--- a/docker/postgresdb/docker-compose.yaml
+++ b/docker/postgresdb/docker-compose.yaml
@@ -1,0 +1,35 @@
+# Local PostgreSQL for scrutineer's postgres backend. This brings up only the
+# database service; scrutineer itself runs separately (go run ./cmd/scrutineer
+# or the container image) and is pointed at this server via the database block
+# in scrutineer.yaml. The schema is created automatically by scrutineer on
+# first connect (GORM AutoMigrate) — nothing is pre-provisioned here.
+#
+#   docker compose -f docker/postgresdb/docker-compose.yaml up -d
+#   # then, in scrutineer.yaml:
+#   #   database:
+#   #     driver: postgres
+#   #     dsn: postgres://scrutineer:scrutineer@127.0.0.1:5432/scrutineer?sslmode=disable
+services:
+  db:
+    image: postgres:16-alpine
+    # Bound to loopback so the database is not reachable from other hosts with
+    # its dev-default password. Override POSTGRES_PASSWORD (and this binding)
+    # before exposing the stack anywhere real.
+    ports:
+      - "127.0.0.1:5432:5432"
+    environment:
+      POSTGRES_USER: scrutineer
+      POSTGRES_DB: scrutineer
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-scrutineer}
+    volumes:
+      - scrutineer-pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U scrutineer -d scrutineer"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 10s
+    restart: unless-stopped
+
+volumes:
+  scrutineer-pgdata:

--- a/go.mod
+++ b/go.mod
@@ -18,12 +18,14 @@ require (
 	github.com/git-pkgs/vulns v0.2.1
 	github.com/glebarez/sqlite v1.11.0
 	github.com/google/uuid v1.6.0
+	github.com/jackc/pgx/v5 v5.9.2
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	github.com/yuin/goldmark v1.8.4
 	golang.org/x/crypto v0.54.0
 	golang.org/x/term v0.45.0
 	gopkg.in/yaml.v3 v3.0.1
+	gorm.io/driver/postgres v1.6.0
 	gorm.io/gorm v1.31.2
 	maragu.dev/goqite v0.4.0
 )
@@ -39,6 +41,9 @@ require (
 	github.com/git-pkgs/vers v0.3.0 // indirect
 	github.com/github/go-spdx/v2 v2.7.0 // indirect
 	github.com/glebarez/go-sqlite v1.22.0 // indirect
+	github.com/jackc/pgpassfile v1.0.0 // indirect
+	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
+	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/kr/text v0.2.0 // indirect
@@ -48,6 +53,7 @@ require (
 	github.com/package-url/packageurl-go v0.1.6 // indirect
 	github.com/pandatix/go-cvss v0.6.2 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
+	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/text v0.40.0 // indirect
 	modernc.org/libc v1.74.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -62,8 +62,8 @@ github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsI
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761/go.mod h1:5TJZWKEWniPve33vlWYSoGYefn3gLQRzjfDlhSJ9ZKM=
-github.com/jackc/pgx/v5 v5.7.5 h1:JHGfMnQY+IEtGM63d+NGMjoRpysB2JBwDr5fsngwmJs=
-github.com/jackc/pgx/v5 v5.7.5/go.mod h1:aruU7o91Tc2q2cFp5h4uP3f6ztExVpyVv88Xl/8Vl8M=
+github.com/jackc/pgx/v5 v5.9.2 h1:3ZhOzMWnR4yJ+RW1XImIPsD1aNSz4T4fyP7zlQb56hw=
+github.com/jackc/pgx/v5 v5.9.2/go.mod h1:mal1tBGAFfLHvZzaYh77YS/eC6IX9OWbRV1QIIM0Jn4=
 github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo=
 github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD/E=
@@ -102,6 +102,7 @@ github.com/santhosh-tekuri/jsonschema/v6 v6.0.2/go.mod h1:JXeL+ps8p7/KNMjDQk3TCw
 github.com/spkg/bom v0.0.0-20160624110644-59b7046e48ad/go.mod h1:qLr4V1qq6nMqFKkMo8ZTx3f+BZEkzsRUY10Xsm2mwU0=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/yuin/goldmark v1.8.4 h1:oat/nd3U6NeQqFEL3xpEJq7d7c86NI+DbSNGAs4xnjA=
@@ -123,8 +124,11 @@ golang.org/x/tools v0.47.0/go.mod h1:dFHnyTvFWY212G+h7ZY4Vsp/K3U4/7W9TyVaAul8uCA
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gorm.io/driver/postgres v1.6.0 h1:2dxzU8xJ+ivvqTRph34QX+WrRaJlmfyPqXmoGVjMBa4=
+gorm.io/driver/postgres v1.6.0/go.mod h1:vUw0mrGgrTK+uPHEhAdV4sfFELrByKVGnaVRkXDhtWo=
 gorm.io/driver/sqlite v1.6.0 h1:WHRRrIiulaPiPFmDcod6prc4l2VGVWHz80KspNsxSfQ=
 gorm.io/driver/sqlite v1.6.0/go.mod h1:AO9V1qIQddBESngQUKWL9yoH93HIeA1X6V633rBwyT8=
 gorm.io/gorm v1.31.2 h1:3o8FXNo9v9S858gil+3LlZA1LkCOzgb4g5BL64FgaCo=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -135,6 +135,11 @@ type Config struct {
 	// which an open finding is automatically transitioned to 'rejected'.
 	// 0 (the default) means this feature is disabled.
 	AutoRejectMissedCount int `yaml:"auto_reject_missed_count"`
+	// Database selects the persistence backend. When omitted, scrutineer
+	// keeps an embedded SQLite database file inside the data directory (the
+	// historical behaviour). Set driver: postgres with a dsn to point at an
+	// external PostgreSQL server instead.
+	Database DatabaseConfig `yaml:"database"`
 	// FederationSalt is the secret shared out of band between federation
 	// members and mixed into interchange finding hashes, so members derive
 	// matching hashes without publishing anything enumerable by outsiders.
@@ -146,6 +151,16 @@ type Config struct {
 	// hash match. Required when FederationSalt is set: startup refuses a
 	// salt without a contact.
 	FederationContact string `yaml:"federation_contact"`
+}
+
+// DatabaseConfig selects and locates the database backend. Driver is
+// "sqlite" (default when empty) or "postgres". DSN is required for
+// postgres (a libpq/pgx connection string or URL, e.g.
+// "postgres://user:pass@host:5432/scrutineer?sslmode=disable"); for sqlite
+// it is ignored and the file lives under the data directory as before.
+type DatabaseConfig struct {
+	Driver string `yaml:"driver"`
+	DSN    string `yaml:"dsn"`
 }
 
 // ParseScanTimeout validates and parses a scan_timeout string. Empty
@@ -173,6 +188,24 @@ func ValidateClone(s string) error {
 		return nil
 	default:
 		return fmt.Errorf("clone: must be \"shallow\" or \"full\", got %q", s)
+	}
+}
+
+// ValidateDatabase checks the database block. The driver must be empty,
+// "sqlite", or "postgres", and postgres requires a dsn (sqlite derives its
+// path from the data directory). Exposed so callers can validate the same
+// rule the loader applies.
+func ValidateDatabase(d DatabaseConfig) error {
+	switch d.Driver {
+	case "", "sqlite":
+		return nil
+	case "postgres":
+		if d.DSN == "" {
+			return errors.New("database: driver \"postgres\" requires a dsn")
+		}
+		return nil
+	default:
+		return fmt.Errorf("database: driver must be \"sqlite\" or \"postgres\", got %q", d.Driver)
 	}
 }
 
@@ -283,6 +316,9 @@ func Load(path string) (*Config, error) {
 		return nil, fmt.Errorf("parse config %s: %w", path, err)
 	}
 	if err := ValidateEffort(c.Effort); err != nil {
+		return nil, fmt.Errorf("parse config %s: %w", path, err)
+	}
+	if err := ValidateDatabase(c.Database); err != nil {
 		return nil, fmt.Errorf("parse config %s: %w", path, err)
 	}
 	return &c, nil

--- a/internal/db/audit.go
+++ b/internal/db/audit.go
@@ -87,10 +87,16 @@ func AuditQueue(gdb *gorm.DB, opts AuditQueueOptions) ([]Finding, error) {
 		).
 		Where("id NOT IN (SELECT finding_id FROM finding_reviews)")
 	if !opts.Since.IsZero() {
-		// SQLite stores timestamps as text with whatever TZ offset the
-		// driver serialised, so a bare >= compares strings, not instants.
-		// datetime() normalises both sides to UTC YYYY-MM-DD HH:MM:SS.
-		q = q.Where("datetime(created_at) >= datetime(?)", opts.Since)
+		if q.Name() == string(DialectSQLite) {
+			// SQLite stores timestamps as text with whatever TZ offset the
+			// driver serialised, so a bare >= compares strings, not instants.
+			// datetime() normalises both sides to UTC YYYY-MM-DD HH:MM:SS.
+			q = q.Where("datetime(created_at) >= datetime(?)", opts.Since)
+		} else {
+			// PostgreSQL stores created_at as timestamptz, so the comparison
+			// is already instant-vs-instant; no normalisation needed.
+			q = q.Where("created_at >= ?", opts.Since)
+		}
 	}
 	var out []Finding
 	err := q.Order("updated_at desc").Limit(limit).Find(&out).Error

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -1,8 +1,11 @@
 // Package db holds GORM setup and the persistent models.
 //
-// SQLite is the default backend. GORM speaks PostgreSQL with a one-line
-// driver swap (gorm.io/driver/postgres) and the schema below uses nothing
-// SQLite-specific, so the migration path is "change the Open call".
+// SQLite is the default backend; PostgreSQL is selected via the database
+// block in the config file (see OpenBackend). The GORM models are shared
+// across both dialects, and the handful of dialect-specific SQL sites
+// branch on gdb.Dialector.Name() ("sqlite" vs "postgres"). SQLite-only
+// operations (VACUUM INTO backups, PRAGMA-based introspection) are guarded
+// so they never run against PostgreSQL.
 package db
 
 import (
@@ -15,9 +18,28 @@ import (
 	"time"
 
 	"github.com/glebarez/sqlite"
+	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 	"gorm.io/gorm/logger"
 )
+
+// Dialect names a supported database backend. It matches both the config
+// file's driver value and the string gorm's Dialector.Name() reports, so
+// callers can compare gdb.Dialector.Name() against these constants.
+type Dialect string
+
+const (
+	DialectSQLite   Dialect = "sqlite"
+	DialectPostgres Dialect = "postgres"
+)
+
+// Options selects and locates the backend OpenBackend connects to. For
+// SQLite, DSN is the database file path (an in-memory DSN in tests); for
+// PostgreSQL it is a pgx/libpq connection string or URL.
+type Options struct {
+	Dialect Dialect
+	DSN     string
+}
 
 type Repository struct {
 	ID   uint   `gorm:"primarykey"`
@@ -1253,15 +1275,60 @@ func withPragmas(dsn string) string {
 	return dsn + sep + connectionPragmas
 }
 
+// Open connects to a SQLite database at dsn (a file path or in-memory DSN)
+// and runs migrations. It is the historical single-argument entrypoint,
+// retained for tests and any SQLite-only caller; OpenBackend is the
+// config-driven path that also handles PostgreSQL.
 func Open(dsn string) (*gorm.DB, error) {
+	return OpenBackend(Options{Dialect: DialectSQLite, DSN: dsn})
+}
+
+// OpenBackend connects to the backend named by opts, then runs AutoMigrate
+// and creates the extra composite index. SQLite gets the per-connection
+// pragmas appended to its DSN (foreign_keys, busy_timeout, WAL); PostgreSQL
+// takes the DSN verbatim. AutoMigrate is dialect-portable, so the same model
+// set builds the schema on either backend.
+func OpenBackend(opts Options) (*gorm.DB, error) {
 	cfg := &gorm.Config{
 		Logger: logger.Default.LogMode(logger.Warn),
 	}
-	gdb, err := gorm.Open(sqlite.Open(withPragmas(dsn)), cfg)
-	if err != nil {
-		return nil, fmt.Errorf("open sqlite: %w", err)
+	var (
+		dialector gorm.Dialector
+		openErr   string
+	)
+	switch opts.Dialect {
+	case DialectPostgres:
+		dialector, openErr = postgres.Open(opts.DSN), "open postgres"
+	case DialectSQLite, "":
+		dialector, openErr = sqlite.Open(withPragmas(opts.DSN)), "open sqlite"
+	default:
+		return nil, fmt.Errorf("unknown database dialect %q", opts.Dialect)
 	}
-	if err := gdb.AutoMigrate(
+	gdb, err := gorm.Open(dialector, cfg)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", openErr, err)
+	}
+	if opts.Dialect == DialectPostgres {
+		// PostgreSQL rejects NUL bytes / invalid UTF-8 in text columns, which
+		// SQLite accepts. Scrub captured text on every write so a stray byte in
+		// scan/finding/chat output cannot fail the write (and strand a scan in
+		// 'running'). See registerTextSanitizer.
+		if err := registerTextSanitizer(gdb); err != nil {
+			return nil, fmt.Errorf("register text sanitizer: %w", err)
+		}
+	}
+	if err := migrate(gdb); err != nil {
+		return nil, fmt.Errorf("automigrate: %w", err)
+	}
+	gdb.Exec(`CREATE INDEX IF NOT EXISTS idx_scans_priority_id ON scans (status_priority, id DESC)`)
+	return gdb, nil
+}
+
+// models is the full set AutoMigrate manages, parents ahead of children.
+// scans.finding_id and findings.scan_id reference each other, so the set
+// contains a foreign-key cycle no ordering can linearise.
+func models() []any {
+	return []any{
 		&Repository{}, &Scan{},
 		&Finding{}, &FindingLabel{}, &FindingNote{},
 		&FindingCommunication{}, &FindingReference{}, &FindingHistory{}, &FindingReview{}, &AuditEvent{},
@@ -1269,11 +1336,26 @@ func Open(dsn string) (*gorm.DB, error) {
 		&Maintainer{}, &Skill{}, &Subproject{},
 		&SBOMUpload{}, &SBOMPackage{}, &CNA{}, &Setting{},
 		&Conversation{}, &ChatMessage{},
-	); err != nil {
-		return nil, fmt.Errorf("automigrate: %w", err)
 	}
-	gdb.Exec(`CREATE INDEX IF NOT EXISTS idx_scans_priority_id ON scans (status_priority, id DESC)`)
-	return gdb, nil
+}
+
+// migrate runs AutoMigrate over every model. SQLite migrates in one pass:
+// it accepts an inline REFERENCES to a table created later, so the
+// scans<->findings foreign-key cycle is fine. PostgreSQL rejects a forward
+// reference at CREATE TABLE, so it takes two passes — first create every
+// table with foreign-key constraints suppressed, then a second pass that
+// adds the constraints now that all tables exist. The end state (all tables,
+// all FKs, cascade deletes) is identical on both backends.
+func migrate(gdb *gorm.DB) error {
+	if gdb.Name() == string(DialectPostgres) {
+		gdb.DisableForeignKeyConstraintWhenMigrating = true
+		err := gdb.AutoMigrate(models()...)
+		gdb.DisableForeignKeyConstraintWhenMigrating = false
+		if err != nil {
+			return err
+		}
+	}
+	return gdb.AutoMigrate(models()...)
 }
 
 // Snapshot writes a consistent copy of the SQLite database at src to dest

--- a/internal/db/finding_helpers.go
+++ b/internal/db/finding_helpers.go
@@ -180,7 +180,7 @@ func retryFindingWrite(gdb *gorm.DB, findingID uint, write func(*gorm.DB) error)
 		if err == nil {
 			return nil
 		}
-		if !errors.Is(err, errFindingWriteConflict) && !isSQLiteBusy(err) {
+		if !errors.Is(err, errFindingWriteConflict) && !isSQLiteBusy(err) && !isPostgresSerializationFailure(err) {
 			return err
 		}
 		if attempt < findingWriteMaxAttempts {
@@ -213,6 +213,25 @@ func conditionalFindingUpdate(gdb *gorm.DB, findingID uint, column string, oldVa
 func isSQLiteBusy(err error) bool {
 	var sqliteErr interface{ Code() int }
 	return errors.As(err, &sqliteErr) && sqliteErr.Code()&0xff == sqliteBusyCode
+}
+
+// isPostgresSerializationFailure is the Postgres analogue of isSQLiteBusy: pgx
+// reports a serialization_failure (SQLSTATE 40001) or deadlock_detected (40P01)
+// when a concurrent transaction wins the compare-and-swap. Like the SQLite
+// case, the owned transaction must be restarted against a fresh snapshot. The
+// SQLState() method is matched structurally so the db package keeps no direct
+// pgconn dependency.
+func isPostgresSerializationFailure(err error) bool {
+	var pgErr interface{ SQLState() string }
+	if !errors.As(err, &pgErr) {
+		return false
+	}
+	switch pgErr.SQLState() {
+	case "40001", "40P01":
+		return true
+	default:
+		return false
+	}
 }
 
 // findingTimeFieldAccessor mirrors findingFieldAccessor for timestamp

--- a/internal/db/postgres_smoke_test.go
+++ b/internal/db/postgres_smoke_test.go
@@ -1,0 +1,53 @@
+package db
+
+import (
+	"os"
+	"testing"
+)
+
+// TestPostgresBackend is a live integration check against a real PostgreSQL
+// server. It is skipped unless SCRUTINEER_TEST_PG_DSN points at one, so the
+// normal `go test ./...` run (SQLite only) is unaffected. It proves the
+// dialect-portable path: OpenBackend runs AutoMigrate on Postgres and the
+// shared models round-trip.
+func TestPostgresBackend(t *testing.T) {
+	dsn := os.Getenv("SCRUTINEER_TEST_PG_DSN")
+	if dsn == "" {
+		t.Skip("set SCRUTINEER_TEST_PG_DSN to run the postgres backend smoke test")
+	}
+
+	gdb, err := OpenBackend(Options{Dialect: DialectPostgres, DSN: dsn})
+	if err != nil {
+		t.Fatalf("OpenBackend postgres: %v", err)
+	}
+	if name := gdb.Name(); name != "postgres" {
+		t.Fatalf("dialector name = %q, want postgres", name)
+	}
+
+	// Start clean so the test is rerunnable: the URL has a unique index, and
+	// the delete cascades to scans/findings via the FK constraints the
+	// postgres two-pass migration added.
+	const repoURL = "https://example.com/pg/repo"
+	if err := gdb.Where("url = ?", repoURL).Delete(&Repository{}).Error; err != nil {
+		t.Fatalf("cleanup: %v", err)
+	}
+
+	// Write and read back through a shared model, including the reserved-word
+	// "commit" column, to confirm AutoMigrate produced a usable schema.
+	repo := Repository{URL: repoURL, Name: "pg-repo"}
+	if err := gdb.Create(&repo).Error; err != nil {
+		t.Fatalf("create repository: %v", err)
+	}
+	scan := Scan{RepositoryID: repo.ID, Commit: "deadbeef", Status: ScanDone}
+	if err := gdb.Create(&scan).Error; err != nil {
+		t.Fatalf("create scan: %v", err)
+	}
+
+	var got Scan
+	if err := gdb.First(&got, scan.ID).Error; err != nil {
+		t.Fatalf("read scan: %v", err)
+	}
+	if got.Commit != "deadbeef" {
+		t.Fatalf("commit round-trip = %q, want deadbeef", got.Commit)
+	}
+}

--- a/internal/db/sanitize.go
+++ b/internal/db/sanitize.go
@@ -1,0 +1,99 @@
+package db
+
+import (
+	"reflect"
+	"strings"
+	"unicode/utf8"
+
+	"gorm.io/gorm"
+)
+
+// SanitizePGText makes s safe for a PostgreSQL text column. PostgreSQL rejects
+// NUL bytes (0x00) and invalid UTF-8; SQLite accepts both. Scan, finding, and
+// chat text is captured verbatim from container/tool/model output and from
+// repository file bytes, any of which can carry those, so it must be scrubbed
+// before it reaches a text column. Empty and already-clean strings return
+// unchanged after two linear scans, so the common case is cheap.
+func SanitizePGText(s string) string {
+	if strings.IndexByte(s, 0) >= 0 {
+		s = strings.ReplaceAll(s, "\x00", "")
+	}
+	if !utf8.ValidString(s) {
+		s = strings.ToValidUTF8(s, "�")
+	}
+	return s
+}
+
+// registerTextSanitizer installs a Create/Update callback that scrubs string
+// values on their way to the database. Without it, a stray NUL byte or invalid
+// UTF-8 sequence in captured output makes the write fail on PostgreSQL — for a
+// scan that is the terminal status write, so the row is stranded in 'running'
+// (its re-delivered job is then dropped as stale). One callback covers every
+// write form: struct Create/Save/Updates (via the statement's reflect value)
+// and column/map updates like Update("log", ...) (via the map destination).
+//
+// It is registered only for PostgreSQL. SQLite tolerates these bytes, so the
+// default backend keeps its historical behaviour and pays no reflect cost.
+func registerTextSanitizer(gdb *gorm.DB) error {
+	if err := gdb.Callback().Create().Before("gorm:create").Register("scrutineer:sanitize_text", sanitizeStatementText); err != nil {
+		return err
+	}
+	return gdb.Callback().Update().Before("gorm:update").Register("scrutineer:sanitize_text", sanitizeStatementText)
+}
+
+// sanitizeStatementText scrubs the pending write in place. Map destinations
+// (column/map updates) have their string values rewritten; everything else is
+// a struct or slice of structs reachable through the statement's reflect value.
+func sanitizeStatementText(db *gorm.DB) {
+	if db.Statement == nil {
+		return
+	}
+	switch dest := db.Statement.Dest.(type) {
+	case map[string]interface{}:
+		for k, v := range dest {
+			switch t := v.(type) {
+			case string:
+				dest[k] = SanitizePGText(t)
+			case *string:
+				if t != nil {
+					*t = SanitizePGText(*t)
+				}
+			}
+		}
+	default:
+		sanitizeReflectStrings(db.Statement.ReflectValue)
+	}
+}
+
+// sanitizeReflectStrings rewrites the settable top-level string and *string
+// fields of a struct value, or of each element of a slice/array of structs
+// (batch insert). Nested structs are not descended into: the models keep their
+// free text at the top level, and skipping them avoids touching stdlib structs
+// such as time.Time whose fields are unexported.
+func sanitizeReflectStrings(rv reflect.Value) {
+	switch rv.Kind() {
+	case reflect.Pointer, reflect.Interface:
+		if !rv.IsNil() {
+			sanitizeReflectStrings(rv.Elem())
+		}
+	case reflect.Slice, reflect.Array:
+		for i := 0; i < rv.Len(); i++ {
+			sanitizeReflectStrings(rv.Index(i))
+		}
+	case reflect.Struct:
+		for i := 0; i < rv.NumField(); i++ {
+			f := rv.Field(i)
+			if !f.CanSet() {
+				continue
+			}
+			switch f.Kind() {
+			case reflect.String:
+				f.SetString(SanitizePGText(f.String()))
+			case reflect.Pointer:
+				if !f.IsNil() && f.Elem().Kind() == reflect.String {
+					f.Elem().SetString(SanitizePGText(f.Elem().String()))
+				}
+			}
+		}
+	}
+}

--- a/internal/db/sanitize_test.go
+++ b/internal/db/sanitize_test.go
@@ -1,0 +1,81 @@
+package db
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSanitizePGText(t *testing.T) {
+	cases := []struct {
+		name, in, want string
+	}{
+		{"clean", "hello world", "hello world"},
+		{"empty", "", ""},
+		{"nul stripped", "a\x00b\x00c", "abc"},
+		{"invalid utf8 replaced", "a\xffb", "a�b"},
+		{"both", "x\x00\xffy", "x�y"},
+	}
+	for _, tc := range cases {
+		if got := SanitizePGText(tc.in); got != tc.want {
+			t.Errorf("%s: SanitizePGText(%q) = %q, want %q", tc.name, tc.in, got, tc.want)
+		}
+	}
+}
+
+// TestTextSanitizerCallback exercises the Create/Update callback end to end.
+// Open() uses SQLite (which tolerates NUL), so the callback is not auto-wired;
+// we register it manually to prove it scrubs both a struct Save and a column
+// Update — the two write forms that carry raw scan output on the live path.
+func TestTextSanitizerCallback(t *testing.T) {
+	gdb, err := Open(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := registerTextSanitizer(gdb); err != nil {
+		t.Fatal(err)
+	}
+
+	repo := Repository{URL: "https://example.com/x", Name: "x"}
+	if err := gdb.Create(&repo).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	// Struct Save (the finalizeScan path): NUL + invalid UTF-8 in log/report/error.
+	scan := Scan{
+		RepositoryID: repo.ID,
+		Kind:         "skill",
+		Status:       ScanDone,
+		Log:          "start\x00middle\xffend",
+		Report:       `{"ok":true}` + "\x00",
+		Error:        "boom\x00",
+	}
+	if err := gdb.Save(&scan).Error; err != nil {
+		t.Fatalf("struct save with NUL text failed: %v", err)
+	}
+	var got Scan
+	if err := gdb.First(&got, scan.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	for name, v := range map[string]string{"log": got.Log, "report": got.Report, "error": got.Error} {
+		if strings.ContainsRune(v, 0) {
+			t.Errorf("%s still contains a NUL byte after save: %q", name, v)
+		}
+	}
+	if got.Log != "startmiddle�end" {
+		t.Errorf("log = %q, want NUL stripped and invalid UTF-8 replaced", got.Log)
+	}
+
+	// Column Update (the streaming log-flush path): Update("log", value) sets a
+	// map destination, which the callback must also scrub.
+	if err := gdb.Model(&Scan{}).Where("id = ?", scan.ID).
+		Update("log", "flush\x00tail").Error; err != nil {
+		t.Fatalf("column update with NUL text failed: %v", err)
+	}
+	got = Scan{}
+	if err := gdb.First(&got, scan.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if strings.ContainsRune(got.Log, 0) || got.Log != "flushtail" {
+		t.Errorf("after column update log = %q, want %q", got.Log, "flushtail")
+	}
+}

--- a/internal/queue/postgres_smoke_test.go
+++ b/internal/queue/postgres_smoke_test.go
@@ -1,0 +1,42 @@
+package queue
+
+import (
+	"context"
+	"database/sql"
+	"io"
+	"log/slog"
+	"os"
+	"testing"
+
+	_ "github.com/jackc/pgx/v5/stdlib"
+)
+
+// TestPostgresQueue exercises the queue against a real PostgreSQL server when
+// SCRUTINEER_TEST_PG_DSN is set (skipped otherwise). It proves the embedded
+// idempotent schema_postgres.sql runs — twice — and that goqite operates in
+// its PostgreSQL flavour through an enqueue/receive round trip.
+func TestPostgresQueue(t *testing.T) {
+	dsn := os.Getenv("SCRUTINEER_TEST_PG_DSN")
+	if dsn == "" {
+		t.Skip("set SCRUTINEER_TEST_PG_DSN to run the postgres queue smoke test")
+	}
+	sqldb, err := sql.Open("pgx", dsn)
+	if err != nil {
+		t.Fatalf("open pgx: %v", err)
+	}
+	defer func() { _ = sqldb.Close() }()
+
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	// Build twice: the second New re-runs the schema, asserting idempotency.
+	if _, err := New(sqldb, log, 1, Postgres); err != nil {
+		t.Fatalf("first New: %v", err)
+	}
+	q, err := New(sqldb, log, 1, Postgres)
+	if err != nil {
+		t.Fatalf("second New (idempotency): %v", err)
+	}
+
+	if err := q.Enqueue(context.Background(), "test-job", 42, 0); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+}

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -18,7 +18,35 @@ import (
 )
 
 //go:embed schema_sqlite.sql
-var schema string
+var schemaSQLite string
+
+//go:embed schema_postgres.sql
+var schemaPostgres string
+
+// Dialect selects which backend the queue table lives in. It mirrors the
+// database dialect chosen for the main GORM handle so goqite emits SQL in
+// the matching flavour (placeholders, upsert syntax) and we run the right
+// schema.
+type Dialect int
+
+const (
+	SQLite Dialect = iota
+	Postgres
+)
+
+func (d Dialect) schema() string {
+	if d == Postgres {
+		return schemaPostgres
+	}
+	return schemaSQLite
+}
+
+func (d Dialect) goqiteFlavor() goqite.SQLFlavor {
+	if d == Postgres {
+		return goqite.SQLFlavorPostgreSQL
+	}
+	return goqite.SQLFlavorSQLite
+}
 
 // Payload is what travels on the queue. The job handler looks up the Scan
 // row by ID; everything else (repo URL, kind) hangs off that record so the
@@ -55,24 +83,55 @@ const (
 	DefaultWorkerConcurrency = 4
 )
 
-// New builds a queue wired to goqite. concurrency controls how many jobs
-// the runner processes in parallel; pass 0 to use DefaultWorkerConcurrency.
-// The runner itself is built lazily in Start (and rebuilt by Reconfigure).
-func New(sqldb *sql.DB, log *slog.Logger, concurrency int) (*Queue, error) {
+// New builds a queue wired to goqite on the given dialect. concurrency
+// controls how many jobs the runner processes in parallel; pass 0 to use
+// DefaultWorkerConcurrency. The runner itself is built lazily in Start (and
+// rebuilt by Reconfigure). Both embedded schemas are idempotent, so running
+// them on every startup is safe.
+func New(sqldb *sql.DB, log *slog.Logger, concurrency int, dialect Dialect) (*Queue, error) {
 	if concurrency <= 0 {
 		concurrency = DefaultWorkerConcurrency
 	}
-	if _, err := sqldb.Exec(schema); err != nil {
+	if err := installSchema(sqldb, dialect); err != nil {
 		return nil, fmt.Errorf("goqite schema: %w", err)
 	}
 	q := goqite.New(goqite.NewOpts{
-		DB:      sqldb,
-		Name:    "scans",
-		Timeout: visibilityTimeout,
+		DB:        sqldb,
+		Name:      "scans",
+		Timeout:   visibilityTimeout,
+		SQLFlavor: dialect.goqiteFlavor(),
 	})
 	queue := &Queue{q: q, log: log, handlers: map[string]jobs.Func{}}
 	queue.concurrency.Store(int64(concurrency))
 	return queue, nil
+}
+
+// goqiteSchemaLockKey is a fixed 64-bit key ("goqite" in ASCII hex) for the
+// Postgres session-level advisory lock that serialises first-run schema DDL.
+const goqiteSchemaLockKey int64 = 0x676f71697465
+
+// installSchema applies the dialect's idempotent schema. On Postgres it holds a
+// session advisory lock across the DDL so that many processes starting against
+// a fresh database do not race `CREATE EXTENSION IF NOT EXISTS`, which collides
+// on the pg_extension_name_index unique constraint under concurrency. SQLite is
+// single-writer, so it just runs the statements.
+func installSchema(sqldb *sql.DB, dialect Dialect) error {
+	if dialect != Postgres {
+		_, err := sqldb.Exec(dialect.schema())
+		return err
+	}
+	ctx := context.Background()
+	conn, err := sqldb.Conn(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = conn.Close() }()
+	if _, err := conn.ExecContext(ctx, "SELECT pg_advisory_lock($1)", goqiteSchemaLockKey); err != nil {
+		return err
+	}
+	defer func() { _, _ = conn.ExecContext(ctx, "SELECT pg_advisory_unlock($1)", goqiteSchemaLockKey) }()
+	_, err = conn.ExecContext(ctx, dialect.schema())
+	return err
 }
 
 // Concurrency reports the parallelism limit the runner is currently using.

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -22,7 +22,7 @@ func newTestQueue(t *testing.T, concurrency int) *Queue {
 	if err != nil {
 		t.Fatal(err)
 	}
-	q, err := New(sqldb, slog.New(slog.NewTextHandler(io.Discard, nil)), concurrency)
+	q, err := New(sqldb, slog.New(slog.NewTextHandler(io.Discard, nil)), concurrency, SQLite)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/queue/schema_postgres.sql
+++ b/internal/queue/schema_postgres.sql
@@ -1,0 +1,31 @@
+-- PostgreSQL counterpart to schema_sqlite.sql, made idempotent so it can
+-- run on every startup like the SQLite version does. goqite's own bundled
+-- schema_postgres.sql is not re-runnable (bare create table / trigger /
+-- function), so we guard each object here instead.
+create extension if not exists pgcrypto;
+
+create or replace function goqite_update_timestamp()
+returns trigger as $$
+begin
+   new.updated = now();
+   return new;
+end;
+$$ language plpgsql;
+
+create table if not exists goqite (
+  id text primary key default ('m_' || encode(gen_random_bytes(16), 'hex')),
+  created timestamptz not null default now(),
+  updated timestamptz not null default now(),
+  queue text not null,
+  body bytea not null,
+  timeout timestamptz not null default now(),
+  received integer not null default 0,
+  priority integer not null default 0
+);
+
+drop trigger if exists goqite_updated_timestamp on goqite;
+create trigger goqite_updated_timestamp
+before update on goqite
+for each row execute function goqite_update_timestamp();
+
+create index if not exists goqite_queue_priority_created_idx on goqite (queue, priority desc, created);

--- a/internal/web/scans.go
+++ b/internal/web/scans.go
@@ -38,7 +38,12 @@ func (s *Server) jobs(w http.ResponseWriter, r *http.Request) {
 	case statusKey:
 		q = q.Order(orderByExpr("status", dir, false)).Order("scans.id desc")
 	case sortRepository:
-		q = q.Joins("Repository").Order(orderByExpr("`Repository`.name", dir, false)).Order("scans.id desc")
+		// clause.OrderByColumn quotes the joined-table column per dialect
+		// (`Repository`.`name` on SQLite, "Repository"."name" on Postgres);
+		// a hardcoded backtick expression is invalid SQL on Postgres.
+		q = q.Joins("Repository").
+			Order(clause.OrderByColumn{Column: clause.Column{Table: "Repository", Name: "name"}, Desc: wantDesc(dir, false)}).
+			Order("scans.id desc")
 	case "findings":
 		// findings_count is a denormalised column on the scan row.
 		q = q.Order(orderByExpr("findings_count", dir, true)).Order("scans.id desc")

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -1011,11 +1011,17 @@ func loadRepoFindings(gdb *gorm.DB, repoID uint, category string) repoFindings {
 			scanIDs = append(scanIDs, f.ScanID)
 		}
 	}
-	// Typed Find so GORM's dialector quotes the reserved-word column
-	// (`commit` on SQLite, "commit" on Postgres) and coerces NULL text to
-	// the Go zero value, replacing the previous Raw + COALESCE.
-	var rows []db.Scan
-	gdb.Select("id", "skill_name", "commit").Where("id IN ?", scanIDs).Find(&rows)
+	var rows []struct {
+		ID        uint
+		SkillName string
+		Commit    string
+	}
+	// "commit" is quoted because it is a reserved word; double quotes are the
+	// SQL-standard identifier quote both SQLite and PostgreSQL accept (and the
+	// input resolves to the column, not a string literal, because the column
+	// exists). The output alias stays "commit" so GORM maps it onto the
+	// struct's Commit field.
+	gdb.Raw(`SELECT id, COALESCE(skill_name, '') AS skill_name, COALESCE("commit", '') AS "commit" FROM scans WHERE id IN ?`, scanIDs).Scan(&rows)
 	for _, row := range rows {
 		rf.ScanSkill[row.ID] = row.SkillName
 		rf.ScanCommit[row.ID] = row.Commit
@@ -2401,14 +2407,14 @@ func (s *Server) latestDepsCommit(repoID uint) string {
 	var commits []string
 	s.DB.Model(&db.Scan{}).
 		Joins("JOIN skills ON skills.id = scans.skill_id").
-		Where("scans.repository_id = ? AND skills.output_kind = ? AND scans.status = ?",
+		Where(`scans.repository_id = ? AND skills.output_kind = ? AND scans.status = ? AND scans."commit" <> ''`,
 			repoID, "dependencies", db.ScanDone).
 		// Not(map) lets GORM's dialector quote the reserved-word column
 		// against the model's table instead of hardcoding scans.`commit`.
 		Not(map[string]any{"commit": ""}).
 		Order("scans.id DESC").
 		Limit(1).
-		Pluck("scans.commit", &commits)
+		Pluck(`scans."commit"`, &commits)
 	if len(commits) > 0 {
 		return commits[0]
 	}

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -29,7 +29,7 @@ func newTestServer(t testing.TB) (*Server, func()) {
 	}
 	sqldb, _ := gdb.DB()
 	log := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
-	q, err := queue.New(sqldb, log, 0)
+	q, err := queue.New(sqldb, log, 0, queue.SQLite)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/web/theme.go
+++ b/internal/web/theme.go
@@ -80,11 +80,19 @@ func (s *Server) settingsShow(w http.ResponseWriter, r *http.Request) {
 	s.DB.Table("maintainers").Count(&stats.Maintainers)
 	s.DB.Table("skills").Count(&stats.Skills)
 
+	// DB size + location are introspected differently per backend: SQLite
+	// exposes them via table-valued pragmas, PostgreSQL via catalog
+	// functions. dbPath is a filesystem path on SQLite and the database name
+	// on PostgreSQL (the file lives on the server, not here).
 	var dbSizeBytes int64
-	s.DB.Raw("SELECT page_count * page_size FROM pragma_page_count(), pragma_page_size()").Scan(&dbSizeBytes)
-
 	var dbPath string
-	s.DB.Raw("SELECT file FROM pragma_database_list WHERE name = 'main'").Scan(&dbPath)
+	if s.DB.Name() == string(db.DialectPostgres) {
+		s.DB.Raw("SELECT pg_database_size(current_database())").Scan(&dbSizeBytes)
+		s.DB.Raw("SELECT current_database()").Scan(&dbPath)
+	} else {
+		s.DB.Raw("SELECT page_count * page_size FROM pragma_page_count(), pragma_page_size()").Scan(&dbSizeBytes)
+		s.DB.Raw("SELECT file FROM pragma_database_list WHERE name = 'main'").Scan(&dbPath)
+	}
 
 	meta := s.toolMetadataCached(r.Context())
 	// Overlay the boot-time staleness verdict onto the (separately cached)

--- a/internal/worker/preflight_test.go
+++ b/internal/worker/preflight_test.go
@@ -26,7 +26,7 @@ func newPreflightWorker(t *testing.T) *Worker {
 		t.Fatal(err)
 	}
 	log := slog.New(slog.NewTextHandler(os.Stderr, nil))
-	q, err := queue.New(sqldb, log, 1)
+	q, err := queue.New(sqldb, log, 1, queue.SQLite)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -616,7 +616,7 @@ func TestWorker_resumeAccountPaused(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	q, err := queue.New(sqldb, slog.New(slog.NewTextHandler(io.Discard, nil)), 1)
+	q, err := queue.New(sqldb, slog.New(slog.NewTextHandler(io.Discard, nil)), 1, queue.SQLite)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -672,7 +672,7 @@ func TestWorker_resumeAccountPausedUsesUTCComparison(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	q, err := queue.New(sqldb, slog.New(slog.NewTextHandler(io.Discard, nil)), 1)
+	q, err := queue.New(sqldb, slog.New(slog.NewTextHandler(io.Discard, nil)), 1, queue.SQLite)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -750,7 +750,7 @@ func TestWorker_resumeAccountPausedRestoreOnEnqueueError(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	q, err := queue.New(sqldb, slog.New(slog.NewTextHandler(io.Discard, nil)), 1)
+	q, err := queue.New(sqldb, slog.New(slog.NewTextHandler(io.Discard, nil)), 1, queue.SQLite)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/scripts/migrate-sqlite-to-postgres/main.go
+++ b/scripts/migrate-sqlite-to-postgres/main.go
@@ -1,0 +1,361 @@
+// Command migrate-sqlite-to-postgres copies a scrutineer SQLite database into
+// a PostgreSQL server so an operator can switch the `database` backend in
+// scrutineer.yaml without losing history.
+//
+// Usage:
+//
+//	go run ./scripts/migrate-sqlite-to-postgres \
+//	    -sqlite ./data/scrutineer.db \
+//	    -postgres 'postgres://scrutineer:secret@localhost:5432/scrutineer?sslmode=disable'
+//
+// It reuses the application's GORM models and db.OpenBackend, so the target
+// schema is created exactly as the server would create it (including the
+// two-pass migration that resolves the scans<->findings foreign-key cycle),
+// and SQLite's text-encoded timestamps/booleans/blobs are converted through
+// their Go types rather than copied as raw strings.
+//
+// The whole copy runs in one transaction with session_replication_role set to
+// 'replica', which suspends foreign-key and trigger enforcement for the load.
+// That sidesteps insert-ordering entirely (again, the scans<->findings cycle)
+// and is the standard bulk-import approach; it requires a superuser or
+// equivalent (rds_superuser on managed Postgres). After the copy, per-table id
+// sequences are advanced past the imported rows.
+//
+// The target must be empty (no repositories) unless -force is given. The
+// SQLite source is opened the same way the server opens it, which brings it up
+// to the current schema before copying — run against a copy if you would
+// rather not touch the live file.
+package main
+
+import (
+	"database/sql"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"reflect"
+	"strings"
+	"unicode/utf8"
+
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+
+	"scrutineer/internal/db"
+)
+
+const batchSize = 200
+
+func main() {
+	var sqlitePath, pgDSN string
+	var force bool
+	flag.StringVar(&sqlitePath, "sqlite", "./data/scrutineer.db", "path to the source SQLite database")
+	flag.StringVar(&pgDSN, "postgres", "", "destination PostgreSQL DSN (required)")
+	flag.BoolVar(&force, "force", false, "copy even if the destination already has data (rows are added, not replaced)")
+	flag.Parse()
+
+	if err := run(sqlitePath, pgDSN, force); err != nil {
+		log.Fatalf("migrate: %v", err)
+	}
+}
+
+func run(sqlitePath, pgDSN string, force bool) error {
+	if pgDSN == "" {
+		return fmt.Errorf("-postgres DSN is required")
+	}
+	if _, err := os.Stat(sqlitePath); err != nil {
+		return fmt.Errorf("source database %s: %w", sqlitePath, err)
+	}
+
+	src, err := db.Open(sqlitePath)
+	if err != nil {
+		return fmt.Errorf("open sqlite source: %w", err)
+	}
+	dst, err := db.OpenBackend(db.Options{Dialect: db.DialectPostgres, DSN: pgDSN})
+	if err != nil {
+		return fmt.Errorf("open postgres destination: %w", err)
+	}
+
+	if !force {
+		var repos int64
+		if err := dst.Model(&db.Repository{}).Count(&repos).Error; err != nil {
+			return fmt.Errorf("check destination: %w", err)
+		}
+		if repos > 0 {
+			return fmt.Errorf("destination already has %d repositories; refusing without -force", repos)
+		}
+
+		// The goqite job queue is transient and intentionally not migrated (see
+		// warnUnhandledTables). A queued or running scan lives as both a scans
+		// row and a queue message; copying only the row would strand it in
+		// Postgres — status=queued with nothing to dispatch it. Refuse so the
+		// operator drains or cancels pending work first; -force migrates anyway.
+		var pending int64
+		if err := src.Model(&db.Scan{}).
+			Where("status IN ?", []db.ScanStatus{db.ScanQueued, db.ScanRunning}).
+			Count(&pending).Error; err != nil {
+			return fmt.Errorf("check pending scans: %w", err)
+		}
+		if pending > 0 {
+			return fmt.Errorf("source has %d queued/running scan(s); the job queue is not migrated so they would be stranded. Let them finish or cancel them first, or pass -force to migrate anyway", pending)
+		}
+	}
+
+	// copiers copy the typed models in an order that reads parents before
+	// children (irrelevant for FK enforcement while it is suspended, but it
+	// keeps the log readable). Each entry resolves its own table name.
+	copiers := []func(src, tx *gorm.DB) (string, int64, error){
+		copyModel[db.Repository], copyModel[db.Scan], copyModel[db.Finding],
+		copyModel[db.ExpectedFinding],
+		copyModel[db.FindingLabel], copyModel[db.FindingNote], copyModel[db.FindingCommunication],
+		copyModel[db.FindingReference], copyModel[db.FindingHistory], copyModel[db.FindingReview],
+		copyModel[db.Dependency], copyModel[db.Package], copyModel[db.Dependent],
+		copyModel[db.FindingDependent], copyModel[db.Advisory], copyModel[db.Maintainer],
+		copyModel[db.Skill], copyModel[db.Subproject], copyModel[db.SBOMUpload],
+		copyModel[db.SBOMPackage], copyModel[db.CNA], copyModel[db.Setting],
+	}
+	// joinTables have no model struct (pure many-to-many link rows). They hold
+	// only integer foreign keys, so a generic row copy is safe.
+	joinTables := []string{"repository_maintainers", "finding_labels_join"}
+
+	if err := warnUnhandledTables(src, dst, joinTables); err != nil {
+		return err
+	}
+
+	handled := make([]string, 0, len(copiers))
+	err = dst.Transaction(func(tx *gorm.DB) error {
+		// Suspend FK/trigger enforcement for this transaction so insert order
+		// and the scans<->findings cycle do not matter.
+		if err := tx.Exec("SET LOCAL session_replication_role = replica").Error; err != nil {
+			return fmt.Errorf("disable fk enforcement: %w", err)
+		}
+		for _, c := range copiers {
+			table, n, err := c(src, tx)
+			if err != nil {
+				return fmt.Errorf("copy %s: %w", table, err)
+			}
+			handled = append(handled, table)
+			log.Printf("copied %-24s %6d rows", table, n)
+		}
+		for _, jt := range joinTables {
+			n, err := copyRaw(src, tx, jt)
+			if err != nil {
+				return fmt.Errorf("copy %s: %w", jt, err)
+			}
+			log.Printf("copied %-24s %6d rows", jt, n)
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	// Sequences were not touched while rows were inserted with explicit ids, so
+	// advance each id sequence past the imported maximum.
+	for _, table := range handled {
+		if err := resetSequence(dst, table); err != nil {
+			return fmt.Errorf("reset sequence for %s: %w", table, err)
+		}
+	}
+
+	log.Printf("done. Set `database: {driver: postgres, dsn: ...}` in scrutineer.yaml to use the migrated data.")
+	return nil
+}
+
+// copyModel streams every row of model T from src into tx in batches, reading
+// through the Go types so SQLite's text/int encodings become the destination's
+// native column types. Associations are omitted so each table is copied exactly
+// once (children are copied by their own entry, not cascaded from the parent).
+func copyModel[T any](src, tx *gorm.DB) (string, int64, error) {
+	table := tableName(tx, new(T))
+	var total, cleaned int64
+	var batch []T
+	res := src.Model(new(T)).FindInBatches(&batch, batchSize, func(_ *gorm.DB, _ int) error {
+		if len(batch) == 0 {
+			return nil
+		}
+		// SQLite stores arbitrary bytes in TEXT columns; PostgreSQL rejects any
+		// row whose text is not valid UTF-8 (or contains a NUL), aborting the
+		// whole load. Scrub each row's string fields first so one corrupt log
+		// or report can't sink the migration.
+		for i := range batch {
+			if sanitizeStrings(&batch[i]) {
+				cleaned++
+			}
+		}
+		if err := tx.Session(&gorm.Session{SkipHooks: true}).
+			Omit(clause.Associations).
+			CreateInBatches(batch, batchSize).Error; err != nil {
+			return err
+		}
+		total += int64(len(batch))
+		return nil
+	})
+	if cleaned > 0 {
+		log.Printf("  note: scrubbed invalid UTF-8/NUL bytes in %d %s row(s)", cleaned, table)
+	}
+	return table, total, res.Error
+}
+
+// sanitizeStrings rewrites every string field of the struct pointed at by ptr
+// so it is safe for a PostgreSQL text column: NUL bytes are dropped and any
+// invalid UTF-8 sequence is replaced with U+FFFD. It reports whether anything
+// changed. Only top-level string and *string fields are touched — associations
+// are omitted from the copy, and []byte fields map to bytea, which takes
+// arbitrary bytes untouched. Returns false for non-struct inputs.
+func sanitizeStrings(ptr any) bool {
+	rv := reflect.ValueOf(ptr)
+	if rv.Kind() != reflect.Pointer || rv.IsNil() {
+		return false
+	}
+	rv = rv.Elem()
+	if rv.Kind() != reflect.Struct {
+		return false
+	}
+	changed := false
+	for i := 0; i < rv.NumField(); i++ {
+		f := rv.Field(i)
+		if !f.CanSet() {
+			continue
+		}
+		switch {
+		case f.Kind() == reflect.String:
+			if clean := cleanText(f.String()); clean != f.String() {
+				f.SetString(clean)
+				changed = true
+			}
+		case f.Kind() == reflect.Pointer && !f.IsNil() && f.Elem().Kind() == reflect.String:
+			if clean := cleanText(f.Elem().String()); clean != f.Elem().String() {
+				f.Elem().SetString(clean)
+				changed = true
+			}
+		}
+	}
+	return changed
+}
+
+// cleanText makes s safe for a PostgreSQL text column: strip NUL bytes (valid
+// UTF-8 but forbidden in text), then replace any remaining invalid byte
+// sequence with the Unicode replacement character.
+func cleanText(s string) string {
+	if s == "" {
+		return s
+	}
+	if strings.IndexByte(s, 0) >= 0 {
+		s = strings.ReplaceAll(s, "\x00", "")
+	}
+	if !utf8.ValidString(s) {
+		s = strings.ToValidUTF8(s, "�")
+	}
+	return s
+}
+
+// copyRaw copies a table generically as untyped rows. Used for the many-to-many
+// join tables, which have no model and carry only integer foreign keys.
+func copyRaw(src, tx *gorm.DB, table string) (int64, error) {
+	var total int64
+	var batch []map[string]any
+	// FindInBatches keeps only batchSize rows in memory at a time instead of
+	// loading the whole table, matching copyModel's bounded footprint.
+	res := src.Table(table).FindInBatches(&batch, batchSize, func(_ *gorm.DB, _ int) error {
+		if len(batch) == 0 {
+			return nil
+		}
+		if err := tx.Table(table).CreateInBatches(batch, batchSize).Error; err != nil {
+			return err
+		}
+		total += int64(len(batch))
+		return nil
+	})
+	return total, res.Error
+}
+
+// resetSequence advances table's id sequence past the largest imported id so
+// future inserts do not collide. Tables without an id serial (e.g. settings,
+// keyed by a string) have no such sequence and are skipped — pg_get_serial_sequence
+// errors rather than returns null for a missing column, so the id column is
+// checked first.
+func resetSequence(dst *gorm.DB, table string) error {
+	var hasID bool
+	if err := dst.Raw(
+		`SELECT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = ? AND column_name = 'id')`,
+		table).Scan(&hasID).Error; err != nil {
+		return err
+	}
+	if !hasID {
+		return nil
+	}
+	var seq sql.NullString
+	if err := dst.Raw("SELECT pg_get_serial_sequence(?, 'id')", table).Scan(&seq).Error; err != nil {
+		return err
+	}
+	if !seq.Valid || seq.String == "" {
+		return nil
+	}
+	// is_called is true only when rows exist, so an empty table leaves the
+	// sequence delivering 1 on the first insert.
+	q := fmt.Sprintf(
+		`SELECT setval(?, COALESCE((SELECT MAX(id) FROM %q), 1), (SELECT MAX(id) FROM %q) IS NOT NULL)`,
+		table, table)
+	return dst.Exec(q, seq.String).Error
+}
+
+// warnUnhandledTables fails loudly if the source holds a table this migrator
+// neither copies nor knowingly skips, so a future schema addition cannot be
+// dropped silently. goqite (transient job queue) and SQLite internals are
+// expected skips.
+func warnUnhandledTables(src, dst *gorm.DB, joinTables []string) error {
+	known := map[string]bool{"goqite": true}
+	for _, jt := range joinTables {
+		known[jt] = true
+	}
+	// Resolve each model's table name via the destination naming strategy.
+	for _, name := range modelTableNames(dst) {
+		known[name] = true
+	}
+
+	var names []string
+	if err := src.Raw(
+		"SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%'",
+	).Scan(&names).Error; err != nil {
+		return fmt.Errorf("list source tables: %w", err)
+	}
+	var unknown []string
+	for _, n := range names {
+		if !known[n] {
+			unknown = append(unknown, n)
+		}
+	}
+	if len(unknown) > 0 {
+		return fmt.Errorf("source has tables this migrator does not handle: %v; update the script before migrating", unknown)
+	}
+	return nil
+}
+
+// modelTableNames returns the destination table name for every copied model,
+// kept in sync with the copiers list above.
+func modelTableNames(g *gorm.DB) []string {
+	models := []any{
+		&db.Repository{}, &db.Scan{}, &db.Finding{},
+		&db.ExpectedFinding{},
+		&db.FindingLabel{}, &db.FindingNote{}, &db.FindingCommunication{},
+		&db.FindingReference{}, &db.FindingHistory{}, &db.FindingReview{},
+		&db.Dependency{}, &db.Package{}, &db.Dependent{},
+		&db.FindingDependent{}, &db.Advisory{}, &db.Maintainer{},
+		&db.Skill{}, &db.Subproject{}, &db.SBOMUpload{},
+		&db.SBOMPackage{}, &db.CNA{}, &db.Setting{},
+	}
+	names := make([]string, 0, len(models))
+	for _, m := range models {
+		names = append(names, tableName(g, m))
+	}
+	return names
+}
+
+// tableName resolves the table a model maps to under g's naming strategy.
+func tableName(g *gorm.DB, model any) string {
+	stmt := &gorm.Statement{DB: g}
+	if err := stmt.Parse(model); err != nil {
+		return fmt.Sprintf("%T", model)
+	}
+	return stmt.Schema.Table
+}

--- a/scripts/migrate-sqlite-to-postgres/main_test.go
+++ b/scripts/migrate-sqlite-to-postgres/main_test.go
@@ -1,0 +1,149 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"scrutineer/internal/db"
+)
+
+// TestMigrate is a live end-to-end check: it seeds a temp SQLite database
+// (including the scans<->findings foreign-key cycle and both many-to-many
+// join tables), migrates it into a real PostgreSQL server, and verifies the
+// row counts and key relationships survive. It is skipped unless
+// SCRUTINEER_TEST_PG_DSN points at an empty-or-forceable Postgres.
+func TestMigrate(t *testing.T) {
+	dsn := os.Getenv("SCRUTINEER_TEST_PG_DSN")
+	if dsn == "" {
+		t.Skip("set SCRUTINEER_TEST_PG_DSN to run the migrator integration test")
+	}
+
+	// Seed a SQLite source.
+	srcPath := filepath.Join(t.TempDir(), "scrutineer.db")
+	src, err := db.Open(srcPath)
+	if err != nil {
+		t.Fatalf("open source: %v", err)
+	}
+	repo := db.Repository{
+		URL:  "https://example.com/repo",
+		Name: "repo",
+		Maintainers: []db.Maintainer{ // many2many -> repository_maintainers
+			{Login: "alice"}, {Login: "bob"},
+		},
+	}
+	must(t, src.Create(&repo).Error)
+	scan := db.Scan{RepositoryID: repo.ID, Commit: "abc123", Status: db.ScanDone}
+	must(t, src.Create(&scan).Error)
+	finding := db.Finding{
+		ScanID: scan.ID,
+		Title:  "example",
+		Labels: []db.FindingLabel{{Name: "triage"}}, // many2many -> finding_labels_join
+	}
+	must(t, src.Create(&finding).Error)
+	// Close the scans<->findings cycle: a finding-scoped scan pointing back.
+	fScan := db.Scan{RepositoryID: repo.ID, Status: db.ScanDone, FindingID: &finding.ID}
+	must(t, src.Create(&fScan).Error)
+	must(t, src.Create(&db.ExpectedFinding{RepositoryID: repo.ID, File: "app.rb", CWE: "CWE-89"}).Error)
+	must(t, src.Create(&db.Setting{Key: "concurrency", Value: "4"}).Error)
+
+	// Migrate into the empty Postgres.
+	if err := run(srcPath, dsn, false); err != nil {
+		t.Fatalf("run migrate: %v", err)
+	}
+
+	dst, err := db.OpenBackend(db.Options{Dialect: db.DialectPostgres, DSN: dsn})
+	if err != nil {
+		t.Fatalf("open dest: %v", err)
+	}
+
+	// Row counts survived.
+	for _, tc := range []struct {
+		model any
+		want  int64
+	}{
+		{&db.Repository{}, 1}, {&db.Scan{}, 2}, {&db.Finding{}, 1},
+		{&db.Maintainer{}, 2}, {&db.FindingLabel{}, 1}, {&db.Setting{}, 1},
+		{&db.ExpectedFinding{}, 1},
+	} {
+		var n int64
+		must(t, dst.Model(tc.model).Count(&n).Error)
+		if n != tc.want {
+			t.Errorf("%T count = %d, want %d", tc.model, n, tc.want)
+		}
+	}
+
+	// Join tables survived.
+	for _, jt := range []struct {
+		table string
+		want  int64
+	}{{"repository_maintainers", 2}, {"finding_labels_join", 1}} {
+		var n int64
+		must(t, dst.Table(jt.table).Count(&n).Error)
+		if n != jt.want {
+			t.Errorf("%s count = %d, want %d", jt.table, n, jt.want)
+		}
+	}
+
+	// The FK-cycle edge survived: the finding-scoped scan still points at the
+	// finding, and the reserved-word commit column round-tripped.
+	var gotScan db.Scan
+	must(t, dst.First(&gotScan, fScan.ID).Error)
+	if gotScan.FindingID == nil || *gotScan.FindingID != finding.ID {
+		t.Errorf("finding-scoped scan lost its FindingID: got %v, want %d", gotScan.FindingID, finding.ID)
+	}
+	var origScan db.Scan
+	must(t, dst.First(&origScan, scan.ID).Error)
+	if origScan.Commit != "abc123" {
+		t.Errorf("commit round-trip = %q, want abc123", origScan.Commit)
+	}
+
+	// Sequence was reset: a fresh insert must not collide with imported ids.
+	newRepo := db.Repository{URL: "https://example.com/after", Name: "after"}
+	must(t, dst.Create(&newRepo).Error)
+	if newRepo.ID <= repo.ID {
+		t.Errorf("new repo id %d did not advance past imported max %d (sequence not reset)", newRepo.ID, repo.ID)
+	}
+}
+
+// TestSanitizeStrings covers the UTF-8/NUL scrubbing that lets SQLite text
+// survive a PostgreSQL text column, without needing a live Postgres.
+func TestSanitizeStrings(t *testing.T) {
+	// The reported failure: a mangled em-dash (doubled 0xe2) in a scan's log,
+	// plus a NUL that Postgres text also forbids.
+	scan := db.Scan{
+		Log:    "before \xe2\xe2\x80 after",
+		Report: "has\x00nul",
+		Commit: "clean",
+	}
+	if !sanitizeStrings(&scan) {
+		t.Fatal("sanitizeStrings reported no change on invalid input")
+	}
+	if !utf8.ValidString(scan.Log) {
+		t.Errorf("Log still invalid UTF-8: %q", scan.Log)
+	}
+	if strings.ContainsRune(scan.Report, 0) {
+		t.Errorf("Report still contains NUL: %q", scan.Report)
+	}
+	if scan.Report != "hasnul" {
+		t.Errorf("Report = %q, want NUL stripped to %q", scan.Report, "hasnul")
+	}
+	if scan.Commit != "clean" {
+		t.Errorf("Commit was altered: %q", scan.Commit)
+	}
+
+	// A clean row is left untouched (and reported as unchanged).
+	clean := db.Scan{Log: "plain — text", Commit: "abc"}
+	if sanitizeStrings(&clean) {
+		t.Error("sanitizeStrings reported a change on clean input")
+	}
+}
+
+func must(t *testing.T, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/scrutineer.sample.yaml
+++ b/scrutineer.sample.yaml
@@ -12,8 +12,27 @@
 # Listen address for the web UI + skill API.
 # addr: 127.0.0.1:8080
 
-# Where scan workspaces and the sqlite DB live.
+# Where scan workspaces and (for the default sqlite backend) the database
+# file live.
 # data: ./data
+
+# Database backend. Omit the block to use the embedded SQLite file at
+# <data>/scrutineer.db (the default, zero-config). Set driver: postgres with
+# a dsn to store everything in an external PostgreSQL server instead — useful
+# for multi-instance or backed-up-elsewhere deployments. The schema is created
+# automatically (GORM AutoMigrate) on first connect, same as SQLite.
+#
+# To move an existing SQLite database into postgres, run the one-shot
+# migrator before switching over:
+#   go run ./scripts/migrate-sqlite-to-postgres \
+#     -sqlite ./data/scrutineer.db -postgres postgres://user:pass@host:5432/db
+#
+# NOTE: the `scrutineer backup` / `scrutineer restore` subcommands are
+# SQLite-only. Under postgres, back up with your own tooling (pg_dump /
+# pg_restore or your provider's managed snapshots).
+# database:
+#   driver: postgres
+#   dsn: postgres://scrutineer:scrutineer@db:5432/scrutineer?sslmode=disable
 
 # Claude effort level for model-backed skills.
 # effort: high


### PR DESCRIPTION
Resolves #636

This is a first pass at postgres support. I'm submitted a PR for first pass review and feedback, it is not fully complete but is functional. A migration path for importing an existing sqlite -> postgres exists, and we are running it on our production instance.

I've copied the issues initial checklist here:

Completed:
- [x] `db.Open`: DSN-based driver selection (`gorm.io/driver/postgres`), skip the `_pragma=foreign_keys(1)&_pragma=busy_timeout(5000)&_pragma=journal_mode(WAL)` string and the `PRAGMA busy_timeout` in the backup path when not on SQLite.
- [x] Queue: `maragu.dev/goqite` is SQLite-backed; check its Postgres story or swap.
- [x] Migration: A migration path is generated in scripts and documented.
- [x] Documentation: Updated across the project for postgres vs. sqlite 

Incomplete:
- [ ] Rename reserved-word columns: This was not done in this branch yet - do we still want it done here? It seems a orthogonal issue and requires migration routes for all existing implementations, while this allows just a drop in postgres exchange with no migrations for the sqlite version.
- [ ] Backup: I have not addressed this at all yet.
- [ ] Search case sensitivity: not addressed yet.
- [ ] CI job against real Postgres so regressions surface; the DryRun guard in #635 only proves the dialector is doing the quoting, not that the SQL runs. 
