### PR TITLE
Make Opus 5 the max tier model

### DIFF
--- a/internal/worker/harness_claude.go
+++ b/internal/worker/harness_claude.go
@@ -71,7 +71,8 @@ func (ClaudeHarness) DefaultModels() []ModelDefault {
 	return []ModelDefault{
 		{Name: "Opus 4.6", ID: "claude-opus-4-6", Tier: "high"},
 		{Name: "Opus 4.7", ID: "claude-opus-4-7"},
-		{Name: "Opus 4.8", ID: "claude-opus-4-8", Tier: "max"},
+		{Name: "Opus 4.8", ID: "claude-opus-4-8"},
+		{Name: "Opus 5.0", ID: "claude-opus-5", Tier: "max"},
 		{Name: "Sonnet 4.6", ID: "claude-sonnet-4-6", Tier: "mid"},
 		{Name: "Sonnet 5.0", ID: "claude-sonnet-5"},
 		{Name: "Fable 5", ID: "claude-fable-5[1m]"},

--- a/internal/worker/pricing.go
+++ b/internal/worker/pricing.go
@@ -27,6 +27,7 @@ var modelPricing = map[string]modelPrice{
 	"claude-opus-4-6":   {In: 5.00, Out: 25.00, CachedIn: 0.50, CacheWrite: 6.25},
 	"claude-opus-4-7":   {In: 5.00, Out: 25.00, CachedIn: 0.50, CacheWrite: 6.25},
 	"claude-opus-4-8":   {In: 5.00, Out: 25.00, CachedIn: 0.50, CacheWrite: 6.25},
+	"claude-opus-5":     {In: 5.00, Out: 25.00, CachedIn: 0.50, CacheWrite: 6.25},
 	"claude-sonnet-4-6": {In: 3.00, Out: 15.00, CachedIn: 0.30, CacheWrite: 3.75},
 	"claude-haiku-4-5":  {In: 1.00, Out: 5.00, CachedIn: 0.10, CacheWrite: 1.25},
 	// Sonnet 5 list rate (intro $2/$10 through 2026-08-31).


### PR DESCRIPTION
Opus 5 (`claude-opus-5`) launched today at $5/$25 per MTok, the same list rates as Opus 4.8. This adds it to the built-in model list as the max tier default, replacing Opus 4.8, and adds its pricing row so the coverage check in `pricing_test.go` passes. The opencode harness picks the entry up automatically since it derives its list from `ClaudeHarness`.