### PR TITLE
Add host-only API delete endpoints

### DIFF
--- a/internal/web/api_export.go
+++ b/internal/web/api_export.go
@@ -47,6 +47,10 @@ func (s *Server) apiDeleteRepository(w http.ResponseWriter, r *http.Request) {
 	}
 	deleted, err := s.deleteRepository(repo)
 	if err != nil {
+		if errors.Is(err, errRepositoryDeleteInFlight) {
+			writeAPIError(w, http.StatusConflict, err.Error())
+			return
+		}
 		writeAPIError(w, http.StatusInternalServerError, err.Error())
 		return
 	}

--- a/internal/web/api_export.go
+++ b/internal/web/api_export.go
@@ -41,7 +41,7 @@ func (s *Server) exportHandler() http.Handler {
 }
 
 func (s *Server) apiDeleteRepository(w http.ResponseWriter, r *http.Request) {
-	repo, ok := loadExportRowByID[db.Repository](s, w, r, "repository")
+	repo, ok := s.loadExportRepositoryByID(w, r)
 	if !ok {
 		return
 	}
@@ -55,7 +55,7 @@ func (s *Server) apiDeleteRepository(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) apiDeleteFinding(w http.ResponseWriter, r *http.Request) {
-	finding, ok := loadExportRowByID[db.Finding](s, w, r, "finding")
+	finding, ok := s.loadExportFindingByID(w, r)
 	if !ok {
 		return
 	}
@@ -68,22 +68,47 @@ func (s *Server) apiDeleteFinding(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
-func loadExportRowByID[T any](s *Server, w http.ResponseWriter, r *http.Request, name string) (T, bool) {
-	var v T
+func (s *Server) loadExportRepositoryByID(w http.ResponseWriter, r *http.Request) (db.Repository, bool) {
+	var repo db.Repository
+	id, ok := exportPathID(w, r, "repository")
+	if !ok {
+		return repo, false
+	}
+	if err := s.DB.First(&repo, id).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			writeAPIError(w, http.StatusNotFound, "repository not found")
+			return repo, false
+		}
+		writeAPIError(w, http.StatusInternalServerError, err.Error())
+		return repo, false
+	}
+	return repo, true
+}
+
+func (s *Server) loadExportFindingByID(w http.ResponseWriter, r *http.Request) (db.Finding, bool) {
+	var finding db.Finding
+	id, ok := exportPathID(w, r, "finding")
+	if !ok {
+		return finding, false
+	}
+	if err := s.DB.First(&finding, id).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			writeAPIError(w, http.StatusNotFound, "finding not found")
+			return finding, false
+		}
+		writeAPIError(w, http.StatusInternalServerError, err.Error())
+		return finding, false
+	}
+	return finding, true
+}
+
+func exportPathID(w http.ResponseWriter, r *http.Request, name string) (int, bool) {
 	id, err := strconv.Atoi(r.PathValue("id"))
 	if err != nil || id <= 0 {
 		writeAPIError(w, http.StatusBadRequest, "invalid "+name+" id")
-		return v, false
+		return 0, false
 	}
-	if err := s.DB.First(&v, id).Error; err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			writeAPIError(w, http.StatusNotFound, name+" not found")
-			return v, false
-		}
-		writeAPIError(w, http.StatusInternalServerError, err.Error())
-		return v, false
-	}
-	return v, true
+	return id, true
 }
 
 // repositoryExportRow is the selected Repositories-tab projection used by the

--- a/internal/web/api_export.go
+++ b/internal/web/api_export.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"log/slog"
 	"net/http"
