### PR TITLE
ci: wait for the commit-matched runner image before releasing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,9 +19,9 @@ jobs:
   preflight:
     name: preflight
     runs-on: ubuntu-24.04
-    timeout-minutes: 20
+    timeout-minutes: 30
     permissions:
-      actions: read # required to derive a stable version date across reruns
+      actions: read # required for stable version dates and Runner Image status
       contents: read
     outputs:
       release_due: ${{ steps.due.outputs.release_due }}
@@ -158,20 +158,13 @@ jobs:
         id: runner
         if: steps.due.outputs.release_due == 'true'
         env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPOSITORY: ${{ github.repository }}
           COMMIT_SHA: ${{ github.sha }}
         run: |
-          RUNNER_TAG="ghcr.io/${REPOSITORY}-runner:sha-${COMMIT_SHA}"
-          if ! MANIFEST=$(docker buildx imagetools inspect "${RUNNER_TAG}" --format '{{json .Manifest}}'); then
-            echo "::error::Runner image ${RUNNER_TAG} is unavailable; if its runner-image workflow was cancelled or failed, re-run it, then re-dispatch this release"
-            exit 1
-          fi
-          DIGEST=$(jq -r '.digest // empty' <<< "${MANIFEST}")
-          if [[ ! "${DIGEST}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
-            echo "::error::Could not resolve a manifest digest for ${RUNNER_TAG}"
-            exit 1
-          fi
-          echo "image=ghcr.io/${REPOSITORY}-runner@${DIGEST}" >> "${GITHUB_OUTPUT}"
+          RUNNER_IMAGE=$(scripts/wait-for-runner-image.sh \
+            "${REPOSITORY}" "${COMMIT_SHA}" 900 15)
+          echo "image=${RUNNER_IMAGE}" >> "${GITHUB_OUTPUT}"
 
   build:
     name: build (${{ matrix.goos }}-${{ matrix.goarch }})

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Test release resolver
         run: scripts/release-resolver_test.sh
 
+      - name: Test runner image resolver
+        run: scripts/wait-for-runner-image_test.sh
+
   tests:
     name: tests (${{ matrix.platform }})
     strategy:

--- a/scripts/wait-for-runner-image.sh
+++ b/scripts/wait-for-runner-image.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'EOF'
+usage: wait-for-runner-image.sh REPOSITORY COMMIT_SHA WAIT_SECONDS POLL_SECONDS
+
+Wait for the successful Runner Image push workflow for COMMIT_SHA, then print
+the immutable GHCR image reference for that commit.
+EOF
+  exit 2
+}
+
+fail() {
+  printf '::error::%s\n' "$*" >&2
+  exit 1
+}
+
+is_nonnegative_integer() {
+  [[ "$1" =~ ^(0|[1-9][0-9]*)$ ]]
+}
+
+[ "$#" -eq 4 ] || usage
+
+repository=$1
+commit_sha=$2
+wait_seconds=$3
+poll_seconds=$4
+
+[[ "$repository" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]] || \
+  fail "Invalid GitHub repository: ${repository}"
+[[ "$commit_sha" =~ ^[0-9a-f]{40}$ ]] || \
+  fail "Invalid commit SHA: ${commit_sha}"
+is_nonnegative_integer "$wait_seconds" || \
+  fail "WAIT_SECONDS must be a non-negative integer, got ${wait_seconds}"
+is_nonnegative_integer "$poll_seconds" || \
+  fail "POLL_SECONDS must be a positive integer, got ${poll_seconds}"
+[ "$poll_seconds" -gt 0 ] || \
+  fail "POLL_SECONDS must be greater than zero"
+
+runner_tag="ghcr.io/${repository}-runner:sha-${commit_sha}"
+workflow_path="runner-image.yml"
+branch="main"
+error_file=$(mktemp "${RUNNER_TEMP:-${TMPDIR:-/tmp}}/wait-for-runner-image.XXXXXX") || \
+  fail "Could not create a temporary error file"
+trap 'rm -f "$error_file"' EXIT
+elapsed=0
+last_state=""
+run_id=""
+run_status=""
+run_conclusion=""
+run_url=""
+
+print_last_error() {
+  if [ -s "$error_file" ]; then
+    printf 'Last command error:\n' >&2
+    cat "$error_file" >&2
+  fi
+}
+
+resolve_image() {
+  local manifest digest
+
+  : > "$error_file"
+  if ! manifest=$(docker buildx imagetools inspect \
+    "$runner_tag" --format '{{json .Manifest}}' 2>"$error_file"); then
+    return 1
+  fi
+
+  : > "$error_file"
+  if ! digest=$(jq -r '.digest // empty' <<< "$manifest" 2>"$error_file"); then
+    print_last_error
+    fail "Could not parse the manifest for ${runner_tag}"
+  fi
+  if [[ ! "$digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+    fail "Could not resolve a manifest digest for ${runner_tag}"
+  fi
+
+  printf 'ghcr.io/%s-runner@%s\n' "$repository" "$digest"
+  exit 0
+}
+
+while :; do
+  api_failed=false
+  : > "$error_file"
+  if ! run_info=$(gh api -X GET \
+    "repos/${repository}/actions/workflows/${workflow_path}/runs" \
+    -f event=push \
+    -f branch="$branch" \
+    -f head_sha="$commit_sha" \
+    -F per_page=10 \
+    --jq '.workflow_runs
+      | sort_by(.created_at)
+      | reverse
+      | .[0]
+      | if . == null then ""
+        else [(.id | tostring), .status, (.conclusion // ""), .html_url]
+          | join("|")
+        end' 2>"$error_file"); then
+    api_failed=true
+    run_info=""
+  fi
+
+  if [ "$api_failed" = true ]; then
+    state="api-error"
+  else
+    run_id=""
+    run_status=""
+    run_conclusion=""
+    run_url=""
+    if [ -n "$run_info" ]; then
+      IFS='|' read -r run_id run_status run_conclusion run_url <<< "$run_info"
+    fi
+
+    if [ "$run_status" = "completed" ] \
+      && [ -n "$run_conclusion" ] \
+      && [ "$run_conclusion" != "success" ]; then
+      fail "Runner Image run ${run_url:-${run_id}} completed with conclusion ${run_conclusion}; refusing to release ${commit_sha}"
+    fi
+
+    # A run that still has work left must finish successfully even if its merge
+    # step has already made the manifest briefly visible. If Actions no longer
+    # retains a run for an older commit, the immutable image remains sufficient.
+    if [ -z "$run_id" ] \
+      || { [ "$run_status" = "completed" ] && [ "$run_conclusion" = "success" ]; }; then
+      resolve_image || true
+    fi
+
+    state="${run_id}|${run_status}|${run_conclusion}"
+  fi
+
+  if [ "$state" != "$last_state" ]; then
+    if [ "$api_failed" = true ]; then
+      printf 'Unable to inspect the Runner Image workflow; retrying\n' >&2
+      print_last_error
+    elif [ -z "$run_id" ]; then
+      printf 'Waiting for the Runner Image push run for %s to appear\n' \
+        "$commit_sha" >&2
+    elif [ "$run_status" = "completed" ] && [ "$run_conclusion" = "success" ]; then
+      printf 'Runner Image run %s succeeded; waiting for %s to become readable\n' \
+        "$run_url" "$runner_tag" >&2
+    elif [ "$run_status" = "completed" ]; then
+      printf 'Runner Image run %s completed without a conclusion; waiting for a stable result\n' \
+        "$run_url" >&2
+    else
+      printf 'Waiting for Runner Image run %s (status: %s)\n' \
+        "$run_url" "${run_status:-unknown}" >&2
+    fi
+    last_state=$state
+  fi
+
+  if [ "$elapsed" -ge "$wait_seconds" ]; then
+    if [ "$api_failed" = true ]; then
+      print_last_error
+      fail "Unable to inspect the Runner Image workflow for ${commit_sha} within ${wait_seconds} seconds"
+    elif [ -z "$run_id" ]; then
+      print_last_error
+      fail "No Runner Image push run appeared for ${commit_sha} within ${wait_seconds} seconds"
+    elif [ "$run_status" = "completed" ] && [ "$run_conclusion" = "success" ]; then
+      print_last_error
+      fail "Runner Image run ${run_url} succeeded, but ${runner_tag} was unavailable after ${wait_seconds} seconds"
+    elif [ "$run_status" = "completed" ]; then
+      fail "Timed out after ${wait_seconds} seconds waiting for Runner Image run ${run_url} to report a conclusion"
+    else
+      fail "Timed out after ${wait_seconds} seconds waiting for Runner Image run ${run_url} (status: ${run_status:-unknown})"
+    fi
+  fi
+
+  delay=$poll_seconds
+  if [ $((elapsed + delay)) -gt "$wait_seconds" ]; then
+    delay=$((wait_seconds - elapsed))
+  fi
+  sleep "$delay"
+  elapsed=$((elapsed + delay))
+done

--- a/scripts/wait-for-runner-image_test.sh
+++ b/scripts/wait-for-runner-image_test.sh
@@ -1,0 +1,318 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+root=$(cd "$(dirname "$0")/.." && pwd)
+resolver="$root/scripts/wait-for-runner-image.sh"
+tests=0
+repository=alpha-omega-security/scrutineer
+commit_sha=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+digest="sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+test_root=$(mktemp -d "${TMPDIR:-/tmp}/wait-for-runner-image-test.XXXXXX")
+stub_bin="$test_root/bin"
+mkdir -p "$stub_bin"
+trap 'rm -rf "$test_root"' EXIT
+
+fail() {
+  printf 'not ok %s - %s\n' "$tests" "$1" >&2
+  exit 1
+}
+
+pass() {
+  tests=$((tests + 1))
+  printf 'ok %s - %s\n' "$tests" "$1"
+}
+
+assert_eq() {
+  expected=$1
+  actual=$2
+  label=$3
+  if [ "$actual" != "$expected" ]; then
+    printf 'expected:\n%s\nactual:\n%s\n' "$expected" "$actual" >&2
+    fail "$label"
+  fi
+  pass "$label"
+}
+
+assert_contains() {
+  value=$1
+  expected=$2
+  label=$3
+  case "$value" in
+    *"$expected"*) pass "$label" ;;
+    *)
+      printf 'expected substring:\n%s\nactual:\n%s\n' "$expected" "$value" >&2
+      fail "$label"
+      ;;
+  esac
+}
+
+assert_command_calls() {
+  expected=$1
+  command_name=$2
+  label=$3
+  file="$case_dir/${command_name}-count"
+  if [ -f "$file" ]; then
+    actual=$(cat "$file")
+  else
+    actual=0
+  fi
+  assert_eq "$expected" "$actual" "$label"
+}
+
+assert_file_lines() {
+  expected=$1
+  file=$2
+  label=$3
+  if [ -f "$file" ]; then
+    actual=$(wc -l < "$file" | tr -d '[:space:]')
+  else
+    actual=0
+  fi
+  assert_eq "$expected" "$actual" "$label"
+}
+
+cat > "$stub_bin/docker" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+state=${RUNNER_IMAGE_TEST_STATE:?}
+count_file="$state/docker-count"
+count=0
+[ ! -f "$count_file" ] || count=$(cat "$count_file")
+count=$((count + 1))
+printf '%s\n' "$count" > "$count_file"
+printf '%s\n' "$*" >> "$state/docker-args"
+response=$(sed -n "${count}p" "$state/docker-responses")
+if [ -z "$response" ] && [ -s "$state/docker-responses" ]; then
+  response=$(tail -n 1 "$state/docker-responses")
+fi
+case "$response" in
+  missing)
+    printf 'manifest unknown\n' >&2
+    exit 1
+    ;;
+  missing:*)
+    printf '%s\n' "${response#missing:}" >&2
+    exit 1
+    ;;
+  malformed)
+    printf '{}\n'
+    ;;
+  digest:*)
+    printf '{"digest":"%s"}\n' "${response#digest:}"
+    ;;
+  *)
+    printf 'unexpected docker response: %s\n' "$response" >&2
+    exit 2
+    ;;
+esac
+EOF
+
+cat > "$stub_bin/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+state=${RUNNER_IMAGE_TEST_STATE:?}
+count_file="$state/gh-count"
+count=0
+[ ! -f "$count_file" ] || count=$(cat "$count_file")
+count=$((count + 1))
+printf '%s\n' "$count" > "$count_file"
+printf '%s\n' "$*" >> "$state/gh-args"
+response=$(sed -n "${count}p" "$state/gh-responses")
+if [ -z "$response" ] && [ -s "$state/gh-responses" ]; then
+  response=$(tail -n 1 "$state/gh-responses")
+fi
+if [ "$response" = error ]; then
+  printf 'simulated GitHub API failure\n' >&2
+  exit 1
+fi
+jq_filter=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --jq)
+      jq_filter=$2
+      shift 2
+      ;;
+    *) shift ;;
+  esac
+done
+[ -n "$jq_filter" ] || {
+  printf 'missing --jq filter\n' >&2
+  exit 2
+}
+printf '%s\n' "$response" | jq -r "$jq_filter"
+EOF
+
+cat > "$stub_bin/sleep" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+state=${RUNNER_IMAGE_TEST_STATE:?}
+printf '%s\n' "$1" >> "$state/sleep-args"
+EOF
+
+chmod +x "$stub_bin/docker" "$stub_bin/gh" "$stub_bin/sleep"
+
+case_number=0
+start_case() {
+  case_number=$((case_number + 1))
+  case_dir="$test_root/case-$case_number"
+  mkdir -p "$case_dir"
+  : > "$case_dir/docker-responses"
+  printf '{"workflow_runs":[]}\n' > "$case_dir/gh-responses"
+}
+
+run_case() {
+  wait_seconds=$1
+  poll_seconds=$2
+  if output=$(PATH="$stub_bin:$PATH" \
+    RUNNER_IMAGE_TEST_STATE="$case_dir" \
+    "$resolver" "$repository" "$commit_sha" \
+    "$wait_seconds" "$poll_seconds" 2>"$case_dir/stderr"); then
+    status=0
+  else
+    status=$?
+  fi
+  error=$(cat "$case_dir/stderr")
+}
+
+start_case
+printf 'digest:%s\n' "$digest" > "$case_dir/docker-responses"
+run_case 2 1
+assert_eq 0 "$status" 'existing image succeeds'
+assert_eq "ghcr.io/${repository}-runner@${digest}" "$output" \
+  'existing image returns immutable reference'
+assert_command_calls 1 gh \
+  'existing image confirms no retained active workflow'
+
+start_case
+printf 'digest:%s\n' "$digest" > "$case_dir/docker-responses"
+printf '%s\n' \
+  '{"workflow_runs":[{"id":100,"status":"completed","conclusion":"failure","html_url":"https://github.example/runs/100","created_at":"2026-07-28T17:00:00Z"},{"id":101,"status":"in_progress","conclusion":null,"html_url":"https://github.example/runs/101","created_at":"2026-07-28T18:00:00Z"}]}' \
+  '{"workflow_runs":[{"id":100,"status":"completed","conclusion":"failure","html_url":"https://github.example/runs/100","created_at":"2026-07-28T17:00:00Z"},{"id":101,"status":"completed","conclusion":"success","html_url":"https://github.example/runs/101","created_at":"2026-07-28T18:00:00Z"}]}' \
+  > "$case_dir/gh-responses"
+run_case 2 1
+assert_eq 0 "$status" 'active runner workflow is awaited'
+assert_eq "ghcr.io/${repository}-runner@${digest}" "$output" \
+  'successful runner workflow resolves immutable reference'
+assert_command_calls 2 gh \
+  'active runner workflow is queried until success'
+assert_file_lines 1 "$case_dir/sleep-args" \
+  'active runner workflow waits between queries'
+assert_command_calls 1 docker \
+  'manifest is not accepted before runner workflow success'
+assert_contains "$error" 'https://github.example/runs/101' \
+  'newest exact-SHA workflow run is selected'
+gh_args=$(cat "$case_dir/gh-args")
+assert_contains "$gh_args" \
+  'repos/alpha-omega-security/scrutineer/actions/workflows/runner-image.yml/runs' \
+  'query selects the runner image workflow'
+assert_contains "$gh_args" 'event=push' 'query selects push runs'
+assert_contains "$gh_args" 'branch=main' 'query selects the main branch'
+assert_contains "$gh_args" "head_sha=${commit_sha}" \
+  'query selects the exact release commit'
+
+start_case
+printf 'digest:%s\n' "$digest" > "$case_dir/docker-responses"
+printf '%s\n' \
+  '{"workflow_runs":[{"id":102,"status":"completed","conclusion":"failure","html_url":"https://github.example/runs/102","created_at":"2026-07-28T18:00:00Z"}]}' \
+  > "$case_dir/gh-responses"
+run_case 2 1
+assert_eq 1 "$status" 'failed runner workflow blocks release'
+assert_contains "$error" 'completed with conclusion failure' \
+  'failed runner workflow reports its conclusion'
+assert_contains "$error" 'https://github.example/runs/102' \
+  'failed runner workflow reports its URL'
+assert_file_lines 0 "$case_dir/sleep-args" \
+  'failed runner workflow does not wait until timeout'
+assert_command_calls 0 docker \
+  'failed runner workflow is not bypassed by a readable manifest'
+
+start_case
+printf '%s\n' missing > "$case_dir/docker-responses"
+printf '%s\n' \
+  '{"workflow_runs":[{"id":103,"status":"completed","conclusion":"cancelled","html_url":"https://github.example/runs/103","created_at":"2026-07-28T18:00:00Z"}]}' \
+  > "$case_dir/gh-responses"
+run_case 2 1
+assert_eq 1 "$status" 'cancelled runner workflow blocks release'
+assert_contains "$error" 'completed with conclusion cancelled' \
+  'cancelled runner workflow reports its conclusion'
+
+start_case
+printf '%s\n' missing > "$case_dir/docker-responses"
+run_case 2 1
+assert_eq 1 "$status" 'missing runner workflow times out'
+assert_contains "$error" \
+  "No Runner Image push run appeared for ${commit_sha} within 2 seconds" \
+  'missing runner workflow reports the exact commit and timeout'
+assert_command_calls 3 gh \
+  'missing runner workflow is queried through the deadline'
+assert_file_lines 2 "$case_dir/sleep-args" \
+  'missing runner workflow stops sleeping at the deadline'
+
+start_case
+printf '%s\n' 'missing:denied: simulated registry failure' > "$case_dir/docker-responses"
+printf '%s\n' \
+  '{"workflow_runs":[{"id":104,"status":"completed","conclusion":"success","html_url":"https://github.example/runs/104","created_at":"2026-07-28T18:00:00Z"}]}' \
+  > "$case_dir/gh-responses"
+run_case 2 1
+assert_eq 1 "$status" 'missing manifest after runner success times out'
+assert_contains "$error" \
+  "succeeded, but ghcr.io/${repository}-runner:sha-${commit_sha} was unavailable after 2 seconds" \
+  'missing manifest reports successful runner and registry timeout'
+assert_contains "$error" 'denied: simulated registry failure' \
+  'registry timeout reports the last inspection error'
+
+start_case
+printf '%s\n' malformed > "$case_dir/docker-responses"
+run_case 2 1
+assert_eq 1 "$status" 'malformed manifest blocks release'
+assert_contains "$error" 'Could not resolve a manifest digest' \
+  'malformed manifest reports digest failure'
+assert_command_calls 1 gh \
+  'malformed readable manifest checks retained workflow state'
+
+start_case
+printf 'digest:%s\n' "$digest" > "$case_dir/docker-responses"
+printf '%s\n' \
+  '{"workflow_runs":[{"id":105,"status":"completed","conclusion":null,"html_url":"https://github.example/runs/105","created_at":"2026-07-28T18:00:00Z"}]}' \
+  '{"workflow_runs":[{"id":105,"status":"completed","conclusion":"success","html_url":"https://github.example/runs/105","created_at":"2026-07-28T18:00:00Z"}]}' \
+  > "$case_dir/gh-responses"
+run_case 2 1
+assert_eq 0 "$status" 'completed run without conclusion is retried'
+assert_file_lines 1 "$case_dir/sleep-args" \
+  'completed run without conclusion waits for a stable result'
+assert_command_calls 1 docker \
+  'completed run without conclusion cannot resolve the manifest early'
+
+start_case
+printf 'digest:%s\n' "$digest" > "$case_dir/docker-responses"
+printf '%s\n' \
+  error \
+  '{"workflow_runs":[{"id":106,"status":"in_progress","conclusion":null,"html_url":"https://github.example/runs/106","created_at":"2026-07-28T18:00:00Z"}]}' \
+  '{"workflow_runs":[{"id":106,"status":"completed","conclusion":"success","html_url":"https://github.example/runs/106","created_at":"2026-07-28T18:00:00Z"}]}' \
+  > "$case_dir/gh-responses"
+run_case 3 1
+assert_eq 0 "$status" 'transient GitHub API failure is retried'
+assert_command_calls 3 gh \
+  'GitHub API is queried again after a transient failure'
+assert_file_lines 2 "$case_dir/sleep-args" \
+  'transient GitHub API failure consumes bounded wait intervals'
+assert_contains "$error" 'simulated GitHub API failure' \
+  'transient GitHub API failure remains visible in diagnostics'
+
+start_case
+printf '%s\n' missing > "$case_dir/docker-responses"
+printf '%s\n' error > "$case_dir/gh-responses"
+run_case 2 1
+assert_eq 1 "$status" 'persistent GitHub API failure blocks release'
+assert_contains "$error" \
+  "Unable to inspect the Runner Image workflow for ${commit_sha} within 2 seconds" \
+  'persistent GitHub API failure reports exact workflow lookup and timeout'
+assert_contains "$error" 'simulated GitHub API failure' \
+  'persistent GitHub API failure reports the last API error'
+assert_command_calls 3 gh \
+  'persistent GitHub API failure is retried through the deadline'
+assert_command_calls 0 docker \
+  'GitHub API failure cannot use the missing-run manifest fallback'
+
+printf '1..%s\n' "$tests"


### PR DESCRIPTION
The scheduled release on 28 July failed resolving the commit-matched runner image: the Runner Image push run for the same commit was still building, and the step inspected ghcr.io exactly once before giving up. The manifest appeared five minutes later. #666 added that single inspect alongside the automated cadence.

This replaces it with a resolver script that polls the Actions API for the `runner-image.yml` push run on `main` matching the exact release SHA, accepts the image only once that run reports `completed` with conclusion `success`, then keeps polling ghcr.io to ride out registry propagation. A run that fails or is cancelled fails the release rather than falling back to whatever manifest happens to be readable, a commit whose run Actions no longer retains still resolves from the immutable image, and transient API errors retry inside the same budget without reaching that fallback. The wait is bounded at 900 seconds on 15 second polls, and preflight's timeout moves from 20 to 30 minutes to contain it.

The state machine lives in `scripts/wait-for-runner-image.sh` with a dependency-free suite that CI runs.
