### PR TITLE
Add ignored paths UI

### DIFF
--- a/internal/repoconfig/config.go
+++ b/internal/repoconfig/config.go
@@ -101,14 +101,34 @@ func Normalise(raw string) (string, Config, error) {
 	if err != nil {
 		return "", Config{}, err
 	}
+	normalised, err := NormaliseConfig(cfg)
+	return normalised, cfg, err
+}
+
+// NormaliseConfig validates a parsed config and returns its stable, readable
+// YAML representation. An empty config clears the durable scan configuration.
+func NormaliseConfig(cfg Config) (string, error) {
+	if err := cfg.validate(); err != nil {
+		return "", err
+	}
 	if cfg.Empty() {
-		return "", cfg, nil
+		return "", nil
 	}
 	b, err := yaml.Marshal(cfg)
 	if err != nil {
-		return "", Config{}, err
+		return "", err
 	}
-	return string(b), cfg, nil
+	return string(b), nil
+}
+
+// NormaliseSkipPattern applies the same validation and path normalisation used
+// for scan_config.skip entries to a single user-provided pattern.
+func NormaliseSkipPattern(pattern string) (string, error) {
+	patterns := []string{pattern}
+	if err := validatePatterns("skip", patterns); err != nil {
+		return "", err
+	}
+	return patterns[0], nil
 }
 
 // Empty reports whether no repository-specific scan guidance is configured.

--- a/internal/repoconfig/config_test.go
+++ b/internal/repoconfig/config_test.go
@@ -81,6 +81,19 @@ func TestParseNormalisesBackslashPatterns(t *testing.T) {
 	}
 }
 
