### PR TITLE
Add per-dependent migration campaign tracking

### DIFF
--- a/docs/database.md
+++ b/docs/database.md
@@ -77,8 +77,8 @@ change history for findings. `payload` is JSON stored portably as text.
 ## package_alternatives
 
 Operator-curated migration targets for repositories classified as abandoned or
-zombie. Later #12 migration-guide and campaign tracking work can join on this
-table instead of reparsing notes or reports.
+zombie. The finding migration guide and dependent campaign tracking join on
+this table instead of reparsing notes or reports.
 
 | Column | Type | Notes |
 |--------|------|-------|
@@ -419,6 +419,9 @@ One row per (finding, dependent) pair the `exposure` skill has audited. Status m
 | rationale | text | One-paragraph explanation written by the skill, rendered in the finding page's per-dependent table. |
 | scan_id | integer FK | Exposure scan that wrote this row. |
 | scan_commit | text | HEAD of the dependent's clone when the verdict was made; lets the operator tell whether a later rescan would still apply. |
+| campaign_status | text | Operator-managed migration outreach state: `notified`, `acked`, `migrated`, `declined`, or `silent`. Empty means outreach has not started. |
+| campaign_note | text | Operator note about the downstream migration conversation or outcome. |
+| campaign_updated_at | datetime | When campaign status or note last changed. Null until outreach is recorded. |
 | created_at | datetime | |
 | updated_at | datetime | |
 

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -1009,6 +1009,35 @@ const (
 	ExposureFixed              = "fixed"
 )
 
+// DependentCampaignStatus is the operator-managed outreach state for one
+// finding/dependent pair. It is deliberately separate from exposure status:
+// whether a consumer is affected and whether it has answered a migration
+// campaign are independent facts.
+type DependentCampaignStatus string
+
+const (
+	CampaignNotified DependentCampaignStatus = "notified"
+	CampaignAcked    DependentCampaignStatus = "acked"
+	CampaignMigrated DependentCampaignStatus = "migrated"
+	CampaignDeclined DependentCampaignStatus = "declined"
+	CampaignSilent   DependentCampaignStatus = "silent"
+)
+
+// DependentCampaignStatuses lists campaign states in workflow order.
+var DependentCampaignStatuses = []DependentCampaignStatus{
+	CampaignNotified, CampaignAcked, CampaignMigrated, CampaignDeclined, CampaignSilent,
+}
+
+// ValidDependentCampaignStatus reports whether status is a campaign state
+// the database accepts. Empty clears campaign tracking for the pair.
+func ValidDependentCampaignStatus(status DependentCampaignStatus) bool {
+	switch status {
+	case "", CampaignNotified, CampaignAcked, CampaignMigrated, CampaignDeclined, CampaignSilent:
+		return true
+	}
+	return false
+}
+
 // CSAF 2.0 VEX flag labels. Only valid when Status is known_not_affected.
 const (
 	JustifComponentNotPresent        = "component_not_present"
@@ -1062,6 +1091,10 @@ type FindingDependent struct {
 
 	ScanID     *uint
 	ScanCommit string
+
+	CampaignStatus    DependentCampaignStatus `gorm:"index"`
+	CampaignNote      string                  `gorm:"type:text"`
+	CampaignUpdatedAt *time.Time
 
 	CreatedAt time.Time
 	UpdatedAt time.Time

--- a/internal/db/finding_helpers.go
+++ b/internal/db/finding_helpers.go
@@ -117,6 +117,60 @@ func EnsureFindingDependent(gdb *gorm.DB, row FindingDependent) error {
 	}).Create(&row).Error
 }
 
