### PR TITLE
worker: have stageContext write context.json to workRoot and skill dir

### DIFF
--- a/internal/worker/diff_rescan_test.go
+++ b/internal/worker/diff_rescan_test.go
@@ -76,7 +76,7 @@ func TestPrepareDiffRescanStagesDiffInputs(t *testing.T) {
 		t.Fatalf("threat model scan id = %v, want %d", stored.DiffThreatModelScanID, tm.ID)
 	}
 
-	if err := stageContext(workRoot, "http://api", "", DefaultMetadataDir, &stored, &repo); err != nil {
+	if err := stageContext(workRoot, "", "http://api", "", DefaultMetadataDir, &stored, &repo); err != nil {
 		t.Fatal(err)
 	}
 	var ctx skillContext

--- a/internal/worker/exposure.go
+++ b/internal/worker/exposure.go
@@ -167,11 +167,13 @@ func (w *Worker) doExposure(ctx context.Context, scan *db.Scan, emit func(Event)
 	}
 
 	skillDir := w.Runner.SkillDir(workRoot, skill.Name)
-	if err := stageContext(workRoot, w.APIBase, w.ForkOrg, w.metadataDir(), scan, &scan.Repository); err != nil {
-		return "", fmt.Errorf("stage context: %w", err)
-	}
+	// stageSkill clears skillDir, so it runs before stageContext, which
+	// writes context.json into that directory (#499).
 	if err := stageSkill(&skill, workRoot, skillDir); err != nil {
 		return "", fmt.Errorf("stage skill: %w", err)
+	}
+	if err := stageContext(workRoot, skillDir, w.APIBase, w.ForkOrg, w.metadataDir(), scan, &scan.Repository); err != nil {
+		return "", fmt.Errorf("stage context: %w", err)
 	}
 
 	depRepo := db.Repository{URL: dep.RepositoryURL, Name: dep.Name}

--- a/internal/worker/novelty_test.go
+++ b/internal/worker/novelty_test.go
@@ -49,7 +49,7 @@ func TestNoveltyContextStagesBoundedChangedFileEvidence(t *testing.T) {
 
 	scan := fixture.scan(head)
 	if err := stageContextWithInputs(
-		fixture.workRoot, "http://127.0.0.1:8080/api", "", DefaultMetadataDir,
+		fixture.workRoot, "", "http://127.0.0.1:8080/api", "", DefaultMetadataDir,
 		scan, &fixture.repo, nil, got,
 	); err != nil {
 		t.Fatal(err)

--- a/internal/worker/skill.go
+++ b/internal/worker/skill.go
@@ -1063,9 +1063,10 @@ func ValidateSkillPaths(name, outputFile string) error {
 //
 // schema.json is also written to workRoot so the `./schema.json` path every
 // SKILL.md references resolves without the model having to glob for it (#221).
-// context.json is mirrored from workRoot into dst so `./context.json` resolves
-// from the skill directory as well as the workspace root; that read means
-// stageSkill must run after stageContext, which is what produces the file.
+//
+// stageSkill owns dst: it clears the directory before writing, so it must run
+// BEFORE stageContext, which writes context.json into dst as well as workRoot
+// (#499). Running it after would delete that copy.
 func stageSkill(skill *db.Skill, workRoot, dst string) error {
 	if err := os.RemoveAll(dst); err != nil {
 		return err
@@ -1083,16 +1084,6 @@ func stageSkill(skill *db.Skill, workRoot, dst string) error {
 		}
 		if err := os.WriteFile(filepath.Join(workRoot, "schema.json"), []byte(skill.SchemaJSON), filePerm); err != nil {
 			return err
-		}
-	}
-	switch data, err := os.ReadFile(filepath.Join(workRoot, "context.json")); {
-	case errors.Is(err, os.ErrNotExist):
-		// stageContext hasn't run (or this caller doesn't use one); no mirror.
-	case err != nil:
-		return fmt.Errorf("read context.json: %w", err)
-	default:
-		if werr := os.WriteFile(filepath.Join(dst, "context.json"), data, filePerm); werr != nil {
-			return werr
 		}
 	}
 	if skill.SourcePath != "" && skill.Source != "ui" {
@@ -1194,12 +1185,12 @@ func (w *Worker) metadataDir() string {
 	return w.MetadataDir
 }
 
-func stageContext(workRoot, apiBase, forkOrg, metadataDir string, scan *db.Scan, repo *db.Repository) error {
-	return stageContextWithInputs(workRoot, apiBase, forkOrg, metadataDir, scan, repo, nil, nil)
+func stageContext(workRoot, skillDir, apiBase, forkOrg, metadataDir string, scan *db.Scan, repo *db.Repository) error {
+	return stageContextWithInputs(workRoot, skillDir, apiBase, forkOrg, metadataDir, scan, repo, nil, nil)
 }
 
 func stageContextWithInputs(
-	workRoot, apiBase, forkOrg, metadataDir string,
+	workRoot, skillDir, apiBase, forkOrg, metadataDir string,
 	scan *db.Scan,
 	repo *db.Repository,
 	recon *skillContextRecon,
@@ -1279,7 +1270,22 @@ func stageContextWithInputs(
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(filepath.Join(workRoot, "context.json"), b, filePerm)
+	// stageContext owns context.json, so it writes every copy: workRoot for
+	// the workspace-relative path, and the skill directory so ./context.json
+	// resolves from there too. Writing both here is what removes stageSkill's
+	// read-back of workRoot/context.json (#499).
+	for _, dir := range []string{workRoot, skillDir} {
+		if dir == "" {
+			continue
+		}
+		if err := os.MkdirAll(dir, dirPerm); err != nil {
+			return err
+		}
+		if err := os.WriteFile(filepath.Join(dir, "context.json"), b, filePerm); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // stageWorkspace writes everything other than ./src into the scan
@@ -1318,16 +1324,18 @@ func stageWorkspaceWithInputs(
 	recon *skillContextRecon,
 	novelty *skillContextNovelty,
 ) error {
+	// stageSkill clears skillDir, so it runs before stageContext, which
+	// writes context.json into that directory (#499).
+	if err := stageSkill(skill, workRoot, skillDir); err != nil {
+		return fmt.Errorf("stage skill: %w", err)
+	}
 	if err := stageContextWithInputs(
-		workRoot, apiBase, forkOrg, metadataDir, scan, &scan.Repository, recon, novelty,
+		workRoot, skillDir, apiBase, forkOrg, metadataDir, scan, &scan.Repository, recon, novelty,
 	); err != nil {
 		return fmt.Errorf("stage context: %w", err)
 	}
 	if err := stageThreatModel(workRoot, scan.SubPath, scan.Repository.ThreatModel); err != nil {
 		return fmt.Errorf("stage threat model: %w", err)
-	}
-	if err := stageSkill(skill, workRoot, skillDir); err != nil {
-		return fmt.Errorf("stage skill: %w", err)
 	}
 	if err := stageImportPayload(workRoot, scan.ImportPayload); err != nil {
 		return fmt.Errorf("stage import payload: %w", err)

--- a/internal/worker/skill_test.go
+++ b/internal/worker/skill_test.go
@@ -1,6 +1,7 @@
 package worker
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -286,7 +287,7 @@ func TestStageContext_writesRepoFacts(t *testing.T) {
 		DefaultBranch: "main",
 	}
 	scan := &db.Scan{ID: 7, RepositoryID: 3, APIToken: "tok"}
-	if err := stageContext(dir, "http://127.0.0.1:8080/api", "", "", scan, repo); err != nil {
+	if err := stageContext(dir, "", "http://127.0.0.1:8080/api", "", "", scan, repo); err != nil {
 		t.Fatal(err)
 	}
 	b, err := os.ReadFile(filepath.Join(dir, "context.json"))
@@ -319,7 +320,7 @@ attack_surface: stdin is attacker controlled
 skip: [tests/**]`,
 	}
 	scan := &db.Scan{ID: 7, RepositoryID: 3, APIToken: "tok"}
-	if err := stageContext(dir, "http://127.0.0.1:8080/api", "", "", scan, repo); err != nil {
+	if err := stageContext(dir, "", "http://127.0.0.1:8080/api", "", "", scan, repo); err != nil {
 		t.Fatal(err)
 	}
 	b, err := os.ReadFile(filepath.Join(dir, "context.json"))
@@ -349,7 +350,7 @@ func TestStageContext_includesReconFocusAreas(t *testing.T) {
 		Notes: []string{"Examples excluded."},
 	}
 	if err := stageContextWithInputs(
-		dir, "http://127.0.0.1:8080/api", "", "", scan, repo, recon, nil,
+		dir, "", "http://127.0.0.1:8080/api", "", "", scan, repo, recon, nil,
 	); err != nil {
 		t.Fatal(err)
 	}
@@ -376,7 +377,7 @@ func TestStageContext_includesFocusArea(t *testing.T) {
 		t.Fatal(err)
 	}
 	scan := &db.Scan{ID: 7, RepositoryID: 3, APIToken: "tok", FocusArea: raw}
-	if err := stageContext(dir, "http://127.0.0.1:8080/api", "", "", scan, repo); err != nil {
+	if err := stageContext(dir, "", "http://127.0.0.1:8080/api", "", "", scan, repo); err != nil {
 		t.Fatal(err)
 	}
 	b, err := os.ReadFile(filepath.Join(dir, "context.json"))
@@ -668,25 +669,84 @@ func TestStageSkill_noScriptsDirIsNoop(t *testing.T) {
 	}
 }
 
-func TestStageSkill_mirrorsContextJSONToSkillDir(t *testing.T) {
-	// stageContext writes context.json to workRoot; stageSkill must copy it
-	// into the skill directory so ./context.json resolves from the skill dir.
+func TestStageContext_writesToWorkRootAndSkillDir(t *testing.T) {
+	// stageContext owns context.json, so it writes both copies itself: the
+	// workspace root and the skill directory, where ./context.json must also
+	// resolve. Byte-identical, so the two can never disagree (#499).
 	work := t.TempDir()
-	ctx := `{"repository":{"url":"https://example.com/r"}}`
-	if err := os.WriteFile(filepath.Join(work, "context.json"), []byte(ctx), 0o644); err != nil {
+	skillDir := filepath.Join(work, ".claude", "skills", "s")
+	repo := &db.Repository{URL: "https://example.com/r", Name: "r"}
+	scan := &db.Scan{ID: 7, RepositoryID: 1, APIToken: "t"}
+	if err := stageContext(work, skillDir, "http://127.0.0.1:8080/api", "", "", scan, repo); err != nil {
 		t.Fatal(err)
 	}
-	skill := &db.Skill{Name: "s", Description: "d", Body: "body", Source: "ui"}
-	dst := filepath.Join(work, ".claude", "skills", "s")
-	if err := stageSkill(skill, work, dst); err != nil {
-		t.Fatal(err)
-	}
-	got, err := os.ReadFile(filepath.Join(dst, "context.json"))
+	atRoot, err := os.ReadFile(filepath.Join(work, "context.json"))
 	if err != nil {
-		t.Fatalf("context.json not mirrored into skill dir: %v", err)
+		t.Fatalf("context.json missing from workRoot: %v", err)
 	}
-	if string(got) != ctx {
-		t.Errorf("mirrored context.json = %q, want %q", string(got), ctx)
+	atSkill, err := os.ReadFile(filepath.Join(skillDir, "context.json"))
+	if err != nil {
+		t.Fatalf("context.json missing from skill dir: %v", err)
+	}
+	if !bytes.Equal(atRoot, atSkill) {
+		t.Errorf("copies differ:\nworkRoot: %s\nskillDir: %s", atRoot, atSkill)
+	}
+	var got skillContext
+	if err := json.Unmarshal(atSkill, &got); err != nil {
+		t.Fatalf("skill dir copy is not valid context.json: %v", err)
+	}
+	if got.Scrutineer.ScanID != 7 {
+		t.Errorf("scan_id = %d, want 7", got.Scrutineer.ScanID)
+	}
+}
+
+func TestStageContext_emptySkillDirWritesWorkRootOnly(t *testing.T) {
+	// Callers that stage no skill (diff rescan, evals) pass an empty skillDir
+	// and must keep the previous single-file behaviour.
+	work := t.TempDir()
+	repo := &db.Repository{URL: "https://example.com/r", Name: "r"}
+	scan := &db.Scan{ID: 1, RepositoryID: 1, APIToken: "t"}
+	if err := stageContext(work, "", "http://127.0.0.1:8080/api", "", "", scan, repo); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(work, "context.json")); err != nil {
+		t.Fatalf("context.json missing from workRoot: %v", err)
+	}
+	entries, err := os.ReadDir(work)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		t.Errorf("empty skillDir should write one file, got %d entries", len(entries))
+	}
+}
+
+func TestStageWorkspace_skillStagingDoesNotEatContextJSON(t *testing.T) {
+	// The ordering hazard #499 is about, pinned from the outside. stageSkill
+	// clears skillDir before writing, so staging the skill AFTER the context
+	// deletes the skill-dir copy and ./context.json stops resolving -- with no
+	// error anywhere. Assert through the wrapper so a future reorder fails here
+	// instead of silently in production.
+	work := t.TempDir()
+	skillDir := filepath.Join(work, ".claude", "skills", "s")
+	skill := &db.Skill{Name: "s", Description: "d", Body: "body", Source: "ui"}
+	scan := &db.Scan{
+		ID:           3,
+		RepositoryID: 1,
+		APIToken:     "t",
+		Repository:   db.Repository{URL: "https://example.com/r", Name: "r"},
+	}
+	if err := StageWorkspace(work, skillDir, "http://127.0.0.1:8080/api", "", "", scan, skill); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(skillDir, "context.json")); err != nil {
+		t.Fatalf("./context.json does not resolve from the skill dir: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(skillDir, "SKILL.md")); err != nil {
+		t.Fatalf("SKILL.md missing, skill bundle was not staged: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(work, "context.json")); err != nil {
+		t.Fatalf("context.json missing from workRoot: %v", err)
 	}
 }
 
@@ -694,7 +754,7 @@ func TestStageContext_includesRef(t *testing.T) {
 	dir := t.TempDir()
 	repo := &db.Repository{URL: "https://example.com/x", Name: "x"}
 	scan := &db.Scan{ID: 1, RepositoryID: 1, APIToken: "t", Ref: "2.4.x"}
-	if err := stageContext(dir, "http://127.0.0.1:8080/api", "", "", scan, repo); err != nil {
+	if err := stageContext(dir, "", "http://127.0.0.1:8080/api", "", "", scan, repo); err != nil {
 		t.Fatal(err)
 	}
 	b, err := os.ReadFile(filepath.Join(dir, "context.json"))
@@ -714,7 +774,7 @@ func TestStageContext_omitsRefWhenEmpty(t *testing.T) {
 	dir := t.TempDir()
 	repo := &db.Repository{URL: "https://example.com/x", Name: "x"}
 	scan := &db.Scan{ID: 1, RepositoryID: 1, APIToken: "t"}
-	if err := stageContext(dir, "http://127.0.0.1:8080/api", "", "", scan, repo); err != nil {
+	if err := stageContext(dir, "", "http://127.0.0.1:8080/api", "", "", scan, repo); err != nil {
 		t.Fatal(err)
 	}
 	b, err := os.ReadFile(filepath.Join(dir, "context.json"))
@@ -733,7 +793,7 @@ func TestStageContext_includesForkOrg(t *testing.T) {
 	dir := t.TempDir()
 	repo := &db.Repository{URL: "https://github.com/o/r", Name: "r"}
 	scan := &db.Scan{ID: 1, RepositoryID: 1, APIToken: "t"}
-	if err := stageContext(dir, "http://127.0.0.1:8080/api", "fork-central", "", scan, repo); err != nil {
+	if err := stageContext(dir, "", "http://127.0.0.1:8080/api", "fork-central", "", scan, repo); err != nil {
 		t.Fatal(err)
 	}
 	b, err := os.ReadFile(filepath.Join(dir, "context.json"))
@@ -753,7 +813,7 @@ func TestStageContext_includesMetadataDir(t *testing.T) {
 	dir := t.TempDir()
 	repo := &db.Repository{URL: "https://github.com/o/r", Name: "r"}
 	scan := &db.Scan{ID: 1, RepositoryID: 1, APIToken: "t"}
-	if err := stageContext(dir, "http://127.0.0.1:8080/api", "", ".ossprey/", scan, repo); err != nil {
+	if err := stageContext(dir, "", "http://127.0.0.1:8080/api", "", ".ossprey/", scan, repo); err != nil {
 		t.Fatal(err)
 	}
 	b, err := os.ReadFile(filepath.Join(dir, "context.json"))


### PR DESCRIPTION
Closes #499.

`stageContext` now writes `context.json` to both `workRoot` and the skill directory, and `stageSkill` drops its read-back of `workRoot/context.json` — the producer owns the data and writes every copy, as the issue describes.

## The ordering constraint doesn't go away — it inverts, and I couldn't make it disappear without changing who owns `skillDir`

The issue expects `stageSkill`'s ordering dependency to disappear once `stageContext` writes both copies. It doesn't, because `stageSkill` opens with `os.RemoveAll(dst)`: it owns the skill directory's lifecycle so a restage can't leave stale files behind. So with the naive shape — `stageContext` first, as both call sites had it — the skill-dir copy is written and then **deleted milliseconds later**, and `./context.json` stops resolving from the skill dir with no error anywhere. That is the same silent failure the issue is trying to remove, just moved.

I verified it rather than assuming it. With the new `stageContext` in place and only the call order flipped back:

```
--- FAIL: TestStageWorkspace_skillStagingDoesNotEatContextJSON
    skill_test.go:743: ./context.json does not resolve from the skill dir:
    stat .../001/.claude/skills/s/context.json: no such file or directory
```

So both call sites now stage the skill **first**, and the doc comment on `stageSkill` says why. The constraint is inverted, not removed, and I'd rather say that plainly than claim the issue's stated benefit.

**The alternative, if you want the constraint genuinely gone:** hoist the `os.RemoveAll(dst)` out of `stageSkill` into an explicit reset at the top of `stageWorkspaceWithInputs` and `doExposure`. Then neither function owns `skillDir`, both just write into an already-cleared directory, and the order really is irrelevant. I didn't take it because it changes `stageSkill`'s contract for the six tests that call it directly and for any future standalone caller that relies on it clearing stale files (`TestStageSkill_remirrorClearsStaleScripts` is the one that would notice). Happy to switch if you'd prefer that shape — it's a small diff.

## Tests

- `TestStageWorkspace_skillStagingDoesNotEatContextJSON` — pins the hazard above from outside, through `StageWorkspace`, so a future reorder fails in CI instead of silently in production. This is the test that fails on the flipped order.
- `TestStageContext_writesToWorkRootAndSkillDir` — both copies exist and are **byte-identical**, so they can't drift apart.
- `TestStageContext_emptySkillDirWritesWorkRootOnly` — callers that stage no skill (diff rescan, evals, the `stageContext` unit tests) pass `skillDir == ""` and keep exactly the old single-file behaviour.
- `TestStageSkill_mirrorsContextJSONToSkillDir` is removed: it asserted the read-back that this PR deletes. Its intent — `./context.json` resolves from the skill dir — is what the first test above now covers end to end, which is the better place for it since that was always a property of the *staging sequence*, not of `stageSkill` alone.

The `#470` test stays as-is and passes.

## Notes

- `stageContext` `MkdirAll`s each destination, so it no longer depends on the skill dir already existing.
- Signature change is internal (`stageContext`, `stageContextWithInputs`); the exported `StageWorkspace` is untouched, so eval harnesses don't need updating.
- No behaviour change for `skillDir == ""` callers.
