### PR TITLE
Test OpenAPI coverage for API routes

### DIFF
--- a/internal/web/openapi_routes_test.go
+++ b/internal/web/openapi_routes_test.go
@@ -184,7 +184,7 @@ func TestAPIRouteFromPatternRejectsUnsupportedMethod(t *testing.T) {
 		"BREW /coffee",
 		"CONNECT /tunnel",
 	} {
-		if _, _, err := apiRouteFromPattern("", pattern); err == nil {
+		if _, err := apiRouteFromPattern("", pattern); err == nil {
 			t.Fatalf("apiRouteFromPattern accepted unsupported method-qualified pattern %q", pattern)
 		}
 	}
@@ -193,6 +193,9 @@ func TestAPIRouteFromPatternRejectsUnsupportedMethod(t *testing.T) {
 func registeredOpenAPIRoutes(t *testing.T) []registeredAPIRoute {
 	t.Helper()
 	routes := append(routesInFunction(t, "api.go", "apiHandler", ""), routesInFunction(t, "api_export.go", "exportHandler", "/v1")...)
+	// claim-check is documented in openapi.yaml but registered on the root
+	// browser mux, outside apiHandler/exportHandler.
+	routes = append(routes, registeredAPIRoute{Method: "POST", Path: "/claim-check"})
 	sort.Slice(routes, func(i, j int) bool {
 		if routes[i].Path == routes[j].Path {
 			return routes[i].Method < routes[j].Method
@@ -246,13 +249,9 @@ func routesInParsedFileResult(file *ast.File, filename, funcName, pathPrefix str
 				extractErr = fmt.Errorf("%s: unquote route pattern: %w", filename, err)
 				return false
 			}
-			route, ok, err := apiRouteFromPattern(pathPrefix, pattern)
+			route, err := apiRouteFromPattern(pathPrefix, pattern)
 			if err != nil {
 				extractErr = fmt.Errorf("%s: unsupported route pattern %q: %w", filename, pattern, err)
-				return false
-			}
-			if !ok {
-				extractErr = fmt.Errorf("%s: route pattern %q must be method-qualified for OpenAPI coverage", filename, pattern)
 				return false
 			}
 			routes = append(routes, route)
@@ -274,19 +273,19 @@ func isRouteRegistration(call *ast.CallExpr) bool {
 	return sel.Sel.Name == "Handle" || sel.Sel.Name == "HandleFunc"
 }
 
-func apiRouteFromPattern(pathPrefix, pattern string) (registeredAPIRoute, bool, error) {
+func apiRouteFromPattern(pathPrefix, pattern string) (registeredAPIRoute, error) {
 	fields := strings.Fields(pattern)
 	switch len(fields) {
 	case 1:
-		return registeredAPIRoute{}, false, errors.New("route pattern must be method-qualified")
+		return registeredAPIRoute{}, errors.New("route pattern must be method-qualified")
 	case 2:
 	default:
-		return registeredAPIRoute{}, false, strconv.ErrSyntax
+		return registeredAPIRoute{}, strconv.ErrSyntax
 	}
 	switch fields[0] {
 	case "DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT", "TRACE":
-		return registeredAPIRoute{Method: fields[0], Path: pathPrefix + fields[1]}, true, nil
+		return registeredAPIRoute{Method: fields[0], Path: pathPrefix + fields[1]}, nil
 	default:
-		return registeredAPIRoute{}, false, strconv.ErrSyntax
+		return registeredAPIRoute{}, strconv.ErrSyntax
 	}
 }

--- a/internal/web/openapi_routes_test.go
+++ b/internal/web/openapi_routes_test.go
@@ -1,6 +1,8 @@
 package web
 
 import (
+	"errors"
+	"fmt"
 	"go/ast"
 	"go/parser"
 	"go/token"
@@ -109,7 +111,6 @@ func sample(mux interface {
 }) {
 	mux.HandleFunc("GET /repositories", nil)
 	mux.Handle("HEAD /repositories", nil)
-	mux.HandleFunc("/claim-check", nil)
 }
 `
 	file, err := parser.ParseFile(token.NewFileSet(), "sample.go", src, 0)
@@ -123,6 +124,58 @@ func sample(mux interface {
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("routes = %#v, want %#v", got, want)
+	}
+}
+
+func TestRoutesInFunctionRejectsUnmappableRegistrations(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want string
+	}{
+		{
+			name: "methodless handlefunc",
+			body: `mux.HandleFunc("/repositories", nil)`,
+			want: "method-qualified",
+		},
+		{
+			name: "methodless handle",
+			body: `mux.Handle("/repositories", nil)`,
+			want: "method-qualified",
+		},
+		{
+			name: "non literal handlefunc",
+			body: `pattern := "GET /repositories"
+	mux.HandleFunc(pattern, nil)`,
+			want: "non-literal route pattern",
+		},
+		{
+			name: "non literal handle",
+			body: `pattern := "GET /repositories"
+	mux.Handle(pattern, nil)`,
+			want: "non-literal route pattern",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			src := `package web
+
+func sample(mux interface {
+	Handle(string, any)
+	HandleFunc(string, any)
+}) {
+	` + tt.body + `
+}
+`
+			file, err := parser.ParseFile(token.NewFileSet(), "sample.go", src, 0)
+			if err != nil {
+				t.Fatal(err)
+			}
+			_, err = routesInParsedFileResult(file, "sample.go", "sample", "/v1")
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("error = %v, want %q", err, tt.want)
+			}
+		})
 	}
 }
 
@@ -160,12 +213,21 @@ func routesInFunction(t *testing.T, filename, funcName, pathPrefix string) []reg
 
 func routesInParsedFile(t *testing.T, file *ast.File, filename, funcName, pathPrefix string) []registeredAPIRoute {
 	t.Helper()
+	routes, err := routesInParsedFileResult(file, filename, funcName, pathPrefix)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return routes
+}
+
+func routesInParsedFileResult(file *ast.File, filename, funcName, pathPrefix string) ([]registeredAPIRoute, error) {
 	var routes []registeredAPIRoute
 	for _, decl := range file.Decls {
 		fn, ok := decl.(*ast.FuncDecl)
 		if !ok || fn.Name.Name != funcName {
 			continue
 		}
+		var extractErr error
 		ast.Inspect(fn.Body, func(n ast.Node) bool {
 			call, ok := n.(*ast.CallExpr)
 			if !ok || len(call.Args) == 0 {
@@ -176,25 +238,32 @@ func routesInParsedFile(t *testing.T, file *ast.File, filename, funcName, pathPr
 			}
 			lit, ok := call.Args[0].(*ast.BasicLit)
 			if !ok || lit.Kind != token.STRING {
-				return true
+				extractErr = fmt.Errorf("%s: non-literal route pattern in %s", filename, funcName)
+				return false
 			}
 			pattern, err := strconv.Unquote(lit.Value)
 			if err != nil {
-				t.Fatalf("%s: unquote route pattern: %v", filename, err)
+				extractErr = fmt.Errorf("%s: unquote route pattern: %w", filename, err)
+				return false
 			}
 			route, ok, err := apiRouteFromPattern(pathPrefix, pattern)
 			if err != nil {
-				t.Fatalf("%s: unsupported route pattern %q: %v", filename, pattern, err)
+				extractErr = fmt.Errorf("%s: unsupported route pattern %q: %w", filename, pattern, err)
+				return false
 			}
-			if ok {
-				routes = append(routes, route)
+			if !ok {
+				extractErr = fmt.Errorf("%s: route pattern %q must be method-qualified for OpenAPI coverage", filename, pattern)
+				return false
 			}
+			routes = append(routes, route)
 			return true
 		})
-		return routes
+		if extractErr != nil {
+			return nil, extractErr
+		}
+		return routes, nil
 	}
-	t.Fatalf("%s: function %s not found", filename, funcName)
-	return nil
+	return nil, fmt.Errorf("%s: function %s not found", filename, funcName)
 }
 
 func isRouteRegistration(call *ast.CallExpr) bool {
@@ -209,7 +278,7 @@ func apiRouteFromPattern(pathPrefix, pattern string) (registeredAPIRoute, bool, 
 	fields := strings.Fields(pattern)
 	switch len(fields) {
 	case 1:
-		return registeredAPIRoute{}, false, nil
+		return registeredAPIRoute{}, false, errors.New("route pattern must be method-qualified")
 	case 2:
 	default:
 		return registeredAPIRoute{}, false, strconv.ErrSyntax

--- a/internal/web/openapi_routes_test.go
+++ b/internal/web/openapi_routes_test.go
@@ -1,0 +1,223 @@
+package web
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"reflect"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+type openAPIPath map[string]any
+
+type openAPIDoc struct {
+	Paths map[string]openAPIPath `yaml:"paths"`
+}
+
+type registeredAPIRoute struct {
+	Method string
+	Path   string
+}
+
+func TestOpenAPICoversRegisteredAPIRoutes(t *testing.T) {
+	doc := loadOpenAPIDoc(t)
+	var missing []string
+	for _, route := range registeredOpenAPIRoutes(t) {
+		ops, ok := doc.Paths[route.Path]
+		if !ok {
+			missing = append(missing, route.Method+" "+route.Path)
+			continue
+		}
+		if _, ok := ops[strings.ToLower(route.Method)]; !ok {
+			missing = append(missing, route.Method+" "+route.Path)
+		}
+	}
+	if len(missing) > 0 {
+		t.Fatalf("openapi.yaml is missing registered API routes:\n%s", strings.Join(missing, "\n"))
+	}
+}
+
+func TestOpenAPIRepositoryPatchRequiresFork(t *testing.T) {
+	doc := loadOpenAPIDoc(t)
+	schema := openAPIRequestSchema(t, doc, "/repositories/{id}", "patch")
+	if _, ok := schema["additionalProperties"]; ok {
+		t.Fatal("PATCH /repositories/{id} schema should not reject unknown fields; the handler ignores them")
+	}
+	required, ok := schema["required"].([]any)
+	if !ok {
+		t.Fatal("PATCH /repositories/{id} schema missing required fields")
+	}
+	for _, field := range required {
+		if field == "fork" {
+			return
+		}
+	}
+	t.Fatalf("PATCH /repositories/{id} required fields = %v, want fork", required)
+}
+
+func loadOpenAPIDoc(t *testing.T) openAPIDoc {
+	t.Helper()
+	data, err := os.ReadFile("../../openapi.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var doc openAPIDoc
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		t.Fatal(err)
+	}
+	return doc
+}
+
+func openAPIRequestSchema(t *testing.T, doc openAPIDoc, path, method string) map[string]any {
+	t.Helper()
+	ops, ok := doc.Paths[path]
+	if !ok {
+		t.Fatalf("openapi path %s not found", path)
+	}
+	op := openAPIMap(t, ops[method], path+" "+method)
+	requestBody := openAPIMap(t, op["requestBody"], path+" "+method+" requestBody")
+	content := openAPIMap(t, requestBody["content"], path+" "+method+" content")
+	jsonContent := openAPIMap(t, content["application/json"], path+" "+method+" application/json")
+	return openAPIMap(t, jsonContent["schema"], path+" "+method+" schema")
+}
+
+func openAPIMap(t *testing.T, value any, label string) map[string]any {
+	t.Helper()
+	switch m := value.(type) {
+	case map[string]any:
+		return m
+	case openAPIPath:
+		return map[string]any(m)
+	default:
+		t.Fatalf("%s is %T, want map[string]any", label, value)
+		return nil
+	}
+}
+
+func TestRoutesInFunctionRecognizesHandleAndHandleFunc(t *testing.T) {
+	src := `package web
+
+func sample(mux interface {
+	Handle(string, any)
+	HandleFunc(string, any)
+}) {
+	mux.HandleFunc("GET /repositories", nil)
+	mux.Handle("HEAD /repositories", nil)
+	mux.HandleFunc("/claim-check", nil)
+}
+`
+	file, err := parser.ParseFile(token.NewFileSet(), "sample.go", src, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := routesInParsedFile(t, file, "sample.go", "sample", "/v1")
+	want := []registeredAPIRoute{
+		{Method: "GET", Path: "/v1/repositories"},
+		{Method: "HEAD", Path: "/v1/repositories"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("routes = %#v, want %#v", got, want)
+	}
+}
+
+func TestAPIRouteFromPatternRejectsUnsupportedMethod(t *testing.T) {
+	for _, pattern := range []string{
+		"BREW /coffee",
+		"CONNECT /tunnel",
+	} {
+		if _, _, err := apiRouteFromPattern("", pattern); err == nil {
+			t.Fatalf("apiRouteFromPattern accepted unsupported method-qualified pattern %q", pattern)
+		}
+	}
+}
+
+func registeredOpenAPIRoutes(t *testing.T) []registeredAPIRoute {
+	t.Helper()
+	routes := append(routesInFunction(t, "api.go", "apiHandler", ""), routesInFunction(t, "api_export.go", "exportHandler", "/v1")...)
+	sort.Slice(routes, func(i, j int) bool {
+		if routes[i].Path == routes[j].Path {
+			return routes[i].Method < routes[j].Method
+		}
+		return routes[i].Path < routes[j].Path
+	})
+	return routes
+}
+
+func routesInFunction(t *testing.T, filename, funcName, pathPrefix string) []registeredAPIRoute {
+	t.Helper()
+	file, err := parser.ParseFile(token.NewFileSet(), filename, nil, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return routesInParsedFile(t, file, filename, funcName, pathPrefix)
+}
+
+func routesInParsedFile(t *testing.T, file *ast.File, filename, funcName, pathPrefix string) []registeredAPIRoute {
+	t.Helper()
+	var routes []registeredAPIRoute
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Name.Name != funcName {
+			continue
+		}
+		ast.Inspect(fn.Body, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok || len(call.Args) == 0 {
+				return true
+			}
+			if !isRouteRegistration(call) {
+				return true
+			}
+			lit, ok := call.Args[0].(*ast.BasicLit)
+			if !ok || lit.Kind != token.STRING {
+				return true
+			}
+			pattern, err := strconv.Unquote(lit.Value)
+			if err != nil {
+				t.Fatalf("%s: unquote route pattern: %v", filename, err)
+			}
+			route, ok, err := apiRouteFromPattern(pathPrefix, pattern)
+			if err != nil {
+				t.Fatalf("%s: unsupported route pattern %q: %v", filename, pattern, err)
+			}
+			if ok {
+				routes = append(routes, route)
+			}
+			return true
+		})
+		return routes
+	}
+	t.Fatalf("%s: function %s not found", filename, funcName)
+	return nil
+}
+
+func isRouteRegistration(call *ast.CallExpr) bool {
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return false
+	}
+	return sel.Sel.Name == "Handle" || sel.Sel.Name == "HandleFunc"
+}
+
+func apiRouteFromPattern(pathPrefix, pattern string) (registeredAPIRoute, bool, error) {
+	fields := strings.Fields(pattern)
+	switch len(fields) {
+	case 1:
+		return registeredAPIRoute{}, false, nil
+	case 2:
+	default:
+		return registeredAPIRoute{}, false, strconv.ErrSyntax
+	}
+	switch fields[0] {
+	case "DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT", "TRACE":
+		return registeredAPIRoute{Method: fields[0], Path: pathPrefix + fields[1]}, true, nil
+	default:
+		return registeredAPIRoute{}, false, strconv.ErrSyntax
+	}
+}

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -24,6 +24,51 @@ security:
   - bearerAuth: []
 
 paths:
+  /claim-check:
+    servers:
+      - url: http://127.0.0.1:8080
+        description: Local scrutineer server root
+    post:
+      summary: Check whether this instance already holds a federated finding claim
+      description: |
+        Accepts a salted finding hash from a federation peer and returns whether
+        this instance already has a claimable matching finding. The request does
+        not reveal the finding; a match discloses only the configured operator
+        contact. Disabled instances, non-POST requests, and instances without a
+        federation salt answer 404 so federation support is not fingerprintable.
+      operationId: claimCheck
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [hash]
+              properties:
+                hash:
+                  type: string
+                  pattern: '^[0-9a-f]{64}$'
+      responses:
+        '200':
+          description: Claim-check result
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [match]
+                properties:
+                  match: { type: boolean }
+                  contact:
+                    type: string
+                    description: Present only when match is true and federation contact is configured.
+        '400':
+          description: Invalid JSON body or hash value
+        '404':
+          description: Claim check disabled or unsupported method
+        '500':
+          description: Failed to load local findings
+
   /repositories/{id}:
     get:
       summary: Fetch a repository summary
@@ -38,6 +83,45 @@ paths:
               schema: { $ref: '#/components/schemas/Repository' }
         '403': { $ref: '#/components/responses/Forbidden' }
         '404': { $ref: '#/components/responses/NotFound' }
+    patch:
+      summary: Update skill-writable repository fields
+      description: |
+        Allows the authenticated scan to write repository fields that are
+        produced by skills rather than owned by metadata refreshes. Currently
+        only `fork` is accepted.
+      operationId: patchRepository
+      parameters:
+        - $ref: '#/components/parameters/RepositoryID'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [fork]
+              properties:
+                fork:
+                  type: string
+                  description: Owner/name of the staging fork prepared for patch work.
+      responses:
+        '204':
+          description: Repository updated
+        '400':
+          description: Body is not valid JSON
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '422':
+          description: No writable fields were supplied
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+        '500':
+          description: Database update failed
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
 
   /repositories/{id}/scans:
     get:
@@ -328,7 +412,9 @@ paths:
                 baseline_scan_id:
                   type: integer
                   format: int64
-                  description: Optional baseline scan to use for `rescan_mode: diff`; omitted lets Scrutineer choose the latest compatible completed scan.
+                  description: |
+                    Optional baseline scan to use for `rescan_mode: diff`; omitted lets Scrutineer
+                    choose the latest compatible completed scan.
       responses:
         '201':
           description: Scan enqueued


### PR DESCRIPTION
Fixes #736

## Summary

Adds test coverage to keep `openapi.yaml` in sync with registered API routes.

The new test parses Scrutineer’s registered `/api/`, `/api/v1/` and `POST /claim-check` routes and fails when a registered route is missing from the OpenAPI spec.

## Changes

- Add an OpenAPI route coverage test for registered API handlers
- Document `POST /claim-check`
- Document the existing `PATCH /repositories/{id}` operation
- Fix an existing YAML syntax issue in `openapi.yaml` so the spec can be parsed by tests

## Tests

- `go test ./internal/web -run TestOpenAPICoversRegisteredAPIRoutes`
- `go test ./internal/web -run 'TestOpenAPI|TestAPI|TestClaimCheck|TestExport'`
- `go test ./...`
- `go test -tags evals ./...`
- `go vet ./...`
- `go vet -tags evals ./...`
- `golangci-lint run ./cmd/... ./internal/...`
- `golangci-lint run --build-tags evals ./cmd/... ./internal/...`
- `git diff --check`