### PR TITLE
Have metadata, packages and advisories skills use cached ecosyste.ms data

### DIFF
--- a/skills/advisories/SKILL.md
+++ b/skills/advisories/SKILL.md
@@ -2,7 +2,7 @@
 name: advisories
 description: Fetch published GHSA and CVE advisories affecting any package this repository produces, via advisories.ecosyste.ms.
 license: MIT
-compatibility: Needs network access to advisories.ecosyste.ms.
+compatibility: Prefers the scrutineer API's cached ecosyste.ms payload; needs network access to advisories.ecosyste.ms only when nothing is cached.
 metadata:
   scrutineer.version: 1
   scrutineer.output_file: report.json
@@ -14,15 +14,16 @@ metadata:
 
 ## Workspace
 
-- `./context.json` — has `repository.url`
+- `./context.json` — has `repository.url`, plus `scrutineer.api_base`, `scrutineer.token` and `scrutineer.repository_id`
 - `./report.json` — write the advisories array here
 - `./schema.json` — output shape
 
 ## What to do
 
-1. Read `./context.json` and extract `repository.url`.
-2. Fetch `https://advisories.ecosyste.ms/api/v1/advisories?repository_url={URL-ENCODED_URL}`. Follow pagination (`Link: <...>; rel="next"`) if present.
-3. For each advisory returned, emit one entry in `report.json` under `advisories`:
+1. Read `./context.json` and extract `repository.url`, `scrutineer.api_base`, `scrutineer.token` and `scrutineer.repository_id`.
+2. Ask scrutineer for the cached payload first: `GET {api_base}/repositories/{repository_id}/ecosystems/advisories/raw` with the bearer token. A 200 is the verbatim upstream response, already collated by the prefetcher — use it, skip the pagination in step 3, and go to step 4. This is the only path that works under `--hardened`, where ecosyste.ms is not in the egress allowlist.
+3. On 404 nothing is cached — the steady state under `ecosystems_enrichment: false` — so fetch `https://advisories.ecosyste.ms/api/v1/advisories?repository_url={URL-ENCODED_URL}` directly. Follow pagination (`Link: <...>; rel="next"`) if present.
+4. For each advisory returned, emit one entry in `report.json` under `advisories`:
    - `uuid` from upstream `uuid`
    - `url` from upstream `url` (or the first reference if `url` is empty)
    - `title` from upstream `title`
@@ -33,4 +34,6 @@ metadata:
    - `packages` — comma-joined list of affected package names upstream lists under `packages` or `package_names`
    - `published_at` and `withdrawn_at` as RFC3339 strings if upstream has them
 
-Return `{"advisories": []}` if upstream has nothing — valid result.
+Return `{"advisories": []}` if a source answered and upstream has nothing — valid result.
+
+Only write that empty array when a source actually answered. If neither source is reachable — the cached endpoint returned 404 *and* the direct fetch failed, which is what `--hardened` looks like on an uncached repository — do not write `./report.json` at all. Exit non-zero instead. The parser replaces the whole advisory set for the repository, deleting every existing row before inserting what you produced, so an empty array reported as success wipes advisories a previous scan recorded rather than leaving them untouched.

--- a/skills/metadata/SKILL.md
+++ b/skills/metadata/SKILL.md
@@ -2,7 +2,7 @@
 name: metadata
 description: Fetch repository metadata (description, default branch, languages, license, stars, archived, icon) from repos.ecosyste.ms and save it on the repository row.
 license: MIT
-compatibility: Needs network access to repos.ecosyste.ms.
+compatibility: Prefers the scrutineer API's cached ecosyste.ms payload; needs network access to repos.ecosyste.ms only when nothing is cached.
 metadata:
   scrutineer.version: 1
   scrutineer.output_file: report.json
@@ -17,16 +17,17 @@ Populate repository metadata from repos.ecosyste.ms. One API call, one flat JSON
 
 ## Workspace
 
-- `./context.json` — has `repository.url` (the git URL of the target repo)
+- `./context.json` — has `repository.url` (the git URL of the target repo), plus `scrutineer.api_base`, `scrutineer.token` and `scrutineer.repository_id`
 - `./report.json` — write the flat metadata here
 - `./schema.json` — output shape
 
 ## What to do
 
