### PR TITLE
Add package alternatives table

### DIFF
--- a/docs/database.md
+++ b/docs/database.md
@@ -71,6 +71,22 @@ change history for findings. `payload` is JSON stored portably as text.
 | payload | text | JSON metadata. Scan events include stable execution metadata and terminal metrics, without duplicating reports or logs. |
 | created_at | datetime | |
 
+## package_alternatives
+
+Operator-curated migration targets for repositories classified as abandoned or
+zombie. Later #12 migration-guide and campaign tracking work can join on this
+table instead of reparsing notes or reports.
+
+| Column | Type | Notes |
+|--------|------|-------|
+| id | integer PK | |
+| repository_id | integer FK | Source repository this alternative applies to. |
+| p_url | text | Package URL of the fork, successor, or equivalent package. Unique with `repository_id` and `kind`. |
+| kind | text | One of `fork`, `successor`, or `equivalent`. |
+| note | text | Operator note explaining why this is a credible migration target. |
+| created_at | datetime | |
+| updated_at | datetime | |
+
 ## scans
 
 One row per skill execution or external import. `skill_name` / `skill_version` pin which skill ran; for imports `skill_name` records the originating tool.

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -376,6 +376,30 @@ type Package struct {
 	CreatedAt time.Time
 }
 
+type PackageAlternativeKind string
+
+const (
+	PackageAlternativeFork       PackageAlternativeKind = "fork"
+	PackageAlternativeSuccessor  PackageAlternativeKind = "successor"
+	PackageAlternativeEquivalent PackageAlternativeKind = "equivalent"
+)
+
+// PackageAlternative records a migration target for a repository's package.
+// It is operator-curated: the source repo may be abandoned or zombie, while
+// the alternative PURL points at a maintained fork, successor, or equivalent.
+type PackageAlternative struct {
+	ID           uint `gorm:"primarykey"`
+	RepositoryID uint `gorm:"index;not null;uniqueIndex:idx_repo_alt_purl_kind"`
+	Repository   Repository
+
+	PURL string                 `gorm:"not null;uniqueIndex:idx_repo_alt_purl_kind"`
+	Kind PackageAlternativeKind `gorm:"index;not null;uniqueIndex:idx_repo_alt_purl_kind"`
+	Note string
+
+	CreatedAt time.Time
+	UpdatedAt time.Time
+}
+
 type MaintainerStatus string
 
 const (
@@ -1233,7 +1257,7 @@ func Open(dsn string) (*gorm.DB, error) {
 		&Repository{}, &Scan{},
 		&Finding{}, &FindingLabel{}, &FindingNote{},
 		&FindingCommunication{}, &FindingReference{}, &FindingHistory{}, &FindingReview{}, &AuditEvent{},
-		&Dependency{}, &ExpectedFinding{}, &Package{}, &Dependent{}, &FindingDependent{}, &Advisory{}, &AdvisoryAudit{},
+		&Dependency{}, &ExpectedFinding{}, &Package{}, &PackageAlternative{}, &Dependent{}, &FindingDependent{}, &Advisory{}, &AdvisoryAudit{},
 		&Maintainer{}, &Skill{}, &Subproject{},
 		&SBOMUpload{}, &SBOMPackage{}, &CNA{}, &Setting{},
 	); err != nil {

--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -106,6 +106,7 @@ func (s *Server) apiHandler() http.Handler {
 	mux.HandleFunc("GET /repositories/{id}/scans", s.apiListScans)
 	mux.HandleFunc("GET /repositories/{id}/maintainers", s.apiListMaintainers)
 	mux.HandleFunc("GET /repositories/{id}/packages", s.apiListPackages)
+	mux.HandleFunc("GET /repositories/{id}/alternatives", s.apiListPackageAlternatives)
 	mux.HandleFunc("GET /repositories/{id}/advisories", s.apiListAdvisories)
 	mux.HandleFunc("GET /repositories/{id}/dependents", s.apiListDependents)
 	mux.HandleFunc("GET /repositories/{id}/ecosystems/{source}/raw", s.apiGetEcosystemsRaw)

--- a/internal/web/api_test.go
+++ b/internal/web/api_test.go
@@ -153,6 +153,7 @@ func TestAPIListsTypedReads(t *testing.T) {
 
 	// Seed one row in each typed table.
 	s.DB.Create(&db.Package{RepositoryID: repo.ID, Name: "foo", Ecosystem: "rubygems", PURL: "pkg:gem/foo"})
+	s.DB.Create(&db.PackageAlternative{RepositoryID: repo.ID, PURL: "pkg:gem/bar", Kind: db.PackageAlternativeEquivalent})
 	s.DB.Create(&db.Dependent{RepositoryID: repo.ID, Name: "bar", Ecosystem: "rubygems"})
 	s.DB.Create(&db.Advisory{RepositoryID: repo.ID, UUID: "u1", Severity: "HIGH", CVSSScore: 7.5})
 	s.DB.Create(&db.Dependency{RepositoryID: repo.ID, Name: "dep", Ecosystem: "rubygems", ManifestPath: "Gemfile"})
@@ -164,6 +165,7 @@ func TestAPIListsTypedReads(t *testing.T) {
 
 	cases := map[string]int{
 		"/api/repositories/%d/packages":     1,
+		"/api/repositories/%d/alternatives": 1,
 		"/api/repositories/%d/dependents":   1,
 		"/api/repositories/%d/advisories":   1,
 		"/api/repositories/%d/dependencies": 1,

--- a/internal/web/package_alternatives.go
+++ b/internal/web/package_alternatives.go
@@ -1,0 +1,136 @@
+package web
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/git-pkgs/purl"
+	"gorm.io/gorm"
+
+	"scrutineer/internal/db"
+)
+
+type packageAlternativeResponse struct {
+	ID           uint   `json:"id"`
+	RepositoryID uint   `json:"repository_id"`
+	PURL         string `json:"purl"`
+	Kind         string `json:"kind"`
+	Note         string `json:"note,omitempty"`
+}
+
+func (s *Server) apiListPackageAlternatives(w http.ResponseWriter, r *http.Request) {
+	repoID, ok := s.repoScopedID(w, r)
+	if !ok {
+		return
+	}
+	rows, err := loadPackageAlternatives(s.DB, repoID)
+	if err != nil {
+		writeAPIError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, packageAlternativeResponses(rows))
+}
+
+func (s *Server) repoPackageAlternativeCreate(w http.ResponseWriter, r *http.Request) {
+	repo, ok := loadByID[db.Repository](s, w, r)
+	if !ok {
+		return
+	}
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	row, err := buildPackageAlternative(repo.ID, r.FormValue("purl"), r.FormValue("kind"), r.FormValue("note"))
+	if err != nil {
+		setFlash(w, Flash{Category: errorKey, Title: err.Error()})
+		s.redirect(w, r, fmt.Sprintf("/repositories/%d#rt15", repo.ID))
+		return
+	}
+	if err := s.DB.Create(&row).Error; err != nil {
+		setFlash(w, Flash{Category: errorKey, Title: "Alternative not saved", Description: err.Error()})
+		s.redirect(w, r, fmt.Sprintf("/repositories/%d#rt15", repo.ID))
+		return
+	}
+	setFlash(w, Flash{Category: successKey, Title: "Alternative saved"})
+	s.redirect(w, r, fmt.Sprintf("/repositories/%d#rt15", repo.ID))
+}
+
+func (s *Server) repoPackageAlternativeDelete(w http.ResponseWriter, r *http.Request) {
+	repo, ok := loadByID[db.Repository](s, w, r)
+	if !ok {
+		return
+	}
+	altID, err := strconv.Atoi(r.PathValue("alternative_id"))
+	if err != nil {
+		http.NotFound(w, r)
+		return
+	}
+	res := s.DB.Where("repository_id = ? AND id = ?", repo.ID, altID).Delete(&db.PackageAlternative{})
+	if res.Error != nil {
+		setFlash(w, Flash{Category: errorKey, Title: "Alternative not deleted", Description: res.Error.Error()})
+	} else if res.RowsAffected > 0 {
+		setFlash(w, Flash{Category: successKey, Title: "Alternative deleted"})
+	}
+	s.redirect(w, r, fmt.Sprintf("/repositories/%d#rt15", repo.ID))
+}
+
+func buildPackageAlternative(repoID uint, purlValue, kindValue, note string) (db.PackageAlternative, error) {
+	purlValue = strings.TrimSpace(purlValue)
+	if purlValue == "" {
+		return db.PackageAlternative{}, fmt.Errorf("purl is required")
+	}
+	if _, err := purl.Parse(purlValue); err != nil {
+		return db.PackageAlternative{}, fmt.Errorf("purl is invalid")
+	}
+	kind, err := packageAlternativeKind(kindValue)
+	if err != nil {
+		return db.PackageAlternative{}, err
+	}
+	return db.PackageAlternative{
+		RepositoryID: repoID,
+		PURL:         purlValue,
+		Kind:         kind,
+		Note:         strings.TrimSpace(note),
+	}, nil
+}
+
+func packageAlternativeKind(value string) (db.PackageAlternativeKind, error) {
+	switch db.PackageAlternativeKind(strings.TrimSpace(value)) {
+	case db.PackageAlternativeFork:
+		return db.PackageAlternativeFork, nil
+	case db.PackageAlternativeSuccessor:
+		return db.PackageAlternativeSuccessor, nil
+	case db.PackageAlternativeEquivalent:
+		return db.PackageAlternativeEquivalent, nil
+	default:
+		return "", fmt.Errorf("kind must be fork, successor, or equivalent")
+	}
+}
+
+func loadPackageAlternatives(gdb *gorm.DB, repoID uint) ([]db.PackageAlternative, error) {
+	var rows []db.PackageAlternative
+	if err := gdb.Where("repository_id = ?", repoID).Order("kind, p_url").Find(&rows).Error; err != nil {
+		return nil, err
+	}
+	return rows, nil
+}
+
+func showPackageAlternatives(repo db.Repository, rows []db.PackageAlternative) bool {
+	return len(rows) > 0 || repo.Health == db.RepositoryHealthAbandoned || repo.Health == db.RepositoryHealthZombie
+}
+
+func packageAlternativeResponses(rows []db.PackageAlternative) []packageAlternativeResponse {
+	out := make([]packageAlternativeResponse, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, packageAlternativeResponse{
+			ID:           row.ID,
+			RepositoryID: row.RepositoryID,
+			PURL:         row.PURL,
+			Kind:         string(row.Kind),
+			Note:         row.Note,
+		})
+	}
+	return out
+}

--- a/internal/web/package_alternatives_test.go
+++ b/internal/web/package_alternatives_test.go
@@ -1,0 +1,115 @@
+package web
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"scrutineer/internal/db"
+)
+
+func TestBuildPackageAlternativeValidatesInput(t *testing.T) {
+	tests := []struct {
+		name string
+		purl string
+		kind string
+		want string
+	}{
+		{name: "missing purl", kind: "fork", want: "purl is required"},
+		{name: "invalid purl", purl: "not-a-purl", kind: "fork", want: "purl is invalid"},
+		{name: "invalid kind", purl: "pkg:npm/example", kind: "replacement", want: "kind must be fork, successor, or equivalent"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := buildPackageAlternative(1, tt.purl, tt.kind, "")
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("error = %v, want %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestRepoPackageAlternativesCRUDAndRender(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	repo := db.Repository{URL: "https://example.com/zombie", Name: "zombie", Health: db.RepositoryHealthZombie}
+	if err := s.DB.Create(&repo).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	body := getRepoPage(t, s, repo.ID)
+	for _, want := range []string{"Alternatives", "Add alternative", "No alternatives recorded yet"} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("initial alternatives tab missing %q: %s", want, body)
+		}
+	}
+
+	w := postForm(t, s, fmt.Sprintf("/repositories/%d/alternatives", repo.ID), url.Values{
+		"purl": {"pkg:npm/successor"},
+		"kind": {"successor"},
+		"note": {"Maintained replacement"},
+	})
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("create status %d: %s", w.Code, w.Body)
+	}
+
+	var alt db.PackageAlternative
+	if err := s.DB.Where("repository_id = ?", repo.ID).First(&alt).Error; err != nil {
+		t.Fatal(err)
+	}
+	if alt.PURL != "pkg:npm/successor" || alt.Kind != db.PackageAlternativeSuccessor || alt.Note != "Maintained replacement" {
+		t.Fatalf("alternative = %+v", alt)
+	}
+
+	body = getRepoPage(t, s, repo.ID)
+	for _, want := range []string{"pkg:npm/successor", "successor", "Maintained replacement"} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("rendered alternatives missing %q: %s", want, body)
+		}
+	}
+
+	w = postForm(t, s, fmt.Sprintf("/repositories/%d/alternatives/%d/delete", repo.ID, alt.ID), url.Values{})
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("delete status %d: %s", w.Code, w.Body)
+	}
+	var count int64
+	s.DB.Model(&db.PackageAlternative{}).Where("repository_id = ?", repo.ID).Count(&count)
+	if count != 0 {
+		t.Fatalf("alternatives count = %d, want 0", count)
+	}
+}
+
+func TestAPIListPackageAlternatives(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	repo, scan := seedRunningScan(t, s)
+	if err := s.DB.Create(&db.PackageAlternative{
+		RepositoryID: repo.ID,
+		PURL:         "pkg:gem/split-ng",
+		Kind:         db.PackageAlternativeFork,
+		Note:         "Maintained fork",
+	}).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	r := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/repositories/%d/alternatives", repo.ID), nil)
+	r.Host = testHost
+	r.Header.Set("Authorization", "Bearer "+scan.APIToken)
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, r)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+	var got []map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&got); err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0]["purl"] != "pkg:gem/split-ng" || got[0]["kind"] != "fork" {
+		t.Fatalf("alternatives response = %+v", got)
+	}
+}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -376,6 +376,8 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("POST /repositories/bulk", s.repoBulkCreate)
 	mux.HandleFunc("POST /repositories/org", s.repoOrgImport)
 	mux.HandleFunc("GET /repositories/{id}", s.repoShow)
