### PR TITLE
Add core scan audit events

### DIFF
--- a/docs/database.md
+++ b/docs/database.md
@@ -50,6 +50,23 @@ The central entity. One row per git URL.
 | created_at | datetime | |
 | updated_at | datetime | |
 
+## audit_events
+
+Append-only audit trail for lifecycle and future operator/system actions. It
+coexists with `finding_histories`, which remains the specialised per-field
+change history for findings. `payload` is JSON stored portably as text.
+
+| Column | Type | Notes |
+|--------|------|-------|
+| id | integer PK | |
+| kind | text | Event name, for example `scan.started`, `scan.finished`, `scan.failed`, `scan.cancelled`, or `scan.paused`. Indexed with `created_at` for chronological dashboards. |
+| subject_type | text | Polymorphic subject type, currently `scan`. Part of the timeline index with `subject_id`. |
+| subject_id | integer | ID of the subject row, for example `scans.id`. |
+| actor | text | Skill name when available, otherwise the scan kind. |
+| source | text | Existing provenance enum, currently `system` for worker lifecycle events. |
+| payload | text | JSON metadata. Scan events include stable execution metadata and terminal metrics, without duplicating reports or logs. |
+| created_at | datetime | |
+
 ## scans
 
 One row per skill execution or external import. `skill_name` / `skill_version` pin which skill ran; for imports `skill_name` records the originating tool.

--- a/internal/db/audit_events.go
+++ b/internal/db/audit_events.go
@@ -1,0 +1,136 @@
+package db
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"gorm.io/gorm"
+)
+
+const (
+	AuditSubjectScan = "scan"
+
+	AuditEventScanStarted   = "scan.started"
+	AuditEventScanFinished  = "scan.finished"
+	AuditEventScanFailed    = "scan.failed"
+	AuditEventScanCancelled = "scan.cancelled"
+	AuditEventScanPaused    = "scan.paused"
+)
+
+// AuditEventInput is the write-only form of AuditEvent. Payload is marshaled
+// by LogEvent so callers cannot persist malformed JSON accidentally.
+type AuditEventInput struct {
+	Kind        string
+	SubjectType string
+	SubjectID   uint
+	Actor       string
+	Source      FindingSource
+	Payload     any
+}
+
+// LogEvent appends one audit event. Call it from the transaction that mutates
+// the subject so state and its audit trail are committed or rolled back
+// together.
+func LogEvent(gdb *gorm.DB, input AuditEventInput) error {
+	input.Kind = strings.TrimSpace(input.Kind)
+	input.SubjectType = strings.TrimSpace(input.SubjectType)
+	if input.Kind == "" {
+		return fmt.Errorf("audit event kind is required")
+	}
+	if input.SubjectType == "" || input.SubjectID == 0 {
+		return fmt.Errorf("audit event subject is required")
+	}
+	if input.Source == "" {
+		return fmt.Errorf("audit event source is required")
+	}
+	if input.Payload == nil {
+		input.Payload = map[string]any{}
+	}
+	payload, err := json.Marshal(input.Payload)
+	if err != nil {
+		return fmt.Errorf("marshal audit event payload: %w", err)
+	}
+	return gdb.Create(&AuditEvent{
+		Kind:        input.Kind,
+		SubjectType: input.SubjectType,
+		SubjectID:   input.SubjectID,
+		Actor:       input.Actor,
+		Source:      input.Source,
+		Payload:     string(payload),
+	}).Error
+}
+
+// LogScanEvent appends a lifecycle event for scan. The payload deliberately
+// captures fields needed for a timeline without duplicating the scan report or
+// transcript, which can be large and may contain sensitive material.
+func LogScanEvent(gdb *gorm.DB, kind string, scan *Scan) error {
+	if scan == nil {
+		return fmt.Errorf("audit event scan is required")
+	}
+	payload := map[string]any{
+		"repository_id": scan.RepositoryID,
+		"scan_kind":     scan.Kind,
+		"status":        scan.Status,
+		"skill_name":    scan.SkillName,
+		"model":         scan.Model,
+		"backend":       scan.Backend,
+	}
+	if scan.FindingID != nil {
+		payload["finding_id"] = *scan.FindingID
+	}
+	if scan.DependentID != nil {
+		payload["dependent_id"] = *scan.DependentID
+	}
+	if scan.StartedAt != nil {
+		payload["started_at"] = scan.StartedAt.UTC().Format(time.RFC3339Nano)
+	}
+	if scan.FinishedAt != nil {
+		payload["finished_at"] = scan.FinishedAt.UTC().Format(time.RFC3339Nano)
+	}
+	if scan.StartedAt != nil && scan.FinishedAt != nil {
+		payload["duration_ms"] = scan.FinishedAt.Sub(*scan.StartedAt).Milliseconds()
+	}
+	if kind != AuditEventScanStarted {
+		payload["cost_usd"] = scan.CostUSD
+		payload["turns"] = scan.Turns
+		payload["input_tokens"] = scan.InputTokens
+		payload["output_tokens"] = scan.OutputTokens
+		payload["cache_read_tokens"] = scan.CacheReadTokens
+		payload["cache_write_tokens"] = scan.CacheWriteTokens
+		if scan.Error != "" {
+			payload["error"] = scan.Error
+		}
+	}
+	actor := scan.SkillName
+	if actor == "" {
+		actor = scan.Kind
+	}
+	return LogEvent(gdb, AuditEventInput{
+		Kind:        kind,
+		SubjectType: AuditSubjectScan,
+		SubjectID:   scan.ID,
+		Actor:       actor,
+		Source:      SourceSystem,
+		Payload:     payload,
+	})
+}
+
+// ScanLifecycleEventKind returns the event associated with a persisted scan
+// lifecycle status. Queued scans are intentionally omitted: this first audit
+// surface records state transitions performed by the worker.
+func ScanLifecycleEventKind(status ScanStatus) (string, bool) {
+	switch status {
+	case ScanDone:
+		return AuditEventScanFinished, true
+	case ScanFailed:
+		return AuditEventScanFailed, true
+	case ScanCancelled:
+		return AuditEventScanCancelled, true
+	case ScanPaused:
+		return AuditEventScanPaused, true
+	default:
+		return "", false
+	}
+}

