### PR TITLE
ci: run deterministic skill eval tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -83,6 +83,14 @@ jobs:
       - name: Test
         run: go test -race ./...
 
+      # The deterministic eval harness is behind //go:build evals. Live model
+      # runs remain disabled unless SCRUTINEER_RUN_EVALS is explicitly set.
+      - name: Vet skill eval harness
+        run: go vet -tags evals ./internal/evals/...
+
+      - name: Test skill eval harness
+        run: go test -race -tags evals ./internal/evals/...
+
       # The podman integration tests are behind //go:build podman and are not
       # built by the steps above; vet them under the tag so they can't silently
       # rot (podman itself is not needed -- the tests skip at run time without it).

--- a/evals/README.md
+++ b/evals/README.md
@@ -1,14 +1,14 @@
 # Skill evals
 
-Fixture-driven skill evals live here. They are off by default in normal CI;
-run the harness explicitly with:
+Fixture-driven skill evals live here. CI runs the deterministic loader, schema,
+judge, staging, and experiment checks with:
 
 ```sh
 go test -tags evals ./internal/evals/...
 ```
 
-That command validates scenario loading and the deterministic judge. To run the
-actual model-backed skills against every fixture, opt in:
+The actual model-backed skills remain off by default. To run them against every
+fixture, opt in explicitly:
 
 ```sh
 SCRUTINEER_RUN_EVALS=1 SCRUTINEER_EVAL_MODEL=claude-sonnet-5 go test -tags evals ./internal/evals/... -run TestRunFixtures -v

--- a/evals/README.md
+++ b/evals/README.md
@@ -1,7 +1,8 @@
 # Skill evals
 
 Fixture-driven skill evals live here. CI runs the deterministic loader, schema,
-judge, staging, and experiment checks with:
+judge, staging, and experiment checks under the race detector. Run the same
+deterministic checks locally with:
 
 ```sh
 go test -tags evals ./internal/evals/...


### PR DESCRIPTION
Part of #118

## Summary

Runs the deterministic skill evaluation harness in CI so scenario loading, schema validation, judging, staging and experiment-pairing behavior cannot silently regress.

Live model-backed evaluations remain explicitly opt-in and are not run in CI.

## Changes

- Vet `internal/evals` with the `evals` build tag.
- Run the tagged eval test suite with the race detector on Linux and macOS.
- Keep `TestRunFixtures` disabled unless `SCRUTINEER_RUN_EVALS=1` is explicitly set.
- Update `evals/README.md` to document deterministic CI coverage and the separate live-run opt-in.

## Tests

- `go mod tidy -diff`
- `go vet ./...`
- `go vet -tags evals ./internal/evals/...`
- `go vet -tags podman ./...`
- `go test -race ./...`
- `go test -race -tags evals ./internal/evals/...`
- `git diff --check`