### PR TITLE
fix(llm): drop x-api-key on cross-origin redirect and require https

### DIFF
--- a/cmd/scrutineer/main.go
+++ b/cmd/scrutineer/main.go
@@ -158,7 +158,7 @@ func registerFlags(fs *flag.FlagSet, f *flags) {
 	fs.DurationVar(&f.scanTimeout, "scan-timeout", worker.DefaultScanTimeout, "wall-clock limit per scan")
 	fs.DurationVar(&f.smokeTimeout, "runtime-smoke-timeout", defaultRuntimeSmokeTimeout, "timeout for each rootless-podman startup container check (keep-id image remap, SELinux mount probe); raise if first-run image remapping is slow, lower if the image is pre-warmed")
 	fs.IntVar(&f.maxTurns, "max-turns", 0, "claude --max-turns limit (0 = unlimited)")
-	fs.StringVar(&f.modelBaseURL, "model-base-url", "", "custom model API base URL for the active backend (env fallback: ANTHROPIC_BASE_URL for claude)")
+	fs.StringVar(&f.modelBaseURL, "model-base-url", "", "custom HTTPS model API base URL for the active backend (HTTP allowed for local development; env fallback: ANTHROPIC_BASE_URL for claude)")
 	fs.StringVar(&f.modelBaseURL, "anthropic-base-url", "", "deprecated alias for -model-base-url")
 	fs.StringVar(&f.forkOrg, "fork-org", "", "GitHub org the fork skill forks into and files draft advisories against")
 	fs.BoolVar(&f.schemaStrict, "schema-strict", false, "fail scans whose report.json does not validate against the skill's schema (default: warn and continue)")
@@ -342,7 +342,10 @@ func validateFlags(f *flags) error {
 	if err := config.ValidateRuntime(f.runtime); err != nil {
 		return err
 	}
-	return config.ValidateSELinux(f.selinux)
+	if err := config.ValidateSELinux(f.selinux); err != nil {
+		return err
+	}
+	return validateModelBaseURL(f.modelBaseURL)
 }
 
 func configureBackendEnvironment(f *flags, log *slog.Logger) {
@@ -398,6 +401,9 @@ func run(log *slog.Logger) error {
 	if err := f.normalizePaths(); err != nil {
 		return err
 	}
+	// Resolve the Claude environment fallback before validation so flags,
+	// config, and ANTHROPIC_BASE_URL all pass through the same URL policy.
+	configureBackendEnvironment(f, log)
 	if err := validateFlags(f); err != nil {
 		return err
 	}
@@ -408,8 +414,6 @@ func run(log *slog.Logger) error {
 	if f.set["selinux"] {
 		log.Info("selinux", "flag", f.selinux, "state", worker.HostSELinuxState())
 	}
-	configureBackendEnvironment(f, log)
-
 	if err := os.MkdirAll(f.dataDir, dataPermSecure); err != nil {
 		return err
 	}
@@ -943,6 +947,33 @@ func baseURLHost(raw string) string {
 		return ""
 	}
 	return u.Hostname()
+}
+
+// validateModelBaseURL requires transport encryption for remote model APIs.
+// Loopback and the container host-gateway alias remain available over HTTP for
+// local model/proxy development.
+func validateModelBaseURL(raw string) error {
+	if raw == "" {
+		return nil
+	}
+	u, err := url.Parse(raw)
+	if err != nil || !u.IsAbs() || u.Host == "" {
+		return fmt.Errorf("model base URL must be an absolute URL")
+	}
+	if strings.EqualFold(u.Scheme, "https") ||
+		(strings.EqualFold(u.Scheme, "http") && localModelHost(u.Hostname())) {
+		return nil
+	}
+	return fmt.Errorf("model base URL must use https (http is allowed only for local development)")
+}
+
+func localModelHost(host string) bool {
+	host = strings.TrimSuffix(host, ".")
+	if strings.EqualFold(host, "localhost") || strings.EqualFold(host, worker.HostGatewayAlias) {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
 }
 
 // cfgPath returns the path the loader actually used for logging.

--- a/cmd/scrutineer/main_test.go
+++ b/cmd/scrutineer/main_test.go
@@ -245,6 +245,42 @@ func TestRegisterFlags_modelBaseURLAliasParsesFromArgv(t *testing.T) {
 	}
 }
 
+func TestValidateFlags_modelBaseURLRequiresHTTPS(t *testing.T) {
+	tests := []struct {
+		name    string
+		baseURL string
+		wantErr bool
+	}{
+		{"empty", "", false},
+		{"https", "https://models.example.com/v1", false},
+		{"loopback IPv4 development", "http://127.0.0.1:11434/v1", false},
+		{"loopback IPv6 development", "http://[::1]:11434/v1", false},
+		{"localhost development", "http://localhost:11434/v1", false},
+		{"container host development", "http://host.docker.internal:11434/v1", false},
+		{"remote http", "http://models.example.com/v1", true},
+		{"non-http scheme", "ftp://models.example.com/v1", true},
+		{"relative URL", "models.example.com/v1", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateFlags(&flags{modelBaseURL: tt.baseURL})
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateFlags(%q) error = %v, wantErr %v", tt.baseURL, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateFlags_rejectsInsecureEnvironmentBaseURL(t *testing.T) {
+	t.Setenv("ANTHROPIC_BASE_URL", "http://models.example.com/v1")
+	f := &flags{}
+	configureBackendEnvironment(f, quietLog())
+	err := validateFlags(f)
+	if err == nil || !strings.Contains(err.Error(), "must use https") {
+		t.Fatalf("resolved environment base URL error = %v", err)
+	}
+}
+
 func TestRegisterFlags_hardenedRuntimeOnlyAliasParsesFromArgv(t *testing.T) {
 	// Both the canonical --hardened-runtime-only and the deprecated
 	// --hardened-rootless-runtime alias must parse off the command line and set

--- a/internal/llm/messages.go
+++ b/internal/llm/messages.go
@@ -8,21 +8,26 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
+	"net/url"
 	"strings"
 )
 
 const (
 	DefaultEndpoint = "https://api.anthropic.com/v1/messages"
 	apiVersion      = "2023-06-01"
+	apiKeyHeader    = "x-api-key"
+	maxRedirects    = 10
 	maxResponseSize = 10 << 20
 	maxErrorSize    = 32 << 10
 )
 
 // Options configures one Anthropic Messages API request. Endpoint is the full
-// Messages endpoint, which lets deployments use a compatible proxy. APIKey,
-// Model, and MaxTokens are required so each call's billing and output budget
-// are explicit at the call site.
+// Messages endpoint, which lets deployments use a compatible proxy. Remote
+// endpoints must use HTTPS; HTTP is retained for local development endpoints.
+// APIKey, Model, and MaxTokens are required so each call's billing and output
+// budget are explicit at the call site.
 type Options struct {
 	Endpoint   string
 	APIKey     string
@@ -104,6 +109,9 @@ func Call(ctx context.Context, prompt string, schema json.RawMessage, opts Optio
 	if endpoint == "" {
 		endpoint = DefaultEndpoint
 	}
+	if err := validateEndpoint(endpoint); err != nil {
+		return nil, Usage{}, err
+	}
 	body, err := json.Marshal(messageRequest{
 		Model:     opts.Model,
 		MaxTokens: opts.MaxTokens,
@@ -122,13 +130,10 @@ func Call(ctx context.Context, prompt string, schema json.RawMessage, opts Optio
 		return nil, Usage{}, fmt.Errorf("llm: create request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("x-api-key", opts.APIKey)
+	req.Header.Set(apiKeyHeader, opts.APIKey)
 	req.Header.Set("anthropic-version", apiVersion)
 
-	client := opts.HTTPClient
-	if client == nil {
-		client = http.DefaultClient
-	}
+	client := redirectSafeClient(opts.HTTPClient)
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, Usage{}, fmt.Errorf("llm: messages request: %w", err)
@@ -151,6 +156,80 @@ func Call(ctx context.Context, prompt string, schema json.RawMessage, opts Optio
 		return nil, decoded.Usage, fmt.Errorf("llm: structured response is not valid JSON")
 	}
 	return result, decoded.Usage, nil
+}
+
+// redirectSafeClient copies the selected client so this request can enforce
+// its credential policy without mutating a caller-owned client or
+// http.DefaultClient. The caller's redirect policy still runs, but cannot
+// restore the API key on a cross-origin request.
+func redirectSafeClient(base *http.Client) *http.Client {
+	if base == nil {
+		base = http.DefaultClient
+	}
+	client := *base
+	previous := base.CheckRedirect
+	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		crossOrigin := len(via) > 0 && !sameOrigin(via[0].URL, req.URL)
+		if crossOrigin {
+			req.Header.Del(apiKeyHeader)
+		}
+		if previous != nil {
+			err := previous(req, via)
+			if crossOrigin {
+				req.Header.Del(apiKeyHeader)
+			}
+			return err
+		}
+		if len(via) >= maxRedirects {
+			return fmt.Errorf("llm: stopped after %d redirects", maxRedirects)
+		}
+		return nil
+	}
+	return &client
+}
+
+// sameOrigin compares scheme, hostname, and effective port so a redirect that
+// only makes the default port explicit (host vs host:443) is not treated as
+// cross-origin, while a genuinely different port still is.
+func sameOrigin(a, b *url.URL) bool {
+	return strings.EqualFold(a.Scheme, b.Scheme) &&
+		strings.EqualFold(a.Hostname(), b.Hostname()) &&
+		originPort(a) == originPort(b)
+}
+
+func originPort(u *url.URL) string {
+	if p := u.Port(); p != "" {
+		return p
+	}
+	switch strings.ToLower(u.Scheme) {
+	case "https":
+		return "443"
+	case "http":
+		return "80"
+	default:
+		return ""
+	}
+}
+
+func validateEndpoint(raw string) error {
+	u, err := url.Parse(raw)
+	if err != nil || !u.IsAbs() || u.Host == "" {
+		return fmt.Errorf("llm: endpoint must be an absolute URL")
+	}
+	if strings.EqualFold(u.Scheme, "https") ||
+		(strings.EqualFold(u.Scheme, "http") && localModelHost(u.Hostname())) {
+		return nil
+	}
+	return fmt.Errorf("llm: endpoint must use https (http is allowed only for local development)")
+}
+
+func localModelHost(host string) bool {
+	host = strings.TrimSuffix(host, ".")
+	if strings.EqualFold(host, "localhost") || strings.EqualFold(host, "host.docker.internal") {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
 }
 
 func responseText(blocks []contentBlock) string {

--- a/internal/llm/messages_test.go
+++ b/internal/llm/messages_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 )
@@ -51,6 +52,68 @@ func TestCall_requestsStructuredOutputAndReturnsUsage(t *testing.T) {
 	}
 	if usage != (Usage{InputTokens: 100, OutputTokens: 12, CacheReadTokens: 30, CacheWriteTokens: 7}) {
 		t.Errorf("usage = %+v", usage)
+	}
+}
+
+func TestCall_crossOriginRedirectDropsAPIKey(t *testing.T) {
+	var targetAPIKey string
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		targetAPIKey = r.Header.Get("x-api-key")
+		_, _ = io.WriteString(w, `{"content":[{"type":"text","text":"{\"answer\":\"ok\"}"}],"usage":{}}`)
+	}))
+	defer target.Close()
+
+	var sourceAPIKey string
+	source := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sourceAPIKey = r.Header.Get("x-api-key")
+		http.Redirect(w, r, target.URL+"/v1/messages", http.StatusTemporaryRedirect)
+	}))
+	defer source.Close()
+
+	client := source.Client()
+	if client.CheckRedirect != nil {
+		t.Fatal("test client unexpectedly has a redirect policy")
+	}
+	_, _, err := Call(context.Background(), "reply as JSON", json.RawMessage(objectSchema), Options{
+		Endpoint: source.URL + "/v1/messages", APIKey: "secret", Model: "claude-sonnet-4-6", MaxTokens: 64, HTTPClient: client,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sourceAPIKey != "secret" {
+		t.Errorf("source x-api-key = %q, want credential on the original request", sourceAPIKey)
+	}
+	if targetAPIKey != "" {
+		t.Errorf("redirect target received x-api-key = %q", targetAPIKey)
+	}
+	if client.CheckRedirect != nil {
+		t.Error("Call mutated the caller-provided HTTP client's redirect policy")
+	}
+}
+
+func TestSameOrigin(t *testing.T) {
+	for _, tt := range []struct {
+		a, b string
+		want bool
+	}{
+		{"https://api.example.com/v1", "https://api.example.com/v2", true},
+		{"https://api.example.com", "https://api.example.com:443/x", true},
+		{"http://host:80", "http://host/y", true},
+		{"https://api.example.com", "https://api.example.com:8443", false},
+		{"https://api.example.com", "http://api.example.com", false},
+		{"https://api.example.com", "https://evil.example.com", false},
+	} {
+		a, err := url.Parse(tt.a)
+		if err != nil {
+			t.Fatal(err)
+		}
+		b, err := url.Parse(tt.b)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := sameOrigin(a, b); got != tt.want {
+			t.Errorf("sameOrigin(%q, %q) = %v, want %v", tt.a, tt.b, got, tt.want)
+		}
 	}
 }
 
@@ -108,5 +171,11 @@ func TestCall_rejectsAPIErrorsAndInvalidOptions(t *testing.T) {
 	_, _, err = Call(context.Background(), "object", json.RawMessage(`{`), Options{APIKey: "key", Model: "m", MaxTokens: 1})
 	if err == nil || !strings.Contains(err.Error(), "schema is not valid JSON") {
 		t.Fatalf("schema error = %v", err)
+	}
+	_, _, err = Call(context.Background(), "object", json.RawMessage(objectSchema), Options{
+		Endpoint: "http://models.example.com/v1/messages", APIKey: "key", Model: "m", MaxTokens: 1,
+	})
+	if err == nil || !strings.Contains(err.Error(), "endpoint must use https") {
+		t.Fatalf("insecure endpoint error = %v", err)
 	}
 }


### PR DESCRIPTION
The Messages client sends the Anthropic credential in the custom x-api-key header and followed redirects with the default policy. Go strips Authorization on a cross-origin redirect but not custom headers, so a redirect from the configured endpoint to another host would forward the key. No caller reaches llm.Call in production today and the endpoint is operator-configured, so this is defense in depth rather than a live leak, done so a future caller can't be bitten.

The request client is shallow-copied (so a caller-provided client and http.DefaultClient are never mutated) and wrapped with a redirect policy that drops x-api-key on any hop that leaves the original endpoint's origin, while still running the caller's own redirect policy. Separately, the configured model base URL must use https; http stays allowed only for loopback, localhost, and the container host-gateway alias, and it is validated at startup across the flag, config, and ANTHROPIC_BASE_URL fallback.

A test drives a cross-origin redirect and asserts the second host never sees the credential while the original endpoint still does. It fails before the change and passes after, including under -race.