+	mux.HandleFunc("POST /repositories/{id}/alternatives", s.repoPackageAlternativeCreate)
+	mux.HandleFunc("POST /repositories/{id}/alternatives/{alternative_id}/delete", s.repoPackageAlternativeDelete)
 	mux.HandleFunc("POST /repositories/{id}/expected", s.repoExpectedFindingCreate)
 	mux.HandleFunc("POST /repositories/{id}/expected/{expected_id}/delete", s.repoExpectedFindingDelete)
 	mux.HandleFunc("GET /repositories/{id}/blob/{commit}/{path...}", s.repoBlob)
@@ -1993,26 +1995,28 @@ func (s *Server) repoShow(w http.ResponseWriter, r *http.Request) {
 }
 
 type repoShowView struct {
-	Repo            db.Repository
-	Scans           []db.Scan
-	Latest          *db.Scan
-	Findings        repoFindings
-	Expected        repoExpectedView
-	Dependencies    repoDependencyView
-	Inventory       repoInventoryView
-	Subprojects     repoSubprojectView
-	Maintainers     []db.Maintainer
-	HealthSummary   string
-	Skills          []db.Skill
-	Workbench       Workbench
-	ThreatModel     map[string]any
-	Category        string
-	TMCommit        string
-	NewFindingCount int
-	FailedScans     int
-	ActiveScans     int
-	PausedScans     int
-	TotalCost       float64
+	Repo             db.Repository
+	Scans            []db.Scan
+	Latest           *db.Scan
+	Findings         repoFindings
+	Expected         repoExpectedView
+	Dependencies     repoDependencyView
+	Inventory        repoInventoryView
+	Subprojects      repoSubprojectView
+	Maintainers      []db.Maintainer
+	Alternatives     []db.PackageAlternative
+	ShowAlternatives bool
+	HealthSummary    string
+	Skills           []db.Skill
+	Workbench        Workbench
+	ThreatModel      map[string]any
+	Category         string
+	TMCommit         string
+	NewFindingCount  int
+	FailedScans      int
+	ActiveScans      int
+	PausedScans      int
+	TotalCost        float64
 	// GlobalScanSchedule is the settings-level default schedule, shown on
 	// the repo page so "inherit" spells out what it inherits.
 	GlobalScanSchedule string
@@ -2030,6 +2034,10 @@ func (s *Server) loadRepoShowView(
 	inventory := s.loadRepoInventoryView(repo.ID, deps.Groups)
 	maintainers := s.repoMaintainers(repo.ID)
 	health := db.AssessRepositoryHealth(repo, inventory.Packages, maintainers, time.Now())
+	alternatives, err := loadPackageAlternatives(s.DB, repo.ID)
+	if err != nil {
+		s.Log.Error("load package alternatives", "repo", repo.ID, "err", err)
+	}
 	// activeScans drives both the delete-confirm warning (a running scan keeps
 	// writing into the repo's clone/workspace until it returns) and the "Cancel
 	// all" button; pausedScans drives "Resume all". Both are counted over every
@@ -2046,6 +2054,8 @@ func (s *Server) loadRepoShowView(
 		Inventory:          inventory,
 		Subprojects:        s.loadRepoSubprojectView(repo.ID),
 		Maintainers:        maintainers,
+		Alternatives:       alternatives,
+		ShowAlternatives:   showPackageAlternatives(repo, alternatives),
 		HealthSummary:      health.Summary,
 		Skills:             s.activeRepoSkills(),
 		Workbench:          loadWorkbench(s.DB, &repo, workbenchSeed(tmScan)),
@@ -2094,6 +2104,8 @@ func (v repoShowView) renderData() map[string]any {
 		"AdvisoriesTotal":    v.Inventory.AdvisoriesTotal,
 		"AdvisoryAudits":     v.Inventory.AdvisoryAudits,
 		"Maintainers":        v.Maintainers,
+		"Alternatives":       v.Alternatives,
+		"ShowAlternatives":   v.ShowAlternatives,
 		"ThreatModel":        v.ThreatModel,
 		"KnownURLs":          v.Inventory.KnownURLs,
 		"KnownPURLs":         v.Inventory.KnownPURLs,

--- a/internal/web/templates/repo_show.html
+++ b/internal/web/templates/repo_show.html
@@ -85,6 +85,11 @@
       Packages
     </button>
     {{end}}
+    {{if .ShowAlternatives}}
+    <button type="button" role="tab" id="rt15" aria-controls="rp15" aria-selected="false">
+      Alternatives{{if .Alternatives}} <span class="badge-outline ml-1">{{len .Alternatives}}</span>{{end}}
+    </button>
+    {{end}}
     {{if or .Deps .HiddenDeps}}
       <button type="button" role="tab" id="rt5" aria-controls="rp5" aria-selected="false">
         Dependencies
@@ -412,6 +417,69 @@
       {{end}}
       </tbody>
     </table>
+  </div>
+  {{end}}
+
+  {{if .ShowAlternatives}}
+  <div role="tabpanel" id="rp15" aria-labelledby="rt15" hidden>
+    <div class="grid gap-4">
+      <section>
+        <h3 class="text-sm font-medium mb-2">Migration alternatives</h3>
+        <p class="text-sm text-muted-foreground mb-4">
+          Operator-curated forks, successors, or equivalent packages for consumers moving away from this repository.
+        </p>
+        {{if .Alternatives}}
+        <table class="table w-full">
+          <thead><tr><th>PURL</th><th>Kind</th><th>Note</th><th class="w-16"></th></tr></thead>
+          <tbody>
+          {{range .Alternatives}}
+            <tr>
+              <td class="whitespace-normal"><code class="text-sm break-all">{{.PURL}}</code></td>
+              <td><span class="badge-outline">{{.Kind}}</span></td>
+              <td class="text-muted-foreground whitespace-normal">{{.Note}}</td>
+              <td>
+                <form method="post" action="/repositories/{{$.Repo.ID}}/alternatives/{{.ID}}/delete"
+                      hx-post="/repositories/{{$.Repo.ID}}/alternatives/{{.ID}}/delete" hx-swap="none"
+                      hx-confirm="Delete this package alternative?">
+                  <button class="btn-sm-ghost" type="submit" aria-label="Delete alternative" data-tooltip="Delete alternative">
+                    <i data-lucide="trash-2"></i>
+                  </button>
+                </form>
+              </td>
+            </tr>
+          {{end}}
+          </tbody>
+        </table>
+        {{else}}
+          <p class="text-muted-foreground text-sm">No alternatives recorded yet.</p>
+        {{end}}
+      </section>
+
+      <section class="card">
+        <h3 class="text-sm font-medium mb-3">Add alternative</h3>
+        <form method="post" action="/repositories/{{.Repo.ID}}/alternatives" class="form grid md:grid-cols-[1fr_12rem] gap-3">
+          <label>
+            <span>PURL</span>
+            <input class="input" type="text" name="purl" placeholder="pkg:npm/example" required>
+          </label>
+          <label>
+            <span>Kind</span>
+            <select class="select" name="kind" required>
+              <option value="fork">Fork</option>
+              <option value="successor">Successor</option>
+              <option value="equivalent">Equivalent</option>
+            </select>
+          </label>
+          <label class="md:col-span-2">
+            <span>Note</span>
+            <input class="input" type="text" name="note" placeholder="Why this is a credible migration target">
+          </label>
+          <div class="md:col-span-2">
+            <button class="btn-sm" type="submit">Save alternative</button>
+          </div>
+        </form>
+      </section>
+    </div>
   </div>
   {{end}}
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -96,6 +96,22 @@ paths:
                 items: { $ref: '#/components/schemas/Package' }
         '403': { $ref: '#/components/responses/Forbidden' }
 
+  /repositories/{id}/alternatives:
+    get:
+      summary: List operator-curated package migration alternatives
+      operationId: listRepositoryAlternatives
+      parameters:
+        - $ref: '#/components/parameters/RepositoryID'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: '#/components/schemas/PackageAlternative' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+
   /repositories/{id}/advisories:
     get:
       summary: List published advisories affecting this repository's packages
@@ -1264,6 +1280,16 @@ components:
         dependent_repos: { type: integer }
         registry_url:    { type: string }
         latest_version:  { type: string }
+
+    PackageAlternative:
+      type: object
+      required: [id, repository_id, purl, kind]
+      properties:
+        id:            { type: integer, format: int64 }
+        repository_id: { type: integer, format: int64 }
+        purl:          { type: string }
+        kind:          { type: string, enum: [fork, successor, equivalent] }
+        note:          { type: string }
 
     Dependency:
       type: object


### PR DESCRIPTION
Part of #12

## Summary

Adds operator-curated package migration alternatives for repositories that are abandoned, zombie or otherwise need a documented replacement path.

This gives Scrutineer a structured place to record maintained forks, successors, or equivalent packages before later migration-guide and campaign workflows are built.

## Changes

- Add `package_alternatives` storage with `purl`, `kind`, and `note`
- Support `fork`, `successor`, and `equivalent` alternative kinds
- Add an Alternatives tab on repository pages when alternatives exist or repository health suggests migration guidance is useful
- Add UI actions to create and delete package alternatives
- Add `/api/repositories/{id}/alternatives` for typed reads
- Document the new table in `docs/database.md`
- Document the API response in `openapi.yaml`
- Add focused tests for validation, UI CRUD/rendering, and API reads

## Tests

- `go test ./...`
- `go test -tags evals ./...`
- `go vet ./...`
- `go vet -tags evals ./...`
- `golangci-lint run ./cmd/... ./internal/...`
- `golangci-lint run --build-tags evals ./cmd/... ./internal/...`
- `git diff --check`