### PR TITLE
fix(web): harden the scan-token API against hostile-repo agents

### DIFF
--- a/cmd/scrutineer/main.go
+++ b/cmd/scrutineer/main.go
@@ -345,6 +345,25 @@ func validateFlags(f *flags) error {
 	return config.ValidateSELinux(f.selinux)
 }
 
+func isLoopbackListenAddr(addr string) bool {
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		return false
+	}
+	host = strings.Trim(host, "[]")
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}
+
+func warnIfNonLoopbackListenAddr(log *slog.Logger, addr string) {
+	if !isLoopbackListenAddr(addr) {
+		log.Warn("scrutineer has no authentication; a non-loopback bind exposes the UI and API to the network", "addr", addr)
+	}
+}
+
 func configureBackendEnvironment(f *flags, log *slog.Logger) {
 	if key := os.Getenv("ANTHROPIC_API_KEY"); strings.HasPrefix(key, "sk-ant-oat") {
 		log.Warn("ANTHROPIC_API_KEY looks like an OAuth token from `claude setup-token`; set it as CLAUDE_CODE_OAUTH_TOKEN instead")
@@ -401,6 +420,7 @@ func run(log *slog.Logger) error {
 	if err := validateFlags(f); err != nil {
 		return err
 	}
+	warnIfNonLoopbackListenAddr(log, f.addr)
 	// When --selinux is given explicitly, surface the host's SELinux mode at
 	// startup so the operator can confirm what scrutineer detected (e.g. that an
 	// enforcing host will get the :z relabel, or that --selinux=off on an

--- a/cmd/scrutineer/main_test.go
+++ b/cmd/scrutineer/main_test.go
@@ -130,6 +130,25 @@ func TestFlagsMerge_zeroConfigLeavesDefaults(t *testing.T) {
 	}
 }
 
+func TestIsLoopbackListenAddr(t *testing.T) {
+	for _, tt := range []struct {
+		addr string
+		want bool
+	}{
+		{addr: "localhost:8080", want: true},
+		{addr: "127.0.0.1:8080", want: true},
+		{addr: "127.23.45.67:8080", want: true},
+		{addr: "[::1]:8080", want: true},
+		{addr: "0.0.0.0:8080", want: false},
+		{addr: "203.0.113.10:8080", want: false},
+		{addr: "scanner.example.com:8080", want: false},
+	} {
+		if got := isLoopbackListenAddr(tt.addr); got != tt.want {
+			t.Errorf("isLoopbackListenAddr(%q) = %v, want %v", tt.addr, got, tt.want)
+		}
+	}
+}
+
 func TestFlagsMerge_zeroConfigSeedsModelsFromHarness(t *testing.T) {
 	// run() calls merge with an empty config when no config file exists;
 	// that path must still seed the pick list from the harness defaults so

--- a/docs/database.md
+++ b/docs/database.md
@@ -240,7 +240,8 @@ Timestamped internal notes on a finding. Replaced the old `findings.notes` colum
 
 Structured human verdicts on a finding, mirroring the revalidate skill's
 enum so reviewer agreement with the model is computable. Populated by the
-`/audit` page and `POST /findings/{id}/reviews`. The audit queue excludes
+`/audit` page and its browser-only `POST /findings/{id}/reviews` form. The
+scan-token API can list reviews but cannot create them. The audit queue excludes
 findings that already have a row here.
 
 | Column | Type | Notes |

--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -24,6 +24,10 @@ import (
 
 const apiPrefix = "/api"
 
+// maxAgentAPIOpenScansPerRepository bounds model-backed work a compromised
+// scan token can enqueue. Normal orchestration stays well below this ceiling.
+const maxAgentAPIOpenScansPerRepository = 16
+
 // NewAPIToken returns a 32-byte hex token suitable for bearer auth.
 func NewAPIToken() string {
 	var b [32]byte
@@ -119,7 +123,6 @@ func (s *Server) apiHandler() http.Handler {
 	mux.HandleFunc("GET /findings/{id}/notes", s.apiListFindingNotes)
 	mux.HandleFunc("POST /findings/{id}/notes", s.apiAddFindingNote)
 	mux.HandleFunc("GET /findings/{id}/reviews", s.apiListFindingReviews)
-	mux.HandleFunc("POST /findings/{id}/reviews", s.apiAddFindingReview)
 	// /audit/queue and /audit/metrics are intentionally on the host-only
 	// /api/v1 export mux, not here: they return findings across every
 	// repository on the instance, so a scan token issued for one repo
@@ -337,6 +340,15 @@ func (s *Server) apiRunSkill(w http.ResponseWriter, r *http.Request) {
 		writeAPIError(w, http.StatusBadRequest, "unknown profile")
 		return
 	}
+	s.agentEnqueueMu.Lock()
+	defer s.agentEnqueueMu.Unlock()
+	if s.hasOpenRepoScopedScan(uint(id), skill.ID) {
+		writeAPIError(w, http.StatusConflict, "equivalent scan already queued or running")
+		return
+	}
+	if !s.agentAPIRepoHasCapacity(w, uint(id)) {
+		return
+	}
 	scanID, err := s.enqueueSkillWith(r.Context(), uint(id), skill.ID, ScanOpts{
 		Model:          body.Model,
 		Ref:            body.Ref,
@@ -395,6 +407,15 @@ func (s *Server) apiRunFindingSkill(w http.ResponseWriter, r *http.Request) {
 	if !decodeOptionalAPIBody(w, r, &body) {
 		return
 	}
+	s.agentEnqueueMu.Lock()
+	defer s.agentEnqueueMu.Unlock()
+	if s.hasOpenFindingScopedScan(uint(id), skill.ID) {
+		writeAPIError(w, http.StatusConflict, "equivalent scan already queued or running")
+		return
+	}
+	if !s.agentAPIRepoHasCapacity(w, repoID) {
+		return
+	}
 	scanID, err := s.enqueueSkillScoped(r.Context(), repoID, skill.ID, new(uint(id)), body.Model)
 	if err != nil {
 		if errors.Is(err, ErrSkillRequiresRemote) {
@@ -407,6 +428,23 @@ func (s *Server) apiRunFindingSkill(w http.ResponseWriter, r *http.Request) {
 	var sc db.Scan
 	s.DB.First(&sc, scanID)
 	writeJSON(w, http.StatusCreated, scanSummary(sc))
+}
+
+// agentAPIRepoHasCapacity rejects scan-token enqueue requests once the target
+// repository already has the maximum number of queued or running scans.
+func (s *Server) agentAPIRepoHasCapacity(w http.ResponseWriter, repoID uint) bool {
+	var open int64
+	if err := s.DB.Model(&db.Scan{}).
+		Where("repository_id = ? AND status IN ?", repoID, []db.ScanStatus{db.ScanQueued, db.ScanRunning}).
+		Count(&open).Error; err != nil {
+		writeAPIError(w, http.StatusInternalServerError, err.Error())
+		return false
+	}
+	if open >= maxAgentAPIOpenScansPerRepository {
+		writeAPIError(w, http.StatusTooManyRequests, "repository has too many queued or running scans")
+		return false
+	}
+	return true
 }
 
 // findingRepoID reads the denormalized Finding.RepositoryID column. Used

--- a/internal/web/api_test.go
+++ b/internal/web/api_test.go
@@ -492,6 +492,59 @@ func TestAPIRunSkill_emptyBodyStillEnqueues(t *testing.T) {
 	}
 }
 
+func TestAPIRunSkill_deduplicatesEquivalentOpenScan(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	repo, scan := seedRunningScan(t, s)
+
+	skill := db.Skill{Name: "metadata", Description: "m", Body: "b", OutputFile: "report.json", Version: 1, Active: true, Source: "ui"}
+	s.DB.Create(&skill)
+
+	if w := runSkillAPIJSON(t, s, repo, scan, skill.Name, `{}`); w.Code != http.StatusCreated {
+		t.Fatalf("first status %d, want 201: %s", w.Code, w.Body)
+	}
+	if w := runSkillAPIJSON(t, s, repo, scan, skill.Name, `{}`); w.Code != http.StatusConflict {
+		t.Fatalf("duplicate status %d, want 409: %s", w.Code, w.Body)
+	}
+	var count int64
+	s.DB.Model(&db.Scan{}).Where("skill_id = ?", skill.ID).Count(&count)
+	if count != 1 {
+		t.Errorf("equivalent scans = %d, want 1", count)
+	}
+}
+
+func TestAPIRunSkill_enforcesRepositoryOpenScanLimit(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	repo, scan := seedRunningScan(t, s)
+
+	// The authenticated parent is already one open scan. Fill the remaining
+	// slots with different work so the target request reaches the repo cap,
+	// not the equivalent-scan guard.
+	for i := 1; i < maxAgentAPIOpenScansPerRepository; i++ {
+		s.DB.Create(&db.Scan{RepositoryID: repo.ID, Kind: worker.JobSkill, Status: db.ScanQueued})
+	}
+	skill := db.Skill{Name: "metadata", Description: "m", Body: "b", OutputFile: "report.json", Version: 1, Active: true, Source: "ui"}
+	s.DB.Create(&skill)
+
+	w := runSkillAPIJSON(t, s, repo, scan, skill.Name, `{}`)
+	if w.Code != http.StatusTooManyRequests {
+		t.Fatalf("status %d, want 429: %s", w.Code, w.Body)
+	}
+	var open int64
+	s.DB.Model(&db.Scan{}).
+		Where("repository_id = ? AND status IN ?", repo.ID, []db.ScanStatus{db.ScanQueued, db.ScanRunning}).
+		Count(&open)
+	if open != maxAgentAPIOpenScansPerRepository {
+		t.Errorf("open scans = %d, want capped at %d", open, maxAgentAPIOpenScansPerRepository)
+	}
+	var targetCount int64
+	s.DB.Model(&db.Scan{}).Where("skill_id = ?", skill.ID).Count(&targetCount)
+	if targetCount != 0 {
+		t.Errorf("over-cap request created %d target scans, want 0", targetCount)
+	}
+}
+
 func TestAPIRunSkill_unknownProfileRejected(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()
@@ -601,6 +654,21 @@ func TestAPIRunFindingSkill_scopesFindingID(t *testing.T) {
 	}
 	if row.APIToken == "" {
 		t.Error("enqueued scan missing api token")
+	}
+
+	r = httptest.NewRequest("POST", path, strings.NewReader("{}"))
+	r.Host = testHost
+	r.Header.Set("Authorization", "Bearer "+scan.APIToken)
+	r.Header.Set("Content-Type", "application/json")
+	w = httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, r)
+	if w.Code != http.StatusConflict {
+		t.Fatalf("duplicate status %d, want 409: %s", w.Code, w.Body)
+	}
+	var count int64
+	s.DB.Model(&db.Scan{}).Where("skill_id = ?", verify.ID).Count(&count)
+	if count != 1 {
+		t.Errorf("equivalent finding scans = %d, want 1", count)
 	}
 }
 

--- a/internal/web/audit.go
+++ b/internal/web/audit.go
@@ -1,7 +1,6 @@
 package web
 
 import (
-	"encoding/json"
 	"net/http"
 	"strconv"
 	"time"
@@ -12,40 +11,6 @@ import (
 // auditMaxLimit caps the audit queue payload. Spot-checking is the use
 // case here; a TOC asking for 10,000 rows is almost certainly a slip.
 const auditMaxLimit = 500
-
-// apiAddFindingReview records one structured human verdict against the
-// automation's outcome on a finding. The automated_outcome field is
-// snapshot from the latest revalidate note at write time so the
-// agreement metric does not bend later when revalidate runs again. The
-// reviewer field is optional free text; scrutineer is single-operator,
-// so populating it is the operator's choice (a GitHub handle, an
-// initials marker, or empty).
-func (s *Server) apiAddFindingReview(w http.ResponseWriter, r *http.Request) {
-	id, ok := s.findingScoped(w, r)
-	if !ok {
-		return
-	}
-	var body struct {
-		Verdict          string `json:"verdict"`
-		Reason           string `json:"reason"`
-		Reviewer         string `json:"reviewer"`
-		AutomatedOutcome string `json:"automated_outcome"`
-	}
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-		writeAPIError(w, http.StatusBadRequest, "body must be JSON")
-		return
-	}
-	automated := body.AutomatedOutcome
-	if automated == "" {
-		automated = db.LatestRevalidateVerdict(s.DB, id)
-	}
-	rev, err := db.AddFindingReview(s.DB, id, body.Verdict, body.Reason, automated, body.Reviewer)
-	if err != nil {
-		writeAPIError(w, http.StatusUnprocessableEntity, err.Error())
-		return
-	}
-	writeJSON(w, http.StatusCreated, rev)
-}
 
 // apiListFindingReviews returns reviews on one finding, newest first.
 // The finding page renders the same data.

--- a/internal/web/audit_test.go
+++ b/internal/web/audit_test.go
@@ -72,7 +72,7 @@ func TestAuditPage_listsQueueAndAgreementRate(t *testing.T) {
 	}
 }
 
-func TestApiAddFindingReview_snapshotsLatestRevalidate(t *testing.T) {
+func TestApiAddFindingReview_notReachableWithScanToken(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()
 	repo := db.Repository{URL: "https://example.com/r", Name: "r"}
@@ -83,10 +83,6 @@ func TestApiAddFindingReview_snapshotsLatestRevalidate(t *testing.T) {
 	s.DB.Create(&scan)
 	f := db.Finding{ScanID: scan.ID, RepositoryID: repo.ID, Title: "t", Severity: "High"}
 	s.DB.Create(&f)
-	if _, err := db.AddFindingNote(s.DB, f.ID, "revalidate: false_positive\n\ntest fixture", "revalidate"); err != nil {
-		t.Fatal(err)
-	}
-
 	r := httptest.NewRequest(http.MethodPost,
 		"/api/findings/"+strconv.Itoa(int(f.ID))+"/reviews",
 		strings.NewReader(`{"verdict":"true_positive","reason":"actually exploitable","reviewer":"andrew"}`))
@@ -95,18 +91,15 @@ func TestApiAddFindingReview_snapshotsLatestRevalidate(t *testing.T) {
 	r.Header.Set("Authorization", "Bearer T1")
 	w := httptest.NewRecorder()
 	s.Handler().ServeHTTP(w, r)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	// The GET reviews route still exists, so net/http reports 405 rather than
+	// 404 for the removed POST route.
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d, want 405; body = %s", w.Code, w.Body.String())
 	}
-	var rev db.FindingReview
-	if err := json.Unmarshal(w.Body.Bytes(), &rev); err != nil {
-		t.Fatal(err)
-	}
-	if rev.AutomatedOutcome != "false_positive" {
-		t.Errorf("automated_outcome = %q, want false_positive (snapshotted from latest revalidate note)", rev.AutomatedOutcome)
-	}
-	if rev.Verdict != "true_positive" {
-		t.Errorf("verdict = %q, want true_positive", rev.Verdict)
+	var count int64
+	s.DB.Model(&db.FindingReview{}).Where("finding_id = ?", f.ID).Count(&count)
+	if count != 0 {
+		t.Errorf("scan-token request created %d reviews, want 0", count)
 	}
 }
 
@@ -139,34 +132,6 @@ func TestApiAuditMetrics_returnsAggregate(t *testing.T) {
 	}
 	if m.TotalReviews != 2 || m.WithAutomatedOutcome != 2 || m.Agreements != 1 {
 		t.Errorf("metrics = %+v, want total=2 auto=2 agree=1", m)
-	}
-}
-
-func TestApiAddFindingReview_validation(t *testing.T) {
-	s, done := newTestServer(t)
-	defer done()
-	f, tok := seedAuditFixture(t, s)
-	path := "/api/findings/" + strconv.Itoa(int(f.ID)) + "/reviews"
-
-	if w := apiReq(t, s, "POST", path, tok, `{"verdict":"not-a-verdict"}`); w.Code != http.StatusUnprocessableEntity {
-		t.Errorf("invalid verdict: status = %d, want 422", w.Code)
-	}
-	if w := apiReq(t, s, "POST", path, tok, `not json`); w.Code != http.StatusBadRequest {
-		t.Errorf("bad json: status = %d, want 400", w.Code)
-	}
-
-	// Explicit automated_outcome wins over the revalidate snapshot.
-	if _, err := db.AddFindingNote(s.DB, f.ID, "revalidate: false_positive\n\nfixture", "revalidate"); err != nil {
-		t.Fatalf("seed revalidate note: %v", err)
-	}
-	w := apiReq(t, s, "POST", path, tok, `{"verdict":"true_positive","automated_outcome":"uncertain"}`)
-	if w.Code != http.StatusCreated {
-		t.Fatalf("status = %d; body=%s", w.Code, w.Body)
-	}
-	var rev db.FindingReview
-	decodeJSON(t, w, &rev)
-	if rev.AutomatedOutcome != "uncertain" {
-		t.Errorf("automated_outcome = %q, want explicit value to win over snapshot", rev.AutomatedOutcome)
 	}
 }
 

--- a/internal/web/finding_osv.go
+++ b/internal/web/finding_osv.go
@@ -96,9 +96,17 @@ func (s *Server) findingOSV(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	var refs []db.FindingReference
-	s.DB.Where("finding_id = ?", f.ID).Order("id desc").Find(&refs)
+	if err := s.DB.Where("finding_id = ?", f.ID).Order("id desc").Find(&refs).Error; err != nil {
+		s.Log.Error("osv references", "finding", f.ID, "err", err)
+		http.Error(w, "failed to load finding references", http.StatusInternalServerError)
+		return
+	}
 	var pkgs []db.Package
-	s.DB.Select("name, ecosystem, p_url").Where("repository_id = ?", f.RepositoryID).Find(&pkgs)
+	if err := s.DB.Select("name, ecosystem, p_url").Where("repository_id = ?", f.RepositoryID).Find(&pkgs).Error; err != nil {
+		s.Log.Error("osv packages", "finding", f.ID, "repository", f.RepositoryID, "err", err)
+		http.Error(w, "failed to load repository packages", http.StatusInternalServerError)
+		return
+	}
 
 	raw, err := json.MarshalIndent(buildOSV(f, repo, refs, pkgs), "", "  ")
 	if err != nil {

--- a/internal/web/finding_osv_test.go
+++ b/internal/web/finding_osv_test.go
@@ -478,6 +478,29 @@ func TestFindingOSV_handlesRepositoryLookupErrors(t *testing.T) {
 	}
 }
 
+func TestFindingOSV_handlesChildLookupErrors(t *testing.T) {
+	for _, table := range []string{"finding_references", "packages"} {
+		t.Run(table, func(t *testing.T) {
+			s, done := newTestServer(t)
+			defer done()
+
+			f := seedCSAFFinding(t, s, nil)
+			if err := s.DB.Callback().Query().Before("gorm:query").Register("test:fail_osv_child_lookup", func(tx *gorm.DB) {
+				if tx.Statement.Table == table {
+					_ = tx.AddError(errors.New("database unavailable"))
+				}
+			}); err != nil {
+				t.Fatal(err)
+			}
+
+			w := getOSV(t, s, f.ID)
+			if w.Code != http.StatusInternalServerError {
+				t.Errorf("status = %d, want 500; body=%s", w.Code, w.Body)
+			}
+		})
+	}
+}
+
 func TestOSVReferenceType(t *testing.T) {
 	cases := []struct {
 		tags string

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -134,6 +134,10 @@ type Server struct {
 	toolMetaCache toolMetadata
 	toolMetaTTL   time.Time
 
+	// agentEnqueueMu makes the scan-token API's deduplication and repository
+	// capacity checks atomic within this server process.
+	agentEnqueueMu sync.Mutex
+
 	// runnerStatus is the result of the boot-time runner-image staleness check
 	// (issue #337), set once by main shortly after startup and read by the
 	// settings page to render the stale-image banner. The zero value renders

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -451,38 +451,6 @@ paths:
               schema:
                 type: array
                 items: { $ref: '#/components/schemas/FindingReview' }
-    post:
-      summary: Record one structured human verdict on a finding
-      description: |
-        Verdicts mirror the revalidate skill's enum so reviewer agreement
-        with the model is computed by direct string comparison. When
-        automated_outcome is omitted the server snapshots the latest
-        revalidate verdict from the finding's notes; explicit values
-        win to support older notes the operator wants to re-pin.
-      operationId: addFindingReview
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              required: [verdict]
-              properties:
-                verdict:
-                  type: string
-                  enum: [true_positive, false_positive, already_fixed, uncertain]
-                reason: { type: string }
-                reviewer: { type: string }
-                automated_outcome:
-                  type: string
-                  description: Optional override for the automation outcome the human is judging. When empty the server pulls it from the finding's latest revalidate note.
-      responses:
-        '201':
-          description: Created
-          content:
-            application/json:
-              schema: { $ref: '#/components/schemas/FindingReview' }
-
   /v1/audit/queue:
     get:
       summary: Sample of recently auto-bucketed findings without a recorded review


### PR DESCRIPTION
A scan runs a coding agent against a potentially hostile repository that can prompt-inject the agent, and the agent holds the scan's bearer token. This closes several paths where a compromised token could do more than intended, plus two smaller robustness fixes found alongside them.

Highlights:
- Enqueue abuse: the skill-run endpoints had no admission control, so an injected agent could loop and enqueue unbounded model-backed work that re-scans the same repository and re-injects, growing the queue and burning model quota. Enqueue now reuses the existing open-scan dedup guard (equivalent work returns 409) and an atomic per-repository cap on queued or running scans (over the cap returns 429).
- Review forgery: the scan-token API exposed the finding-review write route, so a token could forge human audit verdicts, which dropped findings from the audit queue and skewed the human-versus-automation agreement metric. That route is removed; review creation stays on the operator browser form.
- OSV export: errors from the reference and package queries were ignored, so a database failure could return a valid but incomplete advisory. Both are now checked and fail with 500, matching the earlier repository-lookup fix.
- Listen address: warn at startup when the bind is not loopback, since the UI has no authentication and a non-loopback bind exposes it to the network. The host-header check is unchanged.