-1. Read `./context.json` and extract `repository.url`.
-2. Fetch `https://repos.ecosyste.ms/api/v1/repositories/lookup?url={URL-ENCODED_URL}`. Follow redirects.
-3. Keep the raw upstream response available for the `metadata` blob (the parser stores it as `Repository.Metadata`).
-4. Map the fields below into `./report.json` exactly as `./schema.json` describes:
+1. Read `./context.json` and extract `repository.url`, `scrutineer.api_base`, `scrutineer.token` and `scrutineer.repository_id`.
+2. Ask scrutineer for the cached payload first: `GET {api_base}/repositories/{repository_id}/ecosystems/repo/raw` with the bearer token. A 200 is the verbatim upstream lookup response — use it and go to step 4. This is the only path that works under `--hardened`, where ecosyste.ms is not in the egress allowlist, and it avoids a redundant external fetch otherwise.
+3. On 404 nothing is cached — the steady state under `ecosystems_enrichment: false` — so fetch `https://repos.ecosyste.ms/api/v1/repositories/lookup?url={URL-ENCODED_URL}` directly. Follow redirects.
+4. Keep the raw upstream response available for the `metadata` blob (the parser stores it as `Repository.Metadata`).
+5. Map the fields below into `./report.json` exactly as `./schema.json` describes:
    - `full_name` from upstream `full_name`
    - `owner` from upstream `owner`
    - `description` from upstream `description`
@@ -40,4 +41,6 @@ Populate repository metadata from repos.ecosyste.ms. One API call, one flat JSON
    - `html_url` from upstream `html_url`
    - `icon_url` from upstream `icon_url` if present
 
-Omit any field upstream did not provide rather than making one up. If the lookup returns nothing, write `{}` and exit 0 — the parser handles an empty map cleanly.
+Omit any field upstream did not provide rather than making one up. If the lookup genuinely returns nothing, write `{}` and exit 0 — the parser handles an empty map cleanly.
+
+If neither source is reachable — the cached endpoint returned 404 *and* the direct fetch failed, which is what `--hardened` looks like on an uncached repository — do not write `./report.json` at all. Exit non-zero instead. An empty document here is a claim that upstream knows nothing about this repository, and it blanks the stored `metadata` blob and zeroes `stars`/`forks` on the row.

--- a/skills/packages/SKILL.md
+++ b/skills/packages/SKILL.md
@@ -2,7 +2,7 @@
 name: packages
 description: Look up every package this repository publishes across all registries via packages.ecosyste.ms, with downloads, dependent counts, latest version, and registry URL.
 license: MIT
-compatibility: Needs network access to packages.ecosyste.ms.
+compatibility: Prefers the scrutineer API's cached ecosyste.ms payload; needs network access to packages.ecosyste.ms only when nothing is cached.
 metadata:
   scrutineer.version: 1
   scrutineer.output_file: report.json
@@ -16,15 +16,16 @@ One repository can ship multiple packages across multiple ecosystems. Ask packag
 
 ## Workspace
 
-- `./context.json` — has `repository.url`
+- `./context.json` — has `repository.url`, plus `scrutineer.api_base`, `scrutineer.token` and `scrutineer.repository_id`
 - `./report.json` — write the packages array here
 - `./schema.json` — output shape
 
 ## What to do
 
-1. Read `./context.json` and extract `repository.url`.
-2. Fetch `https://packages.ecosyste.ms/api/v1/packages/lookup?repository_url={URL-ENCODED_URL}`. The response is a JSON array, one object per published package.
-3. For each package upstream returns, emit one entry in `report.json` under `packages` mapping these fields:
+1. Read `./context.json` and extract `repository.url`, `scrutineer.api_base`, `scrutineer.token` and `scrutineer.repository_id`.
+2. Ask scrutineer for the cached payload first: `GET {api_base}/repositories/{repository_id}/ecosystems/packages/raw` with the bearer token. A 200 is the verbatim upstream lookup response — use it and go to step 4. This is the only path that works under `--hardened`, where ecosyste.ms is not in the egress allowlist, and it saves re-fetching what the prefetcher already collated.
+3. On 404 nothing is cached — the steady state under `ecosystems_enrichment: false` — so fetch `https://packages.ecosyste.ms/api/v1/packages/lookup?repository_url={URL-ENCODED_URL}` directly. Either way the payload is a JSON array, one object per published package.
+4. For each package upstream returns, emit one entry in `report.json` under `packages` mapping these fields:
    - `name` from upstream `name`
    - `ecosystem` from upstream `ecosystem` (e.g. `rubygems`, `npm`, `pypi`)
    - `purl` from upstream `purl`