+// SetFindingDependentCampaign records the analyst-managed migration outreach
+// state for one finding/dependent pair. UpdateColumns intentionally leaves the
+// row's UpdatedAt untouched: that timestamp describes the exposure verdict,
+// while CampaignUpdatedAt tracks this independent workflow.
+func SetFindingDependentCampaign(
+	gdb *gorm.DB,
+	findingID, dependentID uint,
+	status DependentCampaignStatus,
+	note string,
+) (FindingDependent, error) {
+	note = strings.TrimSpace(note)
+	if !ValidDependentCampaignStatus(status) {
+		return FindingDependent{}, fmt.Errorf("invalid dependent campaign status %q", status)
+	}
+	if status == "" && note != "" {
+		return FindingDependent{}, errors.New("dependent campaign status is required when a note is set")
+	}
+
+	var row FindingDependent
+	err := gdb.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Where("finding_id = ? AND dependent_id = ?", findingID, dependentID).
+			First(&row).Error; err != nil {
+			return err
+		}
+		if row.CampaignStatus == status && row.CampaignNote == note {
+			return nil
+		}
+
+		updates := map[string]any{
+			"campaign_status": status,
+			"campaign_note":   note,
+		}
+		if status == "" {
+			updates["campaign_updated_at"] = nil
+			row.CampaignUpdatedAt = nil
+		} else {
+			now := time.Now().UTC()
+			updates["campaign_updated_at"] = now
+			row.CampaignUpdatedAt = &now
+		}
+		if err := tx.Model(&FindingDependent{}).Where("id = ?", row.ID).
+			UpdateColumns(updates).Error; err != nil {
+			return err
+		}
+		row.CampaignStatus = status
+		row.CampaignNote = note
+		return nil
+	})
+	if err != nil {
+		return FindingDependent{}, err
+	}
+	return row, nil
+}
+
 // WriteFindingTimeField is the time.Time twin of WriteFindingField for
 // timestamp columns the analyst (or a skill) can set. The closed set
 // of writable timestamp columns lives in findingTimeFieldAccessor, so

--- a/internal/db/finding_helpers_test.go
+++ b/internal/db/finding_helpers_test.go
@@ -70,6 +70,100 @@ func TestSeverityAtLeast(t *testing.T) {
 	}
 }
 
