### PR TITLE
feat: share retry primitives and extend bounded git retries

### DIFF
--- a/internal/gitx/retry.go
+++ b/internal/gitx/retry.go
@@ -1,0 +1,304 @@
+// Package gitx runs Git commands and applies a bounded retry policy to
+// network-facing invocations.
+package gitx
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	retryx "scrutineer/internal/retry"
+)
+
+const (
+	DefaultAttempts  = 3
+	DefaultBaseDelay = 500 * time.Millisecond
+	DefaultMaxDelay  = 4 * time.Second
+	DefaultWaitDelay = 10 * time.Second
+)
+
+// Runner runs one Git invocation and returns its combined output.
+type Runner func(ctx context.Context, dir string, env []string, args ...string) (string, error)
+
+// Notice describes a transient failure before the next attempt.
+type Notice struct {
+	Label    string
+	Attempt  int
+	Attempts int
+	Delay    time.Duration
+}
+
+// Command is one remote Git invocation plus operation-specific hooks.
+type Command struct {
+	Label string
+	Dir   string
+	Env   []string
+	Args  []string
+	// Reset runs after a failed attempt, before either another attempt or a
+	// terminal error return. It must only clean command-owned state.
+	Reset func() error
+	// Confirm may recognize that an operation succeeded despite an ambiguous
+	// transient error. A confirmation error does not replace the original Git
+	// error; the normal retry budget continues unless the context ended.
+	Confirm func(context.Context) (bool, error)
+}
+
+// Retry bounds how a remote Git invocation is retried. Its zero value is the
+// production policy; fields are exposed so callers can use a tighter budget
+// or deterministic runners and sleepers in tests.
+type Retry struct {
+	Attempts  int
+	BaseDelay time.Duration
+	MaxDelay  time.Duration
+	Run       Runner
+	Sleep     func(context.Context, time.Duration) error
+	Notify    func(Notice)
+}
+
+// Resolved fills zero-valued options with the production defaults.
+func (r Retry) Resolved() Retry {
+	if r.Attempts <= 0 {
+		r.Attempts = DefaultAttempts
+	}
+	if r.BaseDelay <= 0 {
+		r.BaseDelay = DefaultBaseDelay
+	}
+	if r.MaxDelay <= 0 {
+		r.MaxDelay = DefaultMaxDelay
+	}
+	if r.Run == nil {
+		r.Run = Run
+	}
+	if r.Sleep == nil {
+		r.Sleep = retryx.Sleep
+	}
+	return r
+}
+
+// Do runs cmd, retrying only transient failures while the budget, context,
+// cleanup hook, and optional success confirmation allow another attempt.
+func (r Retry) Do(ctx context.Context, cmd Command) (string, error) {
+	p := r.Resolved()
+	finishFailure := func(out string, err error) (string, error) {
+		if cmd.Reset == nil {
+			return out, err
+		}
+		if resetErr := cmd.Reset(); resetErr != nil {
+			return out, errors.Join(err, resetErr)
+		}
+		return out, err
+	}
+	for attempt := 1; ; attempt++ {
+		out, err := p.Run(ctx, cmd.Dir, cmd.Env, cmd.Args...)
+		if err == nil {
+			return out, nil
+		}
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return finishFailure(out, ctxErr)
+		}
+		if !TransientFailure(out) {
+			return finishFailure(out, err)
+		}
+		if cmd.Confirm != nil {
+			confirmed, _ := cmd.Confirm(ctx)
+			if confirmed {
+				return out, nil
+			}
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return finishFailure(out, ctxErr)
+			}
+		}
+		if attempt >= p.Attempts {
+			return finishFailure(out, err)
+		}
+		if cmd.Reset != nil {
+			if resetErr := cmd.Reset(); resetErr != nil {
+				return out, errors.Join(err, resetErr)
+			}
+		}
+		delay := retryx.BackoffDelay(attempt, p.BaseDelay, p.MaxDelay)
+		if p.Notify != nil {
+			p.Notify(Notice{Label: cmd.Label, Attempt: attempt, Attempts: p.Attempts, Delay: delay})
+		}
+		if sleepErr := p.Sleep(ctx, delay); sleepErr != nil {
+			return out, sleepErr
+		}
+	}
+}
+
+// Run executes Git with the production WaitDelay.
+func Run(ctx context.Context, dir string, env []string, args ...string) (string, error) {
+	return RunnerWithWaitDelay(DefaultWaitDelay)(ctx, dir, env, args...)
+}
+
+// RunnerWithWaitDelay returns a Runner with a bounded wait for transport
+// children that retain Git's output pipe after Git itself exits.
+func RunnerWithWaitDelay(waitDelay time.Duration) Runner {
+	return func(ctx context.Context, dir string, env []string, args ...string) (string, error) {
+		cmd := exec.CommandContext(ctx, "git", args...)
+		cmd.WaitDelay = waitDelay
+		if dir != "" {
+			cmd.Dir = dir
+		}
+		if len(env) > 0 {
+			cmd.Env = append(os.Environ(), env...)
+		}
+		out, err := cmd.CombinedOutput()
+		return string(out), err
+	}
+}
+
+// CloneDestReset returns the cleanup to run after a failed clone attempt, or
+// nil when there is nothing safe to clean. A clone that dies partway can leave
+// the destination behind, and `git clone` refuses a non-empty target, so the
+// cleanup is needed both before retries and before a terminal error return.
+//
+// Removal is offered only when dst is absent or empty at this point. Callers
+// reach the clone path exactly when dst holds no .git, so an absent or empty
+// dst can only ever gain content this call put there. A non-empty one belongs
+// to the caller, and git would reject it as a permanent error that is never
+// retried anyway.
+func CloneDestReset(dst string) func() error {
+	entries, err := os.ReadDir(dst)
+	if err != nil && !os.IsNotExist(err) {
+		return nil
+	}
+	if len(entries) > 0 {
+		return nil
+	}
+	return func() error { return os.RemoveAll(dst) }
+}
+
+// permanentFailures are answers about the repository, the ref, the local
+// destination, or the local machine. Repeating the command cannot change any
+// of them, and retrying would only multiply pointless remote traffic.
+//
+// Several of these matter precisely because git reports them *alongside*
+// transport noise. A clone that runs the disk out of space ends with "fatal:
+// write error: No space left on device" followed by "fatal: the remote end
+// hung up unexpectedly", and a rejected credential can surface as "error: RPC
+// failed; result=22, HTTP code = 401", both of which would otherwise be read
+// as transient. Permanent markers are therefore checked first and win.
+var permanentFailures = []string{
+	// The repository, the ref, or the credentials.
+	"repository not found",
+	"authentication failed",
+	"could not read username",
+	"could not read password",
+	"terminal prompts disabled",
+	"permission denied (publickey)",
+	"remote: permission denied",
+	"access denied",
+	"couldn't find remote ref",
+	"does not appear to be a git repository",
+	"unable to update url base from redirection",
+	"returned error: 401",
+	"returned error: 403",
+	"returned error: 404",
+	"returned error: 410",
+	"returned error: 413",
+	"http code = 401",
+	"http code = 403",
+	"http code = 404",
+	"http code = 413",
+	// A server-side hard limit, not a hiccup.
+	"pack exceeds maximum allowed size",
+	// The local destination and the local machine. These arrive wrapped in
+	// transport noise but no amount of retrying frees a disk or a thread.
+	"already exists and is not an empty directory",
+	"no space left on device",
+	"disk quota exceeded",
+	"input/output error",
+	"read-only file system",
+	"cannot allocate memory",
+	"unable to create thread",
+	"cannot fork",
+	"unable to fork",
+}
+
+// transientFailures are name-resolution, connection, TLS, and
+// remote-availability failures. They say nothing about the repository or the
+// ref, so the same command may well succeed a moment later.
+var transientFailures = []string{
+	"could not resolve host",
+	"couldn't resolve host",
+	"could not resolve proxy",
+	"temporary failure in name resolution",
+	"failed to connect",
+	"connection refused",
+	"connection reset",
+	"connection timed out",
+	"operation timed out",
+	"timeout was reached",
+	"network is unreachable",
+	"no route to host",
+	"the remote end hung up unexpectedly",
+	"early eof",
+	"rpc failed",
+	"unexpected disconnect while reading sideband packet",
+	"transfer closed with",
+	"recv failure",
+	"send failure",
+	"empty reply from server",
+	"gnutls_handshake() failed",
+	"ssl connect error",
+	"ssl_read",
+	"ssl_write",
+	"tls connection was non-properly terminated",
+	"returned error: 408",
+	"returned error: 429",
+	"returned error: 500",
+	"returned error: 502",
+	"returned error: 503",
+	"returned error: 504",
+	// Cloudflare's origin-side range: 520 unknown, 521 down, 522/524 timeout,
+	// 523 unreachable. All say the edge could not reach the origin right now.
+	"returned error: 520",
+	"returned error: 521",
+	"returned error: 522",
+	"returned error: 523",
+	"returned error: 524",
+	"http code = 500",
+	"http code = 502",
+	"http code = 503",
+	"http code = 504",
+	"http code = 520",
+	"http code = 521",
+	"http code = 522",
+	"http code = 523",
+	"http code = 524",
+	"internal server error",
+	"bad gateway",
+	"service unavailable",
+	// Narrowed from "temporarily unavailable": nginx reports 503 as "Service
+	// Temporarily Unavailable", but a bare "Resource temporarily unavailable"
+	// is a local EAGAIN (see "unable to create thread" above) and must stay
+	// permanent.
+	"service temporarily unavailable",
+	"too many requests",
+}
+
+// TransientFailure reports whether Git's combined output describes a failure
+// worth another attempt.
+//
+// The classification fails closed. A permanent marker wins over a transient
+// one, and output matching nothing at all is treated as permanent, so an
+// unfamiliar message keeps today's single-attempt behaviour rather than
+// turning into repeated remote traffic.
+func TransientFailure(out string) bool {
+	lower := strings.ToLower(out)
+	for _, marker := range permanentFailures {
+		if strings.Contains(lower, marker) {
+			return false
+		}
+	}
+	for _, marker := range transientFailures {
+		if strings.Contains(lower, marker) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/gitx/retry_test.go
+++ b/internal/gitx/retry_test.go
@@ -1,0 +1,277 @@
+package gitx
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestRetryConfirmRecognizesAmbiguousSuccess(t *testing.T) {
+	calls := 0
+	retry := Retry{
+		Attempts: 2,
+		Run: func(context.Context, string, []string, ...string) (string, error) {
+			calls++
+			return "fatal: the remote end hung up unexpectedly", errors.New("exit status 128")
+		},
+		Sleep: func(context.Context, time.Duration) error { return nil },
+	}
+	confirmed := 0
+	_, err := retry.Do(context.Background(), Command{
+		Label: "push",
+		Args:  []string{"push"},
+		Confirm: func(context.Context) (bool, error) {
+			confirmed++
+			return true, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	if calls != 1 || confirmed != 1 {
+		t.Fatalf("calls = %d, confirmations = %d, want 1 each", calls, confirmed)
+	}
+}
+
+func TestRetryConfirmErrorFallsBackToRetry(t *testing.T) {
+	calls := 0
+	retry := Retry{
+		Attempts: 2,
+		Run: func(context.Context, string, []string, ...string) (string, error) {
+			calls++
+			if calls == 1 {
+				return "fatal: the remote end hung up unexpectedly", errors.New("exit status 128")
+			}
+			return "", nil
+		},
+		Sleep: func(context.Context, time.Duration) error { return nil },
+	}
+	confirmations := 0
+	_, err := retry.Do(context.Background(), Command{
+		Label: "push",
+		Args:  []string{"push"},
+		Confirm: func(context.Context) (bool, error) {
+			confirmations++
+			return false, errors.New("confirmation unavailable")
+		},
+	})
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	if calls != 2 || confirmations != 1 {
+		t.Fatalf("calls = %d, confirmations = %d, want 2 and 1", calls, confirmations)
+	}
+}
+
+func TestRetryResetsAfterEveryFailedAttempt(t *testing.T) {
+	runErr := errors.New("exit status 128")
+	resets := 0
+	retry := Retry{
+		Attempts: 2,
+		Run: func(context.Context, string, []string, ...string) (string, error) {
+			return "fatal: the remote end hung up unexpectedly", runErr
+		},
+		Sleep: func(context.Context, time.Duration) error { return nil },
+	}
+
+	_, err := retry.Do(context.Background(), Command{
+		Label: "clone",
+		Args:  []string{"clone"},
+		Reset: func() error {
+			resets++
+			return nil
+		},
+	})
+	if !errors.Is(err, runErr) {
+		t.Fatalf("error = %v, want the final Git failure", err)
+	}
+	if resets != 2 {
+		t.Fatalf("resets = %d, want one after each failed attempt", resets)
+	}
+}
+
+func TestRetryResetsAfterPermanentFailure(t *testing.T) {
+	runErr := errors.New("exit status 128")
+	calls := 0
+	resets := 0
+	retry := Retry{
+		Attempts: 3,
+		Run: func(context.Context, string, []string, ...string) (string, error) {
+			calls++
+			return "fatal: write error: No space left on device", runErr
+		},
+		Sleep: func(context.Context, time.Duration) error {
+			t.Fatal("permanent failure must not sleep or retry")
+			return nil
+		},
+	}
+
+	_, err := retry.Do(context.Background(), Command{
+		Label: "clone",
+		Args:  []string{"clone"},
+		Reset: func() error {
+			resets++
+			return nil
+		},
+	})
+	if !errors.Is(err, runErr) {
+		t.Fatalf("error = %v, want the Git failure", err)
+	}
+	if calls != 1 || resets != 1 {
+		t.Fatalf("calls = %d, resets = %d, want 1 each", calls, resets)
+	}
+}
+
+func TestRetryResetsAfterCancellationAndJoinsCleanupError(t *testing.T) {
+	t.Run("cancellation", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		resets := 0
+		retry := Retry{
+			Run: func(context.Context, string, []string, ...string) (string, error) {
+				cancel()
+				return "fatal: the remote end hung up unexpectedly", errors.New("exit status 128")
+			},
+		}
+		_, err := retry.Do(ctx, Command{
+			Label: "clone",
+			Args:  []string{"clone"},
+			Reset: func() error {
+				resets++
+				return nil
+			},
+		})
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("error = %v, want context.Canceled", err)
+		}
+		if resets != 1 {
+			t.Fatalf("resets = %d, want 1", resets)
+		}
+	})
+
+	t.Run("cleanup error", func(t *testing.T) {
+		runErr := errors.New("exit status 128")
+		resetErr := errors.New("remove destination: read-only file system")
+		retry := Retry{
+			Attempts: 1,
+			Run: func(context.Context, string, []string, ...string) (string, error) {
+				return "fatal: the remote end hung up unexpectedly", runErr
+			},
+		}
+		_, err := retry.Do(context.Background(), Command{
+			Label: "clone",
+			Args:  []string{"clone"},
+			Reset: func() error { return resetErr },
+		})
+		if !errors.Is(err, runErr) || !errors.Is(err, resetErr) {
+			t.Fatalf("error = %v, want both Git and cleanup failures", err)
+		}
+	})
+}
+
+func TestTransientFailure(t *testing.T) {
+	transient := []string{
+		"fatal: unable to access 'https://h/r/': Could not resolve host: h",
+		"ssh: Could not resolve hostname h: Temporary failure in name resolution",
+		"fatal: unable to access 'https://h/r/': Could not resolve proxy: proxy.invalid",
+		"fatal: unable to access 'https://h/r/': Failed to connect to h port 443: Connection refused",
+		"fatal: unable to access 'https://h/r/': Recv failure: Connection reset by peer",
+		"fatal: unable to access 'https://h/r/': Operation timed out after 30000 milliseconds",
+		"error: RPC failed; curl 92 HTTP/2 stream 5 was not closed cleanly\nfatal: early EOF",
+		"fatal: the remote end hung up unexpectedly",
+		"error: RPC failed; curl 56 GnuTLS recv error (-54): Error in the pull function.",
+		"fetch-pack: unexpected disconnect while reading sideband packet",
+		"fatal: unable to access 'https://h/r/': The requested URL returned error: 503",
+		"fatal: unable to access 'https://h/r/': The requested URL returned error: 429",
+		"remote: Internal Server Error",
+		"error: RPC failed; HTTP 502 curl 22 The requested URL returned error: 502 Bad Gateway",
+		"error: RPC failed; HTTP 503 curl 22 The requested URL returned error: 503 Service Temporarily Unavailable",
+		"fatal: unable to access 'https://h/r/': The requested URL returned error: 522",
+		"fatal: unable to access 'https://h/r/': The requested URL returned error: 524",
+	}
+	for _, out := range transient {
+		if !TransientFailure(out) {
+			t.Errorf("TransientFailure(%q) = false, want true", out)
+		}
+	}
+
+	permanent := []string{
+		"",
+		"remote: Repository not found.\nfatal: repository 'https://h/r/' not found",
+		"remote: HTTP Basic: Access denied\nfatal: Authentication failed for 'https://h/r/'",
+		"fatal: could not read Username for 'https://h': terminal prompts disabled",
+		"fatal: couldn't find remote ref does-not-exist",
+		"fatal: 'https://h/r' does not appear to be a git repository",
+		"fatal: destination path 'src' already exists and is not an empty directory.",
+		"fatal: unable to access 'https://h/r/': The requested URL returned error: 404",
+		"fatal: could not create work tree dir 'src': Permission denied",
+		"fatal: unable to create thread: Resource temporarily unavailable",
+		"error: RPC failed; HTTP 413 curl 22 The requested URL returned error: 413",
+		"fatal: a failure message nobody has classified yet",
+	}
+	for _, out := range permanent {
+		if TransientFailure(out) {
+			t.Errorf("TransientFailure(%q) = true, want false", out)
+		}
+	}
+}
+
+func TestTransientFailureMixedOutput(t *testing.T) {
+	settled := []struct{ name, out string }{
+		{"repository is gone", "" +
+			"fatal: unable to access 'https://h/r/': Connection reset by peer\n" +
+			"remote: Repository not found."},
+		{"disk is full", "" +
+			"fatal: write error: No space left on device\n" +
+			"fatal: the remote end hung up unexpectedly\n" +
+			"fatal: index-pack failed"},
+		{"quota is exhausted", "" +
+			"error: RPC failed; curl 18 transfer closed with outstanding read data remaining\n" +
+			"fatal: write error: Disk quota exceeded"},
+		{"credentials rejected, older git phrasing", "" +
+			"error: RPC failed; result=22, HTTP code = 401\n" +
+			"fatal: The remote end hung up unexpectedly"},
+		{"repository missing, older git phrasing", "" +
+			"error: RPC failed; result=22, HTTP code = 404\n" +
+			"fatal: The remote end hung up unexpectedly"},
+		{"server-side size limit", "" +
+			"remote: fatal: pack exceeds maximum allowed size (2.00 GiB)\n" +
+			"fatal: the remote end hung up unexpectedly"},
+	}
+	for _, c := range settled {
+		if TransientFailure(c.out) {
+			t.Errorf("%s: classified transient, want permanent", c.name)
+		}
+	}
+
+	blocked := "fatal: unable to access 'https://h/r/': Failed to connect to h port 443: Permission denied"
+	if !TransientFailure(blocked) {
+		t.Error("a firewall-refused connection should stay retryable")
+	}
+}
+
+func TestRunnerWithWaitDelayBoundsLingeringChild(t *testing.T) {
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("needs a POSIX shell to stub git")
+	}
+	bin := t.TempDir()
+	script := "#!/bin/sh\nsleep 30 &\nexit 0\n"
+	if err := os.WriteFile(filepath.Join(bin, "git"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	done := make(chan struct{})
+	go func() {
+		_, _ = RunnerWithWaitDelay(200*time.Millisecond)(context.Background(), "", nil, "clone", "https://example.invalid/repo")
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("runner blocked on a lingering transport child")
+	}
+}

--- a/internal/httpx/retry.go
+++ b/internal/httpx/retry.go
@@ -4,18 +4,17 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"math/rand/v2"
 	"net/http"
 	"strconv"
 	"time"
+
+	retryx "scrutineer/internal/retry"
 )
 
 const (
 	defaultAttempts  = 3
 	defaultBaseDelay = 200 * time.Millisecond
 	defaultMaxDelay  = 2 * time.Second
-	backoffFactor    = 2
-	jitterDivisor    = 4
 )
 
 // RetryOptions configures DoRetry. Zero values use small bounded defaults.
@@ -38,7 +37,7 @@ func DoRetry(req *http.Request, opts RetryOptions) (*http.Response, error) {
 	maxDelay := defaultedDuration(opts.MaxDelay, defaultMaxDelay)
 	sleep := opts.Sleep
 	if sleep == nil {
-		sleep = sleepContext
+		sleep = retryx.Sleep
 	}
 
 	var lastErr error
@@ -60,7 +59,7 @@ func DoRetry(req *http.Request, opts RetryOptions) (*http.Response, error) {
 			return resp, nil
 		}
 
-		delay := backoffDelay(attempt, baseDelay, maxDelay)
+		delay := retryx.BackoffDelay(attempt, baseDelay, maxDelay)
 		if err != nil {
 			lastErr = err
 		} else {
@@ -120,40 +119,4 @@ func capDelay(delay, maxDelay time.Duration) time.Duration {
 		return maxDelay
 	}
 	return delay
-}
-
-func backoffDelay(attempt int, baseDelay, maxDelay time.Duration) time.Duration {
-	delay := baseDelay
-	for range attempt - 1 {
-		delay *= backoffFactor
-		if delay >= maxDelay {
-			return jitter(maxDelay)
-		}
-	}
-	return jitter(delay)
-}
-
-func jitter(delay time.Duration) time.Duration {
-	if delay <= 0 {
-		return 0
-	}
-	spread := delay / jitterDivisor
-	if spread <= 0 {
-		return delay
-	}
-	return delay + time.Duration(rand.Int64N(int64(spread)))
-}
-
-func sleepContext(ctx context.Context, delay time.Duration) error {
-	if delay <= 0 {
-		return ctx.Err()
-	}
-	timer := time.NewTimer(delay)
-	defer timer.Stop()
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	case <-timer.C:
-		return nil
-	}
 }

--- a/internal/retry/retry.go
+++ b/internal/retry/retry.go
@@ -1,0 +1,54 @@
+// Package retry provides the transport-agnostic timing primitives used by
+// bounded retry loops. Callers remain responsible for deciding which
+// operations and failures are safe to retry.
+package retry
+
+import (
+	"context"
+	"math/rand/v2"
+	"time"
+)
+
+const (
+	BackoffFactor = 2
+	JitterDivisor = 4
+)
+
+// BackoffDelay grows baseDelay geometrically up to maxDelay, then adds a
+// small positive jitter so concurrent callers do not retry in lockstep.
+func BackoffDelay(attempt int, baseDelay, maxDelay time.Duration) time.Duration {
+	delay := baseDelay
+	for range attempt - 1 {
+		delay *= BackoffFactor
+		if delay >= maxDelay {
+			return jitter(maxDelay)
+		}
+	}
+	return jitter(delay)
+}
+
+func jitter(delay time.Duration) time.Duration {
+	if delay <= 0 {
+		return 0
+	}
+	spread := delay / JitterDivisor
+	if spread <= 0 {
+		return delay
+	}
+	return delay + time.Duration(rand.Int64N(int64(spread)))
+}
+
+// Sleep waits for delay or returns as soon as ctx ends.
+func Sleep(ctx context.Context, delay time.Duration) error {
+	if delay <= 0 {
+		return ctx.Err()
+	}
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}

--- a/internal/retry/retry_test.go
+++ b/internal/retry/retry_test.go
@@ -1,0 +1,55 @@
+package retry
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestBackoffDelayBounds(t *testing.T) {
+	const (
+		base    = 100 * time.Millisecond
+		ceiling = 400 * time.Millisecond
+	)
+	want := []time.Duration{base, 2 * base, ceiling, ceiling, ceiling}
+	for attempt, floor := range want {
+		got := BackoffDelay(attempt+1, base, ceiling)
+		limit := floor + floor/JitterDivisor
+		if got < floor || got >= limit {
+			t.Errorf("BackoffDelay(%d) = %v, want [%v, %v)", attempt+1, got, floor, limit)
+		}
+	}
+}
+
+func TestBackoffDelayIsJittered(t *testing.T) {
+	const (
+		base    = 100 * time.Millisecond
+		ceiling = time.Second
+		samples = 200
+	)
+	lowest, highest := time.Duration(1<<62), time.Duration(0)
+	for range samples {
+		delay := BackoffDelay(1, base, ceiling)
+		if delay < base || delay >= base+base/JitterDivisor {
+			t.Fatalf("jittered delay %v outside [%v, %v)", delay, base, base+base/JitterDivisor)
+		}
+		lowest = min(lowest, delay)
+		highest = max(highest, delay)
+	}
+	if spread := highest - lowest; spread < base/20 {
+		t.Errorf("%d samples spanned only %v (%v..%v); backoff is effectively unjittered",
+			samples, spread, lowest, highest)
+	}
+}
+
+func TestSleepReturnsOnContextEnd(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := Sleep(ctx, time.Hour); !errors.Is(err, context.Canceled) {
+		t.Errorf("Sleep on a cancelled context = %v, want context.Canceled", err)
+	}
+	if err := Sleep(context.Background(), time.Nanosecond); err != nil {
+		t.Errorf("Sleep for a tiny delay = %v, want nil", err)
+	}
+}

--- a/internal/skills/git.go
+++ b/internal/skills/git.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"scrutineer/internal/gitx"
 )
 
 const dirPerm = 0o755
@@ -68,15 +69,20 @@ func CloneOrPull(ctx context.Context, url, ref, dst string, fullClone bool) (str
 }
 
 func cloneOrPull(ctx context.Context, url, ref, dst string, fullClone bool) (string, error) {
+	return cloneOrPullWithRetry(ctx, gitx.Retry{}, url, ref, dst, fullClone)
+}
+
+func cloneOrPullWithRetry(ctx context.Context, retry gitx.Retry, url, ref, dst string, fullClone bool) (string, error) {
+	policy := retry.Resolved()
 	if _, err := os.Stat(filepath.Join(dst, ".git")); err == nil {
 		fetchArgs := []string{"fetch", "--quiet", "origin"}
 		if fullClone {
-			out, _ := git(ctx, dst, "rev-parse", "--is-shallow-repository")
+			out, _ := policy.Run(ctx, dst, nil, "rev-parse", "--is-shallow-repository")
 			if strings.TrimSpace(out) == "true" {
 				fetchArgs = []string{"fetch", "--unshallow", "--quiet", "origin"}
 			}
 		}
-		if out, err := git(ctx, dst, fetchArgs...); err != nil {
+		if out, err := policy.Do(ctx, gitx.Command{Label: "fetch", Dir: dst, Args: fetchArgs}); err != nil {
 			return "", fmt.Errorf("fetch %s: %s: %w", url, out, err)
 		}
 	} else {
@@ -88,32 +94,32 @@ func cloneOrPull(ctx context.Context, url, ref, dst string, fullClone bool) (str
 			args = []string{"clone", "--depth", "1", "--quiet"}
 		}
 		args = append(args, "--", url, dst)
-		cmd := exec.CommandContext(ctx, "git", args...)
-		cmd.Env = append(os.Environ(), "GIT_PROTOCOL_FROM_USER=0")
-		if out, err := cmd.CombinedOutput(); err != nil {
-			return "", fmt.Errorf("clone %s: %s: %w", url, string(out), err)
+		if out, err := policy.Do(ctx, gitx.Command{
+			Label: "clone",
+			Env:   []string{"GIT_PROTOCOL_FROM_USER=0"},
+			Args:  args,
+			Reset: gitx.CloneDestReset(dst),
+		}); err != nil {
+			return "", fmt.Errorf("clone %s: %s: %w", url, out, err)
 		}
 	}
 	target := "origin/HEAD"
 	if ref != "" {
-		if out, err := git(ctx, dst, "fetch", "--quiet", "origin", "--end-of-options", ref); err != nil {
+		if out, err := policy.Do(ctx, gitx.Command{
+			Label: "fetch",
+			Dir:   dst,
+			Args:  []string{"fetch", "--quiet", "origin", "--end-of-options", ref},
+		}); err != nil {
 			return "", fmt.Errorf("fetch ref %s: %s: %w", ref, out, err)
 		}
 		target = "FETCH_HEAD"
 	}
-	if out, err := git(ctx, dst, "reset", "--quiet", "--hard", target); err != nil {
+	if out, err := policy.Run(ctx, dst, nil, "reset", "--quiet", "--hard", target); err != nil {
 		return "", fmt.Errorf("reset to %s: %s: %w", target, out, err)
 	}
-	out, err := git(ctx, dst, "rev-parse", "HEAD")
+	out, err := policy.Run(ctx, dst, nil, "rev-parse", "HEAD")
 	if err != nil {
 		return "", fmt.Errorf("rev-parse: %s: %w", out, err)
 	}
 	return strings.TrimSpace(out), nil
-}
-
-func git(ctx context.Context, dir string, args ...string) (string, error) {
-	cmd := exec.CommandContext(ctx, "git", args...)
-	cmd.Dir = dir
-	out, err := cmd.CombinedOutput()
-	return string(out), err
 }

--- a/internal/skills/git_test.go
+++ b/internal/skills/git_test.go
@@ -2,12 +2,16 @@ package skills
 
 import (
 	"context"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
+	"time"
 
+	"scrutineer/internal/gitx"
 	"scrutineer/internal/testutil"
 )
 
@@ -159,5 +163,159 @@ func TestCloneOrPull_rejectsNonHTTPS(t *testing.T) {
 	_, err := CloneOrPull(context.Background(), "git://host/path", "", t.TempDir(), false)
 	if err == nil || !strings.Contains(err.Error(), "https://") {
 		t.Fatalf("expected https rejection, got %v", err)
+	}
+}
+
+func TestCloneOrPull_retriesTransientCloneAndResetsDestination(t *testing.T) {
+	dst := filepath.Join(t.TempDir(), "dst")
+	cloneCalls := 0
+	var cloneEnvs [][]string
+	run := func(_ context.Context, _ string, env []string, args ...string) (string, error) {
+		switch args[0] {
+		case "clone":
+			cloneCalls++
+			cloneEnvs = append(cloneEnvs, append([]string(nil), env...))
+			if cloneCalls == 1 {
+				if err := os.MkdirAll(dst, dirPerm); err != nil {
+					return "", err
+				}
+				if err := os.WriteFile(filepath.Join(dst, "partial"), []byte("partial clone"), 0o644); err != nil {
+					return "", err
+				}
+				return "fatal: the remote end hung up unexpectedly", errors.New("exit status 128")
+			}
+			return "", nil
+		case "reset":
+			return "", nil
+		case "rev-parse":
+			return "deadbeef\n", nil
+		default:
+			return "", errors.New("unexpected git command: " + strings.Join(args, " "))
+		}
+	}
+
+	got, err := cloneOrPullWithRetry(context.Background(), fastSkillsRetry(run),
+		"https://example.invalid/skills", "", dst, false)
+	if err != nil {
+		t.Fatalf("cloneOrPullWithRetry: %v", err)
+	}
+	if got != "deadbeef" {
+		t.Fatalf("SHA = %q, want deadbeef", got)
+	}
+	if cloneCalls != 2 {
+		t.Fatalf("clone calls = %d, want 2", cloneCalls)
+	}
+	if _, err := os.Stat(filepath.Join(dst, "partial")); !os.IsNotExist(err) {
+		t.Fatalf("partial clone survived reset: %v", err)
+	}
+	for i, env := range cloneEnvs {
+		if !slices.Contains(env, "GIT_PROTOCOL_FROM_USER=0") {
+			t.Errorf("clone attempt %d env = %v, want protocol hardening", i+1, env)
+		}
+	}
+}
+
+func TestCloneOrPull_exhaustedCloneCleansDestinationForNextInvocation(t *testing.T) {
+	dst := filepath.Join(t.TempDir(), "skills-cache", "repo")
+	failingRun := func(_ context.Context, _ string, _ []string, args ...string) (string, error) {
+		if args[0] != "clone" {
+			return "", errors.New("unexpected git command: " + strings.Join(args, " "))
+		}
+		if err := os.MkdirAll(dst, dirPerm); err != nil {
+			return "", err
+		}
+		if err := os.WriteFile(filepath.Join(dst, "partial"), []byte("partial clone"), 0o644); err != nil {
+			return "", err
+		}
+		return "fatal: the remote end hung up unexpectedly", errors.New("exit status 128")
+	}
+	retry := fastSkillsRetry(failingRun)
+	retry.Attempts = 2
+	if _, err := cloneOrPullWithRetry(context.Background(), retry,
+		"https://example.invalid/skills", "", dst, false); err == nil {
+		t.Fatal("expected exhausted clone retries to fail")
+	}
+	if _, err := os.Stat(dst); !os.IsNotExist(err) {
+		t.Fatalf("terminal clone failure left destination behind: %v", err)
+	}
+
+	freshClone := 0
+	successfulRun := func(_ context.Context, _ string, _ []string, args ...string) (string, error) {
+		switch args[0] {
+		case "clone":
+			freshClone++
+			if _, err := os.Stat(dst); !os.IsNotExist(err) {
+				return "", errors.New("fresh clone destination is not clean")
+			}
+			return "", os.MkdirAll(filepath.Join(dst, ".git"), dirPerm)
+		case "reset":
+			return "", nil
+		case "rev-parse":
+			return "deadbeef\n", nil
+		default:
+			return "", errors.New("unexpected git command: " + strings.Join(args, " "))
+		}
+	}
+	got, err := cloneOrPullWithRetry(context.Background(), fastSkillsRetry(successfulRun),
+		"https://example.invalid/skills", "", dst, false)
+	if err != nil {
+		t.Fatalf("fresh clone after exhausted retries: %v", err)
+	}
+	if got != "deadbeef" || freshClone != 1 {
+		t.Fatalf("fresh clone returned %q after %d clone calls, want deadbeef after 1", got, freshClone)
+	}
+}
+
+func TestCloneOrPull_retriesEveryRemoteFetch(t *testing.T) {
+	for _, tc := range []struct {
+		name, ref string
+		failAt    int
+		wantCalls int
+	}{
+		{name: "cached repository update", failAt: 1, wantCalls: 2},
+		{name: "explicit ref", ref: "v1.2.3", failAt: 2, wantCalls: 3},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dst := t.TempDir()
+			if err := os.Mkdir(filepath.Join(dst, ".git"), dirPerm); err != nil {
+				t.Fatal(err)
+			}
+			fetchCalls := 0
+			run := func(_ context.Context, _ string, _ []string, args ...string) (string, error) {
+				switch args[0] {
+				case "fetch":
+					fetchCalls++
+					if fetchCalls == tc.failAt {
+						return "fatal: unable to access remote: Connection reset by peer", errors.New("exit status 128")
+					}
+					return "", nil
+				case "reset":
+					return "", nil
+				case "rev-parse":
+					return "cafebabe\n", nil
+				default:
+					return "", errors.New("unexpected git command: " + strings.Join(args, " "))
+				}
+			}
+
+			got, err := cloneOrPullWithRetry(context.Background(), fastSkillsRetry(run),
+				"https://example.invalid/skills", tc.ref, dst, false)
+			if err != nil {
+				t.Fatalf("cloneOrPullWithRetry: %v", err)
+			}
+			if got != "cafebabe" {
+				t.Fatalf("SHA = %q, want cafebabe", got)
+			}
+			if fetchCalls != tc.wantCalls {
+				t.Fatalf("fetch calls = %d, want %d", fetchCalls, tc.wantCalls)
+			}
+		})
+	}
+}
+
+func fastSkillsRetry(run gitx.Runner) gitx.Retry {
+	return gitx.Retry{
+		Run:   run,
+		Sleep: func(context.Context, time.Duration) error { return nil },
 	}
 }

--- a/internal/worker/clone.go
+++ b/internal/worker/clone.go
@@ -5,13 +5,13 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"sort"
 	"strings"
 	"time"
 
 	"scrutineer/internal/db"
+	"scrutineer/internal/gitx"
 )
 
 const dirPerm = 0o755
@@ -29,7 +29,7 @@ const (
 // process has exited or been cancelled while a transport grandchild still
 // holds its output pipe. A package var so a test can shrink it; large enough
 // in production never to clip a healthy command's final flush.
-var gitWaitDelay = 10 * time.Second
+var gitWaitDelay = gitx.DefaultWaitDelay
 
 // RepoUnreachableError is returned when git clone/fetch fails because the
 // remote is unreachable (deleted, private, wrong URL, network error).
@@ -177,28 +177,6 @@ func cloneOrFetch(ctx context.Context, retry gitRetry, url, dst string, fullClon
 	return nil
 }
 
-// cloneDestReset returns the cleanup to run before each clone retry, or nil
-// when there is nothing safe to clean. A clone that dies partway can leave
-// the destination behind, and `git clone` refuses a non-empty target, so
-// without this the retry would fail for a reason unrelated to the original
-// failure.
-//
-// Removal is offered only when dst is absent or empty at this point.
-// cloneOrFetch reaches the clone path exactly when dst holds no .git, so an
-// absent or empty dst can only ever gain content this call put there. A
-// non-empty one belongs to the caller, and git would reject it as a
-// permanent error that is never retried anyway.
-func cloneDestReset(dst string) func() error {
-	entries, err := os.ReadDir(dst)
-	if err != nil && !os.IsNotExist(err) {
-		return nil
-	}
-	if len(entries) > 0 {
-		return nil
-	}
-	return func() error { return os.RemoveAll(dst) }
-}
-
 // fetchRef updates an existing cache checkout to ref, or to the remote's
 // default branch when ref is empty. It fetches the ref by name and resets
 // to FETCH_HEAD rather than to origin/<ref>: the cache is a single-branch
@@ -252,11 +230,7 @@ func ListRemoteBranches(ctx context.Context, cloneURL string) ([]string, error) 
 	if err := validateGitURL(cloneURL); err != nil {
 		return nil, err
 	}
-	picker := gitRetry{
-		attempts:  branchPickerAttempts,
-		baseDelay: branchPickerDelay,
-		maxDelay:  branchPickerDelay,
-	}
+	picker := branchPickerRetry(gitRetry{})
 	out, err := picker.do(ctx, gitCommand{
 		label: "ls-remote",
 		env:   []string{"GIT_TERMINAL_PROMPT=0"},
@@ -305,21 +279,5 @@ func git(ctx context.Context, dir string, args ...string) (string, error) {
 }
 
 func gitWithEnv(ctx context.Context, dir string, env []string, args ...string) (string, error) {
-	cmd := exec.CommandContext(ctx, "git", args...)
-	// CommandContext kills git when ctx ends, but git's transport child
-	// (git-remote-https) inherits the output pipe, so CombinedOutput can block
-	// on that grandchild long after git is gone -- turning "stop immediately
-	// on cancellation" into an unbounded wait. WaitDelay bounds it: once git
-	// has exited or been cancelled, Wait waits at most this long for the pipe
-	// to close, then closes it and returns. It never truncates a normally
-	// completing command, whose pipe closes at once.
-	cmd.WaitDelay = gitWaitDelay
-	if dir != "" {
-		cmd.Dir = dir
-	}
-	if len(env) > 0 {
-		cmd.Env = append(os.Environ(), env...)
-	}
-	out, err := cmd.CombinedOutput()
-	return string(out), err
+	return gitx.RunnerWithWaitDelay(gitWaitDelay)(ctx, dir, env, args...)
 }

--- a/internal/worker/git_retry.go
+++ b/internal/worker/git_retry.go
@@ -2,50 +2,34 @@ package worker
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"math/rand/v2"
-	"strings"
 	"time"
+
+	"scrutineer/internal/gitx"
+	retryx "scrutineer/internal/retry"
 )
 
-// Bounds for the remote-git retry policy. They are deliberately small: a
-// scan that cannot reach a forge after a few seconds should fail and be
-// retried as a scan, not hold a worker slot open. At three attempts the
-// waits are 500ms and 1s, so gitRetryMaxDelay only binds if the attempt
-// count is ever raised.
 const (
-	gitRetryAttempts      = 3
-	gitRetryBaseDelay     = 500 * time.Millisecond
-	gitRetryMaxDelay      = 4 * time.Second
-	gitRetryBackoffFactor = 2
-	gitRetryJitterDivisor = 4
+	gitRetryAttempts  = gitx.DefaultAttempts
+	gitRetryBaseDelay = gitx.DefaultBaseDelay
+	gitRetryMaxDelay  = gitx.DefaultMaxDelay
 )
 
-// gitRunner runs one git invocation and returns its combined output.
-// Production always passes gitWithEnv; tests substitute a deterministic fake
-// so the retry policy can be exercised without a network or a real remote.
-type gitRunner func(ctx context.Context, dir string, env []string, args ...string) (string, error)
+type gitRunner = gitx.Runner
 
-// gitCommand is a single remote git invocation plus the cleanup its retries
-// need. label names the operation for the scan log only.
+// gitCommand is the worker-facing form of a remote Git invocation. The
+// adapter keeps worker events out of the reusable gitx package.
 type gitCommand struct {
-	label string
-	dir   string
-	env   []string
-	args  []string
-	// reset runs before each retry, never before the first attempt. It lets
-	// the clone path clear a half-written destination that would otherwise
-	// make the next attempt fail for an unrelated reason. nil means the
-	// command can simply be repeated.
-	reset func() error
+	label   string
+	dir     string
+	env     []string
+	args    []string
+	reset   func() error
+	confirm func(context.Context) (bool, error)
 }
 
-// gitRetry bounds how a remote git invocation is retried. The zero value is
-// the production policy; tests set the fields they need to stay fast and
-// deterministic. Only network-facing commands take this path — local work
-// such as `git reset --hard` is never retried, because repeating it cannot
-// fix anything a retry budget is meant to fix.
+// gitRetry retains the worker's compact, zero-value policy while delegating
+// classification, retry execution, and timing to reusable internal packages.
 type gitRetry struct {
 	attempts  int
 	baseDelay time.Duration
@@ -68,225 +52,44 @@ func (r gitRetry) resolved() gitRetry {
 		r.run = gitWithEnv
 	}
 	if r.sleep == nil {
-		r.sleep = gitSleep
+		r.sleep = retryx.Sleep
 	}
 	return r
 }
 
-// do runs cmd, retrying only while the failure looks transient and the
-// budget, the context, and the cleanup hook all allow another attempt. The
-// first attempt is always made exactly as before, so a permanent failure
-// costs nothing extra. emit may be nil for callers without a scan log.
+func branchPickerRetry(r gitRetry) gitRetry {
+	r.attempts = branchPickerAttempts
+	r.baseDelay = branchPickerDelay
+	r.maxDelay = branchPickerDelay
+	return r
+}
+
 func (r gitRetry) do(ctx context.Context, cmd gitCommand, emit func(Event)) (string, error) {
 	p := r.resolved()
-	for attempt := 1; ; attempt++ {
-		out, err := p.run(ctx, cmd.dir, cmd.env, cmd.args...)
-		if err == nil {
-			return out, nil
-		}
-		// The context is checked before the output is classified: a cancelled
-		// or expired context kills git mid-transfer, and the resulting "hung
-		// up unexpectedly" reads exactly like a transient network failure.
-		// Its own error is returned, not git's, so a caller can tell a
-		// cancelled scan from an unreachable repository (errors.Is against
-		// context.Canceled / DeadlineExceeded) rather than flagging the repo.
-		if ctxErr := ctx.Err(); ctxErr != nil {
-			return out, ctxErr
-		}
-		if attempt >= p.attempts || !transientGitFailure(out) {
-			return out, err
-		}
-		if cmd.reset != nil {
-			// A failed cleanup is surfaced, not swallowed: the next attempt
-			// cannot proceed, and the reset error (typically a local
-			// filesystem fault) is the more actionable of the two.
-			if resetErr := cmd.reset(); resetErr != nil {
-				return out, errors.Join(err, resetErr)
-			}
-		}
-		delay := gitBackoffDelay(attempt, p.baseDelay, p.maxDelay)
-		if emit != nil {
-			// Deliberately carries no URL and no git output: the remote URL
-			// may embed a credential, and the full output is already on the
-			// returned error when every attempt fails.
+	retry := gitx.Retry{
+		Attempts:  p.attempts,
+		BaseDelay: p.baseDelay,
+		MaxDelay:  p.maxDelay,
+		Run:       p.run,
+		Sleep:     p.sleep,
+	}
+	if emit != nil {
+		retry.Notify = func(n gitx.Notice) {
 			emit(Event{Kind: KindText, Text: fmt.Sprintf(
 				"git %s failed with a transient error (attempt %d/%d), retrying in %s",
-				cmd.label, attempt, p.attempts, delay.Round(time.Millisecond))})
-		}
-		if sleepErr := p.sleep(ctx, delay); sleepErr != nil {
-			return out, sleepErr
+				n.Label, n.Attempt, n.Attempts, n.Delay.Round(time.Millisecond))})
 		}
 	}
+	return retry.Do(ctx, gitx.Command{
+		Label:   cmd.label,
+		Dir:     cmd.dir,
+		Env:     cmd.env,
+		Args:    cmd.args,
+		Reset:   cmd.reset,
+		Confirm: cmd.confirm,
+	})
 }
 
-// permanentGitFailures are answers about the repository, the ref, the local
-// destination, or the local machine. Repeating the command cannot change any
-// of them, and retrying would only multiply pointless remote traffic.
-//
-// Several of these matter precisely because git reports them *alongside*
-// transport noise. A clone that runs the disk out of space ends with "fatal:
-// write error: No space left on device" followed by "fatal: the remote end
-// hung up unexpectedly", and a rejected credential can surface as "error: RPC
-// failed; result=22, HTTP code = 401" — both would otherwise be read as
-// transient. Permanent markers are therefore checked first and win.
-var permanentGitFailures = []string{
-	// The repository, the ref, or the credentials.
-	"repository not found",
-	"authentication failed",
-	"could not read username",
-	"could not read password",
-	"terminal prompts disabled",
-	"permission denied (publickey)",
-	"remote: permission denied",
-	"access denied",
-	"couldn't find remote ref",
-	"does not appear to be a git repository",
-	"unable to update url base from redirection",
-	"returned error: 401",
-	"returned error: 403",
-	"returned error: 404",
-	"returned error: 410",
-	"returned error: 413",
-	"http code = 401",
-	"http code = 403",
-	"http code = 404",
-	"http code = 413",
-	// A server-side hard limit, not a hiccup.
-	"pack exceeds maximum allowed size",
-	// The local destination and the local machine. These arrive wrapped in
-	// transport noise but no amount of retrying frees a disk or a thread.
-	"already exists and is not an empty directory",
-	"no space left on device",
-	"disk quota exceeded",
-	"input/output error",
-	"read-only file system",
-	"cannot allocate memory",
-	"unable to create thread",
-	"cannot fork",
-	"unable to fork",
-}
-
-// transientGitFailures are name-resolution, connection, TLS, and
-// remote-availability failures. They say nothing about the repository or the
-// ref, so the same command may well succeed a moment later.
-var transientGitFailures = []string{
-	"could not resolve host",
-	"couldn't resolve host",
-	"could not resolve proxy",
-	"temporary failure in name resolution",
-	"failed to connect",
-	"connection refused",
-	"connection reset",
-	"connection timed out",
-	"operation timed out",
-	"timeout was reached",
-	"network is unreachable",
-	"no route to host",
-	"the remote end hung up unexpectedly",
-	"early eof",
-	"rpc failed",
-	"unexpected disconnect while reading sideband packet",
-	"transfer closed with",
-	"recv failure",
-	"send failure",
-	"empty reply from server",
-	"gnutls_handshake() failed",
-	"ssl connect error",
-	"ssl_read",
-	"ssl_write",
-	"tls connection was non-properly terminated",
-	"returned error: 408",
-	"returned error: 429",
-	"returned error: 500",
-	"returned error: 502",
-	"returned error: 503",
-	"returned error: 504",
-	// Cloudflare's origin-side range: 520 unknown, 521 down, 522/524 timeout,
-	// 523 unreachable. All say the edge could not reach the origin right now.
-	"returned error: 520",
-	"returned error: 521",
-	"returned error: 522",
-	"returned error: 523",
-	"returned error: 524",
-	"http code = 500",
-	"http code = 502",
-	"http code = 503",
-	"http code = 504",
-	"http code = 520",
-	"http code = 521",
-	"http code = 522",
-	"http code = 523",
-	"http code = 524",
-	"internal server error",
-	"bad gateway",
-	"service unavailable",
-	// Narrowed from "temporarily unavailable": nginx reports 503 as "Service
-	// Temporarily Unavailable", but a bare "Resource temporarily unavailable"
-	// is a local EAGAIN (see "unable to create thread" above) and must stay
-	// permanent.
-	"service temporarily unavailable",
-	"too many requests",
-}
-
-// transientGitFailure reports whether git's combined output describes a
-// failure worth another attempt.
-//
-// The classification fails closed. A permanent marker wins over a transient
-// one, and output matching nothing at all is treated as permanent, so an
-// unfamiliar message keeps today's single-attempt behaviour rather than
-// turning into repeated remote traffic.
-func transientGitFailure(out string) bool {
-	lower := strings.ToLower(out)
-	for _, marker := range permanentGitFailures {
-		if strings.Contains(lower, marker) {
-			return false
-		}
-	}
-	for _, marker := range transientGitFailures {
-		if strings.Contains(lower, marker) {
-			return true
-		}
-	}
-	return false
-}
-
-// gitBackoffDelay grows the wait geometrically up to maxDelay and adds
-// jitter so several workers failing against the same forge at the same
-// moment do not retry in lockstep.
-func gitBackoffDelay(attempt int, baseDelay, maxDelay time.Duration) time.Duration {
-	delay := baseDelay
-	for range attempt - 1 {
-		delay *= gitRetryBackoffFactor
-		if delay >= maxDelay {
-			return gitJitter(maxDelay)
-		}
-	}
-	return gitJitter(delay)
-}
-
-func gitJitter(delay time.Duration) time.Duration {
-	if delay <= 0 {
-		return 0
-	}
-	spread := delay / gitRetryJitterDivisor
-	if spread <= 0 {
-		return delay
-	}
-	return delay + time.Duration(rand.Int64N(int64(spread)))
-}
-
-// gitSleep waits for delay, returning early with the context's error when
-// the caller gives up first.
-func gitSleep(ctx context.Context, delay time.Duration) error {
-	if delay <= 0 {
-		return ctx.Err()
-	}
-	timer := time.NewTimer(delay)
-	defer timer.Stop()
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	case <-timer.C:
-		return nil
-	}
+func cloneDestReset(dst string) func() error {
+	return gitx.CloneDestReset(dst)
 }

--- a/internal/worker/git_retry_test.go
+++ b/internal/worker/git_retry_test.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	retryx "scrutineer/internal/retry"
 )
 
 var errGitExit = errors.New("exit status 128")
@@ -152,9 +154,10 @@ func TestGitRetryStopsWhenContextEnds(t *testing.T) {
 	})
 }
 
-// TestGitRetryResetRunsBeforeEachRetry pins when the cleanup hook fires: not
-// before the first attempt, and once before every retry.
-func TestGitRetryResetRunsBeforeEachRetry(t *testing.T) {
+// TestGitRetryResetRunsAfterEachFailedAttempt pins when the cleanup hook
+// fires: never before the first attempt, and once after every failure,
+// including the terminal one.
+func TestGitRetryResetRunsAfterEachFailedAttempt(t *testing.T) {
 	git := &scriptedGit{outcomes: []gitOutcome{transientOutcome()}}
 	var resetsBeforeCall []int
 	retry := gitRetry{run: git.run, sleep: (&recordedSleep{}).sleep}
@@ -170,8 +173,8 @@ func TestGitRetryResetRunsBeforeEachRetry(t *testing.T) {
 	if _, err := retry.do(context.Background(), cmd, func(Event) {}); err == nil {
 		t.Fatal("expected the exhausted budget to fail")
 	}
-	// One reset after attempt 1 and one after attempt 2; none before attempt 1.
-	want := []int{1, 2}
+	// One reset after every failed attempt; none before attempt 1.
+	want := []int{1, 2, 3}
 	if len(resetsBeforeCall) != len(want) {
 		t.Fatalf("reset ran %d times (after attempts %v), want %d", len(resetsBeforeCall), resetsBeforeCall, len(want))
 	}
@@ -255,145 +258,6 @@ func TestGitRetryToleratesNilEmit(t *testing.T) {
 	}
 }
 
-func TestTransientGitFailure(t *testing.T) {
-	transient := []string{
-		"fatal: unable to access 'https://h/r/': Could not resolve host: h",
-		"ssh: Could not resolve hostname h: Temporary failure in name resolution",
-		"fatal: unable to access 'https://h/r/': Could not resolve proxy: proxy.invalid",
-		"fatal: unable to access 'https://h/r/': Failed to connect to h port 443: Connection refused",
-		"fatal: unable to access 'https://h/r/': Recv failure: Connection reset by peer",
-		"fatal: unable to access 'https://h/r/': Operation timed out after 30000 milliseconds",
-		"error: RPC failed; curl 92 HTTP/2 stream 5 was not closed cleanly\nfatal: early EOF",
-		"fatal: the remote end hung up unexpectedly",
-		"error: RPC failed; curl 56 GnuTLS recv error (-54): Error in the pull function.",
-		"fetch-pack: unexpected disconnect while reading sideband packet",
-		"fatal: unable to access 'https://h/r/': The requested URL returned error: 503",
-		"fatal: unable to access 'https://h/r/': The requested URL returned error: 429",
-		"remote: Internal Server Error",
-		"error: RPC failed; HTTP 502 curl 22 The requested URL returned error: 502 Bad Gateway",
-		// nginx phrases 503 as "Service Temporarily Unavailable".
-		"error: RPC failed; HTTP 503 curl 22 The requested URL returned error: 503 Service Temporarily Unavailable",
-		// Cloudflare origin-side timeouts, which the base gave up on after one try.
-		"fatal: unable to access 'https://h/r/': The requested URL returned error: 522",
-		"fatal: unable to access 'https://h/r/': The requested URL returned error: 524",
-	}
-	for _, out := range transient {
-		if !transientGitFailure(out) {
-			t.Errorf("transientGitFailure(%q) = false, want true", out)
-		}
-	}
-
-	permanent := []string{
-		"",
-		"remote: Repository not found.\nfatal: repository 'https://h/r/' not found",
-		"remote: HTTP Basic: Access denied\nfatal: Authentication failed for 'https://h/r/'",
-		"fatal: could not read Username for 'https://h': terminal prompts disabled",
-		"fatal: couldn't find remote ref does-not-exist",
-		"fatal: 'https://h/r' does not appear to be a git repository",
-		"fatal: destination path 'src' already exists and is not an empty directory.",
-		"fatal: unable to access 'https://h/r/': The requested URL returned error: 404",
-		"fatal: could not create work tree dir 'src': Permission denied",
-		// A local EAGAIN reported as "Resource temporarily unavailable": no
-		// amount of retrying frees a thread, and re-cloning wastes a full
-		// download onto a machine that is already out of headroom.
-		"fatal: unable to create thread: Resource temporarily unavailable",
-		// A push rejected for size, in git's older result=/HTTP-code phrasing.
-		"error: RPC failed; HTTP 413 curl 22 The requested URL returned error: 413",
-		"fatal: a failure message nobody has classified yet",
-	}
-	for _, out := range permanent {
-		if transientGitFailure(out) {
-			t.Errorf("transientGitFailure(%q) = true, want false", out)
-		}
-	}
-}
-
-// TestTransientGitFailureMixedOutput covers the cases the ordering exists
-// for: git reports a settled answer *wrapped in* transport noise, so reading
-// only the noise would spend the whole budget re-asking a question that is
-// already answered -- or, worse, re-downloading a pack onto a full disk.
-func TestTransientGitFailureMixedOutput(t *testing.T) {
-	settled := []struct{ name, out string }{
-		{"repository is gone", "" +
-			"fatal: unable to access 'https://h/r/': Connection reset by peer\n" +
-			"remote: Repository not found."},
-		{"disk is full", "" +
-			"fatal: write error: No space left on device\n" +
-			"fatal: the remote end hung up unexpectedly\n" +
-			"fatal: index-pack failed"},
-		{"quota is exhausted", "" +
-			"error: RPC failed; curl 18 transfer closed with outstanding read data remaining\n" +
-			"fatal: write error: Disk quota exceeded"},
-		{"credentials rejected, older git phrasing", "" +
-			"error: RPC failed; result=22, HTTP code = 401\n" +
-			"fatal: The remote end hung up unexpectedly"},
-		{"repository missing, older git phrasing", "" +
-			"error: RPC failed; result=22, HTTP code = 404\n" +
-			"fatal: The remote end hung up unexpectedly"},
-		{"server-side size limit", "" +
-			"remote: fatal: pack exceeds maximum allowed size (2.00 GiB)\n" +
-			"fatal: the remote end hung up unexpectedly"},
-	}
-	for _, c := range settled {
-		if transientGitFailure(c.out) {
-			t.Errorf("%s: classified transient, want permanent", c.name)
-		}
-	}
-
-	// The mirror image: a connect(2) refusal reported as EACCES by a
-	// firewall is a network condition that can clear, so the permanent
-	// markers must be narrow enough not to swallow it.
-	blocked := "fatal: unable to access 'https://h/r/': Failed to connect to h port 443: Permission denied"
-	if !transientGitFailure(blocked) {
-		t.Error("a firewall-refused connection should stay retryable")
-	}
-}
-
-// TestGitBackoffDelayBounds pins the shape of the wait: each step at least
-// the geometric delay and never past the cap plus its jitter.
-func TestGitBackoffDelayBounds(t *testing.T) {
-	const (
-		base    = 100 * time.Millisecond
-		ceiling = 400 * time.Millisecond
-	)
-	want := []time.Duration{base, 2 * base, ceiling, ceiling, ceiling}
-	for attempt, floor := range want {
-		got := gitBackoffDelay(attempt+1, base, ceiling)
-		limit := floor + floor/gitRetryJitterDivisor
-		if got < floor || got >= limit {
-			t.Errorf("gitBackoffDelay(%d) = %v, want [%v, %v)", attempt+1, got, floor, limit)
-		}
-	}
-}
-
-// TestGitBackoffDelayIsJittered is what actually keeps the jitter alive:
-// bounds alone are satisfied by a constant delay, which is exactly the
-// lockstep behaviour the spread exists to prevent when several workers fail
-// against one forge at the same moment.
-func TestGitBackoffDelayIsJittered(t *testing.T) {
-	const (
-		base    = 100 * time.Millisecond
-		ceiling = time.Second
-		samples = 200
-	)
-	lowest, highest := time.Duration(1<<62), time.Duration(0)
-	for range samples {
-		delay := gitBackoffDelay(1, base, ceiling)
-		if delay < base || delay >= base+base/gitRetryJitterDivisor {
-			t.Fatalf("jittered delay %v outside [%v, %v)", delay, base, base+base/gitRetryJitterDivisor)
-		}
-		lowest = min(lowest, delay)
-		highest = max(highest, delay)
-	}
-	// A token spread would satisfy "not constant" while still sending every
-	// worker back at effectively the same moment, so require the observed
-	// range to be a real fraction of the delay.
-	if spread := highest - lowest; spread < base/20 {
-		t.Errorf("%d samples spanned only %v (%v..%v); the backoff is effectively unjittered",
-			samples, spread, lowest, highest)
-	}
-}
-
 // TestRetryBudgetsStaySmall guards the production constants themselves. The
 // policy's value depends on staying far below the deadlines it runs inside:
 // a scan's worker slot, and -- for the branch picker -- the request timeout
@@ -407,7 +271,7 @@ func TestRetryBudgetsStaySmall(t *testing.T) {
 
 	// A zero base delay would retry with no backoff at all -- the lockstep
 	// hammering the policy exists to avoid -- and nothing else notices,
-	// because gitBackoffDelay(_, 0, _) is a valid (if pointless) zero.
+	// because retry.BackoffDelay(_, 0, _) is a valid (if pointless) zero.
 	if gitRetryBaseDelay <= 0 {
 		t.Errorf("gitRetryBaseDelay = %v, want a positive backoff", gitRetryBaseDelay)
 	}
@@ -426,7 +290,7 @@ func TestRetryBudgetsStaySmall(t *testing.T) {
 
 	var scanWorst time.Duration
 	for attempt := 1; attempt < gitRetryAttempts; attempt++ {
-		scanWorst += gitBackoffDelay(attempt, gitRetryBaseDelay, gitRetryMaxDelay)
+		scanWorst += retryx.BackoffDelay(attempt, gitRetryBaseDelay, gitRetryMaxDelay)
 	}
 	if scanWorst > scanBudget {
 		t.Errorf("scan retries can wait %v in total, want at most %v", scanWorst, scanBudget)
@@ -434,7 +298,7 @@ func TestRetryBudgetsStaySmall(t *testing.T) {
 
 	var pickerWorst time.Duration
 	for attempt := 1; attempt < branchPickerAttempts; attempt++ {
-		pickerWorst += gitBackoffDelay(attempt, branchPickerDelay, branchPickerDelay)
+		pickerWorst += retryx.BackoffDelay(attempt, branchPickerDelay, branchPickerDelay)
 	}
 	if pickerWorst > pickerBudget {
 		t.Errorf("branch-picker retries can wait %v in total, want at most %v", pickerWorst, pickerBudget)
@@ -445,16 +309,5 @@ func TestRetryBudgetsStaySmall(t *testing.T) {
 	// minutes-long wait.
 	if gitRetryMaxDelay > capBudget {
 		t.Errorf("gitRetryMaxDelay = %v, want at most %v", gitRetryMaxDelay, capBudget)
-	}
-}
-
-func TestGitSleepReturnsOnContextEnd(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
-	if err := gitSleep(ctx, time.Hour); !errors.Is(err, context.Canceled) {
-		t.Errorf("gitSleep on a cancelled context = %v, want context.Canceled", err)
-	}
-	if err := gitSleep(context.Background(), time.Nanosecond); err != nil {
-		t.Errorf("gitSleep for a tiny delay = %v, want nil", err)
 	}
 }

--- a/internal/worker/upstream.go
+++ b/internal/worker/upstream.go
@@ -24,11 +24,18 @@ func validateScheduleURL(u string) error {
 // also schedulable; only the terminal prompt is disabled so a missing
 // credential fails fast instead of hanging the scheduler.
 func ResolveRemoteHead(ctx context.Context, cloneURL string) (string, error) {
+	return resolveRemoteHead(ctx, branchPickerRetry(gitRetry{}), cloneURL)
+}
+
+func resolveRemoteHead(ctx context.Context, retry gitRetry, cloneURL string) (string, error) {
 	if err := validateScheduleURL(cloneURL); err != nil {
 		return "", err
 	}
-	out, err := gitWithEnv(ctx, "", []string{"GIT_TERMINAL_PROMPT=0"},
-		"ls-remote", "--", cloneURL, "HEAD")
+	out, err := retry.do(ctx, gitCommand{
+		label: "ls-remote",
+		env:   []string{"GIT_TERMINAL_PROMPT=0"},
+		args:  []string{"ls-remote", "--", cloneURL, "HEAD"},
+	}, nil)
 	if err != nil {
 		return "", fmt.Errorf("%s: %w", strings.TrimSpace(out), err)
 	}
@@ -54,17 +61,22 @@ func ResolveRemoteHead(ctx context.Context, cloneURL string) (string, error) {
 // helper, gh auth); only the terminal prompt is disabled so a missing
 // credential fails fast.
 func (w *Worker) SyncUpstream(ctx context.Context, repoURL, upstreamURL string) error {
+	return w.syncUpstream(ctx, gitRetry{}, repoURL, upstreamURL)
+}
+
+func (w *Worker) syncUpstream(ctx context.Context, retry gitRetry, repoURL, upstreamURL string) error {
 	if err := validateScheduleURL(repoURL); err != nil {
 		return fmt.Errorf("repo: %w", err)
 	}
 	if err := validateScheduleURL(upstreamURL); err != nil {
 		return fmt.Errorf("upstream: %w", err)
 	}
-	repoHead, err := ResolveRemoteHead(ctx, repoURL)
+	policy := retry.resolved()
+	repoHead, err := resolveRemoteHead(ctx, branchPickerRetry(policy), repoURL)
 	if err != nil {
 		return fmt.Errorf("resolve repo HEAD: %w", err)
 	}
-	upstreamHead, err := ResolveRemoteHead(ctx, upstreamURL)
+	upstreamHead, err := resolveRemoteHead(ctx, branchPickerRetry(policy), upstreamURL)
 	if err != nil {
 		return fmt.Errorf("resolve upstream HEAD: %w", err)
 	}
@@ -82,20 +94,60 @@ func (w *Worker) SyncUpstream(ctx context.Context, repoURL, upstreamURL string) 
 		if err := os.MkdirAll(filepath.Dir(mirror), dirPerm); err != nil {
 			return err
 		}
-		if out, err := gitWithEnv(ctx, "", env, "clone", "--quiet", "--bare", "--", repoURL, mirror); err != nil {
+		if out, err := policy.do(ctx, gitCommand{
+			label: "clone",
+			env:   env,
+			args:  []string{"clone", "--quiet", "--bare", "--", repoURL, mirror},
+			reset: cloneDestReset(mirror),
+		}, nil); err != nil {
 			return fmt.Errorf("clone staging repo: %s: %w", strings.TrimSpace(out), err)
 		}
 	}
-	branch, err := gitWithEnv(ctx, mirror, env, "symbolic-ref", "--short", "HEAD")
+	branch, err := policy.run(ctx, mirror, env, "symbolic-ref", "--short", "HEAD")
 	if err != nil {
 		return fmt.Errorf("resolve default branch: %s: %w", strings.TrimSpace(branch), err)
 	}
 	branch = strings.TrimSpace(branch)
-	if out, err := gitWithEnv(ctx, mirror, env, "fetch", "--quiet", "--", upstreamURL, "HEAD"); err != nil {
+	if out, err := policy.do(ctx, gitCommand{
+		label: "fetch",
+		dir:   mirror,
+		env:   env,
+		args:  []string{"fetch", "--quiet", "--", upstreamURL, "HEAD"},
+	}, nil); err != nil {
 		return fmt.Errorf("fetch upstream: %s: %w", strings.TrimSpace(out), err)
 	}
-	if out, err := gitWithEnv(ctx, mirror, env, "push", "--quiet", "--force", "origin", "FETCH_HEAD:refs/heads/"+branch); err != nil {
+	desiredHead, err := policy.run(ctx, mirror, env, "rev-parse", "FETCH_HEAD")
+	if err != nil {
+		return fmt.Errorf("resolve fetched HEAD: %s: %w", strings.TrimSpace(desiredHead), err)
+	}
+	desiredHead = strings.TrimSpace(desiredHead)
+	if out, err := policy.do(ctx, gitCommand{
+		label: "push",
+		dir:   mirror,
+		env:   env,
+		args:  []string{"push", "--quiet", "--force", "origin", "FETCH_HEAD:refs/heads/" + branch},
+		confirm: func(ctx context.Context) (bool, error) {
+			return remoteRefMatches(ctx, policy.run, env, repoURL, "refs/heads/"+branch, desiredHead)
+		},
+	}, nil); err != nil {
 		return fmt.Errorf("push to staging repo: %s: %w", strings.TrimSpace(out), err)
 	}
 	return nil
+}
+
+// remoteRefMatches checks whether an ambiguous push already installed the
+// desired object. It intentionally makes one direct attempt: failure to
+// confirm falls back to the push's own bounded retry budget.
+func remoteRefMatches(ctx context.Context, run gitRunner, env []string, repoURL, ref, wantSHA string) (bool, error) {
+	out, err := run(ctx, "", env, "ls-remote", "--refs", "--", repoURL, ref)
+	if err != nil {
+		return false, err
+	}
+	for line := range strings.SplitSeq(out, "\n") {
+		sha, gotRef, ok := strings.Cut(line, "\t")
+		if ok && strings.TrimSpace(gotRef) == ref {
+			return strings.TrimSpace(sha) == wantSHA, nil
+		}
+	}
+	return false, nil
 }

--- a/internal/worker/upstream_retry_test.go
+++ b/internal/worker/upstream_retry_test.go
@@ -1,0 +1,246 @@
+package worker
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestResolveRemoteHeadRetriesTransientFailure(t *testing.T) {
+	calls := 0
+	retry := branchPickerRetry(fastRetry())
+	retry.run = func(context.Context, string, []string, ...string) (string, error) {
+		calls++
+		if calls == 1 {
+			return "fatal: unable to access remote: Connection reset by peer", errGitExit
+		}
+		return "deadbeef\tHEAD\n", nil
+	}
+
+	got, err := resolveRemoteHead(context.Background(), retry, "https://example.invalid/repo")
+	if err != nil {
+		t.Fatalf("resolveRemoteHead: %v", err)
+	}
+	if got != "deadbeef" || calls != 2 {
+		t.Fatalf("HEAD = %q after %d calls, want deadbeef after 2", got, calls)
+	}
+}
+
+func TestSyncUpstreamRetriesRemoteCloneAndFetch(t *testing.T) {
+	for _, failOperation := range []string{"clone", "fetch"} {
+		t.Run(failOperation, func(t *testing.T) {
+			git := newUpstreamScript()
+			git.failOperation = failOperation
+			retry := fastRetry()
+			retry.run = git.run
+			worker := &Worker{DataDir: t.TempDir()}
+
+			if err := worker.syncUpstream(context.Background(), retry, git.repoURL, git.upstreamURL); err != nil {
+				t.Fatalf("syncUpstream: %v", err)
+			}
+			if failOperation == "clone" && (git.cloneCalls != 2 || !git.cloneResetObserved) {
+				t.Fatalf("clone calls = %d, reset observed = %v; want 2 and true", git.cloneCalls, git.cloneResetObserved)
+			}
+			if failOperation == "fetch" && git.fetchCalls != 2 {
+				t.Fatalf("fetch calls = %d, want 2", git.fetchCalls)
+			}
+			if git.pushCalls != 1 || git.remoteSHA != git.desiredSHA {
+				t.Fatalf("push calls = %d, remote SHA = %q; want 1 and %q", git.pushCalls, git.remoteSHA, git.desiredSHA)
+			}
+		})
+	}
+}
+
+func TestSyncUpstreamCancelledCloneCleansMirrorForNextInvocation(t *testing.T) {
+	git := newUpstreamScript()
+	git.failOperation = "clone-cancel"
+	ctx, cancel := context.WithCancel(context.Background())
+	git.cancel = cancel
+	retry := fastRetry()
+	retry.run = git.run
+	worker := &Worker{DataDir: t.TempDir()}
+
+	err := worker.syncUpstream(ctx, retry, git.repoURL, git.upstreamURL)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("syncUpstream error = %v, want context.Canceled", err)
+	}
+	mirror := filepath.Join(RepoCacheRoot(worker.DataDir, git.repoURL), "upstream-sync.git")
+	if _, err := os.Stat(mirror); !os.IsNotExist(err) {
+		t.Fatalf("cancelled clone left mirror behind: %v", err)
+	}
+
+	fresh := newUpstreamScript()
+	freshRetry := fastRetry()
+	freshRetry.run = fresh.run
+	if err := worker.syncUpstream(context.Background(), freshRetry, fresh.repoURL, fresh.upstreamURL); err != nil {
+		t.Fatalf("fresh sync after cancellation: %v", err)
+	}
+	if fresh.cloneCalls != 1 || fresh.remoteSHA != fresh.desiredSHA {
+		t.Fatalf("fresh sync cloned %d times and left SHA %q, want 1 clone and %q",
+			fresh.cloneCalls, fresh.remoteSHA, fresh.desiredSHA)
+	}
+}
+
+func TestSyncUpstreamReconcilesAmbiguousPush(t *testing.T) {
+	for _, mode := range []string{"landed", "missed", "confirmation-error"} {
+		t.Run(mode, func(t *testing.T) {
+			git := newUpstreamScript()
+			git.pushMode = mode
+			retry := fastRetry()
+			retry.run = git.run
+			worker := &Worker{DataDir: t.TempDir()}
+
+			if err := worker.syncUpstream(context.Background(), retry, git.repoURL, git.upstreamURL); err != nil {
+				t.Fatalf("syncUpstream: %v", err)
+			}
+			wantPushes := 1
+			if mode != "landed" {
+				wantPushes = 2
+			}
+			if git.pushCalls != wantPushes {
+				t.Fatalf("push calls = %d, want %d", git.pushCalls, wantPushes)
+			}
+			if git.confirmCalls != 1 {
+				t.Fatalf("confirmation calls = %d, want 1", git.confirmCalls)
+			}
+			if git.remoteSHA != git.desiredSHA {
+				t.Fatalf("remote SHA = %q, want %q", git.remoteSHA, git.desiredSHA)
+			}
+		})
+	}
+}
+
+type upstreamScript struct {
+	repoURL            string
+	upstreamURL        string
+	repoSHA            string
+	upstreamSHA        string
+	desiredSHA         string
+	remoteSHA          string
+	failOperation      string
+	pushMode           string
+	cloneCalls         int
+	fetchCalls         int
+	pushCalls          int
+	confirmCalls       int
+	cloneResetObserved bool
+	cancel             context.CancelFunc
+}
+
+func newUpstreamScript() *upstreamScript {
+	g := &upstreamScript{}
+	g.defaults()
+	return g
+}
+
+func (g *upstreamScript) defaults() {
+	if g.repoURL == "" {
+		g.repoURL = "https://example.invalid/staging"
+	}
+	if g.upstreamURL == "" {
+		g.upstreamURL = "https://example.invalid/upstream"
+	}
+	if g.repoSHA == "" {
+		g.repoSHA = "1111111111111111111111111111111111111111"
+	}
+	if g.upstreamSHA == "" {
+		g.upstreamSHA = "2222222222222222222222222222222222222222"
+	}
+	if g.desiredSHA == "" {
+		g.desiredSHA = g.upstreamSHA
+	}
+	if g.remoteSHA == "" {
+		g.remoteSHA = g.repoSHA
+	}
+}
+
+func (g *upstreamScript) run(_ context.Context, _ string, _ []string, args ...string) (string, error) {
+	g.defaults()
+	if len(args) == 0 {
+		return "", errors.New("missing git command")
+	}
+	switch args[0] {
+	case "ls-remote":
+		return g.lsRemote(args)
+	case "clone":
+		return g.clone(args)
+	case "symbolic-ref":
+		return "main\n", nil
+	case "fetch":
+		return g.fetch()
+	case "rev-parse":
+		return g.desiredSHA + "\n", nil
+	case "push":
+		return g.push()
+	}
+	return "", errors.New("unexpected git command: " + strings.Join(args, " "))
+}
+
+// lsRemote answers the HEAD lookups and the reconciliation --refs query, which
+// pushMode "confirmation-error" scripts to fail once.
+func (g *upstreamScript) lsRemote(args []string) (string, error) {
+	if len(args) > 1 && args[1] == "--refs" {
+		g.confirmCalls++
+		if g.pushMode == "confirmation-error" && g.confirmCalls == 1 {
+			return "fatal: unable to access remote: Connection reset by peer", errGitExit
+		}
+		return g.remoteSHA + "\t" + args[len(args)-1] + "\n", nil
+	}
+	switch args[len(args)-2] {
+	case g.repoURL:
+		return g.remoteSHA + "\tHEAD\n", nil
+	case g.upstreamURL:
+		return g.upstreamSHA + "\tHEAD\n", nil
+	}
+	return "", errors.New("unexpected git command: " + strings.Join(args, " "))
+}
+
+// clone leaves a partial destination and fails once when failOperation is
+// "clone", so the retry can prove it cleared the target first.
+func (g *upstreamScript) clone(args []string) (string, error) {
+	g.cloneCalls++
+	dst := args[len(args)-1]
+	partial := filepath.Join(dst, "partial")
+	if (g.failOperation == "clone" || g.failOperation == "clone-cancel") && g.cloneCalls == 1 {
+		if err := os.MkdirAll(dst, dirPerm); err != nil {
+			return "", err
+		}
+		if err := os.WriteFile(partial, []byte("partial clone"), 0o644); err != nil {
+			return "", err
+		}
+		if g.cancel != nil {
+			g.cancel()
+		}
+		return "fatal: the remote end hung up unexpectedly", errGitExit
+	}
+	if _, err := os.Stat(partial); os.IsNotExist(err) {
+		g.cloneResetObserved = true
+	}
+	return "", os.MkdirAll(dst, dirPerm)
+}
+
+// fetch fails once when failOperation is "fetch".
+func (g *upstreamScript) fetch() (string, error) {
+	g.fetchCalls++
+	if g.failOperation == "fetch" && g.fetchCalls == 1 {
+		return "fatal: unable to access remote: Connection reset by peer", errGitExit
+	}
+	return "", nil
+}
+
+// push fails its first attempt whenever pushMode is set, recording the
+// destination SHA up front only when the ambiguous failure "landed".
+func (g *upstreamScript) push() (string, error) {
+	g.pushCalls++
+	if g.pushCalls == 1 && g.pushMode != "" {
+		if g.pushMode == "landed" {
+			g.remoteSHA = g.desiredSHA
+		}
+		return "fatal: the remote end hung up unexpectedly", errGitExit
+	}
+	g.remoteSHA = g.desiredSHA
+	return "", nil
+}


### PR DESCRIPTION
Closes #683 and closes #684. #682 added a bounded retry policy for the scan clone and fetch paths, but left its backoff, jitter, and context-aware sleep duplicated against `internal/httpx`, and kept its git runner and transient/permanent classifier inside `internal/worker` where `internal/skills` could not reach them.

This extracts the transport-agnostic timing primitives into a new `internal/retry` package and the git runner, WaitDelay handling, failure classifier, and clone-destination cleanup into a new `internal/gitx` package, then routes `internal/httpx` through the shared timing helpers. The move is behaviour-preserving: the backoff shape, the fail-closed classification, and every transient and permanent marker are carried over verbatim, and the HTTP path keeps its own Retry-After handling and 429/5xx decision.

With the policy reachable from both packages, the remaining single-attempt callers adopt it: `ResolveRemoteHead` on the tight branch-picker budget, the `SyncUpstream` bare clone and upstream fetch on the scan budget, and the skills `CloneOrPull` clone, cached fetch, and explicit-ref fetch (which also gain the WaitDelay bound they never had). Local-only work such as reset, rev-parse, and symbolic-ref stays outside the policy, since repeating it cannot fix what a retry budget is meant to fix.

The force push in `SyncUpstream` gets a decision rather than a blanket retry, because a transient failure after the destination ref already moved would re-push a no-op at best. On an ambiguous failure it inspects the destination ref and treats the push as already done when the ref holds the SHA that was just fetched, otherwise falling back to the push's own bounded retry budget. Credential hygiene is unchanged: retry notices still carry neither the remote URL nor git's output, and the reconciliation lookup discards its own error rather than surfacing it.

Highlights:
- new `internal/retry` (backoff, jitter, context-aware sleep) and `internal/gitx` (runner, WaitDelay, classifier, clone-dest cleanup), shared by the worker, skills, and HTTP callers
- bounded retries added to `ResolveRemoteHead`, the `SyncUpstream` clone and fetch, and the skills `CloneOrPull` clone, cached fetch, and explicit-ref fetch
- force-push reconciliation: an ambiguous push that already installed the fetched SHA is not repeated
- classifier, retry budgets, environment hardening, cancellation semantics, and fail-closed behaviour preserved from #682; local-only git operations are never retried
