### PR TITLE
Handle JSONL row iteration errors

### DIFF
--- a/internal/web/api_export.go
+++ b/internal/web/api_export.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"os/exec"
@@ -93,7 +94,7 @@ func (s *Server) apiExportRepositories(w http.ResponseWriter, r *http.Request) {
 			LIMIT 1
 		)`).
 		Order("repositories.updated_at desc")
-	streamJSONL(w, q, repositoryExport)
+	streamJSONL(w, q, s.Log, repositoryExport)
 }
 
 func (s *Server) apiExportRepoFindings(w http.ResponseWriter, r *http.Request) {
@@ -153,7 +154,7 @@ func (s *Server) apiExportRepoFindings(w http.ResponseWriter, r *http.Request) {
 		Where("repository_id = ?", id).
 		Order("id desc")
 	q = applyFindingFilters(q, r)
-	streamJSONL(w, q, findingExport)
+	streamJSONL(w, q, s.Log, findingExport)
 }
 
 // sharingBundle is the self-contained sharing format that round-trips
@@ -531,7 +532,7 @@ func (s *Server) apiExportFindings(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	q := applyFindingFilters(s.DB.Model(&db.Finding{}).Order("id desc"), r)
-	streamJSONL(w, q, findingExport)
+	streamJSONL(w, q, s.Log, findingExport)
 }
 
 func (s *Server) apiExportScans(w http.ResponseWriter, r *http.Request) {
@@ -545,7 +546,7 @@ func (s *Server) apiExportScans(w http.ResponseWriter, r *http.Request) {
 	if v := r.URL.Query().Get("skill"); v != "" {
 		q = q.Where("skill_name = ?", v)
 	}
-	streamJSONL(w, q, scanExport)
+	streamJSONL(w, q, s.Log, scanExport)
 }
 
 // repositoryExport maps a repositoryExportRow to the public JSON object. Repos
@@ -616,9 +617,10 @@ func applyFindingFilters(q *gorm.DB, r *http.Request) *gorm.DB {
 }
 
 // streamJSONL iterates rows incrementally so a million-row export never
-// preloads into memory. The body is partial on mid-stream errors: once
-// we have committed to 200, a truncated stream is the only honest signal.
-func streamJSONL[T any](w http.ResponseWriter, q *gorm.DB, project func(T) map[string]any) {
+// preloads into memory. Before the first row, errors can still return a normal
+// 500; after the stream is committed, errors abort the connection so clients do
+// not mistake a truncated export for a clean EOF.
+func streamJSONL[T any](w http.ResponseWriter, q *gorm.DB, log *slog.Logger, project func(T) map[string]any) {
 	rows, err := q.Rows()
 	if err != nil {
 		writeAPIError(w, http.StatusInternalServerError, err.Error())
@@ -626,20 +628,46 @@ func streamJSONL[T any](w http.ResponseWriter, q *gorm.DB, project func(T) map[s
 	}
 	defer func() { _ = rows.Close() }()
 	w.Header().Set("Content-Type", "application/x-ndjson; charset=utf-8")
-	enc := json.NewEncoder(w)
+	cw := &commitTrackingResponseWriter{ResponseWriter: w}
+	enc := json.NewEncoder(cw)
 	flusher, _ := w.(http.Flusher)
 	for rows.Next() {
 		var item T
 		if err := q.ScanRows(rows, &item); err != nil {
+			handleJSONLStreamError(w, log, err, cw.committed)
 			return
 		}
 		if err := enc.Encode(project(item)); err != nil {
+			handleJSONLStreamError(w, log, err, cw.committed)
 			return
 		}
 		if flusher != nil {
 			flusher.Flush()
 		}
 	}
+	if err := rows.Err(); err != nil {
+		handleJSONLStreamError(w, log, err, cw.committed)
+	}
+}
+
+type commitTrackingResponseWriter struct {
+	http.ResponseWriter
+	committed bool
+}
+
+func (w *commitTrackingResponseWriter) Write(p []byte) (int, error) {
+	w.committed = true
+	n, err := w.ResponseWriter.Write(p)
+	return n, err
+}
+
+func handleJSONLStreamError(w http.ResponseWriter, log *slog.Logger, err error, committed bool) {
+	if !committed {
+		writeAPIError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	log.Error("jsonl export stream failed", "err", err)
+	panic(http.ErrAbortHandler)
 }
 
 // findingExport mirrors every db.Finding column. Relations (labels, notes,

--- a/internal/web/api_export_test.go
+++ b/internal/web/api_export_test.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -95,7 +96,7 @@ func TestStreamJSONLRowsErrorReturns500(t *testing.T) {
 	defer done()
 
 	w := httptest.NewRecorder()
-	streamJSONL[db.Finding](w, s.DB.Raw("SELECT * FROM missing_export_table"), findingExport)
+	streamJSONL[db.Finding](w, s.DB.Raw("SELECT * FROM missing_export_table"), s.Log, findingExport)
 
 	if w.Code != http.StatusInternalServerError {
 		t.Fatalf("status %d, want 500. body=%s", w.Code, w.Body)
@@ -110,6 +111,105 @@ func TestStreamJSONLRowsErrorReturns500(t *testing.T) {
 	if body[errorKey] == "" {
 		t.Fatalf("error response missing %q: %+v", errorKey, body)
 	}
+}
+
+func TestStreamJSONLRowsErrAbortsPartialResponse(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	type exportRow struct {
+		Value string
+	}
+	w := httptest.NewRecorder()
+	defer func() {
+		if got := recover(); got != http.ErrAbortHandler {
+			t.Fatalf("recover() = %v, want http.ErrAbortHandler", got)
+		}
+		rows := readJSONL(t, w.Body.String())
+		if len(rows) != 1 || rows[0]["value"] != "ok" {
+			t.Fatalf("streamed rows = %#v, want one successful row before abort", rows)
+		}
+	}()
+
+	q := s.DB.Raw(`WITH rows(value) AS (
+		VALUES ('ok'), (json_extract('not-json', '$'))
+	) SELECT value FROM rows`)
+	streamJSONL[exportRow](w, q, s.Log, func(row exportRow) map[string]any {
+		return map[string]any{"value": row.Value}
+	})
+}
+
+func TestStreamJSONLWriteErrorAfterPartialWriteAborts(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	type exportRow struct {
+		Value string
+	}
+	w := &failResponseWriter{writeBytes: 1}
+	defer func() {
+		if got := recover(); got != http.ErrAbortHandler {
+			t.Fatalf("recover() = %v, want http.ErrAbortHandler", got)
+		}
+		if strings.Contains(w.body.String(), errorKey) {
+			t.Fatalf("partial stream appended API error: %q", w.body.String())
+		}
+	}()
+
+	q := s.DB.Raw(`SELECT 'ok' AS value`)
+	streamJSONL[exportRow](w, q, s.Log, func(row exportRow) map[string]any {
+		return map[string]any{"value": row.Value}
+	})
+}
+
+func TestStreamJSONLWriteErrorAfterZeroByteWriteAborts(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	type exportRow struct {
+		Value string
+	}
+	w := &failResponseWriter{}
+	defer func() {
+		if got := recover(); got != http.ErrAbortHandler {
+			t.Fatalf("recover() = %v, want http.ErrAbortHandler", got)
+		}
+		if w.body.Len() != 0 {
+			t.Fatalf("zero-byte write unexpectedly wrote body: %q", w.body.String())
+		}
+	}()
+
+	q := s.DB.Raw(`SELECT 'ok' AS value`)
+	streamJSONL[exportRow](w, q, s.Log, func(row exportRow) map[string]any {
+		return map[string]any{"value": row.Value}
+	})
+}
+
+type failResponseWriter struct {
+	header     http.Header
+	body       bytes.Buffer
+	status     int
+	writeBytes int
+}
+
+func (w *failResponseWriter) Header() http.Header {
+	if w.header == nil {
+		w.header = make(http.Header)
+	}
+	return w.header
+}
+
+func (w *failResponseWriter) Write(p []byte) (int, error) {
+	n := w.writeBytes
+	if n > len(p) {
+		n = len(p)
+	}
+	w.body.Write(p[:n])
+	return n, errors.New("write failed")
+}
+
+func (w *failResponseWriter) WriteHeader(status int) {
+	w.status = status
 }
 
 func TestExportRepoFindings_severityFilter(t *testing.T) {


### PR DESCRIPTION
Fixes #732

## Summary

Ensures JSONL exports do not silently finish cleanly when database row iteration fails mid-stream.

`streamJSONL` now checks `rows.Err()` after iteration and aborts already-started responses so clients see an incomplete read instead of a clean truncated `200 OK`.

## Changes

- Check `rows.Err()` after the JSONL streaming loop
- Log committed-stream failures
- Abort committed streams with `http.ErrAbortHandler`
- Preserve normal `500` API errors when failures happen before streaming starts
- Add regression coverage for a mid-stream row iteration error

## Tests

- `go test ./internal/web -run 'TestStreamJSONL|TestExport'`
- `go test ./...`
- `go test -tags evals ./...`
- `go vet ./...`
- `go vet -tags evals ./...`
- `golangci-lint run ./cmd/... ./internal/...`
- `golangci-lint run --build-tags evals ./cmd/... ./internal/...`
- `git diff --check`