### PR TITLE
fix(db): make finding field updates atomic and history-consistent

### DIFF
--- a/internal/db/finding_helpers.go
+++ b/internal/db/finding_helpers.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -20,6 +21,13 @@ import (
 const GHSAIDPattern = `(?i)GHSA(-[0-9a-z]{4}){3}`
 
 var ghsaIDRE = regexp.MustCompile("^" + GHSAIDPattern + "$")
+
+const (
+	findingWriteMaxAttempts = 5
+	sqliteBusyCode          = 5
+)
+
+var errFindingWriteConflict = errors.New("finding changed concurrently")
 
 // validateFindingField rejects values that must follow a fixed format
 // before they reach the column. Most fields are free text and pass
@@ -43,26 +51,26 @@ func validateFindingField(field, value string) error {
 // No-op when the new value equals the current stored value; the history
 // row is only written on an actual change.
 func WriteFindingField(gdb *gorm.DB, findingID uint, field, newValue string, source FindingSource, by string) error {
-	var f Finding
-	if err := gdb.First(&f, findingID).Error; err != nil {
-		return fmt.Errorf("load finding %d: %w", findingID, err)
-	}
-	old, colName, err := findingFieldAccessor(&f, field)
-	if err != nil {
-		return err
-	}
-	if old == newValue {
-		return nil
-	}
-	if err := validateFindingField(field, newValue); err != nil {
-		return err
-	}
 	// The column update, its history row, and any dependent CVSS-score
 	// sync must commit together: a failure between them would change the
 	// stored value with no matching history row (breaking the audit
 	// trail) or leave cvss_score inconsistent with cvss_vector.
-	return gdb.Transaction(func(tx *gorm.DB) error {
-		if err := tx.Model(&Finding{}).Where("id = ?", f.ID).Update(colName, newValue).Error; err != nil {
+	return retryFindingWrite(gdb, findingID, func(tx *gorm.DB) error {
+		var f Finding
+		if err := tx.First(&f, findingID).Error; err != nil {
+			return fmt.Errorf("load finding %d: %w", findingID, err)
+		}
+		old, colName, err := findingFieldAccessor(&f, field)
+		if err != nil {
+			return err
+		}
+		if old == newValue {
+			return nil
+		}
+		if err := validateFindingField(field, newValue); err != nil {
+			return err
+		}
+		if err := conditionalFindingUpdate(tx, f.ID, colName, old, newValue); err != nil {
 			return fmt.Errorf("update %s: %w", colName, err)
 		}
 		if err := tx.Create(&FindingHistory{
@@ -121,26 +129,26 @@ func EnsureFindingDependent(gdb *gorm.DB, row FindingDependent) error {
 // reports the same release timestamp does not log a redundant history
 // row).
 func WriteFindingTimeField(gdb *gorm.DB, findingID uint, field string, newValue time.Time, source FindingSource, by string) error {
-	var f Finding
-	if err := gdb.First(&f, findingID).Error; err != nil {
-		return fmt.Errorf("load finding %d: %w", findingID, err)
-	}
-	old, colName, err := findingTimeFieldAccessor(&f, field)
-	if err != nil {
-		return err
-	}
 	newUTC := newValue.UTC()
-	if old != nil && old.Equal(newUTC) {
-		return nil
-	}
-	oldStr := ""
-	if old != nil {
-		oldStr = old.UTC().Format(time.RFC3339)
-	}
 	// Column update and history row must commit together so the audit
 	// trail can't lose a row on a mid-write failure.
-	return gdb.Transaction(func(tx *gorm.DB) error {
-		if err := tx.Model(&Finding{}).Where("id = ?", f.ID).Update(colName, newUTC).Error; err != nil {
+	return retryFindingWrite(gdb, findingID, func(tx *gorm.DB) error {
+		var f Finding
+		if err := tx.First(&f, findingID).Error; err != nil {
+			return fmt.Errorf("load finding %d: %w", findingID, err)
+		}
+		old, colName, err := findingTimeFieldAccessor(&f, field)
+		if err != nil {
+			return err
+		}
+		if old != nil && old.Equal(newUTC) {
+			return nil
+		}
+		oldStr := ""
+		if old != nil {
+			oldStr = old.UTC().Format(time.RFC3339)
+		}
+		if err := conditionalFindingUpdate(tx, f.ID, colName, old, newUTC); err != nil {
 			return fmt.Errorf("update %s: %w", colName, err)
 		}
 		return tx.Create(&FindingHistory{
@@ -153,6 +161,58 @@ func WriteFindingTimeField(gdb *gorm.DB, findingID uint, field string, newValue 
 			CreatedAt: time.Now(),
 		}).Error
 	})
+}
+
+// retryFindingWrite owns and retries transactions created for raw database
+// handles. A caller-owned transaction cannot be restarted here, so it gets
+// one conditional attempt and returns any conflict to its caller for rollback.
+func retryFindingWrite(gdb *gorm.DB, findingID uint, write func(*gorm.DB) error) error {
+	if _, inTransaction := gdb.Statement.ConnPool.(gorm.TxCommitter); inTransaction {
+		// Keep the helper atomic with a single GORM savepoint, but leave any
+		// outer transaction retry to its owner because its earlier work and
+		// read snapshot cannot be safely reconstructed here.
+		return gdb.Transaction(write)
+	}
+
+	var err error
+	for attempt := 1; attempt <= findingWriteMaxAttempts; attempt++ {
+		err = gdb.Transaction(write)
+		if err == nil {
+			return nil
+		}
+		if !errors.Is(err, errFindingWriteConflict) && !isSQLiteBusy(err) {
+			return err
+		}
+		if attempt < findingWriteMaxAttempts {
+			time.Sleep(time.Millisecond << (attempt - 1))
+		}
+	}
+	return fmt.Errorf("write finding %d failed after %d attempts: %w", findingID, findingWriteMaxAttempts, err)
+}
+
+// conditionalFindingUpdate is the optimistic compare-and-swap shared by
+// string, timestamp, and derived-score writes. clause.Eq renders nil as IS
+// NULL, which is required for an unset ReleasedAt value.
+func conditionalFindingUpdate(gdb *gorm.DB, findingID uint, column string, oldValue, newValue any) error {
+	result := gdb.Model(&Finding{}).
+		Where("id = ?", findingID).
+		Where(clause.Eq{Column: clause.Column{Name: column}, Value: oldValue}).
+		Update(column, newValue)
+	if result.Error != nil {
+		return result.Error
+	}
+	if result.RowsAffected == 0 {
+		return errFindingWriteConflict
+	}
+	return nil
+}
+
+// SQLite reports a stale WAL read transaction as SQLITE_BUSY_SNAPSHOT (an
+// extended SQLITE_BUSY code) instead of returning zero rows from the compare-
+// and-swap. The whole owned transaction must be restarted to get a new snapshot.
+func isSQLiteBusy(err error) bool {
+	var sqliteErr interface{ Code() int }
+	return errors.As(err, &sqliteErr) && sqliteErr.Code()&0xff == sqliteBusyCode
 }
 
 // findingTimeFieldAccessor mirrors findingFieldAccessor for timestamp
@@ -173,11 +233,11 @@ func findingTimeFieldAccessor(f *Finding, field string) (current *time.Time, col
 // unparseable vector clears the score so stale numbers don't linger.
 func syncCVSSScore(gdb *gorm.DB, f *Finding, vector string, source FindingSource, by string) error {
 	score, _ := CVSSV3ScoreFromVector(vector)
+	if err := conditionalFindingUpdate(gdb, f.ID, "cvss_score", f.CVSSScore, score); err != nil {
+		return fmt.Errorf("update cvss_score: %w", err)
+	}
 	if f.CVSSScore == score {
 		return nil
-	}
-	if err := gdb.Model(&Finding{}).Where("id = ?", f.ID).Update("cvss_score", score).Error; err != nil {
-		return fmt.Errorf("update cvss_score: %w", err)
 	}
 	return gdb.Create(&FindingHistory{
 		FindingID: f.ID,
@@ -195,11 +255,11 @@ func syncCVSSScore(gdb *gorm.DB, f *Finding, vector string, source FindingSource
 // vector/score columns rather than overloading the v3 ones.
 func syncCVSSv4Score(gdb *gorm.DB, f *Finding, vector string, source FindingSource, by string) error {
 	score, _ := CVSSV4ScoreFromVector(vector)
+	if err := conditionalFindingUpdate(gdb, f.ID, "cvss_v4_score", f.CVSSv4Score, score); err != nil {
+		return fmt.Errorf("update cvss_v4_score: %w", err)
+	}
 	if f.CVSSv4Score == score {
 		return nil
-	}
-	if err := gdb.Model(&Finding{}).Where("id = ?", f.ID).Update("cvss_v4_score", score).Error; err != nil {
-		return fmt.Errorf("update cvss_v4_score: %w", err)
 	}
 	return gdb.Create(&FindingHistory{
 		FindingID: f.ID,

--- a/internal/db/finding_helpers_test.go
+++ b/internal/db/finding_helpers_test.go
@@ -3,6 +3,7 @@ package db
 import (
 	"errors"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -106,6 +107,93 @@ func TestWriteFindingField_noOpWhenUnchanged(t *testing.T) {
 	}
 }
 
+func TestWriteFindingField_concurrentUpdatesKeepHistoryChain(t *testing.T) {
+	gdb := newTestDB(t)
+	f := seedFinding(t, gdb)
+
+	// Hold both first reads until each writer has loaded the same value. The
+	// second write must detect that its snapshot lost the race, reload, and
+	// record a transition from the first writer's value.
+	const callbackName = "test:barrier_finding_reads"
+	var reads atomic.Int32
+	arrived := make(chan struct{}, 2)
+	release := make(chan struct{})
+	if err := gdb.Callback().Query().After("gorm:query").Register(callbackName, func(d *gorm.DB) {
+		loaded, ok := d.Statement.Dest.(*Finding)
+		if !ok || loaded.ID != f.ID || d.Error != nil {
+			return
+		}
+		if reads.Add(1) <= 2 {
+			arrived <- struct{}{}
+			<-release
+		}
+	}); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := gdb.Callback().Query().Remove(callbackName); err != nil {
+			t.Errorf("remove query barrier: %v", err)
+		}
+	})
+
+	errs := make(chan error, 2)
+	go func() {
+		errs <- WriteFindingField(gdb, f.ID, severityField, "Critical", SourceAnalyst, "analyst-a")
+	}()
+	go func() {
+		errs <- WriteFindingField(gdb, f.ID, severityField, "Medium", SourceModel, "worker-b")
+	}()
+
+	for range 2 {
+		select {
+		case <-arrived:
+		case <-time.After(10 * time.Second):
+			close(release)
+			t.Fatal("timed out waiting for concurrent finding reads")
+		}
+	}
+	close(release)
+	for range 2 {
+		select {
+		case err := <-errs:
+			if err != nil {
+				t.Fatalf("concurrent WriteFindingField: %v", err)
+			}
+		case <-time.After(10 * time.Second):
+			t.Fatal("timed out waiting for concurrent finding writes")
+		}
+	}
+
+	var refreshed Finding
+	if err := gdb.First(&refreshed, f.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	var history []FindingHistory
+	if err := gdb.Where("finding_id = ? AND field = ?", f.ID, severityField).Order("id").Find(&history).Error; err != nil {
+		t.Fatal(err)
+	}
+	if len(history) != 2 {
+		t.Fatalf("history len = %d, want 2: %+v", len(history), history)
+	}
+	if history[0].OldValue != "High" {
+		t.Errorf("first OldValue = %q, want High", history[0].OldValue)
+	}
+	if history[1].OldValue != history[0].NewValue {
+		t.Errorf("history chain is broken: first transition %q -> %q, second %q -> %q",
+			history[0].OldValue, history[0].NewValue, history[1].OldValue, history[1].NewValue)
+	}
+	if refreshed.Severity != history[1].NewValue {
+		t.Errorf("final severity = %q, want last history value %q", refreshed.Severity, history[1].NewValue)
+	}
+	written := map[string]bool{
+		history[0].NewValue: true,
+		history[1].NewValue: true,
+	}
+	if !written["Critical"] || !written["Medium"] {
+		t.Errorf("history transitions = %+v, want both concurrent values", history)
+	}
+}
+
 func TestWriteFindingField_rejectsUnknownField(t *testing.T) {
 	gdb := newTestDB(t)
 	f := seedFinding(t, gdb)
@@ -144,6 +232,39 @@ func TestWriteFindingField_cvssVectorSyncsScore(t *testing.T) {
 	if refreshed.CVSSv4Score != 0 || refreshed.CVSSv4Vector != "" {
 		t.Errorf("v4 columns mutated by v3 write: vec=%q score=%v",
 			refreshed.CVSSv4Vector, refreshed.CVSSv4Score)
+	}
+}
+
+func TestWriteFindingField_cvssSameScoreKeepsScoreHistoryNoOp(t *testing.T) {
+	gdb := newTestDB(t)
+	f := seedFinding(t, gdb)
+	const (
+		oldVector = "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+		newVector = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+	)
+	if err := gdb.Model(&Finding{}).Where("id = ?", f.ID).Updates(map[string]any{
+		"cvss_vector": oldVector,
+		"cvss_score":  9.8,
+	}).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	if err := WriteFindingField(gdb, f.ID, "cvss_vector", newVector, SourceAnalyst, "me"); err != nil {
+		t.Fatal(err)
+	}
+	var refreshed Finding
+	if err := gdb.First(&refreshed, f.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if refreshed.CVSSVector != newVector || refreshed.CVSSScore != 9.8 {
+		t.Fatalf("vector=%q score=%v, want %q and 9.8", refreshed.CVSSVector, refreshed.CVSSScore, newVector)
+	}
+	var history []FindingHistory
+	if err := gdb.Where("finding_id = ?", f.ID).Order("id").Find(&history).Error; err != nil {
+		t.Fatal(err)
+	}
+	if len(history) != 1 || history[0].Field != "cvss_vector" {
+		t.Fatalf("history = %+v, want only the vector transition", history)
 	}
 }
 
@@ -262,6 +383,44 @@ func TestWriteFindingField_rollsBackOnHistoryFailure(t *testing.T) {
 	}
 	var count int64
 	gdb.Model(&FindingHistory{}).Where("finding_id = ?", f.ID).Count(&count)
+	if count != 0 {
+		t.Errorf("history rows = %d, want 0", count)
+	}
+}
+
+// A caller-owned transaction gets one savepoint-backed helper attempt. Even
+// if that caller handles the error and commits its other work, the finding
+// column cannot escape without its history row.
+func TestWriteFindingField_existingTransactionKeepsFailedWriteAtomic(t *testing.T) {
+	gdb := newTestDB(t)
+	f := seedFinding(t, gdb)
+
+	remove := failCreate(t, gdb, func(d *gorm.DB) bool {
+		return d.Statement.Table == "finding_histories"
+	})
+	var writeErr error
+	if err := gdb.Transaction(func(tx *gorm.DB) error {
+		writeErr = WriteFindingField(tx, f.ID, severityField, "Critical", SourceAnalyst, "me")
+		return nil
+	}); err != nil {
+		t.Fatalf("outer transaction: %v", err)
+	}
+	remove()
+	if writeErr == nil {
+		t.Fatal("expected helper error when the history insert fails")
+	}
+
+	var refreshed Finding
+	if err := gdb.First(&refreshed, f.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if refreshed.Severity != "High" {
+		t.Errorf("severity = %q, want High after helper savepoint rollback", refreshed.Severity)
+	}
+	var count int64
+	if err := gdb.Model(&FindingHistory{}).Where("finding_id = ?", f.ID).Count(&count).Error; err != nil {
+		t.Fatal(err)
+	}
 	if count != 0 {
 		t.Errorf("history rows = %d, want 0", count)
 	}


### PR DESCRIPTION
WriteFindingField and WriteFindingTimeField loaded a finding, computed the old value, then updated the column and inserted its history row in a separate, later transaction. Concurrent updates to the same finding (a worker finalizing status while an operator edits it in the browser, sharing one *gorm.DB at worker concurrency) could lose a write and record a history row whose OldValue did not match the row's true prior value. That is not just cosmetic: a rejected finding's status is restored from the latest history row's OldValue, so a stale OldValue can restore the wrong status.

This moves the read inside the transaction and turns the write into an optimistic compare-and-swap on the old value, so a lost race is detected and retried against a fresh snapshot. Raw database handles get up to five attempts with short backoff (retrying CAS conflicts and SQLite busy-snapshot errors); a caller-owned transaction gets one savepoint-backed attempt and returns the conflict for its owner to roll back, since its earlier work and read snapshot cannot be reconstructed here. The cvss_score sync uses the same CAS, and the no-op and history semantics are unchanged.

A new test forces the exact interleaving with a query-callback barrier: two writers read the same value, both write, and the loser must reload and record a transition from the winner's value. It fails before the fix with two rows both claiming OldValue High, and passes after, including under -race.
