### PR TITLE
Preserve harness stream events

### DIFF
--- a/internal/worker/harness_opencode.go
+++ b/internal/worker/harness_opencode.go
@@ -102,6 +102,8 @@ func parseOpencodeLine(raw []byte, emit func(Event)) {
 		emit(Event{Kind: KindTool, Tool: name, Text: summariseInput(name, ev.Part.State.Input)})
 	case ev.Type == "error" || len(ev.Error) > 0:
 		emit(Event{Kind: KindError, Text: opencodeErrorText(ev.Error, line)})
+	case isOpencodeReasoningEvent(ev):
+		emit(Event{Kind: KindThinking, Text: ev.Part.Text})
 	case isOpencodeTextEvent(ev):
 		emit(Event{Kind: KindText, Text: ev.Part.Text})
 	case ev.Type == "step_finish" && ev.Part != nil:
@@ -135,11 +137,18 @@ func isOpencodeToolEvent(ev opencodeLine) bool {
 	return ev.Type == "tool" || ev.Part.Type == "tool" || ev.Part.Tool != "" || ev.Part.Name != ""
 }
 
+func isOpencodeReasoningEvent(ev opencodeLine) bool {
+	if ev.Part == nil || ev.Part.Text == "" {
+		return false
+	}
+	return ev.Type == "reasoning" || ev.Part.Type == "reasoning"
+}
+
 func isOpencodeTextEvent(ev opencodeLine) bool {
 	if ev.Part == nil || ev.Part.Text == "" {
 		return false
 	}
-	return ev.Type == "text" || ev.Type == "reasoning" || ev.Part.Type == "text" || ev.Part.Type == "reasoning"
+	return ev.Type == "text" || ev.Part.Type == "text"
 }
 
 func opencodeErrorText(raw json.RawMessage, fallback string) string {

--- a/internal/worker/harness_opencode_test.go
+++ b/internal/worker/harness_opencode_test.go
@@ -141,13 +141,15 @@ not json
 	var got []Event
 	OpencodeHarness{}.ParseStream(strings.NewReader(in), func(e Event) { got = append(got, e) })
 
-	var sessions, texts, tools, errs, results int
+	var sessions, texts, thinking, tools, errs, results int
 	for _, e := range got {
 		switch e.Kind {
 		case KindSession:
 			sessions++
 		case KindText:
 			texts++
+		case KindThinking:
+			thinking++
 		case KindTool:
 			tools++
 		case KindError:
@@ -175,9 +177,12 @@ not json
 	if got[5].Usage != wantUsage {
 		t.Errorf("Usage = %+v, want %+v (reasoning folded into output)", got[5].Usage, wantUsage)
 	}
-	// "hello", "thinking", and the non-JSON line.
-	if texts != 3 || got[1].Text != "hello" || got[2].Text != "thinking" {
-		t.Errorf("text events = %d, want 3: %v", texts, got)
+	// "hello" and the non-JSON line are text; reasoning is thinking.
+	if texts != 2 || got[1].Text != "hello" {
+		t.Errorf("text events = %d, want 2: %v", texts, got)
+	}
+	if thinking != 1 || got[2].Kind != KindThinking || got[2].Text != "thinking" {
+		t.Errorf("thinking event not mapped: %v", got)
 	}
 }
 

--- a/internal/worker/stream.go
+++ b/internal/worker/stream.go
@@ -157,6 +157,11 @@ func parseStreamLine(raw []byte, emit func(Event)) {
 		if msg.RateLimitInfo != nil {
 			emit(Event{Kind: KindRateLimit, RateLimit: msg.RateLimitInfo})
 		}
+	case "user":
+		// tool_result echoes: full file reads and command output. Dropped
+		// so the transcript stays readable and chat.go's KindText answer
+		// collector does not swallow raw JSON. The tool_use side is
+		// already recorded via the assistant message.
 	default:
 		emit(Event{Kind: KindText, Text: line})
 	}

--- a/internal/worker/stream.go
+++ b/internal/worker/stream.go
@@ -157,6 +157,8 @@ func parseStreamLine(raw []byte, emit func(Event)) {
 		if msg.RateLimitInfo != nil {
 			emit(Event{Kind: KindRateLimit, RateLimit: msg.RateLimitInfo})
 		}
+	default:
+		emit(Event{Kind: KindText, Text: line})
 	}
 }
 

--- a/internal/worker/stream_test.go
+++ b/internal/worker/stream_test.go
@@ -45,6 +45,19 @@ not json at all
 	}
 }
 
+func TestParseStream_UnknownEventPassedThrough(t *testing.T) {
+	in := `{"type":"future_event","payload":{"value":1}}`
+	var got []Event
+	ParseStream(strings.NewReader(in), func(e Event) { got = append(got, e) })
+
+	if len(got) != 1 {
+		t.Fatalf("want 1 event, got %d: %+v", len(got), got)
+	}
+	if got[0].Kind != KindText || got[0].Text != in {
+		t.Errorf("unknown event = %+v, want raw text", got[0])
+	}
+}
+
 func TestParseStream_RateLimitEvent(t *testing.T) {
 	// The exact shape claude-code emits on a subscription run.
 	in := `{"type":"rate_limit_event","rate_limit_info":{"status":"allowed","resetsAt":1782990000,"rateLimitType":"five_hour","overageStatus":"rejected","isUsingOverage":false}}` + "\n"

--- a/internal/worker/stream_test.go
+++ b/internal/worker/stream_test.go
@@ -13,6 +13,7 @@ func TestParseStream(t *testing.T) {
 	in := `
 {"type":"assistant","message":{"content":[{"type":"thinking","thinking":"hmm"}]}}
 {"type":"assistant","message":{"content":[{"type":"tool_use","name":"Bash","input":{"command":"ls -la"}}]}}
+{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"x","content":"file contents"}]}}
 {"type":"assistant","message":{"content":[{"type":"text","text":"done"}]}}
 not json at all
 {"type":"result","result":"ok","total_cost_usd":0.42,"num_turns":7,"duration_ms":1000,"usage":{"input_tokens":10,"output_tokens":66,"cache_read_input_tokens":1200,"cache_creation_input_tokens":34000}}
@@ -21,6 +22,7 @@ not json at all
 	var got []Event
 	ParseStream(strings.NewReader(in), func(e Event) { got = append(got, e) })
 
+	// The user/tool_result line is dropped, not passed through as text.
 	if len(got) != 5 {
 		t.Fatalf("want 5 events, got %d: %+v", len(got), got)
 	}


### PR DESCRIPTION
Pass unknown Claude stream event types through as text so they remain visible in scan transcripts. Map OpenCode reasoning events to thinking while keeping ordinary text events unchanged.