### PR TITLE
Reject a labels body with no array instead of clearing all labels

### DIFF
--- a/internal/web/api_finding_writes.go
+++ b/internal/web/api_finding_writes.go
@@ -160,6 +160,14 @@ func (s *Server) apiSetFindingLabels(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
+	// {} and {"labels": null} both decode to a nil slice, which
+	// SetFindingLabels would apply as an intentional replacement with the
+	// empty set: a malformed body would silently wipe analyst-set labels and
+	// still answer 204. An explicit [] stays the way to clear (#710).
+	if body.Labels == nil {
+		writeAPIError(w, http.StatusBadRequest, "body must be JSON with a labels array")
+		return
+	}
 	if err := db.SetFindingLabels(s.DB, id, body.Labels); err != nil {
 		writeAPIError(w, http.StatusInternalServerError, err.Error())
 		return

--- a/internal/web/api_finding_writes.go
+++ b/internal/web/api_finding_writes.go
@@ -163,7 +163,9 @@ func (s *Server) apiSetFindingLabels(w http.ResponseWriter, r *http.Request) {
 	// {} and {"labels": null} both decode to a nil slice, which
 	// SetFindingLabels would apply as an intentional replacement with the
 	// empty set: a malformed body would silently wipe analyst-set labels and
-	// still answer 204. An explicit [] stays the way to clear (#710).
+	// still answer 204. Clearing stays available to callers that ask for it
+	// with a present array — an explicit [], or one whose names are all
+	// blank, since SetFindingLabels trims and skips blank names (#710).
 	if body.Labels == nil {
 		writeAPIError(w, http.StatusBadRequest, "body must be JSON with a labels array")
 		return

--- a/internal/web/api_finding_writes_test.go
+++ b/internal/web/api_finding_writes_test.go
@@ -263,6 +263,43 @@ func TestAPISetFindingLabels(t *testing.T) {
 	}
 }
 
+// A body that omits labels, or sends null, must not be read as "replace with
+// the empty set": that let a malformed request silently wipe analyst-set
+// labels and still answer 204 (#710). Only an explicit [] clears.
+func TestAPISetFindingLabels_rejectsMissingLabelsArray(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	f, tok, _ := seedFindingForAPI(t, s)
+	path := fmt.Sprintf("/api/findings/%d/labels", f.ID)
+
+	if w := apiReq(t, s, "PUT", path, tok, `{"labels":["wontfix","needs-info"]}`); w.Code != http.StatusNoContent {
+		t.Fatalf("seed labels: status = %d, want 204; body=%s", w.Code, w.Body)
+	}
+
+	for _, body := range []string{`{}`, `{"labels":null}`, `{"other":"field"}`} {
+		w := apiReq(t, s, "PUT", path, tok, body)
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("PUT %s: status = %d, want 400", body, w.Code)
+		}
+		var got db.Finding
+		s.DB.Preload("Labels").First(&got, f.ID)
+		if len(got.Labels) != 2 {
+			t.Errorf("PUT %s cleared labels: have %d, want the 2 already set", body, len(got.Labels))
+		}
+	}
+
+	// The explicit clear-all still works, so the fix does not cost the caller
+	// the one way it had to empty the set.
+	if w := apiReq(t, s, "PUT", path, tok, `{"labels":[]}`); w.Code != http.StatusNoContent {
+		t.Fatalf("explicit clear: status = %d, want 204; body=%s", w.Code, w.Body)
+	}
+	var got db.Finding
+	s.DB.Preload("Labels").First(&got, f.ID)
+	if len(got.Labels) != 0 {
+		t.Errorf("labels after explicit clear = %+v, want 0", got.Labels)
+	}
+}
+
 func TestAPIListFindingHistory(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()

--- a/internal/web/api_finding_writes_test.go
+++ b/internal/web/api_finding_writes_test.go
@@ -265,7 +265,7 @@ func TestAPISetFindingLabels(t *testing.T) {
 
 // A body that omits labels, or sends null, must not be read as "replace with
 // the empty set": that let a malformed request silently wipe analyst-set
-// labels and still answer 204 (#710). Only an explicit [] clears.
+// labels and still answer 204 (#710). A present array still clears.
 func TestAPISetFindingLabels_rejectsMissingLabelsArray(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()
@@ -297,6 +297,51 @@ func TestAPISetFindingLabels_rejectsMissingLabelsArray(t *testing.T) {
 	s.DB.Preload("Labels").First(&got, f.ID)
 	if len(got.Labels) != 0 {
 		t.Errorf("labels after explicit clear = %+v, want 0", got.Labels)
+	}
+}
+
+// Blank and whitespace-only names are trimmed and skipped by
+// db.SetFindingLabels, so an array of nothing but blanks reaches the
+// association layer as the empty set and clears the finding. That is existing
+// behaviour and #710 deliberately leaves it alone; it is pinned here so the
+// handler comment and the OpenAPI description cannot drift away from what the
+// code actually does.
+func TestAPISetFindingLabels_blankNamesAreIgnored(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	f, tok, _ := seedFindingForAPI(t, s)
+	path := fmt.Sprintf("/api/findings/%d/labels", f.ID)
+
+	seed := func(t *testing.T) {
+		t.Helper()
+		if w := apiReq(t, s, "PUT", path, tok, `{"labels":["wontfix","needs-info"]}`); w.Code != http.StatusNoContent {
+			t.Fatalf("seed labels: status = %d, want 204; body=%s", w.Code, w.Body)
+		}
+	}
+
+	for _, body := range []string{`{"labels":[""]}`, `{"labels":[" "]}`, `{"labels":["  ","\t"]}`} {
+		seed(t)
+		w := apiReq(t, s, "PUT", path, tok, body)
+		if w.Code != http.StatusNoContent {
+			t.Errorf("PUT %s: status = %d, want 204", body, w.Code)
+		}
+		var got db.Finding
+		s.DB.Preload("Labels").First(&got, f.ID)
+		if len(got.Labels) != 0 {
+			t.Errorf("PUT %s: labels = %+v, want the blank names ignored and the set cleared", body, got.Labels)
+		}
+	}
+
+	// A blank name alongside a real one is dropped without taking the real
+	// one with it, so this is a trim-and-skip rule and not "any blank clears".
+	seed(t)
+	if w := apiReq(t, s, "PUT", path, tok, `{"labels":[" ","triage"]}`); w.Code != http.StatusNoContent {
+		t.Fatalf("mixed blank and real: status = %d, want 204; body=%s", w.Code, w.Body)
+	}
+	var got db.Finding
+	s.DB.Preload("Labels").First(&got, f.ID)
+	if len(got.Labels) != 1 || got.Labels[0].Name != "triage" {
+		t.Errorf("labels = %+v, want only triage", got.Labels)
 	}
 }
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -720,9 +720,11 @@ paths:
                   items: { type: string }
                   description: |
                     Label names, replacing the finding's current set. Missing
-                    labels are created on demand. Send `[]` to clear every
-                    label; the field is required, so omitting it or sending
-                    null is rejected rather than treated as a clear-all.
+                    labels are created on demand. Blank and whitespace-only
+                    names are trimmed and ignored, so a request whose names are
+                    all blank clears every label just as `[]` does. The field
+                    itself is required: omitting it or sending null is rejected
+                    rather than treated as a clear-all.
       responses:
         '204': { description: Updated }
         '400':

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -718,9 +718,18 @@ paths:
                 labels:
                   type: array
                   items: { type: string }
-                  description: Label names. Missing labels are created on demand.
+                  description: |
+                    Label names, replacing the finding's current set. Missing
+                    labels are created on demand. Send `[]` to clear every
+                    label; the field is required, so omitting it or sending
+                    null is rejected rather than treated as a clear-all.
       responses:
         '204': { description: Updated }
+        '400':
+          description: Body is not valid JSON, or has no labels array
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
 
   /findings/{id}/history:
     get:


### PR DESCRIPTION
Fixes #710.

`PUT /api/findings/{id}/labels` decoded `{}` and `{"labels": null}` to a nil slice and passed it straight to `db.SetFindingLabels`, which replaces the finding's label set with whatever it receives. So a malformed body wiped every analyst-set label **and answered 204** — the client bug looked like a successful update.

Scoped to exactly what @andrew laid out in the issue thread:

- Reject `body.Labels == nil` with **400**, reusing the decoder's existing `"body must be JSON with a labels array"` message.
- `{"labels": []}` still clears, so callers keep the deliberate way to empty the set.
- **Blank-label handling left alone** — `SetFindingLabels` trimming and skipping blanks is forgiving-input behaviour and out of scope, as you said.

**The browser UI is unaffected.** Its "Save labels" form posts to `/findings/{id}/labels` and is served by `finding_forms.go`, not this JSON endpoint, so unchecking every box still clears as before. Worth stating explicitly since "reject the empty case" could plausibly have broken the one UI path that legitimately sends nothing.

**Verification.** `TestAPISetFindingLabels_rejectsMissingLabelsArray` seeds two labels, then sends `{}`, `{"labels":null}` and `{"other":"field"}`, asserting 400 *and* that the two labels survive — the silent data loss is the actual bug, so the test pins the data, not just the status. It ends by confirming the explicit `[]` clear-all still returns 204 and empties the set. Run against the unfixed handler first, it fails with the reported symptom on all three:

```
--- FAIL: TestAPISetFindingLabels_rejectsMissingLabelsArray
    PUT {}: status = 204, want 400
    PUT {} cleared labels: have 0, want the 2 already set
    PUT {"labels":null}: status = 204, want 400
    PUT {"labels":null} cleared labels: have 0, want the 2 already set
    PUT {"other":"field"}: status = 204, want 400
    PUT {"other":"field"} cleared labels: have 0, want the 2 already set
```

Also documented the 400 in `openapi.yaml` and made the `labels` description state that `[]` is the clear-all and that omitting the field is rejected — it previously only said "Missing labels are created on demand", which reads as being about label rows, not the field.

`go build ./...`, `go vet ./...`, and the full `go test ./internal/web ./internal/db` all pass.
