### PR TITLE
Reject credentialed schedule upstream URLs

### DIFF
--- a/internal/web/schedule_test.go
+++ b/internal/web/schedule_test.go
@@ -355,6 +355,29 @@ func TestRepoScheduleUpdate_rejectsNonHTTPSUpstream(t *testing.T) {
 	}
 }
 
+func TestRepoScheduleUpdate_rejectsCredentialedUpstream(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	repo := scheduledRepo(t, s, "", time.Now())
+
+	w := postForm(t, s, "/repositories/"+strconv.FormatUint(uint64(repo.ID), 10)+"/schedule", url.Values{
+		"scan_schedule": {"daily"},
+		"upstream_url":  {"https://token@example.com/upstream"},
+	})
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status %d, want 422", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "must not contain credentials") {
+		t.Fatalf("body = %q, want credential rejection", w.Body.String())
+	}
+
+	var got db.Repository
+	s.DB.First(&got, repo.ID)
+	if got.UpstreamURL != "" || got.ScanSchedule != "" {
+		t.Fatalf("rejected update changed schedule: upstream = %q schedule = %q", got.UpstreamURL, got.ScanSchedule)
+	}
+}
+
 func TestSettingsUpdateScanSchedule_savesAndResetsInheritingRepos(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()

--- a/internal/web/schedule_test.go
+++ b/internal/web/schedule_test.go
@@ -358,7 +358,10 @@ func TestRepoScheduleUpdate_rejectsNonHTTPSUpstream(t *testing.T) {
 func TestRepoScheduleUpdate_rejectsCredentialedUpstream(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()
-	repo := scheduledRepo(t, s, "", time.Now())
+	repo := scheduledRepo(t, s, "weekly", time.Now())
+	if err := s.DB.Model(&repo).Update("upstream_url", "https://example.com/original").Error; err != nil {
+		t.Fatal(err)
+	}
 
 	w := postForm(t, s, "/repositories/"+strconv.FormatUint(uint64(repo.ID), 10)+"/schedule", url.Values{
 		"scan_schedule": {"daily"},
@@ -373,8 +376,28 @@ func TestRepoScheduleUpdate_rejectsCredentialedUpstream(t *testing.T) {
 
 	var got db.Repository
 	s.DB.First(&got, repo.ID)
-	if got.UpstreamURL != "" || got.ScanSchedule != "" {
+	if got.UpstreamURL != "https://example.com/original" || got.ScanSchedule != "weekly" {
 		t.Fatalf("rejected update changed schedule: upstream = %q schedule = %q", got.UpstreamURL, got.ScanSchedule)
+	}
+}
+
+func TestRepoScheduleUpdate_normalisesUpstreamURL(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	repo := scheduledRepo(t, s, "", time.Now())
+
+	w := postForm(t, s, "/repositories/"+strconv.FormatUint(uint64(repo.ID), 10)+"/schedule", url.Values{
+		"scan_schedule": {"daily"},
+		"upstream_url":  {"https://GitHub.com/Acme/Upstream.git?access_token=secret#src"},
+	})
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+
+	var got db.Repository
+	s.DB.First(&got, repo.ID)
+	if got.UpstreamURL != "https://github.com/acme/upstream" {
+		t.Fatalf("upstream = %q, want normalized clone URL", got.UpstreamURL)
 	}
 }
 

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -2704,10 +2704,12 @@ func (s *Server) repoScheduleUpdate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if upstream != "" {
-		if _, err := ParseRepoInput(upstream); err != nil {
-			http.Error(w, "invalid upstream URL: "+err.Error(), http.StatusUnprocessableEntity)
+		input, err := ParseRepoInput(upstream)
+		if err != nil {
+			http.Error(w, strings.Replace(err.Error(), "repository URL", "upstream URL", 1), http.StatusUnprocessableEntity)
 			return
 		}
+		upstream = input.CloneURL
 	}
 	if err := s.DB.Model(&db.Repository{}).Where("id = ?", repo.ID).Updates(map[string]any{
 		"scan_schedule":          schedule,

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -2703,6 +2703,12 @@ func (s *Server) repoScheduleUpdate(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "upstream URL must start with https://", http.StatusUnprocessableEntity)
 		return
 	}
+	if upstream != "" {
+		if _, err := ParseRepoInput(upstream); err != nil {
+			http.Error(w, "invalid upstream URL: "+err.Error(), http.StatusUnprocessableEntity)
+			return
+		}
+	}
 	if err := s.DB.Model(&db.Repository{}).Where("id = ?", repo.ID).Updates(map[string]any{
 		"scan_schedule":          schedule,
 		"upstream_url":           upstream,


### PR DESCRIPTION
Reject credentialed repository URLs in the schedule upstream field by applying `ParseRepoInput` validation before persisting them. Add regression coverage to ensure a rejected update does not change the stored schedule or upstream URL.