### PR TITLE
Make analyst form finding updates atomic

### DIFF
--- a/internal/web/finding_forms.go
+++ b/internal/web/finding_forms.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	"scrutineer/internal/db"
+
+	"gorm.io/gorm"
 )
 
 // The browser-form handlers write finding mutations with
@@ -31,15 +33,20 @@ func (s *Server) findingFields(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-	for _, field := range analystFields {
-		value, ok := r.Form[field]
-		if !ok {
-			continue
+	if err := s.DB.Transaction(func(tx *gorm.DB) error {
+		for _, field := range analystFields {
+			value, ok := r.Form[field]
+			if !ok {
+				continue
+			}
+			if err := db.WriteFindingField(tx, f.ID, field, strings.TrimSpace(value[0]), db.SourceAnalyst, ""); err != nil {
+				return err
+			}
 		}
-		if err := db.WriteFindingField(s.DB, f.ID, field, strings.TrimSpace(value[0]), db.SourceAnalyst, ""); err != nil {
-			http.Error(w, err.Error(), http.StatusUnprocessableEntity)
-			return
-		}
+		return nil
+	}); err != nil {
+		http.Error(w, err.Error(), http.StatusUnprocessableEntity)
+		return
 	}
 	s.redirect(w, r, fmt.Sprintf("/findings/%d", f.ID))
 }

--- a/internal/web/finding_forms_test.go
+++ b/internal/web/finding_forms_test.go
@@ -77,6 +77,64 @@ func TestFindingFields(t *testing.T) {
 	}
 }
 
+func TestFindingFieldsAtomicRollback(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	f := seedFindingForForm(t, s)
+	path := fmt.Sprintf("/findings/%d/fields", f.ID)
+
+	w := postForm(t, s, path, url.Values{
+		"cve_id":  {"CVE-2026-12345"},
+		"ghsa_id": {"not-a-ghsa"},
+	})
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d, want 422; body=%s", w.Code, w.Body)
+	}
+
+	var got db.Finding
+	s.DB.First(&got, f.ID)
+	if got.CVEID != "" || got.GHSAID != "" {
+		t.Fatalf("finding fields committed despite failed form: cve=%q ghsa=%q", got.CVEID, got.GHSAID)
+	}
+	var hist []db.FindingHistory
+	s.DB.Where("finding_id = ?", f.ID).Find(&hist)
+	if len(hist) != 0 {
+		t.Fatalf("history rows = %d, want 0 after rollback: %+v", len(hist), hist)
+	}
+}
+
+func TestFindingFieldsCVSSSyncsInsideTransaction(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	f := seedFindingForForm(t, s)
+	path := fmt.Sprintf("/findings/%d/fields", f.ID)
+	const vec = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+
+	w := postForm(t, s, path, url.Values{
+		"cvss_vector": {vec},
+		"severity":    {"Critical"},
+	})
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("status = %d, want 303; body=%s", w.Code, w.Body)
+	}
+
+	var got db.Finding
+	s.DB.First(&got, f.ID)
+	if got.CVSSVector != vec || got.CVSSScore != 9.8 || got.Severity != "Critical" {
+		t.Fatalf("finding after form: vector=%q score=%v severity=%q", got.CVSSVector, got.CVSSScore, got.Severity)
+	}
+	var hist []db.FindingHistory
+	s.DB.Where("finding_id = ?", f.ID).Order("field").Find(&hist)
+	fields := make([]string, 0, len(hist))
+	for _, h := range hist {
+		fields = append(fields, h.Field)
+	}
+	want := []string{"cvss_score", "cvss_vector", "severity"}
+	if fmt.Sprint(fields) != fmt.Sprint(want) {
+		t.Fatalf("history fields = %v, want %v", fields, want)
+	}
+}
+
 func TestFindingCommunications(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()


### PR DESCRIPTION
Fixes #600

## Summary

- wrap analyst browser-form field updates in one outer database transaction
- preserve the existing analyst field allow-list, trimming, validation, no-op, history, and 422 behavior
- add regression coverage for multi-field rollback and CVSS score synchronization inside the transaction

## Tests

- `go test ./internal/web -run 'TestFindingFields' -count=1`
- `go test -race ./internal/web -run 'TestFindingFields' -count=1`
- `go test ./...`
- `go vet ./...`
- `git diff --check`

## AI disclosure

Implemented with OpenAI Codex assistance and verified with the repository tests listed above.