### PR TITLE
Add reference-driven deep-dive prompt A/B experiment

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -24,6 +24,9 @@ Each scenario YAML names:
   output contract.
 - `experiment` and `variant`: optional paired identifiers used to compare
   multiple prompt variants over the same fixture set. Set both or neither.
+  Every variant must use byte-for-byte identical `given:` text and semantically
+  identical assertions for each fixture; the order of `should_find` and
+  `should_not_find` entries does not matter.
 - `should_find`: required findings the report must include.
 - `should_not_find`: false positives the report must not include.
 - `must_not_contain`: repo-level terms that must not appear anywhere in the

--- a/evals/README.md
+++ b/evals/README.md
@@ -22,6 +22,8 @@ Each scenario YAML names:
 - `schema_skill`: optional bundled skill whose JSON schema should validate the
   report. Use this for eval-only prompt variants that must keep the production
   output contract.
+- `experiment` and `variant`: optional paired identifiers used to compare
+  multiple prompt variants over the same fixture set. Set both or neither.
 - `should_find`: required findings the report must include.
 - `should_not_find`: false positives the report must not include.
 - `must_not_contain`: repo-level terms that must not appear anywhere in the
@@ -32,6 +34,15 @@ also point at an eval-only variant in `evals/skills/<name>/SKILL.md`; this keeps
 prompt experiments out of the production skill set while still letting the same
 fixture harness compare them. Pair those variants with `schema_skill` when the
 variant should emit the same report shape as a production skill.
+
+Live runs print an aggregate line for every `experiment`/`variant` pair after
+the per-scenario results. The aggregate includes scenario passes, runner
+errors, assertion misses, unexpected findings, turns, tokens, and cost. Use the
+same model and the same paired fixtures in one invocation so the production
+baseline and candidate are directly comparable. For example, the
+`security-deep-dive-prompt` experiment compares `production` with
+`reference-driven`; the latter keeps intent and phase order in `SKILL.md` and
+loads sink taxonomy and report policy from `references/` when needed.
 
 Each `should_find` or `should_not_find` assertion may include
 `evidence_contains`:

--- a/evals/security-deep-dive-auth-omission.yaml
+++ b/evals/security-deep-dive-auth-omission.yaml
@@ -1,6 +1,8 @@
 given: an optional session cookie skips validation while an account endpoint still returns protected data
 fixture: fixtures/auth-omission
 skill: security-deep-dive
+experiment: security-deep-dive-prompt
+variant: production
 should_find:
   - finding: session
     cwe: CWE-306

--- a/evals/security-deep-dive-mass-assignment.yaml
+++ b/evals/security-deep-dive-mass-assignment.yaml
@@ -1,6 +1,8 @@
 given: a member endpoint bulk-copies a JSON body containing server-owned fields into an account
 fixture: fixtures/mass-assignment-basic
 skill: security-deep-dive
+experiment: security-deep-dive-prompt
+variant: production
 should_find:
   - finding: mass assignment
     cwe: CWE-915

--- a/evals/security-deep-dive-short-auth-omission.yaml
+++ b/evals/security-deep-dive-short-auth-omission.yaml
@@ -2,6 +2,8 @@ given: an optional session cookie skips validation while an account endpoint sti
 fixture: fixtures/auth-omission
 skill: security-deep-dive-short
 schema_skill: security-deep-dive
+experiment: security-deep-dive-prompt
+variant: reference-driven
 should_find:
   - finding: session
     cwe: CWE-306

--- a/evals/security-deep-dive-short-mass-assignment.yaml
+++ b/evals/security-deep-dive-short-mass-assignment.yaml
@@ -2,6 +2,8 @@ given: a member endpoint bulk-copies a JSON body containing server-owned fields 
 fixture: fixtures/mass-assignment-basic
 skill: security-deep-dive-short
 schema_skill: security-deep-dive
+experiment: security-deep-dive-prompt
+variant: reference-driven
 should_find:
   - finding: mass assignment
     cwe: CWE-915

--- a/evals/security-deep-dive-short-sqli.yaml
+++ b/evals/security-deep-dive-short-sqli.yaml
@@ -2,6 +2,8 @@ given: a Flask handler concatenates user input into a SQL string
 fixture: fixtures/sqli-basic
 skill: security-deep-dive-short
 schema_skill: security-deep-dive
+experiment: security-deep-dive-prompt
+variant: reference-driven
 should_find:
   - finding: SQL injection in buildQuery
     severity: High

--- a/evals/security-deep-dive-sqli.yaml
+++ b/evals/security-deep-dive-sqli.yaml
@@ -1,6 +1,8 @@
 given: a Flask handler concatenates user input into a SQL string
 fixture: fixtures/sqli-basic
 skill: security-deep-dive
+experiment: security-deep-dive-prompt
+variant: production
 should_find:
   - finding: SQL injection in buildQuery
     severity: High

--- a/evals/skills/security-deep-dive-short/SKILL.md
+++ b/evals/skills/security-deep-dive-short/SKILL.md
@@ -31,29 +31,14 @@ If an API call fails or returns no useful data, continue from local code.
 ## Method
 
 1. Identify trust boundaries. Prefer `./threat_model.json` when present. Otherwise use the latest threat-model scan. Copy its components, adversaries, trust boundaries, entry points, provenance, and sources into your reasoning. Treat `provenance: "documented"` as a cited fact and `provenance: "inferred"` as a hypothesis to verify. If no threat model exists, derive boundaries from public inputs: APIs, CLIs, file formats, IPC, network listeners, webhooks, plugins, package consumers, configuration, environment, queues, schedulers, and generated or user-supplied artifacts.
