### PR TITLE
Audit fail-open security input omissions

### DIFF
--- a/evals/fixtures/auth-omission/README.md
+++ b/evals/fixtures/auth-omission/README.md
@@ -1,0 +1,8 @@
+# Authentication omission fixture
+
+The `/account` endpoint conditionally validates its session cookie but returns
+account data when the cookie is absent. The `/account-safe` endpoint is the
+paired fail-closed control: it rejects both a missing and an invalid cookie.
+
+The deep-dive eval should identify the missing-session bypass without flagging
+the fail-closed endpoint.

--- a/evals/fixtures/auth-omission/app.py
+++ b/evals/fixtures/auth-omission/app.py
@@ -1,0 +1,30 @@
+import flask
+
+app = flask.Flask(__name__)
+
+
+def validate_session(session_cookie):
+    return session_cookie == "known-session"
+
+
+def serve_account_data():
+    return flask.jsonify({"account_number": "1234", "balance": 100})
+
+
+@app.get("/account")
+def account():
+    session_cookie = flask.request.cookies.get("session")
+    if session_cookie:
+        if not validate_session(session_cookie):
+            flask.abort(401)
+    return serve_account_data()
+
+
+@app.get("/account-safe")
+def safe_account():
+    session_cookie = flask.request.cookies.get("session")
+    if not session_cookie:
+        flask.abort(401)
+    if not validate_session(session_cookie):
+        flask.abort(401)
+    return serve_account_data()

--- a/evals/security-deep-dive-auth-omission.yaml
+++ b/evals/security-deep-dive-auth-omission.yaml
@@ -15,4 +15,3 @@ should_not_find:
     path: app.py
     evidence_contains:
       - safe_account
-      - abort(401)

--- a/evals/security-deep-dive-auth-omission.yaml
+++ b/evals/security-deep-dive-auth-omission.yaml
@@ -1,0 +1,18 @@
+given: an optional session cookie skips validation while an account endpoint still returns protected data
+fixture: fixtures/auth-omission
+skill: security-deep-dive
+should_find:
+  - finding: session
+    cwe: CWE-306
+    path: app.py
+    evidence_contains:
+      - session_cookie
+      - serve_account_data
+    required: true
+should_not_find:
+  - finding: session
+    cwe: CWE-306
+    path: app.py
+    evidence_contains:
+      - safe_account
+      - abort(401)

--- a/internal/evals/evals_test.go
+++ b/internal/evals/evals_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"os"
 	"path/filepath"
-	"slices"
 	"strings"
 	"testing"
 