+func TestNormaliseSkipPattern(t *testing.T) {
+	got, err := NormaliseSkipPattern(` tests\** `)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "tests/**" {
+		t.Fatalf("pattern = %q, want tests/**", got)
+	}
+	if _, err := NormaliseSkipPattern("../private/**"); err == nil || !strings.Contains(err.Error(), "relative") {
+		t.Fatalf("NormaliseSkipPattern invalid error = %v, want relative", err)
+	}
+}
+
 func TestParseEmpty(t *testing.T) {
 	cfg, err := Parse(" \n")
 	if err != nil || !cfg.Empty() {

--- a/internal/web/repo_scan_config.go
+++ b/internal/web/repo_scan_config.go
@@ -3,6 +3,8 @@ package web
 import (
 	"fmt"
 	"net/http"
+	"slices"
+	"strings"
 
 	"scrutineer/internal/db"
 	"scrutineer/internal/repoconfig"
@@ -31,6 +33,89 @@ func (s *Server) repoScanConfigSave(w http.ResponseWriter, r *http.Request) {
 	s.redirect(w, r, fmt.Sprintf("/repositories/%d%s", repo.ID, scanConfigTab))
 }
 
+func (s *Server) repoIgnoredPathAdd(w http.ResponseWriter, r *http.Request) {
+	repo, ok := loadByID[db.Repository](s, w, r)
+	if !ok {
+		return
+	}
+	cfg, err := repoconfig.Parse(repo.ScanConfig)
+	if err != nil {
+		http.Error(w, "scan config is not valid YAML: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	pattern, ok := ignoredPathPattern(w, r)
+	if !ok {
+		return
+	}
+	if slices.Contains(cfg.Skip, pattern) {
+		setFlash(w, Flash{Category: "success", Title: "Ignored path already exists"})
+		s.redirect(w, r, fmt.Sprintf("/repositories/%d%s", repo.ID, scanConfigTab))
+		return
+	}
+	cfg.Skip = append(cfg.Skip, pattern)
+	config, err := repoconfig.NormaliseConfig(cfg)
+	if err != nil {
+		http.Error(w, "scan config is not valid: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	if err := s.saveScanConfig(repo.ID, config); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	setFlash(w, Flash{Category: "success", Title: "Ignored path added"})
+	s.redirect(w, r, fmt.Sprintf("/repositories/%d%s", repo.ID, scanConfigTab))
+}
+
+func ignoredPathPattern(w http.ResponseWriter, r *http.Request) (string, bool) {
+	raw := r.FormValue("pattern")
+	if strings.TrimSpace(raw) == "" {
+		http.Error(w, "ignored path pattern is required", http.StatusBadRequest)
+		return "", false
+	}
+	pattern, err := repoconfig.NormaliseSkipPattern(raw)
+	if err != nil {
+		http.Error(w, "ignored path pattern is not valid: "+err.Error(), http.StatusBadRequest)
+		return "", false
+	}
+	return pattern, true
+}
+
+func (s *Server) repoIgnoredPathDelete(w http.ResponseWriter, r *http.Request) {
+	repo, ok := loadByID[db.Repository](s, w, r)
+	if !ok {
+		return
+	}
+	cfg, err := repoconfig.Parse(repo.ScanConfig)
+	if err != nil {
+		http.Error(w, "scan config is not valid YAML: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	pattern, ok := ignoredPathPattern(w, r)
+	if !ok {
+		return
+	}
+	before := len(cfg.Skip)
+	cfg.Skip = slices.DeleteFunc(cfg.Skip, func(skip string) bool {
+		return skip == pattern
+	})
+	if len(cfg.Skip) == before {
+		setFlash(w, Flash{Category: "warning", Title: "Ignored path was not configured"})
+		s.redirect(w, r, fmt.Sprintf("/repositories/%d%s", repo.ID, scanConfigTab))
+		return
+	}
+	config, err := repoconfig.NormaliseConfig(cfg)
+	if err != nil {
+		http.Error(w, "scan config is not valid: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	if err := s.saveScanConfig(repo.ID, config); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	setFlash(w, Flash{Category: "success", Title: "Ignored path removed"})
+	s.redirect(w, r, fmt.Sprintf("/repositories/%d%s", repo.ID, scanConfigTab))
+}
+
 func (s *Server) repoScanConfigClear(w http.ResponseWriter, r *http.Request) {
 	repo, ok := loadByID[db.Repository](s, w, r)
 	if !ok {
@@ -43,4 +128,17 @@ func (s *Server) repoScanConfigClear(w http.ResponseWriter, r *http.Request) {
 	}
 	setFlash(w, Flash{Category: "success", Title: "Scan config cleared"})
 	s.redirect(w, r, fmt.Sprintf("/repositories/%d%s", repo.ID, scanConfigTab))
+}
+
+func repoIgnoredPaths(repo db.Repository) []string {
+	cfg, err := repoconfig.Parse(repo.ScanConfig)
+	if err != nil {
+		return nil
+	}
+	return cfg.Skip
+}
+
+func (s *Server) saveScanConfig(repoID uint, config string) error {
+	return s.DB.Model(&db.Repository{}).Where("id = ?", repoID).
+		Update("scan_config", config).Error
 }

--- a/internal/web/repo_scan_config_test.go
+++ b/internal/web/repo_scan_config_test.go
@@ -59,6 +59,113 @@ func TestRepoScanConfigClear(t *testing.T) {
 	}
 }
 
+func TestRepoIgnoredPathAddPreservesScanConfig(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	repo := db.Repository{URL: "https://example.com/config-ignore", Name: "config-ignore", ScanConfig: `focus_areas:
+  - name: parser
+    paths: [src/parse/**]
+    surface: accepts bytes
+known_bugs:
+  - GHSA-xxxx-yyyy
+skip:
+  - tests/**
+`}
+	s.DB.Create(&repo)
+
+	w := postForm(t, s, fmt.Sprintf("/repositories/%d/scan-config/ignored-paths", repo.ID), url.Values{"pattern": {"spec/**"}})
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("code = %d body=%s", w.Code, w.Body.String())
+	}
+
+	var got db.Repository
+	s.DB.First(&got, repo.ID)
+	for _, want := range []string{"focus_areas:", "known_bugs:", "tests/**", "spec/**"} {
+		if !strings.Contains(got.ScanConfig, want) {
+			t.Fatalf("ScanConfig = %q, want %q", got.ScanConfig, want)
+		}
+	}
+}
+
+func TestRepoIgnoredPathAddDetectsNormalisedDuplicate(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	repo := db.Repository{URL: "https://example.com/config-ignore-dupe", Name: "config-ignore-dupe", ScanConfig: "skip:\n  - tests/**\n"}
+	s.DB.Create(&repo)
+
+	w := postForm(t, s, fmt.Sprintf("/repositories/%d/scan-config/ignored-paths", repo.ID), url.Values{"pattern": {`tests\**`}})
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("code = %d body=%s", w.Code, w.Body.String())
+	}
+
+	var got db.Repository
+	s.DB.First(&got, repo.ID)
+	if strings.Count(got.ScanConfig, "tests/**") != 1 {
+		t.Fatalf("ScanConfig = %q, want one tests/** entry", got.ScanConfig)
+	}
+}
+
+func TestRepoIgnoredPathAddRejectsInvalidPattern(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	repo := db.Repository{URL: "https://example.com/config-ignore-invalid", Name: "config-ignore-invalid"}
+	s.DB.Create(&repo)
+
+	w := postForm(t, s, fmt.Sprintf("/repositories/%d/scan-config/ignored-paths", repo.ID), url.Values{"pattern": {"../private/**"}})
+	body := w.Body.String()
+	if w.Code != http.StatusBadRequest || !strings.Contains(body, "relative") || strings.Contains(body, "YAML") {
+		t.Fatalf("code=%d body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestRepoIgnoredPathDelete(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	repo := db.Repository{URL: "https://example.com/config-ignore-delete", Name: "config-ignore-delete", ScanConfig: "skip:\n  - tests/**\n  - spec/**\n"}
+	s.DB.Create(&repo)
+
+	w := postForm(t, s, fmt.Sprintf("/repositories/%d/scan-config/ignored-paths/delete", repo.ID), url.Values{"pattern": {"tests/**"}})
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("code = %d body=%s", w.Code, w.Body.String())
+	}
+
+	var got db.Repository
+	s.DB.First(&got, repo.ID)
+	if strings.Contains(got.ScanConfig, "tests/**") || !strings.Contains(got.ScanConfig, "spec/**") {
+		t.Fatalf("ScanConfig = %q", got.ScanConfig)
+	}
+}
+
+func TestRepoIgnoredPathDeleteNormalisesPattern(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	repo := db.Repository{URL: "https://example.com/config-ignore-delete-normalised", Name: "config-ignore-delete-normalised", ScanConfig: "skip:\n  - tests/**\n  - spec/**\n"}
+	s.DB.Create(&repo)
+
+	w := postForm(t, s, fmt.Sprintf("/repositories/%d/scan-config/ignored-paths/delete", repo.ID), url.Values{"pattern": {`tests\**`}})
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("code = %d body=%s", w.Code, w.Body.String())
+	}
+
+	var got db.Repository
+	s.DB.First(&got, repo.ID)
+	if strings.Contains(got.ScanConfig, "tests/**") || !strings.Contains(got.ScanConfig, "spec/**") {
+		t.Fatalf("ScanConfig = %q", got.ScanConfig)
+	}
+}
+
+func TestRepoIgnoredPathDeleteRejectsEmptyPattern(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	repo := db.Repository{URL: "https://example.com/config-ignore-delete-empty", Name: "config-ignore-delete-empty", ScanConfig: "skip:\n  - tests/**\n"}
+	s.DB.Create(&repo)
+
+	w := postForm(t, s, fmt.Sprintf("/repositories/%d/scan-config/ignored-paths/delete", repo.ID), url.Values{"pattern": {" "}})
+	if w.Code != http.StatusBadRequest || !strings.Contains(w.Body.String(), "required") {
+		t.Fatalf("code=%d body=%s", w.Code, w.Body.String())
+	}
+}
+
 func TestRepoShowScanConfigTab(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()
@@ -70,7 +177,7 @@ func TestRepoShowScanConfigTab(t *testing.T) {
 		t.Fatalf("code=%d body=%s", rw.Code, rw.Body.String())
 	}
 	body := rw.Body.String()
-	for _, want := range []string{"Scan config", "scan-config", "scrutineer.scan_config", "tests/**"} {
+	for _, want := range []string{"Scan config", "scan-config", "scrutineer.scan_config", "Ignored paths", "Path pattern", "tests/**"} {
 		if !strings.Contains(body, want) {
 			t.Errorf("repo page missing %q", want)
 		}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -392,6 +392,8 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("POST /repositories/{id}/threat-model/run", s.repoThreatModelRun)
 	mux.HandleFunc("POST /repositories/{id}/threat-model/clear", s.repoThreatModelClear)
 	mux.HandleFunc("POST /repositories/{id}/scan-config", s.repoScanConfigSave)
+	mux.HandleFunc("POST /repositories/{id}/scan-config/ignored-paths", s.repoIgnoredPathAdd)
+	mux.HandleFunc("POST /repositories/{id}/scan-config/ignored-paths/delete", s.repoIgnoredPathDelete)
 	mux.HandleFunc("POST /repositories/{id}/scan-config/clear", s.repoScanConfigClear)
 	mux.HandleFunc("GET /scans", s.jobs)
 	mux.HandleFunc("GET /orgs", s.orgsList)
@@ -2006,6 +2008,7 @@ type repoShowView struct {
 	Maintainers      []db.Maintainer
 	Alternatives     []db.PackageAlternative
 	ShowAlternatives bool
+	IgnoredPaths     []string
 	HealthSummary    string
 	Skills           []db.Skill
 	Workbench        Workbench
@@ -2038,6 +2041,7 @@ func (s *Server) loadRepoShowView(
 	if err != nil {
 		s.Log.Error("load package alternatives", "repo", repo.ID, "err", err)
 	}
+	ignoredPaths := repoIgnoredPaths(repo)
 	// activeScans drives both the delete-confirm warning (a running scan keeps
 	// writing into the repo's clone/workspace until it returns) and the "Cancel
 	// all" button; pausedScans drives "Resume all". Both are counted over every
@@ -2056,6 +2060,7 @@ func (s *Server) loadRepoShowView(
 		Maintainers:        maintainers,
 		Alternatives:       alternatives,
 		ShowAlternatives:   showPackageAlternatives(repo, alternatives),
+		IgnoredPaths:       ignoredPaths,
 		HealthSummary:      health.Summary,
 		Skills:             s.activeRepoSkills(),
 		Workbench:          loadWorkbench(s.DB, &repo, workbenchSeed(tmScan)),
@@ -2106,6 +2111,7 @@ func (v repoShowView) renderData() map[string]any {
 		"Maintainers":        v.Maintainers,
 		"Alternatives":       v.Alternatives,
 		"ShowAlternatives":   v.ShowAlternatives,
+		"IgnoredPaths":       v.IgnoredPaths,
 		"ThreatModel":        v.ThreatModel,
 		"KnownURLs":          v.Inventory.KnownURLs,
 		"KnownPURLs":         v.Inventory.KnownPURLs,

--- a/internal/web/templates/repo_scan_config.html
+++ b/internal/web/templates/repo_scan_config.html
@@ -5,6 +5,40 @@
   matching files before a skill runs.
 </p>
 
+<section class="mb-6 max-w-4xl">
+  <h3 class="text-sm font-medium mb-2">Ignored paths</h3>
+  <p class="text-sm text-muted-foreground mb-3">
+    Use repository-relative shell globs for files that are out of scope for new scans.
+    Examples: <code>ext/**</code>, <code>spec/**</code>, <code>tool/**</code>, <code>misc/**</code>.
+  </p>
+
+  {{if .IgnoredPaths}}
+  <div class="grid gap-2 mb-4">
+    {{range .IgnoredPaths}}
+    <div class="flex items-center justify-between gap-3 rounded-md border border-border bg-card px-3 py-2">
+      <code class="text-sm break-all">{{.}}</code>
+      <form method="post" action="/repositories/{{$.Repo.ID}}/scan-config/ignored-paths/delete">
+        <input type="hidden" name="pattern" value="{{.}}">
+        <button class="btn-sm-ghost" type="submit" aria-label="Remove ignored path" data-tooltip="Remove ignored path">
+          <i data-lucide="trash-2"></i>
+        </button>
+      </form>
+    </div>
+    {{end}}
+  </div>
+  {{else}}
+  <p class="text-sm text-muted-foreground mb-4">No ignored paths configured.</p>
+  {{end}}
+
+  <form method="post" action="/repositories/{{.Repo.ID}}/scan-config/ignored-paths" class="form grid gap-2 sm:grid-cols-[1fr_auto] items-end">
+    <label>
+      <span>Path pattern</span>
+      <input class="input" type="text" name="pattern" placeholder="spec/**" required>
+    </label>
+    <button type="submit" class="btn-sm"><i data-lucide="plus"></i> Add ignored path</button>
+  </form>
+</section>
+
 <form method="post" action="/repositories/{{.Repo.ID}}/scan-config" class="form grid gap-3 max-w-4xl">
   <textarea name="scan_config" rows="20" spellcheck="false"
             class="input w-full font-mono text-xs"


### PR DESCRIPTION
Fixes #541

## Summary

Adds a dedicated UI for managing repository ignored path patterns without requiring users to edit raw `scan_config` YAML.

Ignored paths are stored in the existing `scan_config.skip` field, so they stay compatible with the threat-model workbench and existing scan context plumbing.

## Changes

- Add ignored-path add/delete actions on the repository Scan config tab
- List currently configured ignored path patterns
- Show examples for repository-relative shell glob semantics
- Preserve existing scan config fields such as `focus_areas`, `known_bugs`, and `attack_surface`
- Reuse existing `repoconfig` validation for invalid glob/path rejection
- Keep the raw YAML editor available for advanced scan configuration
- Add tests for add/delete behavior, validation, preservation, and page rendering

## Tests

- `go test ./...`
- `go test -tags evals ./...`
- `go vet ./...`
- `go vet -tags evals ./...`
- `golangci-lint run ./cmd/... ./internal/...`
- `golangci-lint run --build-tags evals ./cmd/... ./internal/...`
- `git diff --check`