-2. Inventory dangerous sinks before judging them. Include code execution, command execution, deserialization, parser and decoder entry points, archive extraction, filesystem writes, path resolution, network SSRF targets, templating, SQL and query construction, authz/authn decisions, cryptography, secrets handling, logging, update/install flows, CI/workflow execution, and parser/resource-exhaustion surfaces.
+2. Inventory dangerous sinks before judging them. Derive language-specific primitives first. Consult `references/sink-taxonomy.md` when planning that sweep or when a candidate does not fit an obvious class; do not turn the taxonomy into a pattern-matching checklist.
 3. For every sink, trace attacker-controlled data from the named boundary to the sink. A library sink can be reachable through documented public API use, CLI input, plugin loading, file-format parsing, or an installed downstream gadget; it does not need a hosted service.
 4. Decide whether existing validation, escaping, allow-lists, sandboxing, capability checks, or type constraints remove exploitability. Do not assume safety from comments alone.
 5. Check prior art and reach. Use existing advisories, packages, dependents, and local documentation to distinguish new findings from known issues and to rate real exposure.
 6. Report only high-confidence reachable findings. Consolidate the same root cause at the same sink and boundary into one finding. If the same sink is reachable through materially different boundaries or impacts, split it.
 
-## Report Contract
+## Finish
 
-`boundaries[]` should name each actor/boundary, whether it is trusted, the controls relied on, and the source. If a threat-model report exists, fill these from that report rather than inventing new labels.
+Before writing the final report, read `references/report-contract.md`. Build the report from the completed inventory and dispositions, not from whichever candidates were most memorable. Every inventory id must resolve to a finding or ruled-out entry, and the method counts must agree with those arrays.
 
-`inventory[]` is part of the result, not scratch. Each entry needs a stable `id`, `location` as `path:line` when possible, a sink `class`, the `boundary`, and what it consumes.
-
-For each real finding:
-
-- Use `reachability: "reachable"` and `quality_tier: "high"` only when the trace is concrete.
-- Include `sinks` pointing to inventory ids.
-- Use `location` as `path:line` and keep paths repository-relative.
-- In `trace`, name the source, data path, sink, and missing control.
-- In `boundary`, state which trust boundary is crossed.
-- In `validation`, cite the code or behaviour that proves exploitability.
-- In `rating`, explain severity and preconditions.
-- Use `artifacts` as short evidence strings like `path:line command/result`.
-
-For rejected candidates, add `ruled_out[]` entries with `sinks`, `step`, and a disposition-style `reason`: `not_reachable`, `validated`, `out_of_scope`, `duplicate`, `dependency_only`, `known_wontfix`, `insufficient_evidence`, or `expected_safe_behavior`. This vocabulary is consumed by the threat workbench.
-
-If nothing is found, still include the boundaries, inventory, method counts, and ruled-out entries for the sinks inspected. Do not omit required schema fields.
+Write `./report.json`, then use the validation endpoint described in the activation prompt. Repair every schema or reconciliation error before finishing. A clean audit still includes boundaries, inventory, method counts, and ruled-out dispositions; only `findings` is empty.

--- a/evals/skills/security-deep-dive-short/references/report-contract.md
+++ b/evals/skills/security-deep-dive-short/references/report-contract.md
@@ -1,0 +1,40 @@
+# Deep-dive report contract
+
+`schema.json` is authoritative for field types and required fields. This reference covers the semantic rules that JSON Schema cannot express.
+
+## Identity and scope
+
+- Set `repository` from `context.json`'s repository URL, `commit` from `git -C ./src rev-parse HEAD`, `spec_version` to `13`, and `date` to today.
+- Keep every location repository-relative, or relative to `scan_subpath` when one is set. Use `path:line` when a line is known.
+- Describe the actual source-tree or diff scope in `method.scope`. Do not claim coverage outside a focus area, scan subpath, or diff rescan.
+- Populate `boundaries` from the supplied threat model when available. Preserve its labels, provenance, and source instead of inventing replacements.
+
+## Inventory reconciliation
+
+- Give every inventory entry a unique stable id, location, class, boundary, and consumed value.
+- Every inventory id must appear exactly once by disposition: referenced by a real finding or by a `ruled_out` entry. Resolve gaps before writing the report.
+- `method.inventory_count` equals the number of inventory entries. `method.ruled_out_count` equals the number of inventory sink ids assigned to `ruled_out`, not the number of grouped ruled-out entries. `method.unresolved_count` must be zero in a completed report.
+- Record search commands and hit counts in `method.grep_patterns` when the schema requests them. A raw source hit excluded as a comment, fixture, generated file, or third-party code needs its location and reason.
+- When combining subagent output, union all slices and deduplicate only identical location/class/boundary entries. Different boundaries at one source location remain distinct.
+
+## Findings
+
+Report only concrete, high-signal vulnerabilities:
+
+- `reachability` is `reachable`; `quality_tier` is `high`.
+- `sinks` references the applicable inventory ids.
+- `trace` names the attacker-controlled source, data path, sink, and missing control.
+- `boundary` names the crossed trust boundary.
+- `validation` contains reproducible evidence, including commands or scripts and their output when execution is practical.
+- `rating` explains severity, impact, and preconditions.
+- `dup_check` states which existing or sibling findings were compared.
+- `discovered_via` records the first useful source: `source`, `issue-tracker`, `advisory`, or `documentation`.
+- `artifacts` contains short evidence strings such as `path:line command/result`.
+
+Consolidate one root cause at one sink and boundary into one finding. Split only when boundaries or impacts are materially different.
+
+## Ruled out
+
+Each rejected candidate identifies its sink ids, the audit step that rejected it, and a specific reason with code or threat-model evidence. Prefer the vocabulary consumed by the threat workbench: `not_reachable`, `validated`, `out_of_scope`, `duplicate`, `dependency_only`, `known_wontfix`, `insufficient_evidence`, or `expected_safe_behavior`. When a loaded threat model supplies a more specific disposition label, preserve that label and cite its source.
+
+A clean audit uses `findings: []`; it does not omit boundaries, inventory, method evidence, or ruled-out entries.

