### PR TITLE
Use magic classification in code browser

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,9 +8,10 @@ require (
 	filippo.io/age v1.3.1
 	github.com/alpha-omega-security/harness v0.1.2
 	github.com/ecosyste-ms/ecosystems-go v0.4.0
-	github.com/git-pkgs/clone v0.1.2
+	github.com/git-pkgs/clone v0.2.0
 	github.com/git-pkgs/cwe v0.1.0
 	github.com/git-pkgs/enrichment v0.6.4
+	github.com/git-pkgs/magic v0.1.0
 	github.com/git-pkgs/pom v0.1.5
 	github.com/git-pkgs/purl v0.1.15
 	github.com/git-pkgs/sarif v0.1.1

--- a/go.sum
+++ b/go.sum
@@ -22,12 +22,14 @@ github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkp
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/ecosyste-ms/ecosystems-go v0.4.0 h1:5A+zF+XWT8sYYYjlc2/tI1SmiDGzbHLyT9CapVc5dGA=
 github.com/ecosyste-ms/ecosystems-go v0.4.0/go.mod h1:FVswCrp3DQkur1HjVqfDF/gYrDSEmiFflntcB1G0DbA=
-github.com/git-pkgs/clone v0.1.2 h1:1BT+/+ZoCQqIj7feMFfkFhZG1B20Kaq0XHBeHsnMxUI=
-github.com/git-pkgs/clone v0.1.2/go.mod h1:1xNuHmJs5bOoFRXqydrd2guhg6BxwgHlvbMfkIAq3AM=
+github.com/git-pkgs/clone v0.2.0 h1:tejeYhmwSPPaymhHqoT90WrwrfdtadqrCUUzJCR8Q10=
+github.com/git-pkgs/clone v0.2.0/go.mod h1:lgbobKgJ6XbPZPsbn4iK0fVskYpFr4stjKKCeG9RsRc=
 github.com/git-pkgs/cwe v0.1.0 h1:DjE/Ixfvv/OIxtofF5vwumn01qbcXOHf17mUH2lri/g=
 github.com/git-pkgs/cwe v0.1.0/go.mod h1:6yUxEoA+3rI4W3ftqb7PZP1Z7zZFmV4/wfr7P46HtHU=
 github.com/git-pkgs/enrichment v0.6.4 h1:mGrfenttwmcUfPXRkWpB0wBJiiGj55ltniUh66Pq4bU=
 github.com/git-pkgs/enrichment v0.6.4/go.mod h1:zz1vPUak/w8Jhajll0KDRN2MjKaEYeCzQTxumWnVhqY=
+github.com/git-pkgs/magic v0.1.0 h1:xLrqq7CMXB9g5bJnmJyKw17Rvlh0GFiEmO6e5RFsoeY=
+github.com/git-pkgs/magic v0.1.0/go.mod h1:3ndidt+yvFaI1M0aEkkzkOlFnLPkeVQASIUojazcxCI=
 github.com/git-pkgs/packageurl-go v0.3.1 h1:WM3RBABQZLaRBxgKyYughc3cVBE8KyQxbSC6Jt5ak7M=
 github.com/git-pkgs/packageurl-go v0.3.1/go.mod h1:rcIxiG37BlQLB6FZfgdj9Fm7yjhRQd3l+5o7J0QPAk4=
 github.com/git-pkgs/pom v0.1.5 h1:TGT8Az2OMxGWsXnSagtUMGzZm7Oax8HrSCteA+mi0qY=

--- a/internal/web/code_browser.go
+++ b/internal/web/code_browser.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/git-pkgs/clone"
+	"github.com/git-pkgs/magic"
 
 	"scrutineer/internal/db"
 	"scrutineer/internal/worker"
@@ -71,7 +72,7 @@ func (s *Server) repoBlob(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	content, binary, truncated, err := gitShowBlob(r.Context(), cacheSrc, commit, cleanPath)
+	blob, err := gitShowBlob(r.Context(), cacheSrc, commit, cleanPath)
 	if err != nil {
 		s.render(w, r, "code_browser.html", map[string]any{
 			"Repo":      repo,
@@ -82,16 +83,21 @@ func (s *Server) repoBlob(w http.ResponseWriter, r *http.Request) {
 		})
 		return
 	}
+	renderable := renderableBlob(blob.Detection)
+	content := ""
+	if renderable {
+		content = string(blob.Content)
+	}
 
 	s.render(w, r, "code_browser.html", map[string]any{
-		"Repo":      repo,
-		"Commit":    commit,
-		"Path":      cleanPath,
-		"Highlight": parseHighlight(r.URL.Query().Get("line")),
-		"Binary":    binary,
-		"Truncated": truncated,
-		"Content":   content,
-		"Language":  highlightLang(cleanPath),
+		"Repo":        repo,
+		"Commit":      commit,
+		"Path":        cleanPath,
+		"Highlight":   parseHighlight(r.URL.Query().Get("line")),
+		"Unsupported": !renderable,
+		"Truncated":   blob.Truncated,
+		"Content":     content,
+		"Language":    highlightLang(cleanPath),
 	})
 }
 
@@ -100,10 +106,13 @@ func (s *Server) repoBlob(w http.ResponseWriter, r *http.Request) {
 // Also used by forge_link.go for its own path checks.
 func sanitizeBlobPath(p string) (string, bool) { return clone.SanitizePath(p) }
 
-// gitShowBlob wraps clone.Blob at the code browser's fixed byte cap.
-func gitShowBlob(ctx context.Context, repoDir, commit, blobPath string) (string, bool, bool, error) {
-	raw, binary, truncated, err := clone.Blob(ctx, repoDir, commit, blobPath, maxBrowserBytes)
-	return string(raw), binary, truncated, err
+// gitShowBlob wraps clone.InspectBlob at the code browser's fixed byte cap.
+func gitShowBlob(ctx context.Context, repoDir, commit, blobPath string) (clone.BlobResult, error) {
+	return clone.InspectBlob(ctx, repoDir, commit, blobPath, maxBrowserBytes)
+}
+
+func renderableBlob(result magic.Result) bool {
+	return result.Kind == magic.KindText && (result.Encoding == "" || result.Encoding == "utf-8")
 }
 
 // parseHighlight decodes `line=N` or `line=N-M` into an inclusive range.

--- a/internal/web/code_browser_test.go
+++ b/internal/web/code_browser_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/git-pkgs/clone"
+	"github.com/git-pkgs/magic"
 
 	"scrutineer/internal/db"
 	"scrutineer/internal/testutil"
@@ -108,7 +109,10 @@ func seedRepoCache(t *testing.T, dataDir, url string) (commit1, commit2 string) 
 	if err := os.WriteFile(filepath.Join(cacheSrc, "hello.go"), []byte("package main\n\nfunc main() {}\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	run("add", "hello.go")
+	if err := os.WriteFile(filepath.Join(cacheSrc, "image.png"), []byte("\x89PNG\r\n\x1a\ncontent without nul"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	run("add", "hello.go", "image.png")
 	run("commit", "--quiet", "-m", "first")
 	commit1 = run("rev-parse", "HEAD")
 
@@ -119,6 +123,40 @@ func seedRepoCache(t *testing.T, dataDir, url string) (commit1, commit2 string) 
 	run("commit", "--quiet", "-m", "second")
 	commit2 = run("rev-parse", "HEAD")
 	return commit1, commit2
+}
+
+func TestRepoBlob_doesNotRenderUnsupportedContent(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not installed")
+	}
+	s, done := newTestServer(t)
+	defer done()
+
+	dataDir := t.TempDir()
+	s.Worker = &worker.Worker{DataDir: dataDir}
+
+	repo := db.Repository{URL: "https://example.com/foo", Name: "foo"}
+	s.DB.Create(&repo)
+	commit, _ := seedRepoCache(t, dataDir, repo.URL)
+
+	id := strconv.FormatUint(uint64(repo.ID), 10)
+	req := localReq("GET", "/repositories/"+id+"/blob/"+commit+"/image.png")
+	req.SetPathValue("id", id)
+	req.SetPathValue("commit", commit)
+	req.SetPathValue("path", "image.png")
+	rec := httptest.NewRecorder()
+	s.repoBlob(rec, req)
+
+	if rec.Code != 200 {
+		t.Fatalf("status %d: %s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "not UTF-8 text") {
+		t.Errorf("body missing unsupported-content notice:\n%s", body)
+	}
+	if strings.Contains(body, "content without nul") {
+		t.Errorf("body rendered unsupported content:\n%s", body)
+	}
 }
 
 func TestRepoBlob_servesHistoricalCommit(t *testing.T) {
@@ -226,19 +264,115 @@ func TestGitShowBlob_capsAtMaxBrowserBytes(t *testing.T) {
 	}
 	commit := strings.TrimSpace(string(headOut))
 
-	content, binary, truncated, err := gitShowBlob(context.Background(), dir, commit, "big.txt")
+	blob, err := gitShowBlob(context.Background(), dir, commit, "big.txt")
 	if err != nil {
 		t.Fatalf("gitShowBlob: %v", err)
 	}
-	if binary {
-		t.Error("expected non-binary")
+	if !renderableBlob(blob.Detection) {
+		t.Errorf("expected renderable detection, got %+v", blob.Detection)
 	}
-	if !truncated {
+	if !blob.Truncated {
 		t.Error("expected truncated=true")
 	}
-	if len(content) != maxBrowserBytes {
-		t.Errorf("len(content) = %d, want %d", len(content), maxBrowserBytes)
+	if len(blob.Content) != maxBrowserBytes {
+		t.Errorf("len(content) = %d, want %d", len(blob.Content), maxBrowserBytes)
 	}
+}
+
+func TestGitShowBlob_classifiesContent(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not installed")
+	}
+	tests := []struct {
+		name         string
+		content      []byte
+		wantKind     magic.Kind
+		wantEncoding string
+		wantRender   bool
+	}{
+		{name: "UTF-8", content: []byte("hello, world\n"), wantKind: magic.KindText, wantEncoding: "utf-8", wantRender: true},
+		{name: "empty", content: []byte{}, wantKind: magic.KindText, wantRender: true},
+		{name: "PNG without NUL", content: []byte("\x89PNG\r\n\x1a\npayload"), wantKind: magic.KindBinary},
+		{name: "invalid UTF-8", content: []byte{0xff, 'x'}, wantKind: magic.KindUnknown},
+		{name: "UTF-16LE", content: []byte{0xff, 0xfe, 'h', 0, 'i', 0}, wantKind: magic.KindText, wantEncoding: "utf-16le"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			commitBlob(t, dir, "fixture", tt.content)
+
+			blob, err := gitShowBlob(context.Background(), dir, headCommit(t, dir), "fixture")
+			if err != nil {
+				t.Fatalf("gitShowBlob: %v", err)
+			}
+			if blob.Detection.Kind != tt.wantKind {
+				t.Errorf("Kind = %q, want %q", blob.Detection.Kind, tt.wantKind)
+			}
+			if blob.Detection.Encoding != tt.wantEncoding {
+				t.Errorf("Encoding = %q, want %q", blob.Detection.Encoding, tt.wantEncoding)
+			}
+			if got := renderableBlob(blob.Detection); got != tt.wantRender {
+				t.Errorf("renderableBlob() = %v, want %v", got, tt.wantRender)
+			}
+		})
+	}
+}
+
+func TestGitShowBlob_doesNotRenderSplitUTF8Prefix(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not installed")
+	}
+	dir := t.TempDir()
+	content := bytes.Repeat([]byte("a"), maxBrowserBytes-1)
+	content = append(content, []byte("éx")...)
+	commitBlob(t, dir, "split.txt", content)
+
+	blob, err := gitShowBlob(context.Background(), dir, headCommit(t, dir), "split.txt")
+	if err != nil {
+		t.Fatalf("gitShowBlob: %v", err)
+	}
+	if !blob.Truncated {
+		t.Fatal("expected truncated=true")
+	}
+	if blob.Detection.Kind != magic.KindUnknown || blob.Detection.Reason != magic.ReasonNeedMore {
+		t.Errorf("Detection = %+v, want unknown needing more bytes", blob.Detection)
+	}
+	if renderableBlob(blob.Detection) {
+		t.Error("expected split UTF-8 prefix not to render")
+	}
+}
+
+func commitBlob(t *testing.T, dir, name string, content []byte) {
+	t.Helper()
+	runGit := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+		cmd.Env = testutil.GitEnv()
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	runGit("init", "--quiet", "-b", "main")
+	runGit("config", "user.email", "test@example.com")
+	runGit("config", "user.name", "Test")
+	if err := os.WriteFile(filepath.Join(dir, name), content, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit("add", name)
+	runGit("commit", "--quiet", "-m", "fixture")
+}
+
+func headCommit(t *testing.T, dir string) string {
+	t.Helper()
+	cmd := exec.Command("git", "-C", dir, "rev-parse", "HEAD")
+	cmd.Env = testutil.GitEnv()
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return strings.TrimSpace(string(out))
 }
 
 func TestRepoBlob_rendersMissingNoticeWhenNoCache(t *testing.T) {

--- a/internal/web/templates/code_browser.html
+++ b/internal/web/templates/code_browser.html
@@ -29,9 +29,9 @@
     <p class="font-medium mb-1">Could not load this file at <code>{{short .Commit}}</code>.</p>
     <pre class="whitespace-pre-wrap text-xs">{{.Error}}</pre>
   </div>
-{{else if .Binary}}
+{{else if .Unsupported}}
   <div class="rounded border border-dashed p-6 text-sm text-muted-foreground">
-    Binary file — not rendered.
+    This file is not UTF-8 text and cannot be rendered.
   </div>
 {{else}}
   {{if .Truncated}}


### PR DESCRIPTION
The code browser now uses `clone.InspectBlob` and `magic` to classify content before converting it to a string. It renders UTF-8 text and leaves binary, unknown, and UTF-16 content behind a neutral notice, while preserving the 2 MiB limit and truncation banner. This catches signed formats without NUL bytes and malformed UTF-8 that the old `clone.Blob` check could display.