### PR TITLE
Align audit finding location schemas

### DIFF
--- a/internal/worker/schema_bundled_test.go
+++ b/internal/worker/schema_bundled_test.go
@@ -1,10 +1,40 @@
 package worker
 
 import (
+	"encoding/json"
 	"os"
+	"reflect"
 	"strings"
 	"testing"
 )
+
+func TestAuditFindingSchemasStayAligned(t *testing.T) {
+	paths := []string{
+		"../../skills/audit-injection/schema.json",
+		"../../skills/audit-exfil/schema.json",
+		"../../skills/audit-authz/schema.json",
+	}
+
+	var baseline map[string]any
+	for _, path := range paths {
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		var schema map[string]any
+		if err := json.Unmarshal(raw, &schema); err != nil {
+			t.Fatalf("decode %s: %v", path, err)
+		}
+		delete(schema, "title")
+		if baseline == nil {
+			baseline = schema
+			continue
+		}
+		if !reflect.DeepEqual(schema, baseline) {
+			t.Errorf("%s differs from %s beyond title", path, paths[0])
+		}
+	}
+}
 
 // TestBundledSchemas_compileAndAcceptSamples checks that the three schemas
 // added for #182 compile and accept a representative report. repo-overview

--- a/internal/worker/schema_bundled_test.go
+++ b/internal/worker/schema_bundled_test.go
@@ -3,7 +3,6 @@ package worker
 import (
 	"encoding/json"
 	"os"
-	"reflect"
 	"strings"
 	"testing"
 )
@@ -15,7 +14,7 @@ func TestAuditFindingSchemasStayAligned(t *testing.T) {
 		"../../skills/audit-authz/schema.json",
 	}
 
-	var baseline map[string]any
+	var baseline string
 	for _, path := range paths {
 		raw, err := os.ReadFile(path)
 		if err != nil {
@@ -26,12 +25,17 @@ func TestAuditFindingSchemasStayAligned(t *testing.T) {
 			t.Fatalf("decode %s: %v", path, err)
 		}
 		delete(schema, "title")
-		if baseline == nil {
-			baseline = schema
+		normalized, err := json.MarshalIndent(schema, "", "  ")
+		if err != nil {
+			t.Fatalf("normalize %s: %v", path, err)
+		}
+		if baseline == "" {
+			baseline = string(normalized)
 			continue
 		}
-		if !reflect.DeepEqual(schema, baseline) {
-			t.Errorf("%s differs from %s beyond title", path, paths[0])
+		if got := string(normalized); got != baseline {
+			t.Errorf("%s differs from %s beyond title\n%s:\n%s\n%s:\n%s",
+				path, paths[0], paths[0], baseline, path, got)
 		}
 	}
 }

--- a/skills/audit-injection/schema.json
+++ b/skills/audit-injection/schema.json
@@ -44,7 +44,7 @@
     "location": {
       "type": "string",
       "minLength": 1,
-      "pattern": "^[^:]+:[1-9][0-9]*$"
+      "pattern": "^.+:[1-9][0-9]*$"
     },
     "markdown": {
       "type": "string",


### PR DESCRIPTION
Follow-up to https://github.com/alpha-omega-security/scrutineer/pull/784#pullrequestreview-4842148313
Part of #106

## Summary

Aligns the location validation contract across the bundled `audit-injection`, `audit-exfil` and `audit-authz` skills.

This resolves the pre-existing schema drift Andrew noted during review of #784 and prepares the three audit schemas for a future shared `$defs` extraction.

## Changes

- Update `audit-injection`’s location pattern from:
  - `^[^:]+:[1-9][0-9]*$`
  - to `^.+:[1-9][0-9]*$`
- Match the existing `audit-exfil` and `audit-authz` location contract.
- Add a structural parity test for the three audit schemas.
- Ignore only the skill-specific schema title during comparison so any future contract drift fails tests.

The shared `$defs` extraction remains intentionally out of scope for this follow-up.

## Tests

- `go test ./internal/worker -run 'Test(AuditFindingSchemasStayAligned|BundledSchemas)' -count=1`
- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `golangci-lint run ./cmd/... ./docker/... ./internal/... ./skills/...`
- `git diff --check`