### PR TITLE
Prevent skills repository tokens from leaking through Git URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ The `docker build` commands shown for the runner image and profiles can be run a
 | `-data` | `./data` | Data directory for the database and workspaces |
 | `-effort` | `high` | Claude effort level (claude backend only) |
 | `-skills` | - | Additional local directory to load SKILL.md files from; same-named skills override the bundled copies (repeatable) |
-| `-skills-repo` | - | `owner/repo[@ref]` or git HTTPS URL `https://host/path[@ref]` to clone skills from on startup; `@ref` pins a branch, tag or commit and the resolved SHA is recorded on every scan |
+| `-skills-repo` | - | `owner/repo[@ref]` or credential-free git HTTPS URL `https://host/path[@ref]` to clone skills from on startup; `@ref` pins a branch, tag or commit and the resolved SHA is recorded on every scan; private repositories use config-file-only `skills_repo_token` |
 | `-backend` | `claude` | Agent CLI the container runner execs: `claude`, `codex`, or `opencode`. Non-claude backends require the containerised runner |
 | `--runtime` | `docker` | Container runtime: `docker`, `podman` (rootless podman supported), or `apple` (Apple, experimental) |
 | `--selinux` | `auto` | Bind-mount SELinux relabeling: `auto` (relabel when SELinux is detected), `on`, or `off` |
@@ -354,7 +354,7 @@ The `docker build` commands shown for the runner image and profiles can be run a
 
 Every flag above can be set in a YAML config file instead, loaded from `./scrutineer.yaml` by default (override with `-config path/to/file`; command-line flags always take precedence). See [scrutineer.sample.yaml](scrutineer.sample.yaml) for the full shape.
 
-`scrutineer.yaml` may contain long-lived credentials such as the VINCE API key and federation salt. Keep it out of source control and backups, and set owner-only permissions with `chmod 600 scrutineer.yaml`.
+`scrutineer.yaml` may contain long-lived credentials such as `skills_repo_token`, the VINCE API key and federation salt. Keep it out of source control and backups, and set owner-only permissions with `chmod 600 scrutineer.yaml`. A private `skills_repo` must use a credential-free HTTPS URL; Scrutineer passes `skills_repo_token` to Git through `GIT_ASKPASS`, and intentionally provides no token command-line flag.
 
 The config file can also replace the model pick list and pin the fallback default model used by the high tier:
 

