### PR TITLE
feat(worker): add bounded retries for transient remote git failures

### DIFF
--- a/internal/worker/clone.go
+++ b/internal/worker/clone.go
@@ -2,17 +2,34 @@ package worker
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 
 	"scrutineer/internal/db"
 )
 
 const dirPerm = 0o755
+
+// The add-repo branch picker's share of the remote-git retry policy. It is
+// smaller than a scan's because it sits in front of a person: worst case one
+// extra ls-remote and a fifth of a second, well inside the caller's request
+// deadline.
+const (
+	branchPickerAttempts = 2
+	branchPickerDelay    = 200 * time.Millisecond
+)
+
+// gitWaitDelay bounds how long a git invocation may sit in Wait after the
+// process has exited or been cancelled while a transport grandchild still
+// holds its output pipe. A package var so a test can shrink it; large enough
+// in production never to clip a healthy command's final flush.
+var gitWaitDelay = 10 * time.Second
 
 // RepoUnreachableError is returned when git clone/fetch fails because the
 // remote is unreachable (deleted, private, wrong URL, network error).
@@ -69,7 +86,14 @@ func ensureClone(ctx context.Context, repo db.Repository, work string, fullClone
 	if err := os.MkdirAll(work, dirPerm); err != nil {
 		return "", err
 	}
-	if err := cloneOrFetch(ctx, repo.URL, src, fullClone, ref, emit); err != nil {
+	if err := cloneOrFetch(ctx, gitRetry{}, repo.URL, src, fullClone, ref, emit); err != nil {
+		// A cancelled or timed-out scan is not evidence about the repository:
+		// flagging it unreachable would record a spurious clone_error and
+		// hand the caller a fake "repository unreachable" report. Propagate
+		// the cancellation instead so the worker treats it as one.
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return "", err
+		}
 		return "", &RepoUnreachableError{URL: repo.URL, Err: err}
 	}
 	return src, nil
@@ -116,7 +140,7 @@ func ValidateGitRef(ref string) error {
 	return nil
 }
 
-func cloneOrFetch(ctx context.Context, url, dst string, fullClone bool, ref string, emit func(Event)) error {
+func cloneOrFetch(ctx context.Context, retry gitRetry, url, dst string, fullClone bool, ref string, emit func(Event)) error {
 	if err := validateGitURL(url); err != nil {
 		return err
 	}
@@ -124,7 +148,7 @@ func cloneOrFetch(ctx context.Context, url, dst string, fullClone bool, ref stri
 		return err
 	}
 	if _, err := os.Stat(filepath.Join(dst, ".git")); err == nil {
-		return fetchRef(ctx, dst, ref, fullClone, emit)
+		return fetchRef(ctx, retry, dst, ref, fullClone, emit)
 	}
 	args := []string{"clone", "--quiet"}
 	msg := "$ git clone " + url
@@ -134,7 +158,12 @@ func cloneOrFetch(ctx context.Context, url, dst string, fullClone bool, ref stri
 	}
 	args = append(args, "--", url, dst)
 	emit(Event{Kind: KindText, Text: msg})
-	out, err := gitWithEnv(ctx, "", []string{"GIT_PROTOCOL_FROM_USER=0"}, args...)
+	out, err := retry.do(ctx, gitCommand{
+		label: "clone",
+		env:   []string{"GIT_PROTOCOL_FROM_USER=0"},
+		args:  args,
+		reset: cloneDestReset(dst),
+	}, emit)
 	if err != nil {
 		return fmt.Errorf("%s: %w", out, err)
 	}
@@ -143,9 +172,31 @@ func cloneOrFetch(ctx context.Context, url, dst string, fullClone bool, ref stri
 	// in the branch field would fail the first scan yet work on every later
 	// one. Going through fetchRef makes both paths pin a ref identically.
 	if ref != "" {
-		return fetchRef(ctx, dst, ref, fullClone, emit)
+		return fetchRef(ctx, retry, dst, ref, fullClone, emit)
 	}
 	return nil
+}
+
+// cloneDestReset returns the cleanup to run before each clone retry, or nil
+// when there is nothing safe to clean. A clone that dies partway can leave
+// the destination behind, and `git clone` refuses a non-empty target, so
+// without this the retry would fail for a reason unrelated to the original
+// failure.
+//
+// Removal is offered only when dst is absent or empty at this point.
+// cloneOrFetch reaches the clone path exactly when dst holds no .git, so an
+// absent or empty dst can only ever gain content this call put there. A
+// non-empty one belongs to the caller, and git would reject it as a
+// permanent error that is never retried anyway.
+func cloneDestReset(dst string) func() error {
+	entries, err := os.ReadDir(dst)
+	if err != nil && !os.IsNotExist(err) {
+		return nil
+	}
+	if len(entries) > 0 {
+		return nil
+	}
+	return func() error { return os.RemoveAll(dst) }
 }
 
 // fetchRef updates an existing cache checkout to ref, or to the remote's
@@ -155,7 +206,7 @@ func cloneOrFetch(ctx context.Context, url, dst string, fullClone bool, ref stri
 // first cloned at. A different ref — another maintained release branch, a
 // tag, or a commit — is in no remote-tracking ref, but fetching it by name
 // always lands it in FETCH_HEAD.
-func fetchRef(ctx context.Context, dst, ref string, fullClone bool, emit func(Event)) error {
+func fetchRef(ctx context.Context, retry gitRetry, dst, ref string, fullClone bool, emit func(Event)) error {
 	target := ref
 	if target == "" {
 		target = "HEAD"
@@ -174,9 +225,11 @@ func fetchRef(ctx context.Context, dst, ref string, fullClone bool, emit func(Ev
 	// and ls-remote paths. Valid refs never start with "-" so this is safe.
 	fetchArgs = append(fetchArgs, "--", "origin", target)
 	emit(Event{Kind: KindText, Text: fetchMsg})
-	if out, err := git(ctx, "", fetchArgs...); err != nil {
+	if out, err := retry.do(ctx, gitCommand{label: "fetch", args: fetchArgs}, emit); err != nil {
 		return fmt.Errorf("%s: %w", out, err)
 	}
+	// The reset is local: it can only fail for a reason a retry cannot fix,
+	// so it stays outside the network retry policy.
 	if out, err := git(ctx, "", "-C", dst, "reset", "--quiet", "--hard", "FETCH_HEAD"); err != nil {
 		return fmt.Errorf("%s: %w", out, err)
 	}
@@ -188,12 +241,27 @@ func fetchRef(ctx context.Context, dst, ref string, fullClone bool, emit func(Ev
 // best-effort: callers treat any error as "no suggestions" and fall back to
 // free-text entry. GIT_TERMINAL_PROMPT=0 and an empty credential helper make
 // a private repo fail fast instead of blocking on a credential prompt.
+//
+// A transient failure is retried, but on a deliberately tighter budget than
+// a scan's: this runs inside a short request deadline, and the failure a
+// user actually hits here is a mistyped host, which resolves to a transient
+// marker. One extra attempt after ~200ms absorbs a genuine blip while
+// keeping a typo's feedback prompt. An auth or not-found answer stays
+// permanent and is never retried at all.
 func ListRemoteBranches(ctx context.Context, cloneURL string) ([]string, error) {
 	if err := validateGitURL(cloneURL); err != nil {
 		return nil, err
 	}
-	out, err := gitWithEnv(ctx, "", []string{"GIT_TERMINAL_PROMPT=0"},
-		"-c", "credential.helper=", "ls-remote", "--heads", "--", cloneURL)
+	picker := gitRetry{
+		attempts:  branchPickerAttempts,
+		baseDelay: branchPickerDelay,
+		maxDelay:  branchPickerDelay,
+	}
+	out, err := picker.do(ctx, gitCommand{
+		label: "ls-remote",
+		env:   []string{"GIT_TERMINAL_PROMPT=0"},
+		args:  []string{"-c", "credential.helper=", "ls-remote", "--heads", "--", cloneURL},
+	}, nil)
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", strings.TrimSpace(out), err)
 	}
@@ -238,6 +306,14 @@ func git(ctx context.Context, dir string, args ...string) (string, error) {
 
 func gitWithEnv(ctx context.Context, dir string, env []string, args ...string) (string, error) {
 	cmd := exec.CommandContext(ctx, "git", args...)
+	// CommandContext kills git when ctx ends, but git's transport child
+	// (git-remote-https) inherits the output pipe, so CombinedOutput can block
+	// on that grandchild long after git is gone -- turning "stop immediately
+	// on cancellation" into an unbounded wait. WaitDelay bounds it: once git
+	// has exited or been cancelled, Wait waits at most this long for the pipe
+	// to close, then closes it and returns. It never truncates a normally
+	// completing command, whose pipe closes at once.
+	cmd.WaitDelay = gitWaitDelay
 	if dir != "" {
 		cmd.Dir = dir
 	}

--- a/internal/worker/clone_retry_test.go
+++ b/internal/worker/clone_retry_test.go
@@ -1,0 +1,381 @@
+package worker
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// These exercise the retry policy through the real exec path rather than an
+// injected runner, so they also cover the argv, environment, and cleanup the
+// clone and fetch call sites hand to it. A `git` shim ahead of the real one
+// on PATH stands in for the remote; body is shell, and reads the invocation
+// number from $n and the last argument (the clone destination) from $dst.
+type fakeGit struct {
+	t   *testing.T
+	dir string
+}
+
+func fakeGitOnPath(t *testing.T, body string) *fakeGit {
+	t.Helper()
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("needs a POSIX shell to stub git")
+	}
+	f := &fakeGit{t: t, dir: t.TempDir()}
+	script := fmt.Sprintf(`#!/bin/sh
+echo "$@" >> %q
+printf 'GIT_TERMINAL_PROMPT=%%s GIT_PROTOCOL_FROM_USER=%%s\n' \
+  "${GIT_TERMINAL_PROMPT-unset}" "${GIT_PROTOCOL_FROM_USER-unset}" >> %q
+n=$(wc -l < %q | tr -d ' ')
+dst=$(eval echo \${$#})
+%s
+`, f.callsPath(), f.envPath(), f.callsPath(), body)
+	if err := os.WriteFile(filepath.Join(f.dir, "git"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", f.dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	return f
+}
+
+func (f *fakeGit) callsPath() string { return filepath.Join(f.dir, "calls.log") }
+func (f *fakeGit) envPath() string   { return filepath.Join(f.dir, "env.log") }
+
+// calls returns the argv of each invocation, one entry per attempt.
+func (f *fakeGit) calls() []string { return f.readLines(f.callsPath()) }
+
+// env returns the hardening variables each invocation actually saw.
+func (f *fakeGit) env() []string { return f.readLines(f.envPath()) }
+
+func (f *fakeGit) readLines(path string) []string {
+	f.t.Helper()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		f.t.Fatal(err)
+	}
+	var lines []string
+	for _, line := range strings.Split(strings.TrimSpace(string(raw)), "\n") {
+		if line != "" {
+			lines = append(lines, line)
+		}
+	}
+	return lines
+}
+
+// fastRetry keeps the real classification and attempt budget but collapses
+// the backoff, so these tests cost no wall-clock time.
+func fastRetry() gitRetry {
+	return gitRetry{sleep: func(context.Context, time.Duration) error { return nil }}
+}
+
+// TestCloneOrFetchRetriesTransientCloneFailure is the regression for #630:
+// on the unmodified base a single transport hiccup ends the scan, because
+// `git clone` was invoked exactly once.
+func TestCloneOrFetchRetriesTransientCloneFailure(t *testing.T) {
+	git := fakeGitOnPath(t, `if [ "$n" = "1" ]; then
+  echo "fatal: unable to access 'https://example.invalid/repo/': Could not resolve host: example.invalid" >&2
+  exit 128
+fi
+exit 0
+`)
+	dst := filepath.Join(t.TempDir(), "src")
+
+	err := cloneOrFetch(context.Background(), fastRetry(), "https://example.invalid/repo", dst, false, "", func(Event) {})
+	if err != nil {
+		t.Errorf("cloneOrFetch after one transient failure: %v", err)
+	}
+	if calls := git.calls(); len(calls) != 2 {
+		t.Errorf("git invocations = %d (%v), want 2: the first attempt plus one retry", len(calls), calls)
+	}
+}
+
+// TestFetchRefRetriesTransientFetchFailure covers the cache-reuse path, and
+// pins that the local reset still runs once the fetch succeeds.
+func TestFetchRefRetriesTransientFetchFailure(t *testing.T) {
+	git := fakeGitOnPath(t, `if [ "$n" = "1" ]; then
+  echo "fatal: the remote end hung up unexpectedly" >&2
+  exit 128
+fi
+exit 0
+`)
+
+	err := fetchRef(context.Background(), fastRetry(), t.TempDir(), "main", false, func(Event) {})
+	if err != nil {
+		t.Errorf("fetchRef after one transient failure: %v", err)
+	}
+	calls := git.calls()
+	if len(calls) != 3 {
+		t.Fatalf("git invocations = %d (%v), want 3: fetch, fetch retry, reset", len(calls), calls)
+	}
+	if !strings.Contains(calls[2], "reset") {
+		t.Errorf("third invocation = %q, want the local reset", calls[2])
+	}
+}
+
+// TestFetchRefDoesNotRetryLocalReset keeps the network policy off local
+// work: repeating `git reset --hard` cannot fix whatever made it fail.
+func TestFetchRefDoesNotRetryLocalReset(t *testing.T) {
+	git := fakeGitOnPath(t, `case "$*" in
+*reset*)
+  echo "fatal: unable to access: Connection reset by peer" >&2
+  exit 128
+  ;;
+esac
+exit 0
+`)
+
+	if err := fetchRef(context.Background(), fastRetry(), t.TempDir(), "main", false, func(Event) {}); err == nil {
+		t.Error("expected the failing reset to surface")
+	}
+	if calls := git.calls(); len(calls) != 2 {
+		t.Errorf("git invocations = %d (%v), want 2: fetch then a single reset", len(calls), calls)
+	}
+}
+
+// TestCloneOrFetchDoesNotRetryPermanentFailure guards the other side of the
+// policy: a settled answer about the repository costs exactly one attempt,
+// as it did before.
+func TestCloneOrFetchDoesNotRetryPermanentFailure(t *testing.T) {
+	git := fakeGitOnPath(t, `echo "remote: Repository not found." >&2
+echo "fatal: repository 'https://example.invalid/repo/' not found" >&2
+exit 128
+`)
+	dst := filepath.Join(t.TempDir(), "src")
+
+	err := cloneOrFetch(context.Background(), fastRetry(), "https://example.invalid/repo", dst, false, "", func(Event) {})
+	if err == nil {
+		t.Error("cloneOrFetch on a missing repository should fail")
+	}
+	if calls := git.calls(); len(calls) != 1 {
+		t.Errorf("git invocations = %d (%v), want 1: no retry for a permanent failure", len(calls), calls)
+	}
+}
+
+// TestCloneOrFetchClearsPartialDestinationBeforeRetry covers the cleanup a
+// retried clone needs: the stub leaves a half-written destination behind on
+// its first attempt and rejects a non-empty target on the second, exactly as
+// git does.
+func TestCloneOrFetchClearsPartialDestinationBeforeRetry(t *testing.T) {
+	git := fakeGitOnPath(t, `if [ "$n" = "1" ]; then
+  mkdir -p "$dst/.git"
+  echo partial > "$dst/partial"
+  echo "fatal: unable to access 'https://example.invalid/repo/': Connection reset by peer" >&2
+  exit 128
+fi
+if [ -e "$dst" ] && [ -n "$(ls -A "$dst" 2>/dev/null)" ]; then
+  echo "fatal: destination path '$dst' already exists and is not an empty directory." >&2
+  exit 128
+fi
+exit 0
+`)
+	dst := filepath.Join(t.TempDir(), "src")
+
+	err := cloneOrFetch(context.Background(), fastRetry(), "https://example.invalid/repo", dst, false, "", func(Event) {})
+	if err != nil {
+		t.Errorf("cloneOrFetch should clear the partial clone and retry cleanly: %v", err)
+	}
+	if calls := git.calls(); len(calls) != 2 {
+		t.Errorf("git invocations = %d (%v), want 2", len(calls), calls)
+	}
+}
+
+// TestRemoteGitKeepsEnvironmentHardening pins the environment each remote
+// invocation runs with, on the retry as well as the first attempt. Both
+// variables used to sit in the positional argument list; moving them into an
+// optional struct field makes dropping one much easier to miss in review.
+//
+// Each case first sets the variable to the *wrong* value. That is not
+// decoration: `go test` runs the test binary with GIT_TERMINAL_PROMPT=0
+// already exported (cmd/go sets it for module fetches), so a child process
+// inherits the desired value whether or not the call site asks for it, and
+// an assertion without this override would hold even if the call site
+// dropped the variable entirely.
+func TestRemoteGitKeepsEnvironmentHardening(t *testing.T) {
+	t.Run("clone refuses a user-supplied protocol", func(t *testing.T) {
+		t.Setenv("GIT_PROTOCOL_FROM_USER", "1")
+		git := fakeGitOnPath(t, `if [ "$n" = "1" ]; then
+  echo "fatal: unable to access 'https://example.invalid/repo/': Connection reset by peer" >&2
+  exit 128
+fi
+exit 0
+`)
+		dst := filepath.Join(t.TempDir(), "src")
+		if err := cloneOrFetch(context.Background(), fastRetry(), "https://example.invalid/repo", dst, false, "", func(Event) {}); err != nil {
+			t.Fatalf("cloneOrFetch: %v", err)
+		}
+		env := git.env()
+		if len(env) != 2 {
+			t.Fatalf("recorded %d environments (%v), want 2", len(env), env)
+		}
+		for i, line := range env {
+			if !strings.Contains(line, "GIT_PROTOCOL_FROM_USER=0") {
+				t.Errorf("attempt %d ran with %q, want GIT_PROTOCOL_FROM_USER=0", i+1, line)
+			}
+		}
+	})
+
+	t.Run("ls-remote refuses a credential prompt", func(t *testing.T) {
+		t.Setenv("GIT_TERMINAL_PROMPT", "1")
+		git := fakeGitOnPath(t, `if [ "$n" = "1" ]; then
+  echo "fatal: unable to access 'https://example.invalid/repo/': Connection reset by peer" >&2
+  exit 128
+fi
+printf 'deadbeef\trefs/heads/main\n'
+exit 0
+`)
+		if _, err := ListRemoteBranches(context.Background(), "https://example.invalid/repo"); err != nil {
+			t.Fatalf("ListRemoteBranches: %v", err)
+		}
+		env := git.env()
+		if len(env) != 2 {
+			t.Fatalf("recorded %d environments (%v), want 2", len(env), env)
+		}
+		for i, line := range env {
+			if !strings.Contains(line, "GIT_TERMINAL_PROMPT=0") {
+				t.Errorf("attempt %d ran with %q, want GIT_TERMINAL_PROMPT=0", i+1, line)
+			}
+		}
+	})
+}
+
+// TestCloneDestResetKeepsCallerContent is the safety bound on that cleanup:
+// a destination that already holds files is never removed. git rejects it as
+// a permanent error anyway, so the retry policy never reaches this state --
+// but the guard is what makes removing an empty destination provably safe.
+func TestCloneDestResetKeepsCallerContent(t *testing.T) {
+	occupied := t.TempDir()
+	keep := filepath.Join(occupied, "keep")
+	if err := os.WriteFile(keep, []byte("caller content"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if reset := cloneDestReset(occupied); reset != nil {
+		t.Fatal("cloneDestReset must not offer to remove a non-empty destination")
+	}
+
+	empty := t.TempDir()
+	reset := cloneDestReset(empty)
+	if reset == nil {
+		t.Fatal("cloneDestReset should clean an empty destination")
+	}
+	if err := reset(); err != nil {
+		t.Fatalf("reset: %v", err)
+	}
+	if _, err := os.Stat(empty); !os.IsNotExist(err) {
+		t.Errorf("empty destination still present after reset: %v", err)
+	}
+
+	absent := filepath.Join(t.TempDir(), "missing")
+	if reset := cloneDestReset(absent); reset == nil {
+		t.Error("cloneDestReset should clean an absent destination")
+	}
+}
+
+// TestListRemoteBranchesRetriesTransientFailure covers the branch picker:
+// the add-repo form loses its suggestions on a single hiccup otherwise. It
+// runs on the real (tight) picker policy, so it also demonstrates the added
+// latency a person can actually see.
+func TestListRemoteBranchesRetriesTransientFailure(t *testing.T) {
+	git := fakeGitOnPath(t, `if [ "$n" = "1" ]; then
+  echo "fatal: unable to access 'https://example.invalid/repo/': Failed to connect to example.invalid port 443: Connection refused" >&2
+  exit 128
+fi
+printf 'deadbeef\trefs/heads/main\n'
+exit 0
+`)
+
+	branches, err := ListRemoteBranches(context.Background(), "https://example.invalid/repo")
+	if err != nil {
+		t.Fatalf("ListRemoteBranches after one transient failure: %v", err)
+	}
+	if len(branches) != 1 || branches[0] != "main" {
+		t.Errorf("branches = %v, want [main]", branches)
+	}
+	calls := git.calls()
+	if len(calls) != 2 {
+		t.Fatalf("git invocations = %d (%v), want 2", len(calls), calls)
+	}
+	// Every attempt, retry included, must keep disarming the user's
+	// credential helper -- dropping `-c credential.helper=` would let an
+	// ambient helper answer for an arbitrary URL typed into the add-repo box.
+	for i, call := range calls {
+		if !strings.Contains(call, "-c credential.helper= ls-remote --heads") {
+			t.Errorf("attempt %d argv = %q, want it to disarm the credential helper", i+1, call)
+		}
+	}
+}
+
+// TestBranchPickerPolicyResolvesToItsOwnDelay guards the footgun resolved()
+// hides: a zero delay is read as "unset" and replaced by the scan default,
+// so the picker must be built with a positive delay to stay tight. Pinning
+// the resolved value keeps a future edit from silently inheriting the slower
+// scan backoff inside the user-facing request deadline.
+func TestBranchPickerPolicyResolvesToItsOwnDelay(t *testing.T) {
+	resolved := gitRetry{
+		attempts:  branchPickerAttempts,
+		baseDelay: branchPickerDelay,
+		maxDelay:  branchPickerDelay,
+	}.resolved()
+	if resolved.baseDelay != branchPickerDelay || resolved.maxDelay != branchPickerDelay {
+		t.Errorf("resolved picker delay = (%v, %v), want (%v, %v): a zero constant would inherit the scan default %v",
+			resolved.baseDelay, resolved.maxDelay, branchPickerDelay, branchPickerDelay, gitRetryBaseDelay)
+	}
+	if resolved.attempts != branchPickerAttempts {
+		t.Errorf("resolved picker attempts = %d, want %d", resolved.attempts, branchPickerAttempts)
+	}
+}
+
+// TestListRemoteBranchesFailsFastOnPrivateRepo keeps the picker's fail-fast
+// behaviour for the case it was built around: credentials are unavailable,
+// which is an answer, not a hiccup.
+func TestListRemoteBranchesFailsFastOnPrivateRepo(t *testing.T) {
+	git := fakeGitOnPath(t, `echo "fatal: could not read Username for 'https://example.invalid': terminal prompts disabled" >&2
+exit 128
+`)
+
+	if _, err := ListRemoteBranches(context.Background(), "https://example.invalid/repo"); err == nil {
+		t.Error("expected an error for a repository needing credentials")
+	}
+	if calls := git.calls(); len(calls) != 1 {
+		t.Errorf("git invocations = %d (%v), want 1", len(calls), calls)
+	}
+}
+
+// TestGitWithEnvBoundsLingeringChild pins that "stop immediately on
+// cancellation" is real even when git's transport child keeps the output
+// pipe open after git itself is gone. The shim exits at once but leaves a
+// background sleeper holding stdout; without WaitDelay, CombinedOutput would
+// block on that sleeper for its full lifetime.
+func TestGitWithEnvBoundsLingeringChild(t *testing.T) {
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("needs a POSIX shell to stub git")
+	}
+	bin := t.TempDir()
+	// The parent exits immediately; `sleep 30 &` inherits and holds stdout.
+	script := "#!/bin/sh\nsleep 30 &\nexit 0\n"
+	if err := os.WriteFile(filepath.Join(bin, "git"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	prev := gitWaitDelay
+	gitWaitDelay = 200 * time.Millisecond
+	defer func() { gitWaitDelay = prev }()
+
+	done := make(chan struct{})
+	go func() {
+		_, _ = gitWithEnv(context.Background(), "", nil, "clone", "https://example.invalid/repo")
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("gitWithEnv blocked on a lingering child instead of bounding it with WaitDelay")
+	}
+}

--- a/internal/worker/clone_test.go
+++ b/internal/worker/clone_test.go
@@ -149,7 +149,7 @@ func TestFetchRefChecksOutRequestedRef(t *testing.T) {
 		{"", mainSHA},           // empty ref -> default branch
 	}
 	for _, c := range cases {
-		if err := fetchRef(ctx, cache, c.ref, false, noop); err != nil {
+		if err := fetchRef(ctx, gitRetry{}, cache, c.ref, false, noop); err != nil {
 			t.Fatalf("fetchRef(%q): %v", c.ref, err)
 		}
 		if got := git(cache, "rev-parse", "HEAD"); got != c.want {
@@ -157,7 +157,7 @@ func TestFetchRefChecksOutRequestedRef(t *testing.T) {
 		}
 	}
 
-	if err := fetchRef(ctx, cache, "does-not-exist", false, noop); err == nil {
+	if err := fetchRef(ctx, gitRetry{}, cache, "does-not-exist", false, noop); err == nil {
 		t.Error("fetchRef on a nonexistent ref should error")
 	}
 }
@@ -255,7 +255,7 @@ func TestValidateGitRef(t *testing.T) {
 // fall through to `git clone` and try to reach example.invalid.
 func TestCloneOrFetchRejectsBadRefBeforeNetwork(t *testing.T) {
 	dst := t.TempDir()
-	err := cloneOrFetch(context.Background(), "https://example.invalid/repo", dst, false, "--upload-pack=/bin/sh", func(Event) {
+	err := cloneOrFetch(context.Background(), gitRetry{}, "https://example.invalid/repo", dst, false, "--upload-pack=/bin/sh", func(Event) {
 		t.Errorf("emit must not be called when validation rejects the ref")
 	})
 	if err == nil {
@@ -270,7 +270,7 @@ func TestCloneOrFetchRejectsBadRefBeforeNetwork(t *testing.T) {
 // same entry point so a future refactor that re-orders the validators
 // trips this test rather than silently changing the order users see.
 func TestCloneOrFetchRejectsBadURL(t *testing.T) {
-	err := cloneOrFetch(context.Background(), "ssh://git@example.invalid/repo", t.TempDir(), false, "main", func(Event) {})
+	err := cloneOrFetch(context.Background(), gitRetry{}, "ssh://git@example.invalid/repo", t.TempDir(), false, "main", func(Event) {})
 	if err == nil {
 		t.Fatal("expected error for non-https URL")
 	}

--- a/internal/worker/git_retry.go
+++ b/internal/worker/git_retry.go
@@ -1,0 +1,292 @@
+package worker
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/rand/v2"
+	"strings"
+	"time"
+)
+
+// Bounds for the remote-git retry policy. They are deliberately small: a
+// scan that cannot reach a forge after a few seconds should fail and be
+// retried as a scan, not hold a worker slot open. At three attempts the
+// waits are 500ms and 1s, so gitRetryMaxDelay only binds if the attempt
+// count is ever raised.
+const (
+	gitRetryAttempts      = 3
+	gitRetryBaseDelay     = 500 * time.Millisecond
+	gitRetryMaxDelay      = 4 * time.Second
+	gitRetryBackoffFactor = 2
+	gitRetryJitterDivisor = 4
+)
+
+// gitRunner runs one git invocation and returns its combined output.
+// Production always passes gitWithEnv; tests substitute a deterministic fake
+// so the retry policy can be exercised without a network or a real remote.
+type gitRunner func(ctx context.Context, dir string, env []string, args ...string) (string, error)
+
+// gitCommand is a single remote git invocation plus the cleanup its retries
+// need. label names the operation for the scan log only.
+type gitCommand struct {
+	label string
+	dir   string
+	env   []string
+	args  []string
+	// reset runs before each retry, never before the first attempt. It lets
+	// the clone path clear a half-written destination that would otherwise
+	// make the next attempt fail for an unrelated reason. nil means the
+	// command can simply be repeated.
+	reset func() error
+}
+
+// gitRetry bounds how a remote git invocation is retried. The zero value is
+// the production policy; tests set the fields they need to stay fast and
+// deterministic. Only network-facing commands take this path — local work
+// such as `git reset --hard` is never retried, because repeating it cannot
+// fix anything a retry budget is meant to fix.
+type gitRetry struct {
+	attempts  int
+	baseDelay time.Duration
+	maxDelay  time.Duration
+	run       gitRunner
+	sleep     func(context.Context, time.Duration) error
+}
+
+func (r gitRetry) resolved() gitRetry {
+	if r.attempts <= 0 {
+		r.attempts = gitRetryAttempts
+	}
+	if r.baseDelay <= 0 {
+		r.baseDelay = gitRetryBaseDelay
+	}
+	if r.maxDelay <= 0 {
+		r.maxDelay = gitRetryMaxDelay
+	}
+	if r.run == nil {
+		r.run = gitWithEnv
+	}
+	if r.sleep == nil {
+		r.sleep = gitSleep
+	}
+	return r
+}
+
+// do runs cmd, retrying only while the failure looks transient and the
+// budget, the context, and the cleanup hook all allow another attempt. The
+// first attempt is always made exactly as before, so a permanent failure
+// costs nothing extra. emit may be nil for callers without a scan log.
+func (r gitRetry) do(ctx context.Context, cmd gitCommand, emit func(Event)) (string, error) {
+	p := r.resolved()
+	for attempt := 1; ; attempt++ {
+		out, err := p.run(ctx, cmd.dir, cmd.env, cmd.args...)
+		if err == nil {
+			return out, nil
+		}
+		// The context is checked before the output is classified: a cancelled
+		// or expired context kills git mid-transfer, and the resulting "hung
+		// up unexpectedly" reads exactly like a transient network failure.
+		// Its own error is returned, not git's, so a caller can tell a
+		// cancelled scan from an unreachable repository (errors.Is against
+		// context.Canceled / DeadlineExceeded) rather than flagging the repo.
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return out, ctxErr
+		}
+		if attempt >= p.attempts || !transientGitFailure(out) {
+			return out, err
+		}
+		if cmd.reset != nil {
+			// A failed cleanup is surfaced, not swallowed: the next attempt
+			// cannot proceed, and the reset error (typically a local
+			// filesystem fault) is the more actionable of the two.
+			if resetErr := cmd.reset(); resetErr != nil {
+				return out, errors.Join(err, resetErr)
+			}
+		}
+		delay := gitBackoffDelay(attempt, p.baseDelay, p.maxDelay)
+		if emit != nil {
+			// Deliberately carries no URL and no git output: the remote URL
+			// may embed a credential, and the full output is already on the
+			// returned error when every attempt fails.
+			emit(Event{Kind: KindText, Text: fmt.Sprintf(
+				"git %s failed with a transient error (attempt %d/%d), retrying in %s",
+				cmd.label, attempt, p.attempts, delay.Round(time.Millisecond))})
+		}
+		if sleepErr := p.sleep(ctx, delay); sleepErr != nil {
+			return out, sleepErr
+		}
+	}
+}
+
+// permanentGitFailures are answers about the repository, the ref, the local
+// destination, or the local machine. Repeating the command cannot change any
+// of them, and retrying would only multiply pointless remote traffic.
+//
+// Several of these matter precisely because git reports them *alongside*
+// transport noise. A clone that runs the disk out of space ends with "fatal:
+// write error: No space left on device" followed by "fatal: the remote end
+// hung up unexpectedly", and a rejected credential can surface as "error: RPC
+// failed; result=22, HTTP code = 401" — both would otherwise be read as
+// transient. Permanent markers are therefore checked first and win.
+var permanentGitFailures = []string{
+	// The repository, the ref, or the credentials.
+	"repository not found",
+	"authentication failed",
+	"could not read username",
+	"could not read password",
+	"terminal prompts disabled",
+	"permission denied (publickey)",
+	"remote: permission denied",
+	"access denied",
+	"couldn't find remote ref",
+	"does not appear to be a git repository",
+	"unable to update url base from redirection",
+	"returned error: 401",
+	"returned error: 403",
+	"returned error: 404",
+	"returned error: 410",
+	"returned error: 413",
+	"http code = 401",
+	"http code = 403",
+	"http code = 404",
+	"http code = 413",
+	// A server-side hard limit, not a hiccup.
+	"pack exceeds maximum allowed size",
+	// The local destination and the local machine. These arrive wrapped in
+	// transport noise but no amount of retrying frees a disk or a thread.
+	"already exists and is not an empty directory",
+	"no space left on device",
+	"disk quota exceeded",
+	"input/output error",
+	"read-only file system",
+	"cannot allocate memory",
+	"unable to create thread",
+	"cannot fork",
+	"unable to fork",
+}
+
+// transientGitFailures are name-resolution, connection, TLS, and
+// remote-availability failures. They say nothing about the repository or the
+// ref, so the same command may well succeed a moment later.
+var transientGitFailures = []string{
+	"could not resolve host",
+	"couldn't resolve host",
+	"could not resolve proxy",
+	"temporary failure in name resolution",
+	"failed to connect",
+	"connection refused",
+	"connection reset",
+	"connection timed out",
+	"operation timed out",
+	"timeout was reached",
+	"network is unreachable",
+	"no route to host",
+	"the remote end hung up unexpectedly",
+	"early eof",
+	"rpc failed",
+	"unexpected disconnect while reading sideband packet",
+	"transfer closed with",
+	"recv failure",
+	"send failure",
+	"empty reply from server",
+	"gnutls_handshake() failed",
+	"ssl connect error",
+	"ssl_read",
+	"ssl_write",
+	"tls connection was non-properly terminated",
+	"returned error: 408",
+	"returned error: 429",
+	"returned error: 500",
+	"returned error: 502",
+	"returned error: 503",
+	"returned error: 504",
+	// Cloudflare's origin-side range: 520 unknown, 521 down, 522/524 timeout,
+	// 523 unreachable. All say the edge could not reach the origin right now.
+	"returned error: 520",
+	"returned error: 521",
+	"returned error: 522",
+	"returned error: 523",
+	"returned error: 524",
+	"http code = 500",
+	"http code = 502",
+	"http code = 503",
+	"http code = 504",
+	"http code = 520",
+	"http code = 521",
+	"http code = 522",
+	"http code = 523",
+	"http code = 524",
+	"internal server error",
+	"bad gateway",
+	"service unavailable",
+	// Narrowed from "temporarily unavailable": nginx reports 503 as "Service
+	// Temporarily Unavailable", but a bare "Resource temporarily unavailable"
+	// is a local EAGAIN (see "unable to create thread" above) and must stay
+	// permanent.
+	"service temporarily unavailable",
+	"too many requests",
+}
+
+// transientGitFailure reports whether git's combined output describes a
+// failure worth another attempt.
+//
+// The classification fails closed. A permanent marker wins over a transient
+// one, and output matching nothing at all is treated as permanent, so an
+// unfamiliar message keeps today's single-attempt behaviour rather than
+// turning into repeated remote traffic.
+func transientGitFailure(out string) bool {
+	lower := strings.ToLower(out)
+	for _, marker := range permanentGitFailures {
+		if strings.Contains(lower, marker) {
+			return false
+		}
+	}
+	for _, marker := range transientGitFailures {
+		if strings.Contains(lower, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+// gitBackoffDelay grows the wait geometrically up to maxDelay and adds
+// jitter so several workers failing against the same forge at the same
+// moment do not retry in lockstep.
+func gitBackoffDelay(attempt int, baseDelay, maxDelay time.Duration) time.Duration {
+	delay := baseDelay
+	for range attempt - 1 {
+		delay *= gitRetryBackoffFactor
+		if delay >= maxDelay {
+			return gitJitter(maxDelay)
+		}
+	}
+	return gitJitter(delay)
+}
+
+func gitJitter(delay time.Duration) time.Duration {
+	if delay <= 0 {
+		return 0
+	}
+	spread := delay / gitRetryJitterDivisor
+	if spread <= 0 {
+		return delay
+	}
+	return delay + time.Duration(rand.Int64N(int64(spread)))
+}
+
+// gitSleep waits for delay, returning early with the context's error when
+// the caller gives up first.
+func gitSleep(ctx context.Context, delay time.Duration) error {
+	if delay <= 0 {
+		return ctx.Err()
+	}
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}

--- a/internal/worker/git_retry_test.go
+++ b/internal/worker/git_retry_test.go
@@ -1,0 +1,460 @@
+package worker
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+var errGitExit = errors.New("exit status 128")
+
+// scriptedGit is a gitRunner whose outcomes are fixed up front: call i gets
+// outcome i, and the last outcome repeats for any further call. It records
+// every invocation so a test can assert how many attempts were made.
+type scriptedGit struct {
+	outcomes []gitOutcome
+	calls    [][]string
+}
+
+type gitOutcome struct {
+	out string
+	err error
+}
+
+func (g *scriptedGit) run(_ context.Context, _ string, _ []string, args ...string) (string, error) {
+	g.calls = append(g.calls, args)
+	i := len(g.calls) - 1
+	if i >= len(g.outcomes) {
+		i = len(g.outcomes) - 1
+	}
+	return g.outcomes[i].out, g.outcomes[i].err
+}
+
+// recordedSleep stands in for the backoff wait: it records the delays it was
+// asked for and never actually sleeps, so the retry suite is instant. err,
+// when set, simulates a context that ends during the wait.
+type recordedSleep struct {
+	delays []time.Duration
+	err    error
+}
+
+func (s *recordedSleep) sleep(_ context.Context, d time.Duration) error {
+	s.delays = append(s.delays, d)
+	return s.err
+}
+
+func transientOutcome() gitOutcome {
+	return gitOutcome{out: "fatal: unable to access 'https://host/r/': Connection reset by peer\n", err: errGitExit}
+}
+
+// TestGitRetryAttemptBudget pins the whole outcome matrix of the policy in
+// one place: how many times git is invoked, whether the caller sees an
+// error, and how many backoff waits happened.
+func TestGitRetryAttemptBudget(t *testing.T) {
+	ok := gitOutcome{out: "", err: nil}
+	permanent := gitOutcome{out: "remote: Repository not found.\nfatal: repository 'https://host/r/' not found\n", err: errGitExit}
+	unknown := gitOutcome{out: "fatal: a failure this policy has never seen\n", err: errGitExit}
+
+	cases := []struct {
+		name       string
+		outcomes   []gitOutcome
+		wantCalls  int
+		wantSleeps int
+		wantErr    bool
+	}{
+		{"succeeds first time", []gitOutcome{ok}, 1, 0, false},
+		{"transient then success", []gitOutcome{transientOutcome(), ok}, 2, 1, false},
+		{"transient twice then success", []gitOutcome{transientOutcome(), transientOutcome(), ok}, 3, 2, false},
+		{"budget exhausted", []gitOutcome{transientOutcome()}, gitRetryAttempts, gitRetryAttempts - 1, true},
+		{"permanent failure is final", []gitOutcome{permanent}, 1, 0, true},
+		{"unrecognised failure is final", []gitOutcome{unknown}, 1, 0, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			git := &scriptedGit{outcomes: c.outcomes}
+			sleeper := &recordedSleep{}
+			retry := gitRetry{run: git.run, sleep: sleeper.sleep}
+
+			_, err := retry.do(context.Background(), gitCommand{label: "fetch", args: []string{"fetch"}}, func(Event) {})
+
+			if gotErr := err != nil; gotErr != c.wantErr {
+				t.Errorf("error = %v, want error: %v", err, c.wantErr)
+			}
+			if len(git.calls) != c.wantCalls {
+				t.Errorf("git invocations = %d, want %d", len(git.calls), c.wantCalls)
+			}
+			if len(sleeper.delays) != c.wantSleeps {
+				t.Errorf("backoff waits = %d, want %d", len(sleeper.delays), c.wantSleeps)
+			}
+		})
+	}
+}
+
+// TestGitRetryReturnsLastFailure keeps the exhausted-budget error identical
+// in shape to the single-attempt error callers already handle: the combined
+// output of the final attempt, wrapping git's own error.
+func TestGitRetryReturnsLastFailure(t *testing.T) {
+	last := gitOutcome{out: "fatal: unable to access 'https://host/r/': Connection timed out\n", err: errGitExit}
+	git := &scriptedGit{outcomes: []gitOutcome{transientOutcome(), last}}
+	retry := gitRetry{attempts: 2, run: git.run, sleep: (&recordedSleep{}).sleep}
+
+	out, err := retry.do(context.Background(), gitCommand{label: "clone", args: []string{"clone"}}, func(Event) {})
+	if !errors.Is(err, errGitExit) {
+		t.Errorf("error = %v, want it to wrap git's exit error", err)
+	}
+	if out != last.out {
+		t.Errorf("output = %q, want the final attempt's output %q", out, last.out)
+	}
+}
+
+// TestGitRetryStopsWhenContextEnds covers both ways the caller can give up:
+// the context ending while git runs (its own kill makes the failure look
+// transient, which must not be retried) and the context ending during the
+// backoff wait. In each case the returned error must carry the context's
+// cancellation, not git's, so ensureClone can tell a cancelled scan from an
+// unreachable repository instead of recording a spurious clone_error.
+func TestGitRetryStopsWhenContextEnds(t *testing.T) {
+	t.Run("during the git invocation", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		git := &scriptedGit{outcomes: []gitOutcome{
+			{out: "fatal: the remote end hung up unexpectedly\n", err: errGitExit},
+		}}
+		sleeper := &recordedSleep{}
+		retry := gitRetry{run: git.run, sleep: sleeper.sleep}
+
+		_, err := retry.do(ctx, gitCommand{label: "fetch", args: []string{"fetch"}}, func(Event) {})
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("error = %v, want it to carry context.Canceled", err)
+		}
+		if len(git.calls) != 1 {
+			t.Errorf("git invocations = %d, want 1: a cancelled context must not be retried", len(git.calls))
+		}
+		if len(sleeper.delays) != 0 {
+			t.Errorf("backoff waits = %d, want 0", len(sleeper.delays))
+		}
+	})
+
+	t.Run("during the backoff wait", func(t *testing.T) {
+		git := &scriptedGit{outcomes: []gitOutcome{transientOutcome()}}
+		sleeper := &recordedSleep{err: context.DeadlineExceeded}
+		retry := gitRetry{run: git.run, sleep: sleeper.sleep}
+
+		_, err := retry.do(context.Background(), gitCommand{label: "clone", args: []string{"clone"}}, func(Event) {})
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("error = %v, want it to carry context.DeadlineExceeded", err)
+		}
+		if len(git.calls) != 1 {
+			t.Errorf("git invocations = %d, want 1: an interrupted wait ends the sequence", len(git.calls))
+		}
+	})
+}
+
+// TestGitRetryResetRunsBeforeEachRetry pins when the cleanup hook fires: not
+// before the first attempt, and once before every retry.
+func TestGitRetryResetRunsBeforeEachRetry(t *testing.T) {
+	git := &scriptedGit{outcomes: []gitOutcome{transientOutcome()}}
+	var resetsBeforeCall []int
+	retry := gitRetry{run: git.run, sleep: (&recordedSleep{}).sleep}
+	cmd := gitCommand{
+		label: "clone",
+		args:  []string{"clone"},
+		reset: func() error {
+			resetsBeforeCall = append(resetsBeforeCall, len(git.calls))
+			return nil
+		},
+	}
+
+	if _, err := retry.do(context.Background(), cmd, func(Event) {}); err == nil {
+		t.Fatal("expected the exhausted budget to fail")
+	}
+	// One reset after attempt 1 and one after attempt 2; none before attempt 1.
+	want := []int{1, 2}
+	if len(resetsBeforeCall) != len(want) {
+		t.Fatalf("reset ran %d times (after attempts %v), want %d", len(resetsBeforeCall), resetsBeforeCall, len(want))
+	}
+	for i, got := range resetsBeforeCall {
+		if got != want[i] {
+			t.Errorf("reset %d ran after %d attempts, want %d", i+1, got, want[i])
+		}
+	}
+}
+
+// TestGitRetryStopsWhenResetFails keeps a failed cleanup from turning one
+// transport failure into a different, misleading one: the next attempt would
+// hit a destination it could not prepare, so the sequence ends here. Both
+// errors are surfaced -- the transport failure that triggered the retry and
+// the local fault that stopped it -- because the local one (a read-only
+// filesystem, say) is usually the more actionable and must not be swallowed.
+func TestGitRetryStopsWhenResetFails(t *testing.T) {
+	git := &scriptedGit{outcomes: []gitOutcome{transientOutcome()}}
+	retry := gitRetry{run: git.run, sleep: (&recordedSleep{}).sleep}
+	resetErr := errors.New("remove dst: read-only file system")
+	cmd := gitCommand{
+		label: "clone",
+		args:  []string{"clone"},
+		reset: func() error { return resetErr },
+	}
+
+	out, err := retry.do(context.Background(), cmd, func(Event) {})
+	if !errors.Is(err, errGitExit) {
+		t.Errorf("error = %v, want it to carry the original git failure", err)
+	}
+	if !errors.Is(err, resetErr) {
+		t.Errorf("error = %v, want it to also carry the cleanup failure", err)
+	}
+	if !strings.Contains(out, "Connection reset by peer") {
+		t.Errorf("output = %q, want the original git output", out)
+	}
+	if len(git.calls) != 1 {
+		t.Errorf("git invocations = %d, want 1", len(git.calls))
+	}
+}
+
+// TestGitRetryLogLineOmitsCommandDetail keeps credentials out of the scan
+// log. A clone URL may carry a token, and git's output repeats it, so the
+// retry notice must mention neither.
+func TestGitRetryLogLineOmitsCommandDetail(t *testing.T) {
+	const secretURL = "https://ghp_secrettoken@host/owner/repo"
+	git := &scriptedGit{outcomes: []gitOutcome{
+		{out: "fatal: unable to access '" + secretURL + "': Connection reset by peer\n", err: errGitExit},
+	}}
+	var logged []string
+	retry := gitRetry{attempts: 2, run: git.run, sleep: (&recordedSleep{}).sleep}
+
+	_, _ = retry.do(context.Background(), gitCommand{label: "clone", args: []string{"clone", "--", secretURL}},
+		func(e Event) { logged = append(logged, e.Text) })
+
+	if len(logged) != 1 {
+		t.Fatalf("emitted %d lines (%v), want 1 retry notice", len(logged), logged)
+	}
+	line := logged[0]
+	for _, banned := range []string{"ghp_secrettoken", secretURL, "Connection reset by peer"} {
+		if strings.Contains(line, banned) {
+			t.Errorf("retry notice %q must not contain %q", line, banned)
+		}
+	}
+	if !strings.Contains(line, "clone") || !strings.Contains(line, "1/2") {
+		t.Errorf("retry notice %q should name the operation and the attempt", line)
+	}
+}
+
+// TestGitRetryToleratesNilEmit covers ListRemoteBranches, which has no scan
+// log to write to.
+func TestGitRetryToleratesNilEmit(t *testing.T) {
+	git := &scriptedGit{outcomes: []gitOutcome{transientOutcome(), {}}}
+	retry := gitRetry{run: git.run, sleep: (&recordedSleep{}).sleep}
+
+	if _, err := retry.do(context.Background(), gitCommand{label: "ls-remote", args: []string{"ls-remote"}}, nil); err != nil {
+		t.Fatalf("retry with a nil emit: %v", err)
+	}
+	if len(git.calls) != 2 {
+		t.Errorf("git invocations = %d, want 2", len(git.calls))
+	}
+}
+
+func TestTransientGitFailure(t *testing.T) {
+	transient := []string{
+		"fatal: unable to access 'https://h/r/': Could not resolve host: h",
+		"ssh: Could not resolve hostname h: Temporary failure in name resolution",
+		"fatal: unable to access 'https://h/r/': Could not resolve proxy: proxy.invalid",
+		"fatal: unable to access 'https://h/r/': Failed to connect to h port 443: Connection refused",
+		"fatal: unable to access 'https://h/r/': Recv failure: Connection reset by peer",
+		"fatal: unable to access 'https://h/r/': Operation timed out after 30000 milliseconds",
+		"error: RPC failed; curl 92 HTTP/2 stream 5 was not closed cleanly\nfatal: early EOF",
+		"fatal: the remote end hung up unexpectedly",
+		"error: RPC failed; curl 56 GnuTLS recv error (-54): Error in the pull function.",
+		"fetch-pack: unexpected disconnect while reading sideband packet",
+		"fatal: unable to access 'https://h/r/': The requested URL returned error: 503",
+		"fatal: unable to access 'https://h/r/': The requested URL returned error: 429",
+		"remote: Internal Server Error",
+		"error: RPC failed; HTTP 502 curl 22 The requested URL returned error: 502 Bad Gateway",
+		// nginx phrases 503 as "Service Temporarily Unavailable".
+		"error: RPC failed; HTTP 503 curl 22 The requested URL returned error: 503 Service Temporarily Unavailable",
+		// Cloudflare origin-side timeouts, which the base gave up on after one try.
+		"fatal: unable to access 'https://h/r/': The requested URL returned error: 522",
+		"fatal: unable to access 'https://h/r/': The requested URL returned error: 524",
+	}
+	for _, out := range transient {
+		if !transientGitFailure(out) {
+			t.Errorf("transientGitFailure(%q) = false, want true", out)
+		}
+	}
+
+	permanent := []string{
+		"",
+		"remote: Repository not found.\nfatal: repository 'https://h/r/' not found",
+		"remote: HTTP Basic: Access denied\nfatal: Authentication failed for 'https://h/r/'",
+		"fatal: could not read Username for 'https://h': terminal prompts disabled",
+		"fatal: couldn't find remote ref does-not-exist",
+		"fatal: 'https://h/r' does not appear to be a git repository",
+		"fatal: destination path 'src' already exists and is not an empty directory.",
+		"fatal: unable to access 'https://h/r/': The requested URL returned error: 404",
+		"fatal: could not create work tree dir 'src': Permission denied",
+		// A local EAGAIN reported as "Resource temporarily unavailable": no
+		// amount of retrying frees a thread, and re-cloning wastes a full
+		// download onto a machine that is already out of headroom.
+		"fatal: unable to create thread: Resource temporarily unavailable",
+		// A push rejected for size, in git's older result=/HTTP-code phrasing.
+		"error: RPC failed; HTTP 413 curl 22 The requested URL returned error: 413",
+		"fatal: a failure message nobody has classified yet",
+	}
+	for _, out := range permanent {
+		if transientGitFailure(out) {
+			t.Errorf("transientGitFailure(%q) = true, want false", out)
+		}
+	}
+}
+
+// TestTransientGitFailureMixedOutput covers the cases the ordering exists
+// for: git reports a settled answer *wrapped in* transport noise, so reading
+// only the noise would spend the whole budget re-asking a question that is
+// already answered -- or, worse, re-downloading a pack onto a full disk.
+func TestTransientGitFailureMixedOutput(t *testing.T) {
+	settled := []struct{ name, out string }{
+		{"repository is gone", "" +
+			"fatal: unable to access 'https://h/r/': Connection reset by peer\n" +
+			"remote: Repository not found."},
+		{"disk is full", "" +
+			"fatal: write error: No space left on device\n" +
+			"fatal: the remote end hung up unexpectedly\n" +
+			"fatal: index-pack failed"},
+		{"quota is exhausted", "" +
+			"error: RPC failed; curl 18 transfer closed with outstanding read data remaining\n" +
+			"fatal: write error: Disk quota exceeded"},
+		{"credentials rejected, older git phrasing", "" +
+			"error: RPC failed; result=22, HTTP code = 401\n" +
+			"fatal: The remote end hung up unexpectedly"},
+		{"repository missing, older git phrasing", "" +
+			"error: RPC failed; result=22, HTTP code = 404\n" +
+			"fatal: The remote end hung up unexpectedly"},
+		{"server-side size limit", "" +
+			"remote: fatal: pack exceeds maximum allowed size (2.00 GiB)\n" +
+			"fatal: the remote end hung up unexpectedly"},
+	}
+	for _, c := range settled {
+		if transientGitFailure(c.out) {
+			t.Errorf("%s: classified transient, want permanent", c.name)
+		}
+	}
+
+	// The mirror image: a connect(2) refusal reported as EACCES by a
+	// firewall is a network condition that can clear, so the permanent
+	// markers must be narrow enough not to swallow it.
+	blocked := "fatal: unable to access 'https://h/r/': Failed to connect to h port 443: Permission denied"
+	if !transientGitFailure(blocked) {
+		t.Error("a firewall-refused connection should stay retryable")
+	}
+}
+
+// TestGitBackoffDelayBounds pins the shape of the wait: each step at least
+// the geometric delay and never past the cap plus its jitter.
+func TestGitBackoffDelayBounds(t *testing.T) {
+	const (
+		base    = 100 * time.Millisecond
+		ceiling = 400 * time.Millisecond
+	)
+	want := []time.Duration{base, 2 * base, ceiling, ceiling, ceiling}
+	for attempt, floor := range want {
+		got := gitBackoffDelay(attempt+1, base, ceiling)
+		limit := floor + floor/gitRetryJitterDivisor
+		if got < floor || got >= limit {
+			t.Errorf("gitBackoffDelay(%d) = %v, want [%v, %v)", attempt+1, got, floor, limit)
+		}
+	}
+}
+
+// TestGitBackoffDelayIsJittered is what actually keeps the jitter alive:
+// bounds alone are satisfied by a constant delay, which is exactly the
+// lockstep behaviour the spread exists to prevent when several workers fail
+// against one forge at the same moment.
+func TestGitBackoffDelayIsJittered(t *testing.T) {
+	const (
+		base    = 100 * time.Millisecond
+		ceiling = time.Second
+		samples = 200
+	)
+	lowest, highest := time.Duration(1<<62), time.Duration(0)
+	for range samples {
+		delay := gitBackoffDelay(1, base, ceiling)
+		if delay < base || delay >= base+base/gitRetryJitterDivisor {
+			t.Fatalf("jittered delay %v outside [%v, %v)", delay, base, base+base/gitRetryJitterDivisor)
+		}
+		lowest = min(lowest, delay)
+		highest = max(highest, delay)
+	}
+	// A token spread would satisfy "not constant" while still sending every
+	// worker back at effectively the same moment, so require the observed
+	// range to be a real fraction of the delay.
+	if spread := highest - lowest; spread < base/20 {
+		t.Errorf("%d samples spanned only %v (%v..%v); the backoff is effectively unjittered",
+			samples, spread, lowest, highest)
+	}
+}
+
+// TestRetryBudgetsStaySmall guards the production constants themselves. The
+// policy's value depends on staying far below the deadlines it runs inside:
+// a scan's worker slot, and -- for the branch picker -- the request timeout
+// in internal/web. Nothing else in the suite would notice these growing.
+func TestRetryBudgetsStaySmall(t *testing.T) {
+	const (
+		scanBudget   = 3 * time.Second
+		pickerBudget = 500 * time.Millisecond
+		capBudget    = 5 * time.Second
+	)
+
+	// A zero base delay would retry with no backoff at all -- the lockstep
+	// hammering the policy exists to avoid -- and nothing else notices,
+	// because gitBackoffDelay(_, 0, _) is a valid (if pointless) zero.
+	if gitRetryBaseDelay <= 0 {
+		t.Errorf("gitRetryBaseDelay = %v, want a positive backoff", gitRetryBaseDelay)
+	}
+	if gitRetryMaxDelay < gitRetryBaseDelay {
+		t.Errorf("gitRetryMaxDelay = %v, want >= base %v", gitRetryMaxDelay, gitRetryBaseDelay)
+	}
+	// A zero picker delay is worse than it looks: resolved() reads it as
+	// "unset" and substitutes the scan default, silently making the
+	// user-facing path slower than either constant suggests.
+	if branchPickerDelay <= 0 {
+		t.Errorf("branchPickerDelay = %v, want a positive backoff", branchPickerDelay)
+	}
+	if branchPickerAttempts < 1 || gitRetryAttempts < 1 {
+		t.Errorf("attempt budgets must be >= 1, got picker=%d scan=%d", branchPickerAttempts, gitRetryAttempts)
+	}
+
+	var scanWorst time.Duration
+	for attempt := 1; attempt < gitRetryAttempts; attempt++ {
+		scanWorst += gitBackoffDelay(attempt, gitRetryBaseDelay, gitRetryMaxDelay)
+	}
+	if scanWorst > scanBudget {
+		t.Errorf("scan retries can wait %v in total, want at most %v", scanWorst, scanBudget)
+	}
+
+	var pickerWorst time.Duration
+	for attempt := 1; attempt < branchPickerAttempts; attempt++ {
+		pickerWorst += gitBackoffDelay(attempt, branchPickerDelay, branchPickerDelay)
+	}
+	if pickerWorst > pickerBudget {
+		t.Errorf("branch-picker retries can wait %v in total, want at most %v", pickerWorst, pickerBudget)
+	}
+
+	// The cap is unreachable at today's attempt count -- the waits are 500ms
+	// and 1s -- so only this keeps a future increase from turning it into a
+	// minutes-long wait.
+	if gitRetryMaxDelay > capBudget {
+		t.Errorf("gitRetryMaxDelay = %v, want at most %v", gitRetryMaxDelay, capBudget)
+	}
+}
+
+func TestGitSleepReturnsOnContextEnd(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := gitSleep(ctx, time.Hour); !errors.Is(err, context.Canceled) {
+		t.Errorf("gitSleep on a cancelled context = %v, want context.Canceled", err)
+	}
+	if err := gitSleep(context.Background(), time.Nanosecond); err != nil {
+		t.Errorf("gitSleep for a tiny delay = %v, want nil", err)
+	}
+}


### PR DESCRIPTION
Fixes #630.

## Problem

`cloneOrFetch` and `fetchRef` make exactly one remote Git attempt. A DNS blip,
a connection reset, a TLS hiccup, or a forge returning 502/503 therefore fails
the whole scan, even though nothing about the repository or the ref was
actually wrong. Operators then re-run scans by hand for failures that had
nothing to do with repository preparation.

## Invariant

A retry must never be able to change the *answer* — only to recover from a
failure that carried no answer.

Git exit codes are uninformative (128 for nearly everything), so the
classification reads the combined output, and it **fails closed**:

- a permanent marker beats a transient one, and
- output matching nothing at all is treated as final.

So an unfamiliar message keeps today's exact single-attempt behaviour rather
than turning into repeated remote traffic. `repository not found`,
`authentication failed`, `terminal prompts disabled`, `couldn't find remote
ref`, `403/404`, and `destination path … already exists` are never retried.

Two consequences fall out of the same invariant:

- **The context is checked before the output is classified.**
  `exec.CommandContext` kills git mid-transfer on cancellation, and the
  resulting `the remote end hung up unexpectedly` is indistinguishable from a
  real network failure. Checking `ctx.Err()` first is what keeps a cancelled
  scan from being retried.
- **Local work stays outside the policy.** `git reset --hard` is not retried:
  repeating it cannot fix anything a retry budget is meant to fix.

## Changes

`internal/worker/git_retry.go` (new) holds the policy: 3 attempts, 500 ms base
delay doubling to a 4 s cap, jitter so several workers failing against the
same forge do not retry in lockstep, and an injectable runner and sleeper so
the tests are deterministic and instant. The transient/permanent classifier
reads git's combined output and fails closed: a permanent marker beats a
transient one, and unmatched output stays permanent. It deliberately keeps
local/disk faults (`No space left on device`, `Disk quota exceeded`, `unable
to create thread: Resource temporarily unavailable`), server hard limits
(`pack exceeds maximum allowed size`, HTTP 413), and auth/not-found answers on
the single-attempt path, and treats DNS/connection/TLS/5xx (including
Cloudflare 52x) as retryable.

`internal/worker/clone.go`:

- `cloneOrFetch` and `fetchRef` take a `gitRetry` and run their remote
  invocation through it. The first attempt is byte-for-byte the same argv,
  environment, and error shape as before, so a permanent failure costs nothing
  extra.
- `cloneDestReset` clears a half-written clone destination before each retry —
  `git clone` refuses a non-empty target, so without it the retry would fail
  for a reason unrelated to the original failure. Removal is offered **only**
  when the destination is absent or empty at that point: `cloneOrFetch`
  reaches the clone path exactly when there is no `.git` there, so an empty
  destination can only ever gain content this call put there. A destination
  that already holds files belongs to the caller and is never removed (git
  rejects it as a permanent error anyway). A cleanup that itself fails (e.g. a
  read-only filesystem) is surfaced, not swallowed.
- Cancellation is honoured, and told apart from failure: when the context is
  done, the retry returns the context's error, and `ensureClone` propagates it
  instead of flagging the repository unreachable — so a cancelled or timed-out
  scan no longer records a spurious `clone_error`.
- `gitWithEnv` now sets `cmd.WaitDelay`. `CommandContext` kills git on
  cancellation, but its transport child (`git-remote-https`) inherits the
  output pipe, so `CombinedOutput` could otherwise block on that grandchild
  long after git is gone. `WaitDelay` bounds that wait without ever clipping a
  healthy command. This also tightens every other `gitWithEnv` caller,
  including the newly-merged `internal/worker/upstream.go`.
- The branch-picker (`ListRemoteBranches`) retries on a deliberately tighter
  budget (2 attempts / 200 ms) because it runs inside a user-facing request
  deadline; a mistyped host still returns promptly.
- The retry notice in the scan log carries neither the URL nor git's output —
  a clone URL can embed a credential, and the full output is already on the
  returned error when every attempt fails.

## Coordination

- The scheduled-scan work (`internal/worker/upstream.go`,
  `ResolveRemoteHead` / `SyncUpstream`) has since merged to `main`. This PR
  does not touch that file, so there is no conflict, and because it routes
  through `gitWithEnv` it already inherits the `WaitDelay` bound. Adopting the
  full retry policy there is a natural follow-up, though its force `push`
  deserves a deliberate decision rather than an automatic one.
- `internal/skills/git.go` (`CloneOrPull`, the skills-repo sync) has the same
  single-attempt shape. Left out on purpose to keep this PR to one concern —
  happy to follow up.

## Validation

Base `8b9332e200e38d7f19b4e2fef51d23f1b5b0f240`, WSL2 Ubuntu 24.04, Go 1.26.5:

```text
go mod tidy -diff                 clean
go vet ./...                      clean
go vet -tags podman ./...         clean
go test -race ./...               all 12 packages ok
golangci-lint run ./...           0 issues
golangci-lint run --enable gocritic,gocognit,gocyclo,maintidx,dupl,mnd,unparam,ireturn,goconst,errcheck ./internal/worker/
                                  0 issues
govulncheck ./...                 no vulnerabilities
```

Every regression here was first run against unmodified `main` and fails there
for the intended reason — one git invocation instead of two:

```text
--- FAIL: TestCloneOrFetchRetriesTransientCloneFailure
    git invocations = 1 ([clone --quiet --depth 1 -- … ]), want 2
--- FAIL: TestFetchRefRetriesTransientFetchFailure
    git invocations = 1 ([-C … fetch --quiet -- origin main]), want 3
--- FAIL: TestCloneOrFetchClearsPartialDestinationBeforeRetry
    git invocations = 1, want 2
```

`TestFetchRefDoesNotRetryLocalReset`,
`TestCloneOrFetchDoesNotRetryPermanentFailure`, and
`TestListRemoteBranchesFailsFastOnPrivateRepo` pass on `main` as well as here
by design: they constrain over-retrying rather than restating the fix.
