### PR TITLE
fix(worker): reject egress to non-public IPs after DNS resolution

### DIFF
--- a/internal/worker/egress.go
+++ b/internal/worker/egress.go
@@ -11,8 +11,10 @@ import (
 	"maps"
 	"net"
 	"net/http"
+	"net/netip"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 )
 
@@ -164,7 +166,7 @@ const (
 func (p *EgressProxy) init() {
 	p.once.Do(func() {
 		p.transport = &http.Transport{
-			DialContext:         (&net.Dialer{Timeout: egressDialTimeout}).DialContext,
+			DialContext:         p.dialContext,
 			ForceAttemptHTTP2:   false,
 			MaxIdleConnsPerHost: egressIdlePerHost,
 		}
@@ -205,13 +207,17 @@ func (p *EgressProxy) serveConnect(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "egress to "+host+" is not on the allowlist", http.StatusForbidden)
 		return
 	}
-	if p.isAPIHost(host) && p.APIPort != "" && port != p.APIPort {
+	apiHost := p.isAPIHost(host)
+	if apiHost && p.APIPort != "" && port != p.APIPort {
 		p.Log.Warn("egress denied", "method", "CONNECT", "host", host, "port", port, "allowed_port", p.APIPort)
 		http.Error(w, "egress to "+host+" is only allowed on port "+p.APIPort, http.StatusForbidden)
 		return
 	}
-	upstream, err := net.DialTimeout("tcp", p.dialTarget(host, port), egressDialTimeout)
+	upstream, err := dialEgress(r.Context(), "tcp", p.dialTarget(host, port), apiHost)
 	if err != nil {
+		if p.writeIPDenied(w, "CONNECT", host, err) {
+			return
+		}
 		http.Error(w, err.Error(), http.StatusBadGateway)
 		return
 	}
@@ -242,7 +248,8 @@ func (p *EgressProxy) serveForward(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "egress to "+host+" is not on the allowlist", http.StatusForbidden)
 		return
 	}
-	if p.isAPIHost(host) && p.APIPort != "" && port != p.APIPort {
+	apiHost := p.isAPIHost(host)
+	if apiHost && p.APIPort != "" && port != p.APIPort {
 		p.Log.Warn("egress denied", "method", r.Method, "host", host, "port", port, "allowed_port", p.APIPort)
 		http.Error(w, "egress to "+host+" is only allowed on port "+p.APIPort, http.StatusForbidden)
 		return
@@ -250,10 +257,16 @@ func (p *EgressProxy) serveForward(w http.ResponseWriter, r *http.Request) {
 	out := r.Clone(r.Context())
 	out.RequestURI = ""
 	out.URL.Host = p.dialTarget(host, port)
+	if apiHost {
+		out = out.WithContext(context.WithValue(out.Context(), apiGatewayDialKey{}, true))
+	}
 	out.Header.Del("Proxy-Authorization")
 	out.Header.Del("Proxy-Connection")
 	resp, err := p.transport.RoundTrip(out)
 	if err != nil {
+		if p.writeIPDenied(w, r.Method, host, err) {
+			return
+		}
 		http.Error(w, err.Error(), http.StatusBadGateway)
 		return
 	}
@@ -261,6 +274,77 @@ func (p *EgressProxy) serveForward(w http.ResponseWriter, r *http.Request) {
 	maps.Copy(w.Header(), resp.Header)
 	w.WriteHeader(resp.StatusCode)
 	_, _ = io.Copy(w, resp.Body)
+}
+
+// apiGatewayDialKey marks the one intentionally non-public dial path: a request
+// whose original host matched APIHosts and was rewritten by dialTarget to the
+// host API gateway. The private type prevents callers from granting themselves
+// the exemption through an incoming request context.
+type apiGatewayDialKey struct{}
+
+// dialContext is the transport dial hook for forward requests. Ordinary
+// requests resolve and connect with the non-public IP guard enabled. Only the
+// APIHosts path marked by serveForward may dial GatewayDialHost/127.0.0.1.
+func (p *EgressProxy) dialContext(ctx context.Context, network, address string) (net.Conn, error) {
+	apiGateway, _ := ctx.Value(apiGatewayDialKey{}).(bool)
+	return dialEgress(ctx, network, address, apiGateway)
+}
+
+func dialEgress(ctx context.Context, network, address string, apiGateway bool) (net.Conn, error) {
+	dialer := &net.Dialer{
+		Timeout: egressDialTimeout,
+		Control: egressIPControl(apiGateway),
+	}
+	return dialer.DialContext(ctx, network, address)
+}
+
+// cgnatPrefix is RFC 6598 shared address space (100.64.0.0/10). netip.Addr's
+// IsPrivate reports false for it, but carrier-grade NAT and overlay networks
+// such as Tailscale and ZeroTier route it, so a rebind into that range must be
+// denied alongside RFC1918.
+var cgnatPrefix = netip.MustParsePrefix("100.64.0.0/10")
+
+// egressIPControl checks the address selected by net.Dialer after name
+// resolution and immediately before connect. This closes the DNS rebinding
+// window without changing HostAllowed's hostname semantics or pinning a
+// separately resolved address.
+func egressIPControl(apiGateway bool) func(string, string, syscall.RawConn) error {
+	return func(_ string, address string, _ syscall.RawConn) error {
+		if apiGateway {
+			return nil
+		}
+		host, _, err := net.SplitHostPort(address)
+		if err != nil {
+			return &egressIPDeniedError{address: address}
+		}
+		ip, err := netip.ParseAddr(host)
+		if err != nil {
+			return &egressIPDeniedError{address: address}
+		}
+		ip = ip.Unmap()
+		if ip.IsLoopback() || ip.IsPrivate() || cgnatPrefix.Contains(ip) || ip.IsLinkLocalUnicast() || ip.IsUnspecified() || ip.IsMulticast() {
+			return &egressIPDeniedError{address: ip.String()}
+		}
+		return nil
+	}
+}
+
+type egressIPDeniedError struct {
+	address string
+}
+
+func (e *egressIPDeniedError) Error() string {
+	return "egress destination resolved to non-public address " + e.address
+}
+
+func (p *EgressProxy) writeIPDenied(w http.ResponseWriter, method, host string, err error) bool {
+	var denied *egressIPDeniedError
+	if !errors.As(err, &denied) {
+		return false
+	}
+	p.Log.Warn("egress denied", "method", method, "host", host, "remote_ip", denied.address)
+	http.Error(w, "egress to "+host+" is not on the allowlist", http.StatusForbidden)
+	return true
 }
 
 // HostAllowed reports whether host matches any entry in allow. Matching is

--- a/internal/worker/egress_test.go
+++ b/internal/worker/egress_test.go
@@ -164,7 +164,32 @@ func TestEgressProxy_ForwardDenied(t *testing.T) {
 	}
 }
 
-func TestEgressProxy_ForwardAllowedRewritesGateway(t *testing.T) {
+func TestEgressProxy_DeniesNonPublicResolvedIP(t *testing.T) {
+	for _, host := range []string{"127.0.0.1", "10.0.0.1"} {
+		for _, method := range []string{http.MethodConnect, http.MethodGet} {
+			t.Run(host+"/"+method, func(t *testing.T) {
+				p := &EgressProxy{Allow: []string{host}, Log: quietLog()}
+				target := net.JoinHostPort(host, "8080")
+				var r *http.Request
+				if method == http.MethodConnect {
+					r = httptest.NewRequest(method, target, nil)
+				} else {
+					r = httptest.NewRequest(method, "http://"+target+"/private", nil)
+				}
+				w := httptest.NewRecorder()
+				p.ServeHTTP(w, r)
+				if w.Code != http.StatusForbidden {
+					t.Fatalf("got %d: %s, want 403", w.Code, w.Body)
+				}
+				if got, want := strings.TrimSpace(w.Body.String()), "egress to "+host+" is not on the allowlist"; got != want {
+					t.Fatalf("body = %q, want %q", got, want)
+				}
+			})
+		}
+	}
+}
+
+func TestEgressProxy_APIHostGatewayExemptionStillConnects(t *testing.T) {
 	// Upstream stands in for the local scrutineer API on 127.0.0.1.
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("X-Upstream", "yes")
@@ -173,7 +198,7 @@ func TestEgressProxy_ForwardAllowedRewritesGateway(t *testing.T) {
 	defer upstream.Close()
 	_, port, _ := net.SplitHostPort(upstream.Listener.Addr().String())
 
-	p := &EgressProxy{Allow: []string{HostGatewayAlias}, Log: quietLog()}
+	p := &EgressProxy{Allow: []string{HostGatewayAlias}, APIPort: port, Log: quietLog()}
 	target := "http://" + net.JoinHostPort(HostGatewayAlias, port) + "/api/ping"
 	r := httptest.NewRequest("GET", target, nil)
 	w := httptest.NewRecorder()
@@ -379,16 +404,17 @@ func TestWaitHostAPIReachable_FailsClosed(t *testing.T) {
 
 // TestEgressProxy_ConnectEndToEnd exercises the full path the container
 // runner uses: a real listener, Proxy-Authorization in the proxy URL,
-// CONNECT tunnel, then a TLS request over it. The upstream is a local
-// httptest TLS server allowlisted as 127.0.0.1.
+// CONNECT tunnel, then a TLS request over it. The API alias is rewritten to
+// the local httptest TLS server, exercising the intentional gateway exemption.
 func TestEgressProxy_ConnectEndToEnd(t *testing.T) {
 	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, _ = io.WriteString(w, "tunnelled")
 	}))
 	defer upstream.Close()
+	_, upstreamPort, _ := net.SplitHostPort(upstream.Listener.Addr().String())
 
 	token := "tok"
-	p := &EgressProxy{Allow: []string{"127.0.0.1"}, Token: token, Log: quietLog()}
+	p := &EgressProxy{Allow: []string{HostGatewayAlias}, Token: token, APIPort: upstreamPort, Log: quietLog()}
 	proxySrv := httptest.NewServer(p)
 	defer proxySrv.Close()
 
@@ -400,7 +426,8 @@ func TestEgressProxy_ConnectEndToEnd(t *testing.T) {
 	}
 	client := &http.Client{Transport: tr}
 
-	resp, err := client.Get(upstream.URL)
+	target := "https://" + net.JoinHostPort(HostGatewayAlias, upstreamPort)
+	resp, err := client.Get(target)
 	if err != nil {
 		t.Fatalf("get via proxy: %v", err)
 	}
@@ -415,7 +442,7 @@ func TestEgressProxy_ConnectEndToEnd(t *testing.T) {
 	// transport actually re-CONNECTs.
 	tr.CloseIdleConnections()
 	p.Allow = []string{"somewhere.else"}
-	_, err = client.Get(upstream.URL)
+	_, err = client.Get(target)
 	if err == nil {
 		t.Fatalf("expected CONNECT to be refused for non-allowlisted host")
 	}
@@ -454,23 +481,37 @@ func TestEgressProxy_DeniesGatewayOnWrongPort(t *testing.T) {
 	}
 }
 
-func TestEgressProxy_NoPortRestrictionForOtherHosts(t *testing.T) {
-	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, _ = io.WriteString(w, "ok")
-	}))
-	defer upstream.Close()
-	_, port, _ := net.SplitHostPort(upstream.Listener.Addr().String())
-
-	p := &EgressProxy{
-		Allow:   []string{"127.0.0.1"},
-		APIPort: "8080",
-		Log:     quietLog(),
+func TestEgressIPControl_AllowsPublicIPOnNonstandardPort(t *testing.T) {
+	control := egressIPControl(false)
+	for _, host := range []string{"8.8.8.8", "2001:4860:4860::8888"} {
+		if err := control("tcp", net.JoinHostPort(host, "8443"), nil); err != nil {
+			t.Fatalf("public IP %s on a non-standard port denied: %v", host, err)
+		}
 	}
-	r := httptest.NewRequest("GET", "http://127.0.0.1:"+port+"/foo", nil)
-	w := httptest.NewRecorder()
-	p.ServeHTTP(w, r)
-	if w.Code != http.StatusOK {
-		t.Fatalf("non-gateway host on any port should be allowed: got %d", w.Code)
+}
+
+func TestEgressIPControl_DeniesNonPublicRanges(t *testing.T) {
+	control := egressIPControl(false)
+	for _, host := range []string{
+		"127.0.0.1",
+		"::1",
+		"10.0.0.1",
+		"172.16.0.1",
+		"192.168.0.1",
+		"100.64.0.1",
+		"fd00::1",
+		"169.254.1.1",
+		"fe80::1",
+		"0.0.0.0",
+		"::",
+		"224.0.0.1",
+		"ff02::1",
+	} {
+		t.Run(host, func(t *testing.T) {
+			if err := control("tcp", net.JoinHostPort(host, "443"), nil); err == nil {
+				t.Fatalf("non-public IP %s was allowed", host)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
The egress proxy authorized destinations by hostname but then dialed whatever the name resolved to, so an allowlisted domain that resolved or was rebound to an internal address could reach host-local services. That is an SSRF path for a prompt-injected agent or a compromised allowlisted domain.

This adds a net.Dialer.Control guard that inspects the resolved address immediately before connect, on both the CONNECT and forward paths, and rejects loopback, private, IPv6 ULA, link-local, unspecified, and multicast targets. Checking at dial time (rather than resolving separately and trusting the name) closes the rebinding window between the allowlist check and the connection. The one intentional host-local path, an allowlisted API host that dialTarget rewrites to the gateway address, keeps its exemption through a private context marker that an incoming request cannot forge. Proxy auth, the hostname allowlist, and non-standard ports for public destinations are unchanged.