+func TestValidDependentCampaignStatus(t *testing.T) {
+	for _, status := range append([]DependentCampaignStatus{""}, DependentCampaignStatuses...) {
+		if !ValidDependentCampaignStatus(status) {
+			t.Errorf("status %q should be valid", status)
+		}
+	}
+	if ValidDependentCampaignStatus("contacted") {
+		t.Error("unknown campaign status should be invalid")
+	}
+}
+
+func TestSetFindingDependentCampaign(t *testing.T) {
+	gdb := newTestDB(t)
+	finding := seedFinding(t, gdb)
+	dependent := Dependent{RepositoryID: finding.RepositoryID, Name: "consumer", PURL: "pkg:npm/consumer"}
+	if err := gdb.Create(&dependent).Error; err != nil {
+		t.Fatal(err)
+	}
+	exposureAt := time.Date(2026, time.January, 2, 3, 4, 5, 0, time.UTC)
+	row := FindingDependent{
+		FindingID:   finding.ID,
+		DependentID: dependent.ID,
+		Status:      ExposureKnownAffected,
+		Rationale:   "reachable",
+		UpdatedAt:   exposureAt,
+	}
+	if err := gdb.Create(&row).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := SetFindingDependentCampaign(gdb, finding.ID, dependent.ID, CampaignNotified, "  opened issue #42  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.CampaignStatus != CampaignNotified || got.CampaignNote != "opened issue #42" || got.CampaignUpdatedAt == nil {
+		t.Fatalf("campaign row = %+v", got)
+	}
+	firstCampaignUpdate := *got.CampaignUpdatedAt
+
+	var stored FindingDependent
+	if err := gdb.First(&stored, row.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if !stored.UpdatedAt.Equal(exposureAt) {
+		t.Errorf("exposure UpdatedAt = %v, want %v", stored.UpdatedAt, exposureAt)
+	}
+
+	got, err = SetFindingDependentCampaign(gdb, finding.ID, dependent.ID, CampaignNotified, "opened issue #42")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.CampaignUpdatedAt == nil || !got.CampaignUpdatedAt.Equal(firstCampaignUpdate) {
+		t.Errorf("no-op changed CampaignUpdatedAt: got %v, want %v", got.CampaignUpdatedAt, firstCampaignUpdate)
+	}
+
+	if err := UpsertFindingDependent(gdb, FindingDependent{
+		FindingID:   finding.ID,
+		DependentID: dependent.ID,
+		Status:      ExposureFixed,
+		Rationale:   "fixed upstream",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := gdb.First(&stored, row.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if stored.CampaignStatus != CampaignNotified || stored.CampaignNote != "opened issue #42" {
+		t.Errorf("exposure upsert changed campaign fields: %+v", stored)
+	}
+
+	got, err = SetFindingDependentCampaign(gdb, finding.ID, dependent.ID, "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.CampaignStatus != "" || got.CampaignNote != "" || got.CampaignUpdatedAt != nil {
+		t.Errorf("cleared campaign row = %+v", got)
+	}
+}
+
+func TestSetFindingDependentCampaignRejectsInvalidInput(t *testing.T) {
+	gdb := newTestDB(t)
+	finding := seedFinding(t, gdb)
+
+	if _, err := SetFindingDependentCampaign(gdb, finding.ID, 99, "email-sent", ""); err == nil {
+		t.Fatal("expected invalid campaign status error")
+	}
+	if _, err := SetFindingDependentCampaign(gdb, finding.ID, 99, "", "note without status"); err == nil {
+		t.Fatal("expected note without status error")
+	}
+	if _, err := SetFindingDependentCampaign(gdb, finding.ID, 99, CampaignNotified, ""); !errors.Is(err, gorm.ErrRecordNotFound) {
+		t.Fatalf("missing pair error = %v, want record not found", err)
+	}
+}
+
 func TestWriteFindingField_logsHistory(t *testing.T) {
 	gdb := newTestDB(t)
 	f := seedFinding(t, gdb)

--- a/internal/web/finding_campaign.go
+++ b/internal/web/finding_campaign.go
@@ -1,0 +1,45 @@
+package web
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"gorm.io/gorm"
+
+	"scrutineer/internal/db"
+)
+
+func (s *Server) findingDependentCampaignUpdate(w http.ResponseWriter, r *http.Request) {
+	finding, ok := loadByID[db.Finding](s, w, r)
+	if !ok {
+		return
+	}
+	dependentID, err := strconv.Atoi(r.PathValue("dependent_id"))
+	if err != nil || dependentID <= 0 {
+		http.NotFound(w, r)
+		return
+	}
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	_, err = db.SetFindingDependentCampaign(
+		s.DB,
+		finding.ID,
+		uint(dependentID),
+		db.DependentCampaignStatus(r.FormValue("status")),
+		r.FormValue("note"),
+	)
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		http.NotFound(w, r)
+		return
+	}
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusUnprocessableEntity)
+		return
+	}
+	setFlash(w, Flash{Category: successKey, Title: "Dependent campaign updated"})
+	s.redirect(w, r, fmt.Sprintf("/findings/%d", finding.ID))
+}

--- a/internal/web/finding_migration.go
+++ b/internal/web/finding_migration.go
@@ -14,8 +14,9 @@ const migrationGuideRowLimit = 10
 type findingMigrationGuide struct {
 	Health db.RepositoryHealth
 
-	Packages     []db.Package
-	Alternatives []db.PackageAlternative
+	Packages         []db.Package
+	Alternatives     []db.PackageAlternative
+	CampaignStatuses []db.DependentCampaignStatus
 
 	PriorityDependents []migrationDependentRow
 	KnownSafeCount     int
@@ -24,13 +25,17 @@ type findingMigrationGuide struct {
 }
 
 type migrationDependentRow struct {
-	Name           string
-	Ecosystem      string
-	RepositoryURL  string
-	DependentRepos int
-	Status         string
-	Rationale      string
-	UpdatedAt      time.Time
+	DependentID       uint
+	Name              string
+	Ecosystem         string
+	RepositoryURL     string
+	DependentRepos    int
+	Status            string
+	Rationale         string
+	UpdatedAt         time.Time
+	CampaignStatus    db.DependentCampaignStatus
+	CampaignNote      string
+	CampaignUpdatedAt *time.Time
 }
 
 func loadFindingMigrationGuide(
@@ -56,9 +61,10 @@ func loadFindingMigrationGuide(
 	}
 
 	guide := findingMigrationGuide{
-		Health:       repo.Health,
-		Packages:     packages,
-		Alternatives: alternatives,
+		Health:           repo.Health,
+		Packages:         packages,
+		Alternatives:     alternatives,
+		CampaignStatuses: db.DependentCampaignStatuses,
 	}
 	loadMigrationGuideDependents(exposureRows, dependentsByID, &guide)
 	return &guide, nil
@@ -74,41 +80,62 @@ func loadMigrationGuideDependents(
 		return
 	}
 
-	rows := make([]migrationDependentRow, 0, len(exposureRows))
+	actionableRows := make([]migrationDependentRow, 0, len(exposureRows))
+	trackedResolvedRows := make([]migrationDependentRow, 0)
 	for _, row := range exposureRows {
 		row.Status = migrationExposureStatus(row.Status)
+		actionable := true
 		if row.Status == db.ExposureKnownNotAffected {
 			guide.KnownSafeCount++
-			continue
+			actionable = false
 		}
 		if row.Status == db.ExposureFixed {
 			guide.FixedCount++
+			actionable = false
+		}
+		if !actionable && row.CampaignStatus == "" {
 			continue
 		}
 		dep, ok := dependentsByID[row.DependentID]
 		if !ok {
 			continue
 		}
-		rows = append(rows, migrationDependentRow{
-			Name:           dep.Name,
-			Ecosystem:      dep.Ecosystem,
-			RepositoryURL:  dep.RepositoryURL,
-			DependentRepos: dep.DependentRepos,
-			Status:         row.Status,
-			Rationale:      row.Rationale,
-			UpdatedAt:      row.UpdatedAt,
-		})
+		viewRow := migrationDependentRow{
+			DependentID:       dep.ID,
+			Name:              dep.Name,
+			Ecosystem:         dep.Ecosystem,
+			RepositoryURL:     dep.RepositoryURL,
+			DependentRepos:    dep.DependentRepos,
+			Status:            row.Status,
+			Rationale:         row.Rationale,
+			UpdatedAt:         row.UpdatedAt,
+			CampaignStatus:    row.CampaignStatus,
+			CampaignNote:      row.CampaignNote,
+			CampaignUpdatedAt: row.CampaignUpdatedAt,
+		}
+		if actionable {
+			actionableRows = append(actionableRows, viewRow)
+		} else {
+			trackedResolvedRows = append(trackedResolvedRows, viewRow)
+		}
 	}
+	sortMigrationDependentRows(actionableRows)
+	sortMigrationDependentRows(trackedResolvedRows)
+	if len(actionableRows) > migrationGuideRowLimit {
+		actionableRows = actionableRows[:migrationGuideRowLimit]
+	}
+	guide.PriorityDependents = make([]migrationDependentRow, 0, len(actionableRows)+len(trackedResolvedRows))
+	guide.PriorityDependents = append(guide.PriorityDependents, actionableRows...)
+	guide.PriorityDependents = append(guide.PriorityDependents, trackedResolvedRows...)
+}
+
+func sortMigrationDependentRows(rows []migrationDependentRow) {
 	sort.Slice(rows, func(i, j int) bool {
 		if rows[i].DependentRepos != rows[j].DependentRepos {
 			return rows[i].DependentRepos > rows[j].DependentRepos
 		}
 		return rows[i].Name < rows[j].Name
 	})
-	if len(rows) > migrationGuideRowLimit {
-		rows = rows[:migrationGuideRowLimit]
-	}
-	guide.PriorityDependents = rows
 }
 
 func migrationExposureStatus(status string) string {

--- a/internal/web/finding_migration_test.go
+++ b/internal/web/finding_migration_test.go
@@ -4,8 +4,10 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
+	"time"
 
 	"scrutineer/internal/db"
 	"scrutineer/internal/worker"
@@ -70,10 +72,12 @@ func TestFindingShowMigrationGuideRendersAlternativesAndDependents(t *testing.T)
 		t.Fatal(err)
 	}
 	if err := s.DB.Create(&db.FindingDependent{
-		FindingID:   finding.ID,
-		DependentID: dep.ID,
-		Status:      db.ExposureKnownAffected,
-		Rationale:   "consumer reaches the vulnerable parser",
+		FindingID:      finding.ID,
+		DependentID:    dep.ID,
+		Status:         db.ExposureKnownAffected,
+		Rationale:      "consumer reaches the vulnerable parser",
+		CampaignStatus: db.CampaignNotified,
+		CampaignNote:   "issue opened with consumer",
 	}).Error; err != nil {
 		t.Fatal(err)
 	}
@@ -129,6 +133,25 @@ func TestFindingShowMigrationGuideRendersAlternativesAndDependents(t *testing.T)
 	}).Error; err != nil {
 		t.Fatal(err)
 	}
