### PR TITLE
Refactor scan resume enqueue logic

### DIFF
--- a/internal/web/scans.go
+++ b/internal/web/scans.go
@@ -448,12 +448,16 @@ func (s *Server) restorePausedAfterResumeEnqueueFailure(scan db.Scan, err error)
 	)).Error
 }
 
-func (s *Server) enqueueResumedScan(ctx context.Context, scan db.Scan) error {
+func (s *Server) enqueueResumeJob(ctx context.Context, scan db.Scan) error {
 	priority := worker.PrioScan
 	if scan.FindingID != nil {
 		priority = worker.PrioFinding
 	}
-	if err := s.Queue.Enqueue(ctx, scan.Kind, scan.ID, priority); err != nil {
+	return s.Queue.Enqueue(ctx, scan.Kind, scan.ID, priority)
+}
+
+func (s *Server) enqueueResumedScan(ctx context.Context, scan db.Scan) error {
+	if err := s.enqueueResumeJob(ctx, scan); err != nil {
 		return errors.Join(err, s.restorePausedAfterResumeEnqueueFailure(scan, err))
 	}
 	return nil
@@ -522,20 +526,15 @@ func (s *Server) resumeScan(ctx context.Context, scan *db.Scan) error {
 	if optedOut {
 		return ErrRepoFederationOptOut
 	}
-	priority := worker.PrioScan
-	if scan.FindingID != nil {
-		priority = worker.PrioFinding
-	}
-	if err := s.Queue.Enqueue(ctx, scan.Kind, scan.ID, priority); err != nil {
+	// The single path intentionally queues first. If the following update fails,
+	// the worker drops the job because the row is still paused; the operator can
+	// retry. Updating first could instead leave a queued row with no job if both
+	// enqueue and rollback failed.
+	if err := s.enqueueResumeJob(ctx, *scan); err != nil {
 		return err
 	}
-	return s.DB.Model(&db.Scan{}).Where("id = ? AND status = ?", scan.ID, db.ScanPaused).Updates(map[string]any{
-		statusKey:         db.ScanQueued,
-		"status_priority": db.StatusPriorityFor(db.ScanQueued),
-		errorKey:          "",
-		"finished_at":     nil,
-		"paused_until":    nil,
-	}).Error
+	return s.DB.Model(&db.Scan{}).Where("id = ? AND status = ?", scan.ID, db.ScanPaused).
+		Updates(scanStatusUpdates(db.ScanQueued, "", nil, nil)).Error
 }
 
 func retryFailedToast(retried, skipped, errored int) Flash {

--- a/internal/web/scans.go
+++ b/internal/web/scans.go
@@ -448,16 +448,12 @@ func (s *Server) restorePausedAfterResumeEnqueueFailure(scan db.Scan, err error)
 	)).Error
 }
 
-func (s *Server) enqueueResumeJob(ctx context.Context, scan db.Scan) error {
+func (s *Server) enqueueResumedScan(ctx context.Context, scan db.Scan) error {
 	priority := worker.PrioScan
 	if scan.FindingID != nil {
 		priority = worker.PrioFinding
 	}
-	return s.Queue.Enqueue(ctx, scan.Kind, scan.ID, priority)
-}
-
-func (s *Server) enqueueResumedScan(ctx context.Context, scan db.Scan) error {
-	if err := s.enqueueResumeJob(ctx, scan); err != nil {
+	if err := s.Queue.Enqueue(ctx, scan.Kind, scan.ID, priority); err != nil {
 		return errors.Join(err, s.restorePausedAfterResumeEnqueueFailure(scan, err))
 	}
 	return nil
@@ -526,15 +522,15 @@ func (s *Server) resumeScan(ctx context.Context, scan *db.Scan) error {
 	if optedOut {
 		return ErrRepoFederationOptOut
 	}
-	// The single path intentionally queues first. If the following update fails,
-	// the worker drops the job because the row is still paused; the operator can
-	// retry. Updating first could instead leave a queued row with no job if both
-	// enqueue and rollback failed.
-	if err := s.enqueueResumeJob(ctx, *scan); err != nil {
-		return err
+	res := s.DB.Model(&db.Scan{}).Where("id = ? AND status = ?", scan.ID, db.ScanPaused).
+		Updates(scanStatusUpdates(db.ScanQueued, "", nil, nil))
+	if res.Error != nil {
+		return res.Error
 	}
-	return s.DB.Model(&db.Scan{}).Where("id = ? AND status = ?", scan.ID, db.ScanPaused).
-		Updates(scanStatusUpdates(db.ScanQueued, "", nil, nil)).Error
+	if res.RowsAffected != 1 {
+		return fmt.Errorf("scan %d is no longer paused", scan.ID)
+	}
+	return s.enqueueResumedScan(ctx, *scan)
 }
 
 func retryFailedToast(retried, skipped, errored int) Flash {

--- a/internal/web/scans_test.go
+++ b/internal/web/scans_test.go
@@ -355,40 +355,36 @@ func TestScansResumePaused(t *testing.T) {
 	}
 }
 
-func TestEnqueueResumeJob_usesFindingPriority(t *testing.T) {
-	s, done := newTestServer(t)
-	defer done()
-
+func TestEnqueueResumedScan_usesFindingPriority(t *testing.T) {
 	findingID := uint(1)
-	scans := []db.Scan{
-		{ID: 1, Kind: worker.JobSkill},
-		{ID: 2, Kind: worker.JobSkill, FindingID: &findingID},
+	tests := []struct {
+		name     string
+		scan     db.Scan
+		priority int
+	}{
+		{name: "repository scan", scan: db.Scan{ID: 1, Kind: worker.JobSkill}, priority: worker.PrioScan},
+		{name: "finding scan", scan: db.Scan{ID: 2, Kind: worker.JobSkill, FindingID: &findingID}, priority: worker.PrioFinding},
 	}
-	for _, scan := range scans {
-		if err := s.enqueueResumeJob(t.Context(), scan); err != nil {
-			t.Fatal(err)
-		}
-	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s, done := newTestServer(t)
+			defer done()
 
-	sqldb, err := s.DB.DB()
-	if err != nil {
-		t.Fatal(err)
-	}
-	rows, err := sqldb.Query("SELECT priority FROM goqite ORDER BY priority")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() { _ = rows.Close() }()
-	var priorities []int
-	for rows.Next() {
-		var priority int
-		if err := rows.Scan(&priority); err != nil {
-			t.Fatal(err)
-		}
-		priorities = append(priorities, priority)
-	}
-	if len(priorities) != 2 || priorities[0] != worker.PrioScan || priorities[1] != worker.PrioFinding {
-		t.Errorf("resume queue priorities = %v, want [%d %d]", priorities, worker.PrioScan, worker.PrioFinding)
+			if err := s.enqueueResumedScan(t.Context(), tt.scan); err != nil {
+				t.Fatal(err)
+			}
+			sqldb, err := s.DB.DB()
+			if err != nil {
+				t.Fatal(err)
+			}
+			var priority int
+			if err := sqldb.QueryRow("SELECT priority FROM goqite").Scan(&priority); err != nil {
+				t.Fatal(err)
+			}
+			if priority != tt.priority {
+				t.Errorf("resume queue priority = %d, want %d", priority, tt.priority)
+			}
+		})
 	}
 }
 
@@ -415,8 +411,9 @@ func TestResumeScan_enqueueFailureLeavesScanPaused(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	if err := s.resumeScan(ctx, &scan); !errors.Is(err, context.Canceled) {
-		t.Fatalf("resume error = %v, want context canceled", err)
+	resumeErr := s.resumeScan(ctx, &scan)
+	if !errors.Is(resumeErr, context.Canceled) {
+		t.Fatalf("resume error = %v, want context canceled", resumeErr)
 	}
 
 	var got db.Scan
@@ -427,15 +424,20 @@ func TestResumeScan_enqueueFailureLeavesScanPaused(t *testing.T) {
 		t.Errorf("status = %q priority = %d, want paused/%d",
 			got.Status, got.StatusPriority, db.StatusPriorityFor(db.ScanPaused))
 	}
-	if got.Error != scan.Error {
-		t.Errorf("error = %q, want %q", got.Error, scan.Error)
+	wantError := "resume failed: " + resumeErr.Error()
+	if got.Error != wantError {
+		t.Errorf("error = %q, want %q", got.Error, wantError)
 	}
 	if got.PausedUntil == nil || !got.PausedUntil.Equal(pausedUntil) {
 		t.Errorf("paused_until = %v, want %v", got.PausedUntil, pausedUntil)
 	}
+	if got.FinishedAt == nil {
+		t.Error("finished_at = nil, want rollback timestamp")
+	}
+	assertQueuedJobCount(t, s, 0)
 }
 
-func TestResumeScan_updateFailureLeavesPausedScanAndStaleJob(t *testing.T) {
+func TestResumeScan_updateFailureLeavesPausedScanWithoutJob(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()
 
@@ -457,7 +459,9 @@ func TestResumeScan_updateFailureLeavesPausedScanAndStaleJob(t *testing.T) {
 	updateErr := errors.New("injected resume update failure")
 	const callback = "test:fail-single-resume-update"
 	if err := s.DB.Callback().Update().Before("gorm:update").Register(callback, func(tx *gorm.DB) {
-		_ = tx.AddError(updateErr)
+		if tx.Statement.Table == "scans" {
+			_ = tx.AddError(updateErr)
+		}
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -480,7 +484,11 @@ func TestResumeScan_updateFailureLeavesPausedScanAndStaleJob(t *testing.T) {
 	if got.Error != scan.Error {
 		t.Errorf("error = %q, want %q", got.Error, scan.Error)
 	}
+	assertQueuedJobCount(t, s, 0)
+}
 
+func assertQueuedJobCount(t *testing.T, s *Server, want int) {
+	t.Helper()
 	sqldb, err := s.DB.DB()
 	if err != nil {
 		t.Fatal(err)
@@ -489,11 +497,9 @@ func TestResumeScan_updateFailureLeavesPausedScanAndStaleJob(t *testing.T) {
 	if err := sqldb.QueryRow("SELECT COUNT(*) FROM goqite").Scan(&jobs); err != nil {
 		t.Fatal(err)
 	}
-	if jobs != 1 {
-		t.Errorf("queued jobs = %d, want one stale job", jobs)
+	if jobs != want {
+		t.Errorf("queued jobs = %d, want %d", jobs, want)
 	}
-	// TestWorker_skipsPausedScan covers the pickup side: the worker discards
-	// this job without running it because the scan never became queued.
 }
 
 func TestEnqueueResumedScan_restoresPausedUntilOnEnqueueFailure(t *testing.T) {

--- a/internal/web/scans_test.go
+++ b/internal/web/scans_test.go
@@ -487,6 +487,49 @@ func TestResumeScan_updateFailureLeavesPausedScanWithoutJob(t *testing.T) {
 	assertQueuedJobCount(t, s, 0)
 }
 
+func TestResumeScan_noLongerPausedDoesNotEnqueue(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	repo := db.Repository{URL: "https://example.com/r", Name: "r"}
+	if err := s.DB.Create(&repo).Error; err != nil {
+		t.Fatal(err)
+	}
+	scan := db.Scan{
+		RepositoryID:   repo.ID,
+		Kind:           worker.JobSkill,
+		Status:         db.ScanPaused,
+		StatusPriority: db.StatusPriorityFor(db.ScanPaused),
+	}
+	if err := s.DB.Create(&scan).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	var loaded db.Scan
+	if err := s.DB.First(&loaded, scan.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := s.DB.Model(&db.Scan{}).Where("id = ?", scan.ID).
+		Updates(scanStatusUpdates(db.ScanQueued, "", nil, nil)).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	wantErr := fmt.Sprintf("scan %d is no longer paused", scan.ID)
+	if err := s.resumeScan(t.Context(), &loaded); err == nil || err.Error() != wantErr {
+		t.Fatalf("resume error = %v, want %q", err, wantErr)
+	}
+
+	var got db.Scan
+	if err := s.DB.First(&got, scan.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != db.ScanQueued || got.StatusPriority != db.StatusPriorityFor(db.ScanQueued) {
+		t.Errorf("status = %q priority = %d, want queued/%d",
+			got.Status, got.StatusPriority, db.StatusPriorityFor(db.ScanQueued))
+	}
+	assertQueuedJobCount(t, s, 0)
+}
+
 func assertQueuedJobCount(t *testing.T, s *Server, want int) {
 	t.Helper()
 	sqldb, err := s.DB.DB()

--- a/internal/web/scans_test.go
+++ b/internal/web/scans_test.go
@@ -435,6 +435,67 @@ func TestResumeScan_enqueueFailureLeavesScanPaused(t *testing.T) {
 	}
 }
 
+func TestResumeScan_updateFailureLeavesPausedScanAndStaleJob(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	repo := db.Repository{URL: "https://example.com/r", Name: "r"}
+	if err := s.DB.Create(&repo).Error; err != nil {
+		t.Fatal(err)
+	}
+	scan := db.Scan{
+		RepositoryID:   repo.ID,
+		Kind:           worker.JobSkill,
+		Status:         db.ScanPaused,
+		StatusPriority: db.StatusPriorityFor(db.ScanPaused),
+		Error:          "paused by operator",
+	}
+	if err := s.DB.Create(&scan).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	updateErr := errors.New("injected resume update failure")
+	const callback = "test:fail-single-resume-update"
+	if err := s.DB.Callback().Update().Before("gorm:update").Register(callback, func(tx *gorm.DB) {
+		_ = tx.AddError(updateErr)
+	}); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		_ = s.DB.Callback().Update().Remove(callback)
+	}()
+
+	if err := s.resumeScan(t.Context(), &scan); !errors.Is(err, updateErr) {
+		t.Fatalf("resume error = %v, want %v", err, updateErr)
+	}
+
+	var got db.Scan
+	if err := s.DB.First(&got, scan.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != db.ScanPaused || got.StatusPriority != db.StatusPriorityFor(db.ScanPaused) {
+		t.Errorf("status = %q priority = %d, want paused/%d",
+			got.Status, got.StatusPriority, db.StatusPriorityFor(db.ScanPaused))
+	}
+	if got.Error != scan.Error {
+		t.Errorf("error = %q, want %q", got.Error, scan.Error)
+	}
+
+	sqldb, err := s.DB.DB()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var jobs int
+	if err := sqldb.QueryRow("SELECT COUNT(*) FROM goqite").Scan(&jobs); err != nil {
+		t.Fatal(err)
+	}
+	if jobs != 1 {
+		t.Errorf("queued jobs = %d, want one stale job", jobs)
+	}
+	// TestWorker_skipsPausedScan covers the pickup side: the worker discards
+	// this job without running it because the scan never became queued.
+}
+
 func TestEnqueueResumedScan_restoresPausedUntilOnEnqueueFailure(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()

--- a/internal/web/scans_test.go
+++ b/internal/web/scans_test.go
@@ -355,6 +355,86 @@ func TestScansResumePaused(t *testing.T) {
 	}
 }
 
+func TestEnqueueResumeJob_usesFindingPriority(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	findingID := uint(1)
+	scans := []db.Scan{
+		{ID: 1, Kind: worker.JobSkill},
+		{ID: 2, Kind: worker.JobSkill, FindingID: &findingID},
+	}
+	for _, scan := range scans {
+		if err := s.enqueueResumeJob(t.Context(), scan); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	sqldb, err := s.DB.DB()
+	if err != nil {
+		t.Fatal(err)
+	}
+	rows, err := sqldb.Query("SELECT priority FROM goqite ORDER BY priority")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = rows.Close() }()
+	var priorities []int
+	for rows.Next() {
+		var priority int
+		if err := rows.Scan(&priority); err != nil {
+			t.Fatal(err)
+		}
+		priorities = append(priorities, priority)
+	}
+	if len(priorities) != 2 || priorities[0] != worker.PrioScan || priorities[1] != worker.PrioFinding {
+		t.Errorf("resume queue priorities = %v, want [%d %d]", priorities, worker.PrioScan, worker.PrioFinding)
+	}
+}
+
+func TestResumeScan_enqueueFailureLeavesScanPaused(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	repo := db.Repository{URL: "https://example.com/r", Name: "r"}
+	if err := s.DB.Create(&repo).Error; err != nil {
+		t.Fatal(err)
+	}
+	pausedUntil := time.Now().UTC().Add(time.Hour).Truncate(time.Second)
+	scan := db.Scan{
+		RepositoryID:   repo.ID,
+		Kind:           worker.JobSkill,
+		Status:         db.ScanPaused,
+		StatusPriority: db.StatusPriorityFor(db.ScanPaused),
+		Error:          "paused by operator",
+		PausedUntil:    &pausedUntil,
+	}
+	if err := s.DB.Create(&scan).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := s.resumeScan(ctx, &scan); !errors.Is(err, context.Canceled) {
+		t.Fatalf("resume error = %v, want context canceled", err)
+	}
+
+	var got db.Scan
+	if err := s.DB.First(&got, scan.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != db.ScanPaused || got.StatusPriority != db.StatusPriorityFor(db.ScanPaused) {
+		t.Errorf("status = %q priority = %d, want paused/%d",
+			got.Status, got.StatusPriority, db.StatusPriorityFor(db.ScanPaused))
+	}
+	if got.Error != scan.Error {
+		t.Errorf("error = %q, want %q", got.Error, scan.Error)
+	}
+	if got.PausedUntil == nil || !got.PausedUntil.Equal(pausedUntil) {
+		t.Errorf("paused_until = %v, want %v", got.PausedUntil, pausedUntil)
+	}
+}
+
 func TestEnqueueResumedScan_restoresPausedUntilOnEnqueueFailure(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()


### PR DESCRIPTION
Fixes #693

## Summary

Unifies single and bulk scan resume behavior so both paths use the same update-first, enqueue-second and restore-on-failure flow.

## Changes

- Consolidate resume priority selection and enqueue recovery in `enqueueResumedScan`.
- Assign finding-scoped resumes `PrioFinding` and regular scan resumes `PrioScan`.
- Update individual scans to `queued` before enqueueing.
- Restore scans to `paused` when enqueueing fails.
- Avoid enqueueing when the paused-row claim updates no rows.
- Reuse the shared scan-status update fields.
- Add tests covering:
  - Regular and finding-scoped queue priorities without relying on constant ordering.
  - Database update failures creating no queue jobs.
  - Enqueue failures restoring individual scans to `paused`.
  - Preservation of `paused_until` during rollback.
  - Existing bulk-resume rollback behavior.

## Tests

- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `go vet -tags podman ./...`
- `golangci-lint run ./cmd/... ./docker/... ./internal/... ./skills/...`
- `git diff --check`