### PR TITLE
Use harness/skills for SKILL.md parsing and glob matching

### DIFF
--- a/internal/skills/filter.go
+++ b/internal/skills/filter.go
@@ -1,9 +1,10 @@
 package skills
 
 import (
-	"path"
 	"slices"
 	"strings"
+
+	harnessskills "github.com/alpha-omega-security/harness/skills"
 )
 
 // BuiltinSkipPaths is the default skip list applied when a skill does not
@@ -27,6 +28,15 @@ var BuiltinSkipPaths = []string{
 	"**/generated/**",
 	"**/__generated__/**",
 }
+
+// The glob matcher and pattern round-tripping live in
+// github.com/alpha-omega-security/harness/skills.
+var (
+	Match         = harnessskills.Match
+	ValidateGlob  = harnessskills.ValidateGlob
+	SplitPatterns = harnessskills.SplitPatterns
+	JoinPatterns  = harnessskills.JoinPatterns
+)
 
 // DirAllExcluded reports whether every file under directory rel is
 // excluded by the configured filters — i.e. the workspace pruner can
@@ -85,78 +95,4 @@ func PathIncluded(rel string, paths, ignorePaths []string) bool {
 
 func matchAny(patterns []string, name string) bool {
 	return slices.ContainsFunc(patterns, func(p string) bool { return Match(p, name) })
-}
-
-// ValidateGlob returns path.ErrBadPattern when pattern contains a
-// segment that path.Match cannot parse (e.g. `[unclosed`). matchSegments
-// silently treats such patterns as "never matches" at runtime; calling
-// this at parse time turns a skill author's typo into a hard error
-// rather than a silent empty workspace.
-func ValidateGlob(pattern string) error {
-	for seg := range strings.SplitSeq(pattern, "/") {
-		if _, err := path.Match(seg, "x"); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-// Match reports whether name matches the shell glob pattern. Supports
-// `*` (any chars except `/`), `?` (one char except `/`) and the
-// doublestar `**` (any chars including `/`). Both pattern and name are
-// forward-slash separated.
-func Match(pattern, name string) bool {
-	if pattern == "" || name == "" {
-		return pattern == name
-	}
-	return matchSegments(strings.Split(pattern, "/"), strings.Split(name, "/"))
-}
-
-func matchSegments(pat, name []string) bool {
-	for len(pat) > 0 {
-		if pat[0] == "**" {
-			rest := pat[1:]
-			if len(rest) == 0 {
-				return true
-			}
-			for i := 0; i <= len(name); i++ {
-				if matchSegments(rest, name[i:]) {
-					return true
-				}
-			}
-			return false
-		}
-		if len(name) == 0 {
-			return false
-		}
-		ok, _ := path.Match(pat[0], name[0])
-		if !ok {
-			return false
-		}
-		pat = pat[1:]
-		name = name[1:]
-	}
-	return len(name) == 0
-}
-
-// SplitPatterns parses the newline-separated form stored in
-// db.Skill.Paths / db.Skill.IgnorePaths into a clean slice, trimming
-// whitespace and dropping empty lines.
-func SplitPatterns(s string) []string {
-	if s == "" {
-		return nil
-	}
-	var out []string
-	for line := range strings.SplitSeq(s, "\n") {
-		if t := strings.TrimSpace(line); t != "" {
-			out = append(out, t)
-		}
-	}
-	return out
-}
-
-// JoinPatterns serialises a slice of patterns into the newline form
-// stored on db.Skill.
-func JoinPatterns(p []string) string {
-	return strings.Join(p, "\n")
 }

--- a/internal/skills/git.go
+++ b/internal/skills/git.go
@@ -4,51 +4,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 
+	harnessskills "github.com/alpha-omega-security/harness/skills"
 	"github.com/git-pkgs/clone"
 )
 
-// ParseRepoSpec splits a skills_repo spec into a clone URL and an optional
-// git ref. Two forms are accepted:
-//
-//	owner/repo[@ref]                — shorthand expanded to https://github.com/owner/repo
-//	https://host/path/to/repo[@ref] — full URL with an optional trailing ref
-//
-// ref is empty when none is given, meaning "use the repo's default branch".
-// In the URL form, only an `@` that appears after the last `/` is treated as
-// a ref separator, so token-in-URL credentials (https://<token>@host/...)
-// pass through untouched. As a consequence, slash-bearing refs after `@` are
-// not supported; use the short form (`main` instead of `refs/heads/main`).
-func ParseRepoSpec(raw string) (url, ref string, err error) {
-	raw = strings.TrimSpace(raw)
-	if raw == "" {
-		return "", "", fmt.Errorf("empty skills_repo spec")
-	}
-	if i := strings.Index(raw, "://"); i >= 0 {
-		scheme := raw[:i+3]
-		rest := raw[len(scheme):]
-		if at := strings.LastIndex(rest, "@"); at > strings.LastIndex(rest, "/") {
-			ref = rest[at+1:]
-			rest = rest[:at]
-		}
-		url = scheme + rest
-	} else {
-		if at := strings.Index(raw, "@"); at >= 0 {
-			ref = raw[at+1:]
-			raw = raw[:at]
-		}
-		parts := strings.Split(raw, "/")
-		if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
-			return "", "", fmt.Errorf("expected owner/repo or https URL, got %q", raw)
-		}
-		url = "https://github.com/" + raw
-	}
-	if !strings.HasPrefix(url, "https://") {
-		return "", "", fmt.Errorf("skills repo must use https://, got %q", url)
-	}
-	return url, ref, nil
-}
+// ParseRepoSpec splits a skills_repo spec (owner/repo[@ref] or a full https
+// URL) into a clone URL and optional ref. See harness/skills.ParseRepoSpec.
+var ParseRepoSpec = harnessskills.ParseRepoSpec
 
 // CloneOrPull prepares a local copy of a git repo at dst. On first call it
 // clones; on subsequent calls it fetches and resets to the requested ref so

--- a/internal/skills/parse.go
+++ b/internal/skills/parse.go
@@ -157,8 +157,9 @@ func ParseFile(path string) (*Parsed, error) {
 }
 
 // validateMetadata checks the scrutineer.* keys strictly. agentskills.io
-// spec violations stay as warnings (see validate); scrutineer-specific
-// keys are a closed set under our control so typos are hard errors.
+// spec violations stay as warnings (attached by harness/skills.Parse);
+// scrutineer-specific keys are a closed set under our control so typos are
+// hard errors.
 func (p *Parsed) validateMetadata() error {
 	if err := harnessskills.ValidateNamespace(p.Metadata, "scrutineer.", scrutineerKeys); err != nil {
 		return err

--- a/internal/skills/parse.go
+++ b/internal/skills/parse.go
@@ -1,7 +1,8 @@
 // Package skills loads claude-code skill directories from disk and upserts
-// them into the database. A skill is a directory containing a SKILL.md file
-// with YAML frontmatter plus optional supporting files; see the spec at
-// https://agentskills.io/specification.
+// them into the database. Frontmatter parsing, spec-field validation,
+// schema.json loading, and content hashing live in
+// github.com/alpha-omega-security/harness/skills; this package layers the
+// scrutineer.* metadata keys and gorm persistence on top.
 //
 // agentskills.io spec violations (name format, field lengths) are lenient:
 // they log a warning and the skill loads anyway, per the client guide. The
@@ -11,26 +12,18 @@
 package skills
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"os"
 	"path/filepath"
-	"regexp"
 	"strings"
 
-	"gopkg.in/yaml.v3"
+	harnessskills "github.com/alpha-omega-security/harness/skills"
 
 	"scrutineer/internal/db"
 )
 
 const (
 	skillFile           = "SKILL.md"
-	schemaFile          = "schema.json"
-	maxNameLen          = 64
-	maxDescLen          = 1024
-	maxCompatLen        = 500
 	metaOutputFile      = "scrutineer.output_file"
 	metaOutputKind      = "scrutineer.output_kind"
 	metaMaxTurns        = "scrutineer.max_turns"
@@ -104,8 +97,6 @@ var OutputKinds = map[string]bool{
 	"exposure":        true,
 }
 
-var nameRE = regexp.MustCompile(`^[a-z0-9]+(-[a-z0-9]+)*$`)
-
 // ModelValidator gates the scrutineer.model metadata key. When non-nil, a
 // skill declaring a model preference the validator rejects gets a warning and
 // the field is left empty (the scan falls back to the high tier).
@@ -118,18 +109,13 @@ var ModelValidator func(string) bool
 // Wired from main.go after the profile registry is set.
 var ProfileValidator func(string) bool
 
-// Parsed is a SKILL.md-plus-neighbours as extracted from disk. It mirrors the
-// Skill model shape so the caller can persist it without further work.
+// Parsed is a SKILL.md-plus-neighbours as extracted from disk. The
+// agentskills.io spec fields, Body, SchemaJSON, SourcePath, SourceHash, and
+// Warnings come from the embedded harness/skills.Skill; the fields below are
+// the scrutineer.* metadata keys extracted from Metadata.
 type Parsed struct {
-	Name          string
-	Description   string
-	License       string
-	Compatibility string
-	AllowedTools  string
-	Metadata      map[string]any
+	harnessskills.Skill
 
-	Body            string
-	SchemaJSON      string
 	OutputFile      string
 	OutputKind      string
 	MaxTurns        int
@@ -142,102 +128,40 @@ type Parsed struct {
 	Paths           []string
 	IgnorePaths     []string
 	Requires        []string
-
-	SourcePath string // absolute path to the skill directory
-	SourceHash string // sha256 of SKILL.md + schema.json contents
-
-	Warnings []string
-}
-
-type frontmatter struct {
-	Name          string         `yaml:"name"`
-	Description   string         `yaml:"description"`
-	License       string         `yaml:"license"`
-	Compatibility string         `yaml:"compatibility"`
-	AllowedTools  string         `yaml:"allowed-tools"`
-	Metadata      map[string]any `yaml:"metadata"`
 }
 
 // ParseFile reads a single SKILL.md (with its sibling schema.json if any)
 // and returns a Parsed. Errors here are hard failures: unparseable YAML,
 // missing description, or IO trouble. Softer issues land in p.Warnings.
 func ParseFile(path string) (*Parsed, error) {
-	raw, err := os.ReadFile(path)
+	base, err := harnessskills.Parse(path)
 	if err != nil {
-		return nil, fmt.Errorf("read %s: %w", path, err)
+		return nil, err
 	}
-	fm, body, err := splitFrontmatter(raw)
-	if err != nil {
-		return nil, fmt.Errorf("parse %s: %w", path, err)
-	}
-	var f frontmatter
-	if err := yaml.Unmarshal(fm, &f); err != nil {
-		return nil, fmt.Errorf("yaml %s: %w", path, err)
-	}
-	if strings.TrimSpace(f.Description) == "" {
+	// The module treats a missing description as a warning; scrutineer treats
+	// it as a hard error so a bundled skill without one fails startup.
+	if base.Description == "" {
 		return nil, fmt.Errorf("%s: description is required", path)
 	}
-	p := &Parsed{
-		Name:          strings.TrimSpace(f.Name),
-		Description:   strings.TrimSpace(f.Description),
-		License:       strings.TrimSpace(f.License),
-		Compatibility: strings.TrimSpace(f.Compatibility),
-		AllowedTools:  strings.TrimSpace(f.AllowedTools),
-		Metadata:      f.Metadata,
-		Body:          strings.TrimSpace(body),
-		SourcePath:    filepath.Dir(path),
+	p := &Parsed{Skill: *base}
+	// The module warns when name is missing but not when it disagrees with the
+	// directory; scrutineer flags that too so a copy-paste keeps the two in sync.
+	if dir := filepath.Base(p.SourcePath); p.Name != dir {
+		p.Warnings = append(p.Warnings, fmt.Sprintf("name %q does not match directory %q", p.Name, dir))
 	}
-	p.validate()
 	if err := p.validateMetadata(); err != nil {
 		return nil, fmt.Errorf("%s: %w", path, err)
 	}
 	p.extractMetadataKeys()
-	p.loadSchema()
-	p.hash(raw)
 	return p, nil
-}
-
-var frontmatterRE = regexp.MustCompile(`(?s)\A---\r?\n(.*?)\r?\n---\r?\n?(.*)\z`)
-
-func splitFrontmatter(raw []byte) (fm []byte, body string, err error) {
-	m := frontmatterRE.FindSubmatch(raw)
-	if m == nil {
-		return nil, "", fmt.Errorf("no yaml frontmatter delimited by ---")
-	}
-	return m[1], string(m[2]), nil
-}
-
-func (p *Parsed) validate() {
-	dir := filepath.Base(p.SourcePath)
-	if p.Name == "" {
-		p.Warnings = append(p.Warnings, "name missing, using directory name")
-		p.Name = dir
-	}
-	if p.Name != dir {
-		p.Warnings = append(p.Warnings, fmt.Sprintf("name %q does not match directory %q", p.Name, dir))
-	}
-	if len(p.Name) > maxNameLen {
-		p.Warnings = append(p.Warnings, fmt.Sprintf("name %q exceeds %d characters", p.Name, maxNameLen))
-	}
-	if !nameRE.MatchString(p.Name) {
-		p.Warnings = append(p.Warnings, fmt.Sprintf("name %q is not spec-conformant (lowercase, digits, hyphens only)", p.Name))
-	}
-	if len(p.Description) > maxDescLen {
-		p.Warnings = append(p.Warnings, fmt.Sprintf("description exceeds %d characters", maxDescLen))
-	}
-	if len(p.Compatibility) > maxCompatLen {
-		p.Warnings = append(p.Warnings, fmt.Sprintf("compatibility exceeds %d characters", maxCompatLen))
-	}
 }
 
 // validateMetadata checks the scrutineer.* keys strictly. agentskills.io
 // spec violations stay as warnings (see validate); scrutineer-specific
 // keys are a closed set under our control so typos are hard errors.
 func (p *Parsed) validateMetadata() error {
-	for k := range p.Metadata {
-		if strings.HasPrefix(k, "scrutineer.") && !scrutineerKeys[k] {
-			return fmt.Errorf("unknown metadata key %q", k)
-		}
+	if err := harnessskills.ValidateNamespace(p.Metadata, "scrutineer.", scrutineerKeys); err != nil {
+		return err
 	}
 	if v, ok := p.Metadata[metaVersion]; ok {
 		got, ok := v.(int)
@@ -424,23 +348,6 @@ func extractStringList(m map[string]any, key string) []string {
 		return nil
 	}
 	return out
-}
-
-func (p *Parsed) loadSchema() {
-	b, err := os.ReadFile(filepath.Join(p.SourcePath, schemaFile))
-	if err != nil {
-		return
-	}
-	p.SchemaJSON = string(b)
-}
-
-func (p *Parsed) hash(skillMD []byte) {
-	h := sha256.New()
-	h.Write(skillMD)
-	if p.SchemaJSON != "" {
-		h.Write([]byte(p.SchemaJSON))
-	}
-	p.SourceHash = hex.EncodeToString(h.Sum(nil))
 }
 
 // ToModel converts a Parsed to a Skill DB row with Source pre-filled.


### PR DESCRIPTION
`Parsed` embeds `harnessskills.Skill` so the spec fields, `Body`, `SchemaJSON`, `SourcePath`, `SourceHash`, and `Warnings` come from `github.com/alpha-omega-security/harness/skills` via field promotion. Only the `scrutineer.*` metadata table, `ToModel`, `Upsert`, and the `BuiltinSkipPaths` / `.git` handling in `PathIncluded` and `DirAllExcluded` stay here. `Match`, `ValidateGlob`, `SplitPatterns`, `JoinPatterns`, and `ParseRepoSpec` are re-exported.

`ParseFile` keeps scrutineer's stricter checks: an empty description is a hard error (the module makes it a warning), and a name that disagrees with its directory gets a warning.

`SourceHash` is now computed by the module (`sha256(SKILL.md || schema.json)`, same as before). If the bytes differ for any reason the effect is a one-time version bump on every skill at first startup, not a config change.

Independent of #766 (no go.mod change; harness v0.1.1 already present).