+	trackedFixed := db.Dependent{
+		RepositoryID:   repo.ID,
+		Name:           "migrated-consumer",
+		Ecosystem:      "npm",
+		RepositoryURL:  "https://github.com/example/migrated-consumer",
+		DependentRepos: 600,
+	}
+	if err := s.DB.Create(&trackedFixed).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := s.DB.Create(&db.FindingDependent{
+		FindingID:      finding.ID,
+		DependentID:    trackedFixed.ID,
+		Status:         db.ExposureFixed,
+		CampaignStatus: db.CampaignMigrated,
+		CampaignNote:   "released with the successor",
+	}).Error; err != nil {
+		t.Fatal(err)
+	}
 
 	w := httptest.NewRecorder()
 	s.Handler().ServeHTTP(w, localReq(http.MethodGet, fmt.Sprintf("/findings/%d", finding.ID)))
@@ -143,6 +166,11 @@ func TestFindingShowMigrationGuideRendersAlternativesAndDependents(t *testing.T)
 		"pkg:npm/zombie-next",
 		"Maintained successor",
 		"consumer reaches the vulnerable parser",
+		"issue opened with consumer",
+		`value="notified" selected`,
+		"migrated-consumer",
+		"released with the successor",
+		`value="migrated" selected`,
 		"needs-review",
 		db.ExposureUnderInvestigation,
 	} {
@@ -163,6 +191,126 @@ func TestFindingShowMigrationGuideRendersAlternativesAndDependents(t *testing.T)
 	}
 	if strings.Contains(guide, "fixed-consumer") {
 		t.Fatalf("fixed dependent should not be prioritized in migration guide:\n%s", guide)
+	}
+}
+
+func TestLoadMigrationGuideDependentsKeepsTrackedResolvedRowsOutsideLimit(t *testing.T) {
+	exposureRows := make([]db.FindingDependent, 0, migrationGuideRowLimit+2)
+	dependentsByID := make(map[uint]db.Dependent, migrationGuideRowLimit+2)
+	for i := range migrationGuideRowLimit + 1 {
+		id := uint(i + 1)
+		name := fmt.Sprintf("actionable-%02d", i)
+		dependentsByID[id] = db.Dependent{
+			ID:             id,
+			Name:           name,
+			DependentRepos: 1000 - i,
+		}
+		exposureRows = append(exposureRows, db.FindingDependent{
+			DependentID: id,
+			Status:      db.ExposureKnownAffected,
+		})
+	}
+
+	const trackedID = 100
+	dependentsByID[trackedID] = db.Dependent{
+		ID:             trackedID,
+		Name:           "tracked-fixed",
+		DependentRepos: 1,
+	}
+	exposureRows = append(exposureRows, db.FindingDependent{
+		DependentID:    trackedID,
+		Status:         db.ExposureFixed,
+		CampaignStatus: db.CampaignMigrated,
+		CampaignNote:   "migration complete",
+	})
+
+	var guide findingMigrationGuide
+	loadMigrationGuideDependents(exposureRows, dependentsByID, &guide)
+	if got, want := len(guide.PriorityDependents), migrationGuideRowLimit+1; got != want {
+		t.Fatalf("priority rows = %d, want %d", got, want)
+	}
+	if got := guide.PriorityDependents[len(guide.PriorityDependents)-1]; got.DependentID != trackedID || got.CampaignStatus != db.CampaignMigrated {
+		t.Fatalf("last priority row = %+v, want tracked resolved campaign", got)
+	}
+	for _, row := range guide.PriorityDependents {
+		if row.Name == "actionable-10" {
+			t.Fatal("actionable row beyond the top-10 cap was retained")
+		}
+	}
+}
+
+func TestFindingDependentCampaignUpdate(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	repo := db.Repository{URL: "https://github.com/example/zombie", Health: db.RepositoryHealthZombie}
+	if err := s.DB.Create(&repo).Error; err != nil {
+		t.Fatal(err)
+	}
+	scan := db.Scan{RepositoryID: repo.ID, Kind: worker.JobSkill, Status: db.ScanDone}
+	if err := s.DB.Create(&scan).Error; err != nil {
+		t.Fatal(err)
+	}
+	finding := db.Finding{RepositoryID: repo.ID, ScanID: scan.ID, Title: "Bug", Status: db.FindingTriaged}
+	if err := s.DB.Create(&finding).Error; err != nil {
+		t.Fatal(err)
+	}
+	otherFinding := db.Finding{RepositoryID: repo.ID, ScanID: scan.ID, Title: "Other bug", Status: db.FindingTriaged}
+	if err := s.DB.Create(&otherFinding).Error; err != nil {
+		t.Fatal(err)
+	}
+	dependent := db.Dependent{RepositoryID: repo.ID, Name: "consumer"}
+	if err := s.DB.Create(&dependent).Error; err != nil {
+		t.Fatal(err)
+	}
+	otherDependent := db.Dependent{RepositoryID: repo.ID, Name: "other-consumer"}
+	if err := s.DB.Create(&otherDependent).Error; err != nil {
+		t.Fatal(err)
+	}
+	exposureAt := time.Date(2026, time.January, 2, 3, 4, 5, 0, time.UTC)
+	row := db.FindingDependent{
+		FindingID: finding.ID, DependentID: dependent.ID,
+		Status: db.ExposureKnownAffected, UpdatedAt: exposureAt,
+	}
+	if err := s.DB.Create(&row).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := s.DB.Create(&db.FindingDependent{
+		FindingID: otherFinding.ID, DependentID: otherDependent.ID,
+		Status: db.ExposureKnownAffected,
+	}).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	path := fmt.Sprintf("/findings/%d/dependents/%d/campaign", finding.ID, dependent.ID)
+	w := postForm(t, s, path, url.Values{
+		"status": {string(db.CampaignAcked)},
+		"note":   {"  maintainer confirmed migration plan  "},
+	})
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+	var stored db.FindingDependent
+	if err := s.DB.First(&stored, row.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if stored.CampaignStatus != db.CampaignAcked || stored.CampaignNote != "maintainer confirmed migration plan" || stored.CampaignUpdatedAt == nil {
+		t.Fatalf("stored campaign = %+v", stored)
+	}
+	if !stored.UpdatedAt.Equal(exposureAt) {
+		t.Errorf("campaign update changed exposure timestamp: got %v, want %v", stored.UpdatedAt, exposureAt)
+	}
+
+	w = postForm(t, s, path, url.Values{"status": {"invalid"}})
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("invalid status code = %d, want %d", w.Code, http.StatusUnprocessableEntity)
+	}
+	w = postForm(t, s,
+		fmt.Sprintf("/findings/%d/dependents/%d/campaign", finding.ID, otherDependent.ID),
+		url.Values{"status": {string(db.CampaignDeclined)}},
+	)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("cross-finding status code = %d, want %d", w.Code, http.StatusNotFound)
 	}
 }
 

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -526,6 +526,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("POST /findings/{id}/mitigate", s.findingMitigate)
 	mux.HandleFunc("POST /findings/{id}/patch", s.findingPatchRun)
 	mux.HandleFunc("POST /findings/{id}/exposure", s.findingExposureRun)
