### PR TITLE
Validate security-deep-dive sink dispositions

### DIFF
--- a/internal/evals/evals_test.go
+++ b/internal/evals/evals_test.go
@@ -352,8 +352,25 @@ func TestRunnerRejectsSchemaInvalidReport(t *testing.T) {
 		WorkRoot:   t.TempDir(),
 	}
 	_, err = r.RunScenario(context.Background(), sc)
-	if err == nil || !strings.Contains(err.Error(), "failed schema validation") {
-		t.Fatalf("RunScenario error = %v, want schema validation failure", err)
+	if err == nil || !strings.Contains(err.Error(), "failed report validation") {
+		t.Fatalf("RunScenario error = %v, want report validation failure", err)
+	}
+}
+
+func TestRunnerRejectsIncompleteDeepDiveInventory(t *testing.T) {
+	sc, err := LoadScenario("../../evals/security-deep-dive-sqli.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := Runner{
+		Runner:     fakeSkillRunner{report: incompleteDeepDiveReport()},
+		SkillsRoot: "../../skills",
+		EvalsRoot:  "../../evals",
+		WorkRoot:   t.TempDir(),
+	}
+	_, err = r.RunScenario(context.Background(), sc)
+	if err == nil || !strings.Contains(err.Error(), "inventory sink S1 has no disposition") {
+		t.Fatalf("RunScenario error = %v, want unresolved inventory failure", err)
 	}
 }
 
@@ -521,6 +538,11 @@ func validDeepDiveReport() string {
     "class": "Validation",
     "boundary": "HTTP client",
     "consumes": "username query parameter"
+  }, {
+    "id": "S2",
+    "location": "app.py:1",
+    "class": "Validation",
+    "consumes": "unused import"
   }],
   "findings": [{
     "id": "F1",
@@ -536,6 +558,35 @@ func validDeepDiveReport() string {
     "validation": "Manual review of app.py shows string concatenation in buildQuery.",
     "rating": "High impact and directly reachable."
   }],
+  "ruled_out": [{
+    "sinks": ["S2"],
+    "step": 6,
+    "reason": "No additional sinks were present in the fixture."
+  }]
+}`
+}
+
+func incompleteDeepDiveReport() string {
+	return `{
+  "repository": "https://example.com/eval",
+  "commit": "abcdef1",
+  "spec_version": 1,
+  "model": "test-model",
+  "date": "2026-07-09",
+  "languages": ["Python"],
+  "boundaries": [{
+    "actor": "HTTP client",
+    "trusted": "no",
+    "controls": "No input validation before query construction",
+    "source": "app.py"
+  }],
+  "inventory": [{
+    "id": "S1",
+    "location": "app.py:7",
+    "class": "Validation",
+    "consumes": "username query parameter"
+  }],
+  "findings": [],
   "ruled_out": []
 }`
 }

--- a/internal/evals/evals_test.go
+++ b/internal/evals/evals_test.go
@@ -527,8 +527,8 @@ func validDeepDiveReport() string {
   "method": {
     "scope": "./src",
     "grep_patterns": [],
-    "inventory_count": 1,
-    "ruled_out_count": 0,
+    "inventory_count": 2,
+    "ruled_out_count": 1,
     "unresolved_count": 0,
     "notes": ["Python fixture: no memory-unsafe primitives to enumerate."]
   },
@@ -542,6 +542,7 @@ func validDeepDiveReport() string {
     "id": "S2",
     "location": "app.py:1",
     "class": "Validation",
+    "boundary": "HTTP client",
     "consumes": "unused import"
   }],
   "findings": [{
@@ -570,7 +571,7 @@ func incompleteDeepDiveReport() string {
 	return `{
   "repository": "https://example.com/eval",
   "commit": "abcdef1",
-  "spec_version": 1,
+  "spec_version": 13,
   "model": "test-model",
   "date": "2026-07-09",
   "languages": ["Python"],
@@ -580,10 +581,19 @@ func incompleteDeepDiveReport() string {
     "controls": "No input validation before query construction",
     "source": "app.py"
   }],
+  "method": {
+    "scope": "./src",
+    "grep_patterns": [],
+    "inventory_count": 1,
+    "ruled_out_count": 0,
+    "unresolved_count": 0,
+    "notes": ["Python fixture: no memory-unsafe primitives to enumerate."]
+  },
   "inventory": [{
     "id": "S1",
     "location": "app.py:7",
     "class": "Validation",
+    "boundary": "HTTP client",
     "consumes": "username query parameter"
   }],
   "findings": [],