--- a/evals/skills/security-deep-dive-short/references/sink-taxonomy.md
+++ b/evals/skills/security-deep-dive-short/references/sink-taxonomy.md
@@ -1,0 +1,40 @@
+# Sink taxonomy
+
+Use this reference to plan language-specific searches and classify ambiguous candidates. Start from the repository's language and framework primitives; the classes below are coverage prompts, not evidence that a matching call is vulnerable.
+
+## Execution and interpretation
+
+- Code execution: eval, dynamic dispatch, reflection to callables, computed module loading, executable regex features.
+- Command execution: shell invocation and process arguments assembled by concatenation.
+- Template and interpolation: unescaped data crossing into HTML, SQL, shell, regex, format strings, or log records.
+- Deserialization: parsers that instantiate types, invoke constructors, or restore executable state.
+- Agentic execution: untrusted content entering privileged model roles, tool definitions, tool arguments, or outputs consumed by an agent with broader capabilities.
+
+## Files, formats, and networks
+
+- Computed file reads, writes, deletes, links, permissions, imports, and module paths.
+- Temporary files with predictable names, unsafe permissions, symlink following, or check/use gaps.
+- Path normalization and containment decisions, including traversal, symlinks, and case folding.
+- Archive extraction where entry names become filesystem paths.
+- Hand-written and specialized parsers, decoders, configuration readers, protocol readers, and regex extractors. Check ambiguity, partial interpretation, and input-controlled work or allocation.
+- Round trips such as parse/serialize, encode/decode, escape/unescape, and marshal/unmarshal. Check whether stored and reparsed values change meaning.
+- Computed network targets, redirects, DNS resolution, proxy handling, and disabled TLS verification.
+
+## Security decisions and state
+
+- Authentication, authorization, session, CSRF, credential, rate-limit, and lockout decisions. Inspect absent, null, and empty security inputs and verify the protected operation fails closed.
+- Object-level authorization when authenticated actors can select records by external identifiers.
+- Bulk-bound request bodies that can copy server-owned fields such as tenant, owner, role, permission, workflow state, security flags, price, or balance. Shape validation is not field authorization.
+- Public validation predicates whose dangerous outcome is returning the wrong answer.
+- Cryptographic key derivation, nonce/IV handling, modes, padding, MAC verification, and secret comparison.
+- Secret handling and logging where sensitive values cross storage, telemetry, model, or response boundaries.
+- Shared mutable state, global hooks, registries, caches, environment mutation, and caller-visible metaprogramming.
+- Check-then-act races across threads, processes, filesystems, or external state.
+
+## Native and resource safety
+
+- Unsafe memory operations, bounds and lifetime errors, integer arithmetic feeding allocation or copy sizes, FFI, and type punning.
+- Input-bounded allocation, recursion, iteration, decompression, regex work, and unbounded caches.
+- Update, install, build, package, CI, workflow, plugin, and extension loading paths where untrusted artifacts gain execution or persistence.
+
+For each candidate, record a repository-relative location, boundary, and consumed value before tracing it. The same primitive reached through different trust boundaries is more than one inventory entry. Comments, tests, fixtures, and unmodified third-party code are not first-party sinks.

--- a/internal/evals/evals_test.go
+++ b/internal/evals/evals_test.go
@@ -110,8 +110,20 @@ should_find:
 
 func TestValidateExperimentPairs(t *testing.T) {
 	paired := []Scenario{
-		{Path: "a.yaml", Fixture: "fixtures/a", Experiment: "prompt", Variant: "production"},
-		{Path: "a-short.yaml", Fixture: "fixtures/a", Experiment: "prompt", Variant: "candidate"},
+		{
+			Path:       "a.yaml",
+			Fixture:    "fixtures/a",
+			Experiment: "prompt",
+			Variant:    "production",
+			ShouldFind: []Assertion{{Finding: "SQL injection", Required: true}},
+		},
+		{
+			Path:       "a-short.yaml",
+			Fixture:    "fixtures/a",
+			Experiment: "prompt",
+			Variant:    "candidate",
+			ShouldFind: []Assertion{{Finding: "SQL injection", Required: true, requiredSet: true}},
+		},
 	}
 	if err := validateExperimentPairs(paired); err != nil {
 		t.Fatalf("validateExperimentPairs() = %v, want nil", err)
@@ -285,6 +297,30 @@ func TestScenarioValidate(t *testing.T) {
 				Skill:      "security-deep-dive",
 				Experiment: "prompt-test",
 				Variant:    "candidate/one",
+				ShouldFind: []Assertion{{Finding: "x"}},
+			},
+		},
+		{
+			name: "experiment surrounding whitespace",
+			sc: Scenario{
+				Path:       "case.yaml",
+				Given:      "x",
+				Fixture:    "fixtures/x",
+				Skill:      "security-deep-dive",
+				Experiment: " prompt-test",
+				Variant:    "candidate",
+				ShouldFind: []Assertion{{Finding: "x"}},
+			},
+		},
+		{
+			name: "variant surrounding whitespace",
+			sc: Scenario{
+				Path:       "case.yaml",
+				Given:      "x",
+				Fixture:    "fixtures/x",
+				Skill:      "security-deep-dive",
+				Experiment: "prompt-test",
+				Variant:    "candidate ",
 				ShouldFind: []Assertion{{Finding: "x"}},
 			},
 		},

--- a/internal/evals/evals_test.go
+++ b/internal/evals/evals_test.go
@@ -108,6 +108,75 @@ should_find:
 	}
 }
 
