### PR TITLE
feat: decrypt imports and feeds through age identity plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,12 +349,33 @@ The `docker build` commands shown for the runner image and profiles can be run a
 | `-schema-strict` | `false` | Fail a scan when its `report.json` does not validate against the skill's `schema.json` (default: warn in the scan log and parse anyway) |
 | `-model-base-url` | - | Custom model API base URL for the active backend (env fallback: `ANTHROPIC_BASE_URL` for claude). `-anthropic-base-url` is a deprecated alias. |
 | `-ecosystems-enrichment` | `true` | Enrich repositories from ecosyste.ms: the per-repository cache, the warm on repo add, and the PURL-to-repository resolution behind SBOM and dependency import. `=false` stops every lookup scrutineer's own process makes, leaves `egress_allow` untouched (the bundled skills still fetch ecosyste.ms themselves), and leaves the Dependents tab and dependent-exposure analysis with no data |
+| `-recipients-file` | - | Age recipients file (public keys) for encrypted export |
+| `-identity-file` | - | Age identity file or SSH private key for decrypting imports and encrypted federation feeds |
+| `-identity-plugin` | - | Data-less age identity plugin name (`age -j`) for decrypting imports and encrypted federation feeds (repeatable; replaces `identity_plugins` from config when set) |
 
 ## Config file
 
 Every flag above can be set in a YAML config file instead, loaded from `./scrutineer.yaml` by default (override with `-config path/to/file`; command-line flags always take precedence). See [scrutineer.sample.yaml](scrutineer.sample.yaml) for the full shape.
 
 `scrutineer.yaml` may contain long-lived credentials such as `skills_repo_token`, the VINCE API key and federation salt. Keep it out of source control and backups, and set owner-only permissions with `chmod 600 scrutineer.yaml`. A private `skills_repo` must use a credential-free HTTPS URL; Scrutineer passes `skills_repo_token` to Git through `GIT_ASKPASS`, and intentionally provides no token command-line flag.