@@ -36,32 +35,14 @@ func TestAuthOmissionScenario(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if sc.Skill != "security-deep-dive" || sc.Fixture != "fixtures/auth-omission" {
-		t.Fatalf("scenario = %+v", sc)
+	report := `{"findings":[{"title":"Session omission bypass","severity":"High","cwe":"CWE-306","location":"app.py:18","trace":"session_cookie skips validation before serve_account_data."}]}`
+	results, err := (HeuristicJudge{}).Judge(sc, report)
+	if err != nil {
+		t.Fatal(err)
 	}
-	if len(sc.ShouldFind) != 1 || len(sc.ShouldNotFind) != 1 {
-		t.Fatalf("assertions = %+v, want one positive and one negative", sc)
+	if len(results) != 2 || !results[0].Matched || !results[1].Matched {
+		t.Fatalf("scenario results = %+v, want passing positive and negative assertions", results)
 	}
-	positive := sc.ShouldFind[0]
-	if !positive.Required || positive.CWE != "CWE-306" || positive.Path != "app.py" || !hasEvidenceTerms(positive.Evidence, "session_cookie", "serve_account_data") {
-		t.Errorf("positive assertion = %+v", positive)
-	}
-	negative := sc.ShouldNotFind[0]
-	if negative.CWE != "CWE-306" || negative.Path != "app.py" || !hasEvidenceTerms(negative.Evidence, "safe_account", "abort(401)") {
-		t.Errorf("negative assertion = %+v", negative)
-	}
-}
-
-func hasEvidenceTerms(evidence []string, terms ...string) bool {
-	if len(evidence) != len(terms) {
-		return false
-	}
-	for _, term := range terms {
-		if !slices.Contains(evidence, term) {
-			return false
-		}
-	}
-	return true
 }
 
 func TestLoadScenarioDefaultsRequiredButAllowsOptional(t *testing.T) {

--- a/internal/evals/evals_test.go
+++ b/internal/evals/evals_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
@@ -27,6 +28,27 @@ func TestLoadScenarios(t *testing.T) {
 		if _, err := os.Stat(filepath.Join("../../evals", sc.Fixture)); err != nil {
 			t.Fatalf("%s fixture %q missing: %v", sc.Path, sc.Fixture, err)
 		}
+	}
+}
+
+func TestAuthOmissionScenario(t *testing.T) {
+	sc, err := LoadScenario("../../evals/security-deep-dive-auth-omission.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sc.Skill != "security-deep-dive" || sc.Fixture != "fixtures/auth-omission" {
+		t.Fatalf("scenario = %+v", sc)
+	}
+	if len(sc.ShouldFind) != 1 || len(sc.ShouldNotFind) != 1 {
+		t.Fatalf("assertions = %+v, want one positive and one negative", sc)
+	}
+	positive := sc.ShouldFind[0]
+	if !positive.Required || positive.CWE != "CWE-306" || positive.Path != "app.py" || !slices.Equal(positive.Evidence, []string{"session_cookie", "serve_account_data"}) {
+		t.Errorf("positive assertion = %+v", positive)
+	}
+	negative := sc.ShouldNotFind[0]
+	if negative.CWE != "CWE-306" || negative.Path != "app.py" || !slices.Equal(negative.Evidence, []string{"safe_account", "abort(401)"}) {
+		t.Errorf("negative assertion = %+v", negative)
 	}
 }
 

--- a/internal/evals/evals_test.go
+++ b/internal/evals/evals_test.go
@@ -43,13 +43,25 @@ func TestAuthOmissionScenario(t *testing.T) {
 		t.Fatalf("assertions = %+v, want one positive and one negative", sc)
 	}
 	positive := sc.ShouldFind[0]
-	if !positive.Required || positive.CWE != "CWE-306" || positive.Path != "app.py" || !slices.Equal(positive.Evidence, []string{"session_cookie", "serve_account_data"}) {
+	if !positive.Required || positive.CWE != "CWE-306" || positive.Path != "app.py" || !hasEvidenceTerms(positive.Evidence, "session_cookie", "serve_account_data") {
 		t.Errorf("positive assertion = %+v", positive)
 	}
 	negative := sc.ShouldNotFind[0]
-	if negative.CWE != "CWE-306" || negative.Path != "app.py" || !slices.Equal(negative.Evidence, []string{"safe_account", "abort(401)"}) {
+	if negative.CWE != "CWE-306" || negative.Path != "app.py" || !hasEvidenceTerms(negative.Evidence, "safe_account", "abort(401)") {
 		t.Errorf("negative assertion = %+v", negative)
 	}
+}
+
+func hasEvidenceTerms(evidence []string, terms ...string) bool {
+	if len(evidence) != len(terms) {
+		return false
+	}
+	for _, term := range terms {
+		if !slices.Contains(evidence, term) {
+			return false
+		}
+	}
+	return true
 }
 
 func TestLoadScenarioDefaultsRequiredButAllowsOptional(t *testing.T) {

--- a/skills/security-deep-dive/SKILL.md
+++ b/skills/security-deep-dive/SKILL.md
@@ -130,6 +130,29 @@ Even where the input is attacker-controlled, check whether the project has alrea
 
 Even where the input is attacker-controlled, check the precondition does not subsume the conclusion. If reaching the sink requires the attacker to already hold a capability equal to or stronger than what the sink grants — write access to a directory documented as holding executable hooks, MITM position on a connection the finding claims to let them influence — the finding is circular. The attack path's first step already arrives at its last. Write "precondition subsumes conclusion" and move to the next sink.
 
+### Security-decision omission checks
+
+For authentication, authorization, session validation, CSRF, rate-limit or
+lockout, and credential-validation code already under review, identify every
+input whose presence controls whether a security check runs: cookies, headers,
+tokens, request fields, credentials, and equivalent optional values. For each
+one, inspect the absent, null, and empty-value branches. Ask: **if this input
+is absent, null, or empty, does the control fail closed, or is the protected
+operation still reachable?**
+
+Report a candidate when omitting the input skips its security check while the
+protected operation remains reachable without an equivalent guard. When two
+inputs participate in the same decision, also test whether omitting one causes
+the other to be accepted without its normal validation. Record both the
+conditional check and the protected operation in the trace and validation.
+
+An explicit deny, error, redirect-to-login, or equivalent rejection branch for
+the missing value is fail-closed: rule it out and cite the branch. Keep the
+existing threat-model discipline unchanged: dev-only paths, trusted-only entry
+points, and preconditions that already subsume the impact are not findings.
+This is a mandatory question for existing security-decision code, not a second
+whole-repository input inventory.
+
 ### Step 3: Validate
 
 Write a reproduction script and run it. The script demonstrates that the sink does what you traced — hostile input in, dangerous behaviour out. Into the finding's `validation` field, paste the script verbatim — its full contents, not a description of it — followed by the output of running it. A `validation` that shows output but not the script that produced it is useless: a later verify run, or an analyst, cannot tell what was executed or re-run it. Include enough to re-run: the language/runner, the exact input, the command line. If the reproduction is a shell session rather than a file, paste the commands and their output.

--- a/skills/security-deep-dive/SKILL.md
+++ b/skills/security-deep-dive/SKILL.md
@@ -130,7 +130,7 @@ Even where the input is attacker-controlled, check whether the project has alrea
 
 Even where the input is attacker-controlled, check the precondition does not subsume the conclusion. If reaching the sink requires the attacker to already hold a capability equal to or stronger than what the sink grants — write access to a directory documented as holding executable hooks, MITM position on a connection the finding claims to let them influence — the finding is circular. The attack path's first step already arrives at its last. Write "precondition subsumes conclusion" and move to the next sink.
 
-### Security-decision omission checks
+### Step 2a: Security-decision omission checks
 
 For authentication, authorization, session validation, CSRF, rate-limit or
 lockout, and credential-validation code already under review, identify every

--- a/skills/security-deep-dive/SKILL.md
+++ b/skills/security-deep-dive/SKILL.md
@@ -130,8 +130,6 @@ Even where the input is attacker-controlled, check whether the project has alrea
 
 Even where the input is attacker-controlled, check the precondition does not subsume the conclusion. If reaching the sink requires the attacker to already hold a capability equal to or stronger than what the sink grants — write access to a directory documented as holding executable hooks, MITM position on a connection the finding claims to let them influence — the finding is circular. The attack path's first step already arrives at its last. Write "precondition subsumes conclusion" and move to the next sink.
 
-### Step 2a: Security-decision omission checks
-
 For authentication, authorization, session validation, CSRF, rate-limit or
 lockout, and credential-validation code already under review, identify every
 input whose presence controls whether a security check runs: cookies, headers,


### PR DESCRIPTION
Closes #660

## Summary

Extends `security-deep-dive` to examine missing, null, and empty inputs that determine whether a security control runs.

This catches fail-open paths where an optional session, credential, CSRF, authorization, or rate-limit input skips validation while the protected operation remains reachable.

## Changes

- Add a targeted Phase 2 omission check for existing security-decision code.
- Cover authentication, authorization, session validation, CSRF, rate-limit/lockout and credential-validation controls.
- Require candidate findings to identify both:
  - the conditional validation check that is skipped
  - the protected operation still reachable after omission
- Treat explicit reject, error, and redirect-to-login branches as fail-closed.
- Preserve existing threat-model constraints for trusted-only, dev-only and impact-subsuming paths.
- Add an `auth-omission` eval fixture containing:
  - a fail-open optional-session `/account` endpoint
  - a paired fail-closed `/account-safe` endpoint
- Add positive and negative deep-dive eval assertions with evidence requirements.

## Tests

- `go test -tags evals ./internal/evals/...`
- `go test ./...`
- `go test -tags evals ./...`
- `go vet ./...`
- `go vet -tags evals ./...`
- `golangci-lint run ./cmd/... ./internal/...`
- `golangci-lint run --build-tags evals ./cmd/... ./internal/...`
- `git diff --check`