+func TestValidateExperimentPairs(t *testing.T) {
+	paired := []Scenario{
+		{Path: "a.yaml", Fixture: "fixtures/a", Experiment: "prompt", Variant: "production"},
+		{Path: "a-short.yaml", Fixture: "fixtures/a", Experiment: "prompt", Variant: "candidate"},
+	}
+	if err := validateExperimentPairs(paired); err != nil {
+		t.Fatalf("validateExperimentPairs() = %v, want nil", err)
+	}
+
+	tests := []struct {
+		name      string
+		scenarios []Scenario
+		want      string
+	}{
+		{
+			name: "one variant",
+			scenarios: []Scenario{
+				{Path: "a.yaml", Fixture: "fixtures/a", Experiment: "prompt", Variant: "production"},
+			},
+			want: "at least 2",
+		},
+		{
+			name: "different fixtures",
+			scenarios: []Scenario{
+				{Path: "a.yaml", Fixture: "fixtures/a", Experiment: "prompt", Variant: "production"},
+				{Path: "b.yaml", Fixture: "fixtures/b", Experiment: "prompt", Variant: "candidate"},
+			},
+			want: "different fixtures",
+		},
+		{
+			name: "duplicate fixture",
+			scenarios: []Scenario{
+				{Path: "a.yaml", Fixture: "fixtures/a", Experiment: "prompt", Variant: "production"},
+				{Path: "again.yaml", Fixture: "fixtures/a", Experiment: "prompt", Variant: "production"},
+				{Path: "candidate.yaml", Fixture: "fixtures/a", Experiment: "prompt", Variant: "candidate"},
+			},
+			want: "repeats fixture",
+		},
+		{
+			name: "different assertions",
+			scenarios: []Scenario{
+				{
+					Path:       "a.yaml",
+					Fixture:    "fixtures/a",
+					Experiment: "prompt",
+					Variant:    "production",
+					ShouldFind: []Assertion{{Finding: "SQL injection"}},
+				},
+				{
+					Path:       "candidate.yaml",
+					Fixture:    "fixtures/a",
+					Experiment: "prompt",
+					Variant:    "candidate",
+					ShouldFind: []Assertion{{Finding: "command injection"}},
+				},
+			},
+			want: "different assertions",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateExperimentPairs(tc.scenarios)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("validateExperimentPairs() = %v, want %q", err, tc.want)
+			}
+		})
+	}
+}
+
 func TestScenarioValidate(t *testing.T) {
 	tests := []struct {
 		name string
@@ -194,6 +263,29 @@ func TestScenarioValidate(t *testing.T) {
 				Skill:       "security-deep-dive",
 				SchemaSkill: "/security-deep-dive",
 				ShouldFind:  []Assertion{{Finding: "x"}},
+			},
+		},
+		{
+			name: "experiment without variant",
+			sc: Scenario{
+				Path:       "case.yaml",
+				Given:      "x",
+				Fixture:    "fixtures/x",
+				Skill:      "security-deep-dive",
+				Experiment: "prompt-test",
+				ShouldFind: []Assertion{{Finding: "x"}},
+			},
+		},
+		{
+			name: "invalid variant identifier",
+			sc: Scenario{
+				Path:       "case.yaml",
+				Given:      "x",
+				Fixture:    "fixtures/x",
+				Skill:      "security-deep-dive",
+				Experiment: "prompt-test",
+				Variant:    "candidate/one",
+				ShouldFind: []Assertion{{Finding: "x"}},
 			},
 		},
 	}
@@ -372,6 +464,34 @@ func TestRunnerLoadsEvalSkillWithProductionSchema(t *testing.T) {
 	}
 	if res.FailedRequired != 0 || res.Unexpected != 0 {
 		t.Fatalf("unexpected failures: %+v", res)
+	}
+}
+
+func TestRunnerStagesEvalSkillReferences(t *testing.T) {
+	sc := mustLoadScenario(t, "../../evals/security-deep-dive-short-sqli.yaml")
+	inspected := false
+	r := Runner{
+		Runner: fakeSkillRunner{
+			report: validDeepDiveReport(),
+			inspect: func(sj worker.SkillJob) error {
+				inspected = true
+				for _, name := range []string{"sink-taxonomy.md", "report-contract.md"} {
+					if _, err := os.Stat(filepath.Join(sj.SkillDir, "references", name)); err != nil {
+						return fmt.Errorf("staged reference %s: %w", name, err)
+					}
+				}
+				return nil
+			},
+		},
+		SkillsRoot: "../../skills",
+		EvalsRoot:  "../../evals",
+		WorkRoot:   t.TempDir(),
+	}
+	if _, err := r.RunScenario(context.Background(), sc); err != nil {
+		t.Fatal(err)
+	}
+	if !inspected {
+		t.Fatal("skill runner did not inspect staged references")
 	}
 }
 
@@ -638,15 +758,22 @@ func TestRunFixtures(t *testing.T) {
 		}}
 	}
 	results, err := r.RunAll(context.Background(), scenarios)
-	if err != nil {
-		t.Fatal(err)
-	}
 	for _, res := range results {
 		t.Logf("%s: assertions=%d required_misses=%d optional_misses=%d unexpected=%d cost=$%.4f turns=%d",
 			res.Scenario.Path, res.AssertionTotal, res.FailedRequired, res.OptionalMisses, res.Unexpected, res.Cost.USD, res.Cost.Turns)
 		if res.FailedRequired > 0 || res.Unexpected > 0 {
 			t.Fail()
 		}
+	}
+	for _, summary := range SummarizeExperiments(results) {
+		t.Logf("experiment=%s variant=%s scenarios=%d passed=%d errors=%d assertions=%d required_misses=%d optional_misses=%d unexpected=%d cost=$%.4f turns=%d input_tokens=%d output_tokens=%d cache_read_tokens=%d cache_write_tokens=%d",
+			summary.Experiment, summary.Variant, summary.ScenarioTotal, summary.Passed, summary.Errors,
+			summary.AssertionTotal, summary.FailedRequired, summary.OptionalMisses, summary.Unexpected,
+			summary.Cost.USD, summary.Cost.Turns, summary.Cost.InputTokens, summary.Cost.OutputTokens,
+			summary.Cost.CacheReadTokens, summary.Cost.CacheWriteTokens)
+	}
+	if err != nil {
+		t.Errorf("run scenarios: %v", err)
 	}
 }
 
