### PR TITLE
add allow_remote config to permit non-localhost access

### DIFF
--- a/cmd/scrutineer/main.go
+++ b/cmd/scrutineer/main.go
@@ -119,6 +119,7 @@ type flags struct {
 	autoRejectMissedCount int
 	federationSalt        string
 	federationContact     string
+	allowRemote           bool
 	skillLocal            skillDirs
 
 	// set records which flags were passed on the command line so merge
@@ -277,6 +278,9 @@ func (f *flags) merge(cfg *config.Config) {
 	if cfg.FederationContact != "" && !f.set["federation-contact"] {
 		f.federationContact = cfg.FederationContact
 	}
+	// AllowRemote is config-only (no CLI flag); the zero value keeps the
+	// localhost-only host-header check on (remote access denied).
+	f.allowRemote = cfg.AllowRemote
 
 	// Seed the model pick list from the active harness's own defaults,
 	// so a fresh install of any backend has a working list with correct
@@ -560,6 +564,7 @@ func run(log *slog.Logger) error {
 	srv.SetDefaultEffort(f.effort)
 	srv.FederationSalt = f.federationSalt
 	srv.FederationContact = f.federationContact
+	srv.AllowRemote = f.allowRemote
 
 	if f.recipientsFile != "" {
 		recs, err := loadRecipients(f.recipientsFile)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -146,6 +146,15 @@ type Config struct {
 	// hash match. Required when FederationSalt is set: startup refuses a
 	// salt without a contact.
 	FederationContact string `yaml:"federation_contact"`
+	// AllowRemote permits remote (non-localhost) access to the web server. It
+	// defaults to false, which keeps the localhost-only host-header check (the
+	// DNS-rebinding protection in internal/web): requests are served only when
+	// the Host header is 127.0.0.1, localhost, or ::1 (the historical
+	// behaviour). Set it to true to also serve requests for any other Host —
+	// needed when scrutineer runs behind a reverse proxy or is reached over a
+	// LAN. Only enable it when a trusted front end already restricts who can
+	// connect, since it removes the DNS-rebinding protection.
+	AllowRemote bool `yaml:"allow_remote"`
 }
 
 // ParseScanTimeout validates and parses a scan_timeout string. Empty

--- a/internal/web/security_test.go
+++ b/internal/web/security_test.go
@@ -12,7 +12,7 @@ func TestSecurityHeadersRejectsBadHost(t *testing.T) {
 	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
-	h := securityHeaders(inner)
+	h := securityHeaders(false, inner)
 
 	r := httptest.NewRequest("GET", "/", nil)
 	r.Host = "evil.example:8080"
@@ -27,7 +27,7 @@ func TestSecurityHeadersAllowsLocalhost(t *testing.T) {
 	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
-	h := securityHeaders(inner)
+	h := securityHeaders(false, inner)
 
 	for _, host := range []string{
 		"127.0.0.1:8080", "localhost:8080", "[::1]:8080",
@@ -43,11 +43,37 @@ func TestSecurityHeadersAllowsLocalhost(t *testing.T) {
 	}
 }
 
+func TestSecurityHeadersAllowRemoteBypassesHostCheck(t *testing.T) {
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	h := securityHeaders(true, inner)
+
+	// With the toggle on, a non-localhost Host is served instead of rejected.
+	r := httptest.NewRequest("GET", "/", nil)
+	r.Host = "scrutineer.example:8080"
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	if w.Code != http.StatusOK {
+		t.Errorf("allowRemote: got %d, want 200", w.Code)
+	}
+
+	// The CSRF check is independent of the host toggle and still fires.
+	r = httptest.NewRequest("POST", "/repositories", nil)
+	r.Host = "scrutineer.example:8080"
+	r.Header.Set("Sec-Fetch-Site", "cross-site")
+	w = httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	if w.Code != http.StatusForbidden {
+		t.Errorf("allowRemote cross-site POST: got %d, want 403", w.Code)
+	}
+}
+
 func TestSecurityHeadersRejectsCrossSitePost(t *testing.T) {
 	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
-	h := securityHeaders(inner)
+	h := securityHeaders(false, inner)
 
 	r := httptest.NewRequest("POST", "/repositories", nil)
 	r.Host = testHost
@@ -63,7 +89,7 @@ func TestSecurityHeadersAllowsSameOriginPost(t *testing.T) {
 	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
-	h := securityHeaders(inner)
+	h := securityHeaders(false, inner)
 
 	r := httptest.NewRequest("POST", "/repositories", nil)
 	r.Host = testHost

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -102,10 +102,10 @@ type Server struct {
 	claimIndex        claimCheckIndex
 
 	// AllowRemote, when true, permits remote access by disabling
-	// securityHeaders' localhost-only host-header check, so the UI/API can be
-	// served for any Host (e.g. behind a reverse proxy or over a LAN). Defaults
-	// to false, which keeps the DNS-rebinding protection. Set from
-	// config.AllowRemote.
+	// securityHeaders' localhost-only host-header check, so the UI and
+	// unauthenticated /api/v1 export endpoints can be served for any Host (e.g.
+	// behind a reverse proxy or over a LAN). Defaults to false, which keeps the
+	// DNS-rebinding protection. Set from config.AllowRemote.
 	AllowRemote bool
 
 	// resolvePURL maps a Package URL to its source repository URL via

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -101,6 +101,13 @@ type Server struct {
 	FederationContact string
 	claimIndex        claimCheckIndex
 
+	// AllowRemote, when true, permits remote access by disabling
+	// securityHeaders' localhost-only host-header check, so the UI/API can be
+	// served for any Host (e.g. behind a reverse proxy or over a LAN). Defaults
+	// to false, which keeps the DNS-rebinding protection. Set from
+	// config.AllowRemote.
+	AllowRemote bool
+
 	// resolvePURL maps a Package URL to its source repository URL via
 	// packages.ecosyste.ms. Field rather than direct call so tests can
 	// stub the network lookup.
@@ -512,9 +519,9 @@ func (s *Server) Handler() http.Handler {
 	// /api/v1/* are unauthenticated JSONL export endpoints sharing the
 	// browser's host-only boundary; see threatmodel.md.
 	root := http.NewServeMux()
-	root.Handle("/api/v1/", securityHeaders(http.StripPrefix(exportPrefix, s.exportHandler())))
+	root.Handle("/api/v1/", securityHeaders(s.AllowRemote, http.StripPrefix(exportPrefix, s.exportHandler())))
 	root.Handle("/api/", s.apiHandler())
-	root.Handle("/", securityHeaders(mux))
+	root.Handle("/", securityHeaders(s.AllowRemote, mux))
 	return logRequests(s.Log, root)
 }
 
@@ -3050,7 +3057,12 @@ const cspPolicy = "default-src 'self'; " +
 // securityHeaders enforces T3 mitigations: host header check to prevent DNS
 // rebinding, Sec-Fetch-Site check on POST to prevent cross-origin CSRF, and
 // a CSP that prevents stored XSS in any rendered content from executing JS.
-func securityHeaders(h http.Handler) http.Handler {
+//
+// allowRemote=false (the default) keeps the localhost-only host check;
+// allowRemote=true skips it so the server can be reached for any Host, for
+// deployments that front scrutineer with a trusted reverse proxy or serve it on
+// a LAN. See config.AllowRemote.
+func securityHeaders(allowRemote bool, h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Security-Policy", cspPolicy)
 		host := r.Host
@@ -3058,7 +3070,7 @@ func securityHeaders(h http.Handler) http.Handler {
 			host = h
 		}
 		host = strings.Trim(host, "[]")
-		if host != "127.0.0.1" && host != "localhost" && host != "::1" {
+		if !allowRemote && host != "127.0.0.1" && host != "localhost" && host != "::1" {
 			http.Error(w, "forbidden: invalid host", http.StatusForbidden)
 			return
 		}

--- a/scrutineer.sample.yaml
+++ b/scrutineer.sample.yaml
@@ -12,6 +12,13 @@
 # Listen address for the web UI + skill API.
 # addr: 127.0.0.1:8080
 
+# Allow remote (non-localhost) access to the web UI + skill API. Default false
+# keeps the localhost-only host-header check (the DNS-rebinding protection):
+# requests are served only when the Host is 127.0.0.1, localhost, or ::1. Set
+# true to also accept any other Host — needed behind a reverse proxy or on a
+# LAN. Only enable it when a trusted front end already restricts who can connect.
+# allow_remote: false
+
 # Where scan workspaces and the sqlite DB live.
 # data: ./data
 


### PR DESCRIPTION
The web server enforces a localhost-only host-header check (DNS-rebinding protection): requests are served only when Host is 127.0.0.1, localhost, or ::1. That blocks deployments behind a reverse proxy or on a LAN.

Add an `allow_remote` config option (default false) that, when true, skips the host check so the UI + skill API can be reached for any Host. Defaults to false preserves the existing behavour.

- config: Config.AllowRemote (yaml: allow_remote)
- web: Server.AllowRemote gates securityHeaders' host check
- cmd/scrutineer: wire config through to the server (config-only, no flag)
- document in scrutineer.sample.yaml; add securityHeaders bypass test