+
+Identity files and age identity plugins can be used together. The interface is
+provider-neutral: any plugin implementing age's data-less identity (`age -j`)
+contract can be named. Scrutineer delegates only through age's official plugin
+protocol, with no provider-specific SDK or command parsing. For example,
+`age-plugin-1p` can find an SSH key in 1Password while the existing recipients
+file continues to contain ordinary SSH public keys:
+
+    recipients_file: /path/to/recipients.txt
+    identity_plugins:
+      - 1p
+
+`age-plugin-1p` and the 1Password `op` CLI must be installed separately and
+available through `PATH`. Scrutineer uses age's plugin protocol and never
+receives or writes the SSH private key; authentication and Touch ID remain the
+plugin's and 1Password's responsibility. See
+[docs/encrypted-sharing.md](docs/encrypted-sharing.md#age-identity-plugins) for
+interactive and headless-use details.
 
 The config file can also replace the model pick list and pin the fallback default model used by the high tier:
 

--- a/cmd/scrutineer/main.go
+++ b/cmd/scrutineer/main.go
@@ -16,11 +16,13 @@ import (
 	"path/filepath"
 	"runtime/debug"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
 	"filippo.io/age"
 	"filippo.io/age/agessh"
+	"filippo.io/age/plugin"
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/term"
 	"gorm.io/gorm"
@@ -65,6 +67,12 @@ type skillDirs []string
 
 func (s *skillDirs) String() string     { return strings.Join(*s, ",") }
 func (s *skillDirs) Set(v string) error { *s = append(*s, v); return nil }
+
+// pluginNames collects repeated -identity-plugin flags.
+type pluginNames []string
+
+func (p *pluginNames) String() string     { return strings.Join(*p, ",") }
+func (p *pluginNames) Set(v string) error { *p = append(*p, v); return nil }
 
 const (
 	dataPermSecure     = 0o700
@@ -118,6 +126,7 @@ type flags struct {
 	downgradeOnOverage    bool
 	recipientsFile        string
 	identityFile          string
+	identityPlugins       pluginNames
 	autoRejectMissedCount int
 	ecosystemsEnrichment  bool
 	federationSalt        string
@@ -159,8 +168,9 @@ func validateFederation(f *flags) error {
 	if f.federationSalt != "" && f.federationContact == "" {
 		return errors.New("federation: federation_contact is required when federation_salt is set")
 	}
-	if f.federationMembersFeed != "" && (f.recipientsFile == "" || f.identityFile == "") {
-		return errors.New("federation: recipients_file and identity_file are both required when federation_members_feed is set")
+	if f.federationMembersFeed != "" &&
+		(f.recipientsFile == "" || (f.identityFile == "" && len(f.identityPlugins) == 0)) {
+		return errors.New("federation: recipients_file and either identity_file or identity_plugins are required when federation_members_feed is set")
 	}
 	if f.federationPublicFeed != "" && f.federationPublicFeed == f.federationMembersFeed {
 		return errors.New("federation: the public and members feeds must not share a git remote; each tier prunes the records the other publishes")
@@ -246,7 +256,8 @@ func registerFlags(fs *flag.FlagSet, f *flags) {
 	fs.BoolVar(&f.schemaStrict, "schema-strict", false, "fail scans whose report.json does not validate against the skill's schema (default: warn and continue)")
 	fs.BoolVar(&f.downgradeOnOverage, "downgrade-on-overage", false, "on a subscription token, fall the model tier back from max/high to the mid tier for new scans while the account is on overage; restores when the window resets")
 	fs.StringVar(&f.recipientsFile, "recipients-file", "", "age recipients file (public keys) for encrypted export")
-	fs.StringVar(&f.identityFile, "identity-file", "", "age identity file or SSH private key for decrypting imports")
+	fs.StringVar(&f.identityFile, "identity-file", "", "age identity file or SSH private key for decrypting imports and federation feeds")
+	fs.Var(&f.identityPlugins, "identity-plugin", "data-less age identity plugin name for decrypting imports and federation feeds (repeatable)")
 	fs.IntVar(&f.autoRejectMissedCount, "auto-reject-missed-count", 0, "auto-reject findings after this many consecutive missed rescans (0 disables)")
 	fs.BoolVar(&f.ecosystemsEnrichment, "ecosystems-enrichment", true, "enrich repositories from ecosyste.ms (per-repository cache, warm on repo add, PURL-to-repository resolution); =false stops every lookup scrutineer's own process makes and leaves the dependents cache empty. Takes the -flag=false form")
 	// federation_salt has no flag on purpose: a secret in argv leaks via
@@ -354,6 +365,9 @@ func (f *flags) merge(cfg *config.Config) {
 	if cfg.IdentityFile != "" && !f.set["identity-file"] {
 		f.identityFile = cfg.IdentityFile
 	}
+	if len(cfg.IdentityPlugins) > 0 && !f.set["identity-plugin"] {
+		f.identityPlugins = append(pluginNames(nil), cfg.IdentityPlugins...)
+	}
 	if cfg.AutoRejectMissedCount > 0 && !f.set["auto-reject-missed-count"] {
 		f.autoRejectMissedCount = cfg.AutoRejectMissedCount
 	}
@@ -452,6 +466,12 @@ func validateFlags(f *flags) error {
 	}
 	if err := config.ValidateSubprojectScope(f.subprojectScope); err != nil {
 		return err
+	}
+	if _, err := loadIdentityPlugins(f.identityPlugins, &plugin.ClientUI{}); err != nil {
+		return err
+	}
+	if len(f.identityPlugins) > 0 && os.Getenv("AGEDEBUG") == "plugin" {
+		return errors.New("identity plugins: AGEDEBUG=plugin is unsafe because it exposes raw plugin protocol traffic and may expose entered secrets")
 	}
 	if err := validateFederation(f); err != nil {
 		return err
@@ -653,21 +673,8 @@ func run(log *slog.Logger) error {
 	srv.FederationMembersFeed = f.federationMembersFeed
 	srv.FederationImportFeeds = f.federationImportFeeds
 
-	if f.recipientsFile != "" {
-		recs, err := loadRecipients(f.recipientsFile)
-		if err != nil {
-			return fmt.Errorf("recipients: %w", err)
-		}
-		srv.EncRecipients = recs
-		log.Info("loaded recipients", "file", f.recipientsFile, "count", len(recs))
-	}
-	if f.identityFile != "" {
-		ids, err := loadIdentities(f.identityFile)
-		if err != nil {
-			return fmt.Errorf("identity: %w", err)
-		}
-		srv.EncIdentities = ids
-		log.Info("loaded identities", "file", f.identityFile, "count", len(ids))
+	if err := configureEncryption(srv, f, log); err != nil {
+		return err
 	}
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
@@ -695,6 +702,34 @@ func run(log *slog.Logger) error {
 	log.Info("listening", "addr", "http://"+f.addr)
 	if err := httpSrv.ListenAndServe(); !errors.Is(err, http.ErrServerClosed) {
 		return err
+	}
+	return nil
+}
+
+func configureEncryption(srv *web.Server, f *flags, log *slog.Logger) error {
+	if f.recipientsFile != "" {
+		recs, err := loadRecipients(f.recipientsFile)
+		if err != nil {
+			return fmt.Errorf("recipients: %w", err)
+		}
+		srv.EncRecipients = recs
+		log.Info("loaded recipients", "file", f.recipientsFile, "count", len(recs))
+	}
+	if f.identityFile != "" {
+		ids, err := loadIdentities(f.identityFile)
+		if err != nil {
+			return fmt.Errorf("identity: %w", err)
+		}
+		srv.EncIdentities = append(srv.EncIdentities, ids...)
+		log.Info("loaded identities", "file", f.identityFile, "count", len(ids))
+	}
+	if len(f.identityPlugins) > 0 {
+		ids, err := loadIdentityPlugins(f.identityPlugins, newIdentityPluginUI(log))
+		if err != nil {
+			return err
+		}
+		srv.EncIdentities = append(srv.EncIdentities, ids...)
+		log.Info("loaded identity plugins", "count", len(ids))
 	}
 	return nil
 }
@@ -1251,6 +1286,92 @@ func loadIdentities(path string) ([]age.Identity, error) {
 		return nil, fmt.Errorf("parse age identity: %w", err)
 	}
 	return ids, nil
+}
+
+// serializedPluginIdentity keeps terminal-backed plugin interactions from
+// overlapping across concurrent imports and federation passes. It also keeps
+// plugin-supplied error text behind a stable, provider-neutral boundary while
+// preserving the underlying error for errors.Is/errors.As and age's identity
+// fallback behavior.
+type serializedPluginIdentity struct {
+	name     string
+	identity age.Identity
+	mutex    *sync.Mutex
+}
+
+func (i *serializedPluginIdentity) Name() string { return i.name }
+
+func (i *serializedPluginIdentity) Unwrap(stanzas []*age.Stanza) ([]byte, error) {
+	i.mutex.Lock()
+	defer i.mutex.Unlock()
+
+	fileKey, err := i.identity.Unwrap(stanzas)
+	if err != nil {
+		// A non-match is normal age control flow, not a plugin malfunction.
+		// Canonicalize it to age's own sentinel so NoIdentityMatchError stays
+		// accurate without carrying any plugin-controlled error text.
+		if errors.Is(err, age.ErrIncorrectIdentity) {
+			return nil, age.ErrIncorrectIdentity
+		}
+		return nil, &pluginIdentityError{name: i.name, err: err}
+	}
+	return fileKey, nil
+}
+
+type pluginIdentityError struct {
+	name string
+	// err is retained only for errors.Is/errors.As. It can contain
+	// plugin-controlled protocol text and must not be logged or returned
+	// directly to a user.
+	err error
+}
+
+func (e *pluginIdentityError) Error() string {
+	var notFound *plugin.NotFoundError
+	if errors.As(e.err, &notFound) {
+		return fmt.Sprintf(
+			"configured identity plugin %q is unavailable; expected age-plugin-%s in PATH",
+			e.name, e.name)
+	}
+	return fmt.Sprintf("configured identity plugin %q failed", e.name)
+}
+
+func (e *pluginIdentityError) Unwrap() error { return e.err }
+
+// loadIdentityPlugins constructs data-less age plugin identities, equivalent
+// to age's -j option. Construction validates names but does not start plugin
+// executables or trigger authentication; that is deferred until decryption
+// needs an identity.
+func loadIdentityPlugins(names []string, ui *plugin.ClientUI) ([]age.Identity, error) {
+	identities := make([]age.Identity, 0, len(names))
+	mutex := new(sync.Mutex)
+	for _, name := range names {
+		identity, err := plugin.NewIdentityWithoutData(name, ui)
+		if err != nil {
+			return nil, fmt.Errorf("identity plugin %q: %w", name, err)
+		}
+		identities = append(identities, &serializedPluginIdentity{
+			name:     name,
+			identity: identity,
+			mutex:    mutex,
+		})
+	}
+	return identities, nil
+}
+
+// newIdentityPluginUI uses age's terminal UI so plugins can request public or
+// secret input directly from the controlling terminal. Only display messages
+// and UI errors reach structured logs; values entered by the user and raw age
+// plugin protocol traffic do not.
+func newIdentityPluginUI(log *slog.Logger) *plugin.ClientUI {
+	return plugin.NewTerminalUI(
+		func(format string, args ...any) {
+			log.Info("age identity plugin", "message", fmt.Sprintf(format, args...))
+		},
+		func(format string, args ...any) {
+			log.Warn("age identity plugin", "message", fmt.Sprintf(format, args...))
+		},
+	)
 }
 
 // promptPassphrase is the function called when an encrypted SSH key needs

--- a/cmd/scrutineer/main_test.go
+++ b/cmd/scrutineer/main_test.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"bytes"
 	"crypto/ed25519"
 	"encoding/pem"
+	"errors"
 	"flag"
 	"io"
 	"log/slog"
@@ -10,10 +12,13 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"filippo.io/age"
+	"filippo.io/age/plugin"
 	"golang.org/x/crypto/ssh"
 
 	"scrutineer/internal/config"
@@ -22,6 +27,12 @@ import (
 	"scrutineer/internal/web"
 	"scrutineer/internal/worker"
 )
+
+type identityFunc func([]*age.Stanza) ([]byte, error)
+
+func (f identityFunc) Unwrap(stanzas []*age.Stanza) ([]byte, error) {
+	return f(stanzas)
+}
 
 func fullConfig() *config.Config {
 	return &config.Config{
@@ -319,6 +330,21 @@ func TestRegisterFlags_noContainerAliasParsesFromArgv(t *testing.T) {
 		if !f.noContainer {
 			t.Errorf("%s did not set noContainer", name)
 		}
+	}
+}
+
+func TestRegisterFlags_identityPluginIsRepeatable(t *testing.T) {
+	f := &flags{}
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	registerFlags(fs, f)
+	if err := fs.Parse([]string{
+		"-identity-plugin", "1p",
+		"-identity-plugin", "provider-b",
+	}); err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if !slices.Equal([]string(f.identityPlugins), []string{"1p", "provider-b"}) {
+		t.Errorf("identity plugins = %v, want [1p provider-b]", f.identityPlugins)
 	}
 }
 
@@ -667,6 +693,210 @@ func TestLoadIdentities_ageNative(t *testing.T) {
 	}
 }
 
+func TestLoadIdentityPlugins_validAndMultiple(t *testing.T) {
+	ids, err := loadIdentityPlugins([]string{"1p", "provider-b"}, &plugin.ClientUI{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ids) != 2 {
+		t.Fatalf("got %d identities, want 2", len(ids))
+	}
+	for i, want := range []string{"1p", "provider-b"} {
+		id, ok := ids[i].(*serializedPluginIdentity)
+		if !ok {
+			t.Fatalf("identity %d has type %T, want *serializedPluginIdentity", i, ids[i])
+		}
+		if id.Name() != want {
+			t.Errorf("identity %d name = %q, want %q", i, id.Name(), want)
+		}
+	}
+}
+
+func TestConfigureEncryptionCombinesSources(t *testing.T) {
+	id, err := age.GenerateX25519Identity()
+	if err != nil {
+		t.Fatal(err)
+	}
+	f := &flags{
+		recipientsFile:  writeTestKey(t, []byte(id.Recipient().String()+"\n")),
+		identityFile:    writeTestKey(t, []byte(id.String()+"\n")),
+		identityPlugins: pluginNames{"provider-a", "provider-b"},
+	}
+	srv := &web.Server{}
+	if err := configureEncryption(srv, f, quietLog()); err != nil {
+		t.Fatal(err)
+	}
+	if len(srv.EncRecipients) != 1 {
+		t.Fatalf("recipients = %d, want 1", len(srv.EncRecipients))
+	}
+	if len(srv.EncIdentities) != 3 {
+		t.Fatalf("identities = %d, want one file identity and two plugin identities", len(srv.EncIdentities))
+	}
+	// Order is load-bearing: age ties a non-native file identity with the
+	// plugin identities, so insertion order is the only thing that keeps a
+	// local key from being tried after a plugin prompts.
+	if _, isPlugin := srv.EncIdentities[0].(*serializedPluginIdentity); isPlugin {
+		t.Error("a plugin identity precedes the identity file")
+	}
+	for i, want := range []string{"provider-a", "provider-b"} {
+		got, ok := srv.EncIdentities[i+1].(*serializedPluginIdentity)
+		if !ok {
+			t.Errorf("identity %d has type %T, want *serializedPluginIdentity", i+1, srv.EncIdentities[i+1])
+			continue
+		}
+		if got.Name() != want {
+			t.Errorf("identity %d name = %q, want %q", i+1, got.Name(), want)
+		}
+	}
+}
+
+func TestPluginIdentitiesSerializeInteractions(t *testing.T) {
+	var active atomic.Int32
+	var overlapped atomic.Bool
+	underlying := identityFunc(func([]*age.Stanza) ([]byte, error) {
+		if active.Add(1) > 1 {
+			overlapped.Store(true)
+		}
+		time.Sleep(25 * time.Millisecond)
+		active.Add(-1)
+		return nil, age.ErrIncorrectIdentity
+	})
+	mutex := new(sync.Mutex)
+	identities := []*serializedPluginIdentity{
+		{name: "provider-a", identity: underlying, mutex: mutex},
+		{name: "provider-b", identity: underlying, mutex: mutex},
+	}
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for _, id := range identities {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			_, _ = id.Unwrap(nil)
+		}()
+	}
+	close(start)
+	wg.Wait()
+	if overlapped.Load() {
+		t.Fatal("identity plugin interactions overlapped")
+	}
+}
+
+func TestPluginIdentityNonMatchIsNotReportedAsPluginFailure(t *testing.T) {
+	recipientIdentity, err := age.GenerateX25519Identity()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var ciphertext bytes.Buffer
+	w, err := age.Encrypt(&ciphertext, recipientIdentity.Recipient())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := w.Write([]byte("not for this plugin")); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	id := &serializedPluginIdentity{
+		name: "provider-a",
+		identity: identityFunc(func([]*age.Stanza) ([]byte, error) {
+			return nil, age.ErrIncorrectIdentity
+		}),
+		mutex: new(sync.Mutex),
+	}
+	if _, err := id.Unwrap(nil); err != age.ErrIncorrectIdentity {
+		t.Fatalf("Unwrap error = %v, want canonical age.ErrIncorrectIdentity", err)
+	}
+	_, err = age.Decrypt(bytes.NewReader(ciphertext.Bytes()), id)
+	if err == nil {
+		t.Fatal("expected identity non-match")
+	}
+	if !strings.Contains(err.Error(), "identity did not match any of the recipients") {
+		t.Fatalf("error does not describe an ordinary non-match: %v", err)
+	}
+	if strings.Contains(err.Error(), `configured identity plugin "provider-a" failed`) {
+		t.Fatalf("ordinary non-match was reported as a plugin failure: %v", err)
+	}
+}
+
+func TestPluginIdentityErrorsDoNotExposePluginText(t *testing.T) {
+	secret := errors.New("op://vault/item/private-key")
+	id := &serializedPluginIdentity{
+		name: "provider-a",
+		identity: identityFunc(func([]*age.Stanza) ([]byte, error) {
+			return nil, secret
+		}),
+		mutex: new(sync.Mutex),
+	}
+	_, err := id.Unwrap(nil)
+	if err == nil {
+		t.Fatal("expected plugin failure")
+	}
+	if strings.Contains(err.Error(), "op://") {
+		t.Fatalf("plugin error text escaped the safe boundary: %v", err)
+	}
+	if !errors.Is(err, secret) {
+		t.Fatalf("wrapped error no longer preserves its cause: %v", err)
+	}
+}
+
+func TestPluginIdentityMissingExecutableErrorIsSafeAndSpecific(t *testing.T) {
+	underlying := &plugin.NotFoundError{
+		Name: "provider-a",
+		Err:  errors.New("private process detail"),
+	}
+	id := &serializedPluginIdentity{
+		name: "provider-a",
+		identity: identityFunc(func([]*age.Stanza) ([]byte, error) {
+			return nil, underlying
+		}),
+		mutex: new(sync.Mutex),
+	}
+	_, err := id.Unwrap(nil)
+	if err == nil {
+		t.Fatal("expected missing plugin failure")
+	}
+	if got := err.Error(); got != `configured identity plugin "provider-a" is unavailable; expected age-plugin-provider-a in PATH` {
+		t.Fatalf("error = %q", got)
+	}
+	if !errors.Is(err, underlying) {
+		t.Fatalf("wrapped error no longer preserves its cause: %v", err)
+	}
+}
+
+func TestLoadIdentityPlugins_invalidName(t *testing.T) {
+	_, err := loadIdentityPlugins([]string{"1p", "bad/name"}, &plugin.ClientUI{})
+	if err == nil {
+		t.Fatal("expected invalid plugin name error")
+	}
+	if !strings.Contains(err.Error(), `identity plugin "bad/name"`) ||
+		!strings.Contains(err.Error(), "invalid plugin name") {
+		t.Fatalf("error = %v, want the invalid plugin name and source", err)
+	}
+}
+
+func TestValidateFlags_identityPluginNames(t *testing.T) {
+	if err := validateFlags(&flags{identityPlugins: pluginNames{"1p", "test-plugin_2"}}); err != nil {
+		t.Fatalf("valid plugin names rejected: %v", err)
+	}
+	err := validateFlags(&flags{identityPlugins: pluginNames{"bad/name"}})
+	if err == nil || !strings.Contains(err.Error(), `identity plugin "bad/name"`) {
+		t.Fatalf("invalid plugin name error = %v", err)
+	}
+}
+
+func TestValidateFlags_identityPluginsRejectProtocolDebugLogging(t *testing.T) {
+	t.Setenv("AGEDEBUG", "plugin")
+	err := validateFlags(&flags{identityPlugins: pluginNames{"1p"}})
+	if err == nil || !strings.Contains(err.Error(), "raw plugin protocol traffic") ||
+		!strings.Contains(err.Error(), "entered secrets") {
+		t.Fatalf("AGEDEBUG=plugin error = %v", err)
+	}
+}
+
 func TestLoadRecipients_mixedKeyTypes(t *testing.T) {
 	_, sshPub := genSSHKey(t)
 	ageID, _ := age.GenerateX25519Identity()
@@ -800,6 +1030,73 @@ func TestFlagsMerge_recipientsCliFlagWins(t *testing.T) {
 	f.merge(cfg)
 	if f.recipientsFile != "/from/cli" {
 		t.Errorf("CLI flag should win, got %q", f.recipientsFile)
+	}
+}
+
+func TestFlagsMerge_identityPluginPrecedenceAndIdentityFileCombination(t *testing.T) {
+	cfg := &config.Config{
+		IdentityFile:    "/from/config.key",
+		IdentityPlugins: []string{"config-a", "config-b"},
+	}
+
+	fromConfig := &flags{set: map[string]bool{}}
+	fromConfig.merge(cfg)
+	if fromConfig.identityFile != cfg.IdentityFile ||
+		!slices.Equal([]string(fromConfig.identityPlugins), cfg.IdentityPlugins) {
+		t.Errorf("config identities not combined: file=%q plugins=%v", fromConfig.identityFile, fromConfig.identityPlugins)
+	}
+
+	pluginCLI := &flags{
+		identityPlugins: pluginNames{"cli-a", "cli-b"},
+		set:             map[string]bool{"identity-plugin": true},
+	}
+	pluginCLI.merge(cfg)
+	if !slices.Equal([]string(pluginCLI.identityPlugins), []string{"cli-a", "cli-b"}) {
+		t.Errorf("config overrode CLI plugins: %v", pluginCLI.identityPlugins)
+	}
+	if pluginCLI.identityFile != cfg.IdentityFile {
+		t.Errorf("config identity file was not combined with CLI plugins: %q", pluginCLI.identityFile)
+	}
+
+	fileCLI := &flags{
+		identityFile: "/from/cli.key",
+		set:          map[string]bool{"identity-file": true},
+	}
+	fileCLI.merge(cfg)
+	if fileCLI.identityFile != "/from/cli.key" {
+		t.Errorf("config overrode CLI identity file: %q", fileCLI.identityFile)
+	}
+	if !slices.Equal([]string(fileCLI.identityPlugins), cfg.IdentityPlugins) {
+		t.Errorf("config plugins were not combined with CLI identity file: %v", fileCLI.identityPlugins)
+	}
+}
+
+func TestValidateFederation_identitySources(t *testing.T) {
+	for _, tc := range []struct {
+		name            string
+		recipientsFile  string
+		identityFile    string
+		identityPlugins pluginNames
+		wantErr         bool
+	}{
+		{name: "file only", recipientsFile: "./recipients.txt", identityFile: "./identity.key"},
+		{name: "plugin only", recipientsFile: "./recipients.txt", identityPlugins: pluginNames{"1p"}},
+		{name: "both", recipientsFile: "./recipients.txt", identityFile: "./identity.key", identityPlugins: pluginNames{"1p"}},
+		{name: "neither", recipientsFile: "./recipients.txt", wantErr: true},
+		{name: "plugin without recipients", identityPlugins: pluginNames{"1p"}, wantErr: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			f := flags{
+				federationMembersFeed: "git@host:o/f.git",
+				recipientsFile:        tc.recipientsFile,
+				identityFile:          tc.identityFile,
+				identityPlugins:       tc.identityPlugins,
+			}
+			err := validateFederation(&f)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("validateFederation error = %v, wantErr %v", err, tc.wantErr)
+			}
+		})
 	}
 }
 

--- a/docs/encrypted-sharing.md
+++ b/docs/encrypted-sharing.md
@@ -27,6 +27,19 @@ Or in `scrutineer.yaml`:
     recipients_file: ./recipients.txt
     identity_file: ~/.ssh/id_ed25519
 
+An age identity plugin can replace or accompany the identity file. For
+example, to let `age-plugin-1p` locate the matching SSH key in 1Password:
+
+    recipients_file: /path/to/recipients.txt
+    identity_plugins:
+      - 1p
+
+The equivalent CLI option is repeatable:
+
+    go run ./cmd/scrutineer -skills ./skills \
+      -recipients-file /path/to/recipients.txt \
+      -identity-plugin 1p
+
 Export a repo's findings as an encrypted bundle:
 
     curl -o findings.bundle.age \
@@ -100,11 +113,79 @@ Both types can be mixed in a single recipients file. The format is auto-detected
 
 Passphrase-protected SSH keys are supported. When scrutineer detects an encrypted key at startup, it prompts on stderr and reads the passphrase from stdin (echo disabled). The passphrase is validated immediately — a wrong passphrase fails startup, not the first import. If stdin is not a terminal (e.g. systemd, a container), the startup fails with a clear message; use an unencrypted key or an age-native key in headless deployments.
 
+### Age identity plugins
+
+`identity_plugins` is a list of provider-neutral age plugin names using the
+data-less identity contract, equivalent to age's `-j NAME` option. The
+repeatable CLI equivalent is `-identity-plugin NAME`. Each name is validated
+at startup using the age plugin API, passed through verbatim, and maps to an
+`age-plugin-NAME` executable. There is no provider-specific SDK, `op`
+integration, shell command, or private-key output path in Scrutineer.
+
+Scrutineer does not launch the executable or trigger authentication until
+decryption needs it. HTTP imports invoke it on demand. Federation performs one
+pass immediately at startup and then hourly, so an encrypted members export or
+import can invoke an interactive plugin during those passes. Plugin interactions
+are serialized so concurrent requests cannot overlap terminal prompts. The
+selected plugin owns prompt duration, authentication, hardware-touch, and
+noninteractive behavior; headless deployments must use authentication that the
+plugin itself supports. An unanswered prompt holds that serialized interaction
+and delays other plugin-backed decryptions until the plugin returns. A missing
+executable is reported at the decrypting operation with the plugin name and
+expected binary.
+
+Scrutineer refuses `AGEDEBUG=plugin` with configured identity plugins because
+age's raw protocol trace can include values entered at secret prompts.
+Plugin-supplied operational error text is likewise kept out of both HTTP
+responses and logs because an error stanza is not a trusted secret-free
+boundary; use the selected plugin's own safe diagnostic workflow when the
+provider-neutral `configured identity plugin ... failed` message is not enough.
+
+Identity files and plugins are additive and are supplied to age together, which
+supports migration between local key files and plugin-owned keys. Age continues
+to another identity only when the prior one reports `ErrIncorrectIdentity`; a
+plugin launch, authentication, or protocol failure aborts that decrypt instead
+of silently falling through.
+
+This interface intentionally covers plugins that support age's data-less `-j`
+mode. Serialized `AGE-PLUGIN-*` identity payloads are not accepted through
+`identity_file` today, so a plugin that requires serialized identity data is
+outside this interface.
+
+For the 1Password example, install both
+[`age-plugin-1p`](https://github.com/Enzime/age-plugin-1p) and the 1Password
+`op` CLI separately and make both available through `PATH`. The plugin locates
+the SSH key and performs the age identity operation; Scrutineer itself never
+receives or writes the SSH private key. Authentication prompts, Touch ID, and
+session handling belong to the plugin and 1Password.
+
+If `op` is signed in to more than one account, set `OP_ACCOUNT` in the
+environment Scrutineer is launched from so the plugin's `op` calls resolve to
+the right one. It accepts an account shorthand, sign-in address, account ID,
+or user ID; `op account list` shows the available values:
+
+    OP_ACCOUNT=my.1password.com scrutineer \
+      -recipients-file /path/to/recipients.txt \
+      -identity-plugin 1p
+
+Keep it in the service or launcher environment rather than `scrutineer.yaml`:
+it is a 1Password setting the plugin's own `op` invocation reads, and
+Scrutineer's configuration stays provider-neutral.
+
+`age-plugin-1p` can decrypt files encrypted to ordinary `ssh-ed25519` or
+`ssh-rsa` recipients, so existing recipients files and ciphertext bundles do
+not need to be converted or re-encrypted. Headless operation depends on the
+selected plugin's own noninteractive authentication support; Scrutineer does
+not add a separate credential or command-execution mechanism.
+
 ### Unsupported: FIDO2 / ed25519-sk keys
 
 `sk-ssh-ed25519@openssh.com` keys (YubiKey FIDO2, Windows Hello) **cannot** be used with age encryption. Age decrypts via X25519 key agreement, which requires the raw private key; FIDO2 devices only expose signing and never export key material. This is a fundamental protocol mismatch — the age CLI has the same limitation.
 
-**YubiKey users who want hardware-backed decryption** can use `age-plugin-yubikey`, which talks to the YubiKey's PIV applet (a separate applet from FIDO2 on the same device). This produces `age1yubikey1...` recipients and requires physical touch per decrypt. See [github.com/str4d/age-plugin-yubikey](https://github.com/str4d/age-plugin-yubikey). Note that PIV-based decrypt requires someone physically present at the server for each encrypted import, so it is impractical for headless deployments.
+`age-plugin-yubikey` uses the YubiKey PIV applet and serialized plugin identity
+data rather than the data-less `-j` contract. Scrutineer's current
+`identity_plugins` interface therefore does not support it. This is separate
+from the fundamental FIDO2 limitation above.
 
 For headless servers, a dedicated unpassworded ed25519 key with restrictive file permissions is the standard approach:
 
@@ -147,9 +228,10 @@ For age-native identities, the identity file can hold multiple keys (one per lin
 | Flag | Config | Description |
 |------|--------|-------------|
 | `-recipients-file` | `recipients_file` | Public keys for encrypted export |
-| `-identity-file` | `identity_file` | Private key for decrypting imports |
+| `-identity-file` | `identity_file` | Private key for decrypting imports and encrypted federation feeds |
+| `-identity-plugin NAME` (repeatable) | `identity_plugins` | Data-less age identity plugins (`age -j`) for decrypting imports and encrypted federation feeds |
 
-Both are optional. When absent the feature is fully disabled and all endpoints behave exactly as before.
+All are optional. When absent the feature is fully disabled and all endpoints behave exactly as before.
 
 ## Endpoints
 

--- a/docs/interchange.md
+++ b/docs/interchange.md
@@ -257,13 +257,22 @@ and the two feed remotes with `-federation-public-feed` /
 `-federation-members-feed`. The import list is config-file only: a
 repeatable flag would duplicate what a YAML sequence already expresses.
 
-Startup also refuses `federation_members_feed` without both
-`recipients_file` and `identity_file`, the two tiers sharing one git remote
-(each would prune what the other publishes), and any feed remote carrying
-credentials: the remote reaches the job's error messages and log fields, so
-a token in one would end up in the logs. Configure a git credential helper
-on the host instead. The refusal itself names the remote with its userinfo
-replaced, since that message is what the startup logger prints.
+Startup also refuses `federation_members_feed` without `recipients_file` and
+at least one decryption source from `identity_file` or `identity_plugins`, the
+two tiers sharing one git remote (each would prune what the other publishes),
+and any feed remote carrying credentials: the remote reaches the job's error
+messages and log fields, so a token in one would end up in the logs. Configure
+a git credential helper on the host instead. The refusal itself names the
+remote with its userinfo replaced, since that message is what the startup
+logger prints.
+
+Federation runs once immediately at startup and then hourly. When an encrypted
+members feed uses `identity_plugins`, either the read-back check for an export
+or an encrypted imported record can invoke the selected plugin during those
+passes. Interactive authentication and hardware-touch requirements belong to
+the plugin; headless deployments need the plugin's own noninteractive support.
+If an unchanged encrypted export record cannot be decrypted, the pass fails and
+leaves its existing ciphertext untouched rather than silently replacing it.
 
 Feed remotes are pushed with the ambient git credentials and
 `GIT_TERMINAL_PROMPT=0`, so a remote whose credentials are missing fails the

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -135,8 +135,15 @@ type Config struct {
 	// disables encrypted export.
 	RecipientsFile string `yaml:"recipients_file"`
 	// IdentityFile is an age identity file or SSH private key used to
-	// decrypt encrypted imports. Empty disables encrypted import.
+	// decrypt encrypted imports and encrypted federation members feeds.
+	// Can be combined with IdentityPlugins; decryption is disabled only
+	// when both are empty.
 	IdentityFile string `yaml:"identity_file"`
+	// IdentityPlugins names data-less age identity plugins (the age -j
+	// contract) used to decrypt encrypted imports and encrypted federation
+	// members feeds through the age plugin protocol. Can be combined with
+	// IdentityFile; decryption is disabled only when both are empty.
+	IdentityPlugins []string `yaml:"identity_plugins"`
 	// AutoRejectMissedCount is the threshold of consecutive missed rescans at
 	// which an open finding is automatically transitioned to 'rejected'.
 	// 0 (the default) means this feature is disabled.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 	"time"
 )
@@ -38,6 +39,21 @@ func TestLoad_absentDefaultPathIsNoError(t *testing.T) {
 func TestLoad_explicitMissingPathIsError(t *testing.T) {
 	if _, err := Load(filepath.Join(t.TempDir(), "nope.yaml")); err == nil {
 		t.Error("expected error for explicit missing path")
+	}
+}
+
+func TestLoad_identityPlugins(t *testing.T) {
+	c, err := Load(write(t, `
+identity_plugins:
+  - 1p
+  - provider-b
+`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"1p", "provider-b"}
+	if !slices.Equal(c.IdentityPlugins, want) {
+		t.Errorf("identity_plugins = %v, want %v", c.IdentityPlugins, want)
 	}
 }
 

--- a/internal/interchange/feed.go
+++ b/internal/interchange/feed.go
@@ -248,7 +248,11 @@ func writeRecord(path string, raw []byte, encrypted, rotate bool, keys FeedKeys)
 		return writeFile(path, body)
 	}
 	if readErr == nil && !rotate {
-		if plain, err := decryptRecord(existing, keys.Identities); err == nil && bytes.Equal(plain, raw) {
+		plain, err := decryptRecord(existing, keys.Identities)
+		if err != nil {
+			return fmt.Errorf("decrypt existing record: %w", err)
+		}
+		if bytes.Equal(plain, raw) {
 			return nil
 		}
 	}
@@ -400,7 +404,7 @@ func encryptRecord(raw []byte, recipients []age.Recipient) ([]byte, error) {
 }
 
 func decryptRecord(raw []byte, identities []age.Identity) ([]byte, error) {
-	r, err := age.Decrypt(armor.NewReader(bytes.NewReader(raw)), identities...)
+	r, err := age.Decrypt(armor.NewReader(bytes.NewReader(raw)), slices.Clone(identities)...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/interchange/feed_test.go
+++ b/internal/interchange/feed_test.go
@@ -11,8 +11,15 @@ import (
 
 	"filippo.io/age"
 	"filippo.io/age/agessh"
+	"filippo.io/age/plugin"
 	"golang.org/x/crypto/ssh"
 )
+
+type rejectingIdentity struct{}
+
+func (*rejectingIdentity) Unwrap([]*age.Stanza) ([]byte, error) {
+	return nil, age.ErrIncorrectIdentity
+}
 
 func certificate(t *testing.T, status string) Statement {
 	t.Helper()
@@ -237,6 +244,64 @@ func TestWriteFeedReEncryptsOnRecipientChange(t *testing.T) {
 	}
 	if records, _ = ReadFeed(dir, []age.Identity{first}); records[0].Err != nil {
 		t.Fatalf("the remaining recipient must still read the feed: %v", records[0].Err)
+	}
+}
+
+func TestWriteFeedPluginFailureDoesNotRewriteExistingRecord(t *testing.T) {
+	dir := t.TempDir()
+	id := testIdentity(t)
+	rec := certificate(t, "bypass")
+	keys := FeedKeys{
+		Recipients: []age.Recipient{id.Recipient()},
+		Identities: []age.Identity{id},
+	}
+	if err := WriteFeed(dir, TierMembers, []Statement{rec}, keys); err != nil {
+		t.Fatal(err)
+	}
+	names, err := recordFiles(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, names[0])
+	before, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const name = "scrutineer-missing-test"
+	pluginID, err := plugin.NewIdentityWithoutData(name, &plugin.ClientUI{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", t.TempDir())
+	keys.Identities = []age.Identity{pluginID}
+	if err := WriteFeed(dir, TierMembers, []Statement{rec}, keys); err == nil {
+		t.Fatal("missing plugin must fail instead of replacing the existing ciphertext")
+	} else if !strings.Contains(err.Error(), "age-plugin-"+name) {
+		t.Fatalf("error does not identify the missing plugin executable: %v", err)
+	}
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(before, after) {
+		t.Fatal("a failed identity plugin rewrote the existing ciphertext")
+	}
+}
+
+func TestDecryptRecordDoesNotReorderIdentities(t *testing.T) {
+	id := testIdentity(t)
+	raw, err := encryptRecord([]byte("record"), []age.Recipient{id.Recipient()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	reject := &rejectingIdentity{}
+	identities := []age.Identity{reject, id}
+	if _, err := decryptRecord(raw, identities); err != nil {
+		t.Fatal(err)
+	}
+	if identities[0] != reject || identities[1] != id {
+		t.Fatalf("decryptRecord reordered the caller's identities: %T, %T", identities[0], identities[1])
 	}
 }
 

--- a/internal/web/api_export_test.go
+++ b/internal/web/api_export_test.go
@@ -17,6 +17,7 @@ import (
 
 	"filippo.io/age"
 	"filippo.io/age/armor"
+	"filippo.io/age/plugin"
 
 	"scrutineer/internal/db"
 )
@@ -190,6 +191,12 @@ type failResponseWriter struct {
 	body       bytes.Buffer
 	status     int
 	writeBytes int
+}
+
+type rejectingImportIdentity struct{}
+
+func (*rejectingImportIdentity) Unwrap([]*age.Stanza) ([]byte, error) {
+	return nil, age.ErrIncorrectIdentity
 }
 
 func (w *failResponseWriter) Header() http.Header {
@@ -1134,6 +1141,94 @@ func TestImportEncryptedNoIdentity(t *testing.T) {
 	}
 	if !strings.Contains(w.Body.String(), "no identity configured") {
 		t.Errorf("unexpected error: %s", w.Body)
+	}
+}
+
+func TestImportEncryptedMissingIdentityPlugin(t *testing.T) {
+	id, err := age.GenerateX25519Identity()
+	if err != nil {
+		t.Fatal(err)
+	}
+	plain := []byte(`{"repository":"https://example.com/x","tool":"test","findings":[{"title":"t","severity":"High"}]}`)
+	ct, err := encryptBundle(plain, []age.Recipient{id.Recipient()})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const name = "scrutineer-missing-test"
+	pluginID, err := plugin.NewIdentityWithoutData(name, &plugin.ClientUI{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", t.TempDir())
+
+	s, done := newTestServer(t)
+	defer done()
+	s.EncIdentities = []age.Identity{pluginID}
+
+	r := httptest.NewRequest("POST", "/api/v1/import", bytes.NewReader(ct))
+	r.Host = testHost
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, r)
+
+	if w.Code != 422 {
+		t.Fatalf("status %d, want 422: %s", w.Code, w.Body)
+	}
+	if !strings.Contains(w.Body.String(), "age-plugin-"+name) ||
+		!strings.Contains(w.Body.String(), "unavailable") {
+		t.Fatalf("error does not identify the missing plugin executable: %s", w.Body)
+	}
+}
+
+func TestImportEncryptedIdentityNonMatchIsNotAPluginFailure(t *testing.T) {
+	id, err := age.GenerateX25519Identity()
+	if err != nil {
+		t.Fatal(err)
+	}
+	plain := []byte(`{"repository":"https://example.com/x","tool":"test","findings":[{"title":"t","severity":"High"}]}`)
+	ct, err := encryptBundle(plain, []age.Recipient{id.Recipient()})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s, done := newTestServer(t)
+	defer done()
+	s.EncIdentities = []age.Identity{&rejectingImportIdentity{}}
+
+	r := httptest.NewRequest("POST", "/api/v1/import", bytes.NewReader(ct))
+	r.Host = testHost
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, r)
+
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status %d, want 422: %s", w.Code, w.Body)
+	}
+	if !strings.Contains(w.Body.String(), "identity did not match any of the recipients") {
+		t.Fatalf("error does not describe an ordinary identity non-match: %s", w.Body)
+	}
+	if strings.Contains(w.Body.String(), "plugin") && strings.Contains(w.Body.String(), "failed") {
+		t.Fatalf("ordinary identity non-match was reported as a plugin failure: %s", w.Body)
+	}
+}
+
+func TestMaybeDecryptDoesNotReorderConfiguredIdentities(t *testing.T) {
+	id, err := age.GenerateX25519Identity()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ct, err := encryptBundle([]byte(`{"repository":"https://example.com/x"}`), []age.Recipient{id.Recipient()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	s, done := newTestServer(t)
+	defer done()
+	reject := &rejectingImportIdentity{}
+	s.EncIdentities = []age.Identity{reject, id}
+	if _, err := s.maybeDecrypt(ct); err != nil {
+		t.Fatal(err)
+	}
+	if s.EncIdentities[0] != reject || s.EncIdentities[1] != id {
+		t.Fatalf("maybeDecrypt reordered the configured identities: %T, %T", s.EncIdentities[0], s.EncIdentities[1])
 	}
 }
 

--- a/internal/web/import.go
+++ b/internal/web/import.go
@@ -8,12 +8,14 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
 
 	"filippo.io/age"
 	"filippo.io/age/armor"
+	"filippo.io/age/plugin"
 	"gorm.io/gorm"
 
 	"scrutineer/internal/db"
@@ -670,10 +672,16 @@ func (s *Server) maybeDecrypt(body []byte) ([]byte, error) {
 		return body, nil // not encrypted — pass straight through
 	}
 	if len(s.EncIdentities) == 0 {
-		return nil, errors.New("encrypted import received but no identity configured (-identity-file)")
+		return nil, errors.New("encrypted import received but no identity configured (-identity-file or -identity-plugin)")
 	}
-	r, err := age.Decrypt(src, s.EncIdentities...)
+	r, err := age.Decrypt(src, slices.Clone(s.EncIdentities)...)
 	if err != nil {
+		var notFound *plugin.NotFoundError
+		if errors.As(err, &notFound) {
+			return nil, fmt.Errorf(
+				"decrypt: configured identity plugin %q is unavailable; expected age-plugin-%s in PATH",
+				notFound.Name, notFound.Name)
+		}
 		return nil, fmt.Errorf("decrypt: %w", err)
 	}
 	return io.ReadAll(r)

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -105,8 +105,8 @@ type Server struct {
 	// EncRecipients is the parsed recipients file; nil disables encrypted
 	// export. Supports age X25519 and SSH public keys.
 	EncRecipients []age.Recipient
-	// EncIdentities decrypts encrypted imports. Multiple entries support
-	// key rotation (old + new). nil disables encrypted import.
+	// EncIdentities decrypts encrypted imports and federation members feeds.
+	// Multiple entries support migration and fallback. nil disables decryption.
 	EncIdentities []age.Identity
 
 	// FederationSalt is the shared federation secret mixed into

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1206,8 +1206,9 @@ paths:
         routed to the `ingest` skill instead when `?repo=` is supplied:
         the raw payload is staged into the skill workspace and a scan is
         queued, returning 202 with the scan id. Age-encrypted bodies (armored
-        or binary) are transparently decrypted first when an identity is
-        configured (`-identity-file`); plaintext bodies pass through untouched.
+        or binary) are transparently decrypted first when an identity file or
+        plugin is configured (`-identity-file` or `-identity-plugin`); plaintext
+        bodies pass through untouched.
         No bearer token; localhost-only. See docs/import.md for the per-format
         field mapping.
       operationId: importFindings

--- a/scrutineer.sample.yaml
+++ b/scrutineer.sample.yaml
@@ -230,6 +230,15 @@
 # disables encrypted import.
 # identity_file: ~/.ssh/id_ed25519
 
+# Provider-neutral, data-less age identity plugins (the `age -j` contract)
+# used to decrypt imports and encrypted federation feeds. Each name resolves
+# to age-plugin-NAME through PATH. Plugins may be combined with identity_file
+# and are launched only when decryption needs them. For example,
+# age-plugin-1p and the 1Password op CLI must both be installed separately for
+# this configuration; Scrutineer never receives or writes the SSH private key.
+# identity_plugins:
+#   - 1p
+
 # Submit reviewed findings to CERT/CC VINCE. The action is disabled when
 # api_key is empty. Reporter values prefill the editable submission page.
 # scrutineer.yaml contains the long-lived key, so keep the file owner-only
@@ -264,10 +273,11 @@
 
 # Git remote the members-only feed is pushed to: the non-clean fix-audit
 # certificates, each naming a repository whose advertised fix does not
-# hold, so every record is age-encrypted to recipients_file. Requires both
-# recipients_file (or it would push them in the clear) and identity_file
-# (or it could not read back what it published, and would re-encrypt the
-# whole feed on every tick). Empty disables the members export.
+# hold, so every record is age-encrypted to recipients_file. Requires
+# recipients_file (or it would push them in the clear) and at least one
+# decryption source from identity_file or identity_plugins (or it could not
+# read back what it published, and would re-encrypt the whole feed on every
+# tick). Empty disables the members export.
 # federation_members_feed: "git@github.com:example/scrutineer-members-feed.git"
 
 # Peer feed git remotes cloned read-only and ingested hourly. An imported


### PR DESCRIPTION
Encrypted imports and the members feed could only be decrypted with an identity file on disk, so a key held in an external store or on a hardware token had no way in. age's plugin protocol already covers that, and its data-less identity contract (the `-j` option) needs nothing beyond a plugin name.

This adds `identity_plugins` and a repeatable `-identity-plugin` flag, combinable with `identity_file`. Names pass through verbatim to `plugin.NewIdentityWithoutData`, nothing special-cases a particular plugin, and no executable is launched until a decrypt needs one. Plugin interactions are serialized and plugin-supplied error text stays out of responses and logs. `age-plugin-1p` is only a worked example in the docs.

Opus 5 was used to implement this.
