### PR TITLE
Use denormalized repository_id directly for repository finding queries

### DIFF
--- a/internal/web/api_export.go
+++ b/internal/web/api_export.go
@@ -150,7 +150,7 @@ func (s *Server) apiExportRepoFindings(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	q := s.DB.Model(&db.Finding{}).
-		Where("scan_id IN (?)", s.DB.Model(&db.Scan{}).Select("id").Where("repository_id = ?", id)).
+		Where("repository_id = ?", id).
 		Order("id desc")
 	q = applyFindingFilters(q, r)
 	streamJSONL(w, q, findingExport)
@@ -285,8 +285,7 @@ func (s *Server) apiExportRepoBundle(w http.ResponseWriter, r *http.Request, rep
 	includeAll := r.URL.Query().Get("include") == "all"
 
 	var findings []db.Finding
-	q := s.DB.Where("scan_id IN (?)",
-		s.DB.Model(&db.Scan{}).Select("id").Where("repository_id = ?", repo.ID)).
+	q := s.DB.Where("repository_id = ?", repo.ID).
 		Order("id desc")
 	if r.URL.Query().Get("scope") == "findings" {
 		// Curate to the Findings bucket — drop semgrep/zizmor scanner noise,

--- a/internal/web/api_reads.go
+++ b/internal/web/api_reads.go
@@ -243,19 +243,22 @@ func (s *Server) apiListFindings(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	// Direct subquery; GORM's Joins("Scan") aliasing doesn't round-trip on
-	// sqlite when the joined struct has its own relations.
-	scans := s.DB.Model(&db.Scan{}).Select("id").Where("repository_id = ?", id)
-	if skill := r.URL.Query().Get("skill"); skill != "" {
-		scans = scans.Where("skill_name = ?", skill)
+	skill := r.URL.Query().Get("skill")
+	sg := r.URL.Query().Get("scan_group")
+	q := s.DB.Where("repository_id = ?", id)
+	if skill != "" || sg != "" {
+		// Use scan subquery only when filtering by scan-owned attributes
+		// (skill_name, scan_group) that live on the scans table.
+		scans := s.DB.Model(&db.Scan{}).Select("id").Where("repository_id = ?", id)
+		if skill != "" {
+			scans = scans.Where("skill_name = ?", skill)
+		}
+		if sg != "" {
+			scans = scans.Where("scan_group = ?", sg)
+		}
+		q = s.DB.Where("scan_id IN (?)", scans)
 	}
-	// scan_group narrows to one parallel batch so an in-flight audit skill
-	// reads only its siblings' findings. Kept inside the repo-scoped
-	// subquery so a guessed group can never leak another repo's findings.
-	if sg := r.URL.Query().Get("scan_group"); sg != "" {
-		scans = scans.Where("scan_group = ?", sg)
-	}
-	q := s.DB.Where("scan_id IN (?)", scans).Order("id desc")
+	q = q.Order("id desc")
 	if sev := r.URL.Query().Get("severity"); sev != "" {
 		q = q.Where("severity = ?", sev)
 	}

--- a/internal/web/api_reads.go
+++ b/internal/web/api_reads.go
@@ -247,8 +247,8 @@ func (s *Server) apiListFindings(w http.ResponseWriter, r *http.Request) {
 	sg := r.URL.Query().Get("scan_group")
 	q := s.DB.Where("repository_id = ?", id)
 	if skill != "" || sg != "" {
-		// Use scan subquery only when filtering by scan-owned attributes
-		// (skill_name, scan_group) that live on the scans table.
+		// skill_name and scan_group live on scans, but keep repository_id
+		// inside the subquery so a guessed group never leaks another repo's findings.
 		scans := s.DB.Model(&db.Scan{}).Select("id").Where("repository_id = ?", id)
 		if skill != "" {
 			scans = scans.Where("skill_name = ?", skill)

--- a/internal/web/api_test.go
+++ b/internal/web/api_test.go
@@ -262,12 +262,24 @@ func TestAPIFindingReadsAndFilters(t *testing.T) {
 	repo, scan := seedRunningScan(t, s)
 
 	// Simulate a prior deep-dive scan with a couple of findings attached.
-	prior := db.Scan{RepositoryID: repo.ID, Kind: worker.JobSkill, Status: db.ScanDone, SkillName: "security-deep-dive"}
+	prior := db.Scan{RepositoryID: repo.ID, Kind: worker.JobSkill, Status: db.ScanDone, SkillName: "security-deep-dive", ScanGroup: "grp1"}
 	s.DB.Create(&prior)
-	s.DB.Create(&db.Finding{ScanID: prior.ID, RepositoryID: repo.ID, FindingID: "F1", Title: "a", Severity: "High", Location: "a.go:1", Commit: "abc123", SubPath: "services/api", Trace: "trace a", SuggestedRecipients: "@owner (CODEOWNERS: a.go)"})
-	s.DB.Create(&db.Finding{ScanID: prior.ID, RepositoryID: repo.ID, FindingID: "F2", Title: "b", Severity: "Low", Location: "b.go:1", Trace: "trace b"})
+	s.DB.Create(&db.Finding{ScanID: prior.ID, RepositoryID: repo.ID, FindingID: "F1", Title: "a", Severity: "High", Status: db.FindingNew, Location: "a.go:1", Commit: "abc123", SubPath: "services/api", Trace: "trace a", SuggestedRecipients: "@owner (CODEOWNERS: a.go)"})
+	s.DB.Create(&db.Finding{ScanID: prior.ID, RepositoryID: repo.ID, FindingID: "F2", Title: "b", Severity: "Low", Status: db.FindingFixed, Location: "b.go:1", Trace: "trace b"})
 
-	// Unfiltered list
+	// Another scan on same repo with different skill and scan_group
+	otherScan := db.Scan{RepositoryID: repo.ID, Kind: worker.JobSkill, Status: db.ScanDone, SkillName: "vuln-scan", ScanGroup: "grp2"}
+	s.DB.Create(&otherScan)
+	s.DB.Create(&db.Finding{ScanID: otherScan.ID, RepositoryID: repo.ID, FindingID: "F3", Title: "c", Severity: "High", Status: db.FindingNew, Location: "c.go:1", Trace: "trace c"})
+
+	// Finding on a different repository
+	otherRepo := db.Repository{URL: "https://example.com/other", Name: "other"}
+	s.DB.Create(&otherRepo)
+	otherRepoScan := db.Scan{RepositoryID: otherRepo.ID, Kind: worker.JobSkill, Status: db.ScanDone, SkillName: "security-deep-dive"}
+	s.DB.Create(&otherRepoScan)
+	s.DB.Create(&db.Finding{ScanID: otherRepoScan.ID, RepositoryID: otherRepo.ID, FindingID: "F4", Title: "d", Severity: "High", Location: "d.go:1"})
+
+	// Unfiltered list (should return all 3 findings for repo, omitting otherRepo finding)
 	r := httptest.NewRequest("GET", "/api/repositories/"+strconv.FormatUint(uint64(repo.ID), 10)+"/findings", nil)
 	r.Host = testHost
 	r.Header.Set("Authorization", "Bearer "+scan.APIToken)
@@ -278,24 +290,82 @@ func TestAPIFindingReadsAndFilters(t *testing.T) {
 	}
 	var findings []map[string]any
 	_ = json.NewDecoder(w.Body).Decode(&findings)
-	if len(findings) != 2 {
-		t.Fatalf("findings len=%d want=2", len(findings))
+	if len(findings) != 3 {
+		t.Fatalf("findings len=%d want=3", len(findings))
 	}
 
-	// Severity filter
-	r = httptest.NewRequest("GET",
-		"/api/repositories/"+strconv.FormatUint(uint64(repo.ID), 10)+"/findings?severity=High", nil)
+	// Skill filter
+	r = httptest.NewRequest("GET", "/api/repositories/"+strconv.FormatUint(uint64(repo.ID), 10)+"/findings?skill=vuln-scan", nil)
 	r.Host = testHost
 	r.Header.Set("Authorization", "Bearer "+scan.APIToken)
 	w = httptest.NewRecorder()
 	s.Handler().ServeHTTP(w, r)
 	_ = json.NewDecoder(w.Body).Decode(&findings)
-	if len(findings) != 1 || findings[0]["severity"] != "High" {
+	if len(findings) != 1 || findings[0]["finding_id"] != "F3" {
+		t.Errorf("skill filter: %+v", findings)
+	}
+
+	// Scan group filter
+	r = httptest.NewRequest("GET", "/api/repositories/"+strconv.FormatUint(uint64(repo.ID), 10)+"/findings?scan_group=grp1", nil)
+	r.Host = testHost
+	r.Header.Set("Authorization", "Bearer "+scan.APIToken)
+	w = httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, r)
+	_ = json.NewDecoder(w.Body).Decode(&findings)
+	if len(findings) != 2 {
+		t.Errorf("scan_group filter: %+v", findings)
+	}
+
+	// Severity filter on direct query path
+	r = httptest.NewRequest("GET",
+		"/api/repositories/"+strconv.FormatUint(uint64(repo.ID), 10)+"/findings?severity=Low", nil)
+	r.Host = testHost
+	r.Header.Set("Authorization", "Bearer "+scan.APIToken)
+	w = httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, r)
+	_ = json.NewDecoder(w.Body).Decode(&findings)
+	if len(findings) != 1 || findings[0]["severity"] != "Low" {
 		t.Errorf("severity filter: %+v", findings)
 	}
 
+	// Severity and skill filter composed
+	r = httptest.NewRequest("GET",
+		"/api/repositories/"+strconv.FormatUint(uint64(repo.ID), 10)+"/findings?skill=security-deep-dive&severity=High", nil)
+	r.Host = testHost
+	r.Header.Set("Authorization", "Bearer "+scan.APIToken)
+	w = httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, r)
+	_ = json.NewDecoder(w.Body).Decode(&findings)
+	if len(findings) != 1 || findings[0]["finding_id"] != "F1" {
+		t.Errorf("skill and severity filter composed: %+v", findings)
+	}
+
+	// Status filter on direct query path
+	r = httptest.NewRequest("GET",
+		"/api/repositories/"+strconv.FormatUint(uint64(repo.ID), 10)+"/findings?status=fixed", nil)
+	r.Host = testHost
+	r.Header.Set("Authorization", "Bearer "+scan.APIToken)
+	w = httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, r)
+	_ = json.NewDecoder(w.Body).Decode(&findings)
+	if len(findings) != 1 || findings[0]["finding_id"] != "F2" {
+		t.Errorf("status filter: %+v", findings)
+	}
+
 	// Get one finding; should include trace prose.
-	fid := findings[0]["id"]
+	r = httptest.NewRequest("GET", "/api/repositories/"+strconv.FormatUint(uint64(repo.ID), 10)+"/findings?severity=High", nil)
+	r.Host = testHost
+	r.Header.Set("Authorization", "Bearer "+scan.APIToken)
+	w = httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, r)
+	_ = json.NewDecoder(w.Body).Decode(&findings)
+	var fid any
+	for _, f := range findings {
+		if f["finding_id"] == "F1" {
+			fid = f["id"]
+			break
+		}
+	}
 	r = httptest.NewRequest("GET", "/api/findings/"+toString(fid), nil)
 	r.Host = testHost
 	r.Header.Set("Authorization", "Bearer "+scan.APIToken)

--- a/internal/web/api_test.go
+++ b/internal/web/api_test.go
@@ -260,6 +260,21 @@ func TestAPIFindingReadsAndFilters(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()
 	repo, scan := seedRunningScan(t, s)
+	get := func(q string) []map[string]any {
+		r := httptest.NewRequest("GET", fmt.Sprintf("/api/repositories/%d/findings%s", repo.ID, q), nil)
+		r.Host = testHost
+		r.Header.Set("Authorization", "Bearer "+scan.APIToken)
+		w := httptest.NewRecorder()
+		s.Handler().ServeHTTP(w, r)
+		if w.Code != 200 {
+			t.Fatalf("%s: status %d: %s", q, w.Code, w.Body.String())
+		}
+		var rows []map[string]any
+		if err := json.NewDecoder(w.Body).Decode(&rows); err != nil {
+			t.Fatalf("%s: decode response: %v: %s", q, err, w.Body.String())
+		}
+		return rows
+	}
 
 	// Simulate a prior deep-dive scan with a couple of findings attached.
 	prior := db.Scan{RepositoryID: repo.ID, Kind: worker.JobSkill, Status: db.ScanDone, SkillName: "security-deep-dive", ScanGroup: "grp1"}
@@ -280,85 +295,43 @@ func TestAPIFindingReadsAndFilters(t *testing.T) {
 	s.DB.Create(&db.Finding{ScanID: otherRepoScan.ID, RepositoryID: otherRepo.ID, FindingID: "F4", Title: "d", Severity: "High", Location: "d.go:1"})
 
 	// Unfiltered list (should return all 3 findings for repo, omitting otherRepo finding)
-	r := httptest.NewRequest("GET", "/api/repositories/"+strconv.FormatUint(uint64(repo.ID), 10)+"/findings", nil)
-	r.Host = testHost
-	r.Header.Set("Authorization", "Bearer "+scan.APIToken)
-	w := httptest.NewRecorder()
-	s.Handler().ServeHTTP(w, r)
-	if w.Code != 200 {
-		t.Fatalf("findings list status %d: %s", w.Code, w.Body)
-	}
-	var findings []map[string]any
-	_ = json.NewDecoder(w.Body).Decode(&findings)
+	findings := get("")
 	if len(findings) != 3 {
 		t.Fatalf("findings len=%d want=3", len(findings))
 	}
 
 	// Skill filter
-	r = httptest.NewRequest("GET", "/api/repositories/"+strconv.FormatUint(uint64(repo.ID), 10)+"/findings?skill=vuln-scan", nil)
-	r.Host = testHost
-	r.Header.Set("Authorization", "Bearer "+scan.APIToken)
-	w = httptest.NewRecorder()
-	s.Handler().ServeHTTP(w, r)
-	_ = json.NewDecoder(w.Body).Decode(&findings)
+	findings = get("?skill=vuln-scan")
 	if len(findings) != 1 || findings[0]["finding_id"] != "F3" {
 		t.Errorf("skill filter: %+v", findings)
 	}
 
 	// Scan group filter
-	r = httptest.NewRequest("GET", "/api/repositories/"+strconv.FormatUint(uint64(repo.ID), 10)+"/findings?scan_group=grp1", nil)
-	r.Host = testHost
-	r.Header.Set("Authorization", "Bearer "+scan.APIToken)
-	w = httptest.NewRecorder()
-	s.Handler().ServeHTTP(w, r)
-	_ = json.NewDecoder(w.Body).Decode(&findings)
+	findings = get("?scan_group=grp1")
 	if len(findings) != 2 {
 		t.Errorf("scan_group filter: %+v", findings)
 	}
 
 	// Severity filter on direct query path
-	r = httptest.NewRequest("GET",
-		"/api/repositories/"+strconv.FormatUint(uint64(repo.ID), 10)+"/findings?severity=Low", nil)
-	r.Host = testHost
-	r.Header.Set("Authorization", "Bearer "+scan.APIToken)
-	w = httptest.NewRecorder()
-	s.Handler().ServeHTTP(w, r)
-	_ = json.NewDecoder(w.Body).Decode(&findings)
+	findings = get("?severity=Low")
 	if len(findings) != 1 || findings[0]["severity"] != "Low" {
 		t.Errorf("severity filter: %+v", findings)
 	}
 
 	// Severity and skill filter composed
-	r = httptest.NewRequest("GET",
-		"/api/repositories/"+strconv.FormatUint(uint64(repo.ID), 10)+"/findings?skill=security-deep-dive&severity=High", nil)
-	r.Host = testHost
-	r.Header.Set("Authorization", "Bearer "+scan.APIToken)
-	w = httptest.NewRecorder()
-	s.Handler().ServeHTTP(w, r)
-	_ = json.NewDecoder(w.Body).Decode(&findings)
+	findings = get("?skill=security-deep-dive&severity=High")
 	if len(findings) != 1 || findings[0]["finding_id"] != "F1" {
 		t.Errorf("skill and severity filter composed: %+v", findings)
 	}
 
 	// Status filter on direct query path
-	r = httptest.NewRequest("GET",
-		"/api/repositories/"+strconv.FormatUint(uint64(repo.ID), 10)+"/findings?status=fixed", nil)
-	r.Host = testHost
-	r.Header.Set("Authorization", "Bearer "+scan.APIToken)
-	w = httptest.NewRecorder()
-	s.Handler().ServeHTTP(w, r)
-	_ = json.NewDecoder(w.Body).Decode(&findings)
+	findings = get("?status=fixed")
 	if len(findings) != 1 || findings[0]["finding_id"] != "F2" {
 		t.Errorf("status filter: %+v", findings)
 	}
 
 	// Get one finding; should include trace prose.
-	r = httptest.NewRequest("GET", "/api/repositories/"+strconv.FormatUint(uint64(repo.ID), 10)+"/findings?severity=High", nil)
-	r.Host = testHost
-	r.Header.Set("Authorization", "Bearer "+scan.APIToken)
-	w = httptest.NewRecorder()
-	s.Handler().ServeHTTP(w, r)
-	_ = json.NewDecoder(w.Body).Decode(&findings)
+	findings = get("?severity=High")
 	var fid any
 	for _, f := range findings {
 		if f["finding_id"] == "F1" {
@@ -366,16 +339,21 @@ func TestAPIFindingReadsAndFilters(t *testing.T) {
 			break
 		}
 	}
-	r = httptest.NewRequest("GET", "/api/findings/"+toString(fid), nil)
+	if fid == nil {
+		t.Fatalf("severity=High response did not include F1: %+v", findings)
+	}
+	r := httptest.NewRequest("GET", "/api/findings/"+toString(fid), nil)
 	r.Host = testHost
 	r.Header.Set("Authorization", "Bearer "+scan.APIToken)
-	w = httptest.NewRecorder()
+	w := httptest.NewRecorder()
 	s.Handler().ServeHTTP(w, r)
 	if w.Code != 200 {
-		t.Fatalf("get finding status %d: %s", w.Code, w.Body)
+		t.Fatalf("get finding status %d: %s", w.Code, w.Body.String())
 	}
 	var detail map[string]any
-	_ = json.NewDecoder(w.Body).Decode(&detail)
+	if err := json.NewDecoder(w.Body).Decode(&detail); err != nil {
+		t.Fatalf("decode finding detail: %v: %s", err, w.Body.String())
+	}
 	if detail["trace"] != "trace a" {
 		t.Errorf("finding detail missing trace: %+v", detail)
 	}


### PR DESCRIPTION
Fixes #562

### Summary

Optimizes repository finding queries in `apiListFindings`, `apiExportRepoFindings` and `apiExportRepoBundle` by directly filtering on `findings.repository_id` instead of executing an unnecessary subquery against the `scans` table when no scan-level filter (`skill` or `scan_group`) is specified.

### Problem

`apiListFindings` and `apiExportRepoFindings` previously constructed query filters using a subquery:

```go
scans := s.DB.Model(&db.Scan{}).Select("id").Where("repository_id = ?", id)
q := s.DB.Where("scan_id IN (?)", scans)
```
Since db.Finding already contains a denormalized and indexed RepositoryID field, querying through the scans table added unnecessary join/subquery overhead on repositories with large scan histories.

### Solution

• internal/web/api_reads.go: Updated apiListFindings to filter directly by repository_id = ?. Preserved the scan subquery strictly when scan-owned parameters (skill or scan_group) are provided in the query string.
• internal/web/api_export.go: Updated apiExportRepoFindings and apiExportRepoBundle to use repository_id = ? directly.
• internal/web/api_test.go: Added unit test assertions in TestAPIFindingReadsAndFilters to verify:
  • Default direct repository_id path returns all repository findings.
  • skill and scan_group filters still filter correctly via the subquery path.
  • Severity and status filters compose properly with both paths.
  • Cross-repository findings are not leaked.


### Verification

• Formatted code with gofmt -s -w.
• Checked with go vet ./....
• Executed full test suite (go test ./...) with all tests passing cleanly.

