### PR TITLE
Serve openapi.yaml at GET /api/openapi.yaml

### DIFF
--- a/internal/web/openapi.go
+++ b/internal/web/openapi.go
@@ -6,17 +6,45 @@ import (
 	"scrutineer"
 )
 
-// openAPISpec serves the embedded openapi.yaml.
+// openAPISpecHandler serves the embedded openapi.yaml under two access rules,
+// because the two callers the document exists for reach the server very
+// differently.
 //
-// It is registered on the root mux rather than inside apiHandler because
-// apiAuth only accepts a bearer token belonging to a RUNNING scan: a tool
-// discovering the API has no scan to borrow a token from, so serving the spec
-// from behind that middleware would defeat the point of serving it at all.
-// Reading it is unauthenticated but still host-only via securityHeaders, the
-// same boundary the /api/v1 export surface relies on (see threatmodel.md).
-// The document is already public in the repository, so this discloses nothing
-// a reader could not fetch from GitHub.
-func (s *Server) openAPISpec(w http.ResponseWriter, r *http.Request) {
+// A caller on the host -- the browser UI, curl, a tool discovering the API --
+// gets it unauthenticated. It has no running scan to borrow a bearer token
+// from, so requiring one would defeat the point of serving the spec at all;
+// the Host check is what keeps a DNS-rebound browser out, the same boundary
+// the /api/v1 export surface relies on (see threatmodel.md).
+//
+// A skill inside the runner container cannot satisfy that check. context.json
+// advertises the runtime's host endpoint (host.docker.internal for
+// docker/podman, the default gateway IP under Apple's container), and the
+// egress proxy rewrites the dial target to loopback but forwards the original
+// Host, so the request arrives with a non-local Host and would 403. Those
+// callers instead present the per-scan bearer token they already hold for the
+// rest of /api. That is not a weaker boundary: a rebound browser cannot mint a
+// running scan's token, and it cannot attach an Authorization header
+// cross-origin without a preflight this server never answers.
+//
+// The document is already public in the repository either way, so neither path
+// discloses anything a reader could not fetch from GitHub.
+func (s *Server) openAPISpecHandler() http.Handler {
+	spec := http.HandlerFunc(s.openAPISpec)
+	fromHost := securityHeaders(spec)
+	fromContainer := s.apiAuth(spec)
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if localHost(r.Host) {
+			fromHost.ServeHTTP(w, r)
+			return
+		}
+		w.Header().Set("Content-Security-Policy", cspPolicy)
+		fromContainer.ServeHTTP(w, r)
+	})
+}
+
+// openAPISpec writes the embedded copy of the repository's openapi.yaml.
+// openAPISpecHandler owns the access rules; this only serves bytes.
+func (s *Server) openAPISpec(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "application/yaml")
 	if _, err := w.Write(scrutineer.OpenAPISpec); err != nil {
 		s.Log.Error("serve openapi spec", "err", err)

--- a/internal/web/openapi.go
+++ b/internal/web/openapi.go
@@ -1,0 +1,24 @@
+package web
+
+import (
+	"net/http"
+
+	"scrutineer"
+)
+
+// openAPISpec serves the embedded openapi.yaml.
+//
+// It is registered on the root mux rather than inside apiHandler because
+// apiAuth only accepts a bearer token belonging to a RUNNING scan: a tool
+// discovering the API has no scan to borrow a token from, so serving the spec
+// from behind that middleware would defeat the point of serving it at all.
+// Reading it is unauthenticated but still host-only via securityHeaders, the
+// same boundary the /api/v1 export surface relies on (see threatmodel.md).
+// The document is already public in the repository, so this discloses nothing
+// a reader could not fetch from GitHub.
+func (s *Server) openAPISpec(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/yaml")
+	if _, err := w.Write(scrutineer.OpenAPISpec); err != nil {
+		s.Log.Error("serve openapi spec", "err", err)
+	}
+}

--- a/internal/web/openapi_routes_test.go
+++ b/internal/web/openapi_routes_test.go
@@ -196,6 +196,9 @@ func registeredOpenAPIRoutes(t *testing.T) []registeredAPIRoute {
 	// claim-check is documented in openapi.yaml but registered on the root
 	// browser mux, outside apiHandler/exportHandler.
 	routes = append(routes, registeredAPIRoute{Method: "POST", Path: "/claim-check"})
+	// GET /api/openapi.yaml is likewise registered on the root mux, so that
+	// serving the spec does not sit behind the scan-token auth.
+	routes = append(routes, registeredAPIRoute{Method: "GET", Path: "/openapi.yaml"})
 	sort.Slice(routes, func(i, j int) bool {
 		if routes[i].Path == routes[j].Path {
 			return routes[i].Method < routes[j].Method

--- a/internal/web/openapi_spec_test.go
+++ b/internal/web/openapi_spec_test.go
@@ -1,0 +1,94 @@
+package web
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// GET /api/openapi.yaml serves the spec so a skill or external tool can read
+// the API surface from a running server without a checkout (#731).
+func TestOpenAPISpecServedOverHTTP(t *testing.T) {
+	s, cleanup := newTestServer(t)
+	defer cleanup()
+
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq(http.MethodGet, "/api/openapi.yaml"))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET /api/openapi.yaml status = %d, want %d", w.Code, http.StatusOK)
+	}
+	if got := w.Header().Get("Content-Type"); got != "application/yaml" {
+		t.Errorf("Content-Type = %q, want %q", got, "application/yaml")
+	}
+
+	var doc struct {
+		Info struct {
+			Title string `yaml:"title"`
+		} `yaml:"info"`
+		Paths map[string]any `yaml:"paths"`
+	}
+	if err := yaml.Unmarshal(w.Body.Bytes(), &doc); err != nil {
+		t.Fatalf("served spec does not parse as YAML: %v", err)
+	}
+	if doc.Info.Title == "" {
+		t.Error("served spec has no info.title")
+	}
+	if _, ok := doc.Paths["/openapi.yaml"]; !ok {
+		t.Error("served spec does not document its own /openapi.yaml path")
+	}
+}
+
+// The embedded copy must stay byte-identical to the file the repo ships, so a
+// stale binary cannot serve a spec that disagrees with openapi.yaml.
+func TestOpenAPISpecMatchesRepoFile(t *testing.T) {
+	s, cleanup := newTestServer(t)
+	defer cleanup()
+
+	onDisk, err := os.ReadFile("../../openapi.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq(http.MethodGet, "/api/openapi.yaml"))
+
+	if got := w.Body.Bytes(); string(got) != string(onDisk) {
+		t.Errorf("served spec differs from openapi.yaml (%d served bytes, %d on disk)", len(got), len(onDisk))
+	}
+}
+
+// The spec is unauthenticated but keeps the host-only boundary the rest of the
+// browser surface relies on; see threatmodel.md.
+func TestOpenAPISpecRejectsNonLocalHost(t *testing.T) {
+	s, cleanup := newTestServer(t)
+	defer cleanup()
+
+	r := httptest.NewRequest(http.MethodGet, "/api/openapi.yaml", nil)
+	r.Host = "evil.example.com"
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, r)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("non-local host status = %d, want %d", w.Code, http.StatusForbidden)
+	}
+}
+
+// Reading the spec must not require a scan bearer token: an external tool
+// discovering the API has no running scan to borrow one from.
+func TestOpenAPISpecNeedsNoBearerToken(t *testing.T) {
+	s, cleanup := newTestServer(t)
+	defer cleanup()
+
+	w := httptest.NewRecorder()
+	r := localReq(http.MethodGet, "/api/openapi.yaml")
+	r.Header.Del("Authorization")
+	s.Handler().ServeHTTP(w, r)
+
+	if w.Code == http.StatusUnauthorized {
+		t.Fatal("GET /api/openapi.yaml required a bearer token; the spec must be readable without a running scan")
+	}
+}

--- a/internal/web/openapi_spec_test.go
+++ b/internal/web/openapi_spec_test.go
@@ -1,13 +1,31 @@
 package web
 
 import (
+	"bytes"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"testing"
 
 	"gopkg.in/yaml.v3"
+
+	"scrutineer/internal/db"
 )
+
+// runningScanToken seeds a running scan and returns its API token, the
+// credential a skill inside the runner container holds while it works.
+func runningScanToken(t *testing.T, s *Server) string {
+	t.Helper()
+	repo := db.Repository{URL: "https://example.com/spec", Name: "spec"}
+	if err := s.DB.Create(&repo).Error; err != nil {
+		t.Fatal(err)
+	}
+	scan := db.Scan{RepositoryID: repo.ID, Status: db.ScanRunning, APIToken: NewAPIToken()}
+	if err := s.DB.Create(&scan).Error; err != nil {
+		t.Fatal(err)
+	}
+	return scan.APIToken
+}
 
 // GET /api/openapi.yaml serves the spec so a skill or external tool can read
 // the API surface from a running server without a checkout (#731).
@@ -56,29 +74,82 @@ func TestOpenAPISpecMatchesRepoFile(t *testing.T) {
 	w := httptest.NewRecorder()
 	s.Handler().ServeHTTP(w, localReq(http.MethodGet, "/api/openapi.yaml"))
 
-	if got := w.Body.Bytes(); string(got) != string(onDisk) {
+	if got := w.Body.Bytes(); !bytes.Equal(got, onDisk) {
 		t.Errorf("served spec differs from openapi.yaml (%d served bytes, %d on disk)", len(got), len(onDisk))
 	}
 }
 
-// The spec is unauthenticated but keeps the host-only boundary the rest of the
-// browser surface relies on; see threatmodel.md.
-func TestOpenAPISpecRejectsNonLocalHost(t *testing.T) {
+// A skill in the runner container reaches the loopback-bound server through the
+// egress proxy, which rewrites the dial target but forwards the Host that
+// context.json advertises -- host.docker.internal under docker/podman, the
+// default gateway IP under Apple's container. Neither is local, so the spec has
+// to be reachable with the per-scan bearer token those callers already hold;
+// otherwise the endpoint 403s exactly where #731 wants it to work.
+func TestOpenAPISpecServedToContainerWithScanToken(t *testing.T) {
 	s, cleanup := newTestServer(t)
 	defer cleanup()
+	token := runningScanToken(t, s)
 
-	r := httptest.NewRequest(http.MethodGet, "/api/openapi.yaml", nil)
-	r.Host = "evil.example.com"
-	w := httptest.NewRecorder()
-	s.Handler().ServeHTTP(w, r)
+	onDisk, err := os.ReadFile("../../openapi.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
 
-	if w.Code != http.StatusForbidden {
-		t.Fatalf("non-local host status = %d, want %d", w.Code, http.StatusForbidden)
+	for _, apiHost := range []string{"host.docker.internal:8080", "192.168.64.1:8080"} {
+		r := httptest.NewRequest(http.MethodGet, "/api/openapi.yaml", nil)
+		r.Host = apiHost
+		r.Header.Set("Authorization", "Bearer "+token)
+		w := httptest.NewRecorder()
+		s.Handler().ServeHTTP(w, r)
+
+		if w.Code != http.StatusOK {
+			t.Errorf("Host %s with a running scan token: status = %d, want %d; body=%s",
+				apiHost, w.Code, http.StatusOK, w.Body)
+			continue
+		}
+		if !bytes.Equal(w.Body.Bytes(), onDisk) {
+			t.Errorf("Host %s served %d bytes, want the %d-byte spec", apiHost, w.Body.Len(), len(onDisk))
+		}
 	}
 }
 
-// Reading the spec must not require a scan bearer token: an external tool
-// discovering the API has no running scan to borrow one from.
+// Bearer access must not become a way around the host boundary for callers with
+// no scan: a non-local Host still gets nothing without a valid running-scan
+// token, so a DNS-rebound browser cannot read the document.
+func TestOpenAPISpecNonLocalHostNeedsValidToken(t *testing.T) {
+	s, cleanup := newTestServer(t)
+	defer cleanup()
+	// A scan that is not running, so its token must not open the endpoint.
+	repo := db.Repository{URL: "https://example.com/done", Name: "done"}
+	s.DB.Create(&repo)
+	finished := db.Scan{RepositoryID: repo.ID, Status: db.ScanDone, APIToken: NewAPIToken()}
+	s.DB.Create(&finished)
+
+	cases := map[string]string{
+		"no token":             "",
+		"garbage token":        "not-a-real-token",
+		"token of a done scan": finished.APIToken,
+	}
+	for name, token := range cases {
+		r := httptest.NewRequest(http.MethodGet, "/api/openapi.yaml", nil)
+		r.Host = "evil.example.com"
+		if token != "" {
+			r.Header.Set("Authorization", "Bearer "+token)
+		}
+		w := httptest.NewRecorder()
+		s.Handler().ServeHTTP(w, r)
+
+		if w.Code != http.StatusUnauthorized {
+			t.Errorf("%s from a non-local host: status = %d, want %d", name, w.Code, http.StatusUnauthorized)
+		}
+		if bytes.Contains(w.Body.Bytes(), []byte("openapi:")) {
+			t.Errorf("%s from a non-local host: response leaked the spec", name)
+		}
+	}
+}
+
+// Reading the spec from the host must not require a scan bearer token: an
+// external tool discovering the API has no running scan to borrow one from.
 func TestOpenAPISpecNeedsNoBearerToken(t *testing.T) {
 	s, cleanup := newTestServer(t)
 	defer cleanup()

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -528,9 +528,10 @@ func (s *Server) Handler() http.Handler {
 	// browser's host-only boundary; see threatmodel.md.
 	root := http.NewServeMux()
 	root.Handle("/api/v1/", securityHeaders(http.StripPrefix(exportPrefix, s.exportHandler())))
-	// More specific than "/api/", so it wins the mux match and stays outside
-	// the scan-token auth apiHandler applies; see openAPISpec.
-	root.Handle("GET /api/openapi.yaml", securityHeaders(http.HandlerFunc(s.openAPISpec)))
+	// More specific than "/api/", so it wins the mux match and gets its own
+	// access rule rather than the scan-token auth apiHandler applies; see
+	// openAPISpecHandler.
+	root.Handle("GET /api/openapi.yaml", s.openAPISpecHandler())
 	root.Handle("/api/", s.apiHandler())
 	root.Handle("/", securityHeaders(mux))
 	return logRequests(s.Log, root)
@@ -3228,18 +3229,26 @@ const cspPolicy = "default-src 'self'; " +
 	"frame-ancestors 'none'; " +
 	"object-src 'none'"
 
+// localHost reports whether the request Host is the loopback name or address
+// the web server is bound to. Extracted from securityHeaders so a route can
+// distinguish "a caller on the host, no credential needed" from "a caller that
+// cannot satisfy the host check and must authenticate instead"; see
+// openAPISpecHandler.
+func localHost(host string) bool {
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		host = h
+	}
+	host = strings.Trim(host, "[]")
+	return host == "127.0.0.1" || host == "localhost" || host == "::1"
+}
+
 // securityHeaders enforces T3 mitigations: host header check to prevent DNS
 // rebinding, Sec-Fetch-Site check on POST to prevent cross-origin CSRF, and
 // a CSP that prevents stored XSS in any rendered content from executing JS.
 func securityHeaders(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Security-Policy", cspPolicy)
-		host := r.Host
-		if h, _, err := net.SplitHostPort(host); err == nil {
-			host = h
-		}
-		host = strings.Trim(host, "[]")
-		if host != "127.0.0.1" && host != "localhost" && host != "::1" {
+		if !localHost(r.Host) {
 			http.Error(w, "forbidden: invalid host", http.StatusForbidden)
 			return
 		}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -528,6 +528,9 @@ func (s *Server) Handler() http.Handler {
 	// browser's host-only boundary; see threatmodel.md.
 	root := http.NewServeMux()
 	root.Handle("/api/v1/", securityHeaders(http.StripPrefix(exportPrefix, s.exportHandler())))
+	// More specific than "/api/", so it wins the mux match and stays outside
+	// the scan-token auth apiHandler applies; see openAPISpec.
+	root.Handle("GET /api/openapi.yaml", securityHeaders(http.HandlerFunc(s.openAPISpec)))
 	root.Handle("/api/", s.apiHandler())
 	root.Handle("/", securityHeaders(mux))
 	return logRequests(s.Log, root)

--- a/openapi.go
+++ b/openapi.go
@@ -1,0 +1,13 @@
+// Package scrutineer embeds repository-root assets that ship inside the
+// binary. It holds no logic; //go:embed cannot reach a parent directory, so
+// the OpenAPI document at the repo root needs a package alongside it.
+package scrutineer
+
+import _ "embed"
+
+// OpenAPISpec is openapi.yaml, served at GET /api/openapi.yaml so a skill or
+// an external tool can read the API surface from a running server without a
+// checkout.
+//
+//go:embed openapi.yaml
+var OpenAPISpec []byte

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -30,11 +30,19 @@ paths:
       description: |
         Returns the embedded copy of `openapi.yaml`, so a skill or an external
         tool can read the API surface from a running server without a checkout.
-        Unauthenticated: a caller discovering the API has no running scan to
-        take a bearer token from. The same localhost-only host check as the
-        browser UI still applies; see threatmodel.md.
+
+        Two ways in. From localhost it is unauthenticated, because a caller
+        discovering the API has no running scan to take a bearer token from;
+        the host check is the boundary, as on the browser UI. A skill inside
+        the runner container cannot pass that check -- it reaches the server
+        through the egress proxy on the host endpoint `api_base` advertises,
+        which forwards the original `Host` -- so it authenticates with the
+        per-scan bearer token it already holds for the rest of this API.
+        See threatmodel.md.
       operationId: getOpenAPISpec
-      security: []
+      security:
+        - {}
+        - bearerAuth: []
       responses:
         "200":
           description: The OpenAPI document
@@ -42,8 +50,10 @@ paths:
             application/yaml:
               schema:
                 type: string
-        "403":
-          description: Request did not come from localhost
+        "401":
+          description: |
+            Request came from a non-local host without a bearer token
+            belonging to a currently running scan
   /claim-check:
     servers:
       - url: http://127.0.0.1:8080

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: Scrutineer Skill API
-  version: 0.3.0
+  version: 0.4.0
   description: |
     A narrow HTTP surface that claude-code skills use while they run. The
     goal is enough to let a skill orchestrate other skills and read prior
@@ -24,6 +24,26 @@ security:
   - bearerAuth: []
 
 paths:
+  /openapi.yaml:
+    get:
+      summary: Fetch this OpenAPI document
+      description: |
+        Returns the embedded copy of `openapi.yaml`, so a skill or an external
+        tool can read the API surface from a running server without a checkout.
+        Unauthenticated: a caller discovering the API has no running scan to
+        take a bearer token from. The same localhost-only host check as the
+        browser UI still applies; see threatmodel.md.
+      operationId: getOpenAPISpec
+      security: []
+      responses:
+        "200":
+          description: The OpenAPI document
+          content:
+            application/yaml:
+              schema:
+                type: string
+        "403":
+          description: Request did not come from localhost
   /claim-check:
     servers:
       - url: http://127.0.0.1:8080


### PR DESCRIPTION
Fixes #731.

Embeds the repo-root `openapi.yaml` and serves it from a running server, so a skill or an external tool can read the API surface without a checkout.

## Where it is registered, and why not in `apiHandler`

`apiHandler` wraps every route in `apiAuth`, which only accepts a bearer token belonging to a **currently running scan**. A tool discovering the API has no scan to take a token from, so mounting the spec there would have defeated the point of serving it — the first version of the test showed exactly that, a `401` on `GET /api/openapi.yaml`.

So it is registered on the root mux as `GET /api/openapi.yaml`, which is more specific than the existing `"/api/"` pattern and therefore wins the match. It is wrapped in `securityHeaders`, so it keeps the **localhost-only host check** the browser UI and the `/api/v1` export surface rely on. Reading it is unauthenticated, which discloses nothing new: the document is already public in this repository. This mirrors how `/claim-check` sits on the root mux while still being documented in the spec.

## The embed needed a root package

`//go:embed` cannot reach a parent directory, and `openapi.yaml` lives at the repo root while the server is in `internal/web`. Rather than move the file — which would break the `../../openapi.yaml` read in the new coverage test from #751, plus docs references — this adds a tiny root package (`openapi.go`, `package scrutineer`) that embeds it and exposes `OpenAPISpec`.

## Spec and coverage test

- Documented the new path in `openapi.yaml` with `security: []`, and bumped `info.version` to `0.4.0`. The server base is `/api`, so the path key `/openapi.yaml` resolves to `/api/openapi.yaml`.
- Added the route to `registeredOpenAPIRoutes` in the #751 coverage test, next to the existing `/claim-check` entry, since root-mux registrations are not auto-discovered from `apiHandler`/`exportHandler`.

## Tests

Written against the unfixed code first and confirmed failing (`401`/`403` mismatch), then passing:

- `TestOpenAPISpecServedOverHTTP` — 200, `Content-Type: application/yaml`, parses as YAML, documents its own path.
- `TestOpenAPISpecMatchesRepoFile` — served bytes are identical to `openapi.yaml` on disk, so a stale embed cannot silently serve a spec that disagrees with the repo.
- `TestOpenAPISpecRejectsNonLocalHost` — a non-local `Host` still gets 403.
- `TestOpenAPISpecNeedsNoBearerToken` — pins the reason it is not behind `apiAuth`.

`go build ./...`, `go vet ./...` and the full `go test ./internal/web` suite pass locally.

Happy to move it behind `apiAuth` or change the content type if you would rather have it a different way.