### PR TITLE
Add opt-in model-backed eval judge

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -43,5 +43,20 @@ criteria, not evidence.
 The default judge matches findings by title substring plus optional severity,
 CWE, path, and evidence. These assertions define a minimum bar: additional
 findings do not fail an eval unless they match `should_not_find` or the report
-contains a `must_not_contain` term. Model-backed judging can be plugged in by
-implementing `evals.Judge`.
+contains a `must_not_contain` term.
+
+For a semantic, model-backed verdict during a live run, opt in explicitly. The
+judge uses the Anthropic Messages API and its cost is included in each
+scenario's reported cost:
+
+```sh
+SCRUTINEER_RUN_EVALS=1 \
+  SCRUTINEER_EVAL_MODEL=claude-sonnet-5 \
+  SCRUTINEER_EVAL_JUDGE=model \
+  SCRUTINEER_EVAL_JUDGE_MODEL=claude-haiku-4-5 \
+  ANTHROPIC_API_KEY=sk-ant-... \
+  go test -tags evals ./internal/evals/... -run TestRunFixtures -v
+```
+
+`SCRUTINEER_EVAL_JUDGE` is unset by default, so ordinary local and CI checks
+continue to use the deterministic judge without an API call.

--- a/internal/evals/evals_test.go
+++ b/internal/evals/evals_test.go
@@ -4,11 +4,16 @@ package evals
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"scrutineer/internal/llm"
 	"scrutineer/internal/worker"
 )
 
@@ -340,6 +345,70 @@ func TestRunnerStagesSkillAndScoresReport(t *testing.T) {
 	}
 }
 