--- a/cmd/scrutineer/main.go
+++ b/cmd/scrutineer/main.go
@@ -105,6 +105,7 @@ type flags struct {
 	runnerImage           string
 	profilesDir           string
 	skillsRepo            string
+	skillsRepoToken       string
 	concurrency           int
 	cloneMode             string
 	scanTimeout           time.Duration
@@ -304,12 +305,7 @@ func (f *flags) merge(cfg *config.Config) {
 	if cfg.ProfilesDir != nil && !f.set["profiles-dir"] {
 		f.profilesDir = *cfg.ProfilesDir
 	}
-	if cfg.SkillsRepo != "" && !f.set["skills-repo"] {
-		f.skillsRepo = cfg.SkillsRepo
-	}
-	if len(cfg.Skills) > 0 && !f.set["skills"] {
-		f.skillLocal = append(f.skillLocal, cfg.Skills...)
-	}
+	f.mergeSkillsConfig(cfg)
 	if cfg.Concurrency > 0 && !f.set["concurrency"] {
 		f.concurrency = cfg.Concurrency
 	}
@@ -382,6 +378,19 @@ func (f *flags) merge(cfg *config.Config) {
 	}
 	if cfg.Theme != "" {
 		web.SetTheme(cfg.Theme)
+	}
+}
+
+func (f *flags) mergeSkillsConfig(cfg *config.Config) {
+	if cfg.SkillsRepo != "" && !f.set["skills-repo"] {
+		f.skillsRepo = cfg.SkillsRepo
+	}
+	// Config-only: a command-line token would be visible in process listings.
+	if cfg.SkillsRepoToken != "" {
+		f.skillsRepoToken = cfg.SkillsRepoToken
+	}
+	if len(cfg.Skills) > 0 && !f.set["skills"] {
+		f.skillLocal = append(f.skillLocal, cfg.Skills...)
 	}
 }
 
@@ -587,7 +596,7 @@ func run(log *slog.Logger) error {
 
 	skills.ModelValidator = web.ValidModelPreference
 	skills.ProfileValidator = worker.IsNamedProfile
-	skillsRepoSHA, err := loadSkills(log, gdb, f.dataDir, f.skillLocal, f.skillsRepo, f.fullClone())
+	skillsRepoSHA, err := loadSkills(log, gdb, f.dataDir, f.skillLocal, f.skillsRepo, f.skillsRepoToken, f.fullClone())
 	if err != nil {
 		return err
 	}
@@ -747,7 +756,7 @@ func checkRunnerImage(srv *web.Server, runner worker.SkillRunner, log *slog.Logg
 // version on every restart. Returns the resolved commit SHA of the remote repo
 // (empty when no repo is set) so the caller can stamp it on each Scan for
 // reproducibility.
-func loadSkills(log *slog.Logger, gdb *gorm.DB, dataDir string, dirs skillDirs, repoSpec string, fullClone bool) (string, error) {
+func loadSkills(log *slog.Logger, gdb *gorm.DB, dataDir string, dirs skillDirs, repoSpec, repoToken string, fullClone bool) (string, error) {
 	bundleDir, bundleHash, err := bundledassets.Materialize(bundledskills.FS, dataDir, "bundled-skills")
 	if err != nil {
 		return "", fmt.Errorf("materialize bundled skills: %w", err)
@@ -769,12 +778,14 @@ func loadSkills(log *slog.Logger, gdb *gorm.DB, dataDir string, dirs skillDirs, 
 	if repoSpec != "" {
 		url, ref, err := skills.ParseRepoSpec(repoSpec)
 		if err != nil {
-			return "", fmt.Errorf("parse skills_repo %q: %w", repoSpec, err)
+			// repoSpec may come from an older credential-bearing configuration.
+			// The parser explains the validation failure without echoing the URL.
+			return "", fmt.Errorf("parse skills_repo: %w", err)
 		}
 		dst := filepath.Join(dataDir, "skills-cache", hashPath(repoSpec))
 		ctx, cancel := context.WithTimeout(context.Background(), skillsCloneTimeout)
 		defer cancel()
-		sha, err = skills.CloneOrPull(ctx, url, ref, dst, fullClone)
+		sha, err = skills.CloneOrPull(ctx, url, ref, dst, fullClone, repoToken)
 		if err != nil {
 			return "", fmt.Errorf("clone skills repo: %w", err)
 		}

--- a/cmd/scrutineer/main.go
+++ b/cmd/scrutineer/main.go
@@ -265,7 +265,7 @@ func registerFlags(fs *flag.FlagSet, f *flags) {
 // list and theme into the web package; runtime defaults (model, effort)
 // are stored on flags here and applied to the Server after construction.
 //
-//nolint:gocognit,gocyclo // flat: one guarded assignment per config key
+//nolint:gocognit,gocyclo,maintidx // flat: one guarded assignment per config key
 func (f *flags) merge(cfg *config.Config) {
 	if cfg.Addr != "" && !f.set["addr"] {
 		f.addr = cfg.Addr
@@ -305,7 +305,16 @@ func (f *flags) merge(cfg *config.Config) {
 	if cfg.ProfilesDir != nil && !f.set["profiles-dir"] {
 		f.profilesDir = *cfg.ProfilesDir
 	}
-	f.mergeSkillsConfig(cfg)
+	if cfg.SkillsRepo != "" && !f.set["skills-repo"] {
+		f.skillsRepo = cfg.SkillsRepo
+	}
+	// Config-only: a command-line token would be visible in process listings.
+	if cfg.SkillsRepoToken != "" {
+		f.skillsRepoToken = cfg.SkillsRepoToken
+	}
+	if len(cfg.Skills) > 0 && !f.set["skills"] {
+		f.skillLocal = append(f.skillLocal, cfg.Skills...)
+	}
 	if cfg.Concurrency > 0 && !f.set["concurrency"] {
 		f.concurrency = cfg.Concurrency
 	}
@@ -378,19 +387,6 @@ func (f *flags) merge(cfg *config.Config) {
 	}
 	if cfg.Theme != "" {
 		web.SetTheme(cfg.Theme)
-	}
-}
-
-func (f *flags) mergeSkillsConfig(cfg *config.Config) {
-	if cfg.SkillsRepo != "" && !f.set["skills-repo"] {
-		f.skillsRepo = cfg.SkillsRepo
-	}
-	// Config-only: a command-line token would be visible in process listings.
-	if cfg.SkillsRepoToken != "" {
-		f.skillsRepoToken = cfg.SkillsRepoToken
-	}
-	if len(cfg.Skills) > 0 && !f.set["skills"] {
-		f.skillLocal = append(f.skillLocal, cfg.Skills...)
 	}
 }
 

--- a/cmd/scrutineer/main_test.go
+++ b/cmd/scrutineer/main_test.go
@@ -25,21 +25,22 @@ import (
 
 func fullConfig() *config.Config {
 	return &config.Config{
-		Addr:         "0.0.0.0:9090",
-		Data:         "/var/lib/scrutineer",
-		Effort:       "medium",
-		Backend:      "codex",
-		NoContainer:  new(true),
-		Hardened:     new(true),
-		RunnerImage:  "custom:v1",
-		SkillsRepo:   "https://example.com/skills.git",
-		Skills:       []string{"/etc/skills"},
-		Concurrency:  8,
-		Clone:        "full",
-		ScanTimeout:  "30m",
-		MaxTurns:     200,
-		ModelBaseURL: "https://proxy.corp.com/v1",
-		ForkOrg:      "fork-central",
+		Addr:            "0.0.0.0:9090",
+		Data:            "/var/lib/scrutineer",
+		Effort:          "medium",
+		Backend:         "codex",
+		NoContainer:     new(true),
+		Hardened:        new(true),
+		RunnerImage:     "custom:v1",
+		SkillsRepo:      "https://example.com/skills.git",
+		SkillsRepoToken: "private-skills-token",
+		Skills:          []string{"/etc/skills"},
+		Concurrency:     8,
+		Clone:           "full",
+		ScanTimeout:     "30m",
+		MaxTurns:        200,
+		ModelBaseURL:    "https://proxy.corp.com/v1",
+		ForkOrg:         "fork-central",
 
 		FederationSalt:    "s3cret",
 		FederationContact: "security@corp.com",
@@ -73,6 +74,9 @@ func TestFlagsMerge_configFillsUnset(t *testing.T) {
 	}
 	if len(f.skillLocal) != 1 || f.skillLocal[0] != "/etc/skills" {
 		t.Errorf("skillLocal = %v", f.skillLocal)
+	}
+	if f.skillsRepoToken != cfg.SkillsRepoToken {
+		t.Errorf("skillsRepoToken was not loaded from config")
 	}
 	if f.scanTimeout != 30*time.Minute {
 		t.Errorf("scanTimeout = %v", f.scanTimeout)
@@ -825,7 +829,7 @@ func TestLoadSkillsLoadsBundledSkillsWithoutLocalDirectory(t *testing.T) {
 	}
 	log := slog.New(slog.NewTextHandler(io.Discard, nil))
 
-	sha, err := loadSkills(log, gdb, dataDir, nil, "", false)
+	sha, err := loadSkills(log, gdb, dataDir, nil, "", "", false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -848,6 +852,25 @@ func TestLoadSkillsLoadsBundledSkillsWithoutLocalDirectory(t *testing.T) {
 	}
 }
 
+func TestLoadSkillsRejectsRepoUserinfoWithoutEcho(t *testing.T) {
+	dataDir := t.TempDir()
+	gdb, err := db.Open(filepath.Join(dataDir, "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	const secret = "private-skills-token"
+
+	_, err = loadSkills(log, gdb, dataDir, nil,
+		"https://user:"+secret+"@github.com/org/skills", "", false)
+	if err == nil {
+		t.Fatal("expected URL userinfo to be rejected")
+	}
+	if strings.Contains(err.Error(), secret) {
+		t.Fatalf("loadSkills error leaked repository credential: %v", err)
+	}
+}
+
 func TestLoadSkillsLocalDirectoryOverridesBundledSkill(t *testing.T) {
 	dataDir := t.TempDir()
 	localRoot := filepath.Join(t.TempDir(), "skills")
@@ -865,7 +888,7 @@ func TestLoadSkillsLocalDirectoryOverridesBundledSkill(t *testing.T) {
 	}
 	log := slog.New(slog.NewTextHandler(io.Discard, nil))
 
-	if _, err := loadSkills(log, gdb, dataDir, skillDirs{localRoot}, "", false); err != nil {
+	if _, err := loadSkills(log, gdb, dataDir, skillDirs{localRoot}, "", "", false); err != nil {
 		t.Fatal(err)
 	}
 	var metadata db.Skill
@@ -883,7 +906,7 @@ func TestLoadSkillsLocalDirectoryOverridesBundledSkill(t *testing.T) {
 		t.Fatalf("metadata body = %q, want local override", metadata.Body)
 	}
 	version := metadata.Version
-	if _, err := loadSkills(log, gdb, dataDir, skillDirs{localRoot}, "", false); err != nil {
+	if _, err := loadSkills(log, gdb, dataDir, skillDirs{localRoot}, "", "", false); err != nil {
 		t.Fatal(err)
 	}
 	if err := gdb.Where("name = ?", "metadata").First(&metadata).Error; err != nil {

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -246,7 +246,7 @@ The token is scoped to the scan's own repository: a skill cannot read or write r
 Skills are loaded at startup from any combination of:
 
 - `-skills <dir>` (repeatable) for local directories,
-- `-skills-repo <owner/repo[@ref]>` (or full `https://host/path[@ref]`) to clone a git repository of skills on startup; an `@ref` suffix pins a branch, tag or commit, and the resolved SHA is stamped onto every scan. The ref must be a single segment (`main`, `v1.0`, or a SHA; not `refs/heads/main`), which leaves `https://<token>@host/...` usable for private repos,
+- `-skills-repo <owner/repo[@ref]>` (or full `https://host/path[@ref]`) to clone a git repository of skills on startup; an `@ref` suffix pins a branch, tag or commit, and the resolved SHA is stamped onto every scan. For a private repository, set `skills_repo_token` in `scrutineer.yaml`; Scrutineer supplies it through `GIT_ASKPASS`, never the repository URL or Git argv. URLs containing userinfo are rejected. The token has no command-line flag because flags are visible in process listings. Keep the config file owner-readable only. The ref must be a single segment (`main`, `v1.0`, or a SHA; not `refs/heads/main`),
 - the `/skills` page in the UI to create or edit a skill in the browser.
 
 A skill loaded from disk replaces any UI-edited skill of the same name on the next restart. Disable a skill on `/skills` to keep it in the database but reject any attempt to run it.

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.26.5
 
 require (
 	filippo.io/age v1.3.1
-	github.com/alpha-omega-security/harness v0.1.2
+	github.com/alpha-omega-security/harness v0.1.3
 	github.com/ecosyste-ms/ecosystems-go v0.4.0
 	github.com/git-pkgs/clone v0.2.0
 	github.com/git-pkgs/cwe v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -7,8 +7,8 @@ filippo.io/edwards25519 v1.2.0/go.mod h1:xzAOLCNug/yB62zG1bQ8uziwrIqIuxhctzJT18Q
 filippo.io/hpke v0.4.0 h1:p575VVQ6ted4pL+it6M00V/f2qTZITO0zgmdKCkd5+A=
 filippo.io/hpke v0.4.0/go.mod h1:EmAN849/P3qdeK+PCMkDpDm83vRHM5cDipBJ8xbQLVY=
 github.com/RaveNoX/go-jsoncommentstrip v1.0.0/go.mod h1:78ihd09MekBnJnxpICcwzCMzGrKSKYe4AqU6PDYYpjk=
-github.com/alpha-omega-security/harness v0.1.2 h1:Pji9xf32GvFHYmkEPezWO/cFRRS1chScG8H/HXSVB5o=
-github.com/alpha-omega-security/harness v0.1.2/go.mod h1:/nym/38ro7lLq4jVmQhYqblV+0uMo3YpeueqaXNMpOs=
+github.com/alpha-omega-security/harness v0.1.3 h1:laXc9TRrHZhscWBEQr1xqGFGhId+FNFHea0fmyQ+d5Q=
+github.com/alpha-omega-security/harness v0.1.3/go.mod h1:/nym/38ro7lLq4jVmQhYqblV+0uMo3YpeueqaXNMpOs=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0 h1:axGnT1gRIfimI7gJifB699GoE/oq+F2MU7Dml6nw9rQ=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0/go.mod h1:lvDnEdqiQrp0O42VQGgmlKpxL1AP2+08jFMw88y4klk=
 github.com/bmatcuk/doublestar v1.1.1/go.mod h1:UD6OnuiIn0yFxxA2le/rnRU1G4RaI4UvFv1sNto9p6w=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -31,6 +31,10 @@ type Config struct {
 	Models       []Model  `yaml:"models"`
 	Skills       []string `yaml:"skills"`
 	SkillsRepo   string   `yaml:"skills_repo"`
+	// SkillsRepoToken authenticates an HTTPS skills repository without putting
+	// the credential in the repository URL or Git's command-line arguments.
+	// It is config-file-only because a CLI flag would expose it through argv.
+	SkillsRepoToken string `yaml:"skills_repo_token"`
 	// Backend selects the agent CLI the container runner execs:
 	// "claude" (default), "codex", or "opencode". Empty leaves the
 	// built-in default (claude). Non-claude backends require the

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -132,6 +132,17 @@ vince:
 	}
 }
 
+func TestLoad_skillsRepoToken(t *testing.T) {
+	path := write(t, "skills_repo_token: private-skills-token\n")
+	c, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c.SkillsRepoToken != "private-skills-token" {
+		t.Errorf("skills_repo_token = %q", c.SkillsRepoToken)
+	}
+}
+
 func TestLoad_noContainerAlias(t *testing.T) {
 	// no_docker is the retained pre-rename alias; Load folds it into NoContainer.
 	aliasOnly, err := Load(write(t, "no_docker: true\n"))

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -132,17 +132,6 @@ vince:
 	}
 }
 
-func TestLoad_skillsRepoToken(t *testing.T) {
-	path := write(t, "skills_repo_token: private-skills-token\n")
-	c, err := Load(path)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if c.SkillsRepoToken != "private-skills-token" {
-		t.Errorf("skills_repo_token = %q", c.SkillsRepoToken)
-	}
-}
-
 func TestLoad_noContainerAlias(t *testing.T) {
 	// no_docker is the retained pre-rename alias; Load folds it into NoContainer.
 	aliasOnly, err := Load(write(t, "no_docker: true\n"))

--- a/internal/skills/git.go
+++ b/internal/skills/git.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"slices"
 	"strings"
 
@@ -35,7 +36,7 @@ func CloneOrPull(ctx context.Context, url, ref, dst string, fullClone bool, toke
 }
 
 func cloneOrPullWithRetry(ctx context.Context, retry clone.Retry, url, ref, dst string, fullClone bool, token string) (string, error) {
-	retry, cleanup, err := withSkillsRepoToken(retry, token)
+	retry, cleanup, err := withSkillsRepoToken(retry, token, filepath.Dir(dst))
 	if err != nil {
 		return "", err
 	}
@@ -58,7 +59,7 @@ func cloneOrPullWithRetry(ctx context.Context, retry clone.Retry, url, ref, dst 
 // withSkillsRepoToken supplies private-repository credentials through
 // GIT_ASKPASS. The temporary executable contains only an environment-variable
 // lookup; the token itself stays out of both the script and Git's argv.
-func withSkillsRepoToken(retry clone.Retry, token string) (clone.Retry, func(), error) {
+func withSkillsRepoToken(retry clone.Retry, token, askpassDir string) (clone.Retry, func(), error) {
 	if token == "" {
 		return retry, func() {}, nil
 	}
@@ -66,7 +67,12 @@ func withSkillsRepoToken(retry clone.Retry, token string) (clone.Retry, func(), 
 		return retry, func() {}, fmt.Errorf("skills repo token must be a single line")
 	}
 
-	f, err := os.CreateTemp("", "scrutineer-skills-askpass-*")
+	// Keep the executable beside the skills cache because a system TMPDIR may
+	// be mounted noexec. The script contains no credential and is removed below.
+	if err := os.MkdirAll(askpassDir, askpassPerm); err != nil {
+		return retry, func() {}, fmt.Errorf("create skills repo cache directory: %w", err)
+	}
+	f, err := os.CreateTemp(askpassDir, ".scrutineer-skills-askpass-*")
 	if err != nil {
 		return retry, func() {}, fmt.Errorf("create skills repo askpass: %w", err)
 	}
@@ -92,8 +98,8 @@ func withSkillsRepoToken(retry clone.Retry, token string) (clone.Retry, func(), 
 		baseRun = clone.Run
 	}
 	retry.Run = func(ctx context.Context, dir string, env []string, args ...string) (string, error) {
-		// clone marks only remote-touching commands with this environment.
-		// Keep the credential away from local inspection/reset commands.
+		// git-pkgs/clone's remoteEnv() adds GIT_TERMINAL_PROMPT=0 only to
+		// remote-touching commands; keep credentials off local inspection/reset.
 		if !slices.Contains(env, "GIT_TERMINAL_PROMPT=0") {
 			return baseRun(ctx, dir, env, args...)
 		}

--- a/internal/skills/git.go
+++ b/internal/skills/git.go
@@ -4,9 +4,18 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
+	"slices"
+	"strings"
 
 	harnessskills "github.com/alpha-omega-security/harness/skills"
 	"github.com/git-pkgs/clone"
+)
+
+const (
+	skillsRepoTokenEnv = "SCRUTINEER_SKILLS_REPO_TOKEN"
+	askpassScript      = "#!/bin/sh\nexec printf '%s\\n' \"${" + skillsRepoTokenEnv + ":?}\"\n"
+	askpassPerm        = 0o700
 )
 
 // ParseRepoSpec splits a skills_repo spec (owner/repo[@ref] or a full https
@@ -21,11 +30,17 @@ var ParseRepoSpec = harnessskills.ParseRepoSpec
 // true. Returns the resolved commit SHA so callers can record exactly which
 // version of the skills produced each scan. https-only, same rationale as
 // internal/worker/clone.go (T2/T4).
-func CloneOrPull(ctx context.Context, url, ref, dst string, fullClone bool) (string, error) {
-	return cloneOrPullWithRetry(ctx, clone.Retry{}, url, ref, dst, fullClone)
+func CloneOrPull(ctx context.Context, url, ref, dst string, fullClone bool, token string) (string, error) {
+	return cloneOrPullWithRetry(ctx, clone.Retry{}, url, ref, dst, fullClone, token)
 }
 
-func cloneOrPullWithRetry(ctx context.Context, retry clone.Retry, url, ref, dst string, fullClone bool) (string, error) {
+func cloneOrPullWithRetry(ctx context.Context, retry clone.Retry, url, ref, dst string, fullClone bool, token string) (string, error) {
+	retry, cleanup, err := withSkillsRepoToken(retry, token)
+	if err != nil {
+		return "", err
+	}
+	defer cleanup()
+
 	if err := clone.Ensure(ctx, retry, url, dst, ref, fullClone); err != nil {
 		var ue *clone.UnreachableError
 		if errors.As(err, &ue) {
@@ -38,4 +53,58 @@ func cloneOrPullWithRetry(ctx context.Context, retry clone.Retry, url, ref, dst 
 		return "", fmt.Errorf("skills repo %s: rev-parse HEAD failed", url)
 	}
 	return sha, nil
+}
+
+// withSkillsRepoToken supplies private-repository credentials through
+// GIT_ASKPASS. The temporary executable contains only an environment-variable
+// lookup; the token itself stays out of both the script and Git's argv.
+func withSkillsRepoToken(retry clone.Retry, token string) (clone.Retry, func(), error) {
+	if token == "" {
+		return retry, func() {}, nil
+	}
+	if strings.ContainsAny(token, "\x00\r\n") {
+		return retry, func() {}, fmt.Errorf("skills repo token must be a single line")
+	}
+
+	f, err := os.CreateTemp("", "scrutineer-skills-askpass-*")
+	if err != nil {
+		return retry, func() {}, fmt.Errorf("create skills repo askpass: %w", err)
+	}
+	path := f.Name()
+	cleanup := func() { _ = os.Remove(path) }
+	if _, err := f.WriteString(askpassScript); err != nil {
+		_ = f.Close()
+		cleanup()
+		return retry, func() {}, fmt.Errorf("write skills repo askpass: %w", err)
+	}
+	if err := f.Chmod(askpassPerm); err != nil {
+		_ = f.Close()
+		cleanup()
+		return retry, func() {}, fmt.Errorf("chmod skills repo askpass: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		cleanup()
+		return retry, func() {}, fmt.Errorf("close skills repo askpass: %w", err)
+	}
+
+	baseRun := retry.Run
+	if baseRun == nil {
+		baseRun = clone.Run
+	}
+	retry.Run = func(ctx context.Context, dir string, env []string, args ...string) (string, error) {
+		// clone marks only remote-touching commands with this environment.
+		// Keep the credential away from local inspection/reset commands.
+		if !slices.Contains(env, "GIT_TERMINAL_PROMPT=0") {
+			return baseRun(ctx, dir, env, args...)
+		}
+		authEnv := []string{
+			"GIT_ASKPASS=" + path,
+			skillsRepoTokenEnv + "=" + token,
+		}
+		// An ambient helper that returns both fields prevents Git from invoking
+		// askpass. Clear helpers for this command so the explicit token wins.
+		authArgs := append([]string{"-c", "credential.helper="}, args...)
+		return baseRun(ctx, dir, append(env, authEnv...), authArgs...)
+	}
+	return retry, cleanup, nil
 }

--- a/internal/skills/git_test.go
+++ b/internal/skills/git_test.go
@@ -232,8 +232,9 @@ func TestCloneOrPull_tokenUsesAskPassWithoutArgvLeak(t *testing.T) {
 		},
 	}
 
+	dst := filepath.Join(t.TempDir(), "skills-cache", "checkout")
 	_, err := cloneOrPullWithRetry(context.Background(), retry,
-		"https://skills.test/org/private-skills", "", t.TempDir(), false, token)
+		"https://skills.test/org/private-skills", "", dst, false, token)
 	if err == nil {
 		t.Fatal("expected the inspecting runner to stop the clone")
 	}
@@ -248,6 +249,9 @@ func TestCloneOrPull_tokenUsesAskPassWithoutArgvLeak(t *testing.T) {
 	}
 	if askpassOut != token {
 		t.Errorf("askpass output = %q, want configured token", askpassOut)
+	}
+	if filepath.Dir(askpassPath) != filepath.Dir(dst) {
+		t.Errorf("askpass directory = %q, want skills cache %q", filepath.Dir(askpassPath), filepath.Dir(dst))
 	}
 	if strings.Contains(script, token) {
 		t.Fatal("temporary askpass script contains the token")
@@ -268,7 +272,7 @@ func TestWithSkillsRepoToken_excludesLocalGitCommands(t *testing.T) {
 			gotEnv = append([]string{}, env...)
 			return "", nil
 		},
-	}, token)
+	}, token, t.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/skills/git_test.go
+++ b/internal/skills/git_test.go
@@ -2,11 +2,15 @@ package skills
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/git-pkgs/clone"
 
 	"scrutineer/internal/testutil"
 )
@@ -22,8 +26,8 @@ func TestParseRepoSpec(t *testing.T) {
 		{"shorthand branch with slash", "org/skills@feature/foo", "https://github.com/org/skills", "feature/foo", false},
 		{"https no ref", "https://github.com/org/skills", "https://github.com/org/skills", "", false},
 		{"https with tag", "https://github.com/org/skills@v0.3.1", "https://github.com/org/skills", "v0.3.1", false},
-		{"https with credential no ref", "https://token@github.com/org/skills", "https://token@github.com/org/skills", "", false},
-		{"https with credential and ref", "https://token@github.com/org/skills@v1.0", "https://token@github.com/org/skills", "v1.0", false},
+		{"https with credential no ref", "https://token@github.com/org/skills", "", "", true},
+		{"https with credential and ref", "https://token@github.com/org/skills@v1.0", "", "", true},
 		{"https slash-bearing ref not supported", "https://gitlab.com/org/skills@refs/heads/main", "https://gitlab.com/org/skills@refs/heads/main", "", false},
 		{"trims whitespace", "  org/skills@main  ", "https://github.com/org/skills", "main", false},
 		{"empty", "", "", "", true},
@@ -45,6 +49,17 @@ func TestParseRepoSpec(t *testing.T) {
 				t.Errorf("got (%q,%q) want (%q,%q)", url, ref, c.wantURL, c.wantRef)
 			}
 		})
+	}
+}
+
+func TestParseRepoSpec_rejectsUserinfoWithoutEcho(t *testing.T) {
+	const secret = "private-skills-token"
+	_, _, err := ParseRepoSpec("https://user:" + secret + "@github.com/org/skills")
+	if err == nil {
+		t.Fatal("expected URL userinfo to be rejected")
+	}
+	if strings.Contains(err.Error(), secret) {
+		t.Fatalf("parser error leaked repository credential: %v", err)
 	}
 }
 
@@ -104,7 +119,7 @@ func TestCloneOrPull_noRefUsesDefaultBranch(t *testing.T) {
 	}
 	origin, _, headSHA, _ := initOrigin(t)
 	dst := filepath.Join(t.TempDir(), "dst")
-	got, err := CloneOrPull(context.Background(), origin, "", dst, false)
+	got, err := CloneOrPull(context.Background(), origin, "", dst, false, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -121,7 +136,7 @@ func TestCloneOrPull_pinsTagToResolvedSHA(t *testing.T) {
 	dst := filepath.Join(t.TempDir(), "dst")
 	// fullClone=true so the tag fetch always works regardless of how the
 	// initial clone hydrated refs.
-	got, err := CloneOrPull(context.Background(), origin, tag, dst, true)
+	got, err := CloneOrPull(context.Background(), origin, tag, dst, true, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -136,7 +151,7 @@ func TestCloneOrPull_unknownRefErrors(t *testing.T) {
 	}
 	origin, _, _, _ := initOrigin(t)
 	dst := filepath.Join(t.TempDir(), "dst")
-	_, err := CloneOrPull(context.Background(), origin, "no-such-ref", dst, true)
+	_, err := CloneOrPull(context.Background(), origin, "no-such-ref", dst, true, "")
 	if err == nil {
 		t.Fatal("expected error for unknown ref")
 	}
@@ -148,14 +163,14 @@ func TestCloneOrPull_secondCallReusesClone(t *testing.T) {
 	}
 	origin, _, headSHA, _ := initOrigin(t)
 	dst := filepath.Join(t.TempDir(), "dst")
-	if _, err := CloneOrPull(context.Background(), origin, "", dst, true); err != nil {
+	if _, err := CloneOrPull(context.Background(), origin, "", dst, true, ""); err != nil {
 		t.Fatal(err)
 	}
 	// Second call must hit the fetch path (.git exists already).
 	if _, err := os.Stat(filepath.Join(dst, ".git")); err != nil {
 		t.Fatalf(".git missing: %v", err)
 	}
-	got, err := CloneOrPull(context.Background(), origin, "", dst, true)
+	got, err := CloneOrPull(context.Background(), origin, "", dst, true, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -165,9 +180,118 @@ func TestCloneOrPull_secondCallReusesClone(t *testing.T) {
 }
 
 func TestCloneOrPull_rejectsNonHTTPS(t *testing.T) {
-	_, err := CloneOrPull(context.Background(), "git://host/path", "", t.TempDir(), false)
+	_, err := CloneOrPull(context.Background(), "git://host/path", "", t.TempDir(), false, "")
 	if err == nil || !strings.Contains(err.Error(), "https://") {
 		t.Fatalf("expected https rejection, got %v", err)
+	}
+}
+
+func TestCloneOrPull_tokenUsesAskPassWithoutArgvLeak(t *testing.T) {
+	const token = "private-skills-token"
+	var (
+		askpassPath string
+		askpassOut  string
+		script      string
+		gotArgs     []string
+		askpassMode os.FileMode
+	)
+	retry := clone.Retry{
+		Attempts: 1,
+		Run: func(_ context.Context, _ string, env []string, args ...string) (string, error) {
+			gotArgs = append([]string{}, args...)
+			var tokenEnv string
+			for _, value := range env {
+				if strings.HasPrefix(value, "GIT_ASKPASS=") {
+					askpassPath = strings.TrimPrefix(value, "GIT_ASKPASS=")
+				}
+				if strings.HasPrefix(value, skillsRepoTokenEnv+"=") {
+					tokenEnv = value
+				}
+			}
+			if askpassPath == "" || tokenEnv != skillsRepoTokenEnv+"="+token {
+				return "", fmt.Errorf("missing askpass environment: %q", env)
+			}
+			body, err := os.ReadFile(askpassPath)
+			if err != nil {
+				return "", err
+			}
+			info, err := os.Stat(askpassPath)
+			if err != nil {
+				return "", err
+			}
+			askpassMode = info.Mode().Perm()
+			script = string(body)
+			cmd := exec.Command(askpassPath, "Password for https://skills.test")
+			cmd.Env = env
+			out, err := cmd.Output()
+			askpassOut = strings.TrimSpace(string(out))
+			if err != nil {
+				return "", err
+			}
+			return "", errors.New("stop after inspecting git invocation")
+		},
+	}
+
+	_, err := cloneOrPullWithRetry(context.Background(), retry,
+		"https://skills.test/org/private-skills", "", t.TempDir(), false, token)
+	if err == nil {
+		t.Fatal("expected the inspecting runner to stop the clone")
+	}
+	if strings.Contains(strings.Join(gotArgs, " "), token) {
+		t.Fatalf("token leaked into git argv: %q", gotArgs)
+	}
+	if len(gotArgs) < 2 || gotArgs[0] != "-c" || gotArgs[1] != "credential.helper=" {
+		t.Fatalf("git argv does not disable ambient credential helpers: %q", gotArgs)
+	}
+	if strings.Contains(err.Error(), token) {
+		t.Fatalf("token leaked into clone error: %v", err)
+	}
+	if askpassOut != token {
+		t.Errorf("askpass output = %q, want configured token", askpassOut)
+	}
+	if strings.Contains(script, token) {
+		t.Fatal("temporary askpass script contains the token")
+	}
+	if askpassMode != askpassPerm {
+		t.Errorf("askpass mode = %o, want 700", askpassMode)
+	}
+	if _, statErr := os.Stat(askpassPath); !errors.Is(statErr, os.ErrNotExist) {
+		t.Errorf("askpass file was not removed: %v", statErr)
+	}
+}
+
+func TestWithSkillsRepoToken_excludesLocalGitCommands(t *testing.T) {
+	const token = "private-skills-token"
+	var gotEnv []string
+	retry, cleanup, err := withSkillsRepoToken(clone.Retry{
+		Run: func(_ context.Context, _ string, env []string, _ ...string) (string, error) {
+			gotEnv = append([]string{}, env...)
+			return "", nil
+		},
+	}, token)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+	if _, err := retry.Run(context.Background(), "", nil, "rev-parse", "HEAD"); err != nil {
+		t.Fatal(err)
+	}
+	for _, value := range gotEnv {
+		if strings.Contains(value, token) || strings.HasPrefix(value, "GIT_ASKPASS=") {
+			t.Fatalf("local git command received authentication environment: %q", gotEnv)
+		}
+	}
+}
+
+func TestCloneOrPull_rejectsMultilineToken(t *testing.T) {
+	const token = "first-line\nsecond-line"
+	_, err := cloneOrPullWithRetry(context.Background(), clone.Retry{},
+		"https://skills.test/org/private-skills", "", t.TempDir(), false, token)
+	if err == nil || !strings.Contains(err.Error(), "single line") {
+		t.Fatalf("expected single-line token rejection, got %v", err)
+	}
+	if strings.Contains(err.Error(), token) {
+		t.Fatalf("token leaked into validation error: %v", err)
 	}
 }
 

--- a/scrutineer.sample.yaml
+++ b/scrutineer.sample.yaml
@@ -61,6 +61,10 @@
 # on every scan so two runs a week apart can be told apart.
 # skills_repo: https://github.com/alpha-omega-security/scrutineer-skills
 # skills_repo: alpha-omega-security/scrutineer-skills@v0.3.1
+# For a private repository, keep credentials out of skills_repo and set the
+# token here. This key is config-file-only so the token never enters argv.
+# Keep this file owner-readable only (`chmod 600 scrutineer.yaml`).
+# skills_repo_token: replace-with-a-repository-read-token
 
 # Container runtime: docker (default), podman, or Apple's container runtime
 # (`apple`, experimental). Rootless podman is detected automatically and


### PR DESCRIPTION
Fixes #759

## Summary

Replaces credential-bearing skills repository URLs with config-only token authentication through `GIT_ASKPASS`.

This prevents private repository credentials from appearing in Git command arguments, process listings, logs, or repository URLs.

## Changes

- Bump `github.com/alpha-omega-security/harness` to `v0.1.3`.
- Reject `skills_repo` HTTPS URLs containing userinfo.
- Add the config-only `skills_repo_token` setting.
- Authenticate remote skills repository operations through a temporary `GIT_ASKPASS` helper.
- Keep the token out of Git arguments and the askpass script itself.
- Restrict the authentication environment to remote Git operations.
- Disable ambient credential helpers when the explicit token is used.
- Reject multiline token values.
- Remove the temporary askpass helper after repository synchronization.
- Avoid echoing credential-bearing repository URLs in parser and startup errors.
- Document private skills repository configuration in the README, skills documentation and sample configuration.
- Add focused coverage for configuration loading, URL rejection, credential redaction and askpass behavior.

## Security Notes

`skills_repo_token` intentionally has no command-line flag because command-line values can be exposed through process listings.

Operators should keep `scrutineer.yaml` out of source control and restrict it to the owning user:

```bash
chmod 600 scrutineer.yaml
```
## Tests

- go mod tidy -diff
- go vet ./...
- go test -race ./...
- go vet -tags evals ./internal/evals/...
- go test -race -tags evals ./internal/evals/...
- go vet -tags podman ./...
- golangci-lint v2.12.2
- govulncheck ./...
- git diff --check