### PR TITLE
Reject repository URLs containing embedded credentials

### DIFF
--- a/internal/web/parse_repo_url.go
+++ b/internal/web/parse_repo_url.go
@@ -68,6 +68,15 @@ func ParseRepoInput(raw string) (RepoInput, error) {
 	if err != nil {
 		return RepoInput{}, fmt.Errorf("parse url: %w", err)
 	}
+	// Reject credentials embedded in the URL. Repository.URL is stored,
+	// logged, exported, and staged into the model workspace via
+	// context.json; a token pasted here would cross the container boundary
+	// the README documents as isolated. Redacting is not enough because
+	// tokens are commonly supplied as the username, so refuse the input
+	// and point at the credential-helper flow instead.
+	if u.User != nil {
+		return RepoInput{}, fmt.Errorf("repository URL must not contain credentials; configure a git credential helper on the host instead (see README)")
+	}
 	u.Host = strings.ToLower(u.Host)
 	u.RawQuery = ""
 

--- a/internal/web/parse_repo_url_test.go
+++ b/internal/web/parse_repo_url_test.go
@@ -155,6 +155,16 @@ func TestParseRepoInput(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name:    "userinfo user:token rejected",
+			input:   "https://user:token@github.com/owner/repo",
+			wantErr: true,
+		},
+		{
+			name:    "userinfo bare username rejected",
+			input:   "https://ghp_aaaa@github.com/owner/repo",
+			wantErr: true,
+		},
+		{
 			name:    "empty rejected",
 			input:   "   ",
 			wantErr: true,


### PR DESCRIPTION
`ParseRepoInput` accepted `https://user:token@host/...` and stored the credential-bearing URL as `Repository.URL`. From there it was logged in the `$ git clone ...` scan-log line, staged into `context.json` inside the model workspace, and returned by the export APIs — crossing the container boundary the README says host git credentials never cross.

Reject `u.User != nil` at parse time and point the operator at the credential-helper flow the README already documents. Redacting isn't sufficient since tokens are commonly supplied as the username, and rejecting at parse means nothing downstream (clone log, `context.json`, exports, `DefaultHTMLURL`) ever sees it.

Operators who have previously added a URL in this form should rotate the token; existing `repositories.url` and `scans.log` rows may still contain it.

Reported by @abhinavgautam01 via GHSA-6v66-53jv-7fq6.