### PR TITLE
Share JSON decoding across API write handlers

### DIFF
--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -66,6 +66,15 @@ func (s *Server) apiAuth(next http.Handler) http.Handler {
 
 const apiMaxBody = 1 << 20
 
+func decodeAPIBody[T any](w http.ResponseWriter, r *http.Request, errorMessage string) (T, bool) {
+	var body T
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeAPIError(w, http.StatusBadRequest, errorMessage)
+		return body, false
+	}
+	return body, true
+}
+
 func decodeOptionalAPIBody(w http.ResponseWriter, r *http.Request, dst any) bool {
 	if err := json.NewDecoder(r.Body).Decode(dst); err != nil {
 		if errors.Is(err, io.EOF) {
@@ -218,11 +227,10 @@ func (s *Server) apiPatchRepository(w http.ResponseWriter, r *http.Request) {
 		writeAPIError(w, http.StatusForbidden, "scan may only edit its own repository")
 		return
 	}
-	var body struct {
+	body, ok := decodeAPIBody[struct {
 		Fork *string `json:"fork"`
-	}
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-		writeAPIError(w, http.StatusBadRequest, "body must be JSON")
+	}](w, r, "body must be JSON")
+	if !ok {
 		return
 	}
 	if body.Fork == nil {

--- a/internal/web/api_finding_writes.go
+++ b/internal/web/api_finding_writes.go
@@ -1,7 +1,6 @@
 package web
 
 import (
-	"encoding/json"
 	"net/http"
 	"sort"
 	"strconv"
@@ -28,12 +27,11 @@ func (s *Server) apiPatchFinding(w http.ResponseWriter, r *http.Request) {
 		writeAPIError(w, http.StatusForbidden, "scan may only edit findings on its own repository")
 		return
 	}
-	var body struct {
+	body, ok := decodeAPIBody[struct {
 		Fields map[string]string `json:"fields"`
 		By     string            `json:"by"`
-	}
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-		writeAPIError(w, http.StatusBadRequest, "body must be JSON with a fields map")
+	}](w, r, "body must be JSON with a fields map")
+	if !ok {
 		return
 	}
 	source := sourceFromRequest(r)
@@ -61,12 +59,11 @@ func (s *Server) apiAddFindingNote(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	var body struct {
+	body, ok := decodeAPIBody[struct {
 		Body string `json:"body"`
 		By   string `json:"by"`
-	}
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-		writeAPIError(w, http.StatusBadRequest, "body must be JSON")
+	}](w, r, "body must be JSON")
+	if !ok {
 		return
 	}
 	n, err := db.AddFindingNote(s.DB, id, body.Body, body.By)
@@ -92,16 +89,15 @@ func (s *Server) apiAddFindingCommunication(w http.ResponseWriter, r *http.Reque
 	if !ok {
 		return
 	}
-	var body struct {
+	body, ok := decodeAPIBody[struct {
 		Channel     string    `json:"channel"`
 		Direction   string    `json:"direction"`
 		Actor       string    `json:"actor"`
 		Body        string    `json:"body"`
 		OfferedHelp string    `json:"offered_help"`
 		At          time.Time `json:"at"`
-	}
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-		writeAPIError(w, http.StatusBadRequest, "body must be JSON")
+	}](w, r, "body must be JSON")
+	if !ok {
 		return
 	}
 	c, err := db.AddFindingCommunication(s.DB, id, body.Channel, body.Direction, body.Actor, body.Body, body.OfferedHelp, body.At)
@@ -127,13 +123,12 @@ func (s *Server) apiAddFindingReference(w http.ResponseWriter, r *http.Request) 
 	if !ok {
 		return
 	}
-	var body struct {
+	body, ok := decodeAPIBody[struct {
 		URL     string `json:"url"`
 		Tags    string `json:"tags"`
 		Summary string `json:"summary"`
-	}
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-		writeAPIError(w, http.StatusBadRequest, "body must be JSON")
+	}](w, r, "body must be JSON")
+	if !ok {
 		return
 	}
 	ref, err := db.AddFindingReference(s.DB, id, body.URL, body.Tags, body.Summary)
@@ -159,11 +154,10 @@ func (s *Server) apiSetFindingLabels(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	var body struct {
+	body, ok := decodeAPIBody[struct {
 		Labels []string `json:"labels"`
-	}
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-		writeAPIError(w, http.StatusBadRequest, "body must be JSON with a labels array")
+	}](w, r, "body must be JSON with a labels array")
+	if !ok {
 		return
 	}
 	if err := db.SetFindingLabels(s.DB, id, body.Labels); err != nil {

--- a/internal/web/api_test.go
+++ b/internal/web/api_test.go
@@ -258,6 +258,29 @@ func TestAPIPatchRepositoryRejectsEmptyBody(t *testing.T) {
 	}
 }
 
+func TestAPIPatchRepositoryRejectsInvalidJSON(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	repo, scan := seedRunningScan(t, s)
+
+	r := httptest.NewRequest("PATCH", "/api/repositories/"+strconv.FormatUint(uint64(repo.ID), 10),
+		strings.NewReader(`not json`))
+	r.Host = testHost
+	r.Header.Set("Authorization", "Bearer "+scan.APIToken)
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, r)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status %d, want 400", w.Code)
+	}
+	var body map[string]string
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("decode error response: %v", err)
+	}
+	if body[errorKey] != "body must be JSON" {
+		t.Fatalf("error = %q, want body must be JSON", body[errorKey])
+	}
+}
+
 func TestAPIFindingReadsAndFilters(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()


### PR DESCRIPTION
## Summary

- add a typed `decodeAPIBody` helper for required JSON request bodies
- migrate the six API write handlers to the shared decode-and-400 path
- preserve each handler's existing error response
- add malformed JSON coverage for repository updates

This removes duplicated request parsing while keeping the API behavior unchanged.

Closes #734

## Validation

- `go mod tidy -diff`
- `go vet ./...`
- `go vet -tags podman ./...`
- `go test -count=1 ./internal/web`
- `go test -race -count=1 ./internal/web`
- `go test -race -count=1 ./internal/worker`
- `gofmt` and `git diff --check`

AI assistance disclosure: This contribution was prepared with OpenAI Codex assistance. The final diff and validation results were reviewed before submission.