+	mux.HandleFunc("POST /findings/{id}/dependents/{dependent_id}/campaign", s.findingDependentCampaignUpdate)
 	mux.HandleFunc("GET /findings/{id}/patch.diff", s.findingPatchDownload)
 	mux.HandleFunc("GET /findings/{id}/bundle.tar.gz", s.findingBundleDownload)
 	mux.HandleFunc("POST /findings/{id}/notes", s.findingNotes)

--- a/internal/web/templates/finding_show.html
+++ b/internal/web/templates/finding_show.html
@@ -382,10 +382,10 @@
         {{if $g.PriorityDependents}}
         <table class="w-full text-sm">
           <thead class="text-xs text-muted-foreground">
-            <tr><th class="text-left py-2">Dependent</th><th class="text-left">Status</th><th class="text-left">Reach</th><th class="text-left">Notes</th></tr>
+            <tr><th class="text-left py-2">Dependent</th><th class="text-left">Exposure</th><th class="text-left">Reach</th><th class="text-left">Evidence</th><th class="text-left">Campaign</th></tr>
           </thead>
           <tbody>
-            {{range $g.PriorityDependents}}
+            {{range $g.PriorityDependents}}{{$row := .}}
             <tr class="border-t align-top">
               <td class="py-2">
                 {{if .RepositoryURL}}<a class="hover:underline" href="{{.RepositoryURL}}" rel="noopener" target="_blank"><code>{{.Name}}</code></a>{{else}}<code>{{.Name}}</code>{{end}}
