### PR TITLE
Make multi-result imports atomic

### DIFF
--- a/internal/web/import.go
+++ b/internal/web/import.go
@@ -70,14 +70,10 @@ func (s *Server) handleImport(w http.ResponseWriter, r *http.Request) {
 	}
 
 	repoOverride := r.URL.Query().Get("repo")
-	out := make([]map[string]any, 0, len(results))
-	for _, res := range results {
-		summary, err := s.importResult(res, repoOverride, revalidate)
-		if err != nil {
-			writeAPIError(w, http.StatusUnprocessableEntity, err.Error())
-			return
-		}
-		out = append(out, summary)
+	out, err := s.importResults(results, repoOverride, revalidate)
+	if err != nil {
+		writeAPIError(w, http.StatusUnprocessableEntity, err.Error())
+		return
 	}
 	writeJSON(w, http.StatusCreated, map[string]any{
 		"format":  string(format),
@@ -154,6 +150,10 @@ func (s *Server) importFallback(w http.ResponseWriter, r *http.Request, body []b
 // ensureImportRepo resolves a repository URL from an import request to a
 // Repository row, creating it on first sight.
 func (s *Server) ensureImportRepo(repoURL string) (db.Repository, error) {
+	return ensureImportRepoWith(s.DB, repoURL)
+}
+
+func ensureImportRepoWith(database *gorm.DB, repoURL string) (db.Repository, error) {
 	input, err := ParseRepoInput(repoURL)
 	if err != nil {
 		return db.Repository{}, fmt.Errorf("repository %q: %w", repoURL, err)
@@ -179,23 +179,86 @@ func (s *Server) ensureImportRepo(repoURL string) (db.Repository, error) {
 	if input.Owner != "" {
 		repo.FullName = input.Owner + "/" + input.Name
 	}
-	if err := s.DB.Where(db.Repository{URL: input.CloneURL}).FirstOrCreate(&repo).Error; err != nil {
+	if err := database.Where(db.Repository{URL: input.CloneURL}).FirstOrCreate(&repo).Error; err != nil {
 		return db.Repository{}, err
 	}
 	return repo, nil
 }
 
-func (s *Server) importResult(res ingest.Result, repoOverride string, revalidate bool) (map[string]any, error) {
+type importedResult struct {
+	repo     db.Repository
+	scan     db.Scan
+	tool     string
+	created  []db.Finding
+	observed int
+}
+
+func (s *Server) importResults(results []ingest.Result, repoOverride string, revalidate bool) ([]map[string]any, error) {
+	imported := make([]importedResult, 0, len(results))
+	err := s.DB.Transaction(func(tx *gorm.DB) error {
+		for _, res := range results {
+			outcome, err := s.importResultWith(tx, res, repoOverride)
+			if err != nil {
+				return err
+			}
+			imported = append(imported, outcome)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]map[string]any, 0, len(imported))
+	for _, result := range imported {
+		s.enqueueImportedRepoMetadata(context.Background(), result.repo)
+		// Imported findings carry an external tool's unvalidated severity
+		// claim, so revalidate runs over every newly-imported finding
+		// regardless of severity (not just High/Critical, as it does for
+		// security-deep-dive output). ?revalidate=false skips this — and the
+		// verify it chains into — for callers importing already-audited
+		// findings such as a trusted sharing bundle. Enqueued after commit so
+		// a rolled-back import never queues work against phantom findings.
+		if revalidate {
+			for i := range result.created {
+				// Imports have no parent scan and hence no resolved profile to carry;
+				// revalidate detects fresh, and its resolved profile then carries into
+				// the chained verify (autoChainVerifyAfterRevalidate). See #548.
+				s.enqueueRevalidateForFinding(context.Background(), &result.created[i], "")
+			}
+		}
+		s.Log.Info("import",
+			"repo", result.repo.URL, "tool", result.tool, "scan", result.scan.ID,
+			"created", len(result.created), "observed", result.observed)
+
+		ids := make([]uint, len(result.created))
+		for i, finding := range result.created {
+			ids[i] = finding.ID
+		}
+		out = append(out, map[string]any{
+			"repository_id": result.repo.ID,
+			"repository":    result.repo.URL,
+			"scan_id":       result.scan.ID,
+			"tool":          result.tool,
+			"created":       len(result.created),
+			"observed":      result.observed,
+			"finding_ids":   ids,
+		})
+	}
+	return out, nil
+}
+
+func (s *Server) importResultWith(tx *gorm.DB, res ingest.Result, repoOverride string) (importedResult, error) {
 	repoURL := res.RepoURL
 	if repoOverride != "" {
 		repoURL = repoOverride
 	}
 	if repoURL == "" {
-		return nil, fmt.Errorf("repository unknown: report has no provenance and no ?repo= supplied")
+		return importedResult{}, fmt.Errorf("repository unknown: report has no provenance and no ?repo= supplied")
 	}
-	repo, err := s.ensureImportRepo(repoURL)
+	repo, err := ensureImportRepoWith(tx, repoURL)
 	if err != nil {
-		return nil, err
+		return importedResult{}, err
 	}
 
 	now := time.Now()
@@ -211,50 +274,19 @@ func (s *Server) importResult(res ingest.Result, repoOverride string, revalidate
 	}
 	scan.StatusPriority = db.StatusPriorityFor(scan.Status)
 
-	var created []db.Finding
-	var observed int
-	err = s.DB.Transaction(func(tx *gorm.DB) error {
-		if err := tx.Create(&scan).Error; err != nil {
-			return err
-		}
-		created, observed, err = s.importFindings(tx, &scan, res)
-		return err
-	})
+	if err := tx.Create(&scan).Error; err != nil {
+		return importedResult{}, err
+	}
+	created, observed, err := s.importFindings(tx, &scan, res)
 	if err != nil {
-		return nil, err
+		return importedResult{}, err
 	}
-	s.enqueueImportedRepoMetadata(context.Background(), repo)
-	// Imported findings carry an external tool's unvalidated severity
-	// claim, so revalidate runs over every newly-imported finding
-	// regardless of severity (not just High/Critical, as it does for
-	// security-deep-dive output). ?revalidate=false skips this — and the
-	// verify it chains into — for callers importing already-audited
-	// findings such as a trusted sharing bundle. Enqueued after commit so
-	// a rolled-back import never queues work against phantom findings.
-	if revalidate {
-		for i := range created {
-			// Imports have no parent scan and hence no resolved profile to carry;
-			// revalidate detects fresh, and its resolved profile then carries into
-			// the chained verify (autoChainVerifyAfterRevalidate). See #548.
-			s.enqueueRevalidateForFinding(context.Background(), &created[i], "")
-		}
-	}
-	s.Log.Info("import",
-		"repo", repo.URL, "tool", res.Tool, "scan", scan.ID,
-		"created", len(created), "observed", observed)
-
-	ids := make([]uint, len(created))
-	for i, f := range created {
-		ids[i] = f.ID
-	}
-	return map[string]any{
-		"repository_id": repo.ID,
-		"repository":    repo.URL,
-		"scan_id":       scan.ID,
-		"tool":          res.Tool,
-		"created":       len(created),
-		"observed":      observed,
-		"finding_ids":   ids,
+	return importedResult{
+		repo:     repo,
+		scan:     scan,
+		tool:     res.Tool,
+		created:  created,
+		observed: observed,
 	}, nil
 }
 

--- a/internal/web/import_test.go
+++ b/internal/web/import_test.go
@@ -2,6 +2,7 @@ package web
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -15,6 +16,9 @@ func importSingleResult(s *Server, res ingest.Result, revalidate bool) (map[stri
 	out, err := s.importResults([]ingest.Result{res}, "", revalidate)
 	if err != nil {
 		return nil, err
+	}
+	if len(out) != 1 {
+		return nil, fmt.Errorf("import results = %d, want 1", len(out))
 	}
 	return out[0], nil
 }

--- a/internal/web/import_test.go
+++ b/internal/web/import_test.go
@@ -11,6 +11,14 @@ import (
 	"scrutineer/internal/ingest"
 )
 
+func importSingleResult(s *Server, res ingest.Result, revalidate bool) (map[string]any, error) {
+	out, err := s.importResults([]ingest.Result{res}, "", revalidate)
+	if err != nil {
+		return nil, err
+	}
+	return out[0], nil
+}
+
 func TestKnownPURLsMatchWithAndWithoutQualifiers(t *testing.T) {
 	gdb, err := db.Open("file::memory:?cache=shared")
 	if err != nil {
@@ -126,7 +134,7 @@ func TestImportFindings_reimportBumpsSeenCount(t *testing.T) {
 			{Title: "two", Severity: "Low", Location: "b.go:1", CWE: "CWE-89"},
 		},
 	}
-	first, err := s.importResult(res, "", false)
+	first, err := importSingleResult(s, res, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -140,7 +148,7 @@ func TestImportFindings_reimportBumpsSeenCount(t *testing.T) {
 		{Title: "one", Severity: "High", Location: "a.go:1", CWE: "CWE-79"},
 		{Title: "three", Severity: "Medium", Location: "c.go:1", CWE: "CWE-22"},
 	}
-	second, err := s.importResult(res, "", false)
+	second, err := importSingleResult(s, res, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -280,7 +288,7 @@ func TestImportFindings_revalidateToggle(t *testing.T) {
 					{Title: "low", Severity: "Low", Location: "b.go:1"},
 				},
 			}
-			out, err := s.importResult(res, "", tc.revalidate)
+			out, err := importSingleResult(s, res, tc.revalidate)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -303,7 +311,7 @@ func TestImportFindings_skipsRevalidateWhenSkillAbsent(t *testing.T) {
 	defer done()
 	// No revalidate skill registered. Import must still succeed.
 	res := ingest.Result{RepoURL: "https://example.com/r", Tool: "x", Findings: []ingest.Finding{{Title: "t", Severity: "High", Location: "a.go:1"}}}
-	out, err := s.importResult(res, "", true)
+	out, err := importSingleResult(s, res, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -323,11 +331,11 @@ func TestImportFindings_enqueuesOneMetadataOnboardingRunForExistingHollowRepo(t 
 
 	res := ingest.Result{RepoURL: repo.URL, Tool: "scrutineer",
 		Findings: []ingest.Finding{{Title: "imported", Severity: "High", Location: "lib/rdoc.rb:1"}}}
-	if _, err := s.importResult(res, "", false); err != nil {
+	if _, err := importSingleResult(s, res, false); err != nil {
 		t.Fatal(err)
 	}
 	// Reimport while metadata is queued must not pile up another run.
-	if _, err := s.importResult(res, "", false); err != nil {
+	if _, err := importSingleResult(s, res, false); err != nil {
 		t.Fatal(err)
 	}
 
@@ -354,7 +362,7 @@ func TestImportFindings_existingDoneMetadataIsNotDuplicated(t *testing.T) {
 
 	res := ingest.Result{RepoURL: repo.URL, Tool: "scrutineer",
 		Findings: []ingest.Finding{{Title: "imported", Severity: "Medium"}}}
-	if _, err := s.importResult(res, "", false); err != nil {
+	if _, err := importSingleResult(s, res, false); err != nil {
 		t.Fatal(err)
 	}
 	var count int64
@@ -376,7 +384,7 @@ func TestImportFindings_localRepoWithValidPathGetsNoMetadataScan(t *testing.T) {
 	dir := t.TempDir()
 	res := ingest.Result{RepoURL: LocalScheme + dir, Tool: "scrutineer",
 		Findings: []ingest.Finding{{Title: "local", Severity: "High", Location: "main.go:1"}}}
-	if _, err := s.importResult(res, "", false); err != nil {
+	if _, err := importSingleResult(s, res, false); err != nil {
 		t.Fatal(err)
 	}
 	var count int64

--- a/internal/web/ingest_import_test.go
+++ b/internal/web/ingest_import_test.go
@@ -97,6 +97,66 @@ func TestHandleImportSARIF(t *testing.T) {
 	}
 }
 
+func TestHandleImport_multiResultFailureRollsBackAllRows(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	s.DB.Create(&db.Skill{
+		Name: metadataSkillName, OutputFile: "report.json",
+		OutputKind: "repo_metadata", Version: 1, Active: true,
+	})
+	s.DB.Create(&db.Skill{
+		Name: revalidateSkillName, OutputFile: "report.json",
+		OutputKind: "revalidate", Version: 1, Active: true,
+	})
+
+	body := `{
+		"version": "2.1.0",
+		"runs": [
+			{
+				"tool": {"driver": {"name": "first"}},
+				"versionControlProvenance": [{
+					"repositoryUri": "https://example.com/first",
+					"revisionId": "abc123"
+				}],
+				"results": [{
+					"ruleId": "rule-1",
+					"level": "error",
+					"message": {"text": "first finding"}
+				}]
+			},
+			{
+				"tool": {"driver": {"name": "second"}},
+				"results": [{
+					"ruleId": "rule-2",
+					"level": "warning",
+					"message": {"text": "second finding"}
+				}]
+			}
+		]
+	}`
+	w := postImport(t, s, "/api/v1/import", body)
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d, want 422; body=%s", w.Code, w.Body)
+	}
+	if !strings.Contains(w.Body.String(), "repository unknown") {
+		t.Fatalf("body = %q, want repository error", w.Body.String())
+	}
+
+	for name, model := range map[string]any{
+		"repositories": &db.Repository{},
+		"scans":        &db.Scan{},
+		"findings":     &db.Finding{},
+	} {
+		var count int64
+		if err := s.DB.Model(model).Count(&count).Error; err != nil {
+			t.Fatalf("count %s: %v", name, err)
+		}
+		if count != 0 {
+			t.Errorf("%s rows = %d, want 0 after rollback", name, count)
+		}
+	}
+}
+
 func TestHandleImportDedupesOnReimport(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()

--- a/internal/web/ingest_import_test.go
+++ b/internal/web/ingest_import_test.go
@@ -100,14 +100,18 @@ func TestHandleImportSARIF(t *testing.T) {
 func TestHandleImport_multiResultFailureRollsBackAllRows(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()
-	s.DB.Create(&db.Skill{
+	if err := s.DB.Create(&db.Skill{
 		Name: metadataSkillName, OutputFile: "report.json",
 		OutputKind: "repo_metadata", Version: 1, Active: true,
-	})
-	s.DB.Create(&db.Skill{
+	}).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := s.DB.Create(&db.Skill{
 		Name: revalidateSkillName, OutputFile: "report.json",
 		OutputKind: "revalidate", Version: 1, Active: true,
-	})
+	}).Error; err != nil {
+		t.Fatal(err)
+	}
 
 	body := `{
 		"version": "2.1.0",


### PR DESCRIPTION
Import all parsed results inside one database transaction so a later result failure rolls back repositories, scans, findings, and observed updates from earlier results.

Defer metadata and revalidation enqueue work until the transaction commits.