### PR TITLE
Buffer template rendering before writing HTTP responses

### DIFF
--- a/internal/web/render_test.go
+++ b/internal/web/render_test.go
@@ -1,0 +1,98 @@
+package web
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// A template error raised after some output has already been produced must
+// still yield a clean 500. Executing straight into the ResponseWriter commits
+// a 200 plus the partial HTML before the error is known, so the http.Error
+// that follows cannot change the status and only appends plain text to a
+// half-rendered page (#573).
+func TestRenderTemplateErrorAfterPartialOutput(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	const marker = "PARTIAL-OUTPUT-MARKER"
+	_, err := s.tmpl.New("boom_test.html").
+		Funcs(map[string]any{
+			"boom": func() (string, error) { return "", errors.New("boom") },
+		}).
+		// The padding matters: bufio in net/http only flushes to the recorder
+		// once enough bytes accumulate, so a short prefix could pass by luck
+		// rather than because the fix works.
+		Parse(`<!doctype html><title>t</title><div>` + marker +
+			strings.Repeat("x", 8<<10) + `</div>{{ boom }}`)
+	if err != nil {
+		t.Fatalf("parse test template: %v", err)
+	}
+
+	w := httptest.NewRecorder()
+	s.render(w, localReq("GET", "/"), "boom_test.html", nil)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500", w.Code)
+	}
+	if got := w.Body.String(); strings.Contains(got, marker) {
+		t.Errorf("response carries partially rendered HTML; body starts: %q", got[:min(len(got), 120)])
+	}
+	if ct := w.Header().Get("Content-Type"); strings.Contains(ct, "text/html") {
+		t.Errorf("Content-Type = %q, want the plain-text error type, not HTML", ct)
+	}
+}
+
+// The success path is unchanged apart from now being able to declare its
+// length, since the whole body is known before anything is written.
+func TestRenderSuccessSetsHTMLHeaders(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	const body = "<!doctype html><title>ok</title><p>hello</p>"
+	if _, err := s.tmpl.New("ok_test.html").Parse(body); err != nil {
+		t.Fatalf("parse test template: %v", err)
+	}
+
+	w := httptest.NewRecorder()
+	s.render(w, localReq("GET", "/"), "ok_test.html", nil)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	if got := w.Body.String(); got != body {
+		t.Errorf("body = %q, want %q", got, body)
+	}
+	if ct := w.Header().Get("Content-Type"); ct != "text/html; charset=utf-8" {
+		t.Errorf("Content-Type = %q", ct)
+	}
+	if cl := w.Header().Get("Content-Length"); cl != strconv.Itoa(len(body)) {
+		t.Errorf("Content-Length = %q, want %d", cl, len(body))
+	}
+}
+
+// Buffers are pooled and reused, so a large page must not leave its bytes
+// visible to the next render.
+func TestRenderPooledBufferDoesNotLeakBetweenPages(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	const leak = "LEAK-FROM-FIRST-PAGE"
+	if _, err := s.tmpl.New("big_test.html").Parse(leak + strings.Repeat("y", 4<<10)); err != nil {
+		t.Fatalf("parse big template: %v", err)
+	}
+	if _, err := s.tmpl.New("small_test.html").Parse("small"); err != nil {
+		t.Fatalf("parse small template: %v", err)
+	}
+
+	s.render(httptest.NewRecorder(), localReq("GET", "/"), "big_test.html", nil)
+
+	w := httptest.NewRecorder()
+	s.render(w, localReq("GET", "/"), "small_test.html", nil)
+	if got := w.Body.String(); got != "small" {
+		t.Errorf("body = %q, want %q — pooled buffer was not reset", got, "small")
+	}
+}