@@ -394,6 +394,21 @@
               <td>{{.Status}}</td>
               <td>{{bignum .DependentRepos}} repos</td>
               <td class="text-xs text-muted-foreground">{{if .Rationale}}{{.Rationale}}{{else}}-{{end}}</td>
+              <td class="py-2 min-w-64">
+                <form method="post" action="/findings/{{$f.ID}}/dependents/{{.DependentID}}/campaign" class="grid gap-2">
+                  <select class="input text-xs" name="status" aria-label="Campaign status for {{.Name}}">
+                    <option value=""{{if not .CampaignStatus}} selected{{end}}>not started</option>
+                    {{range $g.CampaignStatuses}}
+                    <option value="{{.}}"{{if eq . $row.CampaignStatus}} selected{{end}}>{{.}}</option>
+                    {{end}}
+                  </select>
+                  <input class="input text-xs" name="note" value="{{.CampaignNote}}" placeholder="Campaign note">
+                  <div class="flex items-center justify-between gap-2">
+                    <span class="text-xs text-muted-foreground">{{if .CampaignUpdatedAt}}Updated {{.CampaignUpdatedAt.Format "2006-01-02"}}{{end}}</span>
+                    <button type="submit" class="btn-sm">Save</button>
+                  </div>
+                </form>
+              </td>
             </tr>
             {{end}}
           </tbody>


