### PR TITLE
fix(web): reject non-boolean ?active= with 400 on GET /api/skills

### DIFF
--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -11,6 +11,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"strconv"
@@ -495,7 +496,14 @@ func (s *Server) apiListCNAs(w http.ResponseWriter, r *http.Request) {
 func (s *Server) apiListSkills(w http.ResponseWriter, r *http.Request) {
 	q := s.DB.Order("name")
 	if v := r.URL.Query().Get("active"); v != "" {
-		active, _ := strconv.ParseBool(v)
+		// A malformed value is a 400 rather than a silent fall-back to false,
+		// so ?active=yes never quietly returns the inactive skills instead.
+		active, err := strconv.ParseBool(v)
+		if err != nil {
+			writeAPIError(w, http.StatusBadRequest,
+				fmt.Sprintf("active: must be true or false, got %q", v))
+			return
+		}
 		q = q.Where("active = ?", active)
 	}
 	var rows []db.Skill

--- a/internal/web/api_skills_active_test.go
+++ b/internal/web/api_skills_active_test.go
@@ -1,0 +1,74 @@
+package web
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+
+	"scrutineer/internal/db"
+)
+
+// TestAPIListSkills_activeFilter covers the ?active= query parameter: valid
+// booleans filter, and a value that is not a boolean is rejected with 400
+// rather than being treated as false (which silently returned the inactive
+// skills for ?active=yes).
+func TestAPIListSkills_activeFilter(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	_, auth := seedRunningScan(t, s)
+
+	s.DB.Create(&db.Skill{Name: "active-skill", Active: true})
+	// Skill.Active is `not null;default:true`, so creating with Active:false
+	// writes true — GORM omits Go zero values and the column default wins.
+	// The retired skill has to be deactivated with an explicit update.
+	retired := db.Skill{Name: "retired-skill"}
+	s.DB.Create(&retired)
+	s.DB.Model(&retired).Update("active", false)
+
+	get := func(q string) (int, []map[string]any) {
+		r := httptest.NewRequest("GET", "/api/skills"+q, nil)
+		r.Host = testHost
+		r.Header.Set("Authorization", "Bearer "+auth.APIToken)
+		w := httptest.NewRecorder()
+		s.Handler().ServeHTTP(w, r)
+		var rows []map[string]any
+		_ = json.NewDecoder(w.Body).Decode(&rows)
+		return w.Code, rows
+	}
+
+	names := func(rows []map[string]any) map[string]bool {
+		out := map[string]bool{}
+		for _, r := range rows {
+			out[r["name"].(string)] = true
+		}
+		return out
+	}
+
+	if code, rows := get("?active=true"); code != 200 {
+		t.Errorf("?active=true: status %d, want 200", code)
+	} else if n := names(rows); !n["active-skill"] || n["retired-skill"] {
+		t.Errorf("?active=true returned %v", n)
+	}
+
+	if code, rows := get("?active=false"); code != 200 {
+		t.Errorf("?active=false: status %d, want 200", code)
+	} else if n := names(rows); !n["retired-skill"] || n["active-skill"] {
+		t.Errorf("?active=false returned %v", n)
+	}
+
+	// The regression: these used to parse as false and return the inactive
+	// skills instead of reporting the bad input.
+	for _, bad := range []string{"yes", "typo", "2"} {
+		code, rows := get("?active=" + bad)
+		if code != 400 {
+			t.Errorf("?active=%s: status %d, want 400 (rows=%v)", bad, code, rows)
+		}
+	}
+
+	// An empty value keeps its existing meaning: no filter at all.
+	if code, rows := get("?active="); code != 200 {
+		t.Errorf("?active= (empty): status %d, want 200", code)
+	} else if n := names(rows); !n["active-skill"] || !n["retired-skill"] {
+		t.Errorf("?active= (empty) should not filter, got %v", n)
+	}
+}

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -760,6 +760,9 @@ paths:
         - name: active
           in: query
           schema: { type: boolean }
+          description: >
+            Filter by active state. An empty value applies no filter; a value
+            that is not a boolean returns 400.
       responses:
         '200':
           description: OK
@@ -768,6 +771,7 @@ paths:
               schema:
                 type: array
                 items: { $ref: '#/components/schemas/SkillSummary' }
+        '400': { $ref: '#/components/responses/BadRequest' }
 
   /cnas:
     get:


### PR DESCRIPTION
Closes #733.

`apiListSkills` parsed `?active=` with `strconv.ParseBool` and discarded the error, so `?active=yes` became `false` and returned the *inactive* skills — the opposite of what the caller asked for, with a 200.

```go
active, err := strconv.ParseBool(v)
if err != nil {
    writeAPIError(w, http.StatusBadRequest,
        fmt.Sprintf("active: must be true or false, got %q", v))
    return
}
```

The message mirrors `importRevalidate`'s `revalidate: must be true or false, got %q`, since it's the same situation and that comment already spells out the reasoning ("a malformed value is a 400 rather than a silent fall-back"). An empty `?active=` keeps its current meaning: no filter.

**Test.** `TestAPIListSkills_activeFilter` covers `true`, `false`, empty, and `yes`/`typo`/`2`. I ran it against the unfixed handler first to confirm it actually pins the bug — it fails there, and the failure output shows the reported symptom exactly (`?active=yes: status 200 ... rows=[... name:retired-skill]`).

One thing worth flagging for anyone writing similar tests: `Skill.Active` is `not null;default:true`, so `db.Skill{Name: "x", Active: false}` inserts **true** — GORM omits Go zero values and the column default wins. The retired fixture needs an explicit `Update("active", false)`. That cost me a confusing first run.

**Spec.** `openapi.yaml` documented only a `200` for this route, so I added the `400` (`$ref: BadRequest`, matching the other routes) and noted the empty-value behaviour on the parameter.

- `go test ./internal/web/ -count=1` — passes
- `gofmt -l`, `go vet ./internal/web/` — clean

Unrelated, spotted while validating my edit and **not touched in this PR**: `openapi.yaml` doesn't parse as YAML on `main`. Line 331 has an unquoted description containing `: ` —

```yaml
description: Optional baseline scan to use for `rescan_mode: diff`; omitted lets Scrutineer choose the latest compatible completed scan.
```

`rescan_mode: diff` makes it a mapping value, so `yaml.safe_load` fails there. Quoting the string fixes it. Happy to open a separate issue or PR if useful — it seemed like it might matter to #751.
