### PR TITLE
Align prompts across skill harnesses

### DIFF
--- a/internal/worker/claude.go
+++ b/internal/worker/claude.go
@@ -337,17 +337,7 @@ func buildClaudeArgs(sj SkillJob, effort string, globalMaxTurns int) []string {
 		args = append(args, "--resume", sj.ResumeSessionID)
 	}
 	args = append(args, "--max-turns", strconv.Itoa(effectiveMaxTurns(sj.MaxTurns, globalMaxTurns)))
-	switch {
-	case sj.ResumeSessionID != "" && sj.ResumePrompt != "":
-		args = append(args, sj.ResumePrompt)
-	case sj.ResumeSessionID != "":
-		args = append(args, buildResumePrompt(sj.Name, sj.OutputFile))
-	case sj.Prompt != "":
-		args = append(args, sj.Prompt)
-	default:
-		args = append(args, buildSkillPrompt(sj.Name, sj.OutputFile))
-	}
-	return args
+	return append(args, ClaudeHarness{}.Prompt(sj))
 }
 
 // claudePermissionMode picks the permission mode for a job that declares an
@@ -411,11 +401,16 @@ func schemaValidationHint(outputFile string) string {
 }
 
 // buildLoggedPrompt is what scrutineer records on scan.Prompt for the UI. It
