### PR TITLE
Bound scanListStats aggregate to non-terminal statuses

### DIFF
--- a/internal/web/scans.go
+++ b/internal/web/scans.go
@@ -85,7 +85,11 @@ type scanListStats struct {
 
 func (s *Server) scanListStats() scanListStats {
 	var stats scanListStats
+	// All three counts are over queued+paused rows only, so bound the
+	// aggregate to those two statuses and let the status index skip the
+	// terminal history (#694).
 	s.DB.Model(&db.Scan{}).
+		Where("status IN (?, ?)", db.ScanQueued, db.ScanPaused).
 		Select(
 			"COUNT(CASE WHEN status = ? THEN 1 END) AS queued_count, "+
 				"COUNT(CASE WHEN status = ? THEN 1 END) AS paused_count, "+


### PR DESCRIPTION
The three `CASE` counts in `scanListStats` are all over `queued` and `paused` rows, but without a `WHERE` the aggregate walks the full `scans` table and evaluates each `CASE` per historical row. Add `WHERE status IN (queued, paused)` so the existing status index bounds the scan to the handful of non-terminal rows and the Jobs page stops getting slower as terminal history accumulates.

`TestScanListStatsAggregatesCounts` already seeds `ScanRunning` and `ScanFailed` rows alongside the queued/paused ones and asserts `queued=2 paused=2 account-paused=1`, so it covers the change.

Fixes #694.