### PR TITLE
Sort maintainers by repository and finding counts

### DIFF
--- a/internal/web/maintainers.go
+++ b/internal/web/maintainers.go
@@ -9,6 +9,27 @@ import (
 	"scrutineer/internal/db"
 )
 
+const maintainerRepositoryCountSQL = `(
+	SELECT COUNT(*)
+	FROM repository_maintainers rm_count
+	WHERE rm_count.maintainer_id = maintainers.id
+)`
+
+var maintainerFindingCountSQL = `(
+	SELECT COUNT(f.id)
+	FROM repository_maintainers rm_count
+	JOIN findings f ON f.repository_id = rm_count.repository_id
+	LEFT JOIN scans s ON s.id = f.scan_id
+	WHERE rm_count.maintainer_id = maintainers.id
+	  AND ` + aliasedFindingsScanFilter + `
+)`
+
+type maintainerListRow struct {
+	db.Maintainer
+	RepositoryCount int `gorm:"column:repository_count"`
+	FindingCount    int `gorm:"column:finding_count"`
+}
+
 func (s *Server) maintainersList(w http.ResponseWriter, r *http.Request) {
 	q := s.DB.Model(&db.Maintainer{})
 	status := r.URL.Query().Get(statusKey)
@@ -25,6 +46,12 @@ func (s *Server) maintainersList(w http.ResponseWriter, r *http.Request) {
 	const nameSort = "name"
 	sortCol, dir := splitSort(r.URL.Query().Get("sort"))
 	switch sortCol {
+	case "findings":
+		q = q.Order(orderByExpr(maintainerFindingCountSQL, dir, true)).
+			Order("CASE WHEN name = '' THEN 1 ELSE 0 END, name, login")
+	case "repos":
+		q = q.Order(orderByExpr(maintainerRepositoryCountSQL, dir, true)).
+			Order("CASE WHEN name = '' THEN 1 ELSE 0 END, name, login")
 	case "login":
 		q = q.Order(orderByExpr("login", dir, false))
 	case statusKey:
@@ -49,49 +76,17 @@ func (s *Server) maintainersList(w http.ResponseWriter, r *http.Request) {
 	q.Count(&total)
 	page := paginate(r, total)
 
-	var rows []db.Maintainer
-	q.Preload("Repositories").
-		Limit(perPage).Offset((page.N - 1) * perPage).Find(&rows)
-
-	// Batch-count findings across each maintainer's linked repositories
-	// in a single grouped query rather than one query per maintainer.
-	findingCounts := map[uint]int{}
-	if len(rows) > 0 {
-		ids := make([]uint, 0, len(rows))
-		for _, m := range rows {
-			ids = append(ids, m.ID)
-		}
-		type row struct {
-			MaintainerID uint
-			N            int
-		}
-		var counts []row
-		// LEFT JOIN scans so the COUNT only includes the findings the Findings
-		// tab shows — the LLM audits (security-deep-dive, vuln-scan) plus
-		// operator imports, via aliasedFindingsScanFilter. Scanner output
-		// (zizmor, semgrep) is per-repo lint noise and shouldn't drive
-		// maintainer routing.
-		s.DB.Raw(`
-			SELECT rm.maintainer_id, COUNT(f.id) AS n
-			FROM repository_maintainers rm
-			LEFT JOIN findings f ON f.repository_id = rm.repository_id
-			LEFT JOIN scans s ON s.id = f.scan_id
-			WHERE rm.maintainer_id IN ?
-			  AND `+aliasedFindingsScanFilter+`
-			GROUP BY rm.maintainer_id
-		`, ids, deepDiveSkillName, vulnScanSkillName, advisoryDeepDiveSkillName).Scan(&counts)
-		for _, c := range counts {
-			findingCounts[c.MaintainerID] = c.N
-		}
-	}
+	var rows []maintainerListRow
+	q.Select("maintainers.*, " + maintainerRepositoryCountSQL + " AS repository_count, " +
+		maintainerFindingCountSQL + " AS finding_count").
+		Limit(perPage).Offset((page.N - 1) * perPage).Scan(&rows)
 
 	s.render(w, r, "maintainers.html", map[string]any{
-		"Maintainers":   rows,
-		"Page":          page,
-		"Status":        status,
-		"Q":             search,
-		"Sort":          sort,
-		"FindingCounts": findingCounts,
+		"Maintainers": rows,
+		"Page":        page,
+		"Status":      status,
+		"Q":           search,
+		"Sort":        sort,
 	})
 }
 

--- a/internal/web/orgs.go
+++ b/internal/web/orgs.go
@@ -81,9 +81,9 @@ func (s *Server) orgsList(w http.ResponseWriter, r *http.Request) {
 			LEFT JOIN findings f ON f.repository_id = r.id
 			LEFT JOIN scans s ON s.id = f.scan_id
 			WHERE r.owner != ''
-			  AND `+aliasedFindingsScanFilter+`
+			  AND ` + aliasedFindingsScanFilter + `
 			GROUP BY r.owner
-		`, deepDiveSkillName, vulnScanSkillName, advisoryDeepDiveSkillName).Scan(&counts)
+		`).Scan(&counts)
 		for _, x := range counts {
 			findingCounts[x.Owner] = x.N
 		}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -1279,21 +1279,6 @@ const (
 	// findings belong in the curated Findings bucket alongside the deep-dive
 	// audit rather than the Scanners tab full of cheap tool output (#458).
 	vulnScanSkillName = "vuln-scan"
-	// aliasedFindingsScanFilter is the same Findings-tab predicate as
-	// nonScannerScanFilter, written for the raw aggregate counts on the
-	// maintainers and orgs indexes. Those queries LEFT JOIN scans under the
-	// alias `s` and group findings, so they filter s.skill_name/s.kind directly
-	// rather than threading findings.scan_id through a subquery. A finding
-	// counts when its scan is one of the LLM audits (security-deep-dive,
-	// vuln-scan, advisory-deep-dive), a legacy/empty skill_name, or an operator
-	// import (kind=import); the three ?s bind deepDiveSkillName, vulnScanSkillName
-	// and advisoryDeepDiveSkillName in that order. The `s.skill_name IS NULL` arm
-	// doubles as the LEFT JOIN "this row has no findings" guard, so zero-count
-	// maintainers/orgs stay in the result with n=0. Keep it in lockstep with
-	// findingsBucketSkillSQL — a copy that lacked the kind='import' arm is exactly
-	// what kept imports out of these totals after they began showing in the
-	// Findings tab.
-	aliasedFindingsScanFilter = "(s.skill_name IN (?, ?, ?) OR s.skill_name = '' OR s.skill_name IS NULL OR s.kind = 'import')"
 	// threatModelSkillName is the skill whose report feeds the Threat Model
 	// tab when present; repos that predate it fall back to the boundaries
 	// section of the deep-dive report so older scans keep rendering.
@@ -1306,6 +1291,12 @@ const (
 // the skill names through db.SQLStringLiteral for defense-in-depth quote
 // escaping — a function call, which a Go const initializer cannot contain.
 var (
+	// aliasedFindingsScanFilter is the Findings-bucket predicate for aggregate
+	// queries that join scans as `s`. It uses escaped literals because the
+	// maintainer index also embeds it in a correlated ORDER BY subquery, where
+	// GORM cannot bind values. The `s.skill_name IS NULL` arm also keeps empty
+	// LEFT JOIN groups at zero. Keep this in lockstep with findingsBucketSkillSQL.
+	aliasedFindingsScanFilter = "(s.skill_name IN (" + db.SQLStringLiteral(deepDiveSkillName) + ", " + db.SQLStringLiteral(vulnScanSkillName) + ", " + db.SQLStringLiteral(advisoryDeepDiveSkillName) + ") OR s.skill_name = '' OR s.skill_name IS NULL OR s.kind = 'import')"
 	// findingsBucketSkillSQL is the single source of truth for which scans'
 	// findings populate the curated Findings bucket: the LLM audit skills
 	// (security-deep-dive, vuln-scan, advisory-deep-dive), legacy claude jobs

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"slices"
 	"sort"
 	"strings"
 	"testing"
@@ -2102,6 +2103,142 @@ func TestMaintainersSortOptions(t *testing.T) {
 	newestOrder := orderBy("/maintainers?sort=newest")
 	if newestOrder[0] != charlie {
 		t.Errorf("sort=newest expected charlie first, got %v", newestOrder)
+	}
+}
+
+func TestMaintainersSortByRepositoryAndFindingCounts(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	maintainers := []db.Maintainer{
+		{Login: "none", Name: "A None"},
+		{Login: "one", Name: "B One"},
+		{Login: "many", Name: "C Many"},
+		{Login: "noisy", Name: "D Noisy"},
+	}
+	for i := range maintainers {
+		if err := s.DB.Create(&maintainers[i]).Error; err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	type repoSeed struct {
+		name       string
+		maintainer int
+		skill      string
+		findings   int
+	}
+	seeds := []repoSeed{
+		{name: "one", maintainer: 1, skill: deepDiveSkillName, findings: 1},
+		{name: "many-a", maintainer: 2, skill: deepDiveSkillName, findings: 1},
+		{name: "many-b", maintainer: 2, skill: "trivy", findings: 1},
+		{name: "noisy", maintainer: 3, skill: "semgrep", findings: 5},
+	}
+	for _, seed := range seeds {
+		repo := db.Repository{URL: "https://github.com/example/" + seed.name, Name: seed.name}
+		if err := s.DB.Create(&repo).Error; err != nil {
+			t.Fatal(err)
+		}
+		if err := s.DB.Model(&repo).Association("Maintainers").Append(&maintainers[seed.maintainer]); err != nil {
+			t.Fatal(err)
+		}
+		kind := "skill"
+		if seed.skill == "trivy" {
+			kind = "import"
+		}
+		scan := db.Scan{RepositoryID: repo.ID, Kind: kind, Status: db.ScanDone, SkillName: seed.skill}
+		if err := s.DB.Create(&scan).Error; err != nil {
+			t.Fatal(err)
+		}
+		for i := range seed.findings {
+			finding := db.Finding{
+				ScanID: scan.ID, RepositoryID: repo.ID,
+				Title: fmt.Sprintf("%s-%d", seed.name, i), Severity: "High",
+			}
+			if err := s.DB.Create(&finding).Error; err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+
+	order := func(path string) []string {
+		t.Helper()
+		w := httptest.NewRecorder()
+		s.Handler().ServeHTTP(w, localReq("GET", path))
+		if w.Code != http.StatusOK {
+			t.Fatalf("%s status %d: %s", path, w.Code, w.Body.String())
+		}
+		body := w.Body.String()
+		logins := []string{"none", "one", "many", "noisy"}
+		positions := make(map[string]int, len(logins))
+		for _, login := range logins {
+			positions[login] = strings.Index(body, ">"+login+"</td>")
+			if positions[login] < 0 {
+				t.Fatalf("%s missing maintainer %q", path, login)
+			}
+		}
+		sort.Slice(logins, func(i, j int) bool {
+			return positions[logins[i]] < positions[logins[j]]
+		})
+		return logins
+	}
+
+	assertOrder := func(path string, want []string) {
+		t.Helper()
+		if got := order(path); !slices.Equal(got, want) {
+			t.Errorf("%s order = %v, want %v", path, got, want)
+		}
+	}
+	assertOrder("/maintainers?sort=findings", []string{"many", "one", "none", "noisy"})
+	assertOrder("/maintainers?sort=findings.asc", []string{"none", "noisy", "one", "many"})
+	assertOrder("/maintainers?sort=repos", []string{"many", "one", "noisy", "none"})
+	assertOrder("/maintainers?sort=repos.asc", []string{"none", "one", "noisy", "many"})
+}
+
+func TestMaintainersCountSortRunsBeforePagination(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	for i := range perPage {
+		m := db.Maintainer{Login: fmt.Sprintf("filler-%02d", i), Name: fmt.Sprintf("A Filler %02d", i)}
+		if err := s.DB.Create(&m).Error; err != nil {
+			t.Fatal(err)
+		}
+	}
+	priority := db.Maintainer{Login: "priority", Name: "Z Priority"}
+	if err := s.DB.Create(&priority).Error; err != nil {
+		t.Fatal(err)
+	}
+	repo := db.Repository{URL: "https://github.com/example/priority", Name: "priority"}
+	if err := s.DB.Create(&repo).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := s.DB.Model(&repo).Association("Maintainers").Append(&priority); err != nil {
+		t.Fatal(err)
+	}
+	scan := db.Scan{RepositoryID: repo.ID, Kind: "skill", Status: db.ScanDone, SkillName: deepDiveSkillName}
+	if err := s.DB.Create(&scan).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := s.DB.Create(&db.Finding{
+		ScanID: scan.ID, RepositoryID: repo.ID, Title: "priority finding", Severity: "High",
+	}).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	for _, key := range []string{"repos", "findings"} {
+		w := httptest.NewRecorder()
+		s.Handler().ServeHTTP(w, localReq("GET", "/maintainers?sort="+key))
+		if w.Code != http.StatusOK {
+			t.Fatalf("sort=%s status %d: %s", key, w.Code, w.Body.String())
+		}
+		body := w.Body.String()
+		if !strings.Contains(body, ">priority</td>") {
+			t.Errorf("sort=%s omitted high-count maintainer from page one", key)
+		}
+		if got := strings.Count(body, `<tr id="maintainer-`); got != perPage {
+			t.Errorf("sort=%s rendered %d rows, want %d", key, got, perPage)
+		}
 	}
 }
 

--- a/internal/web/templates/maintainers.html
+++ b/internal/web/templates/maintainers.html
@@ -30,12 +30,12 @@
     <div class="dropdown-menu">
       <button type="button" class="btn-outline" aria-haspopup="menu" aria-expanded="false">
         <i data-lucide="arrow-down-wide-narrow"></i>
-        {{$sk := sortkey .Sort}}{{if eq $sk "login"}}Login{{else if eq $sk "status"}}Status{{else if eq $sk "newest"}}Newest{{else}}Name{{end}}
+        {{$sk := sortkey .Sort}}{{if eq $sk "login"}}Login{{else if eq $sk "status"}}Status{{else if eq $sk "newest"}}Newest{{else if eq $sk "repos"}}Repos{{else if eq $sk "findings"}}Findings{{else}}Name{{end}}
         <i data-lucide="chevron-down"></i>
       </button>
       <div data-popover aria-hidden="true" data-align="end">
         <div role="menu">
-          {{range (list "name" "login" "status" "newest")}}
+          {{range (list "name" "login" "status" "repos" "findings" "newest")}}
             <a role="menuitem" href="/maintainers?q={{$.Q}}&status={{$.Status}}&sort={{.}}"
                {{if eq . (sortkey $.Sort)}}aria-current="true"{{end}}>{{.}}</a>
           {{end}}
@@ -52,11 +52,11 @@
       {{template "th-sort" (dict "Sorter" .Sorter "Key" "login" "Def" "asc" "Label" "Login" "Class" "")}}
       {{template "th-sort" (dict "Sorter" .Sorter "Key" "email" "Def" "asc" "Label" "Email" "Class" "")}}
       {{template "th-sort" (dict "Sorter" .Sorter "Key" "company" "Def" "asc" "Label" "Company" "Class" "")}}
-      <th>Repos</th><th>Findings</th>
+      {{template "th-sort" (dict "Sorter" .Sorter "Key" "repos" "Def" "desc" "Label" "Repos" "Class" "w-24 text-right")}}
+      {{template "th-sort" (dict "Sorter" .Sorter "Key" "findings" "Def" "desc" "Label" "Findings" "Class" "w-24 text-right")}}
       {{template "th-sort" (dict "Sorter" .Sorter "Key" "status" "Def" "asc" "Label" "Status" "Class" "")}}
     </tr></thead>
     <tbody>
-    {{$counts := .FindingCounts}}
     {{range .Maintainers}}
       <tr id="maintainer-{{.ID}}">
         <td>
@@ -66,8 +66,8 @@
         <td class="text-muted-foreground">{{.Login}}</td>
         <td class="text-muted-foreground">{{.Email}}</td>
         <td class="text-muted-foreground">{{.Company}}</td>
-        <td class="text-muted-foreground">{{len .Repositories}}</td>
-        <td>{{template "findings-badge" (index $counts .ID)}}</td>
+        <td class="text-right text-muted-foreground">{{.RepositoryCount}}</td>
+        <td class="text-right">{{template "findings-badge" .FindingCount}}</td>
         <td>{{template "status-badge" (printf "%s" .Status)}}</td>
       </tr>
     {{end}}


### PR DESCRIPTION
Fixes #695

## Summary

Makes the Repos and Findings columns on the Maintainers page sortable.

Counts are now calculated in the primary maintainer query, allowing sorting to happen before pagination. This makes it possible to identify maintainers associated with the largest number of actionable findings across the complete result set.

## Changes

- Add sortable Repos and Findings table headers.
- Add repository and finding count options to the sort menu.
- Compute both counts using correlated SQL subqueries before pagination.
- Default count sorting to descending order.
- Use stable name and login ordering when counts are equal.
- Preserve the existing actionable-findings filter:
  - Include model-backed audit findings and imports.
  - Exclude scanner-only findings such as Semgrep output.
- Use escaped SQL literals for skill names embedded in aggregate queries.
- Remove the post-pagination finding count query and repository preload.
- Add tests covering:
  - Ascending and descending count sorting.
  - Imported and scanner finding classification.
  - Sorting across pagination boundaries.

## Tests

- `go test ./...`
- `go test -race ./internal/web -run TestMaintainers`
- `go vet ./...`
- `golangci-lint run ./cmd/... ./docker/... ./internal/... ./skills/...`
- `git diff --check`