-// pairs the activation invocation with the rendered SKILL.md so the Prompt
-// tab shows the actual instructions Claude executed (#308), not just the
-// "use the X skill" wrapper.
-func buildLoggedPrompt(skill *db.Skill) string {
-	return buildSkillPrompt(skill.Name, skill.OutputFile) +
+// pairs the selected harness's activation invocation with the rendered
+// SKILL.md so the Prompt tab shows the instructions the agent received (#308),
+// not just an activation wrapper.
+func buildLoggedPrompt(skill *db.Skill, backend string) string {
+	harness, err := HarnessByName(backend)
+	if err != nil {
+		harness = ClaudeHarness{}
+	}
+	prompt := harness.Prompt(SkillJob{Name: skill.Name, OutputFile: skill.OutputFile})
+	return prompt +
 		"\n\n--- SKILL.md ---\n\n" + renderSkillMD(skill)
 }
 
@@ -427,6 +422,7 @@ func buildResumePrompt(name, outputFile string) string {
 	p := fmt.Sprintf("Continue the %q skill on the repository at ./src from where you left off.", name)
 	if outputFile != "" {
 		p += fmt.Sprintf(" Write your structured output to ./%s as the skill specifies.", outputFile)
+		p += schemaValidationHint(outputFile)
 	}
 	return p
 }

--- a/internal/worker/claude_test.go
+++ b/internal/worker/claude_test.go
@@ -18,7 +18,7 @@ func TestBuildLoggedPrompt_includesActivationAndRenderedSkill(t *testing.T) {
 		Body:        "## Workspace\n\n- `./src` — the cloned repo.",
 		OutputFile:  "report.json",
 	}
-	got := buildLoggedPrompt(skill)
+	got := buildLoggedPrompt(skill, "claude")
 	for _, want := range []string{
 		buildSkillPrompt("metadata", "report.json"),
 		"--- SKILL.md ---",
@@ -30,6 +30,31 @@ func TestBuildLoggedPrompt_includesActivationAndRenderedSkill(t *testing.T) {
 		if !strings.Contains(got, want) {
 			t.Errorf("logged prompt missing %q\nfull prompt:\n%s", want, got)
 		}
+	}
+}
+
+func TestBuildLoggedPrompt_usesBackendActivationPrompt(t *testing.T) {
+	skill := &db.Skill{
+		Name:        "metadata",
+		Description: "Identify the repository.",
+		OutputFile:  "report.json",
+	}
+	for _, tc := range []struct {
+		backend string
+		prefix  string
+	}{
+		{"codex", "Follow the instructions in ./skills/metadata/SKILL.md"},
+		{"opencode", "Follow the instructions in ./.opencode/skill/metadata/SKILL.md"},
+	} {
+		t.Run(tc.backend, func(t *testing.T) {
+			got := buildLoggedPrompt(skill, tc.backend)
+			if !strings.HasPrefix(got, tc.prefix) {
+				t.Errorf("logged prompt = %q, want prefix %q", got, tc.prefix)
+			}
+			if strings.HasPrefix(got, `Use the "metadata" skill`) {
+				t.Errorf("logged prompt uses claude activation wording: %q", got)
+			}
+		})
 	}
 }
 
@@ -155,6 +180,9 @@ func TestBuildClaudeArgs_Resume(t *testing.T) {
 	// The deliverable still has to be restated so a resumed agent writes it.
 	if !strings.Contains(last, "report.json") {
 		t.Errorf("resume prompt %q should restate the output file", last)
+	}
+	if !strings.Contains(last, "validate-report") {
+		t.Errorf("resume prompt %q should restate schema validation", last)
 	}
 }
 

--- a/internal/worker/exposure.go
+++ b/internal/worker/exposure.go
@@ -175,7 +175,7 @@ func (w *Worker) doExposure(ctx context.Context, scan *db.Scan, emit func(Event)
 	}
 
 	depRepo := db.Repository{URL: dep.RepositoryURL, Name: dep.Name}
-	prompt := buildLoggedPrompt(&skill)
+	prompt := buildLoggedPrompt(&skill, scan.Backend)
 	scan.Prompt = prompt
 	w.DB.Model(scan).Update("prompt", prompt)
 

--- a/internal/worker/harness.go
+++ b/internal/worker/harness.go
@@ -88,6 +88,10 @@ type Harness interface {
 	// the operator's model-API base URL override; harnesses that do not
 	// pass it as an env var can translate it into CLI/config arguments.
 	Args(sj SkillJob, effort string, globalMaxTurns int, baseURL string) []string
+	// Prompt is the final user prompt Args passes to the harness. Keeping
+	// prompt construction on the harness lets scan.Prompt record the same
+	// activation wording the selected backend receives.
+	Prompt(sj SkillJob) string
 	// ParseStream reads the harness's combined stdout/stderr and emits one
 	// Event per logical line. The Event vocabulary (KindText, KindTool,
 	// KindSession, KindError, ...) is harness-neutral; this method maps

--- a/internal/worker/harness_claude.go
+++ b/internal/worker/harness_claude.go
@@ -19,6 +19,19 @@ func (ClaudeHarness) Args(sj SkillJob, effort string, globalMaxTurns int, _ stri
 	return buildClaudeArgs(sj, effort, globalMaxTurns)
 }
 
+func (ClaudeHarness) Prompt(sj SkillJob) string {
+	switch {
+	case sj.ResumeSessionID != "" && sj.ResumePrompt != "":
+		return sj.ResumePrompt
+	case sj.ResumeSessionID != "":
+		return buildResumePrompt(sj.Name, sj.OutputFile)
+	case sj.Prompt != "":
+		return sj.Prompt
+	default:
+		return buildSkillPrompt(sj.Name, sj.OutputFile)
+	}
+}
+
 func (ClaudeHarness) ParseStream(r io.Reader, emit func(Event)) {
 	ParseStream(r, emit)
 }

--- a/internal/worker/harness_codex.go
+++ b/internal/worker/harness_codex.go
@@ -49,7 +49,11 @@ func (CodexHarness) Args(sj SkillJob, _ string, _ int, baseURL string) []string 
 	if sj.ResumeSessionID != "" {
 		args = append(args, "resume", sj.ResumeSessionID)
 	}
-	return append(args, explicitSkillPrompt(sj, "./skills/"+sj.Name))
+	return append(args, CodexHarness{}.Prompt(sj))
+}
+
+func (CodexHarness) Prompt(sj SkillJob) string {
+	return explicitSkillPrompt(sj, "./skills/"+sj.Name)
 }
 
 // ParseStream reads `codex exec --json` JSONL output. The event shapes

--- a/internal/worker/harness_opencode.go
+++ b/internal/worker/harness_opencode.go
@@ -34,7 +34,11 @@ func (OpencodeHarness) Args(sj SkillJob, _ string, _ int, _ string) []string {
 	if sj.ResumeSessionID != "" {
 		args = append(args, "--session", sj.ResumeSessionID)
 	}
-	return append(args, explicitSkillPrompt(sj, "./.opencode/skill/"+sj.Name))
+	return append(args, OpencodeHarness{}.Prompt(sj))
+}
+
+func (OpencodeHarness) Prompt(sj SkillJob) string {
+	return explicitSkillPrompt(sj, "./.opencode/skill/"+sj.Name)
 }
 
 func (OpencodeHarness) ParseStream(r io.Reader, emit func(Event)) {

--- a/internal/worker/harness_test.go
+++ b/internal/worker/harness_test.go
@@ -116,14 +116,17 @@ type stubHarness struct {
 	acctErr string
 }
 
-func (s stubHarness) Binary() string                              { return s.bin }
-func (s stubHarness) Args(SkillJob, string, int, string) []string { return []string{"--stub"} }
-func (s stubHarness) ParseStream(io.Reader, func(Event))          {}
-func (s stubHarness) SkillDir(wr, n string) string                { return filepath.Join(wr, "stub-skills", n) }
-func (s stubHarness) GuideFilename() string                       { return s.guide }
-func (s stubHarness) EgressHosts() []string                       { return s.egress }
-func (s stubHarness) Env(string) []string                         { return s.env }
-func (s stubHarness) StateEnv(string) []string                    { return s.state }
+func (s stubHarness) Binary() string { return s.bin }
+func (s stubHarness) Args(sj SkillJob, _ string, _ int, _ string) []string {
+	return []string{s.Prompt(sj)}
+}
+func (stubHarness) Prompt(SkillJob) string               { return "--stub" }
+func (s stubHarness) ParseStream(io.Reader, func(Event)) {}
+func (s stubHarness) SkillDir(wr, n string) string       { return filepath.Join(wr, "stub-skills", n) }
+func (s stubHarness) GuideFilename() string              { return s.guide }
+func (s stubHarness) EgressHosts() []string              { return s.egress }
+func (s stubHarness) Env(string) []string                { return s.env }
+func (s stubHarness) StateEnv(string) []string           { return s.state }
 func (s stubHarness) AccountErrorText(t string) string {
 	if s.acctErr != "" && strings.Contains(t, s.acctErr) {
 		return t
@@ -131,6 +134,21 @@ func (s stubHarness) AccountErrorText(t string) string {
 	return ""
 }
 func (s stubHarness) DefaultModels() []ModelDefault { return nil }
+
+func TestHarnessArgs_endWithHarnessPrompt(t *testing.T) {
+	sj := SkillJob{Name: "deep-dive", OutputFile: "report.json"}
+	for name, harness := range harnesses {
+		if name == "" {
+			continue
+		}
+		t.Run(name, func(t *testing.T) {
+			args := harness.Args(sj, "", 0, "")
+			if got, want := args[len(args)-1], harness.Prompt(sj); got != want {
+				t.Errorf("final arg = %q, want prompt %q", got, want)
+			}
+		})
+	}
+}
 
 func TestHarnessDefaultModels_registryEntriesAreComplete(t *testing.T) {
 	// Every registered harness must supply a non-empty default model

--- a/internal/worker/skill.go
+++ b/internal/worker/skill.go
@@ -195,7 +195,7 @@ func (w *Worker) doSkill(ctx context.Context, scan *db.Scan, emit func(Event)) (
 		return "", err
 	}
 
-	prompt := buildLoggedPrompt(&skill)
+	prompt := buildLoggedPrompt(&skill, scan.Backend)
 	scan.Prompt = prompt
 	w.DB.Model(scan).Update("prompt", prompt)
 


### PR DESCRIPTION
Build activation prompts through the selected harness so recorded scan prompts match the wording sent to Claude, Codex, or OpenCode. Preserve schema-validation guidance when resuming Claude skills with JSON output.