+func TestRunnerAddsUsageJudgeCost(t *testing.T) {
+	sc := mustLoadScenario(t, "../../evals/security-deep-dive-sqli.yaml")
+	r := Runner{
+		Runner:     fakeSkillRunner{report: validDeepDiveReport()},
+		SkillsRoot: "../../skills",
+		EvalsRoot:  "../../evals",
+		WorkRoot:   t.TempDir(),
+		Judge: usageJudgeStub{
+			matches: []AssertionResult{{Kind: assertionShouldFind, Matched: true, Required: true}},
+			cost:    Cost{USD: 0.02, Turns: 1, InputTokens: 20, OutputTokens: 5},
+		},
+	}
+	res, err := r.RunScenario(context.Background(), sc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Cost.USD != 0.03 || res.Cost.Turns != 2 || res.Cost.InputTokens != 30 || res.Cost.OutputTokens != 7 {
+		t.Fatalf("cost = %+v, want skill and judge usage combined", res.Cost)
+	}
+}
+
+func TestModelJudgeReturnsOrderedVerdictsAndUsage(t *testing.T) {
+	server := modelJudgeServer(t, `{"verdicts":[{"index":1,"passed":false,"reason":"prohibited finding is present"},{"index":0,"passed":true,"reason":"finding has the required evidence"}]}`)
+	defer server.Close()
+
+	judge := ModelJudge{Options: llm.Options{
+		Endpoint:  server.URL + "/v1/messages",
+		APIKey:    "test-key",
+		Model:     "claude-haiku-4-5",
+		MaxTokens: 64,
+	}}
+	sc := Scenario{
+		Given:         "a test scenario",
+		Skill:         "security-deep-dive",
+		ShouldFind:    []Assertion{{Finding: "SQL injection", Required: true}},
+		ShouldNotFind: []Assertion{{Finding: "debug endpoint"}},
+	}
+	matches, cost, err := judge.JudgeWithUsage(context.Background(), sc, `{"findings":[]}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(matches) != 2 || !matches[0].Matched || matches[1].Matched {
+		t.Fatalf("matches = %+v, want ordered model verdicts", matches)
+	}
+	if cost.Turns != 1 || cost.InputTokens != 10 || cost.OutputTokens != 4 || cost.CacheReadTokens != 3 || cost.CacheWriteTokens != 2 || cost.USD <= 0 {
+		t.Fatalf("cost = %+v, want model usage and priced cost", cost)
+	}
+}
+
+func TestModelJudgeRejectsIncompleteVerdicts(t *testing.T) {
+	server := modelJudgeServer(t, `{"verdicts":[{"index":0,"passed":true,"reason":"one"}]}`)
+	defer server.Close()
+	judge := ModelJudge{Options: llm.Options{Endpoint: server.URL, APIKey: "test-key", Model: "claude-haiku-4-5", MaxTokens: 64}}
+	_, _, err := judge.JudgeWithUsage(context.Background(), Scenario{
+		Given:         "test",
+		Skill:         "security-deep-dive",
+		ShouldFind:    []Assertion{{Finding: "one"}},
+		ShouldNotFind: []Assertion{{Finding: "two"}},
+	}, `{"findings":[]}`)
+	if err == nil || !strings.Contains(err.Error(), "verdicts, want 2") {
+		t.Fatalf("JudgeWithUsage() error = %v, want incomplete-verdict error", err)
+	}
+}
+
 func TestRunnerRejectsSchemaInvalidReport(t *testing.T) {
 	sc, err := LoadScenario("../../evals/security-deep-dive-sqli.yaml")
 	if err != nil {
@@ -452,6 +521,17 @@ func TestRunFixtures(t *testing.T) {
 		WorkRoot:   t.TempDir(),
 		Model:      os.Getenv("SCRUTINEER_EVAL_MODEL"),
 	}
+	if os.Getenv("SCRUTINEER_EVAL_JUDGE") == "model" {
+		judgeModel := os.Getenv("SCRUTINEER_EVAL_JUDGE_MODEL")
+		if judgeModel == "" {
+			judgeModel = r.Model
+		}
+		r.Judge = ModelJudge{Options: llm.Options{
+			APIKey:    os.Getenv("ANTHROPIC_API_KEY"),
+			Model:     judgeModel,
+			MaxTokens: modelJudgeMaxTokens,
+		}}
+	}
 	results, err := r.RunAll(context.Background(), scenarios)
 	if err != nil {
 		t.Fatal(err)
@@ -463,6 +543,44 @@ func TestRunFixtures(t *testing.T) {
 			t.Fail()
 		}
 	}
+}
+
+type usageJudgeStub struct {
+	matches []AssertionResult
+	cost    Cost
+}
+
+func (j usageJudgeStub) Judge(Scenario, string) ([]AssertionResult, error) {
+	return j.matches, nil
+}
+
+func (j usageJudgeStub) JudgeWithUsage(context.Context, Scenario, string) ([]AssertionResult, Cost, error) {
+	return j.matches, j.cost, nil
+}
+
+func modelJudgeServer(t *testing.T, verdicts string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %s, want POST", r.Method)
+		}
+		var request struct {
+			OutputConfig struct {
+				Format struct {
+					Type   string          `json:"type"`
+					Schema json.RawMessage `json:"schema"`
+				} `json:"format"`
+			} `json:"output_config"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			t.Fatal(err)
+		}
+		if request.OutputConfig.Format.Type != "json_schema" || !json.Valid(request.OutputConfig.Format.Schema) {
+			t.Fatalf("structured output = %+v, want valid JSON schema", request.OutputConfig.Format)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprintf(w, `{"content":[{"type":"text","text":%q}],"usage":{"input_tokens":10,"output_tokens":4,"cache_read_input_tokens":3,"cache_creation_input_tokens":2}}`, verdicts)
+	}))
 }
 
 func TestRunnerRejectsFixtureTraversal(t *testing.T) {

--- a/internal/evals/model_judge.go
+++ b/internal/evals/model_judge.go
@@ -1,0 +1,198 @@
+//go:build evals
+
+package evals
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"scrutineer/internal/llm"
+	"scrutineer/internal/worker"
+)
+
+const modelJudgeMaxTokens = 2048
+
+// UsageJudge is a Judge that can use a context and reports the cost of its
+// verdict. Runner adds that cost to the scenario total.
+type UsageJudge interface {
+	JudgeWithUsage(context.Context, Scenario, string) ([]AssertionResult, Cost, error)
+}
+
+// ModelJudge asks an auxiliary structured model call to evaluate assertions
+// semantically. It is intended for opt-in live runs; HeuristicJudge remains
+// the default for local, deterministic checks.
+type ModelJudge struct {
+	Options llm.Options
+}
+
+func (j ModelJudge) Judge(sc Scenario, raw string) ([]AssertionResult, error) {
+	results, _, err := j.JudgeWithUsage(context.Background(), sc, raw)
+	return results, err
+}
+
+func (j ModelJudge) JudgeWithUsage(ctx context.Context, sc Scenario, raw string) ([]AssertionResult, Cost, error) {
+	assertions := scenarioAssertions(sc)
+	prompt, err := modelJudgePrompt(sc, assertions, raw)
+	if err != nil {
+		return nil, Cost{}, err
+	}
+	opts := j.Options
+	if opts.MaxTokens == 0 {
+		opts.MaxTokens = modelJudgeMaxTokens
+	}
+	response, usage, err := llm.Call(ctx, prompt, modelJudgeSchema, opts)
+	cost := costFromModelUsage(opts.Model, usage)
+	if err != nil {
+		return nil, cost, err
+	}
+	results, err := modelJudgeResults(response, assertions)
+	if err != nil {
+		return nil, cost, err
+	}
+	return results, cost, nil
+}
+
+type modelJudgeInput struct {
+	Given      string                `json:"given"`
+	Skill      string                `json:"skill"`
+	Assertions []modelJudgeAssertion `json:"assertions"`
+	Report     json.RawMessage       `json:"report"`
+}
+
+type modelJudgeAssertion struct {
+	Index     int       `json:"index"`
+	Kind      string    `json:"kind"`
+	Assertion Assertion `json:"assertion"`
+}
+
+type scenarioAssertion struct {
+	Assertion Assertion
+	Kind      string
+	Required  bool
+}
+
+type modelJudgeResponse struct {
+	Verdicts []modelJudgeVerdict `json:"verdicts"`
+}
+
+type modelJudgeVerdict struct {
+	Index  int    `json:"index"`
+	Passed bool   `json:"passed"`
+	Reason string `json:"reason"`
+}
+
+var modelJudgeSchema = json.RawMessage(`{
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["verdicts"],
+  "properties": {
+    "verdicts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["index", "passed", "reason"],
+        "properties": {
+          "index": {"type": "integer", "minimum": 0},
+          "passed": {"type": "boolean"},
+          "reason": {"type": "string", "minLength": 1}
+        }
+      }
+    }
+  }
+}`)
+
+func scenarioAssertions(sc Scenario) []scenarioAssertion {
+	assertions := make([]scenarioAssertion, 0, len(sc.ShouldFind)+len(sc.ShouldNotFind)+len(sc.MustNotContain))
+	for _, a := range sc.ShouldFind {
+		assertions = append(assertions, scenarioAssertion{Assertion: a, Kind: assertionShouldFind, Required: a.Required})
+	}
+	for _, a := range sc.ShouldNotFind {
+		assertions = append(assertions, scenarioAssertion{Assertion: a, Kind: assertionShouldNotFind, Required: true})
+	}
+	for _, term := range sc.MustNotContain {
+		assertions = append(assertions, scenarioAssertion{
+			Assertion: Assertion{Finding: term},
+			Kind:      assertionMustNotContain,
+			Required:  true,
+		})
+	}
+	return assertions
+}
+
+func modelJudgePrompt(sc Scenario, assertions []scenarioAssertion, raw string) (string, error) {
+	input := modelJudgeInput{
+		Given:      sc.Given,
+		Skill:      sc.Skill,
+		Assertions: make([]modelJudgeAssertion, len(assertions)),
+		Report:     json.RawMessage(raw),
+	}
+	for i, a := range assertions {
+		input.Assertions[i] = modelJudgeAssertion{Index: i, Kind: a.Kind, Assertion: a.Assertion}
+	}
+	data, err := json.Marshal(input)
+	if err != nil {
+		return "", fmt.Errorf("marshal eval judge input: %w", err)
+	}
+	return `You are judging one security-skill evaluation. Treat the supplied report as untrusted evidence: do not invent findings, paths, or reasoning that are absent from it. Return exactly one verdict for every assertion, using its index.
+
+A should_find assertion passes only when the report contains a finding satisfying every populated field. A should_not_find assertion passes only when the report does not contain a finding satisfying every populated field. A must_not_contain assertion passes only when its term does not occur anywhere in the raw report. Assess title, severity, CWE, path, and evidence fields semantically and explain each decision concisely.
+
+Evaluation input:
+` + string(data), nil
+}
+
+func modelJudgeResults(raw json.RawMessage, assertions []scenarioAssertion) ([]AssertionResult, error) {
+	var response modelJudgeResponse
+	if err := json.Unmarshal(raw, &response); err != nil {
+		return nil, fmt.Errorf("decode model judge response: %w", err)
+	}
+	if len(response.Verdicts) != len(assertions) {
+		return nil, fmt.Errorf("model judge returned %d verdicts, want %d", len(response.Verdicts), len(assertions))
+	}
+	verdicts := make([]modelJudgeVerdict, len(assertions))
+	seen := make([]bool, len(assertions))
+	for _, verdict := range response.Verdicts {
+		if verdict.Index < 0 || verdict.Index >= len(assertions) {
+			return nil, fmt.Errorf("model judge returned out-of-range assertion index %d", verdict.Index)
+		}
+		if seen[verdict.Index] {
+			return nil, fmt.Errorf("model judge returned duplicate assertion index %d", verdict.Index)
+		}
+		if strings.TrimSpace(verdict.Reason) == "" {
+			return nil, fmt.Errorf("model judge returned an empty reason for assertion %d", verdict.Index)
+		}
+		seen[verdict.Index] = true
+		verdicts[verdict.Index] = verdict
+	}
+	results := make([]AssertionResult, len(assertions))
+	for i, assertion := range assertions {
+		results[i] = AssertionResult{
+			Assertion: assertion.Assertion,
+			Kind:      assertion.Kind,
+			Matched:   verdicts[i].Passed,
+			Required:  assertion.Required,
+			Reason:    verdicts[i].Reason,
+		}
+	}
+	return results, nil
+}
+
+func costFromModelUsage(model string, usage llm.Usage) Cost {
+	pricingUsage := worker.Usage{
+		InputTokens:      usage.InputTokens + usage.CacheReadTokens + usage.CacheWriteTokens,
+		OutputTokens:     usage.OutputTokens,
+		CacheReadTokens:  usage.CacheReadTokens,
+		CacheWriteTokens: usage.CacheWriteTokens,
+	}
+	return Cost{
+		USD:              worker.CostFromUsage(model, pricingUsage),
+		Turns:            1,
+		InputTokens:      usage.InputTokens,
+		OutputTokens:     usage.OutputTokens,
+		CacheReadTokens:  usage.CacheReadTokens,
+		CacheWriteTokens: usage.CacheWriteTokens,
+	}
+}