### PR DESCRIPTION
Part of #12

## Summary

Adds operator-managed migration campaign tracking for downstream consumers affected by findings in abandoned or zombie package repositories.

Each finding/dependent pair can now record its current outreach state, an operator note and when the campaign information last changed.

## Changes

- Add migration campaign states:
  - `notified`
  - `acked`
  - `migrated`
  - `declined`
  - `silent`
- Store campaign status, note and update timestamp on `FindingDependent`.
- Add campaign controls to each actionable consumer in the finding migration guide.
- Validate campaign states and reject notes without a selected status.
- Scope updates to the requested finding/dependent pair.
- Keep campaign timestamps separate from exposure-verdict timestamps.
- Preserve campaign data when exposure scans upsert new verdicts.
- Keep completed tracked campaigns visible after a consumer becomes fixed or known not affected.
- Continue prioritizing actionable consumers by downstream reach.
- Document the new database fields.
- Add persistence, validation, scoping, rendering and regression tests.

This leaves dependent-count history and plotting as the remaining follow-up in #12.

## Tests

- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `go vet -tags evals ./internal/evals/...`
- `go test -race -tags evals ./internal/evals/...`
- `go vet -tags podman ./...`
- `go mod tidy -diff`
- `golangci-lint run`
- `git diff --check`