### PR TITLE
Preserve paused deadline when resume enqueue fails

### DIFF
--- a/internal/web/scans.go
+++ b/internal/web/scans.go
@@ -15,7 +15,6 @@ import (
 	"scrutineer/internal/worker"
 
 	"gorm.io/gorm"
-	"gorm.io/gorm/clause"
 )
 
 func (s *Server) jobs(w http.ResponseWriter, r *http.Request) {
@@ -398,24 +397,30 @@ func scanStatusUpdates(status db.ScanStatus, msg string, finishedAt *time.Time, 
 
 func (s *Server) bulkResumePaused(base *gorm.DB) ([]db.Scan, error) {
 	var scans []db.Scan
-	res := base.Model(&scans).Clauses(clause.Returning{
-		Columns: []clause.Column{
-			{Name: "id"},
-			{Name: "kind"},
-			{Name: "finding_id"},
-			{Name: "error"},
-			{Name: "paused_until"},
-		},
-	}).Where("status = ?", db.ScanPaused).Updates(scanStatusUpdates(
-		db.ScanQueued,
-		"",
-		nil,
-		nil,
-	))
-	if res.Error != nil {
-		return nil, res.Error
+	if err := base.Select("id", "kind", "finding_id", "error", "paused_until").
+		Where("status = ?", db.ScanPaused).
+		Find(&scans).Error; err != nil {
+		return nil, err
 	}
-	return scans, nil
+	resumed := make([]db.Scan, 0, len(scans))
+	err := s.DB.Transaction(func(tx *gorm.DB) error {
+		for _, scan := range scans {
+			res := tx.Model(&db.Scan{}).
+				Where("id = ? AND status = ?", scan.ID, db.ScanPaused).
+				Updates(scanStatusUpdates(db.ScanQueued, "", nil, nil))
+			if res.Error != nil {
+				return res.Error
+			}
+			if res.RowsAffected > 0 {
+				resumed = append(resumed, scan)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return resumed, nil
 }
 
 func (s *Server) restorePausedAfterResumeEnqueueFailure(scan db.Scan, err error) error {

--- a/internal/web/scans.go
+++ b/internal/web/scans.go
@@ -15,6 +15,7 @@ import (
 	"scrutineer/internal/worker"
 
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 func (s *Server) jobs(w http.ResponseWriter, r *http.Request) {
@@ -396,24 +397,33 @@ func scanStatusUpdates(status db.ScanStatus, msg string, finishedAt *time.Time, 
 }
 
 func (s *Server) bulkResumePaused(base *gorm.DB) ([]db.Scan, error) {
-	var scans []db.Scan
-	if err := base.Select("id", "kind", "finding_id", "error", "paused_until").
-		Where("status = ?", db.ScanPaused).
-		Find(&scans).Error; err != nil {
-		return nil, err
-	}
-	resumed := make([]db.Scan, 0, len(scans))
-	err := s.DB.Transaction(func(tx *gorm.DB) error {
-		for _, scan := range scans {
-			res := tx.Model(&db.Scan{}).
-				Where("id = ? AND status = ?", scan.ID, db.ScanPaused).
-				Updates(scanStatusUpdates(db.ScanQueued, "", nil, nil))
-			if res.Error != nil {
-				return res.Error
-			}
-			if res.RowsAffected > 0 {
-				resumed = append(resumed, scan)
-			}
+	var resumed []db.Scan
+	err := base.Transaction(func(tx *gorm.DB) error {
+		var paused []db.Scan
+		if err := tx.Select("id", "kind", "finding_id", "error", "paused_until").
+			Where("status = ?", db.ScanPaused).
+			Find(&paused).Error; err != nil {
+			return err
+		}
+		if len(paused) == 0 {
+			return nil
+		}
+
+		byID := make(map[uint]db.Scan, len(paused))
+		for _, scan := range paused {
+			byID[scan.ID] = scan
+		}
+		var claimed []db.Scan
+		res := tx.Model(&claimed).Clauses(clause.Returning{
+			Columns: []clause.Column{{Name: "id"}},
+		}).Where("status = ?", db.ScanPaused).
+			Updates(scanStatusUpdates(db.ScanQueued, "", nil, nil))
+		if res.Error != nil {
+			return res.Error
+		}
+		resumed = make([]db.Scan, 0, len(claimed))
+		for _, scan := range claimed {
+			resumed = append(resumed, byID[scan.ID])
 		}
 		return nil
 	})

--- a/internal/web/scans_test.go
+++ b/internal/web/scans_test.go
@@ -1,12 +1,14 @@
 package web
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"scrutineer/internal/db"
 	"scrutineer/internal/worker"
@@ -347,6 +349,47 @@ func TestScansResumePaused(t *testing.T) {
 	s.DB.First(&p1got, p1.ID)
 	if p1got.StatusPriority != db.StatusPriorityFor(db.ScanQueued) {
 		t.Errorf("status_priority = %d, want queued priority", p1got.StatusPriority)
+	}
+}
+
+func TestEnqueueResumedScan_restoresPausedUntilOnEnqueueFailure(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	repo := db.Repository{URL: "https://example.com/r", Name: "r"}
+	s.DB.Create(&repo)
+	pausedUntil := time.Now().UTC().Add(time.Hour).Truncate(time.Second)
+	scan := db.Scan{
+		RepositoryID:   repo.ID,
+		Kind:           worker.JobSkill,
+		Status:         db.ScanPaused,
+		StatusPriority: db.StatusPriorityFor(db.ScanPaused),
+		Error:          worker.AccountPausePrefix + "reset pending",
+		PausedUntil:    &pausedUntil,
+	}
+	s.DB.Create(&scan)
+
+	scans, err := s.bulkResumePaused(s.DB)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(scans) != 1 {
+		t.Fatalf("resumed scans = %d, want 1", len(scans))
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := s.enqueueResumedScan(ctx, scans[0]); err == nil {
+		t.Fatal("enqueue with cancelled context succeeded")
+	}
+
+	var got db.Scan
+	s.DB.First(&got, scan.ID)
+	if got.Status != db.ScanPaused {
+		t.Fatalf("status = %q, want paused", got.Status)
+	}
+	if got.PausedUntil == nil || !got.PausedUntil.Equal(pausedUntil) {
+		t.Errorf("paused_until = %v, want %v", got.PausedUntil, pausedUntil)
 	}
 }
 

--- a/internal/web/scans_test.go
+++ b/internal/web/scans_test.go
@@ -2,6 +2,7 @@ package web
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -12,6 +13,8 @@ import (
 
 	"scrutineer/internal/db"
 	"scrutineer/internal/worker"
+
+	"gorm.io/gorm"
 )
 
 func TestResumeOpts(t *testing.T) {
@@ -390,6 +393,78 @@ func TestEnqueueResumedScan_restoresPausedUntilOnEnqueueFailure(t *testing.T) {
 	}
 	if got.PausedUntil == nil || !got.PausedUntil.Equal(pausedUntil) {
 		t.Errorf("paused_until = %v, want %v", got.PausedUntil, pausedUntil)
+	}
+}
+
+func TestBulkResumePaused_usesSetBasedUpdate(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	repo := db.Repository{URL: "https://example.com/r", Name: "r"}
+	s.DB.Create(&repo)
+	for range 2 {
+		s.DB.Create(&db.Scan{
+			RepositoryID: repo.ID,
+			Kind:         worker.JobSkill,
+			Status:       db.ScanPaused,
+		})
+	}
+
+	updates := 0
+	const callback = "test:count-bulk-resume-updates"
+	if err := s.DB.Callback().Update().Before("gorm:update").Register(callback, func(*gorm.DB) {
+		updates++
+	}); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		_ = s.DB.Callback().Update().Remove(callback)
+	}()
+
+	scans, err := s.bulkResumePaused(s.DB)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(scans) != 2 {
+		t.Fatalf("resumed scans = %d, want 2", len(scans))
+	}
+	if updates != 1 {
+		t.Fatalf("update statements = %d, want 1", updates)
+	}
+}
+
+func TestBulkResumePaused_usesCallerTransaction(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	repo := db.Repository{URL: "https://example.com/r", Name: "r"}
+	s.DB.Create(&repo)
+	scan := db.Scan{
+		RepositoryID: repo.ID,
+		Kind:         worker.JobSkill,
+		Status:       db.ScanPaused,
+	}
+	s.DB.Create(&scan)
+
+	rollback := errors.New("roll back test")
+	err := s.DB.Transaction(func(tx *gorm.DB) error {
+		scans, err := s.bulkResumePaused(tx)
+		if err != nil {
+			return err
+		}
+		if len(scans) != 1 {
+			t.Fatalf("resumed scans = %d, want 1", len(scans))
+		}
+		return rollback
+	})
+	if !errors.Is(err, rollback) {
+		t.Fatalf("transaction error = %v, want %v", err, rollback)
+	}
+
+	var got db.Scan
+	s.DB.First(&got, scan.ID)
+	if got.Status != db.ScanPaused {
+		t.Fatalf("status after caller rollback = %q, want paused", got.Status)
 	}
 }
 


### PR DESCRIPTION
Capture paused scan state before moving it to queued so an enqueue failure can restore the original `paused_until`. Claim paused scans with status-guarded updates inside one transaction and cover the rollback path.