@@ -24,8 +25,10 @@ const exportPrefix = "/api/v1"
 
 func (s *Server) exportHandler() http.Handler {
 	mux := http.NewServeMux()
+	mux.HandleFunc("DELETE /repositories/{id}", s.apiDeleteRepository)
 	mux.HandleFunc("GET /repositories/{id}/findings", s.apiExportRepoFindings)
 	mux.HandleFunc("GET /repositories", s.apiExportRepositories)
+	mux.HandleFunc("DELETE /findings/{id}", s.apiDeleteFinding)
 	mux.HandleFunc("GET /findings", s.apiExportFindings)
 	mux.HandleFunc("GET /scans", s.apiExportScans)
 	mux.HandleFunc("POST /import", s.handleImport)
@@ -35,6 +38,52 @@ func (s *Server) exportHandler() http.Handler {
 	mux.HandleFunc("GET /audit/queue", s.apiAuditQueue)
 	mux.HandleFunc("GET /audit/metrics", s.apiAuditMetrics)
 	return mux
+}
+
+func (s *Server) apiDeleteRepository(w http.ResponseWriter, r *http.Request) {
+	repo, ok := loadExportRowByID[db.Repository](s, w, r, "repository")
+	if !ok {
+		return
+	}
+	deleted, err := s.deleteRepository(repo)
+	if err != nil {
+		writeAPIError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	s.removeRepositoryArtifacts(deleted)
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *Server) apiDeleteFinding(w http.ResponseWriter, r *http.Request) {
+	finding, ok := loadExportRowByID[db.Finding](s, w, r, "finding")
+	if !ok {
+		return
+	}
+	deleted, err := s.deleteFinding(finding)
+	if err != nil {
+		writeAPIError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	s.removeFindingArtifacts(deleted)
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func loadExportRowByID[T any](s *Server, w http.ResponseWriter, r *http.Request, name string) (T, bool) {
+	var v T
+	id, err := strconv.Atoi(r.PathValue("id"))
+	if err != nil || id <= 0 {
+		writeAPIError(w, http.StatusBadRequest, "invalid "+name+" id")
+		return v, false
+	}
+	if err := s.DB.First(&v, id).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			writeAPIError(w, http.StatusNotFound, name+" not found")
+			return v, false
+		}
+		writeAPIError(w, http.StatusInternalServerError, err.Error())
+		return v, false
+	}
+	return v, true
 }
 
 // repositoryExportRow is the selected Repositories-tab projection used by the

--- a/internal/web/api_export.go
+++ b/internal/web/api_export.go
@@ -61,6 +61,10 @@ func (s *Server) apiDeleteFinding(w http.ResponseWriter, r *http.Request) {
 	}
 	deleted, err := s.deleteFinding(finding)
 	if err != nil {
+		if errors.Is(err, errFindingDeleteInFlight) {
+			writeAPIError(w, http.StatusConflict, err.Error())
+			return
+		}
 		writeAPIError(w, http.StatusInternalServerError, err.Error())
 		return
 	}

--- a/internal/web/api_export_test.go
+++ b/internal/web/api_export_test.go
@@ -280,6 +280,83 @@ func TestAPIv1DeleteRepository(t *testing.T) {
 	}
 }
 
+func TestAPIv1DeleteRepositoryRejectsInFlightScans(t *testing.T) {
+	for _, status := range []db.ScanStatus{db.ScanQueued, db.ScanRunning} {
+		t.Run(string(status), func(t *testing.T) {
+			s, done := newTestServer(t)
+			defer done()
+
+			repo := db.Repository{URL: "https://github.com/acme/busy-repo", Name: "busy-repo"}
+			if err := s.DB.Create(&repo).Error; err != nil {
+				t.Fatal(err)
+			}
+			scan := db.Scan{RepositoryID: repo.ID, Kind: "skill", Status: status, SkillName: deepDiveSkillName}
+			if err := s.DB.Create(&scan).Error; err != nil {
+				t.Fatal(err)
+			}
+
+			r := httptest.NewRequest("DELETE", "/api/v1/repositories/"+strconv.FormatUint(uint64(repo.ID), 10), nil)
+			r.Host = testHost
+			w := httptest.NewRecorder()
+			s.Handler().ServeHTTP(w, r)
+
+			if w.Code != http.StatusConflict {
+				t.Fatalf("status %d, want 409. body=%s", w.Code, w.Body)
+			}
+			if !strings.Contains(w.Body.String(), "queued, running, or paused scans") {
+				t.Fatalf("body %q missing in-flight scan explanation", w.Body.String())
+			}
+			if n := countRows(t, s, &db.Repository{}, "id = ?", repo.ID); n != 1 {
+				t.Fatalf("repository count = %d, want 1 after rejected delete", n)
+			}
+			if n := countRows(t, s, &db.Scan{}, "id = ?", scan.ID); n != 1 {
+				t.Fatalf("scan count = %d, want 1 after rejected delete", n)
+			}
+		})
+	}
+}
+
+func TestAPIv1DeleteRepositoryRejectsInFlightFindingScopedScans(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	repo := db.Repository{URL: "https://github.com/acme/busy-finding-repo", Name: "busy-finding-repo"}
+	if err := s.DB.Create(&repo).Error; err != nil {
+		t.Fatal(err)
+	}
+	scan := db.Scan{RepositoryID: repo.ID, Kind: "skill", Status: db.ScanDone, SkillName: deepDiveSkillName}
+	if err := s.DB.Create(&scan).Error; err != nil {
+		t.Fatal(err)
+	}
+	finding := db.Finding{RepositoryID: repo.ID, ScanID: scan.ID, Title: "busy finding", Severity: sevHigh}
+	if err := s.DB.Create(&finding).Error; err != nil {
+		t.Fatal(err)
+	}
+	otherRepo := db.Repository{URL: "https://github.com/acme/worker-repo", Name: "worker-repo"}
+	if err := s.DB.Create(&otherRepo).Error; err != nil {
+		t.Fatal(err)
+	}
+	linked := db.Scan{RepositoryID: otherRepo.ID, FindingID: &finding.ID, Kind: "skill", Status: db.ScanPaused, SkillName: "verify"}
+	if err := s.DB.Create(&linked).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	r := httptest.NewRequest("DELETE", "/api/v1/repositories/"+strconv.FormatUint(uint64(repo.ID), 10), nil)
+	r.Host = testHost
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, r)
+
+	if w.Code != http.StatusConflict {
+		t.Fatalf("status %d, want 409. body=%s", w.Code, w.Body)
+	}
+	if n := countRows(t, s, &db.Repository{}, "id = ?", repo.ID); n != 1 {
+		t.Fatalf("repository count = %d, want 1 after rejected delete", n)
+	}
+	if n := countRows(t, s, &db.Scan{}, "id = ?", linked.ID); n != 1 {
+		t.Fatalf("finding-scoped scan count = %d, want 1 after rejected delete", n)
+	}
+}
+
 func TestAPIv1DeleteFinding(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()

--- a/internal/web/api_export_test.go
+++ b/internal/web/api_export_test.go
@@ -245,6 +245,126 @@ func TestExportRepoFindings_unknownRepo(t *testing.T) {
 	}
 }
 
