### PR TITLE
renovate: set mode to "full"

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
+  "mode": "full",
   "enabledManagers": [
     "gomod",
     "github-actions",


### PR DESCRIPTION
This will allow PR's to be opened without having to manually approve them in the Dependency Dashboard.