--- a/internal/web/render_test.go
+++ b/internal/web/render_test.go
@@ -23,11 +23,7 @@ func TestRenderTemplateErrorAfterPartialOutput(t *testing.T) {
 		Funcs(map[string]any{
 			"boom": func() (string, error) { return "", errors.New("boom") },
 		}).
-		// The padding matters: bufio in net/http only flushes to the recorder
-		// once enough bytes accumulate, so a short prefix could pass by luck
-		// rather than because the fix works.
-		Parse(`<!doctype html><title>t</title><div>` + marker +
-			strings.Repeat("x", 8<<10) + `</div>{{ boom }}`)
+		Parse(`<!doctype html><title>t</title><div>` + marker + `</div>{{ boom }}`)
 	if err != nil {
 		t.Fatalf("parse test template: %v", err)
 	}
@@ -74,25 +70,39 @@ func TestRenderSuccessSetsHTMLHeaders(t *testing.T) {
 	}
 }
 
-// Buffers are pooled and reused, so a large page must not leave its bytes
-// visible to the next render.
-func TestRenderPooledBufferDoesNotLeakBetweenPages(t *testing.T) {
+// Buffers are pooled and a failed render hands its buffer back with the
+// partial page still in it, so the reset in render() is what stops that page
+// reaching the next request. Success alone cannot show this: WriteTo drains
+// the buffer on its way out, so a success-then-success pair leaves nothing to
+// leak either way.
+func TestRenderPooledBufferDoesNotLeakFailedPageIntoNextRender(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()
 
-	const leak = "LEAK-FROM-FIRST-PAGE"
-	if _, err := s.tmpl.New("big_test.html").Parse(leak + strings.Repeat("y", 4<<10)); err != nil {
-		t.Fatalf("parse big template: %v", err)
+	const leak = "LEAK-FROM-FAILED-PAGE"
+	if _, err := s.tmpl.New("leak_boom_test.html").
+		Funcs(map[string]any{
+			"boom": func() (string, error) { return "", errors.New("boom") },
+		}).
+		Parse(leak + strings.Repeat("y", 4<<10) + `{{ boom }}`); err != nil {
+		t.Fatalf("parse failing template: %v", err)
 	}
-	if _, err := s.tmpl.New("small_test.html").Parse("small"); err != nil {
+	if _, err := s.tmpl.New("leak_small_test.html").Parse("small"); err != nil {
 		t.Fatalf("parse small template: %v", err)
 	}
 
-	s.render(httptest.NewRecorder(), localReq("GET", "/"), "big_test.html", nil)
+	s.render(httptest.NewRecorder(), localReq("GET", "/"), "leak_boom_test.html", nil)
 
 	w := httptest.NewRecorder()
-	s.render(w, localReq("GET", "/"), "small_test.html", nil)
+	s.render(w, localReq("GET", "/"), "leak_small_test.html", nil)
+
 	if got := w.Body.String(); got != "small" {
-		t.Errorf("body = %q, want %q — pooled buffer was not reset", got, "small")
+		t.Errorf("body = %q, want %q — the failed render's buffer reached the next request",
+			got[:min(len(got), 80)], "small")
+	}
+	// The leak is served as a well-formed response rather than a truncated
+	// one, so nothing downstream would flag it.
+	if cl := w.Header().Get("Content-Length"); cl != strconv.Itoa(len("small")) {
+		t.Errorf("Content-Length = %q, want %d", cl, len("small"))
 	}
 }

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -1,6 +1,7 @@
 package web
 
 import (
+	"bytes"
 	"context"
 	"embed"
 	"encoding/base64"
@@ -565,12 +566,44 @@ func (s *Server) render(w http.ResponseWriter, r *http.Request, name string, dat
 		sorterQuery.Set("sort", eff)
 	}
 	data["Sorter"] = sortCtx{path: r.URL.Path, query: sorterQuery}
-	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	if err := s.tmpl.ExecuteTemplate(w, name, data); err != nil {
+	// Render into a buffer first. ExecuteTemplate writes incrementally, so
+	// executing straight into the ResponseWriter commits a 200 and part of the
+	// page before a mid-template error is known; the http.Error below then
+	// cannot change the status and only appends plain text to half-rendered
+	// HTML. Buffering keeps the failure path able to send a clean 500.
+	buf := renderBufPool.Get().(*bytes.Buffer)
+	buf.Reset()
+	defer func() {
+		// One outsized page (a long findings list) would otherwise pin its
+		// capacity in the pool for the process lifetime, so oversized buffers
+		// are dropped instead of recycled.
+		if buf.Cap() <= maxPooledRenderBuf {
+			renderBufPool.Put(buf)
+		}
+	}()
+
+	if err := s.tmpl.ExecuteTemplate(buf, name, data); err != nil {
 		s.Log.Error("render", "tmpl", name, "err", err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.Header().Set("Content-Length", strconv.Itoa(buf.Len()))
+	if _, err := buf.WriteTo(w); err != nil {
+		// Headers and status are already sent, so this can only be logged:
+		// the client hung up or the connection broke mid-write.
+		s.Log.Error("render write", "tmpl", name, "err", err)
 	}
 }
+
+// render() runs on every page load, so the buffers are pooled rather than
+// allocated per request.
+var renderBufPool = sync.Pool{
+	New: func() any { return new(bytes.Buffer) },
+}
+
+// Buffers larger than this are dropped rather than returned to the pool.
+const maxPooledRenderBuf = 1 << 20
 
 // Flash is a one-shot message carried across a redirect via the "flash"
 // cookie and rendered server-side into #toaster on the next page load.


### PR DESCRIPTION
Closes #573.

`render()` executed the template straight into the `ResponseWriter`. Because `ExecuteTemplate` writes incrementally, a mid-template error arrives after the 200 and part of the page are already committed — the `http.Error` that follows can't change the status and only appends plain text to half-rendered HTML.

Built to the approach you laid out in the issue: a `sync.Pool` of `*bytes.Buffer`, reset on Get, execute into it, and only on success set the headers and `WriteTo(w)`; on error, log and `http.Error` exactly as before, with nothing written yet.

**Verified against the unfixed code first**, so this states a fact rather than a hunch — on `main` the new test reports:

```
render_test.go:35: status = 200, want 500
render_test.go:38: response carries partially rendered HTML; body starts:
    "<!doctype html><title>t</title><div>PARTIAL-OUTPUT-MARKER</div>template: boom_test.html:1:66: ..."
```

Three tests: the error-after-partial-output case, the success path, and one that drives a **failed** render and then a successful one, to prove the failed page can't reach the next request out of the pool.

_Updated after review (c793677, tests only)._ The pooled-buffer test originally went success -> success, which asserts nothing: `WriteTo` drains the buffer as it writes, so that pair passes with `buf.Reset()` deleted — as it did. The reset is load-bearing on the **error** path, where the failed render returns its buffer to the pool with the partial page still in it; without the reset the next request is served 4122 bytes of the previous page under a matching `Content-Length`. The test now drives that path and fails on exactly it. I also dropped the 8 KiB of padding in the error test: the comment credited `net/http`'s buffering, but `render()` writes to an `httptest.ResponseRecorder`, whose `Write` appends straight to `Body` — no `bufio` in the path. Unpadded, the test still fails on pre-fix `render()` with `status = 200` and the marker in the body.

Two things I added beyond the issue, both easy to drop if you'd rather not have them:

- **Oversized buffers are dropped instead of recycled** (`maxPooledRenderBuf`, 1 MiB). Without it one long findings list pins that capacity in the pool for the process lifetime.
- **`Content-Length` is now set**, since buffering means the whole body is known before the first write. This is the one externally visible change: responses that were previously chunked now carry a length.

`render()` is the only place that changes; as you noted, the SSE endpoints don't go through it, so there's no streaming to preserve. `go build ./...`, `go vet`, `gofmt` and the full `internal/web` suite pass locally.