+func TestAPIv1DeleteRepository(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	s.Worker.DataDir = t.TempDir()
+
+	repo := db.Repository{URL: "https://github.com/acme/delete-me", Name: "delete-me"}
+	s.DB.Create(&repo)
+	scan := db.Scan{RepositoryID: repo.ID, Kind: "skill", Status: db.ScanDone, SkillName: deepDiveSkillName}
+	s.DB.Create(&scan)
+	finding := db.Finding{ScanID: scan.ID, RepositoryID: repo.ID, Title: "doomed", Severity: sevHigh}
+	s.DB.Create(&finding)
+	s.DB.Create(&db.FindingReview{FindingID: finding.ID, Verdict: "true_positive", Reviewer: "analyst"})
+	s.DB.Create(&db.FindingNote{FindingID: finding.ID, Body: "note"})
+
+	r := httptest.NewRequest("DELETE", "/api/v1/repositories/"+strconv.FormatUint(uint64(repo.ID), 10), nil)
+	r.Host = testHost
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, r)
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("status %d, want 204. body=%s", w.Code, w.Body)
+	}
+	for name, n := range map[string]int64{
+		"repositories": countRows(t, s, &db.Repository{}, "id = ?", repo.ID),
+		"scans":        countRows(t, s, &db.Scan{}, "repository_id = ?", repo.ID),
+		"findings":     countRows(t, s, &db.Finding{}, "repository_id = ?", repo.ID),
+		"reviews":      countRows(t, s, &db.FindingReview{}, "finding_id = ?", finding.ID),
+		"notes":        countRows(t, s, &db.FindingNote{}, "finding_id = ?", finding.ID),
+	} {
+		if n != 0 {
+			t.Fatalf("%s rows survived repository delete: %d", name, n)
+		}
+	}
+}
+
+func TestAPIv1DeleteFinding(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	s.Worker.DataDir = t.TempDir()
+
+	repo := db.Repository{URL: "https://github.com/acme/keep-repo", Name: "keep-repo"}
+	s.DB.Create(&repo)
+	scan := db.Scan{RepositoryID: repo.ID, Kind: "skill", Status: db.ScanDone, SkillName: deepDiveSkillName}
+	s.DB.Create(&scan)
+	finding := db.Finding{ScanID: scan.ID, RepositoryID: repo.ID, Title: "delete finding", Severity: sevHigh}
+	s.DB.Create(&finding)
+	other := db.Finding{ScanID: scan.ID, RepositoryID: repo.ID, Title: "keep finding", Severity: "Low"}
+	s.DB.Create(&other)
+	findingScopedScan := db.Scan{RepositoryID: repo.ID, FindingID: &finding.ID, Kind: "skill", Status: db.ScanDone, SkillName: "verify"}
+	s.DB.Create(&findingScopedScan)
+
+	s.DB.Create(&db.FindingNote{FindingID: finding.ID, Body: "note"})
+	s.DB.Create(&db.FindingCommunication{FindingID: finding.ID, Channel: "email", Direction: "outbound"})
+	s.DB.Create(&db.FindingReference{FindingID: finding.ID, URL: "https://example.com/ref"})
+	s.DB.Create(&db.FindingHistory{FindingID: finding.ID, Field: "status", NewValue: "new"})
+	s.DB.Create(&db.FindingReview{FindingID: finding.ID, Verdict: "true_positive", Reviewer: "analyst"})
+	dependent := db.Dependent{RepositoryID: repo.ID, Name: "downstream", Ecosystem: "npm"}
+	s.DB.Create(&dependent)
+	s.DB.Create(&db.FindingDependent{FindingID: finding.ID, DependentID: dependent.ID, Status: db.ExposureKnownAffected})
+	label := db.FindingLabel{Name: "delete-me"}
+	s.DB.Create(&label)
+	if err := s.DB.Model(&finding).Association("Labels").Append(&label); err != nil {
+		t.Fatal(err)
+	}
+	conv := db.Conversation{RepositoryID: repo.ID, FindingID: &finding.ID, Title: "finding chat"}
+	s.DB.Create(&conv)
+	s.DB.Create(&db.ChatMessage{ConversationID: conv.ID, Role: db.ChatRoleUser, Content: "hello"})
+
+	r := httptest.NewRequest("DELETE", "/api/v1/findings/"+strconv.FormatUint(uint64(finding.ID), 10), nil)
+	r.Host = testHost
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, r)
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("status %d, want 204. body=%s", w.Code, w.Body)
+	}
+	for name, n := range map[string]int64{
+		"finding":      countRows(t, s, &db.Finding{}, "id = ?", finding.ID),
+		"notes":        countRows(t, s, &db.FindingNote{}, "finding_id = ?", finding.ID),
+		"comms":        countRows(t, s, &db.FindingCommunication{}, "finding_id = ?", finding.ID),
+		"refs":         countRows(t, s, &db.FindingReference{}, "finding_id = ?", finding.ID),
+		"history":      countRows(t, s, &db.FindingHistory{}, "finding_id = ?", finding.ID),
+		"reviews":      countRows(t, s, &db.FindingReview{}, "finding_id = ?", finding.ID),
+		"exposure":     countRows(t, s, &db.FindingDependent{}, "finding_id = ?", finding.ID),
+		"conversation": countRows(t, s, &db.Conversation{}, "finding_id = ?", finding.ID),
+		"messages":     countRows(t, s, &db.ChatMessage{}, "conversation_id = ?", conv.ID),
+	} {
+		if n != 0 {
+			t.Fatalf("%s rows survived finding delete: %d", name, n)
+		}
+	}
+	var labelLinks int64
+	s.DB.Raw("SELECT COUNT(*) FROM finding_labels_join WHERE finding_id = ?", finding.ID).Scan(&labelLinks)
+	if labelLinks != 0 {
+		t.Fatalf("label join rows survived finding delete: %d", labelLinks)
+	}
+	if n := countRows(t, s, &db.Repository{}, "id = ?", repo.ID); n != 1 {
+		t.Fatalf("repository count = %d, want 1", n)
+	}
+	if n := countRows(t, s, &db.Finding{}, "id = ?", other.ID); n != 1 {
+		t.Fatalf("unrelated finding count = %d, want 1", n)
+	}
+	var survivingScan db.Scan
+	if err := s.DB.First(&survivingScan, findingScopedScan.ID).Error; err != nil {
+		t.Fatalf("finding-scoped scan should survive: %v", err)
+	}
+	if survivingScan.FindingID != nil {
+		t.Fatalf("finding-scoped scan finding_id = %v, want nil", *survivingScan.FindingID)
+	}
+}
+
+func countRows(t *testing.T, s *Server, model any, where string, args ...any) int64 {
+	t.Helper()
+	var n int64
+	if err := s.DB.Model(model).Where(where, args...).Count(&n).Error; err != nil {
+		t.Fatal(err)
+	}
+	return n
+}
+
 func TestExportFindings_acrossRepos(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()

--- a/internal/web/api_export_test.go
+++ b/internal/web/api_export_test.go
@@ -356,6 +356,54 @@ func TestAPIv1DeleteFinding(t *testing.T) {
 	}
 }
 