--- a/internal/db/audit_events_test.go
+++ b/internal/db/audit_events_test.go
@@ -1,0 +1,93 @@
+package db
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"gorm.io/gorm"
+)
+
+func TestLogEventPersistsJSONPayloadAndIndexes(t *testing.T) {
+	gdb, err := Open(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := LogEvent(gdb, AuditEventInput{
+		Kind:        "scan.started",
+		SubjectType: "scan",
+		SubjectID:   42,
+		Actor:       "security-deep-dive",
+		Source:      SourceSystem,
+		Payload:     map[string]any{"repository_id": 7, "status": "running"},
+	}); err != nil {
+		t.Fatalf("LogEvent: %v", err)
+	}
+
+	var got AuditEvent
+	if err := gdb.First(&got).Error; err != nil {
+		t.Fatal(err)
+	}
+	if got.Kind != "scan.started" || got.SubjectType != "scan" || got.SubjectID != 42 {
+		t.Fatalf("event = %#v", got)
+	}
+	if got.Source != SourceSystem || got.Actor != "security-deep-dive" {
+		t.Fatalf("provenance = source %q actor %q", got.Source, got.Actor)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(got.Payload), &payload); err != nil {
+		t.Fatalf("payload %q is not JSON: %v", got.Payload, err)
+	}
+	if payload["status"] != "running" || payload["repository_id"] != float64(7) {
+		t.Fatalf("payload = %#v", payload)
+	}
+	for _, name := range []string{"idx_audit_events_kind_created_at", "idx_audit_events_subject"} {
+		if !gdb.Migrator().HasIndex(&AuditEvent{}, name) {
+			t.Errorf("missing index %s", name)
+		}
+	}
+}
+
+func TestLogEventRejectsInvalidInput(t *testing.T) {
+	gdb, err := Open(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cases := []AuditEventInput{
+		{SubjectType: "scan", SubjectID: 1, Source: SourceSystem},
+		{Kind: "scan.started", SubjectID: 1, Source: SourceSystem},
+		{Kind: "scan.started", SubjectType: "scan", Source: SourceSystem},
+		{Kind: "scan.started", SubjectType: "scan", SubjectID: 1},
+		{Kind: "scan.started", SubjectType: "scan", SubjectID: 1, Source: SourceSystem, Payload: make(chan int)},
+	}
+	for _, input := range cases {
+		if err := LogEvent(gdb, input); err == nil {
+			t.Errorf("LogEvent(%#v) succeeded", input)
+		}
+	}
+}
+
+func TestLogEventParticipatesInCallerTransaction(t *testing.T) {
+	gdb, err := Open(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = gdb.Transaction(func(tx *gorm.DB) error {
+		if err := LogEvent(tx, AuditEventInput{
+			Kind: "scan.started", SubjectType: "scan", SubjectID: 1, Source: SourceSystem,
+		}); err != nil {
+			return err
+		}
+		return errors.New("roll back")
+	})
+	if err == nil {
+		t.Fatal("Transaction succeeded")
+	}
+	var count int64
+	if err := gdb.Model(&AuditEvent{}).Count(&count).Error; err != nil {
+		t.Fatal(err)
+	}
+	if count != 0 {
+		t.Errorf("event count = %d, want 0 after rollback", count)
+	}
+}

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -899,6 +899,24 @@ type FindingHistory struct {
 	CreatedAt time.Time
 }
 
+// AuditEvent records an append-only event for any auditable entity. It sits
+// alongside FindingHistory, which remains the specialised field-level record
+// for findings. Payload is JSON stored as text so the schema stays portable
+// between SQLite and PostgreSQL.
+type AuditEvent struct {
+	ID uint `gorm:"primarykey"`
+	// Kind identifies the action, for example scan.started or scan.failed.
+	Kind string `gorm:"not null;index:idx_audit_events_kind_created_at,priority:1"`
+	// SubjectType and SubjectID form a polymorphic reference to the entity the
+	// event describes, for example scan/42 or finding/17.
+	SubjectType string `gorm:"not null;index:idx_audit_events_subject,priority:1"`
+	SubjectID   uint   `gorm:"not null;index:idx_audit_events_subject,priority:2"`
+	Actor       string
+	Source      FindingSource `gorm:"not null;index"`
+	Payload     string        `gorm:"type:text;not null"`
+	CreatedAt   time.Time     `gorm:"index:idx_audit_events_kind_created_at,priority:2"`
+}
+
 // FindingReview is a structured human verdict against an automation
 // outcome. Verdict mirrors the revalidate skill's enum so reviewer
 // agreement with the model can be measured directly. AutomatedOutcome
@@ -1147,7 +1165,7 @@ func Open(dsn string) (*gorm.DB, error) {
 	if err := gdb.AutoMigrate(
 		&Repository{}, &Scan{},
 		&Finding{}, &FindingLabel{}, &FindingNote{},
-		&FindingCommunication{}, &FindingReference{}, &FindingHistory{}, &FindingReview{},
+		&FindingCommunication{}, &FindingReference{}, &FindingHistory{}, &FindingReview{}, &AuditEvent{},
 		&Dependency{}, &ExpectedFinding{}, &Package{}, &Dependent{}, &FindingDependent{}, &Advisory{},
 		&Maintainer{}, &Skill{}, &Subproject{},
 		&SBOMUpload{}, &SBOMPackage{}, &CNA{}, &Setting{},

--- a/internal/worker/audit_events_test.go
+++ b/internal/worker/audit_events_test.go
@@ -1,0 +1,138 @@
+package worker
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"scrutineer/internal/db"
+	"scrutineer/internal/queue"
+
+	"gorm.io/gorm"
+)
+
+func TestWorkerRecordsScanLifecycleEvents(t *testing.T) {
+	tests := []struct {
+		name      string
+		runnerErr error
+		ctx       context.Context
+		wantKind  string
+		wantState db.ScanStatus
+	}{
+		{name: "finished", wantKind: db.AuditEventScanFinished, wantState: db.ScanDone},
+		{name: "failed", runnerErr: errors.New("runner failed"), wantKind: db.AuditEventScanFailed, wantState: db.ScanFailed},
+		{name: "cancelled", ctx: cancelledContext(), wantKind: db.AuditEventScanCancelled, wantState: db.ScanCancelled},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertScanLifecycleEvents(t, tt.runnerErr, tt.ctx, tt.wantKind, tt.wantState)
+		})
+	}
+}
+
+func assertScanLifecycleEvents(t *testing.T, runnerErr error, ctx context.Context, wantKind string, wantState db.ScanStatus) {
+	t.Helper()
+	runner := &recordingRunner{err: runnerErr}
+	w, skill, repoID := newResumeTestWorker(t, runner)
+	scan := db.Scan{
+		RepositoryID: repoID,
+		Kind:         JobSkill,
+		Status:       db.ScanQueued,
+		SkillID:      &skill.ID,
+		SkillName:    skill.Name,
+		Model:        "test-model",
+	}
+	if err := w.DB.Create(&scan).Error; err != nil {
+		t.Fatal(err)
+	}
+	body, err := json.Marshal(queue.Payload{ScanID: scan.ID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := w.wrap(w.doSkill)(ctx, body); err != nil {
+		t.Fatalf("wrap: %v", err)
+	}
+
+	var got db.Scan
+	if err := w.DB.First(&got, scan.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != wantState {
+		t.Fatalf("status = %q, want %q", got.Status, wantState)
+	}
+	var events []db.AuditEvent
+	if err := w.DB.Where("subject_type = ? AND subject_id = ?", db.AuditSubjectScan, scan.ID).Order("id").Find(&events).Error; err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("event count = %d, want 2: %#v", len(events), events)
+	}
+	if events[0].Kind != db.AuditEventScanStarted || events[1].Kind != wantKind {
+		t.Fatalf("event kinds = %q, %q; want %q, %q", events[0].Kind, events[1].Kind, db.AuditEventScanStarted, wantKind)
+	}
+	if events[1].Source != db.SourceSystem || events[1].Actor != skill.Name {
+		t.Fatalf("terminal provenance = source %q actor %q", events[1].Source, events[1].Actor)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(events[1].Payload), &payload); err != nil {
+		t.Fatal(err)
+	}
+	if payload["status"] != string(wantState) || payload["repository_id"] != float64(repoID) {
+		t.Fatalf("terminal payload = %#v", payload)
+	}
+	if _, ok := payload["duration_ms"]; !ok {
+		t.Fatalf("terminal payload missing duration: %#v", payload)
+	}
+	if runnerErr != nil && payload["error"] != runnerErr.Error() {
+		t.Fatalf("failure error = %#v, want %q", payload["error"], runnerErr)
+	}
+}
+
+func TestWorkerRollsBackRunningStateWhenAuditEventWriteFails(t *testing.T) {
+	w, skill, repoID := newResumeTestWorker(t, &recordingRunner{})
+	scan := db.Scan{RepositoryID: repoID, Kind: JobSkill, Status: db.ScanQueued, SkillID: &skill.ID, SkillName: skill.Name}
+	if err := w.DB.Create(&scan).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := w.DB.Callback().Create().Before("gorm:create").Register("test:fail_audit_event", func(tx *gorm.DB) {
+		if tx.Statement.Schema != nil && tx.Statement.Schema.Name == "AuditEvent" {
+			if err := tx.AddError(errors.New("audit event write failed")); err == nil {
+				panic("AddError returned nil")
+			}
+		}
+	}); err != nil {
+		t.Fatal(err)
+	}
+	body, err := json.Marshal(queue.Payload{ScanID: scan.ID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := w.wrap(w.doSkill)(context.Background(), body); err == nil {
+		t.Fatal("wrap succeeded despite audit event write failure")
+	}
+
+	var got db.Scan
+	if err := w.DB.First(&got, scan.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != db.ScanQueued {
+		t.Errorf("status = %q, want queued after rollback", got.Status)
+	}
+	var events int64
+	if err := w.DB.Model(&db.AuditEvent{}).Count(&events).Error; err != nil {
+		t.Fatal(err)
+	}
+	if events != 0 {
+		t.Errorf("event count = %d, want 0 after rollback", events)
+	}
+}
+
+func cancelledContext() context.Context {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	return ctx
+}

--- a/internal/worker/audit_events_test.go
+++ b/internal/worker/audit_events_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"testing"
+	"time"
 
 	"scrutineer/internal/db"
 	"scrutineer/internal/queue"
@@ -128,6 +129,46 @@ func TestWorkerRollsBackRunningStateWhenAuditEventWriteFails(t *testing.T) {
 	}
 	if events != 0 {
 		t.Errorf("event count = %d, want 0 after rollback", events)
+	}
+}
+
+func TestWorkerRollsBackTerminalStateWhenAuditEventWriteFails(t *testing.T) {
+	w, skill, repoID := newResumeTestWorker(t, &recordingRunner{})
+	scan := db.Scan{RepositoryID: repoID, Kind: JobSkill, Status: db.ScanQueued, SkillID: &skill.ID, SkillName: skill.Name}
+	if err := w.DB.Create(&scan).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := w.startScan(&scan); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.DB.Callback().Create().Before("gorm:create").Register("test:fail_terminal_audit_event", func(tx *gorm.DB) {
+		if tx.Statement.Schema != nil && tx.Statement.Schema.Name == "AuditEvent" {
+			if err := tx.AddError(errors.New("terminal audit event write failed")); err == nil {
+				panic("AddError returned nil")
+			}
+		}
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	err := w.finalizeScan(context.Background(), &scan, "", errors.New("runner failed"), time.Minute, func(Event) {}, func() {})
+	if err == nil {
+		t.Fatal("finalizeScan succeeded despite terminal audit event write failure")
+	}
+
+	var got db.Scan
+	if err := w.DB.First(&got, scan.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != db.ScanRunning {
+		t.Errorf("status = %q, want running after rollback", got.Status)
+	}
+	var events []db.AuditEvent
+	if err := w.DB.Where("subject_type = ? AND subject_id = ?", db.AuditSubjectScan, scan.ID).Find(&events).Error; err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 1 || events[0].Kind != db.AuditEventScanStarted {
+		t.Errorf("events = %#v, want only scan.started", events)
 	}
 }
 

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -591,9 +591,10 @@ func (w *Worker) wrap(h handler) func(context.Context, []byte) error {
 // so a scan never appears to have started without a corresponding timeline
 // entry.
 func (w *Worker) startScan(scan *db.Scan) error {
+	now := time.Now()
 	scan.Status = db.ScanRunning
 	scan.StatusPriority = db.StatusPriorityFor(db.ScanRunning)
-	scan.StartedAt = new(time.Now())
+	scan.StartedAt = &now
 	scan.Log = ""
 	scan.Error = ""
 	if br, ok := w.Runner.(BackendReporter); ok {

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -570,15 +570,7 @@ func (w *Worker) wrap(h handler) func(context.Context, []byte) error {
 			w.mu.Unlock()
 		}()
 
-		scan.Status = db.ScanRunning
-		scan.StatusPriority = db.StatusPriorityFor(db.ScanRunning)
-		scan.StartedAt = new(time.Now())
-		scan.Log = ""
-		scan.Error = ""
-		if br, ok := w.Runner.(BackendReporter); ok {
-			scan.Backend = br.Backend()
-		}
-		if err := w.DB.Save(&scan).Error; err != nil {
+		if err := w.startScan(&scan); err != nil {
 			return err
 		}
 
@@ -595,6 +587,26 @@ func (w *Worker) wrap(h handler) func(context.Context, []byte) error {
 	}
 }
 
+// startScan records the running state and its audit event in one transaction
+// so a scan never appears to have started without a corresponding timeline
+// entry.
+func (w *Worker) startScan(scan *db.Scan) error {
+	scan.Status = db.ScanRunning
+	scan.StatusPriority = db.StatusPriorityFor(db.ScanRunning)
+	scan.StartedAt = new(time.Now())
+	scan.Log = ""
+	scan.Error = ""
+	if br, ok := w.Runner.(BackendReporter); ok {
+		scan.Backend = br.Backend()
+	}
+	return w.DB.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Save(scan).Error; err != nil {
+			return err
+		}
+		return db.LogScanEvent(tx, db.AuditEventScanStarted, scan)
+	})
+}
+
 // finalizeScan persists the terminal/paused scan state, fires
 // post-completion hooks, bulk-pauses the rest of the queue when this scan
 // hit an account-level Claude problem, cleans up the workspace, and publishes
@@ -607,7 +619,16 @@ func (w *Worker) finalizeScan(ctx context.Context, scan *db.Scan, report string,
 		w.clearSessionStore(scan)
 	}
 	scan.StatusPriority = db.StatusPriorityFor(scan.Status)
-	if saveErr := w.DB.Save(scan).Error; saveErr != nil {
+	if eventKind, ok := db.ScanLifecycleEventKind(scan.Status); ok {
+		if saveErr := w.DB.Transaction(func(tx *gorm.DB) error {
+			if err := tx.Save(scan).Error; err != nil {
+				return err
+			}
+			return db.LogScanEvent(tx, eventKind, scan)
+		}); saveErr != nil {
+			return saveErr
+		}
+	} else if saveErr := w.DB.Save(scan).Error; saveErr != nil {
 		return saveErr
 	}
 	w.maybeFireScanFinalized(scan, err)


### PR DESCRIPTION
Part of #659

## Summary

Adds the first append-only audit-event surface for scan lifecycle activity, while keeping the existing finding-specific history table unchanged.

## Changes

- Add portable `audit_events` storage with timeline and dashboard indexes:
  - `(subject_type, subject_id)`
  - `(kind, created_at)`
- Add `db.LogEvent` to safely marshal structured JSON payloads.
- Add `db.LogScanEvent` for consistent scan lifecycle metadata.
- Record `scan.started` transactionally with the running-state update.
- Record terminal worker events transactionally with the final scan update:
  - `scan.finished`
  - `scan.failed`
  - `scan.cancelled`
  - `scan.paused`
- Include repository, skill, model, backend, duration, cost, turns, token usage and terminal error metadata without duplicating scan reports or logs.
- Document the new table in `docs/database.md`.
- Add tests for JSON payloads, indexes, invalid inputs, lifecycle events and transaction rollback behavior.

## Tests

- `go test ./...`
- `go test -tags evals ./...`
- `go vet ./...`
- `go vet -tags evals ./...`
- `golangci-lint run ./cmd/... ./internal/...`
- `golangci-lint run --build-tags evals ./cmd/... ./internal/...`
- `git diff --check`