### PR TITLE
Bound repository dependency API results

### DIFF
--- a/internal/web/api_reads.go
+++ b/internal/web/api_reads.go
@@ -11,10 +11,31 @@ import (
 	"scrutineer/internal/worker"
 )
 
+const (
+	repositoryReadDefaultLimit = 200
+	repositoryReadMaxLimit     = 1000
+)
+
 // The read endpoints below expose the structured rows scrutineer already
 // populates from prior skill scans. Skills that need context for a repo
 // (verify/patch/disclose, security-deep-dive's reach and prior-art steps)
 // call these instead of re-parsing the original scan reports.
+
+func parseLimit(r *http.Request, defaultN, maxN int) (int, error) {
+	query := r.URL.Query()
+	if !query.Has("limit") {
+		return defaultN, nil
+	}
+	raw := query.Get("limit")
+	n, err := strconv.Atoi(raw)
+	if err != nil || n < 0 {
+		return 0, errors.New("limit must be a non-negative integer")
+	}
+	if n > maxN {
+		n = maxN
+	}
+	return n, nil
+}
 
 // repoScopedID parses the path id and enforces the scan-owns-repo auth
 // rule for the apiList* handlers. Returns false when the response has
@@ -153,8 +174,13 @@ func (s *Server) apiListDependents(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
+	limit, err := parseLimit(r, repositoryReadDefaultLimit, repositoryReadMaxLimit)
+	if err != nil {
+		writeAPIError(w, http.StatusBadRequest, err.Error())
+		return
+	}
 	var rows []db.Dependent
-	s.DB.Where("repository_id = ?", id).Order("dependent_repos desc").Find(&rows)
+	s.DB.Where("repository_id = ?", id).Order("dependent_repos desc").Limit(limit).Find(&rows)
 	out := make([]dependentResponse, 0, len(rows))
 	for _, d := range rows {
 		out = append(out, dependentResponse{
@@ -190,8 +216,13 @@ func (s *Server) apiListDependencies(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
+	limit, err := parseLimit(r, repositoryReadDefaultLimit, repositoryReadMaxLimit)
+	if err != nil {
+		writeAPIError(w, http.StatusBadRequest, err.Error())
+		return
+	}
 	var rows []db.Dependency
-	s.DB.Where("repository_id = ?", id).Order("ecosystem, name").Find(&rows)
+	s.DB.Where("repository_id = ?", id).Order("ecosystem, name").Limit(limit).Find(&rows)
 	out := make([]dependencyResponse, 0, len(rows))
 	for _, d := range rows {
 		out = append(out, dependencyResponse{

--- a/internal/web/api_reads_test.go
+++ b/internal/web/api_reads_test.go
@@ -10,6 +10,141 @@ import (
 	"scrutineer/internal/worker"
 )
 
+func TestParseLimit(t *testing.T) {
+	tests := []struct {
+		query   string
+		want    int
+		wantErr bool
+	}{
+		{"", 200, false},
+		{"?limit=25", 25, false},
+		{"?limit=1001", 1000, false},
+		{"?limit=0", 0, false},
+		{"?limit=", 0, true},
+		{"?limit", 0, true},
+		{"?limit=-1", 0, true},
+		{"?limit=nope", 0, true},
+	}
+	for _, tc := range tests {
+		r := httptest.NewRequest("GET", "/api/repositories/1/dependencies"+tc.query, nil)
+		got, err := parseLimit(r, 200, 1000)
+		if (err != nil) != tc.wantErr {
+			t.Errorf("%q: error = %v, wantErr %v", tc.query, err, tc.wantErr)
+		}
+		if got != tc.want {
+			t.Errorf("%q: limit = %d, want %d", tc.query, got, tc.want)
+		}
+	}
+}
+
+func TestAPIListDependents_limit(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	repo, scan := seedRunningScan(t, s)
+
+	rows := make([]db.Dependent, 0, 201)
+	for i := range 201 {
+		rows = append(rows, db.Dependent{
+			RepositoryID:   repo.ID,
+			Name:           fmt.Sprintf("dependent-%03d", i),
+			DependentRepos: i,
+		})
+	}
+	if err := s.DB.Create(&rows).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	get := func(query string) []dependentResponse {
+		t.Helper()
+		path := fmt.Sprintf("/api/repositories/%d/dependents%s", repo.ID, query)
+		w := apiReq(t, s, "GET", path, scan.APIToken, "")
+		if w.Code != 200 {
+			t.Fatalf("%s: status = %d, want 200; body=%s", query, w.Code, w.Body)
+		}
+		var got []dependentResponse
+		if err := json.NewDecoder(w.Body).Decode(&got); err != nil {
+			t.Fatal(err)
+		}
+		return got
+	}
+
+	got := get("")
+	if len(got) != 200 {
+		t.Fatalf("default dependents = %d, want 200", len(got))
+	}
+	if got[0].Name != "dependent-200" || got[199].Name != "dependent-001" {
+		t.Errorf("default dependents range = %q..%q, want dependent-200..dependent-001", got[0].Name, got[199].Name)
+	}
+
+	got = get("?limit=2")
+	if len(got) != 2 {
+		t.Fatalf("dependents = %d, want 2", len(got))
+	}
+	if got[0].Name != "dependent-200" || got[1].Name != "dependent-199" {
+		t.Errorf("dependents = %+v, want dependent-200 then dependent-199", got)
+	}
+
+	path := fmt.Sprintf("/api/repositories/%d/dependents?limit=", repo.ID)
+	w := apiReq(t, s, "GET", path, scan.APIToken, "")
+	if w.Code != 400 {
+		t.Errorf("empty limit status = %d, want 400; body=%s", w.Code, w.Body)
+	}
+}
+
+func TestAPIListDependencies_limit(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	repo, scan := seedRunningScan(t, s)
+
+	rows := make([]db.Dependency, 0, 201)
+	for i := range 201 {
+		rows = append(rows, db.Dependency{
+			RepositoryID: repo.ID,
+			Name:         fmt.Sprintf("dependency-%03d", i),
+			Ecosystem:    "npm",
+		})
+	}
+	if err := s.DB.Create(&rows).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	get := func(query string) []dependencyResponse {
+		t.Helper()
+		path := fmt.Sprintf("/api/repositories/%d/dependencies%s", repo.ID, query)
+		w := apiReq(t, s, "GET", path, scan.APIToken, "")
+		if w.Code != 200 {
+			t.Fatalf("%s: status = %d, want 200; body=%s", query, w.Code, w.Body)
+		}
+		var got []dependencyResponse
+		if err := json.NewDecoder(w.Body).Decode(&got); err != nil {
+			t.Fatal(err)
+		}
+		return got
+	}
+
+	got := get("")
+	if len(got) != 200 {
+		t.Fatalf("default dependencies = %d, want 200", len(got))
+	}
+	if got[0].Name != "dependency-000" || got[199].Name != "dependency-199" {
+		t.Errorf("default dependencies range = %q..%q, want dependency-000..dependency-199", got[0].Name, got[199].Name)
+	}
+
+	got = get("?limit=2")
+	if len(got) != 2 {
+		t.Fatalf("dependencies = %d, want 2", len(got))
+	}
+	if got[0].Name != "dependency-000" || got[1].Name != "dependency-001" {
+		t.Errorf("dependencies = %+v, want dependency-000 then dependency-001", got)
+	}
+
+	path := fmt.Sprintf("/api/repositories/%d/dependencies?limit=", repo.ID)
+	w := apiReq(t, s, "GET", path, scan.APIToken, "")
+	if w.Code != 400 {
+		t.Errorf("empty limit status = %d, want 400; body=%s", w.Code, w.Body)
+	}
+}
+
 func TestAPIListFindings_filtersBySkill(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -134,6 +134,7 @@ paths:
       operationId: listRepositoryDependents
       parameters:
         - $ref: '#/components/parameters/RepositoryID'
+        - $ref: '#/components/parameters/RepositoryReadLimit'
       responses:
         '200':
           description: OK
@@ -142,6 +143,7 @@ paths:
               schema:
                 type: array
                 items: { $ref: '#/components/schemas/Dependent' }
+        '400': { $ref: '#/components/responses/BadRequest' }
         '403': { $ref: '#/components/responses/Forbidden' }
 
   /repositories/{id}/ecosystems/{source}/raw:
@@ -191,6 +193,7 @@ paths:
       operationId: listRepositoryDependencies
       parameters:
         - $ref: '#/components/parameters/RepositoryID'
+        - $ref: '#/components/parameters/RepositoryReadLimit'
       responses:
         '200':
           description: OK
@@ -199,6 +202,7 @@ paths:
               schema:
                 type: array
                 items: { $ref: '#/components/schemas/Dependency' }
+        '400': { $ref: '#/components/responses/BadRequest' }
         '403': { $ref: '#/components/responses/Forbidden' }
 
   /repositories/{id}/findings:
@@ -1104,6 +1108,11 @@ components:
       in: path
       required: true
       schema: { type: integer, format: int64 }
+    RepositoryReadLimit:
+      name: limit
+      in: query
+      description: Maximum number of rows to return; defaults to 200 and is capped at 1000.
+      schema: { type: integer, minimum: 0, maximum: 1000, default: 200 }
 
   responses:
     NotFound:
@@ -1117,7 +1126,7 @@ components:
         application/json:
           schema: { $ref: '#/components/schemas/Error' }
     BadRequest:
-      description: Malformed request body or a missing required field
+      description: Malformed query or request body, or a missing required field
       content:
         application/json:
           schema: { $ref: '#/components/schemas/Error' }


### PR DESCRIPTION
## Summary

- add a shared `parseLimit` helper for repository dependency reads, defaulting to 200 rows and capping requests at 1000
- apply the bound to the dependents and dependencies queries, returning `400 Bad Request` for empty, non-numeric, or negative values
- document the query parameter and cover default, explicit, capped, zero, and invalid limits

## Testing

The Linux-target checks below ran against an LF snapshot of the exact candidate tree:

- `go mod tidy -diff`
- `GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go vet ./...`
- `GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go vet -tags podman ./...`
- `GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go test -c ./internal/web`
- `GOOS=linux GOARCH=amd64 CGO_ENABLED=0 golangci-lint run ./...` (0 issues)

The three targeted runtime tests also passed locally on Windows with a temporary process-control compatibility shim for upstream's Unix-only worker code; the shim is not part of this patch.

Closes #713.

Disclosure: Prepared with OpenAI Codex assistance; the resulting patch and validation evidence were reviewed before submission.