+func TestAPIv1DeleteFindingRejectsInFlightScans(t *testing.T) {
+	for _, status := range []db.ScanStatus{db.ScanQueued, db.ScanRunning} {
+		t.Run(string(status), func(t *testing.T) {
+			s, done := newTestServer(t)
+			defer done()
+
+			repo := db.Repository{URL: "https://github.com/acme/busy", Name: "busy"}
+			if err := s.DB.Create(&repo).Error; err != nil {
+				t.Fatal(err)
+			}
+			scan := db.Scan{RepositoryID: repo.ID, Kind: "skill", Status: db.ScanDone, SkillName: deepDiveSkillName}
+			if err := s.DB.Create(&scan).Error; err != nil {
+				t.Fatal(err)
+			}
+			finding := db.Finding{ScanID: scan.ID, RepositoryID: repo.ID, Title: "busy finding", Severity: sevHigh}
+			if err := s.DB.Create(&finding).Error; err != nil {
+				t.Fatal(err)
+			}
+			linked := db.Scan{RepositoryID: repo.ID, FindingID: &finding.ID, Kind: "skill", Status: status, SkillName: "verify"}
+			if err := s.DB.Create(&linked).Error; err != nil {
+				t.Fatal(err)
+			}
+
+			r := httptest.NewRequest("DELETE", "/api/v1/findings/"+strconv.FormatUint(uint64(finding.ID), 10), nil)
+			r.Host = testHost
+			w := httptest.NewRecorder()
+			s.Handler().ServeHTTP(w, r)
+
+			if w.Code != http.StatusConflict {
+				t.Fatalf("status %d, want 409. body=%s", w.Code, w.Body)
+			}
+			if !strings.Contains(w.Body.String(), "queued, running, or paused scans") {
+				t.Fatalf("body %q missing in-flight scan explanation", w.Body.String())
+			}
+			if n := countRows(t, s, &db.Finding{}, "id = ?", finding.ID); n != 1 {
+				t.Fatalf("finding count = %d, want 1 after rejected delete", n)
+			}
+			var got db.Scan
+			if err := s.DB.First(&got, linked.ID).Error; err != nil {
+				t.Fatal(err)
+			}
+			if got.FindingID == nil || *got.FindingID != finding.ID {
+				t.Fatalf("linked scan finding_id = %v, want %d", got.FindingID, finding.ID)
+			}
+		})
+	}
+}
+
 func countRows(t *testing.T, s *Server, model any, where string, args ...any) int64 {
 	t.Helper()
 	var n int64

--- a/internal/web/repo_delete_test.go
+++ b/internal/web/repo_delete_test.go
@@ -63,6 +63,7 @@ func TestRepoDelete_removesRepoAndAllLinkedData(t *testing.T) {
 	s.DB.Create(&db.FindingCommunication{FindingID: finding.ID, Channel: "email", Direction: "outbound"})
 	s.DB.Create(&db.FindingReference{FindingID: finding.ID, URL: "https://x/ref"})
 	s.DB.Create(&db.FindingHistory{FindingID: finding.ID, Field: "status", NewValue: "new"})
+	s.DB.Create(&db.FindingReview{FindingID: finding.ID, Verdict: "true_positive", Reviewer: "analyst"})
 
 	dependent := db.Dependent{RepositoryID: repo.ID, Name: "downstream", Ecosystem: "npm"}
 	s.DB.Create(&dependent)
@@ -139,6 +140,7 @@ func TestRepoDelete_removesRepoAndAllLinkedData(t *testing.T) {
 		"comms":        count(&db.FindingCommunication{}, "finding_id = ?", finding.ID),
 		"refs":         count(&db.FindingReference{}, "finding_id = ?", finding.ID),
 		"history":      count(&db.FindingHistory{}, "finding_id = ?", finding.ID),
+		"reviews":      count(&db.FindingReview{}, "finding_id = ?", finding.ID),
 		"findingdep":   count(&db.FindingDependent{}, "finding_id = ?", finding.ID),
 	} {
 		if n != 0 {

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -2689,8 +2689,19 @@ type deletedFinding struct {
 	ConversationIDs []uint
 }
 
+var errFindingDeleteInFlight = errors.New("finding has queued, running, or paused scans")
+
 func (s *Server) deleteFinding(finding db.Finding) (deletedFinding, error) {
 	var deleted deletedFinding
+	var inFlight int64
+	if err := s.DB.Model(&db.Scan{}).
+		Where("finding_id = ? AND status IN ?", finding.ID, []db.ScanStatus{db.ScanQueued, db.ScanRunning, db.ScanPaused}).
+		Count(&inFlight).Error; err != nil {
+		return deletedFinding{}, err
+	}
+	if inFlight > 0 {
+		return deletedFinding{}, fmt.Errorf("%w; cancel or wait for %d linked scan(s) before deleting", errFindingDeleteInFlight, inFlight)
+	}
 	if err := s.DB.Model(&db.Conversation{}).Where("finding_id = ?", finding.ID).
 		Pluck("id", &deleted.ConversationIDs).Error; err != nil {
 		return deletedFinding{}, err

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -2585,16 +2585,38 @@ func (s *Server) repoDelete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	deleted, err := s.deleteRepository(repo)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	s.removeRepositoryArtifacts(deleted)
+
+	setFlash(w, Flash{Category: "success", Title: "Repository deleted",
+		Description: repo.Name + " and all its scans, findings and cached clone were removed."})
+	s.redirect(w, r, "/")
+}
+
+type deletedRepository struct {
+	Repo            db.Repository
+	ScanIDs         []uint
+	ConversationIDs []uint
+}
+
+func (s *Server) deleteRepository(repo db.Repository) (deletedRepository, error) {
+	deleted := deletedRepository{Repo: repo}
 	// Collected before the transaction deletes the scan rows: each scan's
 	// per-scan workspace and claude session store under DataDir are reclaimed
 	// after the commit.
-	var scanIDs []uint
-	s.DB.Model(&db.Scan{}).Where("repository_id = ?", repo.ID).Pluck("id", &scanIDs)
+	if err := s.DB.Model(&db.Scan{}).Where("repository_id = ?", repo.ID).Pluck("id", &deleted.ScanIDs).Error; err != nil {
+		return deletedRepository{}, err
+	}
 	// Chat conversation workspaces are reclaimed after the commit, same as
 	// scan workspaces. Finding-scoped conversations carry the finding's
 	// repository_id, so this covers them too.
-	var convIDs []uint
-	s.DB.Model(&db.Conversation{}).Where("repository_id = ?", repo.ID).Pluck("id", &convIDs)
+	if err := s.DB.Model(&db.Conversation{}).Where("repository_id = ?", repo.ID).Pluck("id", &deleted.ConversationIDs).Error; err != nil {
+		return deletedRepository{}, err
+	}
 
 	err := s.DB.Transaction(func(tx *gorm.DB) error {
 		// Match scans by the *finding's* repo, not the scan's own: a finding-
@@ -2615,7 +2637,7 @@ func (s *Server) repoDelete(w http.ResponseWriter, r *http.Request) {
 		}
 		for _, child := range []any{
 			&db.FindingNote{}, &db.FindingCommunication{}, &db.FindingReference{},
-			&db.FindingHistory{}, &db.FindingDependent{},
+			&db.FindingHistory{}, &db.FindingDependent{}, &db.FindingReview{},
 		} {
 			if err := tx.Where(findingsOfRepo, repo.ID).Delete(child).Error; err != nil {
 				return err
@@ -2642,27 +2664,70 @@ func (s *Server) repoDelete(w http.ResponseWriter, r *http.Request) {
 		return tx.Delete(&repo).Error
 	})
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
+		return deletedRepository{}, err
 	}
+	return deleted, nil
+}
 
-	if err := os.RemoveAll(worker.RepoCacheRoot(s.Worker.DataDir, repo.URL)); err != nil {
-		s.Log.Error("repoDelete: remove clone cache", "repo", repo.ID, "err", err)
+func (s *Server) removeRepositoryArtifacts(deleted deletedRepository) {
+	if err := os.RemoveAll(worker.RepoCacheRoot(s.Worker.DataDir, deleted.Repo.URL)); err != nil {
+		s.Log.Error("repoDelete: remove clone cache", "repo", deleted.Repo.ID, "err", err)
 	}
-	for _, id := range scanIDs {
+	for _, id := range deleted.ScanIDs {
 		if err := s.Worker.RemoveScanArtifacts(id); err != nil {
 			s.Log.Error("repoDelete: remove scan workspace", "scan", id, "err", err)
 		}
 	}
-	for _, id := range convIDs {
+	for _, id := range deleted.ConversationIDs {
 		if err := s.Worker.RemoveChatArtifacts(id); err != nil {
 			s.Log.Error("repoDelete: remove chat workspace", "conv", id, "err", err)
 		}
 	}
+}
 
-	setFlash(w, Flash{Category: "success", Title: "Repository deleted",
-		Description: repo.Name + " and all its scans, findings and cached clone were removed."})
-	s.redirect(w, r, "/")
+type deletedFinding struct {
+	ConversationIDs []uint
+}
+
+func (s *Server) deleteFinding(finding db.Finding) (deletedFinding, error) {
+	var deleted deletedFinding
+	if err := s.DB.Model(&db.Conversation{}).Where("finding_id = ?", finding.ID).
+		Pluck("id", &deleted.ConversationIDs).Error; err != nil {
+		return deletedFinding{}, err
+	}
+	err := s.DB.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Model(&db.Scan{}).Where("finding_id = ?", finding.ID).
+			Update("finding_id", nil).Error; err != nil {
+			return err
+		}
+		if err := tx.Exec("DELETE FROM finding_labels_join WHERE finding_id = ?", finding.ID).Error; err != nil {
+			return err
+		}
+		for _, child := range []any{
+			&db.FindingNote{}, &db.FindingCommunication{}, &db.FindingReference{},
+			&db.FindingHistory{}, &db.FindingDependent{}, &db.FindingReview{},
+		} {
+			if err := tx.Where("finding_id = ?", finding.ID).Delete(child).Error; err != nil {
+				return err
+			}
+		}
+		if err := deleteFindingConversations(tx, finding.ID); err != nil {
+			return err
+		}
+		return tx.Delete(&finding).Error
+	})
+	if err != nil {
+		return deletedFinding{}, err
+	}
+	return deleted, nil
+}
+
+func (s *Server) removeFindingArtifacts(deleted deletedFinding) {
+	for _, id := range deleted.ConversationIDs {
+		if err := s.Worker.RemoveChatArtifacts(id); err != nil {
+			s.Log.Error("deleteFinding: remove chat workspace", "conv", id, "err", err)
+		}
+	}
 }
 
 // deleteRepoConversations removes a repository's chat conversations and their
@@ -2673,6 +2738,13 @@ func deleteRepoConversations(tx *gorm.DB, repoID uint) error {
 		return err
 	}
 	return tx.Where("repository_id = ?", repoID).Delete(&db.Conversation{}).Error
+}
+
+func deleteFindingConversations(tx *gorm.DB, findingID uint) error {
+	if err := tx.Exec("DELETE FROM chat_messages WHERE conversation_id IN (SELECT id FROM conversations WHERE finding_id = ?)", findingID).Error; err != nil {
+		return err
+	}
+	return tx.Where("finding_id = ?", findingID).Delete(&db.Conversation{}).Error
 }
 
 // repoDisclosureChannel lets the analyst overwrite (or clear) the

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -2587,6 +2587,10 @@ func (s *Server) repoDelete(w http.ResponseWriter, r *http.Request) {
 
 	deleted, err := s.deleteRepository(repo)
 	if err != nil {
+		if errors.Is(err, errRepositoryDeleteInFlight) {
+			http.Error(w, err.Error(), http.StatusConflict)
+			return
+		}
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -2603,20 +2607,10 @@ type deletedRepository struct {
 	ConversationIDs []uint
 }
 
+var errRepositoryDeleteInFlight = errors.New("repository has queued, running, or paused scans")
+
 func (s *Server) deleteRepository(repo db.Repository) (deletedRepository, error) {
 	deleted := deletedRepository{Repo: repo}
-	// Collected before the transaction deletes the scan rows: each scan's
-	// per-scan workspace and claude session store under DataDir are reclaimed
-	// after the commit.
-	if err := s.DB.Model(&db.Scan{}).Where("repository_id = ?", repo.ID).Pluck("id", &deleted.ScanIDs).Error; err != nil {
-		return deletedRepository{}, err
-	}
-	// Chat conversation workspaces are reclaimed after the commit, same as
-	// scan workspaces. Finding-scoped conversations carry the finding's
-	// repository_id, so this covers them too.
-	if err := s.DB.Model(&db.Conversation{}).Where("repository_id = ?", repo.ID).Pluck("id", &deleted.ConversationIDs).Error; err != nil {
-		return deletedRepository{}, err
-	}
 
 	err := s.DB.Transaction(func(tx *gorm.DB) error {
 		// Match scans by the *finding's* repo, not the scan's own: a finding-
@@ -2625,6 +2619,27 @@ func (s *Server) deleteRepository(repo db.Repository) (deletedRepository, error)
 		// must have its NO ACTION link cleared or the finding delete 787s. The
 		// subquery also avoids materialising a (possibly >999) id list.
 		const findingsOfRepo = "finding_id IN (SELECT id FROM findings WHERE repository_id = ?)"
+		var inFlight int64
+		if err := tx.Model(&db.Scan{}).
+			Where("(repository_id = ? OR "+findingsOfRepo+") AND status IN ?", repo.ID, repo.ID, inFlightScanStatuses()).
+			Count(&inFlight).Error; err != nil {
+			return err
+		}
+		if inFlight > 0 {
+			return fmt.Errorf("%w; cancel or wait for %d linked scan(s) before deleting", errRepositoryDeleteInFlight, inFlight)
+		}
+		// Collected before the transaction deletes the scan rows: each scan's
+		// per-scan workspace and claude session store under DataDir are reclaimed
+		// after the commit.
+		if err := tx.Model(&db.Scan{}).Where("repository_id = ?", repo.ID).Pluck("id", &deleted.ScanIDs).Error; err != nil {
+			return err
+		}
+		// Chat conversation workspaces are reclaimed after the commit, same as
+		// scan workspaces. Finding-scoped conversations carry the finding's
+		// repository_id, so this covers them too.
+		if err := tx.Model(&db.Conversation{}).Where("repository_id = ?", repo.ID).Pluck("id", &deleted.ConversationIDs).Error; err != nil {
+			return err
+		}
 		if err := tx.Model(&db.Scan{}).Where(findingsOfRepo, repo.ID).
 			Update("finding_id", nil).Error; err != nil {
 			return err
@@ -2693,20 +2708,20 @@ var errFindingDeleteInFlight = errors.New("finding has queued, running, or pause
 
 func (s *Server) deleteFinding(finding db.Finding) (deletedFinding, error) {
 	var deleted deletedFinding
-	var inFlight int64
-	if err := s.DB.Model(&db.Scan{}).
-		Where("finding_id = ? AND status IN ?", finding.ID, []db.ScanStatus{db.ScanQueued, db.ScanRunning, db.ScanPaused}).
-		Count(&inFlight).Error; err != nil {
-		return deletedFinding{}, err
-	}
-	if inFlight > 0 {
-		return deletedFinding{}, fmt.Errorf("%w; cancel or wait for %d linked scan(s) before deleting", errFindingDeleteInFlight, inFlight)
-	}
-	if err := s.DB.Model(&db.Conversation{}).Where("finding_id = ?", finding.ID).
-		Pluck("id", &deleted.ConversationIDs).Error; err != nil {
-		return deletedFinding{}, err
-	}
 	err := s.DB.Transaction(func(tx *gorm.DB) error {
+		var inFlight int64
+		if err := tx.Model(&db.Scan{}).
+			Where("finding_id = ? AND status IN ?", finding.ID, inFlightScanStatuses()).
+			Count(&inFlight).Error; err != nil {
+			return err
+		}
+		if inFlight > 0 {
+			return fmt.Errorf("%w; cancel or wait for %d linked scan(s) before deleting", errFindingDeleteInFlight, inFlight)
+		}
+		if err := tx.Model(&db.Conversation{}).Where("finding_id = ?", finding.ID).
+			Pluck("id", &deleted.ConversationIDs).Error; err != nil {
+			return err
+		}
 		if err := tx.Model(&db.Scan{}).Where("finding_id = ?", finding.ID).
 			Update("finding_id", nil).Error; err != nil {
 			return err
@@ -2731,6 +2746,10 @@ func (s *Server) deleteFinding(finding db.Finding) (deletedFinding, error) {
 		return deletedFinding{}, err
 	}
 	return deleted, nil
+}
+
+func inFlightScanStatuses() []db.ScanStatus {
+	return []db.ScanStatus{db.ScanQueued, db.ScanRunning, db.ScanPaused}
 }
 
 func (s *Server) removeFindingArtifacts(deleted deletedFinding) {

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -842,6 +842,26 @@ paths:
         '403':
           description: Host header is not localhost
 
+  /v1/repositories/{id}:
+    delete:
+      summary: Delete a repository and its linked data
+      description: |
+        Host-only operator endpoint for local automation. Removes the
+        repository, its scans, findings, repository-scoped rows, chat
+        conversations, and cached clone/workspace artifacts using the same
+        cleanup path as the browser delete action. Not reachable with a
+        per-scan bearer token.
+      operationId: deleteRepository
+      security: []
+      parameters:
+        - $ref: '#/components/parameters/RepositoryID'
+      responses:
+        '204': { description: Repository deleted }
+        '400': { description: Invalid repository id }
+        '403': { description: Host header is not localhost }
+        '404': { description: Repository not found }
+        '500': { description: Delete failed }
+
   /v1/repositories/{id}/findings:
     get:
       summary: Export findings for a repository (JSONL, or a shareable bundle)
@@ -970,6 +990,29 @@ paths:
           description: Unsupported format query value, or `encrypt`/`scope`/`include` requested (only valid on per-repository bundle exports).
         '403':
           description: Host header is not localhost
+
+  /v1/findings/{id}:
+    delete:
+      summary: Delete one finding and its linked data
+      description: |
+        Host-only operator endpoint for local automation. Removes the finding,
+        labels join rows, notes, communications, references, history, reviews,
+        exposure rows, and finding-scoped chat conversations. Scans that
+        pointed at the finding are preserved with `finding_id` cleared. Not
+        reachable with a per-scan bearer token.
+      operationId: deleteFinding
+      security: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: { type: integer, format: int64 }
+      responses:
+        '204': { description: Finding deleted }
+        '400': { description: Invalid finding id }
+        '403': { description: Host header is not localhost }
+        '404': { description: Finding not found }
+        '500': { description: Delete failed }
 
   /v1/scans:
     get:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -860,6 +860,7 @@ paths:
         '400': { description: Invalid repository id }
         '403': { description: Host header is not localhost }
         '404': { description: Repository not found }
+        '409': { description: Repository has queued, running, or paused scans }
         '500': { description: Delete failed }
 
   /v1/repositories/{id}/findings:
@@ -1012,6 +1013,7 @@ paths:
         '400': { description: Invalid finding id }
         '403': { description: Host header is not localhost }
         '404': { description: Finding not found }
+        '409': { description: Finding has queued, running, or paused scans }
         '500': { description: Delete failed }
 
   /v1/scans:


### PR DESCRIPTION
Fixes #735

## Summary

Adds host-only `/api/v1` delete endpoints so local automation can clean up repositories and findings without form-posting to browser routes.

The scan-token API remains read/update only; these delete routes live on the localhost-only `/api/v1` surface.

## Changes

- Add `DELETE /api/v1/repositories/{id}`
- Add `DELETE /api/v1/findings/{id}`
- Reuse the existing repository delete cleanup path for API repository deletion
- Add finding deletion cleanup for:
  - child notes, communications, references, history and reviews
  - exposure rows
  - label join rows
  - finding-scoped chat conversations
- Preserve scans when deleting a finding by clearing `scan.finding_id`
- Update OpenAPI documentation
- Add tests for both delete endpoints

## Tests

- `go test ./internal/web -run 'TestAPIv1Delete|TestRepoDelete|TestExportRejectsBadHost'`
- `go test ./...`
- `go vet ./...`
- `git diff --check`