@@ -39,4 +40,6 @@ One repository can ship multiple packages across multiple ecosystems. Ask packag
    - `dependent_packages_url` from upstream `dependent_packages_url`
    - `metadata` — the whole upstream object for this package, verbatim
 
-If there are no packages (lookup returns `[]`), write `{"packages": []}`. That is a valid result, not an error.
+If upstream answered and this repository genuinely publishes no packages (the lookup returns `[]`), write `{"packages": []}`. That is a valid result, not an error.
+
+Only write that empty array when a source actually answered. If neither source is reachable — the cached endpoint returned 404 *and* the direct fetch failed, which is what `--hardened` looks like on an uncached repository — do not write `./report.json` at all. Exit non-zero instead. The parser replaces the whole package set for the repository, deleting every existing row before inserting what you produced, so an empty array reported as success wipes packages a previous scan recorded rather than leaving them untouched.


### PR DESCRIPTION
Closes #520.

The three bundled ecosyste.ms skills now try `GET {api_base}/repositories/{repository_id}/ecosystems/{source}/raw` with the scan's bearer token before falling back to the direct upstream URL on 404, using the mapping from the issue (`metadata` → `repo`, `packages` → `packages`, `advisories` → `advisories`).

I took the correction in your comment as the framing: the PR does not claim a context-size win, since `/raw` returns the verbatim upstream payload either way. The wins as written are `--hardened`, offline, and letting `advisories` skip re-paginating what the prefetcher already collated.

The `--hardened` claim is pinned by tests already in the repo, so it is stated as a fact rather than a hunch — `cmd/scrutineer/main_test.go:474` asserts default mode contains `*.ecosyste.ms` and `:489` asserts hardened mode does not. Under `--hardened` the direct fetch is refused by the egress proxy, so the cached endpoint is not an optimisation for these three skills, it is the only path that works.

### One thing the issue did not mention, and the reason this is not purely docs

Adding the fallback creates a state that could not be reached before: **both sources unavailable at once.** Under `--hardened` on a repository with nothing cached, the endpoint 404s *and* the direct fetch is blocked.

That matters because of what the parsers do. `parsePackagesOutput` and `parseAdvisoriesOutput` replace the whole row set — `DELETE WHERE repository_id = ?` and then insert whatever the skill produced. The old instructions told the skill to write `{"packages": []}` when it had nothing, and called it "a valid result, not an error". In the new unreachable state that empty array is reported as success and **deletes packages and advisories a previous scan recorded**, which is the same hazard your comment above `buildEgressAllow` describes for `ecosystems_enrichment`.

So each skill now separates the two cases explicitly:

- a source **answered** and upstream genuinely has nothing → write the empty array, unchanged behaviour
- **no source answered** → do not write `./report.json`; exit non-zero

I checked that the harness honours that before writing it in: in `internal/worker/skill.go`, a `RunSkill` error returns before the parse (only a `MaxTurnsReachedError` gets the partial path), and the parse is additionally guarded by `if report != ""`. So both refusing to write and exiting non-zero leave the existing rows untouched.

`metadata` gets the same rule for consistency, though it is the mildest of the three: `parseRepoMetadataOutput` guards each field with `if m.X != ""`, so `{}` mostly leaves the row alone. It does still blank the stored `metadata` blob and set `stars`/`forks` to zero unconditionally, which is why an unreachable run should not report one.

**If you would rather keep the skills always-writes and treat this as out of scope, say so and I will cut it back to the cached-first step alone** — it is a behaviour change to the failure path, and #520 as filed only asked for the endpoint swap.

### Notes

- The fallback is documented as a first-class path, not an error path, since `ecosystems_enrichment: false` makes 404 the steady state — matching the wording already in `apiGetEcosystemsRaw`'s doc comment.
- `compatibility:` in the frontmatter was updated on all three; it previously promised network access to ecosyste.ms as a hard requirement. No other copies of those strings exist in the tree, so nothing drifted.
- No test added. The change is prose inside `SKILL.md`, and a test asserting on instruction wording would break on the next reword without protecting anything. I did verify all three still parse with `skills.ParseFile` — correct names, `requires_remote` preserved, **zero warnings** — and `go build ./...`, `go vet`, `go test ./internal/skills/... ./internal/bundledassets/...` are green.
