### PR TITLE
Generate per-repository SBOM snapshots from the dependencies scan

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -1378,7 +1378,9 @@ func Open(dsn string) (*gorm.DB, error) {
 	if err != nil {
 		return nil, fmt.Errorf("open sqlite: %w", err)
 	}
-	preMigrate(gdb)
+	if err := preMigrate(gdb); err != nil {
+		return nil, fmt.Errorf("premigrate: %w", err)
+	}
 	if err := gdb.AutoMigrate(
 		&Repository{}, &Scan{},
 		&Finding{}, &FindingLabel{}, &FindingNote{},
@@ -1410,16 +1412,21 @@ func Open(dsn string) (*gorm.DB, error) {
 // preMigrate applies structural changes AutoMigrate cannot express, chiefly
 // column renames. It must run before AutoMigrate so a renamed column is not
 // re-added under its new name alongside the old one. Each step is guarded so
-// a fresh database and an already-migrated database are both no-ops.
-func preMigrate(gdb *gorm.DB) {
+// a fresh database and an already-migrated database are both no-ops. A failed
+// rename is fatal: proceeding to AutoMigrate would add the new column
+// alongside the old one and strand its data.
+func preMigrate(gdb *gorm.DB) error {
 	m := gdb.Migrator()
 	// SBOMPackage.RepositoryID became SourceRepositoryID when SBOMUpload
 	// gained its own RepositoryID pointing at the scanned repository; the
 	// package-level field points at the repository that publishes the
 	// package, which is the opposite direction.
 	if m.HasTable(&SBOMPackage{}) && m.HasColumn(&SBOMPackage{}, "repository_id") {
-		_ = m.RenameColumn(&SBOMPackage{}, "repository_id", "source_repository_id")
+		if err := m.RenameColumn(&SBOMPackage{}, "repository_id", "source_repository_id"); err != nil {
+			return fmt.Errorf("rename sbom_packages.repository_id: %w", err)
+		}
 	}
+	return nil
 }
 
 // Snapshot writes a consistent copy of the SQLite database at src to dest

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -1378,6 +1378,7 @@ func Open(dsn string) (*gorm.DB, error) {
 	if err != nil {
 		return nil, fmt.Errorf("open sqlite: %w", err)
 	}
+	preMigrate(gdb)
 	if err := gdb.AutoMigrate(
 		&Repository{}, &Scan{},
 		&Finding{}, &FindingLabel{}, &FindingNote{},
@@ -1404,6 +1405,21 @@ func Open(dsn string) (*gorm.DB, error) {
 		gdb.Exec(`CREATE UNIQUE INDEX IF NOT EXISTS idx_subprojects_repo_path ON subprojects (repository_id, path)`)
 	}
 	return gdb, nil
+}
+
+// preMigrate applies structural changes AutoMigrate cannot express, chiefly
+// column renames. It must run before AutoMigrate so a renamed column is not
+// re-added under its new name alongside the old one. Each step is guarded so
+// a fresh database and an already-migrated database are both no-ops.
+func preMigrate(gdb *gorm.DB) {
+	m := gdb.Migrator()
+	// SBOMPackage.RepositoryID became SourceRepositoryID when SBOMUpload
+	// gained its own RepositoryID pointing at the scanned repository; the
+	// package-level field points at the repository that publishes the
+	// package, which is the opposite direction.
+	if m.HasTable(&SBOMPackage{}) && m.HasColumn(&SBOMPackage{}, "repository_id") {
+		_ = m.RenameColumn(&SBOMPackage{}, "repository_id", "source_repository_id")
+	}
 }
 
 // Snapshot writes a consistent copy of the SQLite database at src to dest
@@ -1449,9 +1465,16 @@ func Snapshot(src, dest string) error {
 	return nil
 }
 
-// SBOMUpload is one CycloneDX or SPDX document a user uploaded. Packages
-// are replaced wholesale on re-upload (cascade delete) but the resolved
-// Repository rows survive so prior scan results stay attached.
+const (
+	SBOMOriginUploaded  = "uploaded"
+	SBOMOriginGenerated = "generated"
+)
+
+// SBOMUpload is one CycloneDX or SPDX document. Origin distinguishes a
+// document a user uploaded from one the dependencies scan generated for a
+// repository at a specific commit. Packages are replaced wholesale on
+// re-upload (cascade delete) but the resolved Repository rows survive so
+// prior scan results stay attached.
 type SBOMUpload struct {
 	ID uint `gorm:"primarykey"`
 
@@ -1459,7 +1482,26 @@ type SBOMUpload struct {
 	Filename    string
 	Format      string
 	SpecVersion string
-	Raw         []byte
+	// Raw holds the document bytes for uploaded origin so the operator can
+	// re-download exactly what was submitted. Generated snapshots leave it
+	// nil since retaining every historical CycloneDX document per repository
+	// is not worth the storage.
+	Raw []byte
+
+	// Origin is SBOMOriginUploaded or SBOMOriginGenerated. The default keeps
+	// rows created before the column existed classified as uploads.
+	Origin string `gorm:"index;not null;default:uploaded"`
+	// RepositoryID and Commit identify the scanned repository and revision
+	// for a generated snapshot. Nil for uploads.
+	RepositoryID *uint `gorm:"index:idx_sbom_uploads_repo_current"`
+	Repository   *Repository
+	ScanID       *uint `gorm:"index"`
+	Commit       string
+	// Current marks the newest successful generated snapshot for
+	// RepositoryID. Portfolio queries filter on it so they read one row per
+	// repository without a per-repo subquery. The dependencies parser moves
+	// the flag inside the same transaction that writes the new snapshot.
+	Current bool `gorm:"index:idx_sbom_uploads_repo_current"`
 
 	PackageCount int
 	// ImportPending is true after a newly parsed upload and until the operator
@@ -1472,9 +1514,11 @@ type SBOMUpload struct {
 	UpdatedAt time.Time
 }
 
-// SBOMPackage is one component listed in an upload. RepositoryID is set
-// asynchronously once the PURL has been resolved to a source repo and the
-// triage scan enqueued; until then it is nil.
+// SBOMPackage is one component listed in an upload. SourceRepositoryID is set
+// asynchronously once the PURL has been resolved to the repository that
+// publishes the package and a triage scan enqueued; until then it is nil.
+// It is distinct from SBOMUpload.RepositoryID, which for a generated
+// snapshot points at the repository whose dependencies were scanned.
 type SBOMPackage struct {
 	ID           uint `gorm:"primarykey"`
 	SBOMUploadID uint `gorm:"index;not null"`
@@ -1490,9 +1534,9 @@ type SBOMPackage struct {
 	// dependency graph to derive it from.
 	Scope string `gorm:"index"`
 
-	RepositoryID *uint `gorm:"index"`
-	Repository   *Repository
-	ResolveError string
+	SourceRepositoryID *uint `gorm:"index"`
+	SourceRepository   *Repository
+	ResolveError       string
 
 	CreatedAt time.Time
 }

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -274,6 +274,85 @@ func TestOpenAndMigrate(t *testing.T) {
 	}
 }
 
+func TestPreMigrate_renamesSBOMPackageRepositoryID(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "old.db")
+	// Simulate a database written before the rename: sbom_packages has a
+	// repository_id column with data in it. Open must rename the column
+	// before AutoMigrate would otherwise add source_repository_id alongside
+	// it and strand the old values.
+	raw, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stmts := []string{
+		`CREATE TABLE repositories (id INTEGER PRIMARY KEY, url TEXT, name TEXT)`,
+		`INSERT INTO repositories (id, url, name) VALUES (42, 'https://example.com/r', 'r')`,
+		`CREATE TABLE sbom_uploads (id INTEGER PRIMARY KEY, name TEXT)`,
+		`INSERT INTO sbom_uploads (id, name) VALUES (1, 'old')`,
+		`CREATE TABLE sbom_packages (id INTEGER PRIMARY KEY, sbom_upload_id INTEGER, repository_id INTEGER)`,
+		`INSERT INTO sbom_packages (id, sbom_upload_id, repository_id) VALUES (1, 1, 42)`,
+	}
+	for _, s := range stmts {
+		if _, err := raw.Exec(s); err != nil {
+			t.Fatal(err)
+		}
+	}
+	_ = raw.Close()
+
+	gdb, err := Open(path)
+	if err != nil {
+		t.Fatalf("open with old schema: %v", err)
+	}
+	if gdb.Migrator().HasColumn(&SBOMPackage{}, "repository_id") {
+		t.Error("repository_id column should have been renamed, still present")
+	}
+	var pkg SBOMPackage
+	if err := gdb.First(&pkg, 1).Error; err != nil {
+		t.Fatalf("read migrated row: %v", err)
+	}
+	if pkg.SourceRepositoryID == nil || *pkg.SourceRepositoryID != 42 {
+		t.Errorf("SourceRepositoryID = %v, want 42", pkg.SourceRepositoryID)
+	}
+
+	// Idempotent: a second Open on the already-migrated file must not fail.
+	if _, err := Open(path); err != nil {
+		t.Fatalf("second open: %v", err)
+	}
+}
+
+func TestSBOMUpload_originAndCurrent(t *testing.T) {
+	gdb, err := Open(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo := Repository{URL: "https://example.com/r", Name: "r"}
+	gdb.Create(&repo)
+	// A row that omits Origin lands as "uploaded" via the column default,
+	// matching rows written before the column existed.
+	up := SBOMUpload{Name: "x"}
+	if err := gdb.Create(&up).Error; err != nil {
+		t.Fatal(err)
+	}
+	var got SBOMUpload
+	gdb.First(&got, up.ID)
+	if got.Origin != SBOMOriginUploaded {
+		t.Errorf("default Origin = %q, want %q", got.Origin, SBOMOriginUploaded)
+	}
+	if got.Current {
+		t.Error("uploaded SBOM should not be Current")
+	}
+
+	gen := SBOMUpload{Name: "g", Origin: SBOMOriginGenerated, RepositoryID: &repo.ID, Commit: "abc", Current: true}
+	if err := gdb.Create(&gen).Error; err != nil {
+		t.Fatal(err)
+	}
+	var current []SBOMUpload
+	gdb.Where("repository_id = ? AND current = ?", repo.ID, true).Find(&current)
+	if len(current) != 1 || current[0].ID != gen.ID {
+		t.Errorf("current lookup = %+v, want [%d]", current, gen.ID)
+	}
+}
+
 func TestWithPragmas_joinsOnExistingQuery(t *testing.T) {
 	cases := map[string]string{
 		"data/scrutineer.db":         "data/scrutineer.db?" + connectionPragmas,

--- a/internal/web/repo_delete_test.go
+++ b/internal/web/repo_delete_test.go
@@ -87,9 +87,14 @@ func TestRepoDelete_removesRepoAndAllLinkedData(t *testing.T) {
 	}
 
 	upload := db.SBOMUpload{Name: "bom", Packages: []db.SBOMPackage{
-		{Name: "acme-pkg", PURL: "pkg:npm/acme-pkg", RepositoryID: &repo.ID},
+		{Name: "acme-pkg", PURL: "pkg:npm/acme-pkg", SourceRepositoryID: &repo.ID},
 	}}
 	s.DB.Create(&upload)
+	generated := db.SBOMUpload{
+		Name: "gen", Origin: db.SBOMOriginGenerated, RepositoryID: &repo.ID, Current: true,
+		Packages: []db.SBOMPackage{{Name: "left-pad", PURL: "pkg:npm/left-pad@1.3.0"}},
+	}
+	s.DB.Create(&generated)
 
 	// On-disk clone cache for the doomed repo.
 	cacheDir := worker.RepoCacheRoot(dataDir, repo.URL)
@@ -177,8 +182,14 @@ func TestRepoDelete_removesRepoAndAllLinkedData(t *testing.T) {
 	}
 	var pkg db.SBOMPackage
 	s.DB.First(&pkg, upload.Packages[0].ID)
-	if pkg.RepositoryID != nil {
-		t.Errorf("sbom package repository_id should be nulled, got %v", *pkg.RepositoryID)
+	if pkg.SourceRepositoryID != nil {
+		t.Errorf("sbom package source_repository_id should be nulled, got %v", *pkg.SourceRepositoryID)
+	}
+	if n := count(&db.SBOMUpload{}, "id = ?", generated.ID); n != 0 {
+		t.Errorf("generated snapshot for deleted repo should be removed, got %d", n)
+	}
+	if n := count(&db.SBOMPackage{}, "sbom_upload_id = ?", generated.ID); n != 0 {
+		t.Errorf("generated snapshot packages should cascade, got %d", n)
 	}
 
 	// The unrelated repo is untouched.

--- a/internal/web/sboms.go
+++ b/internal/web/sboms.go
@@ -31,7 +31,10 @@ func (s *Server) registerSBOMRoutes(mux *http.ServeMux) {
 }
 
 func (s *Server) sbomList(w http.ResponseWriter, r *http.Request) {
-	q := s.DB.Model(&db.SBOMUpload{})
+	// Generated per-repository snapshots share this table but are one row per
+	// dependencies scan; listing them here would bury the operator's uploads.
+	// They surface via the repository and portfolio views instead.
+	q := s.DB.Model(&db.SBOMUpload{}).Where("origin = ?", db.SBOMOriginUploaded)
 	sortCol, dir := splitSort(r.URL.Query().Get("sort"))
 	switch sortCol {
 	case "name":

--- a/internal/web/sboms.go
+++ b/internal/web/sboms.go
@@ -87,6 +87,7 @@ func (s *Server) sbomUpload(w http.ResponseWriter, r *http.Request) {
 		Format:        string(doc.Type),
 		SpecVersion:   doc.SpecVersion,
 		Raw:           data,
+		Origin:        db.SBOMOriginUploaded,
 		PackageCount:  len(doc.Packages),
 		ImportPending: true,
 	}
@@ -149,7 +150,7 @@ func (s *Server) sbomShow(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 		return
 	}
-	if err := s.DB.Preload("Packages.Repository").First(&up, id).Error; err != nil {
+	if err := s.DB.Preload("Packages.SourceRepository").First(&up, id).Error; err != nil {
 		http.NotFound(w, r)
 		return
 	}
@@ -173,8 +174,8 @@ func (s *Server) sbomShow(w http.ResponseWriter, r *http.Request) {
 
 	reposByID := make(map[uint]db.Repository)
 	for _, p := range pkgs {
-		if p.Repository != nil {
-			reposByID[p.Repository.ID] = *p.Repository
+		if p.SourceRepository != nil {
+			reposByID[p.SourceRepository.ID] = *p.SourceRepository
 		}
 	}
 	repoIDs := make([]uint, 0, len(reposByID))
@@ -221,10 +222,10 @@ func (s *Server) sbomShow(w http.ResponseWriter, r *http.Request) {
 
 	resolved, withRepo := 0, 0
 	for _, p := range pkgs {
-		if p.RepositoryID != nil || p.ResolveError != "" {
+		if p.SourceRepositoryID != nil || p.ResolveError != "" {
 			resolved++
 		}
-		if p.RepositoryID != nil {
+		if p.SourceRepositoryID != nil {
 			withRepo++
 		}
 	}
@@ -321,7 +322,7 @@ func (s *Server) resolveSBOMPackages(uploadID uint) {
 	defer cancel()
 
 	var pkgs []db.SBOMPackage
-	s.DB.Where("sbom_upload_id = ? AND repository_id IS NULL", uploadID).Find(&pkgs)
+	s.DB.Where("sbom_upload_id = ? AND source_repository_id IS NULL", uploadID).Find(&pkgs)
 
 	for i := range pkgs {
 		p := &pkgs[i]
@@ -353,7 +354,7 @@ func (s *Server) resolveSBOMPackages(uploadID uint) {
 			s.DB.Model(p).Update("resolve_error", err.Error())
 			continue
 		}
-		s.DB.Model(p).Updates(map[string]any{"repository_id": repo.ID, "resolve_error": ""})
+		s.DB.Model(p).Updates(map[string]any{"source_repository_id": repo.ID, "resolve_error": ""})
 	}
 }
 

--- a/internal/web/sboms_test.go
+++ b/internal/web/sboms_test.go
@@ -139,7 +139,7 @@ func TestSBOMResolveHandler(t *testing.T) {
 
 	var pkg db.SBOMPackage
 	s.DB.Where("sbom_upload_id = ?", up.ID).First(&pkg)
-	if pkg.RepositoryID == nil {
+	if pkg.SourceRepositoryID == nil {
 		t.Errorf("package not linked after resolve handler: %+v", pkg)
 	}
 
@@ -187,7 +187,7 @@ func TestSBOMResolve_recordsReasonWhenEnrichmentDisabled(t *testing.T) {
 	if len(byName) != 3 {
 		t.Fatalf("packages = %d, want 3", len(byName))
 	}
-	if byName["lodash"].RepositoryID != nil {
+	if byName["lodash"].SourceRepositoryID != nil {
 		t.Errorf("package linked with enrichment disabled: %+v", byName["lodash"])
 	}
 	if got := byName["lodash"].ResolveError; got != ecosystemsDisabled {
@@ -258,11 +258,11 @@ func TestSBOMConfirm_resolvesAfterOperatorConfirmation(t *testing.T) {
 		t.Fatal("confirmation did not clear ImportPending")
 	}
 	for _, p := range confirmed.Packages {
-		if p.RepositoryID == nil {
+		if p.SourceRepositoryID == nil {
 			t.Fatalf("package %s was not resolved", p.Name)
 		}
 		var count int64
-		s.DB.Model(&db.Scan{}).Where("repository_id = ?", *p.RepositoryID).Count(&count)
+		s.DB.Model(&db.Scan{}).Where("repository_id = ?", *p.SourceRepositoryID).Count(&count)
 		want := int64(0)
 		if p.Scope == sbom.ScopeDirect {
 			want = 1
@@ -420,11 +420,11 @@ func TestSBOMResolve_linksRepoAndEnqueuesTriage(t *testing.T) {
 	var pkgs []db.SBOMPackage
 	s.DB.Where("sbom_upload_id = ?", up.ID).Order("id").Find(&pkgs)
 
-	if pkgs[0].RepositoryID == nil {
+	if pkgs[0].SourceRepositoryID == nil {
 		t.Fatalf("lodash not linked: %+v", pkgs[0])
 	}
 	var repo db.Repository
-	s.DB.First(&repo, *pkgs[0].RepositoryID)
+	s.DB.First(&repo, *pkgs[0].SourceRepositoryID)
 	if repo.URL != "https://github.com/lodash/lodash" {
 		t.Errorf("repo url = %q", repo.URL)
 	}
@@ -434,18 +434,18 @@ func TestSBOMResolve_linksRepoAndEnqueuesTriage(t *testing.T) {
 		t.Errorf("triage scan not enqueued for direct dependency, scans = %d", scans)
 	}
 
-	if pkgs[1].RepositoryID == nil {
+	if pkgs[1].SourceRepositoryID == nil {
 		t.Fatalf("flat-scope package not linked: %+v", pkgs[1])
 	}
-	s.DB.Model(&db.Scan{}).Where("repository_id = ?", *pkgs[1].RepositoryID).Count(&scans)
+	s.DB.Model(&db.Scan{}).Where("repository_id = ?", *pkgs[1].SourceRepositoryID).Count(&scans)
 	if scans != 1 {
 		t.Errorf("triage scan not enqueued for flat-scope dependency, scans = %d", scans)
 	}
 
-	if pkgs[2].RepositoryID == nil {
+	if pkgs[2].SourceRepositoryID == nil {
 		t.Fatalf("transitive not linked: %+v", pkgs[2])
 	}
-	s.DB.Model(&db.Scan{}).Where("repository_id = ?", *pkgs[2].RepositoryID).Count(&scans)
+	s.DB.Model(&db.Scan{}).Where("repository_id = ?", *pkgs[2].SourceRepositoryID).Count(&scans)
 	if scans != 0 {
 		t.Errorf("triage scan enqueued for transitive dependency, scans = %d", scans)
 	}
@@ -477,7 +477,7 @@ func TestSBOMShow_aggregatesFindings(t *testing.T) {
 	s.DB.Create(&db.Finding{ScanID: scan.ID, RepositoryID: other.ID, Title: "unrelated", Severity: "High"})
 
 	up := db.SBOMUpload{Name: "demo", PackageCount: 1, Packages: []db.SBOMPackage{
-		{Name: "r-pkg", PURL: "pkg:npm/r", RepositoryID: &repo.ID},
+		{Name: "r-pkg", PURL: "pkg:npm/r", SourceRepositoryID: &repo.ID},
 	}}
 	s.DB.Create(&up)
 
@@ -516,7 +516,7 @@ func TestSBOMShow_findingsSort(t *testing.T) {
 	s.DB.Create(&db.Finding{ScanID: scan.ID, RepositoryID: repo.ID, Title: "new-low", Severity: "Low"})
 
 	up := db.SBOMUpload{Name: "demo", PackageCount: 1, Packages: []db.SBOMPackage{
-		{Name: "p", RepositoryID: &repo.ID},
+		{Name: "p", SourceRepositoryID: &repo.ID},
 	}}
 	s.DB.Create(&up)
 
@@ -552,7 +552,7 @@ func TestSBOMShow_listsAdvisories(t *testing.T) {
 	s.DB.Create(&db.Advisory{RepositoryID: repo.ID, Title: "withdrawn-one", WithdrawnAt: new(time.Now())})
 
 	up := db.SBOMUpload{Name: "demo", PackageCount: 1, Packages: []db.SBOMPackage{
-		{Name: "adv-pkg", PURL: "pkg:npm/adv", RepositoryID: &repo.ID},
+		{Name: "adv-pkg", PURL: "pkg:npm/adv", SourceRepositoryID: &repo.ID},
 	}}
 	s.DB.Create(&up)
 
@@ -600,8 +600,8 @@ func TestSBOMShow_scopeFilter(t *testing.T) {
 	s.DB.Create(&db.Finding{ScanID: scan.ID, RepositoryID: repoB.ID, Title: "trans-dep-finding", Severity: "High"})
 
 	up := db.SBOMUpload{Name: "demo", PackageCount: 2, Packages: []db.SBOMPackage{
-		{Name: "pkg-direct", Scope: sbom.ScopeDirect, RepositoryID: &repoA.ID},
-		{Name: "pkg-trans", Scope: sbom.ScopeTransitive, RepositoryID: &repoB.ID},
+		{Name: "pkg-direct", Scope: sbom.ScopeDirect, SourceRepositoryID: &repoA.ID},
+		{Name: "pkg-trans", Scope: sbom.ScopeTransitive, SourceRepositoryID: &repoB.ID},
 	}}
 	s.DB.Create(&up)
 

--- a/internal/web/sboms_test.go
+++ b/internal/web/sboms_test.go
@@ -586,6 +586,35 @@ func TestSBOMList_renders(t *testing.T) {
 	}
 }
 
+func TestSBOMList_excludesGeneratedSnapshots(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	repo := db.Repository{URL: "https://example.com/r", Name: "r"}
+	s.DB.Create(&repo)
+	s.DB.Create(&db.SBOMUpload{Name: "user.cdx", Format: "cyclonedx", Origin: db.SBOMOriginUploaded})
+	s.DB.Create(&db.SBOMUpload{
+		Name: "generated-snapshot", Format: "cyclonedx",
+		Origin: db.SBOMOriginGenerated, RepositoryID: &repo.ID, Current: true,
+	})
+
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq("GET", "/sboms"))
+	if w.Code != 200 {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, "user.cdx") {
+		t.Errorf("uploaded SBOM not listed")
+	}
+	if strings.Contains(body, "generated-snapshot") {
+		t.Errorf("generated snapshot listed on /sboms")
+	}
+	if n := strings.Count(body, `<tr id="sbom-`); n != 1 {
+		t.Errorf("rows = %d, want 1", n)
+	}
+}
+
 func TestSBOMShow_scopeFilter(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -2792,14 +2792,17 @@ func (s *Server) deleteRepository(repo db.Repository) (deletedRepository, error)
 		}
 		for _, child := range []any{
 			&db.Finding{}, &db.Scan{}, &db.Subproject{}, &db.Dependency{},
-			&db.Dependent{}, &db.Package{}, &db.Advisory{},
+			&db.Dependent{}, &db.Package{}, &db.Advisory{}, &db.SBOMUpload{},
 		} {
 			if err := tx.Where("repository_id = ?", repo.ID).Delete(child).Error; err != nil {
 				return err
 			}
 		}
-		if err := tx.Model(&db.SBOMPackage{}).Where("repository_id = ?", repo.ID).
-			Update("repository_id", nil).Error; err != nil {
+		// Generated snapshots for the deleted repo were removed above via
+		// repository_id; packages in other uploads that resolved to this repo
+		// as their source keep their row but drop the pointer.
+		if err := tx.Model(&db.SBOMPackage{}).Where("source_repository_id = ?", repo.ID).
+			Update("source_repository_id", nil).Error; err != nil {
 			return err
 		}
 		if err := tx.Exec("DELETE FROM repository_maintainers WHERE repository_id = ?", repo.ID).Error; err != nil {

--- a/internal/web/templates/sbom_show.html
+++ b/internal/web/templates/sbom_show.html
@@ -115,8 +115,8 @@
           <td class="text-muted-foreground text-xs">{{.Version}}</td>
           <td class="text-muted-foreground text-xs">{{.License}}</td>
           <td class="whitespace-normal">
-            {{if .Repository}}
-              <a href="/repositories/{{.Repository.ID}}" class="hover:underline">{{.Repository.Name}}</a>
+            {{if .SourceRepository}}
+              <a href="/repositories/{{.SourceRepository.ID}}" class="hover:underline">{{.SourceRepository.Name}}</a>
             {{else if .ResolveError}}
               <span class="text-xs text-muted-foreground">{{.ResolveError}}</span>
             {{else if $.SBOM.ImportPending}}

--- a/internal/worker/dependencies_script_test.go
+++ b/internal/worker/dependencies_script_test.go
@@ -9,10 +9,9 @@ import (
 )
 
 type scriptSection struct {
-	Status  string            `json:"status"`
-	Error   string            `json:"error"`
-	Result  json.RawMessage   `json:"result"`
-	Sources []json.RawMessage `json:"sources"`
+	Status string          `json:"status"`
+	Error  string          `json:"error"`
+	Result json.RawMessage `json:"result"`
 }
 
 type scriptEnvelope struct {
@@ -53,7 +52,13 @@ func TestDependenciesScript_ok(t *testing.T) {
 	if env.GitPkgsVersion != "git-pkgs 0.0.0-test" {
 		t.Errorf("git_pkgs_version = %q", env.GitPkgsVersion)
 	}
-	for _, name := range []string{"inventory", "sbom", "licenses", "vulnerabilities", "outdated", "deprecated"} {
+	// Only the two per-repo analyses run; the schema's additionalProperties:false
+	// on the analyses object rejects anything else, so a stray section would
+	// have failed the schema check above.
+	if len(env.Analyses) != 2 {
+		t.Errorf("analyses = %v, want inventory+sbom", env.Analyses)
+	}
+	for _, name := range []string{"inventory", "sbom"} {
 		if env.Analyses[name].Status != "ok" {
 			t.Errorf("%s status = %q: %s", name, env.Analyses[name].Status, env.Analyses[name].Error)
 		}
@@ -66,13 +71,10 @@ func TestDependenciesScript_ok(t *testing.T) {
 	if err := json.Unmarshal(env.Analyses["sbom"].Result, &bom); err != nil || bom["bomFormat"] != "CycloneDX" {
 		t.Errorf("sbom result = %s", env.Analyses["sbom"].Result)
 	}
-	// Bare-array output from vulns is normalised to result+sources.
-	var vulns []map[string]any
-	if err := json.Unmarshal(env.Analyses["vulnerabilities"].Result, &vulns); err != nil || len(vulns) != 1 {
-		t.Errorf("vulnerabilities result = %s", env.Analyses["vulnerabilities"].Result)
-	}
-	if env.Analyses["vulnerabilities"].Sources == nil {
-		t.Error("vulnerabilities sources missing")
+	// The stub records --skip-enrichment reaching the sbom command so no
+	// registry is contacted from inside the scan.
+	if got := bom["_saw_skip_enrichment"]; got != true {
+		t.Errorf("sbom command not passed --skip-enrichment: %v", bom)
 	}
 }
 
@@ -84,27 +86,12 @@ func TestDependenciesScript_listNull(t *testing.T) {
 }
 
 func TestDependenciesScript_sectionFailure(t *testing.T) {
-	env := runAndDecodeDependenciesScript(t, "vulns-fail")
-	if s := env.Analyses["vulnerabilities"]; s.Status != "error" || s.Error == "" {
-		t.Errorf("vulns exit 1 should be status=error: %+v", s)
+	env := runAndDecodeDependenciesScript(t, "sbom-fail")
+	if s := env.Analyses["sbom"]; s.Status != "error" || s.Error == "" {
+		t.Errorf("sbom exit 1 should be status=error: %+v", s)
 	}
 	if env.Analyses["inventory"].Status != "ok" {
-		t.Error("failed vulns must not fail inventory")
-	}
-}
-
-func TestDependenciesScript_post306Object(t *testing.T) {
-	env := runAndDecodeDependenciesScript(t, "post306")
-	out := env.Analyses["outdated"]
-	if out.Status != "ok" {
-		t.Fatalf("status = %q: %s", out.Status, out.Error)
-	}
-	var res []map[string]any
-	if err := json.Unmarshal(out.Result, &res); err != nil || len(res) != 1 || res[0]["name"] != "lodash" {
-		t.Errorf("object-form results not passed through: %s", out.Result)
-	}
-	if len(out.Sources) != 1 {
-		t.Errorf("object-form sources not passed through: %v", out.Sources)
+		t.Error("failed sbom must not fail inventory")
 	}
 }
 
@@ -139,7 +126,8 @@ func runDependenciesScript(t *testing.T, mode string) (string, error) {
 
 // fakeGitPkgsScript stands in for the git-pkgs CLI. GP_MODE selects a
 // scenario; every command not overridden by the scenario emits a minimal
-// representative payload so the envelope assembler sees all six sections.
+// representative payload. The default arm rejects any command index.sh should
+// no longer be running (licenses, vulns, outdated, deprecated).
 const fakeGitPkgsScript = `#!/usr/bin/env bash
 set -euo pipefail
 mode="${GP_MODE:-ok}"
@@ -151,24 +139,10 @@ case "$1" in
     printf '[{"name":"left-pad","ecosystem":"npm","manifest_path":"package.json"}]\n'
     ;;
   sbom)
-    printf '{"bomFormat":"CycloneDX","specVersion":"1.5","components":[]}\n'
-    ;;
-  licenses)
-    printf '[]\n'
-    ;;
-  vulns)
-    if [ "$mode" = "vulns-fail" ]; then echo "osv.dev unreachable" >&2; exit 1; fi
-    printf '[{"id":"GHSA-xxxx","package":"left-pad"}]\n'
-    ;;
-  outdated)
-    if [ "$mode" = "post306" ]; then
-      printf '{"results":[{"name":"lodash"}],"sources":[{"ecosystem":"npm","status":"ok"}]}\n'
-      exit 0
-    fi
-    printf '[]\n'
-    ;;
-  deprecated)
-    printf '[]\n'
+    if [ "$mode" = "sbom-fail" ]; then echo "sbom failed" >&2; exit 1; fi
+    skip=false
+    for a in "$@"; do [ "$a" = "--skip-enrichment" ] && skip=true; done
+    printf '{"bomFormat":"CycloneDX","specVersion":"1.5","components":[],"_saw_skip_enrichment":%s}\n' "$skip"
     ;;
   *)
     echo "unexpected git-pkgs command: $*" >&2

--- a/internal/worker/dependencies_script_test.go
+++ b/internal/worker/dependencies_script_test.go
@@ -1,50 +1,110 @@
 package worker
 
 import (
+	"encoding/json"
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
 	"testing"
 )
 
-func TestDependenciesScriptNormalizesEmptyGitPkgsOutput(t *testing.T) {
-	cases := []struct {
-		name string
-		mode string
-		want string
-	}{
-		{"null", "null", `{"dependencies":[]}` + "\n"},
-		{"empty", "empty", `{"dependencies":[]}` + "\n"},
-		{"array", "array", `{"dependencies":[{"name":"left-pad","ecosystem":"npm"}]}` + "\n"},
+type scriptSection struct {
+	Status  string            `json:"status"`
+	Error   string            `json:"error"`
+	Result  json.RawMessage   `json:"result"`
+	Sources []json.RawMessage `json:"sources"`
+}
+
+type scriptEnvelope struct {
+	SchemaVersion  int                      `json:"schema_version"`
+	Commit         string                   `json:"commit"`
+	GitPkgsVersion string                   `json:"git_pkgs_version"`
+	Analyses       map[string]scriptSection `json:"analyses"`
+}
+
+// runAndDecodeDependenciesScript runs index.sh against the stub git-pkgs in
+// the given scenario, validates the output against the bundled schema, and
+// returns the parsed envelope.
+func runAndDecodeDependenciesScript(t *testing.T, mode string) scriptEnvelope {
+	t.Helper()
+	out, err := runDependenciesScript(t, mode)
+	if err != nil {
+		t.Fatalf("script failed: %v\n%s", err, out)
 	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			out, err := runDependenciesScript(t, tc.mode)
-			if err != nil {
-				t.Fatalf("script failed: %v\n%s", err, out)
-			}
-			if out != tc.want {
-				t.Fatalf("output = %q, want %q", out, tc.want)
-			}
-			schema, err := os.ReadFile("../../skills/dependencies/schema.json")
-			if err != nil {
-				t.Fatal(err)
-			}
-			if got := ValidateReportSchema(string(schema), out); got != "" {
-				t.Fatalf("script output failed schema validation: %s\n%s", got, out)
-			}
-		})
+	schema, err := os.ReadFile("../../skills/dependencies/schema.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := ValidateReportSchema(string(schema), out); got != "" {
+		t.Fatalf("schema: %s\n%s", got, out)
+	}
+	var env scriptEnvelope
+	if err := json.Unmarshal([]byte(out), &env); err != nil {
+		t.Fatalf("parse envelope: %v\n%s", err, out)
+	}
+	return env
+}
+
+func TestDependenciesScript_ok(t *testing.T) {
+	env := runAndDecodeDependenciesScript(t, "ok")
+	if env.SchemaVersion != 1 {
+		t.Errorf("schema_version = %d", env.SchemaVersion)
+	}
+	if env.GitPkgsVersion != "git-pkgs 0.0.0-test" {
+		t.Errorf("git_pkgs_version = %q", env.GitPkgsVersion)
+	}
+	for _, name := range []string{"inventory", "sbom", "licenses", "vulnerabilities", "outdated", "deprecated"} {
+		if env.Analyses[name].Status != "ok" {
+			t.Errorf("%s status = %q: %s", name, env.Analyses[name].Status, env.Analyses[name].Error)
+		}
+	}
+	var inv []map[string]any
+	if err := json.Unmarshal(env.Analyses["inventory"].Result, &inv); err != nil || len(inv) != 1 || inv[0]["name"] != "left-pad" {
+		t.Errorf("inventory result = %s", env.Analyses["inventory"].Result)
+	}
+	var bom map[string]any
+	if err := json.Unmarshal(env.Analyses["sbom"].Result, &bom); err != nil || bom["bomFormat"] != "CycloneDX" {
+		t.Errorf("sbom result = %s", env.Analyses["sbom"].Result)
+	}
+	// Bare-array output from vulns is normalised to result+sources.
+	var vulns []map[string]any
+	if err := json.Unmarshal(env.Analyses["vulnerabilities"].Result, &vulns); err != nil || len(vulns) != 1 {
+		t.Errorf("vulnerabilities result = %s", env.Analyses["vulnerabilities"].Result)
+	}
+	if env.Analyses["vulnerabilities"].Sources == nil {
+		t.Error("vulnerabilities sources missing")
 	}
 }
 
-func TestDependenciesScriptRejectsNonArrayGitPkgsOutput(t *testing.T) {
-	out, err := runDependenciesScript(t, "object")
-	if err == nil {
-		t.Fatalf("script succeeded with non-array output: %s", out)
+func TestDependenciesScript_listNull(t *testing.T) {
+	env := runAndDecodeDependenciesScript(t, "list-null")
+	if s := env.Analyses["inventory"]; s.Status != "ok" || string(s.Result) != "[]" {
+		t.Errorf("null list should normalise to ok/[]: %+v", s)
 	}
-	if !strings.Contains(out, "want array") {
-		t.Fatalf("output = %q, want array error", out)
+}
+
+func TestDependenciesScript_sectionFailure(t *testing.T) {
+	env := runAndDecodeDependenciesScript(t, "vulns-fail")
+	if s := env.Analyses["vulnerabilities"]; s.Status != "error" || s.Error == "" {
+		t.Errorf("vulns exit 1 should be status=error: %+v", s)
+	}
+	if env.Analyses["inventory"].Status != "ok" {
+		t.Error("failed vulns must not fail inventory")
+	}
+}
+
+func TestDependenciesScript_post306Object(t *testing.T) {
+	env := runAndDecodeDependenciesScript(t, "post306")
+	out := env.Analyses["outdated"]
+	if out.Status != "ok" {
+		t.Fatalf("status = %q: %s", out.Status, out.Error)
+	}
+	var res []map[string]any
+	if err := json.Unmarshal(out.Result, &res); err != nil || len(res) != 1 || res[0]["name"] != "lodash" {
+		t.Errorf("object-form results not passed through: %s", out.Result)
+	}
+	if len(out.Sources) != 1 {
+		t.Errorf("object-form sources not passed through: %v", out.Sources)
 	}
 }
 
@@ -63,37 +123,7 @@ func runDependenciesScript(t *testing.T, mode string) (string, error) {
 		t.Fatal(err)
 	}
 	fakeGitPkgs := filepath.Join(bin, "git-pkgs")
-	if err := os.WriteFile(fakeGitPkgs, []byte(`#!/usr/bin/env bash
-set -euo pipefail
-case "$1" in
-  init)
-    exit 0
-    ;;
-  list)
-    case "${GIT_PKGS_LIST_OUTPUT:-array}" in
-      null)
-        printf 'null\n'
-        ;;
-      empty)
-        ;;
-      object)
-        printf '{"name":"left-pad"}\n'
-        ;;
-      array)
-        printf '[{"name":"left-pad","ecosystem":"npm"}]\n'
-        ;;
-      *)
-        echo "unknown mode: ${GIT_PKGS_LIST_OUTPUT}" >&2
-        exit 2
-        ;;
-    esac
-    ;;
-  *)
-    echo "unexpected git-pkgs command: $*" >&2
-    exit 2
-    ;;
-esac
-`), 0o755); err != nil {
+	if err := os.WriteFile(fakeGitPkgs, []byte(fakeGitPkgsScript), 0o755); err != nil {
 		t.Fatal(err)
 	}
 
@@ -101,8 +131,48 @@ esac
 	cmd.Dir = root
 	cmd.Env = append(os.Environ(),
 		"PATH="+bin+string(os.PathListSeparator)+os.Getenv("PATH"),
-		"GIT_PKGS_LIST_OUTPUT="+mode,
+		"GP_MODE="+mode,
 	)
 	out, err := cmd.CombinedOutput()
 	return string(out), err
 }
+
+// fakeGitPkgsScript stands in for the git-pkgs CLI. GP_MODE selects a
+// scenario; every command not overridden by the scenario emits a minimal
+// representative payload so the envelope assembler sees all six sections.
+const fakeGitPkgsScript = `#!/usr/bin/env bash
+set -euo pipefail
+mode="${GP_MODE:-ok}"
+case "$1" in
+  --version) echo "git-pkgs 0.0.0-test" ;;
+  init) exit 0 ;;
+  list)
+    if [ "$mode" = "list-null" ]; then printf 'null\n'; exit 0; fi
+    printf '[{"name":"left-pad","ecosystem":"npm","manifest_path":"package.json"}]\n'
+    ;;
+  sbom)
+    printf '{"bomFormat":"CycloneDX","specVersion":"1.5","components":[]}\n'
+    ;;
+  licenses)
+    printf '[]\n'
+    ;;
+  vulns)
+    if [ "$mode" = "vulns-fail" ]; then echo "osv.dev unreachable" >&2; exit 1; fi
+    printf '[{"id":"GHSA-xxxx","package":"left-pad"}]\n'
+    ;;
+  outdated)
+    if [ "$mode" = "post306" ]; then
+      printf '{"results":[{"name":"lodash"}],"sources":[{"ecosystem":"npm","status":"ok"}]}\n'
+      exit 0
+    fi
+    printf '[]\n'
+    ;;
+  deprecated)
+    printf '[]\n'
+    ;;
+  *)
+    echo "unexpected git-pkgs command: $*" >&2
+    exit 2
+    ;;
+esac
+`

--- a/internal/worker/schema_bundled_test.go
+++ b/internal/worker/schema_bundled_test.go
@@ -107,11 +107,14 @@ func TestBundledSchemas_compileAndAcceptSamples(t *testing.T) {
 			"../../skills/dependencies/schema.json",
 			`{"schema_version":1,"analyses":{
 				"inventory":{"status":"error","error":"git-pkgs: exit 1"},
-				"sbom":{"status":"error","error":"git-pkgs: exit 1"},
-				"licenses":{"status":"error","error":"x"},
-				"vulnerabilities":{"status":"error","error":"x"},
-				"outdated":{"status":"error","error":"x"},
-				"deprecated":{"status":"error","error":"x"}}}`,
+				"sbom":{"status":"error","error":"git-pkgs: exit 1"}}}`,
+		},
+		{
+			// The SKILL.md fallback shape for a wholesale script failure:
+			// analyses is present but empty. Sections are not required so
+			// schema validation still surfaces the top-level error.
+			"../../skills/dependencies/schema.json",
+			`{"schema_version":1,"analyses":{},"error":"git-pkgs init failed"}`,
 		},
 		{
 			"../../skills/public-issue/schema.json",
@@ -347,6 +350,9 @@ func TestBundledSchemas_rejectBadShapes(t *testing.T) {
 		{"../../skills/dependencies/schema.json", `{"schema_version":1}`, "analyses"},
 		{"../../skills/dependencies/schema.json",
 			`{"schema_version":1,"analyses":{"inventory":{"status":"maybe"}}}`,
+			"/analyses/inventory"},
+		{"../../skills/dependencies/schema.json",
+			`{"schema_version":1,"analyses":{"inventory":{"status":"ok"},"licenses":{"status":"ok"}}}`,
 			"/analyses"},
 		{"../../skills/advisories/schema.json",
 			`{"advisories":[{"uuid":"u1","severity":"HIGHISH"}]}`,

--- a/internal/worker/schema_bundled_test.go
+++ b/internal/worker/schema_bundled_test.go
@@ -97,11 +97,21 @@ func TestBundledSchemas_compileAndAcceptSamples(t *testing.T) {
 		},
 		{
 			"../../skills/dependencies/schema.json",
-			`{"dependencies":[]}`,
+			depEnvelope(`[]`, ""),
 		},
 		{
 			"../../skills/dependencies/schema.json",
-			`{"dependencies":[],"error":"git-pkgs not found on PATH"}`,
+			depEnvelope(`[{"name":"x","ecosystem":"npm","type":"runtime"}]`, cdxEnvelopeFixture),
+		},
+		{
+			"../../skills/dependencies/schema.json",
+			`{"schema_version":1,"analyses":{
+				"inventory":{"status":"error","error":"git-pkgs: exit 1"},
+				"sbom":{"status":"error","error":"git-pkgs: exit 1"},
+				"licenses":{"status":"error","error":"x"},
+				"vulnerabilities":{"status":"error","error":"x"},
+				"outdated":{"status":"error","error":"x"},
+				"deprecated":{"status":"error","error":"x"}}}`,
 		},
 		{
 			"../../skills/public-issue/schema.json",
@@ -334,7 +344,10 @@ func TestBundledSchemas_rejectBadShapes(t *testing.T) {
 		{"../../skills/sbom/schema.json", `{"bomFormat":"SPDX","specVersion":"1.5"}`, "/bomFormat"},
 		{"../../skills/sbom/schema.json", `{"specVersion":"1.5"}`, "bomFormat"},
 		{"../../skills/sbom/schema.json", `{}`, "oneOf"},
-		{"../../skills/dependencies/schema.json", `{"dependencies":null}`, "/dependencies"},
+		{"../../skills/dependencies/schema.json", `{"schema_version":1}`, "analyses"},
+		{"../../skills/dependencies/schema.json",
+			`{"schema_version":1,"analyses":{"inventory":{"status":"maybe"}}}`,
+			"/analyses"},
 		{"../../skills/advisories/schema.json",
 			`{"advisories":[{"uuid":"u1","severity":"HIGHISH"}]}`,
 			"/advisories/0/severity"},

--- a/internal/worker/skill_parsers.go
+++ b/internal/worker/skill_parsers.go
@@ -322,9 +322,25 @@ func (w *Worker) parseDependenciesOutput(scan *db.Scan, report string, emit func
 		return fmt.Errorf("parse dependencies: %w", err)
 	}
 
+	// Dependency rows and the Current snapshot are whole-repo projections; a
+	// sub-path-scoped scan sees only one sub-package's manifests and would
+	// otherwise wipe the full-repo set and mark a partial SBOM as current.
+	// Per-sub-package snapshots are deferred until SBOMUpload/Dependency are
+	// keyed on sub-path.
+	if scan.SubPath != "" {
+		emit(Event{Kind: KindText, Text: "sub-path scan: repo-level dependency rows and SBOM snapshot unchanged"})
+		return nil
+	}
+
 	inv := env.Analyses.Inventory
-	if inv.Status == analysisError {
-		emit(Event{Kind: KindText, Text: "inventory failed: " + inv.Error})
+	replaceInventory := inv.Status != analysisError
+	if !replaceInventory {
+		// The prior row set stays: an errored git-pkgs run says nothing about
+		// what the repository depends on, so replacing it with an empty set
+		// would be data loss. Mirrors the sbom section, where up == nil
+		// leaves the previous Current snapshot in place. The sbom section is
+		// still applied below since it reports its own status independently.
+		emit(Event{Kind: KindText, Text: "inventory failed, prior dependency rows kept: " + inv.Error})
 	}
 	w.resolveMavenDependencyRequirements(scan, inv.Result, emit)
 	rows := make([]db.Dependency, 0, len(inv.Result))
@@ -363,12 +379,14 @@ func (w *Worker) parseDependenciesOutput(scan *db.Scan, report string, emit func
 	// this skill whole-tree (repoWideProjectionKinds) and the git-pkgs script
 	// enumerates all of ./src rather than honouring scan_subpath.
 	if err := w.DB.Transaction(func(tx *gorm.DB) error {
-		if err := tx.Where("repository_id = ?", scan.RepositoryID).Delete(&db.Dependency{}).Error; err != nil {
-			return fmt.Errorf("delete old dependencies: %w", err)
-		}
-		if len(rows) > 0 {
-			if err := tx.CreateInBatches(&rows, insertBatchSize).Error; err != nil {
-				return fmt.Errorf("save dependencies: %w", err)
+		if replaceInventory {
+			if err := tx.Where("repository_id = ?", scan.RepositoryID).Delete(&db.Dependency{}).Error; err != nil {
+				return fmt.Errorf("delete old dependencies: %w", err)
+			}
+			if len(rows) > 0 {
+				if err := tx.CreateInBatches(&rows, insertBatchSize).Error; err != nil {
+					return fmt.Errorf("save dependencies: %w", err)
+				}
 			}
 		}
 		if up != nil {
@@ -387,7 +405,10 @@ func (w *Worker) parseDependenciesOutput(scan *db.Scan, report string, emit func
 		return err
 	}
 
-	summary := fmt.Sprintf("saved %d dependenc(ies)", len(rows))
+	summary := "prior dependency rows kept"
+	if replaceInventory {
+		summary = fmt.Sprintf("saved %d dependenc(ies)", len(rows))
+	}
 	if up != nil {
 		summary += fmt.Sprintf(", %d resolved component(s) at %s", up.PackageCount, shortCommit(up.Commit))
 	}

--- a/internal/worker/skill_parsers.go
+++ b/internal/worker/skill_parsers.go
@@ -459,9 +459,10 @@ func (e *dependencyEnvelope) reportDeferredSections(emit func(Event)) {
 }
 
 // buildGeneratedSBOM parses the envelope's sbom section into an SBOMUpload
-// snapshot for the scan's repository. A missing or errored section returns
-// (nil, nil) so the caller writes inventory rows without a snapshot; a
-// present but unparseable document returns an error for the caller to log.
+// snapshot for the scan's repository. A missing or empty section returns
+// (nil, nil); a section that reported an error, or a document that fails to
+// parse, returns that error for the caller to log. Either way the caller
+// writes inventory rows without a snapshot.
 func buildGeneratedSBOM(scan *db.Scan, env dependencyEnvelope) (*db.SBOMUpload, error) {
 	sec := env.Analyses.SBOM
 	if sec.Status != analysisOK {

--- a/internal/worker/skill_parsers.go
+++ b/internal/worker/skill_parsers.go
@@ -325,6 +325,9 @@ func (w *Worker) parseDependenciesOutput(scan *db.Scan, report string, emit func
 	// Dependency rows and the Current snapshot are whole-repo projections; a
 	// sub-path-scoped scan sees only one sub-package's manifests and would
 	// otherwise wipe the full-repo set and mark a partial SBOM as current.
+	// scanScopeHard keeps this skill whole-tree (repoWideProjectionKinds) so
+	// SubPath is normally empty here; this guard is the parseMaintainersOutput-
+	// style belt-and-braces for a scan that reaches the parser scoped anyway.
 	// Per-sub-package snapshots are deferred until SBOMUpload/Dependency are
 	// keyed on sub-path.
 	if scan.SubPath != "" {
@@ -350,26 +353,7 @@ func (w *Worker) parseDependenciesOutput(scan *db.Scan, report string, emit func
 		emit(Event{Kind: KindText, Text: "inventory failed, prior dependency rows kept: " + reason})
 	}
 	w.resolveMavenDependencyRequirements(scan, inv.Result, emit)
-	rows := make([]db.Dependency, 0, len(inv.Result))
-	for _, d := range inv.Result {
-		depType := d.Type
-		if depType == "" {
-			depType = d.DependencyType
-		}
-		depType = db.NormalizeDependencyType(depType)
-		rows = append(rows, db.Dependency{
-			RepositoryID:          scan.RepositoryID,
-			Name:                  d.Name,
-			Ecosystem:             db.EcosystemType(d.PURL, d.Ecosystem),
-			PURL:                  d.PURL,
-			Requirement:           d.Requirement,
-			RequirementUnresolved: d.RequirementUnresolved,
-			RequirementResolution: d.RequirementResolution,
-			DependencyType:        depType,
-			ManifestPath:          d.ManifestPath,
-			ManifestKind:          d.ManifestKind,
-		})
-	}
+	rows := dependencyRows(scan.RepositoryID, inv.Result)
 
 	up, sbomErr := buildGeneratedSBOM(scan, env)
 	if sbomErr != nil {
@@ -379,12 +363,7 @@ func (w *Worker) parseDependenciesOutput(scan *db.Scan, report string, emit func
 
 	// Replace the prior row set and move the Current flag atomically so a
 	// failed insert can't leave the repository with zero dependencies or
-	// two current snapshots. This delete-and-replace assumes a whole-repository
-	// view: Dependency rows are repo-level (no SubprojectID), so a
-	// sub-path-scoped run that saw only one sub-package's manifests would wipe
-	// every sibling's rows. That view holds today because scanScopeHard keeps
-	// this skill whole-tree (repoWideProjectionKinds) and the git-pkgs script
-	// enumerates all of ./src rather than honouring scan_subpath.
+	// two current snapshots.
 	if err := w.DB.Transaction(func(tx *gorm.DB) error {
 		if replaceInventory {
 			if err := tx.Where("repository_id = ?", scan.RepositoryID).Delete(&db.Dependency{}).Error; err != nil {
@@ -421,6 +400,32 @@ func (w *Worker) parseDependenciesOutput(scan *db.Scan, report string, emit func
 	}
 	emit(Event{Kind: KindText, Text: summary})
 	return nil
+}
+
+// dependencyRows maps the inventory section's report rows to Dependency
+// records for repoID, folding the type/dependency_type alias and normalising
+// the phase.
+func dependencyRows(repoID uint, in []dependencyReportRow) []db.Dependency {
+	rows := make([]db.Dependency, 0, len(in))
+	for _, d := range in {
+		depType := d.Type
+		if depType == "" {
+			depType = d.DependencyType
+		}
+		rows = append(rows, db.Dependency{
+			RepositoryID:          repoID,
+			Name:                  d.Name,
+			Ecosystem:             db.EcosystemType(d.PURL, d.Ecosystem),
+			PURL:                  d.PURL,
+			Requirement:           d.Requirement,
+			RequirementUnresolved: d.RequirementUnresolved,
+			RequirementResolution: d.RequirementResolution,
+			DependencyType:        db.NormalizeDependencyType(depType),
+			ManifestPath:          d.ManifestPath,
+			ManifestKind:          d.ManifestKind,
+		})
+	}
+	return rows
 }
 
 const (

--- a/internal/worker/skill_parsers.go
+++ b/internal/worker/skill_parsers.go
@@ -333,14 +333,21 @@ func (w *Worker) parseDependenciesOutput(scan *db.Scan, report string, emit func
 	}
 
 	inv := env.Analyses.Inventory
-	replaceInventory := inv.Status != analysisError
+	replaceInventory := inv.Status == analysisOK
 	if !replaceInventory {
-		// The prior row set stays: an errored git-pkgs run says nothing about
-		// what the repository depends on, so replacing it with an empty set
-		// would be data loss. Mirrors the sbom section, where up == nil
-		// leaves the previous Current snapshot in place. The sbom section is
-		// still applied below since it reports its own status independently.
-		emit(Event{Kind: KindText, Text: "inventory failed, prior dependency rows kept: " + inv.Error})
+		// The prior row set stays: an errored, or entirely missing, inventory
+		// section says nothing about what the repository depends on, so
+		// replacing it with an empty set would be data loss. Missing arises
+		// from the SKILL.md fallback shape for a wholesale script failure,
+		// {"schema_version":1,"analyses":{},"error":...}. Mirrors the sbom
+		// section, where up == nil leaves the previous Current snapshot in
+		// place. The sbom section is still applied below since it reports
+		// its own status independently.
+		reason := inv.Error
+		if inv.Status == "" {
+			reason = "no inventory section in report"
+		}
+		emit(Event{Kind: KindText, Text: "inventory failed, prior dependency rows kept: " + reason})
 	}
 	w.resolveMavenDependencyRequirements(scan, inv.Result, emit)
 	rows := make([]db.Dependency, 0, len(inv.Result))

--- a/internal/worker/skill_parsers.go
+++ b/internal/worker/skill_parsers.go
@@ -312,8 +312,10 @@ func (w *Worker) parseAdvisoryAuditOutput(skill *db.Skill, scan *db.Scan, report
 // parseDependenciesOutput consumes the versioned envelope emitted by
 // skills/dependencies/scripts/index.sh. The inventory section replaces
 // Dependency rows for the scan's repository; the sbom section becomes a
-// generated SBOMUpload snapshot with Current moved to it. Remaining sections
-// are decoded and reported but not yet persisted.
+// generated SBOMUpload snapshot with Current moved to it. Per-package
+// registry lookups (licences, vulnerabilities, latest-version, deprecation)
+// are not part of the envelope; scrutineer performs those once per package
+// outside the scan.
 func (w *Worker) parseDependenciesOutput(scan *db.Scan, report string, emit func(Event)) error {
 	var env dependencyEnvelope
 	if err := json.Unmarshal([]byte(report), &env); err != nil {
@@ -390,7 +392,6 @@ func (w *Worker) parseDependenciesOutput(scan *db.Scan, report string, emit func
 		summary += fmt.Sprintf(", %d resolved component(s) at %s", up.PackageCount, shortCommit(up.Commit))
 	}
 	emit(Event{Kind: KindText, Text: summary})
-	env.reportDeferredSections(emit)
 	return nil
 }
 
@@ -413,10 +414,6 @@ type dependencyEnvelope struct {
 			analysisSection
 			Result json.RawMessage `json:"result"`
 		} `json:"sbom"`
-		Licenses        rawAnalysisSection `json:"licenses"`
-		Vulnerabilities rawAnalysisSection `json:"vulnerabilities"`
-		Outdated        rawAnalysisSection `json:"outdated"`
-		Deprecated      rawAnalysisSection `json:"deprecated"`
 	} `json:"analyses"`
 }
 
@@ -424,38 +421,6 @@ type analysisSection struct {
 	Status   string   `json:"status"`
 	Error    string   `json:"error"`
 	Warnings []string `json:"warnings"`
-}
-
-// rawAnalysisSection covers licenses/vulnerabilities/outdated/deprecated:
-// decoded so section status and row counts can be surfaced now, with the row
-// bodies left opaque until the persistence step lands.
-type rawAnalysisSection struct {
-	analysisSection
-	Result  []json.RawMessage `json:"result"`
-	Sources []json.RawMessage `json:"sources"`
-}
-
-// reportDeferredSections emits a one-line status for each analysis whose rows
-// are not yet persisted so an operator can see they ran and whether the
-// upstream returned anything, without having to read the raw report.
-func (e *dependencyEnvelope) reportDeferredSections(emit func(Event)) {
-	deferred := []struct {
-		name string
-		sec  rawAnalysisSection
-	}{
-		{"licenses", e.Analyses.Licenses},
-		{"vulnerabilities", e.Analyses.Vulnerabilities},
-		{"outdated", e.Analyses.Outdated},
-		{"deprecated", e.Analyses.Deprecated},
-	}
-	for _, d := range deferred {
-		switch d.sec.Status {
-		case analysisOK:
-			emit(Event{Kind: KindText, Text: fmt.Sprintf("%s: %d row(s), not yet persisted", d.name, len(d.sec.Result))})
-		case analysisError:
-			emit(Event{Kind: KindText, Text: fmt.Sprintf("%s failed: %s", d.name, d.sec.Error)})
-		}
-	}
 }
 
 // buildGeneratedSBOM parses the envelope's sbom section into an SBOMUpload

--- a/internal/worker/skill_parsers.go
+++ b/internal/worker/skill_parsers.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	mavenpom "github.com/git-pkgs/pom"
+	"github.com/git-pkgs/sbom"
 	"gorm.io/gorm"
 
 	"scrutineer/internal/db"
@@ -308,19 +309,24 @@ func (w *Worker) parseAdvisoryAuditOutput(skill *db.Skill, scan *db.Scan, report
 	return ingestErr
 }
 
-// parseDependenciesOutput replaces Dependency rows for the scan's repository.
-// Dependencies come from a git-pkgs-style manifest scan: one row per
-// (name, ecosystem, manifest_path) tuple.
+// parseDependenciesOutput consumes the versioned envelope emitted by
+// skills/dependencies/scripts/index.sh. The inventory section replaces
+// Dependency rows for the scan's repository; the sbom section becomes a
+// generated SBOMUpload snapshot with Current moved to it. Remaining sections
+// are decoded and reported but not yet persisted.
 func (w *Worker) parseDependenciesOutput(scan *db.Scan, report string, emit func(Event)) error {
-	var result struct {
-		Dependencies []dependencyReportRow `json:"dependencies"`
-	}
-	if err := json.Unmarshal([]byte(report), &result); err != nil {
+	var env dependencyEnvelope
+	if err := json.Unmarshal([]byte(report), &env); err != nil {
 		return fmt.Errorf("parse dependencies: %w", err)
 	}
-	w.resolveMavenDependencyRequirements(scan, result.Dependencies, emit)
-	rows := make([]db.Dependency, 0, len(result.Dependencies))
-	for _, d := range result.Dependencies {
+
+	inv := env.Analyses.Inventory
+	if inv.Status == analysisError {
+		emit(Event{Kind: KindText, Text: "inventory failed: " + inv.Error})
+	}
+	w.resolveMavenDependencyRequirements(scan, inv.Result, emit)
+	rows := make([]db.Dependency, 0, len(inv.Result))
+	for _, d := range inv.Result {
 		depType := d.Type
 		if depType == "" {
 			depType = d.DependencyType
@@ -339,16 +345,21 @@ func (w *Worker) parseDependenciesOutput(scan *db.Scan, report string, emit func
 			ManifestKind:          d.ManifestKind,
 		})
 	}
-	// Replace the prior row set atomically so a failed insert can't leave
-	// the repository with zero dependencies. This delete-and-replace assumes a
-	// whole-repository view: Dependency rows are repo-level (no SubprojectID), so
-	// a sub-path-scoped run that saw only one sub-package's manifests would wipe
+
+	up, sbomErr := buildGeneratedSBOM(scan, env)
+	if sbomErr != nil {
+		// A malformed sbom section should not discard a valid inventory.
+		emit(Event{Kind: KindText, Text: "sbom section skipped: " + sbomErr.Error()})
+	}
+
+	// Replace the prior row set and move the Current flag atomically so a
+	// failed insert can't leave the repository with zero dependencies or
+	// two current snapshots. This delete-and-replace assumes a whole-repository
+	// view: Dependency rows are repo-level (no SubprojectID), so a
+	// sub-path-scoped run that saw only one sub-package's manifests would wipe
 	// every sibling's rows. That view holds today because scanScopeHard keeps
 	// this skill whole-tree (repoWideProjectionKinds) and the git-pkgs script
-	// enumerates all of ./src rather than honouring scan_subpath. If this skill
-	// is ever made sub-path-aware, it must gain a per-subproject partition (or a
-	// scoped-run guard like parseMaintainersOutput's) before it can run scoped —
-	// otherwise a scoped run silently deletes the rest of the repo's dependencies.
+	// enumerates all of ./src rather than honouring scan_subpath.
 	if err := w.DB.Transaction(func(tx *gorm.DB) error {
 		if err := tx.Where("repository_id = ?", scan.RepositoryID).Delete(&db.Dependency{}).Error; err != nil {
 			return fmt.Errorf("delete old dependencies: %w", err)
@@ -358,12 +369,154 @@ func (w *Worker) parseDependenciesOutput(scan *db.Scan, report string, emit func
 				return fmt.Errorf("save dependencies: %w", err)
 			}
 		}
+		if up != nil {
+			if err := tx.Model(&db.SBOMUpload{}).
+				Where("repository_id = ? AND origin = ? AND current = ?",
+					scan.RepositoryID, db.SBOMOriginGenerated, true).
+				Update("current", false).Error; err != nil {
+				return fmt.Errorf("clear current snapshot: %w", err)
+			}
+			if err := tx.Create(up).Error; err != nil {
+				return fmt.Errorf("save generated sbom: %w", err)
+			}
+		}
 		return nil
 	}); err != nil {
 		return err
 	}
-	emit(Event{Kind: KindText, Text: fmt.Sprintf("saved %d dependenc(ies)", len(rows))})
+
+	summary := fmt.Sprintf("saved %d dependenc(ies)", len(rows))
+	if up != nil {
+		summary += fmt.Sprintf(", %d resolved component(s) at %s", up.PackageCount, shortCommit(up.Commit))
+	}
+	emit(Event{Kind: KindText, Text: summary})
+	env.reportDeferredSections(emit)
 	return nil
+}
+
+const (
+	analysisOK    = "ok"
+	analysisError = "error"
+)
+
+type dependencyEnvelope struct {
+	SchemaVersion  int    `json:"schema_version"`
+	Commit         string `json:"commit"`
+	GeneratedAt    string `json:"generated_at"`
+	GitPkgsVersion string `json:"git_pkgs_version"`
+	Analyses       struct {
+		Inventory struct {
+			analysisSection
+			Result []dependencyReportRow `json:"result"`
+		} `json:"inventory"`
+		SBOM struct {
+			analysisSection
+			Result json.RawMessage `json:"result"`
+		} `json:"sbom"`
+		Licenses        rawAnalysisSection `json:"licenses"`
+		Vulnerabilities rawAnalysisSection `json:"vulnerabilities"`
+		Outdated        rawAnalysisSection `json:"outdated"`
+		Deprecated      rawAnalysisSection `json:"deprecated"`
+	} `json:"analyses"`
+}
+
+type analysisSection struct {
+	Status   string   `json:"status"`
+	Error    string   `json:"error"`
+	Warnings []string `json:"warnings"`
+}
+
+// rawAnalysisSection covers licenses/vulnerabilities/outdated/deprecated:
+// decoded so section status and row counts can be surfaced now, with the row
+// bodies left opaque until the persistence step lands.
+type rawAnalysisSection struct {
+	analysisSection
+	Result  []json.RawMessage `json:"result"`
+	Sources []json.RawMessage `json:"sources"`
+}
+
+// reportDeferredSections emits a one-line status for each analysis whose rows
+// are not yet persisted so an operator can see they ran and whether the
+// upstream returned anything, without having to read the raw report.
+func (e *dependencyEnvelope) reportDeferredSections(emit func(Event)) {
+	deferred := []struct {
+		name string
+		sec  rawAnalysisSection
+	}{
+		{"licenses", e.Analyses.Licenses},
+		{"vulnerabilities", e.Analyses.Vulnerabilities},
+		{"outdated", e.Analyses.Outdated},
+		{"deprecated", e.Analyses.Deprecated},
+	}
+	for _, d := range deferred {
+		switch d.sec.Status {
+		case analysisOK:
+			emit(Event{Kind: KindText, Text: fmt.Sprintf("%s: %d row(s), not yet persisted", d.name, len(d.sec.Result))})
+		case analysisError:
+			emit(Event{Kind: KindText, Text: fmt.Sprintf("%s failed: %s", d.name, d.sec.Error)})
+		}
+	}
+}
+
+// buildGeneratedSBOM parses the envelope's sbom section into an SBOMUpload
+// snapshot for the scan's repository. A missing or errored section returns
+// (nil, nil) so the caller writes inventory rows without a snapshot; a
+// present but unparseable document returns an error for the caller to log.
+func buildGeneratedSBOM(scan *db.Scan, env dependencyEnvelope) (*db.SBOMUpload, error) {
+	sec := env.Analyses.SBOM
+	if sec.Status != analysisOK {
+		if sec.Error != "" {
+			return nil, errors.New(sec.Error)
+		}
+		return nil, nil
+	}
+	if len(sec.Result) == 0 || string(sec.Result) == "{}" || string(sec.Result) == "null" {
+		return nil, nil
+	}
+	doc, err := sbom.Parse(sec.Result)
+	if err != nil {
+		return nil, fmt.Errorf("parse cyclonedx: %w", err)
+	}
+	commit := env.Commit
+	if commit == "" {
+		commit = scan.Commit
+	}
+	up := db.SBOMUpload{
+		Name:         doc.Document.Name,
+		Format:       string(doc.Type),
+		SpecVersion:  doc.SpecVersion,
+		Origin:       db.SBOMOriginGenerated,
+		RepositoryID: &scan.RepositoryID,
+		ScanID:       &scan.ID,
+		Commit:       commit,
+		Current:      true,
+		PackageCount: len(doc.Packages),
+	}
+	scope := doc.ClassifyScope()
+	for _, p := range doc.Packages {
+		purl := p.PURL()
+		lic := p.LicenseDeclared
+		if lic == "" {
+			lic = p.LicenseConcluded
+		}
+		up.Packages = append(up.Packages, db.SBOMPackage{
+			Name:      p.Name,
+			Version:   p.Version,
+			PURL:      purl,
+			Ecosystem: db.EcosystemType(purl, ""),
+			License:   lic,
+			Scope:     scope[p.ID],
+		})
+	}
+	return &up, nil
+}
+
+func shortCommit(s string) string {
+	const n = 12
+	if len(s) > n {
+		return s[:n]
+	}
+	return s
 }
 
 type dependencyReportRow struct {

--- a/internal/worker/skill_parsers_test.go
+++ b/internal/worker/skill_parsers_test.go
@@ -1945,6 +1945,43 @@ func TestParseDependencies_inventoryErrorKeepsPriorRows(t *testing.T) {
 	}
 }
 
+func TestParseDependencies_scriptFallbackKeepsPriorRows(t *testing.T) {
+	w, scan, gdb, repo := newDependencyParser(t)
+
+	if err := w.parseDependenciesOutput(scan,
+		depEnvelope(`[{"name":"prior","ecosystem":"npm"}]`, ""),
+		func(Event) {}); err != nil {
+		t.Fatal(err)
+	}
+
+	// The SKILL.md fallback for a wholesale script failure has an empty
+	// analyses object. Status is "" for both sections; that must be treated
+	// as failure, not as an ok run that found nothing.
+	report := `{"schema_version":1,"analyses":{},"error":"git-pkgs init: exit 1"}`
+	var events []Event
+	if err := w.parseDependenciesOutput(scan, report, func(e Event) { events = append(events, e) }); err != nil {
+		t.Fatalf("script fallback should not fail parse: %v", err)
+	}
+
+	var deps []db.Dependency
+	gdb.Where("repository_id = ?", repo.ID).Find(&deps)
+	if len(deps) != 1 || deps[0].Name != "prior" {
+		t.Errorf("script fallback wiped prior dependency rows: %+v", deps)
+	}
+	var uploads int64
+	gdb.Model(&db.SBOMUpload{}).Where("repository_id = ?", repo.ID).Count(&uploads)
+	if uploads != 0 {
+		t.Errorf("script fallback should not create a snapshot, got %d", uploads)
+	}
+	joined := ""
+	for _, e := range events {
+		joined += e.Text + "\n"
+	}
+	if !strings.Contains(joined, "no inventory section in report") {
+		t.Errorf("events missing missing-section reason:\n%s", joined)
+	}
+}
+
 func TestParseDependencies_subPathScanLeavesRepoLevelRows(t *testing.T) {
 	w, scan, gdb, repo := newDependencyParser(t)
 

--- a/internal/worker/skill_parsers_test.go
+++ b/internal/worker/skill_parsers_test.go
@@ -1655,14 +1655,29 @@ func TestParseFindingDedup_skipsClosedAndCrossRepoFindings(t *testing.T) {
 	}
 }
 
+// depEnvelope wraps a JSON fragment of inventory rows and an optional
+// CycloneDX document in the versioned envelope the dependencies parser
+// expects, filling the remaining sections as empty ok results.
+func depEnvelope(inventory, sbom string) string {
+	if sbom == "" {
+		sbom = "{}"
+	}
+	empty := `{"status":"ok","result":[],"sources":[]}`
+	return `{"schema_version":1,"commit":"cafef00d","analyses":{` +
+		`"inventory":{"status":"ok","result":` + inventory + `},` +
+		`"sbom":{"status":"ok","result":` + sbom + `},` +
+		`"licenses":` + empty + `,"vulnerabilities":` + empty + `,` +
+		`"outdated":` + empty + `,"deprecated":` + empty + `}}`
+}
+
 func TestParseDependencies_acceptsTypeOrDependencyType(t *testing.T) {
-	report := `{"dependencies":[
+	report := depEnvelope(`[
 		{"name":"a","ecosystem":"npm","type":"runtime","manifest_path":"package.json"},
 		{"name":"b","ecosystem":"npm","dependency_type":"development","manifest_path":"package.json"},
 		{"name":"c","ecosystem":"cpan","dependency_type":"test_requires","manifest_path":"META.json"},
 		{"name":"d","ecosystem":"cpan","dependency_type":"configure_requires","manifest_path":"META.json"},
 		{"name":"m","ecosystem":"maven","requirement":"${missing.version}","requirement_unresolved":true,"manifest_path":"pom.xml"}
-	]}`
+	]`, "")
 	repo, gdb := runSkillWithReport(t, "dependencies", report)
 	var rows []db.Dependency
 	gdb.Where("repository_id = ?", repo.ID).Find(&rows)
@@ -1691,11 +1706,11 @@ func TestParseDependencies_resolvesMavenRequirementsWithPOM(t *testing.T) {
 	src := filepath.Join(w.scanWorkRoot(scan), "src")
 	writeMavenResolverFixture(t, src)
 
-	report := `{"dependencies":[
+	report := depEnvelope(`[
 		{"name":"org.openjdk.jmh:jmh-core","ecosystem":"maven","requirement":"${jmh.version}","manifest_path":"pom.xml"},
 		{"name":"org.example:child-dep","ecosystem":"maven","requirement":"${project.version}","manifest_path":"module/pom.xml"},
 		{"name":"org.example:missing","ecosystem":"maven","requirement":"${missing.version}","manifest_path":"pom.xml"}
-	]}`
+	]`, "")
 	if err := w.parseDependenciesOutput(scan, report, func(Event) {}); err != nil {
 		t.Fatal(err)
 	}
@@ -1727,9 +1742,9 @@ func TestParseDependencies_skipsMavenParentOutsideSrc(t *testing.T) {
 	w, scan, gdb, repo := newDependencyParser(t)
 	writeEscapingMavenResolverFixture(t, w.scanWorkRoot(scan))
 
-	report := `{"dependencies":[
+	report := depEnvelope(`[
 		{"name":"org.example:escape","ecosystem":"maven","requirement":"${secret.version}","manifest_path":"escape/pom.xml"}
-	]}`
+	]`, "")
 	if err := w.parseDependenciesOutput(scan, report, func(Event) {}); err != nil {
 		t.Fatal(err)
 	}
@@ -1760,12 +1775,159 @@ func TestParseDependencies_largeBatchExceedsSQLiteVariableLimit(t *testing.T) {
 			"manifest_path": "package.json",
 		}
 	}
-	b, _ := json.Marshal(map[string]any{"dependencies": deps})
-	repo, gdb := runSkillWithReport(t, "dependencies", string(b))
+	b, _ := json.Marshal(deps)
+	repo, gdb := runSkillWithReport(t, "dependencies", depEnvelope(string(b), ""))
 	var count int64
 	gdb.Model(&db.Dependency{}).Where("repository_id = ?", repo.ID).Count(&count)
 	if count != n {
 		t.Fatalf("count = %d, want %d", count, n)
+	}
+}
+
+const cdxEnvelopeFixture = `{
+  "bomFormat":"CycloneDX","specVersion":"1.5",
+  "metadata":{"component":{"type":"application","name":"demo","version":"1.0.0"}},
+  "components":[
+    {"type":"library","name":"lodash","version":"4.17.21","purl":"pkg:npm/lodash@4.17.21",
+     "licenses":[{"license":{"id":"MIT"}}]}
+  ]
+}`
+
+func TestParseDependencies_createsGeneratedSBOM(t *testing.T) {
+	w, scan, gdb, repo := newDependencyParser(t)
+
+	report := depEnvelope(
+		`[{"name":"lodash","ecosystem":"npm","requirement":"^4.17.0","manifest_path":"package.json"}]`,
+		cdxEnvelopeFixture)
+	if err := w.parseDependenciesOutput(scan, report, func(Event) {}); err != nil {
+		t.Fatal(err)
+	}
+
+	var deps []db.Dependency
+	gdb.Where("repository_id = ?", repo.ID).Find(&deps)
+	if len(deps) != 1 || deps[0].Name != "lodash" {
+		t.Fatalf("dependencies = %+v", deps)
+	}
+
+	var up db.SBOMUpload
+	if err := gdb.Preload("Packages").
+		Where("repository_id = ? AND origin = ?", repo.ID, db.SBOMOriginGenerated).
+		First(&up).Error; err != nil {
+		t.Fatalf("generated snapshot not created: %v", err)
+	}
+	if up.Commit != "cafef00d" {
+		t.Errorf("Commit = %q, want cafef00d from envelope", up.Commit)
+	}
+	if !up.Current {
+		t.Error("first generated snapshot should be Current")
+	}
+	if up.ScanID == nil || *up.ScanID != scan.ID {
+		t.Errorf("ScanID = %v, want %d", up.ScanID, scan.ID)
+	}
+	if up.Raw != nil {
+		t.Errorf("generated snapshot stored Raw (%d bytes)", len(up.Raw))
+	}
+	if up.PackageCount != 1 || len(up.Packages) != 1 {
+		t.Fatalf("packages = %d (%d rows)", up.PackageCount, len(up.Packages))
+	}
+	pkg := up.Packages[0]
+	if pkg.PURL != "pkg:npm/lodash@4.17.21" || pkg.Ecosystem != "npm" || pkg.License != "MIT" {
+		t.Errorf("package = %+v", pkg)
+	}
+
+	// A second scan writes a new snapshot and moves Current in the same
+	// transaction so at most one row per repository has Current=true.
+	scan2 := db.Scan{RepositoryID: repo.ID}
+	gdb.Create(&scan2)
+	if err := w.parseDependenciesOutput(&scan2, report, func(Event) {}); err != nil {
+		t.Fatal(err)
+	}
+	var uploads []db.SBOMUpload
+	gdb.Where("repository_id = ? AND origin = ?", repo.ID, db.SBOMOriginGenerated).
+		Order("id").Find(&uploads)
+	if len(uploads) != 2 {
+		t.Fatalf("uploads = %d, want 2 (history retained)", len(uploads))
+	}
+	if uploads[0].Current {
+		t.Error("prior snapshot still Current after second scan")
+	}
+	if !uploads[1].Current {
+		t.Error("newest snapshot should be Current")
+	}
+	var currentCount int64
+	gdb.Model(&db.SBOMUpload{}).Where("repository_id = ? AND current = ?", repo.ID, true).Count(&currentCount)
+	if currentCount != 1 {
+		t.Errorf("current snapshots for repo = %d, want 1", currentCount)
+	}
+
+	// A generated snapshot for one repository must not touch another
+	// repository's Current flag.
+	other := db.Repository{URL: "https://example.com/y", Name: "y"}
+	gdb.Create(&other)
+	gdb.Create(&db.SBOMUpload{Origin: db.SBOMOriginGenerated, RepositoryID: &other.ID, Current: true})
+	if err := w.parseDependenciesOutput(&scan2, report, func(Event) {}); err != nil {
+		t.Fatal(err)
+	}
+	var otherCurrent int64
+	gdb.Model(&db.SBOMUpload{}).Where("repository_id = ? AND current = ?", other.ID, true).Count(&otherCurrent)
+	if otherCurrent != 1 {
+		t.Errorf("unrelated repo current = %d, want 1", otherCurrent)
+	}
+}
+
+func TestParseDependencies_sbomSectionErrorKeepsInventory(t *testing.T) {
+	w, scan, gdb, repo := newDependencyParser(t)
+
+	report := `{"schema_version":1,"analyses":{
+		"inventory":{"status":"ok","result":[{"name":"x","ecosystem":"npm"}]},
+		"sbom":{"status":"error","error":"boom"},
+		"licenses":{"status":"error","error":"unreachable"},
+		"vulnerabilities":{"status":"ok","result":[{"id":"GHSA-x"}],"sources":[]},
+		"outdated":{"status":"ok","result":[],"sources":[]},
+		"deprecated":{"status":"ok","result":[],"sources":[]}
+	}}`
+	var events []Event
+	if err := w.parseDependenciesOutput(scan, report, func(e Event) { events = append(events, e) }); err != nil {
+		t.Fatalf("errored sbom section should not fail parse: %v", err)
+	}
+
+	var deps int64
+	gdb.Model(&db.Dependency{}).Where("repository_id = ?", repo.ID).Count(&deps)
+	if deps != 1 {
+		t.Errorf("inventory rows = %d, want 1", deps)
+	}
+	var uploads int64
+	gdb.Model(&db.SBOMUpload{}).Where("repository_id = ?", repo.ID).Count(&uploads)
+	if uploads != 0 {
+		t.Errorf("errored sbom section should not create a snapshot, got %d", uploads)
+	}
+	joined := ""
+	for _, e := range events {
+		joined += e.Text + "\n"
+	}
+	for _, want := range []string{"sbom section skipped: boom", "licenses failed: unreachable", "vulnerabilities: 1 row(s)"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("events missing %q:\n%s", want, joined)
+		}
+	}
+}
+
+func TestParseDependencies_malformedSBOMKeepsInventory(t *testing.T) {
+	w, scan, gdb, repo := newDependencyParser(t)
+
+	report := depEnvelope(`[{"name":"x","ecosystem":"npm"}]`, `{"bomFormat":"garbage"}`)
+	if err := w.parseDependenciesOutput(scan, report, func(Event) {}); err != nil {
+		t.Fatalf("malformed sbom document should not fail parse: %v", err)
+	}
+	var deps int64
+	gdb.Model(&db.Dependency{}).Where("repository_id = ?", repo.ID).Count(&deps)
+	if deps != 1 {
+		t.Errorf("inventory rows = %d, want 1", deps)
+	}
+	var uploads int64
+	gdb.Model(&db.SBOMUpload{}).Count(&uploads)
+	if uploads != 0 {
+		t.Errorf("malformed sbom should not create a snapshot, got %d", uploads)
 	}
 }
 

--- a/internal/worker/skill_parsers_test.go
+++ b/internal/worker/skill_parsers_test.go
@@ -1657,17 +1657,14 @@ func TestParseFindingDedup_skipsClosedAndCrossRepoFindings(t *testing.T) {
 
 // depEnvelope wraps a JSON fragment of inventory rows and an optional
 // CycloneDX document in the versioned envelope the dependencies parser
-// expects, filling the remaining sections as empty ok results.
+// expects.
 func depEnvelope(inventory, sbom string) string {
 	if sbom == "" {
 		sbom = "{}"
 	}
-	empty := `{"status":"ok","result":[],"sources":[]}`
 	return `{"schema_version":1,"commit":"cafef00d","analyses":{` +
 		`"inventory":{"status":"ok","result":` + inventory + `},` +
-		`"sbom":{"status":"ok","result":` + sbom + `},` +
-		`"licenses":` + empty + `,"vulnerabilities":` + empty + `,` +
-		`"outdated":` + empty + `,"deprecated":` + empty + `}}`
+		`"sbom":{"status":"ok","result":` + sbom + `}}}`
 }
 
 func TestParseDependencies_acceptsTypeOrDependencyType(t *testing.T) {
@@ -1880,11 +1877,7 @@ func TestParseDependencies_sbomSectionErrorKeepsInventory(t *testing.T) {
 
 	report := `{"schema_version":1,"analyses":{
 		"inventory":{"status":"ok","result":[{"name":"x","ecosystem":"npm"}]},
-		"sbom":{"status":"error","error":"boom"},
-		"licenses":{"status":"error","error":"unreachable"},
-		"vulnerabilities":{"status":"ok","result":[{"id":"GHSA-x"}],"sources":[]},
-		"outdated":{"status":"ok","result":[],"sources":[]},
-		"deprecated":{"status":"ok","result":[],"sources":[]}
+		"sbom":{"status":"error","error":"boom"}
 	}}`
 	var events []Event
 	if err := w.parseDependenciesOutput(scan, report, func(e Event) { events = append(events, e) }); err != nil {
@@ -1905,10 +1898,8 @@ func TestParseDependencies_sbomSectionErrorKeepsInventory(t *testing.T) {
 	for _, e := range events {
 		joined += e.Text + "\n"
 	}
-	for _, want := range []string{"sbom section skipped: boom", "licenses failed: unreachable", "vulnerabilities: 1 row(s)"} {
-		if !strings.Contains(joined, want) {
-			t.Errorf("events missing %q:\n%s", want, joined)
-		}
+	if !strings.Contains(joined, "sbom section skipped: boom") {
+		t.Errorf("events missing sbom skip message:\n%s", joined)
 	}
 }
 

--- a/internal/worker/skill_parsers_test.go
+++ b/internal/worker/skill_parsers_test.go
@@ -1903,6 +1903,91 @@ func TestParseDependencies_sbomSectionErrorKeepsInventory(t *testing.T) {
 	}
 }
 
+func TestParseDependencies_inventoryErrorKeepsPriorRows(t *testing.T) {
+	w, scan, gdb, repo := newDependencyParser(t)
+
+	// Seed a prior successful run so there is something to lose.
+	if err := w.parseDependenciesOutput(scan,
+		depEnvelope(`[{"name":"prior","ecosystem":"npm"}]`, cdxEnvelopeFixture),
+		func(Event) {}); err != nil {
+		t.Fatal(err)
+	}
+
+	// A run where git-pkgs list failed but sbom succeeded: prior Dependency
+	// rows must survive, and the sbom section is still applied independently.
+	report := `{"schema_version":1,"commit":"deadbeef","analyses":{
+		"inventory":{"status":"error","error":"git-pkgs list: exit 1"},
+		"sbom":{"status":"ok","result":` + cdxEnvelopeFixture + `}
+	}}`
+	var events []Event
+	if err := w.parseDependenciesOutput(scan, report, func(e Event) { events = append(events, e) }); err != nil {
+		t.Fatalf("errored inventory section should not fail parse: %v", err)
+	}
+
+	var deps []db.Dependency
+	gdb.Where("repository_id = ?", repo.ID).Find(&deps)
+	if len(deps) != 1 || deps[0].Name != "prior" {
+		t.Errorf("prior dependency rows should survive an errored inventory, got %+v", deps)
+	}
+	var current db.SBOMUpload
+	if err := gdb.Where("repository_id = ? AND current = ?", repo.ID, true).First(&current).Error; err != nil {
+		t.Fatalf("current snapshot: %v", err)
+	}
+	if current.Commit != "deadbeef" {
+		t.Errorf("sbom section not applied independently: current commit = %q", current.Commit)
+	}
+	joined := ""
+	for _, e := range events {
+		joined += e.Text + "\n"
+	}
+	if !strings.Contains(joined, "inventory failed, prior dependency rows kept") {
+		t.Errorf("events missing inventory-kept message:\n%s", joined)
+	}
+}
+
+func TestParseDependencies_subPathScanLeavesRepoLevelRows(t *testing.T) {
+	w, scan, gdb, repo := newDependencyParser(t)
+
+	// Seed the whole-repo state.
+	if err := w.parseDependenciesOutput(scan,
+		depEnvelope(`[{"name":"full-repo","ecosystem":"npm"}]`, cdxEnvelopeFixture),
+		func(Event) {}); err != nil {
+		t.Fatal(err)
+	}
+	var seeded db.SBOMUpload
+	gdb.Where("repository_id = ? AND current = ?", repo.ID, true).First(&seeded)
+
+	// A sub-path-scoped scan sees only one sub-package's manifests; it must
+	// not replace the full-repo Dependency set nor demote its Current
+	// snapshot with a partial one.
+	scoped := db.Scan{RepositoryID: repo.ID, SubPath: "packages/foo"}
+	gdb.Create(&scoped)
+	var events []Event
+	if err := w.parseDependenciesOutput(&scoped,
+		depEnvelope(`[{"name":"partial","ecosystem":"npm"}]`, cdxEnvelopeFixture),
+		func(e Event) { events = append(events, e) }); err != nil {
+		t.Fatal(err)
+	}
+
+	var deps []db.Dependency
+	gdb.Where("repository_id = ?", repo.ID).Find(&deps)
+	if len(deps) != 1 || deps[0].Name != "full-repo" {
+		t.Errorf("sub-path scan replaced repo-level dependency rows: %+v", deps)
+	}
+	var uploads []db.SBOMUpload
+	gdb.Where("repository_id = ?", repo.ID).Find(&uploads)
+	if len(uploads) != 1 || uploads[0].ID != seeded.ID || !uploads[0].Current {
+		t.Errorf("sub-path scan touched repo-level snapshot: %+v", uploads)
+	}
+	joined := ""
+	for _, e := range events {
+		joined += e.Text + "\n"
+	}
+	if !strings.Contains(joined, "sub-path scan") {
+		t.Errorf("events missing sub-path skip message:\n%s", joined)
+	}
+}
+
 func TestParseDependencies_malformedSBOMKeepsInventory(t *testing.T) {
 	w, scan, gdb, repo := newDependencyParser(t)
 

--- a/skills/dependencies/SKILL.md
+++ b/skills/dependencies/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dependencies
-description: Index the repository's dependencies via `git-pkgs list`, recording manifest path, ecosystem, and requirement per entry.
+description: Run git-pkgs list, sbom, licenses, vulns, outdated, and deprecated against the repository and emit one envelope with per-section status.
 license: MIT
 compatibility: Requires `git-pkgs` (https://github.com/git-pkgs/git-pkgs) and `python3` on PATH.
 metadata:
@@ -20,7 +20,7 @@ metadata:
 
 # dependencies
 
-Wrap `git-pkgs list --format json` so scrutineer can read the result as a dependencies report. Preserve dependency phase/type fields from git-pkgs; scrutineer normalizes common aliases to `runtime`, `dev`, `test`, or `build`. Scrutineer's worker resolves Maven requirements from local `pom.xml` files with `git-pkgs/pom`, fills `requirement_resolution`, and marks unresolved placeholders with `requirement_unresolved`.
+Run six git-pkgs analyses after one `git-pkgs init` and assemble the results into a versioned envelope. `analyses.inventory` is the manifest occurrence list from `git-pkgs list`; `analyses.sbom` is the CycloneDX document from `git-pkgs sbom`; `licenses`, `vulnerabilities`, `outdated`, and `deprecated` carry the per-dependency rows from the matching commands. Each section has its own `status` so a failed registry lookup does not discard a valid inventory. Scrutineer's worker resolves Maven requirements from local `pom.xml` files with `git-pkgs/pom`, fills `requirement_resolution`, and marks unresolved placeholders with `requirement_unresolved`.
 
 ## Workspace
 
@@ -31,7 +31,7 @@ Wrap `git-pkgs list --format json` so scrutineer can read the result as a depend
 
 ## Available scripts
 
-- `scripts/index.sh` — runs `git-pkgs init` then `git-pkgs list --format json` inside `./src`, normalises empty or `null` output to an empty array, and writes `{"dependencies": [...]}`.
+- `scripts/index.sh` — runs `git-pkgs init` inside `./src`, then `list`, `sbom`, `licenses`, `vulns`, `outdated`, and `deprecated` in turn, capturing stdout, stderr, and exit code per command, and writes the assembled envelope to stdout.
 
 ## What to do
 
@@ -41,8 +41,6 @@ Run the script and capture its stdout as the report:
 bash scripts/index.sh > ./report.json
 ```
 
-If the script exits non-zero, read its stderr, then write a short `{"dependencies": [], "error": "..."}` document to `./report.json` so the caller sees why no dependencies were indexed.
+If the script exits non-zero, read its stderr, then write `{"schema_version": 1, "analyses": {}, "error": "..."}` to `./report.json` so the caller sees why nothing was collected.
 
-The wrapper already emits the exact schema the parser expects — no post-processing needed. Do not merge test, build, development, and runtime dependencies together; keep the phase/type field on each row when git-pkgs reports one.
-
-Do not inspect manifests yourself, infer dependencies from files that `git-pkgs` did not report, or hand-author dependency rows. If the wrapper returns `{"dependencies":[]}`, write that exact report and stop. Missing coverage in `git-pkgs` should produce an empty dependency report, not model-authored package data.
+The wrapper already emits the exact schema the parser expects, including per-section `status: "error"` for a failed command. Do not post-process, merge sections, or hand-author dependency rows. Do not inspect manifests yourself or infer dependencies from files that `git-pkgs` did not report. An empty `analyses.inventory.result` means git-pkgs found no manifests; write that report and stop.

--- a/skills/dependencies/SKILL.md
+++ b/skills/dependencies/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dependencies
-description: Run git-pkgs list, sbom, licenses, vulns, outdated, and deprecated against the repository and emit one envelope with per-section status.
+description: Run git-pkgs list and sbom against the repository and emit one envelope with per-section status.
 license: MIT
 compatibility: Requires `git-pkgs` (https://github.com/git-pkgs/git-pkgs) and `python3` on PATH.
 metadata:
@@ -20,7 +20,7 @@ metadata:
 
 # dependencies
 
-Run six git-pkgs analyses after one `git-pkgs init` and assemble the results into a versioned envelope. `analyses.inventory` is the manifest occurrence list from `git-pkgs list`; `analyses.sbom` is the CycloneDX document from `git-pkgs sbom`; `licenses`, `vulnerabilities`, `outdated`, and `deprecated` carry the per-dependency rows from the matching commands. Each section has its own `status` so a failed registry lookup does not discard a valid inventory. Scrutineer's worker resolves Maven requirements from local `pom.xml` files with `git-pkgs/pom`, fills `requirement_resolution`, and marks unresolved placeholders with `requirement_unresolved`.
+Run the two per-repository git-pkgs analyses after one `git-pkgs init` and assemble the results into a versioned envelope. `analyses.inventory` is the manifest occurrence list from `git-pkgs list`; `analyses.sbom` is the CycloneDX document from `git-pkgs sbom --skip-enrichment`. Each section has its own `status` so a failure in one does not discard the other. Per-package registry lookups (licences, vulnerabilities, latest-version, deprecation) are not run here; scrutineer performs those once per package outside the scan. Scrutineer's worker resolves Maven requirements from local `pom.xml` files with `git-pkgs/pom`, fills `requirement_resolution`, and marks unresolved placeholders with `requirement_unresolved`.
 
 ## Workspace
 
@@ -31,7 +31,7 @@ Run six git-pkgs analyses after one `git-pkgs init` and assemble the results int
 
 ## Available scripts
 
-- `scripts/index.sh` — runs `git-pkgs init` inside `./src`, then `list`, `sbom`, `licenses`, `vulns`, `outdated`, and `deprecated` in turn, capturing stdout, stderr, and exit code per command, and writes the assembled envelope to stdout.
+- `scripts/index.sh` — runs `git-pkgs init` inside `./src`, then `list` and `sbom --skip-enrichment`, capturing stdout, stderr, and exit code per command, and writes the assembled envelope to stdout.
 
 ## What to do
 

--- a/skills/dependencies/schema.json
+++ b/skills/dependencies/schema.json
@@ -2,36 +2,84 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "dependencies report",
   "type": "object",
-  "required": ["dependencies"],
+  "required": ["schema_version", "analyses"],
   "additionalProperties": false,
   "properties": {
-    "error": { "type": "string" },
-    "dependencies": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "required": ["name", "ecosystem"],
-        "additionalProperties": false,
-        "properties": {
-          "name":            { "type": "string" },
-          "ecosystem":       { "type": "string" },
-          "purl":            { "type": "string" },
-          "requirement":     { "type": "string" },
-          "requirement_unresolved": {
-            "type": "boolean",
-            "description": "True when the requirement still contains an unresolved manifest expression such as ${missing.version}."
-          },
-          "requirement_resolution": {
-            "type": "string",
-            "description": "Resolver tag explaining how requirement was determined, such as resolved, unresolved_property, unresolved_env, unresolved_parent, unresolved_profile_gated, or unresolved_missing."
-          },
-          "dependency_type": {
-            "type": "string",
-            "description": "Dependency phase. Scrutineer normalizes common aliases to runtime, dev, test, or build."
-          },
-          "manifest_path":   { "type": "string" },
-          "manifest_kind":   { "type": "string" }
-        }
+    "schema_version":   { "const": 1 },
+    "commit":           { "type": "string" },
+    "generated_at":     { "type": "string" },
+    "git_pkgs_version": { "type": "string" },
+    "error":            { "type": "string" },
+    "analyses": {
+      "type": "object",
+      "required": ["inventory", "sbom", "licenses", "vulnerabilities", "outdated", "deprecated"],
+      "additionalProperties": false,
+      "properties": {
+        "inventory": {
+          "allOf": [{ "$ref": "#/$defs/section" }],
+          "properties": {
+            "result": { "type": "array", "items": { "$ref": "#/$defs/dependency" } }
+          }
+        },
+        "sbom": {
+          "allOf": [{ "$ref": "#/$defs/section" }],
+          "properties": {
+            "result": {
+              "type": "object",
+              "description": "CycloneDX JSON document as emitted by git-pkgs sbom."
+            }
+          }
+        },
+        "licenses":        { "$ref": "#/$defs/shimmedSection" },
+        "vulnerabilities": { "$ref": "#/$defs/shimmedSection" },
+        "outdated":        { "$ref": "#/$defs/shimmedSection" },
+        "deprecated":      { "$ref": "#/$defs/shimmedSection" }
+      }
+    }
+  },
+  "$defs": {
+    "section": {
+      "type": "object",
+      "required": ["status"],
+      "properties": {
+        "status":   { "enum": ["ok", "error"] },
+        "error":    { "type": "string" },
+        "warnings": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "shimmedSection": {
+      "allOf": [{ "$ref": "#/$defs/section" }],
+      "properties": {
+        "result":  { "type": "array", "items": { "type": "object" } },
+        "sources": { "type": "array", "items": { "type": "object" } }
+      }
+    },
+    "dependency": {
+      "type": "object",
+      "required": ["name", "ecosystem"],
+      "properties": {
+        "name":            { "type": "string" },
+        "ecosystem":       { "type": "string" },
+        "purl":            { "type": "string" },
+        "requirement":     { "type": "string" },
+        "requirement_unresolved": {
+          "type": "boolean",
+          "description": "True when the requirement still contains an unresolved manifest expression such as ${missing.version}."
+        },
+        "requirement_resolution": {
+          "type": "string",
+          "description": "Resolver tag explaining how requirement was determined, such as resolved, unresolved_property, unresolved_env, unresolved_parent, unresolved_profile_gated, or unresolved_missing."
+        },
+        "type": {
+          "type": "string",
+          "description": "Alias for dependency_type accepted from older git-pkgs output."
+        },
+        "dependency_type": {
+          "type": "string",
+          "description": "Dependency phase. Scrutineer normalizes common aliases to runtime, dev, test, or build."
+        },
+        "manifest_path":   { "type": "string" },
+        "manifest_kind":   { "type": "string" }
       }
     }
   }

--- a/skills/dependencies/schema.json
+++ b/skills/dependencies/schema.json
@@ -12,7 +12,6 @@
     "error":            { "type": "string" },
     "analyses": {
       "type": "object",
-      "required": ["inventory", "sbom", "licenses", "vulnerabilities", "outdated", "deprecated"],
       "additionalProperties": false,
       "properties": {
         "inventory": {
@@ -29,11 +28,7 @@
               "description": "CycloneDX JSON document as emitted by git-pkgs sbom."
             }
           }
-        },
-        "licenses":        { "$ref": "#/$defs/shimmedSection" },
-        "vulnerabilities": { "$ref": "#/$defs/shimmedSection" },
-        "outdated":        { "$ref": "#/$defs/shimmedSection" },
-        "deprecated":      { "$ref": "#/$defs/shimmedSection" }
+        }
       }
     }
   },
@@ -45,13 +40,6 @@
         "status":   { "enum": ["ok", "error"] },
         "error":    { "type": "string" },
         "warnings": { "type": "array", "items": { "type": "string" } }
-      }
-    },
-    "shimmedSection": {
-      "allOf": [{ "$ref": "#/$defs/section" }],
-      "properties": {
-        "result":  { "type": "array", "items": { "type": "object" } },
-        "sources": { "type": "array", "items": { "type": "object" } }
       }
     },
     "dependency": {

--- a/skills/dependencies/scripts/index.sh
+++ b/skills/dependencies/scripts/index.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
-# Run the git-pkgs dependency analyses against the clone and emit a single
-# versioned envelope on stdout. Each analysis has its own status so a
-# registry timeout in one does not discard a valid inventory from another.
+# Run the two per-repository git-pkgs analyses against the clone and emit a
+# versioned envelope on stdout. Each analysis has its own status so a failure
+# in one does not discard a valid result from the other. Per-package registry
+# lookups (licences, vulnerabilities, latest-version, deprecation) are not run
+# here; scrutineer performs those once per package outside the scan.
 set -euo pipefail
 
 if ! command -v git-pkgs >/dev/null 2>&1; then
@@ -24,14 +26,11 @@ trap 'rm -rf "$work"' EXIT
 
 # One line per section: <name> <command> [args...]. Each command's stdout,
 # stderr, and exit code are captured independently so the assembler can
-# report partial failure.
+# report partial failure. sbom runs with --skip-enrichment so no registry is
+# contacted from inside the scan; scrutineer fills licence data per package.
 sections=(
-  "inventory       list       --format json"
-  "sbom            sbom       --format json"
-  "licenses        licenses   --format json"
-  "vulnerabilities vulns      --format json"
-  "outdated        outdated   --format json"
-  "deprecated      deprecated --format json"
+  "inventory list --format json"
+  "sbom      sbom --format json --skip-enrichment"
 )
 
 for spec in "${sections[@]}"; do
@@ -48,11 +47,7 @@ WORK="$work" COMMIT="$commit" GP_VERSION="$gp_version" python3 - <<'PY'
 import json, os, sys, datetime
 
 work = os.environ["WORK"]
-sections = ["inventory", "sbom", "licenses", "vulnerabilities", "outdated", "deprecated"]
-# licenses/vulns/outdated/deprecated currently emit a bare array; once
-# git-pkgs/git-pkgs#306 lands they emit {"results": [...], "sources": [...]}.
-# Normalise both so this script keeps working across the transition.
-shimmed = {"licenses", "vulnerabilities", "outdated", "deprecated"}
+sections = ["inventory", "sbom"]
 
 def load(name):
     with open(os.path.join(work, name + ".exit")) as f:
@@ -69,18 +64,7 @@ def load(name):
             result = json.loads(raw)
         except ValueError as e:
             return {"status": "error", "error": f"parse output: {e}"}
-    section = {"status": "ok"}
-    if name in shimmed:
-        if isinstance(result, dict) and "results" in result:
-            section["result"] = result.get("results") or []
-            section["sources"] = result.get("sources") or []
-        elif isinstance(result, list):
-            section["result"] = result
-            section["sources"] = []
-        else:
-            return {"status": "error", "error": f"unexpected {type(result).__name__} output"}
-    else:
-        section["result"] = result
+    section = {"status": "ok", "result": result}
     if err:
         section["warnings"] = [err]
     return section

--- a/skills/dependencies/scripts/index.sh
+++ b/skills/dependencies/scripts/index.sh
@@ -1,8 +1,7 @@
 #!/usr/bin/env bash
-# Index every dependency manifest in the clone and wrap git-pkgs's output in
-# the `{"dependencies": [...]}` envelope the scrutineer parser expects. Exits
-# non-zero with an informative message if git-pkgs is missing or emits a
-# non-array JSON value other than null.
+# Run the git-pkgs dependency analyses against the clone and emit a single
+# versioned envelope on stdout. Each analysis has its own status so a
+# registry timeout in one does not discard a valid inventory from another.
 set -euo pipefail
 
 if ! command -v git-pkgs >/dev/null 2>&1; then
@@ -18,19 +17,82 @@ git fetch --unshallow --quiet >/dev/null 2>&1 || true
 
 git-pkgs init --no-hooks >/dev/null
 
-# Wrap the array in a top-level object so the output matches schema.json.
-# Older git-pkgs builds can emit null or nothing when they find no manifests;
-# both mean "no dependencies" here, not permission to infer rows by hand.
-git-pkgs list --format json | python3 -c 'import json, sys
-raw = sys.stdin.read().strip()
-if raw == "" or raw == "null":
-    deps = []
-else:
-    deps = json.loads(raw)
-if deps is None:
-    deps = []
-if not isinstance(deps, list):
-    raise SystemExit(f"git-pkgs list returned {type(deps).__name__}, want array")
-json.dump({"dependencies": deps}, sys.stdout, separators=(",", ":"))
+commit="$(git rev-parse HEAD 2>/dev/null || true)"
+gp_version="$(git-pkgs --version 2>/dev/null || true)"
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+# One line per section: <name> <command> [args...]. Each command's stdout,
+# stderr, and exit code are captured independently so the assembler can
+# report partial failure.
+sections=(
+  "inventory       list       --format json"
+  "sbom            sbom       --format json"
+  "licenses        licenses   --format json"
+  "vulnerabilities vulns      --format json"
+  "outdated        outdated   --format json"
+  "deprecated      deprecated --format json"
+)
+
+for spec in "${sections[@]}"; do
+  read -r name cmd rest <<<"$spec"
+  # shellcheck disable=SC2086
+  if git-pkgs "$cmd" $rest >"$work/$name.json" 2>"$work/$name.err"; then
+    echo 0 >"$work/$name.exit"
+  else
+    echo $? >"$work/$name.exit"
+  fi
+done
+
+WORK="$work" COMMIT="$commit" GP_VERSION="$gp_version" python3 - <<'PY'
+import json, os, sys, datetime
+
+work = os.environ["WORK"]
+sections = ["inventory", "sbom", "licenses", "vulnerabilities", "outdated", "deprecated"]
+# licenses/vulns/outdated/deprecated currently emit a bare array; once
+# git-pkgs/git-pkgs#306 lands they emit {"results": [...], "sources": [...]}.
+# Normalise both so this script keeps working across the transition.
+shimmed = {"licenses", "vulnerabilities", "outdated", "deprecated"}
+
+def load(name):
+    with open(os.path.join(work, name + ".exit")) as f:
+        code = int(f.read().strip() or "1")
+    with open(os.path.join(work, name + ".err"), errors="replace") as f:
+        err = f.read().strip()
+    raw = open(os.path.join(work, name + ".json"), errors="replace").read().strip()
+    if code != 0:
+        return {"status": "error", "error": err or f"git-pkgs exited {code}"}
+    if raw in ("", "null"):
+        result = [] if name != "sbom" else {}
+    else:
+        try:
+            result = json.loads(raw)
+        except ValueError as e:
+            return {"status": "error", "error": f"parse output: {e}"}
+    section = {"status": "ok"}
+    if name in shimmed:
+        if isinstance(result, dict) and "results" in result:
+            section["result"] = result.get("results") or []
+            section["sources"] = result.get("sources") or []
+        elif isinstance(result, list):
+            section["result"] = result
+            section["sources"] = []
+        else:
+            return {"status": "error", "error": f"unexpected {type(result).__name__} output"}
+    else:
+        section["result"] = result
+    if err:
+        section["warnings"] = [err]
+    return section
+
+envelope = {
+    "schema_version": 1,
+    "commit": os.environ.get("COMMIT", ""),
+    "generated_at": datetime.datetime.now(datetime.timezone.utc)
+        .isoformat().replace("+00:00", "Z"),
+    "git_pkgs_version": os.environ.get("GP_VERSION", ""),
+    "analyses": {name: load(name) for name in sections},
+}
+json.dump(envelope, sys.stdout, separators=(",", ":"))
 sys.stdout.write("\n")
-'
+PY


### PR DESCRIPTION
First step of native dependency analysis: give every scanned repository a resolved-component snapshot produced by `git-pkgs`, stored in the existing `SBOMUpload`/`SBOMPackage` tables rather than a new parallel catalogue. Later PRs will hang licence, vulnerability and version observations off these rows and add portfolio views.

`SBOMUpload` gains `Origin` (`uploaded`/`generated`, defaulting to `uploaded` so existing rows are classified), nullable `RepositoryID`/`ScanID`/`Commit`, and a `Current` flag indexed with `RepositoryID` so "current snapshot per repository" is a flat lookup. `Raw` is left unset for generated snapshots so retaining history does not store every CycloneDX document.

`SBOMPackage.RepositoryID` is renamed to `SourceRepositoryID`. It already meant "repository that publishes this package" (populated by the ecosyste.ms resolver); once the upload row has its own `RepositoryID` meaning "repository we scanned", keeping the same name on both would be misleading. A new `preMigrate` step in `db.Open` renames the column before `AutoMigrate` runs, since AutoMigrate would otherwise add the new column alongside the old one and strand the data. Deleting a repository now removes its generated snapshots and continues to null `source_repository_id` on packages in other uploads that resolved to it.

`skills/dependencies/scripts/index.sh` now runs `list` and `sbom --skip-enrichment` after one `git-pkgs init` and assembles a versioned envelope with independent per-section `status` and `error`, so a failure in one does not discard the other. Per-package registry lookups (licences, vulnerabilities, latest-version, deprecation) are not run inside the scan; scrutineer performs those once per package against the resulting `SBOMPackage` rows outside it, so a package shared by many repositories is queried once rather than per scan, and the report the model handles is smaller.

`parseDependenciesOutput` decodes the envelope: the inventory section still replaces `Dependency` rows (Maven property resolution unchanged); the sbom section is parsed with `git-pkgs/sbom` into a generated `SBOMUpload` plus `SBOMPackage` rows, with `Current` moved from the previous snapshot inside the same transaction.

Nothing here depends on the git-pkgs prework in https://github.com/git-pkgs/git-pkgs/issues/306 (no longer relevant to the scan since the four analysis commands are not run there) or https://github.com/git-pkgs/git-pkgs/issues/307; `DependencyResolution` is deferred until #307 lands.