### PR TITLE
Revert "renovate: set mode to "full""

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
-  "mode": "full",
   "enabledManagers": [
     "gomod",
     "github-actions",


### PR DESCRIPTION
Mend’s repository engine is still set to Silent, which applies `dryRun=lookup` outside the repository configuration. Setting `mode: full` in `renovate.json` therefore cannot enable PR creation.

@andrew, can you switch this repository from Silent to Interactive in the Mend console and rerun Renovate?

Reverts alpha-omega-security/scrutineer#702