### PR TITLE
Serialize automatic skill enqueue

### DIFF
--- a/internal/web/advisory_audit_enqueue.go
+++ b/internal/web/advisory_audit_enqueue.go
@@ -66,10 +66,7 @@ func (s *Server) autoEnqueueAdvisoryAudit(scan *db.Scan) {
 		}
 		return
 	}
-	if s.hasOpenRepoScopedScan(scan.RepositoryID, skill.ID) {
-		return
-	}
-	if _, err := s.enqueueSkillWith(context.Background(), scan.RepositoryID, skill.ID, ScanOpts{}); err != nil {
+	if err := s.enqueueRepoScopedSkillIfIdle(context.Background(), scan.RepositoryID, skill.ID); err != nil {
 		s.Log.Warn("advisory regression watch: enqueue",
 			"repo", scan.RepositoryID, "skill", advisoryDeepDiveSkillName, "err", err)
 	}

--- a/internal/web/advisory_audit_enqueue_test.go
+++ b/internal/web/advisory_audit_enqueue_test.go
@@ -1,6 +1,7 @@
 package web
 
 import (
+	"sync"
 	"testing"
 	"time"
 
@@ -119,5 +120,37 @@ func TestAutoEnqueueAdvisoryAudit_skipsWhenAlreadyInFlight(t *testing.T) {
 
 	if got := advisoryAuditQueued(s, repoID, skillID); got != 1 {
 		t.Fatalf("queued audits = %d, want 1 (no duplicate enqueue)", got)
+	}
+}
+
+func TestAutoEnqueueAdvisoryAudit_doesNotDoubleQueueConcurrently(t *testing.T) {
+	s, done, repoID, skillID := advisoryAuditSetup(t)
+	defer done()
+
+	auditedAt := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	released := auditedAt.Add(48 * time.Hour)
+	seedDoneAudit(s, repoID, auditedAt)
+	seedPackage(s, repoID, &released)
+
+	const finalizers = 16
+	scans := make([]*db.Scan, finalizers)
+	for i := range scans {
+		scans[i] = newScan(t, s, repoID, packagesSkillName)
+	}
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for _, scan := range scans {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			s.autoEnqueueAdvisoryAudit(scan)
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	if got := advisoryAuditQueued(s, repoID, skillID); got != 1 {
+		t.Fatalf("queued audits = %d, want 1", got)
 	}
 }

--- a/internal/web/finding_dedup_enqueue.go
+++ b/internal/web/finding_dedup_enqueue.go
@@ -94,16 +94,6 @@ func (s *Server) enqueueFindingDedupForRepo(ctx context.Context, repoID uint) {
 	}
 }
 
-func (s *Server) enqueueRepoScopedSkillIfIdle(ctx context.Context, repoID, skillID uint) error {
-	s.agentEnqueueMu.Lock()
-	defer s.agentEnqueueMu.Unlock()
-	if s.hasOpenRepoScopedScan(repoID, skillID) {
-		return nil
-	}
-	_, err := s.enqueueSkillWith(ctx, repoID, skillID, ScanOpts{})
-	return err
-}
-
 // hasOpenRepoScopedScan returns true when a queued or running repository-scoped
 // scan (no finding attached) of the given skill already exists for the repo.
 // Mirrors hasOpenFindingScopedScan for repo-wide passes like finding-dedup.

--- a/internal/web/finding_dedup_enqueue.go
+++ b/internal/web/finding_dedup_enqueue.go
@@ -88,13 +88,20 @@ func (s *Server) enqueueFindingDedupForRepo(ctx context.Context, repoID uint) {
 	if err := s.DB.Where("name = ? AND active = ?", findingDedupSkillName, true).First(&skill).Error; err != nil {
 		return
 	}
-	if s.hasOpenRepoScopedScan(repoID, skill.ID) {
-		return
-	}
-	if _, err := s.enqueueSkillWith(ctx, repoID, skill.ID, ScanOpts{}); err != nil {
+	if err := s.enqueueRepoScopedSkillIfIdle(ctx, repoID, skill.ID); err != nil {
 		s.Log.Warn("auto-enqueue finding-dedup",
 			"repo", repoID, "skill", findingDedupSkillName, "err", err)
 	}
+}
+
+func (s *Server) enqueueRepoScopedSkillIfIdle(ctx context.Context, repoID, skillID uint) error {
+	s.agentEnqueueMu.Lock()
+	defer s.agentEnqueueMu.Unlock()
+	if s.hasOpenRepoScopedScan(repoID, skillID) {
+		return nil
+	}
+	_, err := s.enqueueSkillWith(ctx, repoID, skillID, ScanOpts{})
+	return err
 }
 
 // hasOpenRepoScopedScan returns true when a queued or running repository-scoped

--- a/internal/web/finding_dedup_enqueue_test.go
+++ b/internal/web/finding_dedup_enqueue_test.go
@@ -1,6 +1,7 @@
 package web
 
 import (
+	"sync"
 	"testing"
 
 	"scrutineer/internal/db"
@@ -161,17 +162,31 @@ func TestAutoEnqueueFindingDedup_conditions(t *testing.T) {
 	}
 }
 
-func TestAutoEnqueueFindingDedup_doesNotDoubleQueue(t *testing.T) {
+func TestAutoEnqueueFindingDedup_doesNotDoubleQueueConcurrently(t *testing.T) {
 	s, done, repoID, dedupID := dedupTestSetup(t)
 	defer done()
 
 	prior := newScan(t, s, repoID, "security-deep-dive")
 	newFindingUnder(t, s, repoID, prior.ID, db.FindingNew)
-	scan := newScan(t, s, repoID, "security-deep-dive")
-	newFindingUnder(t, s, repoID, scan.ID, db.FindingNew)
 
-	s.autoEnqueueFindingDedup(scan)
-	s.autoEnqueueFindingDedup(scan)
+	const finalizers = 16
+	scans := make([]*db.Scan, finalizers)
+	for i := range scans {
+		scans[i] = newScan(t, s, repoID, "security-deep-dive")
+		newFindingUnder(t, s, repoID, scans[i].ID, db.FindingNew)
+	}
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for _, scan := range scans {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			s.autoEnqueueFindingDedup(scan)
+		}()
+	}
+	close(start)
+	wg.Wait()
 
 	if n := dedupQueued(s, repoID, dedupID); n != 1 {
 		t.Errorf("queued = %d, want 1 (re-queue guard)", n)

--- a/internal/web/revalidate_enqueue.go
+++ b/internal/web/revalidate_enqueue.go
@@ -63,22 +63,27 @@ func (s *Server) enqueueRevalidateForFinding(ctx context.Context, f *db.Finding,
 	if err := s.DB.Where("name = ? AND active = ?", revalidateSkillName, true).First(&skill).Error; err != nil {
 		return
 	}
-	if s.hasOpenRevalidate(f.ID, skill.ID) {
-		return
-	}
-	fid := f.ID
-	if _, err := s.enqueueSkillWith(ctx, f.RepositoryID, skill.ID, ScanOpts{FindingID: &fid, Profile: profile}); err != nil {
+	if err := s.enqueueFindingScopedSkillIfIdle(ctx, f.RepositoryID, f.ID, skill.ID, ScanOpts{Profile: profile}); err != nil {
 		s.Log.Warn("auto-enqueue revalidate",
 			"finding", f.ID, "repo", f.RepositoryID, "skill", revalidateSkillName, "err", err)
 	}
 }
 
-// hasOpenRevalidate returns true when a queued or running revalidate scan
-// already exists for the finding. Avoids piling duplicate work onto the
-// queue when the same finding is observed by both an import and a rescan,
-// or when two findings parsers race in tests.
-func (s *Server) hasOpenRevalidate(findingID, skillID uint) bool {
-	return s.hasOpenFindingScopedScan(findingID, skillID)
+// enqueueFindingScopedSkillIfIdle serializes the open-scan check and enqueue
+// for finding-scoped auto-enqueue paths (revalidate, verify) under the shared
+// server enqueue mutex. Avoids piling duplicate work onto the queue when the
+// same finding is observed by both an import and a rescan, or when two
+// findings parsers race. opts.FindingID is set from findingID; callers pass
+// only the extra opts they need (Profile).
+func (s *Server) enqueueFindingScopedSkillIfIdle(ctx context.Context, repoID, findingID, skillID uint, opts ScanOpts) error {
+	s.agentEnqueueMu.Lock()
+	defer s.agentEnqueueMu.Unlock()
+	if s.hasOpenFindingScopedScan(findingID, skillID) {
+		return nil
+	}
+	opts.FindingID = &findingID
+	_, err := s.enqueueSkillWith(ctx, repoID, skillID, opts)
+	return err
 }
 
 func (s *Server) hasOpenFindingScopedScan(findingID, skillID uint) bool {
@@ -141,11 +146,7 @@ func (s *Server) enqueueVerifyForFinding(ctx context.Context, f *db.Finding, pro
 	if err := s.DB.Where("name = ? AND active = ?", verifySkillName, true).First(&skill).Error; err != nil {
 		return
 	}
-	if s.hasOpenFindingScopedScan(f.ID, skill.ID) {
-		return
-	}
-	fid := f.ID
-	if _, err := s.enqueueSkillWith(ctx, f.RepositoryID, skill.ID, ScanOpts{FindingID: &fid, Profile: profile}); err != nil {
+	if err := s.enqueueFindingScopedSkillIfIdle(ctx, f.RepositoryID, f.ID, skill.ID, ScanOpts{Profile: profile}); err != nil {
 		s.Log.Warn("auto-chain verify after revalidate",
 			"finding", f.ID, "repo", f.RepositoryID, "skill", verifySkillName, "err", err)
 	}

--- a/internal/web/revalidate_enqueue.go
+++ b/internal/web/revalidate_enqueue.go
@@ -69,23 +69,6 @@ func (s *Server) enqueueRevalidateForFinding(ctx context.Context, f *db.Finding,
 	}
 }
 
-// enqueueFindingScopedSkillIfIdle serializes the open-scan check and enqueue
-// for finding-scoped auto-enqueue paths (revalidate, verify) under the shared
-// server enqueue mutex. Avoids piling duplicate work onto the queue when the
-// same finding is observed by both an import and a rescan, or when two
-// findings parsers race. opts.FindingID is set from findingID; callers pass
-// only the extra opts they need (Profile).
-func (s *Server) enqueueFindingScopedSkillIfIdle(ctx context.Context, repoID, findingID, skillID uint, opts ScanOpts) error {
-	s.agentEnqueueMu.Lock()
-	defer s.agentEnqueueMu.Unlock()
-	if s.hasOpenFindingScopedScan(findingID, skillID) {
-		return nil
-	}
-	opts.FindingID = &findingID
-	_, err := s.enqueueSkillWith(ctx, repoID, skillID, opts)
-	return err
-}
-
 func (s *Server) hasOpenFindingScopedScan(findingID, skillID uint) bool {
 	return s.hasOpenScan("finding_id = ? AND skill_id = ?", findingID, skillID)
 }

--- a/internal/web/revalidate_enqueue_test.go
+++ b/internal/web/revalidate_enqueue_test.go
@@ -1,6 +1,7 @@
 package web
 
 import (
+	"sync"
 	"testing"
 
 	"scrutineer/internal/db"
@@ -75,5 +76,68 @@ func TestAutoChainVerify_nilScanDetectsFresh(t *testing.T) {
 	}
 	if derived.Profile != "" {
 		t.Errorf("derived Profile = %q, want empty (detect fresh)", derived.Profile)
+	}
+}
+
+func TestAutoChainVerify_doesNotDoubleQueueConcurrently(t *testing.T) {
+	s, done, verify, newFinding := chainTestSetup(t)
+	defer done()
+	f := newFinding("High")
+
+	const callers = 16
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for range callers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			s.autoChainVerifyAfterRevalidate(nil, f, "true_positive", "High")
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	var queued int64
+	s.DB.Model(&db.Scan{}).
+		Where("finding_id = ? AND skill_id = ? AND status = ?", f.ID, verify.ID, db.ScanQueued).
+		Count(&queued)
+	if queued != 1 {
+		t.Fatalf("queued verify scans = %d, want 1", queued)
+	}
+}
+
+func TestAutoEnqueueRevalidate_doesNotDoubleQueueConcurrently(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	repo := db.Repository{URL: "https://example.com/r", Name: "r"}
+	s.DB.Create(&repo)
+	revalidate := db.Skill{Name: "revalidate", OutputFile: "report.json", OutputKind: "revalidate", Version: 1, Active: true}
+	s.DB.Create(&revalidate)
+	scan := db.Scan{RepositoryID: repo.ID, Status: db.ScanDone, SkillName: "security-deep-dive"}
+	s.DB.Create(&scan)
+	f := db.Finding{ScanID: scan.ID, RepositoryID: repo.ID, Title: "t", Severity: "High"}
+	s.DB.Create(&f)
+
+	const callers = 16
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for range callers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			s.autoEnqueueRevalidate(&scan, &f)
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	var queued int64
+	s.DB.Model(&db.Scan{}).
+		Where("finding_id = ? AND skill_id = ? AND status = ?", f.ID, revalidate.ID, db.ScanQueued).
+		Count(&queued)
+	if queued != 1 {
+		t.Fatalf("queued revalidate scans = %d, want 1", queued)
 	}
 }

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -2773,6 +2773,36 @@ func (s *Server) enqueueSkillScoped(ctx context.Context, repoID, skillID uint, f
 	return s.enqueueSkillWith(ctx, repoID, skillID, ScanOpts{Model: model, FindingID: findingID})
 }
 
+// enqueueRepoScopedSkillIfIdle serializes the open-scan check and enqueue for
+// repo-scoped auto-enqueue paths (advisory audit, finding-dedup) under
+// agentEnqueueMu so concurrent scan finalizers cannot both pass the check.
+func (s *Server) enqueueRepoScopedSkillIfIdle(ctx context.Context, repoID, skillID uint) error {
+	s.agentEnqueueMu.Lock()
+	defer s.agentEnqueueMu.Unlock()
+	if s.hasOpenRepoScopedScan(repoID, skillID) {
+		return nil
+	}
+	_, err := s.enqueueSkillWith(ctx, repoID, skillID, ScanOpts{})
+	return err
+}
+
+// enqueueFindingScopedSkillIfIdle serializes the open-scan check and enqueue
+// for finding-scoped auto-enqueue paths (revalidate, verify) under
+// agentEnqueueMu. Avoids piling duplicate work onto the queue when the same
+// finding is observed by both an import and a rescan, or when two findings
+// parsers race. opts.FindingID is set from findingID; callers pass only the
+// extra opts they need (Profile).
+func (s *Server) enqueueFindingScopedSkillIfIdle(ctx context.Context, repoID, findingID, skillID uint, opts ScanOpts) error {
+	s.agentEnqueueMu.Lock()
+	defer s.agentEnqueueMu.Unlock()
+	if s.hasOpenFindingScopedScan(findingID, skillID) {
+		return nil
+	}
+	opts.FindingID = &findingID
+	_, err := s.enqueueSkillWith(ctx, repoID, skillID, opts)
+	return err
+}
+
 // enqueueSkillWith creates a skill scan using the given ScanOpts. Empty
 // fields default cleanly: unset FindingID means not-finding-scoped, empty
 // SubPath means root-scoped. Model precedence is: explicit opts.Model >


### PR DESCRIPTION
Serialize the open-scan check and enqueue used by advisory audits and finding deduplication. Concurrent scan finalizers now share the existing server enqueue mutex and cannot queue duplicate repository-scoped runs.