### PR TITLE
Auto-close already fixed revalidate findings

### DIFF
--- a/internal/worker/skill_parsers.go
+++ b/internal/worker/skill_parsers.go
@@ -1011,9 +1011,10 @@ func (w *Worker) parseReleaseWatchOutput(scan *db.Scan, report string, emit func
 // parseRevalidateOutput records the cheap classifier verdict for a
 // finding. The verdict and reason become a FindingNote; an adjusted
 // severity overwrites the finding's severity (with the change recorded
-// in finding history via WriteFindingField); status transitions
-// new -> enriched only on true_positive. Rejection of false positives
-// stays a human act, so false_positive does not transition status.
+// in finding history via WriteFindingField); true_positive promotes
+// new -> enriched, and already_fixed closes active findings as fixed.
+// Rejection of false positives stays a human act, so false_positive
+// does not transition status.
 func (w *Worker) parseRevalidateOutput(scan *db.Scan, report string, emit func(Event)) error {
 	if scan.FindingID == nil {
 		return fmt.Errorf("revalidate scan has no finding_id")
@@ -1062,10 +1063,17 @@ func (w *Worker) parseRevalidateOutput(scan *db.Scan, report string, emit func(E
 		return fmt.Errorf("update last_revalidate_verdict: %w", err)
 	}
 
-	// Status transition: only true_positive promotes new -> enriched.
+	// Status transitions: true_positive promotes new -> enriched;
+	// already_fixed auto-closes active findings because the cheap git-history
+	// check found an upstream change that addressed the trace (#112).
 	// false_positive does not auto-reject; the analyst owns rejection.
-	if result.Verdict == "true_positive" && f.Status == db.FindingNew {
+	switch {
+	case result.Verdict == "true_positive" && f.Status == db.FindingNew:
 		if err := db.WriteFindingField(w.DB, f.ID, "status", string(db.FindingEnriched), db.SourceModel, "revalidate"); err != nil {
+			return fmt.Errorf("update status: %w", err)
+		}
+	case result.Verdict == "already_fixed":
+		if err := db.WriteFindingField(w.DB, f.ID, "status", string(db.FindingFixed), db.SourceModel, "revalidate"); err != nil {
 			return fmt.Errorf("update status: %w", err)
 		}
 	}

--- a/internal/worker/skill_parsers_test.go
+++ b/internal/worker/skill_parsers_test.go
@@ -829,6 +829,28 @@ func TestParseRevalidate_truePositiveMovesNewToEnriched(t *testing.T) {
 	}
 }
 
+func TestParseRevalidate_alreadyFixedMovesOpenFindingToFixed(t *testing.T) {
+	report := `{"verdict":"already_fixed","reason":"commit abc1234 added a containment check before opening the path"}`
+	f, gdb := runSkillWithFinding(t, "revalidate", report, db.FindingReady)
+	if f.Status != db.FindingFixed {
+		t.Errorf("status = %s, want fixed", f.Status)
+	}
+	if f.LastRevalidateVerdict != "already_fixed" {
+		t.Errorf("last_revalidate_verdict = %q, want already_fixed", f.LastRevalidateVerdict)
+	}
+	notes := findingNotes(gdb, f.ID)
+	if len(notes) == 0 || !strings.Contains(notes[0].Body, "commit abc1234") {
+		t.Errorf("notes missing already_fixed evidence: %+v", notes)
+	}
+	var hist db.FindingHistory
+	if err := gdb.Where("finding_id = ? AND field = ?", f.ID, "status").First(&hist).Error; err != nil {
+		t.Fatalf("status history missing: %v", err)
+	}
+	if hist.By != "revalidate" || hist.OldValue != string(db.FindingReady) || hist.NewValue != string(db.FindingFixed) {
+		t.Errorf("status history = %+v, want ready -> fixed by revalidate", hist)
+	}
+}
+
 func TestParseRevalidate_recordsPrivilegeRequired(t *testing.T) {
 	report := `{"verdict":"true_positive","reason":"trace holds","privilege_required":"authenticated"}`
 	f, gdb := runSkillWithFinding(t, "revalidate", report, db.FindingNew)

--- a/skills/revalidate/SKILL.md
+++ b/skills/revalidate/SKILL.md
@@ -90,7 +90,9 @@ Write `./report.json` matching `./schema.json`:
 Scrutineer applies this:
 
 - `verdict` and `reason` are appended to the finding's notes as a timestamped revalidate record.
-- `true_positive` moves a `new` finding to `enriched`. Any other verdict leaves status alone (rejection is a human act).
+- `true_positive` moves a `new` finding to `enriched`.
+- `already_fixed` moves any open finding to `fixed`; cite the upstream commit or code change in `reason` so the note explains why it was auto-closed.
+- `false_positive` and `uncertain` leave status alone (rejection is a human act).
 - `adjusted_severity` overwrites the finding's severity field, with the change recorded in finding history (so the original is preserved and auditable). The analyst can always change it back.
 - When `verdict` is `true_positive` AND the post-adjustment severity is `High` or `Critical`, scrutineer chains the `verify` skill: a finding-scoped run that actually executes the reproduction against HEAD. The chain reads the adjusted severity, so a Critical you mark down to Medium correctly stops at revalidate.
 


### PR DESCRIPTION
Part of #112

## Summary

Updates the `revalidate` flow so findings classified as `already_fixed` are automatically moved to the `fixed` lifecycle state.

The revalidate skill already performs the cheap git-history check described in #112 and records the evidence in a finding note. This change makes that verdict actionable instead of leaving already-fixed findings active for manual disclosure review.

## Changes

- Move open findings to `fixed` when `revalidate` returns `already_fixed`
- Preserve the existing closed-finding guard so rejected, duplicate, published and other closed findings are not clobbered
- Keep caching `last_revalidate_verdict` for audit/review visibility
- Update `skills/revalidate/SKILL.md` to document the new lifecycle behavior
- Add parser coverage for the auto-close transition, evidence note and history attribution

## Tests

- `git diff --check`
- `go test ./internal/worker -run 'TestParseRevalidate|TestBundledSchemas'`
- `go test ./...`
- `go vet ./...`