@@ -721,6 +848,48 @@ func TestRunAllContinuesAfterScenarioError(t *testing.T) {
 	}
 	if results[1].Error != "" || results[1].FailedRequired != 0 {
 		t.Fatalf("second scenario should still run successfully: %+v", results[1])
+	}
+}
+
+func TestSummarizeExperiments(t *testing.T) {
+	results := []Result{
+		{
+			Scenario:       Scenario{Experiment: "prompt", Variant: "production"},
+			AssertionTotal: 2,
+			Cost:           Cost{USD: 0.03, Turns: 2, InputTokens: 30},
+		},
+		{
+			Scenario:       Scenario{Experiment: "prompt", Variant: "production"},
+			AssertionTotal: 3,
+			FailedRequired: 1,
+			OptionalMisses: 1,
+			Cost:           Cost{USD: 0.04, Turns: 3, InputTokens: 40},
+		},
+		{
+			Scenario:       Scenario{Experiment: "prompt", Variant: "reference-driven"},
+			AssertionTotal: 2,
+			Unexpected:     1,
+			Cost:           Cost{USD: 0.02, Turns: 1, InputTokens: 20},
+		},
+		{
+			Scenario: Scenario{Experiment: "prompt", Variant: "reference-driven"},
+			Error:    "runner failed",
+		},
+		{Scenario: Scenario{Skill: "unpaired"}, AssertionTotal: 99},
+	}
+
+	got := SummarizeExperiments(results)
+	if len(got) != 2 {
+		t.Fatalf("summaries = %d, want 2: %+v", len(got), got)
+	}
+	if got[0].Variant != "production" || got[0].ScenarioTotal != 2 || got[0].Passed != 1 ||
+		got[0].AssertionTotal != 5 || got[0].FailedRequired != 1 || got[0].OptionalMisses != 1 ||
+		got[0].Cost.USD < 0.0699 || got[0].Cost.USD > 0.0701 || got[0].Cost.Turns != 5 || got[0].Cost.InputTokens != 70 {
+		t.Fatalf("production summary = %+v", got[0])
+	}
+	if got[1].Variant != "reference-driven" || got[1].ScenarioTotal != 2 || got[1].Passed != 0 ||
+		got[1].Errors != 1 || got[1].Unexpected != 1 || got[1].AssertionTotal != 2 {
+		t.Fatalf("reference-driven summary = %+v", got[1])
 	}
 }
 