--- a/internal/evals/runner.go
+++ b/internal/evals/runner.go
@@ -102,8 +102,8 @@ func (r Runner) RunScenario(ctx context.Context, sc Scenario) (Result, error) {
 	if err != nil {
 		return Result{}, fmt.Errorf("%s: run %s: %w", sc.Path, sc.Skill, err)
 	}
-	if detail := worker.ValidateReportSchema(skill.SchemaJSON, res.Report); detail != "" {
-		return Result{}, fmt.Errorf("%s: %s failed schema validation: %s", sc.Path, skill.OutputFile, detail)
+	if detail := worker.ValidateSkillReport(skill.Name, skill.SchemaJSON, res.Report); detail != "" {
+		return Result{}, fmt.Errorf("%s: %s failed report validation: %s", sc.Path, skill.OutputFile, detail)
 	}
 	matches, err := judge.Judge(sc, res.Report)
 	if err != nil {

--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -307,7 +307,7 @@ func (s *Server) apiValidateReport(w http.ResponseWriter, r *http.Request) {
 		writeAPIError(w, http.StatusRequestEntityTooLarge, "could not read body (max 1 MB)")
 		return
 	}
-	if detail := worker.ValidateReportSchema(skill.SchemaJSON, string(body)); detail != "" {
+	if detail := worker.ValidateSkillReport(skill.Name, skill.SchemaJSON, string(body)); detail != "" {
 		writeJSON(w, http.StatusOK, map[string]any{"valid": false, "errors": detail})
 		return
 	}

--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -277,7 +277,7 @@ func (s *Server) apiGetScan(w http.ResponseWriter, r *http.Request) {
 // its skill's schema without installing a JSON Schema library inside the runner
 // container. The request body is the candidate report; the response is
 // {"valid":true} or {"valid":false,"errors":"..."} using the exact same
-// validator (worker.ValidateReportSchema) the harness runs after the scan, so
+// validator (worker.ValidateSkillReport) the harness runs after the scan, so
 // an in-container pass guarantees the harness will not send a repair prompt.
 //
 // The body is already capped at apiMaxBody (1 MB) by apiAuth's MaxBytesReader;

--- a/internal/worker/exposure.go
+++ b/internal/worker/exposure.go
@@ -228,7 +228,7 @@ func (w *Worker) recordExposureResult(skill *db.Skill, scan *db.Scan, depID uint
 func (w *Worker) parseExposureOutput(skill *db.Skill, scan *db.Scan, depID uint, report string, emit func(Event)) error {
 	if skill.SchemaJSON != "" {
 		if detail := ValidateSkillReport(skill.Name, skill.SchemaJSON, report); detail != "" {
-			emit(Event{Kind: KindError, Text: "schema: report.json does not validate against schema.json:\n" + detail})
+			emit(reportValidationEvent(skill, detail))
 			if w.SchemaStrict {
 				return &SchemaValidationError{Skill: skill.Name, Detail: detail}
 			}

--- a/internal/worker/exposure.go
+++ b/internal/worker/exposure.go
@@ -227,7 +227,7 @@ func (w *Worker) recordExposureResult(skill *db.Skill, scan *db.Scan, depID uint
 // back to under_investigation; invalid justification labels are dropped.
 func (w *Worker) parseExposureOutput(skill *db.Skill, scan *db.Scan, depID uint, report string, emit func(Event)) error {
 	if skill.SchemaJSON != "" {
-		if detail := ValidateReportSchema(skill.SchemaJSON, report); detail != "" {
+		if detail := ValidateSkillReport(skill.Name, skill.SchemaJSON, report); detail != "" {
 			emit(Event{Kind: KindError, Text: "schema: report.json does not validate against schema.json:\n" + detail})
 			if w.SchemaStrict {
 				return &SchemaValidationError{Skill: skill.Name, Detail: detail}

--- a/internal/worker/exposure_test.go
+++ b/internal/worker/exposure_test.go
@@ -3,6 +3,7 @@ package worker
 import (
 	"log/slog"
 	"os"
+	"strings"
 	"testing"
 
 	"scrutineer/internal/db"
@@ -105,6 +106,24 @@ func TestParseExposureOutput_invalidJSON(t *testing.T) {
 	if err := w.parseExposureOutput(&skill, &scan, dep.ID, "not-json", func(Event) {}); err == nil {
 		t.Fatal("expected error on invalid JSON")
 	}
+}
+
+func TestParseExposureOutputReportsGenericValidationFailure(t *testing.T) {
+	w := newExposureWorker(t)
+	scan, skill, dep := seedExposureFixtures(t, w)
+	skill.SchemaJSON = `{"type":"object","required":["status"]}`
+	var events []Event
+	if err := w.parseExposureOutput(&skill, &scan, dep.ID, `{}`, func(event Event) {
+		events = append(events, event)
+	}); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	for _, event := range events {
+		if strings.Contains(event.Text, "validation: report.json does not pass Scrutineer report validation") {
+			return
+		}
+	}
+	t.Fatalf("validation event missing from %#v", events)
 }
 
 func TestParseExposureOutput_upsertsExistingRow(t *testing.T) {

--- a/internal/worker/report_semantics_test.go
+++ b/internal/worker/report_semantics_test.go
@@ -117,8 +117,8 @@ func TestRepairSchemaReportRepairsSemanticFailure(t *testing.T) {
 	if len(runner.jobs) != 1 {
 		t.Fatalf("RunSkill calls = %d, want 1", len(runner.jobs))
 	}
-	if prompt := runner.jobs[0].ResumePrompt; !strings.Contains(prompt, "inventory sink S1 has no disposition") {
-		t.Fatalf("repair prompt missing semantic failure: %q", prompt)
+	if prompt := runner.jobs[0].ResumePrompt; !strings.Contains(prompt, "inventory sink S1 has no disposition") || !strings.Contains(prompt, "comply with any skill-specific report rules") {
+		t.Fatalf("repair prompt does not require semantic repair: %q", prompt)
 	}
 	for _, event := range events {
 		if strings.Contains(event.Text, "still does not validate") {

--- a/internal/worker/report_semantics_test.go
+++ b/internal/worker/report_semantics_test.go
@@ -1,0 +1,128 @@
+package worker
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"scrutineer/internal/db"
+)
+
+const semanticValidationTestSchema = `{
+  "type": "object",
+  "required": ["inventory", "findings", "ruled_out"],
+  "properties": {
+    "inventory": {"type": "array"},
+    "findings": {"type": "array"},
+    "ruled_out": {"type": "array"}
+  }
+}`
+
+func TestValidateReportSemanticsDeepDiveSinkDispositions(t *testing.T) {
+	tests := []struct {
+		name   string
+		report string
+		want   string
+	}{
+		{
+			name:   "complete",
+			report: `{"inventory":[{"id":"S1"},{"id":"S2"}],"findings":[{"id":"F1","sinks":["S1"]}],"ruled_out":[{"sinks":["S2"]}]}`,
+		},
+		{
+			name:   "unresolved inventory",
+			report: `{"inventory":[{"id":"S1"}],"findings":[],"ruled_out":[]}`,
+			want:   "inventory sink S1 has no disposition",
+		},
+		{
+			name:   "unknown finding reference",
+			report: `{"inventory":[{"id":"S1"}],"findings":[{"id":"F3","sinks":["S99"]}],"ruled_out":[{"sinks":["S1"]}]}`,
+			want:   "finding F3 references unknown sink S99",
+		},
+		{
+			name:   "duplicate inventory id",
+			report: `{"inventory":[{"id":"S1"},{"id":"S1"}],"findings":[{"id":"F1","sinks":["S1"]}],"ruled_out":[]}`,
+			want:   "inventory sink S1 is duplicated",
+		},
+		{
+			name:   "finding ruled out conflict",
+			report: `{"inventory":[{"id":"S4"}],"findings":[{"id":"F1","sinks":["S4"]}],"ruled_out":[{"sinks":["S4"]}]}`,
+			want:   "sink S4 appears in both findings and ruled_out",
+		},
+		{
+			name:   "repeated finding reference",
+			report: `{"inventory":[{"id":"S1"}],"findings":[{"id":"F1","sinks":["S1","S1"]}],"ruled_out":[]}`,
+			want:   "finding F1 repeats sink S1",
+		},
+		{
+			name:   "repeated ruled out reference",
+			report: `{"inventory":[{"id":"S1"}],"findings":[],"ruled_out":[{"sinks":["S1","S1"]}]}`,
+			want:   "ruled_out[0] repeats sink S1",
+		},
+		{
+			name:   "empty inventory",
+			report: `{"inventory":[],"findings":[],"ruled_out":[]}`,
+		},
+		{
+			name:   "malformed json",
+			report: `{"inventory":`,
+			want:   "report.json is not valid JSON",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ValidateReportSemantics(deepDiveSkillName, tc.report)
+			if tc.want == "" && got != "" {
+				t.Fatalf("ValidateReportSemantics() = %q, want valid", got)
+			}
+			if tc.want != "" && !strings.Contains(got, tc.want) {
+				t.Fatalf("ValidateReportSemantics() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestValidateSkillReportAppliesSemanticsOnlyToDeepDive(t *testing.T) {
+	incomplete := `{"inventory":[{"id":"S1"}],"findings":[],"ruled_out":[]}`
+	if got := ValidateSkillReport("posture", semanticValidationTestSchema, incomplete); got != "" {
+		t.Fatalf("other skill validation = %q, want schema-valid report", got)
+	}
+	if got := ValidateSkillReport(deepDiveSkillName, semanticValidationTestSchema, incomplete); !strings.Contains(got, "inventory sink S1 has no disposition") {
+		t.Fatalf("deep-dive validation = %q, want unresolved sink", got)
+	}
+}
+
+func TestRepairSchemaReportRepairsSemanticFailure(t *testing.T) {
+	incomplete := `{"inventory":[{"id":"S1"}],"findings":[],"ruled_out":[]}`
+	repaired := `{"inventory":[{"id":"S1"}],"findings":[{"id":"F1","sinks":["S1"]}],"ruled_out":[]}`
+	runner := &sequenceRunner{results: []SkillResult{{Report: repaired}}}
+	skill := &db.Skill{Name: deepDiveSkillName, SchemaJSON: semanticValidationTestSchema, OutputKind: "freeform"}
+	scan := &db.Scan{SessionID: "session-1"}
+	w := &Worker{
+		Log:          slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Runner:       runner,
+		SchemaStrict: true,
+	}
+	var events []Event
+	report, err := w.repairAndParseSkillOutput(context.Background(), skill, scan, SkillJob{}, incomplete, func(e Event) {
+		events = append(events, e)
+	})
+	if err != nil {
+		t.Fatalf("repairAndParseSkillOutput: %v", err)
+	}
+	if report != repaired {
+		t.Fatalf("report = %q, want repaired report", report)
+	}
+	if len(runner.jobs) != 1 {
+		t.Fatalf("RunSkill calls = %d, want 1", len(runner.jobs))
+	}
+	if prompt := runner.jobs[0].ResumePrompt; !strings.Contains(prompt, "inventory sink S1 has no disposition") {
+		t.Fatalf("repair prompt missing semantic failure: %q", prompt)
+	}
+	for _, event := range events {
+		if strings.Contains(event.Text, "still does not validate") {
+			t.Fatalf("repair should have revalidated semantic output: %#v", events)
+		}
+	}
+}

--- a/internal/worker/report_semantics_test.go
+++ b/internal/worker/report_semantics_test.go
@@ -93,6 +93,18 @@ func TestValidateSkillReportAppliesSemanticsOnlyToDeepDive(t *testing.T) {
 	}
 }
 
+func TestValidateReportSemanticsKeepsCausalErrorOrder(t *testing.T) {
+	report := `{"inventory":[{"id":"S1"},{"id":"S1"}],"findings":[{"id":"F1","sinks":["S99"]}],"ruled_out":[]}`
+	want := strings.Join([]string{
+		"inventory sink S1 is duplicated",
+		"finding F1 references unknown sink S99",
+		"inventory sink S1 has no disposition",
+	}, "\n")
+	if got := ValidateReportSemantics(deepDiveSkillName, report); got != want {
+		t.Fatalf("ValidateReportSemantics() = %q, want %q", got, want)
+	}
+}
+
 func TestRepairSchemaReportRepairsSemanticFailure(t *testing.T) {
 	incomplete := `{"inventory":[{"id":"S1"}],"findings":[],"ruled_out":[]}`
 	repaired := `{"inventory":[{"id":"S1"}],"findings":[{"id":"F1","sinks":["S1"]}],"ruled_out":[]}`

--- a/internal/worker/schema_validate.go
+++ b/internal/worker/schema_validate.go
@@ -3,7 +3,6 @@ package worker
 import (
 	"encoding/json"
 	"fmt"
-	"sort"
 	"strings"
 
 	"github.com/santhosh-tekuri/jsonschema/v6"
@@ -198,7 +197,6 @@ func formatSemanticValidationErrors(errs []string) string {
 	if len(errs) == 0 {
 		return ""
 	}
-	sort.Strings(errs)
 	if len(errs) <= maxSchemaErrors {
 		return strings.Join(errs, "\n")
 	}

--- a/internal/worker/schema_validate.go
+++ b/internal/worker/schema_validate.go
@@ -1,14 +1,16 @@
 package worker
 
 import (
+	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/santhosh-tekuri/jsonschema/v6"
 )
 
 // SchemaValidationError carries the formatted validator output for a report
-// that did not match its skill's schema. wrap() treats it like
+// that did not pass schema or skill-specific semantic validation. wrap() treats it like
 // FailOnThresholdError: the scan is marked failed but Scan.Report is kept so
 // the operator can inspect what was produced.
 type SchemaValidationError struct {
@@ -17,10 +19,34 @@ type SchemaValidationError struct {
 }
 
 func (e *SchemaValidationError) Error() string {
-	return fmt.Sprintf("report.json failed schema validation for skill %q: %s", e.Skill, e.Detail)
+	return fmt.Sprintf("report.json failed report validation for skill %q: %s", e.Skill, e.Detail)
 }
 
 const maxSchemaErrors = 8
+
+// ValidateSkillReport validates both a skill's JSON Schema and any
+// skill-specific semantic contract. Schema validation always runs first so a
+// malformed report keeps the established JSON/schema error path.
+func ValidateSkillReport(skillName, schemaJSON, report string) string {
+	if detail := ValidateReportSchema(schemaJSON, report); detail != "" {
+		return detail
+	}
+	return ValidateReportSemantics(skillName, report)
+}
+
+// ValidateReportSemantics checks report invariants that JSON Schema cannot
+// express. It intentionally applies only to skills with an explicit contract;
+// all other skills retain their existing schema-only validation behavior.
+func ValidateReportSemantics(skillName, report string) string {
+	if skillName != deepDiveSkillName {
+		return ""
+	}
+	var parsed deepDiveSemanticReport
+	if err := json.Unmarshal([]byte(report), &parsed); err != nil {
+		return "report.json is not valid JSON: " + err.Error()
+	}
+	return validateDeepDiveSinkDispositions(parsed)
+}
 
 // ValidateReportSchema compiles schemaJSON and validates report against it.
 // Returns "" when valid, otherwise a one-line-per-failure summary capped at
@@ -86,4 +112,95 @@ func formatValidationError(ve *jsonschema.ValidationError) string {
 		return ve.Error()
 	}
 	return strings.Join(lines, "\n")
+}
+
+// deepDiveSemanticReport holds only the cross-reference fields needed to
+// verify the inventory coverage invariant. Keeping this separate from finding
+// ingestion means validation does not tighten unrelated report fields.
+type deepDiveSemanticReport struct {
+	Inventory []struct {
+		ID string `json:"id"`
+	} `json:"inventory"`
+	Findings []struct {
+		ID    string   `json:"id"`
+		Sinks []string `json:"sinks"`
+	} `json:"findings"`
+	RuledOut []struct {
+		Sinks []string `json:"sinks"`
+	} `json:"ruled_out"`
+}
+
+func validateDeepDiveSinkDispositions(report deepDiveSemanticReport) string {
+	inventory := make(map[string]struct{}, len(report.Inventory))
+	inventoryOrder := make([]string, 0, len(report.Inventory))
+	var errs []string
+	for i, sink := range report.Inventory {
+		id := strings.TrimSpace(sink.ID)
+		if id == "" {
+			errs = append(errs, fmt.Sprintf("inventory[%d] has an empty id", i))
+			continue
+		}
+		if _, exists := inventory[id]; exists {
+			errs = append(errs, fmt.Sprintf("inventory sink %s is duplicated", id))
+			continue
+		}
+		inventory[id] = struct{}{}
+		inventoryOrder = append(inventoryOrder, id)
+	}
+
+	findingSinks := make(map[string]struct{})
+	for i, finding := range report.Findings {
+		label := fmt.Sprintf("finding[%d]", i)
+		if id := strings.TrimSpace(finding.ID); id != "" {
+			label = "finding " + id
+		}
+		errs = append(errs, validateDispositionReferences(label, finding.Sinks, inventory, findingSinks)...)
+	}
+	ruledOutSinks := make(map[string]struct{})
+	for i, ruledOut := range report.RuledOut {
+		label := fmt.Sprintf("ruled_out[%d]", i)
+		errs = append(errs, validateDispositionReferences(label, ruledOut.Sinks, inventory, ruledOutSinks)...)
+	}
+
+	for _, id := range inventoryOrder {
+		_, found := findingSinks[id]
+		_, ruledOut := ruledOutSinks[id]
+		switch {
+		case found && ruledOut:
+			errs = append(errs, fmt.Sprintf("sink %s appears in both findings and ruled_out", id))
+		case !found && !ruledOut:
+			errs = append(errs, fmt.Sprintf("inventory sink %s has no disposition", id))
+		}
+	}
+	return formatSemanticValidationErrors(errs)
+}
+
+func validateDispositionReferences(label string, sinks []string, inventory, dispositions map[string]struct{}) []string {
+	var errs []string
+	seen := make(map[string]struct{}, len(sinks))
+	for _, rawID := range sinks {
+		id := strings.TrimSpace(rawID)
+		if _, repeated := seen[id]; repeated {
+			errs = append(errs, fmt.Sprintf("%s repeats sink %s", label, id))
+			continue
+		}
+		seen[id] = struct{}{}
+		if _, known := inventory[id]; !known {
+			errs = append(errs, fmt.Sprintf("%s references unknown sink %s", label, id))
+			continue
+		}
+		dispositions[id] = struct{}{}
+	}
+	return errs
+}
+
+func formatSemanticValidationErrors(errs []string) string {
+	if len(errs) == 0 {
+		return ""
+	}
+	sort.Strings(errs)
+	if len(errs) <= maxSchemaErrors {
+		return strings.Join(errs, "\n")
+	}
+	return strings.Join(errs[:maxSchemaErrors], "\n") + fmt.Sprintf("\n... (%d more)", len(errs)-maxSchemaErrors)
 }

--- a/internal/worker/schema_validate_test.go
+++ b/internal/worker/schema_validate_test.go
@@ -178,7 +178,7 @@ func TestParseSkillOutput_schemaWarnAndContinue(t *testing.T) {
 
 	var sawSchemaErr, sawParserSuccess bool
 	for _, e := range events {
-		if e.Kind == KindError && strings.Contains(e.Text, "schema:") {
+		if e.Kind == KindError && strings.Contains(e.Text, "validation:") {
 			sawSchemaErr = true
 		}
 		if strings.Contains(e.Text, "posture: ready") {
@@ -288,14 +288,14 @@ func TestDoSkill_schemaRepairStillInvalidFailsStrict(t *testing.T) {
 	if got.Report != `{"tier":{"x":1}}` {
 		t.Errorf("Report = %q, want original report after invalid repair", got.Report)
 	}
-	if !strings.Contains(got.Error, "schema validation") {
-		t.Errorf("Error = %q, want schema validation error", got.Error)
+	if !strings.Contains(got.Error, "report validation") {
+		t.Errorf("Error = %q, want report validation error", got.Error)
 	}
 	if len(runner.jobs) != 2 {
 		t.Errorf("RunSkill calls = %d, want 2", len(runner.jobs))
 	}
-	if count := strings.Count(got.Log, "does not validate against schema.json"); count != 1 {
-		t.Errorf("schema validation detail logged %d times, want 1; log:\n%s", count, got.Log)
+	if count := strings.Count(got.Log, "does not pass Scrutineer report validation"); count != 1 {
+		t.Errorf("report validation detail logged %d times, want 1; log:\n%s", count, got.Log)
 	}
 }
 
@@ -325,8 +325,8 @@ func TestDoSkill_schemaRepairErrorFallsBackInWarnMode(t *testing.T) {
 	if !strings.Contains(got.Log, "repair attempt for report.json failed: cli flake; parsing original output") {
 		t.Errorf("Log should mention best-effort repair failure, got %q", got.Log)
 	}
-	if count := strings.Count(got.Log, "does not validate against schema.json"); count != 1 {
-		t.Errorf("schema validation detail logged %d times, want 1; log:\n%s", count, got.Log)
+	if count := strings.Count(got.Log, "does not pass Scrutineer report validation"); count != 1 {
+		t.Errorf("report validation detail logged %d times, want 1; log:\n%s", count, got.Log)
 	}
 
 	var repo db.Repository
@@ -371,8 +371,8 @@ func TestParseSkillOutput_schemaMessageUsesOutputFile(t *testing.T) {
 		t.Fatalf("warn mode should not fail on schema mismatch: %v", err)
 	}
 	for _, e := range events {
-		if e.Kind == KindError && strings.Contains(e.Text, "schema:") {
-			if !strings.Contains(e.Text, "custom-output.json does not validate against schema.json") {
+		if e.Kind == KindError && strings.Contains(e.Text, "validation:") {
+			if !strings.Contains(e.Text, "custom-output.json does not pass Scrutineer report validation") {
 				t.Errorf("schema message should use output file, got %q", e.Text)
 			}
 			return
@@ -433,8 +433,8 @@ func TestWrap_schemaStrictKeepsReportOnFailure(t *testing.T) {
 	if got.Report != report {
 		t.Errorf("Report = %q, want preserved %q", got.Report, report)
 	}
-	if !strings.Contains(got.Error, "schema validation") {
-		t.Errorf("Error = %q, want mention of schema validation", got.Error)
+	if !strings.Contains(got.Error, "report validation") {
+		t.Errorf("Error = %q, want mention of report validation", got.Error)
 	}
 }
 

--- a/internal/worker/skill.go
+++ b/internal/worker/skill.go
@@ -23,7 +23,8 @@ const (
 	skillSchemaFile           = "schema.json"
 	schemaRepairMaxTurns      = 4
 	schemaRepairReportMaxSize = 4000
-	refusalAuditSkillName     = "security-deep-dive"
+	deepDiveSkillName         = "security-deep-dive"
+	refusalAuditSkillName     = deepDiveSkillName
 	refusalAuditOutputFile    = "refusal_audit.json"
 	refusalAuditMaxTurns      = 3
 	threatModelSkillName      = "threat-model"
@@ -276,7 +277,7 @@ func (w *Worker) parsePartialSkillReport(skill *db.Skill, scan *db.Scan, report 
 
 func (w *Worker) repairAndParseSkillOutput(ctx context.Context, skill *db.Skill, scan *db.Scan, sj SkillJob, report string, emit func(Event)) (string, error) {
 	if skill.SchemaJSON != "" {
-		if detail := ValidateReportSchema(skill.SchemaJSON, report); detail != "" {
+		if detail := ValidateSkillReport(skill.Name, skill.SchemaJSON, report); detail != "" {
 			if repairedReport, ok := w.repairSchemaReport(ctx, skill, scan, sj, report, detail, emit); ok {
 				report = repairedReport
 			}
@@ -294,7 +295,7 @@ func (w *Worker) repairSchemaReport(ctx context.Context, skill *db.Skill, scan *
 		return "", false
 	}
 
-	emit(Event{Kind: KindText, Text: fmt.Sprintf("schema: %s failed validation; asking the agent to repair it", outputFile)})
+	emit(Event{Kind: KindText, Text: fmt.Sprintf("validation: %s failed validation; asking the agent to repair it", outputFile)})
 	repairJob := sj
 	repairJob.ResumeSessionID = scan.SessionID
 	repairJob.ResumePrompt = buildSchemaRepairPrompt(skill, detail, report)
@@ -302,24 +303,24 @@ func (w *Worker) repairSchemaReport(ctx context.Context, skill *db.Skill, scan *
 	res, err := w.Runner.RunSkill(ctx, repairJob, emit)
 	w.applySkillResult(scan, res)
 	if err != nil {
-		emit(Event{Kind: KindError, Text: fmt.Sprintf("schema: repair attempt for %s failed: %v; parsing original output", outputFile, err)})
+		emit(Event{Kind: KindError, Text: fmt.Sprintf("validation: repair attempt for %s failed: %v; parsing original output", outputFile, err)})
 		return "", false
 	}
 	if res.Report == "" {
-		emit(Event{Kind: KindError, Text: fmt.Sprintf("schema: repair attempt did not produce %s; parsing original output", outputFile)})
+		emit(Event{Kind: KindError, Text: fmt.Sprintf("validation: repair attempt did not produce %s; parsing original output", outputFile)})
 		return "", false
 	}
-	if detail = ValidateReportSchema(skill.SchemaJSON, res.Report); detail == "" {
-		emit(Event{Kind: KindText, Text: fmt.Sprintf("schema: repaired %s validates", outputFile)})
+	if detail = ValidateSkillReport(skill.Name, skill.SchemaJSON, res.Report); detail == "" {
+		emit(Event{Kind: KindText, Text: fmt.Sprintf("validation: repaired %s validates", outputFile)})
 		return res.Report, true
 	}
-	emit(Event{Kind: KindText, Text: fmt.Sprintf("schema: repaired %s still does not validate; parsing original output", outputFile)})
+	emit(Event{Kind: KindText, Text: fmt.Sprintf("validation: repaired %s still does not validate; parsing original output", outputFile)})
 	return "", false
 }
 
 func buildSchemaRepairPrompt(skill *db.Skill, detail, report string) string {
 	outputFile := skillOutputFile(skill)
-	return fmt.Sprintf(`Your previous %q skill run wrote ./%s, but it failed validation against ./%s.
+	return fmt.Sprintf(`Your previous %q skill run wrote ./%s, but it failed Scrutineer report validation against ./%s and any skill-specific report rules.
 
 Validation errors:
 %s
@@ -337,8 +338,8 @@ func skillOutputFile(skill *db.Skill) string {
 	return defaultSkillOutputFile
 }
 
-func schemaValidationEvent(skill *db.Skill, detail string) Event {
-	return Event{Kind: KindError, Text: fmt.Sprintf("schema: %s does not validate against %s:\n%s", skillOutputFile(skill), skillSchemaFile, detail)}
+func reportValidationEvent(skill *db.Skill, detail string) Event {
+	return Event{Kind: KindError, Text: fmt.Sprintf("validation: %s does not pass Scrutineer report validation:\n%s", skillOutputFile(skill), detail)}
 }
 
 func truncateSchemaRepairReport(report string) string {
@@ -351,8 +352,8 @@ func truncateSchemaRepairReport(report string) string {
 
 func (w *Worker) parseSkillOutput(skill *db.Skill, scan *db.Scan, report string, emit func(Event)) error {
 	if skill.SchemaJSON != "" {
-		if detail := ValidateReportSchema(skill.SchemaJSON, report); detail != "" {
-			emit(schemaValidationEvent(skill, detail))
+		if detail := ValidateSkillReport(skill.Name, skill.SchemaJSON, report); detail != "" {
+			emit(reportValidationEvent(skill, detail))
 			if w.SchemaStrict {
 				return &SchemaValidationError{Skill: skill.Name, Detail: detail}
 			}
@@ -1355,7 +1356,7 @@ func (w *Worker) parseReconContext(reconScan db.Scan) (*skillContextRecon, error
 		}
 		return nil, fmt.Errorf("load recon schema: %w", err)
 	}
-	report, err := parseReconReport(reconSkill.SchemaJSON, reconScan.Report)
+	report, err := parseReconReport(reconSkill.Name, reconSkill.SchemaJSON, reconScan.Report)
 	if err != nil {
 		w.Log.Warn("ignore invalid recon report", "scan", reconScan.ID, "err", err)
 		return nil, nil
@@ -1363,8 +1364,8 @@ func (w *Worker) parseReconContext(reconScan db.Scan) (*skillContextRecon, error
 	return report, nil
 }
 
-func parseReconReport(schema, raw string) (*skillContextRecon, error) {
-	if detail := ValidateReportSchema(schema, raw); detail != "" {
+func parseReconReport(skillName, schema, raw string) (*skillContextRecon, error) {
+	if detail := ValidateSkillReport(skillName, schema, raw); detail != "" {
 		return nil, errors.New(detail)
 	}
 	var report skillContextRecon

--- a/internal/worker/skill.go
+++ b/internal/worker/skill.go
@@ -325,7 +325,7 @@ func buildSchemaRepairPrompt(skill *db.Skill, detail, report string) string {
 Validation errors:
 %s
 
-Rewrite only ./%s with JSON that validates against ./%s. Preserve the facts from the previous run, do not restart the analysis, and do not write prose outside the JSON file.
+Rewrite only ./%s with JSON that satisfies every validation requirement above: it must validate against ./%s and comply with any skill-specific report rules. Preserve the facts from the previous run, do not restart the analysis, and do not write prose outside the JSON file.
 
 Previous invalid ./%s:
 %s`, skill.Name, outputFile, skillSchemaFile, detail, outputFile, skillSchemaFile, outputFile, truncateSchemaRepairReport(report))


### PR DESCRIPTION
Fixes #662

## Summary

Adds skill-specific semantic validation for `security-deep-dive` reports so every inventoried sink has one consistent disposition.

## Changes

- Require unique inventory sink IDs.
- Require each inventory sink to be referenced by either a finding or a `ruled_out` entry.
- Reject unknown, repeated, and conflicting sink references.
- Apply the semantic checks during normal parsing, repair attempts, the report-validation API and eval runs.
- Keep all non-deep-dive skills on their existing JSON-Schema-only validation path.
- Add coverage for each semantic invariant and eval rejection of an incomplete deep-dive report.

## Tests

- `go test ./...`
- `go test -tags evals ./...`
- `go vet ./...`
- `go vet -tags evals ./...`
- `golangci-lint run ./cmd/... ./internal/...`
- `golangci-lint run --build-tags evals ./cmd/... ./internal/...`
- `git diff --check`