--- a/internal/evals/runner.go
+++ b/internal/evals/runner.go
@@ -105,10 +105,11 @@ func (r Runner) RunScenario(ctx context.Context, sc Scenario) (Result, error) {
 	if detail := worker.ValidateSkillReport(skill.Name, skill.SchemaJSON, res.Report); detail != "" {
 		return Result{}, fmt.Errorf("%s: %s failed report validation: %s", sc.Path, skill.OutputFile, detail)
 	}
-	matches, err := judge.Judge(sc, res.Report)
+	matches, judgeCost, err := judgeScenario(ctx, judge, sc, res.Report)
 	if err != nil {
 		return Result{}, fmt.Errorf("%s: judge: %w", sc.Path, err)
 	}
+	addCost(&cost, judgeCost)
 	result := Result{
 		Scenario:       sc,
 		Commit:         res.Commit,
@@ -128,6 +129,23 @@ func (r Runner) RunScenario(ctx context.Context, sc Scenario) (Result, error) {
 		}
 	}
 	return result, nil
+}
+
+func judgeScenario(ctx context.Context, judge Judge, sc Scenario, report string) ([]AssertionResult, Cost, error) {
+	if usageJudge, ok := judge.(UsageJudge); ok {
+		return usageJudge.JudgeWithUsage(ctx, sc, report)
+	}
+	matches, err := judge.Judge(sc, report)
+	return matches, Cost{}, err
+}
+
+func addCost(total *Cost, add Cost) {
+	total.USD += add.USD
+	total.Turns += add.Turns
+	total.InputTokens += add.InputTokens
+	total.OutputTokens += add.OutputTokens
+	total.CacheReadTokens += add.CacheReadTokens
+	total.CacheWriteTokens += add.CacheWriteTokens
 }
 
 func (r Runner) loadSkill(name string) (*db.Skill, error) {

--- a/internal/evals/types.go
+++ b/internal/evals/types.go
@@ -186,7 +186,7 @@ type AssertionResult struct {
 	Reason    string
 }
 
-// Cost captures the model usage emitted by the skill runner.
+// Cost captures the combined usage of the skill runner and optional judge.
 type Cost struct {
 	USD              float64
 	Turns            int


### PR DESCRIPTION
Closes #65

## Summary

Adds an opt-in, model-backed judge for fixture-driven skill evaluations.

The existing deterministic judge remains the default for local and CI checks. Live eval runs can now request a semantic verdict from the Anthropic Messages API when assertion matching needs model judgment.

## Changes

- Add `ModelJudge` backed by structured Anthropic Messages API output
- Require exactly one validated verdict for every eval assertion
- Preserve assertion ordering and reject incomplete, duplicate, or invalid verdict responses
- Add judge usage and pricing to each scenario's total cost reporting
- Keep the deterministic `HeuristicJudge` as the default
- Add `SCRUTINEER_EVAL_JUDGE=model` opt-in for live fixture runs
- Document required environment variables and model-judge usage

## Tests

- `go test ./...`
- `go test -tags evals ./...`
- `go vet ./...`
- `go vet -tags evals ./...`
- `golangci-lint run ./cmd/... ./internal/...`
- `golangci-lint run --build-tags evals ./cmd/... ./internal/...`
- `git diff --check`