@@ -858,13 +1027,19 @@ func incompleteDeepDiveReport() string {
 }
 
 type fakeSkillRunner struct {
-	report string
-	err    error
+	report  string
+	err     error
+	inspect func(worker.SkillJob) error
 }
 
 func (f fakeSkillRunner) RunSkill(ctx context.Context, sj worker.SkillJob, emit func(worker.Event)) (worker.SkillResult, error) {
 	if f.err != nil {
 		return worker.SkillResult{}, f.err
+	}
+	if f.inspect != nil {
+		if err := f.inspect(sj); err != nil {
+			return worker.SkillResult{}, err
+		}
 	}
 	if sj.Name == "" || sj.SkillDir == "" || sj.OutputFile == "" {
 		return worker.SkillResult{}, os.ErrInvalid

--- a/internal/evals/evals_test.go
+++ b/internal/evals/evals_test.go
@@ -112,17 +112,33 @@ func TestValidateExperimentPairs(t *testing.T) {
 	paired := []Scenario{
 		{
 			Path:       "a.yaml",
+			Given:      "same fixture and rubric",
 			Fixture:    "fixtures/a",
 			Experiment: "prompt",
 			Variant:    "production",
-			ShouldFind: []Assertion{{Finding: "SQL injection", Required: true}},
+			ShouldFind: []Assertion{
+				{Finding: "SQL injection", Required: true},
+				{Finding: "command injection", Required: true},
+			},
+			ShouldNotFind: []Assertion{
+				{Finding: "unused import"},
+				{Finding: "dead code"},
+			},
 		},
 		{
 			Path:       "a-short.yaml",
+			Given:      "same fixture and rubric",
 			Fixture:    "fixtures/a",
 			Experiment: "prompt",
 			Variant:    "candidate",
-			ShouldFind: []Assertion{{Finding: "SQL injection", Required: true, requiredSet: true}},
+			ShouldFind: []Assertion{
+				{Finding: "command injection", Required: true, requiredSet: true},
+				{Finding: "SQL injection", Required: true, requiredSet: true},
+			},
+			ShouldNotFind: []Assertion{
+				{Finding: "dead code"},
+				{Finding: "unused import"},
+			},
 		},
 	}
 	if err := validateExperimentPairs(paired); err != nil {
@@ -157,6 +173,28 @@ func TestValidateExperimentPairs(t *testing.T) {
 				{Path: "candidate.yaml", Fixture: "fixtures/a", Experiment: "prompt", Variant: "candidate"},
 			},
 			want: "repeats fixture",
+		},
+		{
+			name: "different given",
+			scenarios: []Scenario{
+				{
+					Path:       "a.yaml",
+					Given:      "SQL injection reaches the database",
+					Fixture:    "fixtures/a",
+					Experiment: "prompt",
+					Variant:    "production",
+					ShouldFind: []Assertion{{Finding: "SQL injection"}},
+				},
+				{
+					Path:       "candidate.yaml",
+					Given:      "An injection reaches the database",
+					Fixture:    "fixtures/a",
+					Experiment: "prompt",
+					Variant:    "candidate",
+					ShouldFind: []Assertion{{Finding: "SQL injection"}},
+				},
+			},
+			want: "different given text",
 		},
 		{
 			name: "different assertions",

--- a/internal/evals/experiment.go
+++ b/internal/evals/experiment.go
@@ -1,0 +1,64 @@
+//go:build evals
+
+package evals
+
+import "sort"
+
+// ExperimentSummary aggregates comparable scenario results for one prompt
+// variant. Scenarios without experiment metadata are intentionally omitted.
+type ExperimentSummary struct {
+	Experiment     string
+	Variant        string
+	ScenarioTotal  int
+	Passed         int
+	Errors         int
+	AssertionTotal int
+	FailedRequired int
+	OptionalMisses int
+	Unexpected     int
+	Cost           Cost
+}
+
+// SummarizeExperiments groups results by experiment and variant so a live eval
+// run reports quality and cost for the production baseline and candidate using
+// the same fixtures and model.
+func SummarizeExperiments(results []Result) []ExperimentSummary {
+	type key struct {
+		experiment string
+		variant    string
+	}
+	summaries := make(map[key]ExperimentSummary)
+	for _, result := range results {
+		if result.Scenario.Experiment == "" {
+			continue
+		}
+		k := key{experiment: result.Scenario.Experiment, variant: result.Scenario.Variant}
+		summary := summaries[k]
+		summary.Experiment = k.experiment
+		summary.Variant = k.variant
+		summary.ScenarioTotal++
+		summary.AssertionTotal += result.AssertionTotal
+		summary.FailedRequired += result.FailedRequired
+		summary.OptionalMisses += result.OptionalMisses
+		summary.Unexpected += result.Unexpected
+		addCost(&summary.Cost, result.Cost)
+		if result.Error != "" {
+			summary.Errors++
+		} else if result.FailedRequired == 0 && result.Unexpected == 0 {
+			summary.Passed++
+		}
+		summaries[k] = summary
+	}
+
+	out := make([]ExperimentSummary, 0, len(summaries))
+	for _, summary := range summaries {
+		out = append(out, summary)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Experiment != out[j].Experiment {
+			return out[i].Experiment < out[j].Experiment
+		}
+		return out[i].Variant < out[j].Variant
+	})
+	return out
+}

--- a/internal/evals/load.go
+++ b/internal/evals/load.go
@@ -7,11 +7,14 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"sort"
 	"strings"
 
 	"gopkg.in/yaml.v3"
 )
+
+const minExperimentVariants = 2
 
 // LoadScenarios reads every top-level .yaml/.yml file under root.
 func LoadScenarios(root string) ([]Scenario, error) {
@@ -36,7 +39,85 @@ func LoadScenarios(root string) ([]Scenario, error) {
 		scenarios = append(scenarios, sc)
 	}
 	sort.Slice(scenarios, func(i, j int) bool { return scenarios[i].Path < scenarios[j].Path })
+	if err := validateExperimentPairs(scenarios); err != nil {
+		return nil, err
+	}
 	return scenarios, nil
+}
+
+func validateExperimentPairs(scenarios []Scenario) error {
+	type fixtureScenarios map[string]Scenario
+	experiments := make(map[string]map[string]fixtureScenarios)
+	for _, sc := range scenarios {
+		if sc.Experiment == "" {
+			continue
+		}
+		variants := experiments[sc.Experiment]
+		if variants == nil {
+			variants = make(map[string]fixtureScenarios)
+			experiments[sc.Experiment] = variants
+		}
+		fixtures := variants[sc.Variant]
+		if fixtures == nil {
+			fixtures = make(fixtureScenarios)
+			variants[sc.Variant] = fixtures
+		}
+		if previous, exists := fixtures[sc.Fixture]; exists {
+			return fmt.Errorf("experiment %q variant %q repeats fixture %q in %s and %s",
+				sc.Experiment, sc.Variant, sc.Fixture, previous.Path, sc.Path)
+		}
+		fixtures[sc.Fixture] = sc
+	}
+
+	for experiment, variants := range experiments {
+		if len(variants) < minExperimentVariants {
+			return fmt.Errorf("experiment %q has %d variant; need at least 2", experiment, len(variants))
+		}
+		variantNames := make([]string, 0, len(variants))
+		for variant := range variants {
+			variantNames = append(variantNames, variant)
+		}
+		sort.Strings(variantNames)
+		baselineName := variantNames[0]
+		baseline := variants[baselineName]
+		for _, variant := range variantNames[1:] {
+			fixtures := variants[variant]
+			if missing, extra := fixtureDifference(baseline, fixtures); len(missing) > 0 || len(extra) > 0 {
+				return fmt.Errorf("experiment %q variants %q and %q use different fixtures (missing=%v extra=%v)",
+					experiment, baselineName, variant, missing, extra)
+			}
+			for fixture, baselineScenario := range baseline {
+				if !sameScenarioRubric(baselineScenario, fixtures[fixture]) {
+					return fmt.Errorf("experiment %q variants %q and %q use different assertions for fixture %q",
+						experiment, baselineName, variant, fixture)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func fixtureDifference(want, got map[string]Scenario) (missing, extra []string) {
+	for fixture := range want {
+		if _, ok := got[fixture]; !ok {
+			missing = append(missing, fixture)
+		}
+	}
+	for fixture := range got {
+		if _, ok := want[fixture]; !ok {
+			extra = append(extra, fixture)
+		}
+	}
+	sort.Strings(missing)
+	sort.Strings(extra)
+	return missing, extra
+}
+
+func sameScenarioRubric(a, b Scenario) bool {
+	return a.Given == b.Given &&
+		reflect.DeepEqual(a.ShouldFind, b.ShouldFind) &&
+		reflect.DeepEqual(a.ShouldNotFind, b.ShouldNotFind) &&
+		reflect.DeepEqual(a.MustNotContain, b.MustNotContain)
 }
 
 // LoadScenario parses one scenario YAML file.

--- a/internal/evals/load.go
+++ b/internal/evals/load.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"reflect"
+	"slices"
 	"sort"
 	"strings"
 
@@ -15,6 +15,8 @@ import (
 )
 
 const minExperimentVariants = 2
+
+type fixtureScenarios map[string]Scenario
 
 // LoadScenarios reads every top-level .yaml/.yml file under root.
 func LoadScenarios(root string) ([]Scenario, error) {
@@ -46,7 +48,6 @@ func LoadScenarios(root string) ([]Scenario, error) {
 }
 
 func validateExperimentPairs(scenarios []Scenario) error {
-	type fixtureScenarios map[string]Scenario
 	experiments := make(map[string]map[string]fixtureScenarios)
 	for _, sc := range scenarios {
 		if sc.Experiment == "" {
@@ -97,7 +98,7 @@ func validateExperimentPairs(scenarios []Scenario) error {
 	return nil
 }
 
-func fixtureDifference(want, got map[string]Scenario) (missing, extra []string) {
+func fixtureDifference(want, got fixtureScenarios) (missing, extra []string) {
 	for fixture := range want {
 		if _, ok := got[fixture]; !ok {
 			missing = append(missing, fixture)
@@ -115,9 +116,26 @@ func fixtureDifference(want, got map[string]Scenario) (missing, extra []string) 
 
 func sameScenarioRubric(a, b Scenario) bool {
 	return a.Given == b.Given &&
-		reflect.DeepEqual(a.ShouldFind, b.ShouldFind) &&
-		reflect.DeepEqual(a.ShouldNotFind, b.ShouldNotFind) &&
-		reflect.DeepEqual(a.MustNotContain, b.MustNotContain)
+		sameAssertions(a.ShouldFind, b.ShouldFind) &&
+		sameAssertions(a.ShouldNotFind, b.ShouldNotFind) &&
+		slices.Equal(a.MustNotContain, b.MustNotContain)
+}
+
+func sameAssertions(a, b []Assertion) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i].Finding != b[i].Finding ||
+			a[i].Severity != b[i].Severity ||
+			a[i].CWE != b[i].CWE ||
+			a[i].Path != b[i].Path ||
+			a[i].Required != b[i].Required ||
+			!slices.Equal(a[i].Evidence, b[i].Evidence) {
+			return false
+		}
+	}
+	return true
 }
 
 // LoadScenario parses one scenario YAML file.

--- a/internal/evals/load.go
+++ b/internal/evals/load.go
@@ -82,17 +82,28 @@ func validateExperimentPairs(scenarios []Scenario) error {
 		baselineName := variantNames[0]
 		baseline := variants[baselineName]
 		for _, variant := range variantNames[1:] {
-			fixtures := variants[variant]
-			if missing, extra := fixtureDifference(baseline, fixtures); len(missing) > 0 || len(extra) > 0 {
-				return fmt.Errorf("experiment %q variants %q and %q use different fixtures (missing=%v extra=%v)",
-					experiment, baselineName, variant, missing, extra)
+			if err := validateExperimentVariant(experiment, baselineName, variant, baseline, variants[variant]); err != nil {
+				return err
 			}
-			for fixture, baselineScenario := range baseline {
-				if !sameScenarioRubric(baselineScenario, fixtures[fixture]) {
-					return fmt.Errorf("experiment %q variants %q and %q use different assertions for fixture %q",
-						experiment, baselineName, variant, fixture)
-				}
-			}
+		}
+	}
+	return nil
+}
+
+func validateExperimentVariant(experiment, baselineName, variant string, baseline, candidate fixtureScenarios) error {
+	if missing, extra := fixtureDifference(baseline, candidate); len(missing) > 0 || len(extra) > 0 {
+		return fmt.Errorf("experiment %q variants %q and %q use different fixtures (missing=%v extra=%v)",
+			experiment, baselineName, variant, missing, extra)
+	}
+	for fixture, baselineScenario := range baseline {
+		candidateScenario := candidate[fixture]
+		if baselineScenario.Given != candidateScenario.Given {
+			return fmt.Errorf("experiment %q variants %q and %q use different given text for fixture %q",
+				experiment, baselineName, variant, fixture)
+		}
+		if !sameScenarioRubric(baselineScenario, candidateScenario) {
+			return fmt.Errorf("experiment %q variants %q and %q use different assertions for fixture %q",
+				experiment, baselineName, variant, fixture)
 		}
 	}
 	return nil
@@ -115,8 +126,7 @@ func fixtureDifference(want, got fixtureScenarios) (missing, extra []string) {
 }
 
 func sameScenarioRubric(a, b Scenario) bool {
-	return a.Given == b.Given &&
-		sameAssertions(a.ShouldFind, b.ShouldFind) &&
+	return sameAssertions(a.ShouldFind, b.ShouldFind) &&
 		sameAssertions(a.ShouldNotFind, b.ShouldNotFind) &&
 		slices.Equal(a.MustNotContain, b.MustNotContain)
 }
@@ -125,17 +135,31 @@ func sameAssertions(a, b []Assertion) bool {
 	if len(a) != len(b) {
 		return false
 	}
-	for i := range a {
-		if a[i].Finding != b[i].Finding ||
-			a[i].Severity != b[i].Severity ||
-			a[i].CWE != b[i].CWE ||
-			a[i].Path != b[i].Path ||
-			a[i].Required != b[i].Required ||
-			!slices.Equal(a[i].Evidence, b[i].Evidence) {
+	matched := make([]bool, len(b))
+	for _, assertion := range a {
+		found := false
+		for i, candidate := range b {
+			if matched[i] || !sameAssertion(assertion, candidate) {
+				continue
+			}
+			matched[i] = true
+			found = true
+			break
+		}
+		if !found {
 			return false
 		}
 	}
 	return true
+}
+
+func sameAssertion(a, b Assertion) bool {
+	return a.Finding == b.Finding &&
+		a.Severity == b.Severity &&
+		a.CWE == b.CWE &&
+		a.Path == b.Path &&
+		a.Required == b.Required &&
+		slices.Equal(a.Evidence, b.Evidence)
 }
 
 // LoadScenario parses one scenario YAML file.

--- a/internal/evals/types.go
+++ b/internal/evals/types.go
@@ -134,6 +134,12 @@ func (s Scenario) validateExperiment() error {
 	if (experiment == "") != (variant == "") {
 		return fmt.Errorf("%s experiment and variant must be set together", s.Path)
 	}
+	if s.Experiment != experiment {
+		return fmt.Errorf("%s experiment %q has surrounding whitespace", s.Path, s.Experiment)
+	}
+	if s.Variant != variant {
+		return fmt.Errorf("%s variant %q has surrounding whitespace", s.Path, s.Variant)
+	}
 	if experiment != "" && !scenarioIdentifierRE.MatchString(experiment) {
 		return fmt.Errorf("%s experiment %q is not a valid identifier", s.Path, s.Experiment)
 	}

--- a/internal/evals/types.go
+++ b/internal/evals/types.go
@@ -10,7 +10,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-var scenarioSkillNameRE = regexp.MustCompile(`^[a-z0-9]+(?:-[a-z0-9]+)*$`)
+var scenarioIdentifierRE = regexp.MustCompile(`^[a-z0-9]+(?:-[a-z0-9]+)*$`)
 
 // Scenario is one YAML eval file under evals/. It points at a fixture
 // repository and names the skill whose output should be judged.
@@ -20,6 +20,8 @@ type Scenario struct {
 	Fixture        string      `yaml:"fixture"`
 	Skill          string      `yaml:"skill"`
 	SchemaSkill    string      `yaml:"schema_skill"`
+	Experiment     string      `yaml:"experiment"`
+	Variant        string      `yaml:"variant"`
 	ShouldFind     []Assertion `yaml:"should_find"`
 	ShouldNotFind  []Assertion `yaml:"should_not_find"`
 	MustNotContain []string    `yaml:"must_not_contain"`
@@ -100,11 +102,14 @@ func (s Scenario) validate() error {
 	if len(missing) > 0 {
 		return fmt.Errorf("%s missing %s", s.Path, strings.Join(missing, ", "))
 	}
-	if !scenarioSkillNameRE.MatchString(s.Skill) {
+	if !scenarioIdentifierRE.MatchString(s.Skill) {
 		return fmt.Errorf("%s skill %q is not a valid skill name", s.Path, s.Skill)
 	}
-	if s.SchemaSkill != "" && !scenarioSkillNameRE.MatchString(s.SchemaSkill) {
+	if s.SchemaSkill != "" && !scenarioIdentifierRE.MatchString(s.SchemaSkill) {
 		return fmt.Errorf("%s schema_skill %q is not a valid skill name", s.Path, s.SchemaSkill)
+	}
+	if err := s.validateExperiment(); err != nil {
+		return err
 	}
 	if len(s.ShouldFind) == 0 && len(s.ShouldNotFind) == 0 && len(s.MustNotContain) == 0 {
 		return fmt.Errorf("%s has no assertions", s.Path)
@@ -119,6 +124,21 @@ func (s Scenario) validate() error {
 		if strings.TrimSpace(term) == "" {
 			return fmt.Errorf("%s must_not_contain[%d]: empty term", s.Path, i)
 		}
+	}
+	return nil
+}
+
+func (s Scenario) validateExperiment() error {
+	experiment := strings.TrimSpace(s.Experiment)
+	variant := strings.TrimSpace(s.Variant)
+	if (experiment == "") != (variant == "") {
+		return fmt.Errorf("%s experiment and variant must be set together", s.Path)
+	}
+	if experiment != "" && !scenarioIdentifierRE.MatchString(experiment) {
+		return fmt.Errorf("%s experiment %q is not a valid identifier", s.Path, s.Experiment)
+	}
+	if variant != "" && !scenarioIdentifierRE.MatchString(variant) {
+		return fmt.Errorf("%s variant %q is not a valid identifier", s.Path, s.Variant)
 	}
 	return nil
 }


### PR DESCRIPTION
Part of #118

## Summary

Extends the deep-dive prompt experiment with a reference-driven candidate and reproducible A/B reporting.

The production `security-deep-dive` skill remains unchanged. The eval-only candidate keeps audit intent and phase order in a compact `SKILL.md`, while moving the sink taxonomy and report contract into focused reference files.

## Changes

- Refactor the eval-only deep-dive candidate into:
  - A 44-line top-level `SKILL.md`
  - An on-demand sink taxonomy reference
  - A final report-contract reference
- Mark the existing SQL injection, authentication omission and mass-assignment scenarios as a paired experiment:
  - `production`
  - `reference-driven`
- Require every experiment to:
  - Define at least two variants
  - Use identical fixture sets
  - Use identical assertions for each paired fixture
  - Avoid duplicate fixture entries within a variant
- Add aggregate experiment reporting for:
  - Scenario passes and execution errors
  - Required and optional misses
  - Unexpected findings
  - Turns, tokens and cost
- Continue reporting all scenario results when one scenario fails
- Add tests proving the reference files are staged through the production workspace path
- Document experiment metadata and comparison output in `evals/README.md`

## Scope

This PR does not modify or promote changes to the production deep-dive prompt. It provides the controlled experiment needed to compare the reference-driven candidate against the current production baseline using the same model, fixtures, schemas and assertions.

## Tests

- `go test -count=1 ./cmd/... ./docker/... ./internal/... ./skills/...`
- `go test -count=1 -tags evals ./internal/evals/...`
- `go test -count=1 -race -tags evals ./internal/evals/...`
- `go vet ./cmd/... ./docker/... ./internal/... ./skills/...`
- `go vet -tags evals ./cmd/... ./docker/... ./internal/... ./skills/...`
- `golangci-lint run ./cmd/... ./internal/...`
- `golangci-lint run --build-tags evals ./cmd/... ./internal/...`
- `git diff --check`