### PR TITLE
Snapshot an immutable scan recipe on `Scan`

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -337,6 +337,30 @@ type Scan struct {
 	// workspace.
 	ResumedFromScanID *uint `gorm:"index"`
 
+	// ParentScanID points at the scan this one was enqueued as a rerun of:
+	// the *immediate* parent, so a chain of reruns can be walked one hop at
+	// a time and each hop's Recipe diffed against its parent's. Nil on a
+	// fresh scan. Deliberately separate from ResumedFromScanID, which is
+	// pinned to the lineage root because it addresses a workspace, and
+	// which is only set when the retry actually resumes a harness session
+	// — a retry of a done or cancelled scan has a parent but no session.
+	ParentScanID *uint `gorm:"index"`
+
+	// Recipe is an immutable JSON snapshot (worker.ScanRecipe) of the
+	// inputs the worker was handed, written once inside the transaction
+	// that claims the scan and never updated. The columns it duplicates are
+	// mutable and some are backfilled later, so they record what the row
+	// looks like now rather than what the worker started from; the recipe
+	// also digests the Repository threat model and scan config in effect at
+	// claim time, which nothing else records. Empty on rows claimed before
+	// the column existed.
+	//
+	// The write-once guarantee is enforced in SQL, not just by writing it
+	// at claim: a paused scan returns to `queued` on the same row (operator
+	// resume, bulk resume, and the account-pause auto-resume), so the claim
+	// itself can run more than once per row.
+	Recipe string `gorm:"type:text"`
+
 	Commit     string
 	StartedAt  *time.Time
 	FinishedAt *time.Time

--- a/internal/web/scans.go
+++ b/internal/web/scans.go
@@ -250,6 +250,7 @@ func (s *Server) scanRetry(w http.ResponseWriter, r *http.Request) {
 		FocusArea:         scan.FocusArea,
 		SessionID:         sessionID,
 		ResumedFromScanID: resumeOf,
+		ParentScanID:      &scan.ID,
 		// An ingest scan's input is the uploaded payload, not ./src;
 		// without it the retry stages no import/report and the model
 		// runs against a missing file.
@@ -340,6 +341,7 @@ func (s *Server) scansRetryFailed(w http.ResponseWriter, r *http.Request) {
 	var retried, errored int
 	for _, sc := range scans {
 		sessionID, resumeOf := s.resumeOpts(sc)
+		parent := sc.ID
 		if _, err := s.enqueueSkillWith(r.Context(), sc.RepositoryID, *sc.SkillID, ScanOpts{
 			Model:             sc.Model,
 			Effort:            sc.Effort,
@@ -354,6 +356,7 @@ func (s *Server) scansRetryFailed(w http.ResponseWriter, r *http.Request) {
 			FocusArea:         sc.FocusArea,
 			SessionID:         sessionID,
 			ResumedFromScanID: resumeOf,
+			ParentScanID:      &parent,
 			ImportPayload:     sc.ImportPayload,
 		}); err != nil {
 			errored++

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -3053,6 +3053,11 @@ type ScanOpts struct {
 	// on a normal (non-resuming) enqueue. See scanRetry.
 	SessionID         string
 	ResumedFromScanID *uint
+	// ParentScanID records the scan this enqueue is a rerun of. Unlike
+	// ResumedFromScanID it is the immediate parent and is set on every
+	// retry, including retries that start a fresh harness session, so the
+	// rerun chain stays walkable hop by hop. Nil on a first-time enqueue.
+	ParentScanID *uint
 	// ImportPayload is the raw uploaded report for an ingest-skill run
 	// created by the /v1/import fallback; the worker stages it into the
 	// workspace at import/report. Empty for every other enqueue.
@@ -3184,6 +3189,7 @@ func (s *Server) enqueueSkillWith(ctx context.Context, repoID, skillID uint, opt
 		Profile:            opts.Profile,
 		SessionID:          opts.SessionID,
 		ResumedFromScanID:  opts.ResumedFromScanID,
+		ParentScanID:       opts.ParentScanID,
 		ImportPayload:      opts.ImportPayload,
 		SkillsRepoSHA:      s.SkillsRepoSHA,
 		APIToken:           NewAPIToken(),

--- a/internal/worker/recipe.go
+++ b/internal/worker/recipe.go
@@ -1,0 +1,113 @@
+package worker
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+
+	"scrutineer/internal/db"
+)
+
+// ScanRecipe is the immutable snapshot of the inputs a worker was handed when
+// it claimed a scan. It answers "what was this run asked to do", which the
+// individual Scan columns stop answering over time: several of them are
+// mutable, some are backfilled after the fact, and the threat model and scan
+// config that shaped the run live on Repository, where a later edit leaves no
+// trace that the scan ran against the older text.
+//
+// Two deliberate omissions, both because a recipe that is written once cannot
+// carry a value that does not exist yet at claim time:
+//
+//   - The resolved commit. Scan.Commit is set from gitHead after the clone
+//     (skill.go), which is well after the claim, so a recipe written at pickup
+//     would pin an empty string forever. Recipe.Ref records what was asked for;
+//     Scan.Commit remains the record of what that resolved to.
+//   - The runner image digest, effective tool set and egress policy. Those are
+//     properties of the container the scan runs in, which is not created until
+//     after the claim either.
+type ScanRecipe struct {
+	Kind string `json:"kind,omitempty"`
+
+	// Ref is the requested git ref, not the commit it resolved to. Empty
+	// means the repository's default branch.
+	Ref string `json:"ref,omitempty"`
+
+	// Backend is the backend the worker resolved at claim time, which is
+	// not necessarily the one recorded when the scan was queued.
+	Backend string `json:"backend,omitempty"`
+	Model   string `json:"model,omitempty"`
+	Effort  string `json:"effort,omitempty"`
+
+	Skill              string `json:"skill,omitempty"`
+	SkillVersion       int    `json:"skill_version,omitempty"`
+	SkillSchemaVersion int    `json:"skill_schema_version,omitempty"`
+	SkillsRepoSHA      string `json:"skills_repo_sha,omitempty"`
+
+	Profile   string `json:"profile,omitempty"`
+	SubPath   string `json:"sub_path,omitempty"`
+	ScopeMode string `json:"scope_mode,omitempty"`
+
+	// FocusArea is embedded as parsed JSON rather than an escaped string so
+	// a recipe diff shows the focus fields that changed, not one opaque
+	// blob. Invalid JSON is dropped rather than failing the claim.
+	FocusArea json.RawMessage `json:"focus_area,omitempty"`
+
+	RescanMode     string `json:"rescan_mode,omitempty"`
+	DiffBaseScanID *uint  `json:"diff_base_scan_id,omitempty"`
+
+	// ParentScanID is the scan this one was enqueued as a rerun of, so a
+	// chain of reruns can be walked one hop at a time. It is distinct from
+	// ResumedFromScanID, which pins the lineage *root* for session reuse.
+	ParentScanID *uint `json:"parent_scan_id,omitempty"`
+
+	// ThreatModelSHA256 and ScanConfigSHA256 digest the Repository text in
+	// effect at claim time, so a rerun after an edit is distinguishable
+	// from one before it. Absent when the repository had none set.
+	ThreatModelSHA256 string `json:"threat_model_sha256,omitempty"`
+	ScanConfigSHA256  string `json:"scan_config_sha256,omitempty"`
+}
+
+// textDigest returns the hex SHA-256 of s, or "" when s is empty, so an
+// unset threat model is absent from the recipe rather than recorded as the
+// digest of the empty string.
+func textDigest(s string) string {
+	if s == "" {
+		return ""
+	}
+	sum := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(sum[:])
+}
+
+// buildScanRecipe renders the recipe for scan as JSON. backend is passed
+// separately because the worker resolves it during the claim and the value on
+// scan may still be the one recorded at enqueue. threatModel and scanConfig
+// are the repository's text as read inside the claiming transaction.
+func buildScanRecipe(scan *db.Scan, backend, threatModel, scanConfig string) (string, error) {
+	r := ScanRecipe{
+		Kind:               scan.Kind,
+		Ref:                scan.Ref,
+		Backend:            backend,
+		Model:              scan.Model,
+		Effort:             scan.Effort,
+		Skill:              scan.SkillName,
+		SkillVersion:       scan.SkillVersion,
+		SkillSchemaVersion: scan.SkillSchemaVersion,
+		SkillsRepoSHA:      scan.SkillsRepoSHA,
+		Profile:            scan.Profile,
+		SubPath:            scan.SubPath,
+		ScopeMode:          scan.ScopeMode,
+		RescanMode:         scan.RescanMode,
+		DiffBaseScanID:     scan.DiffBaseScanID,
+		ParentScanID:       scan.ParentScanID,
+		ThreatModelSHA256:  textDigest(threatModel),
+		ScanConfigSHA256:   textDigest(scanConfig),
+	}
+	if scan.FocusArea != "" && json.Valid([]byte(scan.FocusArea)) {
+		r.FocusArea = json.RawMessage(scan.FocusArea)
+	}
+	b, err := json.Marshal(r)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}

--- a/internal/worker/recipe_test.go
+++ b/internal/worker/recipe_test.go
@@ -1,0 +1,242 @@
+package worker
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"path/filepath"
+	"testing"
+
+	"scrutineer/internal/db"
+)
+
+// backendRunner reports a backend the way the real harnesses do, so the claim
+// resolves one instead of falling back to the value stored at enqueue.
+type backendRunner struct{ backend string }
+
+func (backendRunner) RunSkill(context.Context, SkillJob, func(Event)) (SkillResult, error) {
+	return SkillResult{}, nil
+}
+
+func (backendRunner) SkillDir(workRoot, name string) string {
+	return ClaudeHarness{}.SkillDir(workRoot, name)
+}
+
+func (b backendRunner) Backend() string { return b.backend }
+
+func newRecipeWorker(t *testing.T, threatModel, scanConfig, backend string) (*Worker, db.Scan, uint) {
+	t.Helper()
+	gdb, err := db.Open(filepath.Join(t.TempDir(), "recipe.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo := db.Repository{
+		URL:         "https://example.com/x",
+		Name:        "x",
+		ThreatModel: threatModel,
+		ScanConfig:  scanConfig,
+	}
+	gdb.Create(&repo)
+	skill := db.Skill{Name: "deep-dive", Description: "x", Body: "b", Active: true, Source: "ui", Version: 7}
+	gdb.Create(&skill)
+	scan := db.Scan{
+		RepositoryID:       repo.ID,
+		Kind:               JobSkill,
+		Status:             db.ScanQueued,
+		SkillID:            &skill.ID,
+		SkillName:          "deep-dive",
+		SkillVersion:       7,
+		SkillSchemaVersion: 3,
+		Model:              "sonnet",
+		Effort:             "high",
+		Ref:                "release-2.1",
+		Profile:            "ruby",
+		SubPath:            "core",
+		SkillsRepoSHA:      "abc123",
+		// The backend recorded at enqueue, which the claim re-resolves.
+		Backend: "codex",
+	}
+	gdb.Create(&scan)
+	w := &Worker{
+		DB:             gdb,
+		Log:            slog.New(slog.NewTextHandler(io.Discard, nil)),
+		DataDir:        t.TempDir(),
+		Runner:         backendRunner{backend: backend},
+		PrepareRepoSrc: stubPrepareRepoSrc,
+	}
+	return w, scan, repo.ID
+}
+
+func recipeOf(t *testing.T, w *Worker, scanID uint) ScanRecipe {
+	t.Helper()
+	var got db.Scan
+	if err := w.DB.First(&got, scanID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if got.Recipe == "" {
+		t.Fatal("no recipe was written at claim")
+	}
+	var r ScanRecipe
+	if err := json.Unmarshal([]byte(got.Recipe), &r); err != nil {
+		t.Fatalf("recipe is not valid JSON: %v (%s)", err, got.Recipe)
+	}
+	return r
+}
+
+func TestStartScan_writesRecipeSnapshotAtClaim(t *testing.T) {
+	w, scan, _ := newRecipeWorker(t, "threats: sql injection", "paths:\n  - core", "claude")
+	if err := w.startScan(&scan); err != nil {
+		t.Fatalf("startScan: %v", err)
+	}
+
+	r := recipeOf(t, w, scan.ID)
+	if r.Ref != "release-2.1" {
+		t.Errorf("ref = %q, want release-2.1", r.Ref)
+	}
+	if r.Skill != "deep-dive" || r.SkillVersion != 7 || r.SkillSchemaVersion != 3 {
+		t.Errorf("skill pin = %q/%d/%d, want deep-dive/7/3", r.Skill, r.SkillVersion, r.SkillSchemaVersion)
+	}
+	if r.Profile != "ruby" || r.SubPath != "core" || r.SkillsRepoSHA != "abc123" {
+		t.Errorf("profile/subpath/skills sha = %q/%q/%q", r.Profile, r.SubPath, r.SkillsRepoSHA)
+	}
+	// The backend the worker resolved, not the one the row carried in.
+	if r.Backend != "claude" {
+		t.Errorf("backend = %q, want the claim-time claude, not the enqueued codex", r.Backend)
+	}
+	if r.ThreatModelSHA256 == "" || r.ScanConfigSHA256 == "" {
+		t.Errorf("digests = %q/%q, want both set", r.ThreatModelSHA256, r.ScanConfigSHA256)
+	}
+	if r.ThreatModelSHA256 == r.ScanConfigSHA256 {
+		t.Error("threat model and scan config digest the same value")
+	}
+}
+
+// The recipe exists to record what the worker started from, and a paused scan
+// returns to `queued` on the same row rather than as a new one, so the claim
+// runs again on a scan that already has a recipe. Without the write-once guard
+// the second claim overwrites the first pickup's snapshot with the state at
+// resume time, which is precisely the history the column is for. The backend is
+// the sharpest case: it is re-resolved on every claim, so a -backend switch
+// across the pause would silently restamp the original recipe.
+func TestStartScan_recipeSurvivesAPausedScanResuming(t *testing.T) {
+	w, scan, repoID := newRecipeWorker(t, "threats: sql injection", "paths:\n  - core", "claude")
+	if err := w.startScan(&scan); err != nil {
+		t.Fatalf("first claim: %v", err)
+	}
+	first := recipeOf(t, w, scan.ID)
+
+	// Pause, then edit both things the recipe pins, then resume the same row
+	// the way scansResume and the account-pause auto-resume do.
+	if err := w.DB.Model(&db.Scan{}).Where("id = ?", scan.ID).
+		Update("status", db.ScanPaused).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := w.DB.Model(&db.Repository{}).Where("id = ?", repoID).
+		Update("threat_model", "threats: sql injection AND ssrf").Error; err != nil {
+		t.Fatal(err)
+	}
+	w.Runner = backendRunner{backend: "codex"}
+	if err := w.DB.Model(&db.Scan{}).Where("id = ?", scan.ID).
+		Update("status", db.ScanQueued).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	var requeued db.Scan
+	if err := w.DB.First(&requeued, scan.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := w.startScan(&requeued); err != nil {
+		t.Fatalf("second claim: %v", err)
+	}
+
+	second := recipeOf(t, w, scan.ID)
+	if second.Backend != first.Backend {
+		t.Errorf("backend = %q after resume, want the first pickup's %q", second.Backend, first.Backend)
+	}
+	if second.ThreatModelSHA256 != first.ThreatModelSHA256 {
+		t.Errorf("threat model digest = %q after resume, want the first pickup's %q",
+			second.ThreatModelSHA256, first.ThreatModelSHA256)
+	}
+}
+
+// #773 lists `commit` first in the recipe, but Scan.Commit is resolved from
+// gitHead after the clone, which is well after the claim. A recipe written at
+// pickup can only ever record the empty string for it, so the field is left out
+// and Scan.Commit stays the record of what the ref resolved to. This pins the
+// premise: if the commit ever becomes known at claim time, this test fails and
+// the omission should be revisited.
+func TestStartScan_commitIsNotKnownAtClaimTime(t *testing.T) {
+	w, scan, _ := newRecipeWorker(t, "", "", "claude")
+	if err := w.startScan(&scan); err != nil {
+		t.Fatalf("startScan: %v", err)
+	}
+	var got db.Scan
+	if err := w.DB.First(&got, scan.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if got.Commit != "" {
+		t.Fatalf("commit = %q at claim time; the recipe could carry it after all", got.Commit)
+	}
+	if got.StartedAt == nil {
+		t.Error("the scan did claim, so this is a real claim-time observation")
+	}
+}
+
+func TestBuildScanRecipe_digestsAndOptionalFields(t *testing.T) {
+	base := &db.Scan{Kind: JobSkill, SkillName: "deep-dive"}
+
+	// An unset threat model is absent rather than recorded as the digest of
+	// the empty string, so "no threat model" cannot be mistaken for one.
+	empty, err := buildScanRecipe(base, "claude", "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var r ScanRecipe
+	if err := json.Unmarshal([]byte(empty), &r); err != nil {
+		t.Fatal(err)
+	}
+	if r.ThreatModelSHA256 != "" || r.ScanConfigSHA256 != "" {
+		t.Errorf("digests = %q/%q for unset text, want both absent", r.ThreatModelSHA256, r.ScanConfigSHA256)
+	}
+
+	// An edit to the threat model has to change the digest, or a rerun
+	// before and after the edit stays indistinguishable — the thing #773
+	// exists to fix.
+	before, err := buildScanRecipe(base, "claude", "threats: a", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	after, err := buildScanRecipe(base, "claude", "threats: a and b", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if before == after {
+		t.Error("recipe is unchanged across a threat-model edit")
+	}
+
+	// A focus area is embedded as JSON so a recipe diff shows which focus
+	// fields moved; invalid JSON is dropped rather than failing the claim.
+	withFocus := *base
+	withFocus.FocusArea = `{"area":"auth"}`
+	out, err := buildScanRecipe(&withFocus, "claude", "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal([]byte(out), &r); err != nil {
+		t.Fatal(err)
+	}
+	if string(r.FocusArea) != `{"area":"auth"}` {
+		t.Errorf("focus_area = %s, want embedded JSON", r.FocusArea)
+	}
+
+	broken := *base
+	broken.FocusArea = "not json"
+	out, err = buildScanRecipe(&broken, "claude", "", "")
+	if err != nil {
+		t.Fatalf("a malformed focus area must not fail the claim: %v", err)
+	}
+	if !json.Valid([]byte(out)) {
+		t.Errorf("recipe is not valid JSON with a malformed focus area: %s", out)
+	}
+}

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -759,11 +759,35 @@ func (w *Worker) startScan(scan *db.Scan) error {
 			return errScanClaimLost
 		}
 		var repo db.Repository
-		if err := tx.Select("id, federation_opt_out_at").First(&repo, scan.RepositoryID).Error; err != nil {
+		if err := tx.Select("id, federation_opt_out_at, threat_model, scan_config").First(&repo, scan.RepositoryID).Error; err != nil {
 			return err
 		}
 		if repo.FederationOptedOut() {
 			return errRepoOptedOut
+		}
+		// Snapshot the inputs this run was handed, including digests of the
+		// repository threat model and scan config as they stand inside this
+		// transaction. Guarded on emptiness in SQL rather than on the
+		// in-memory value: the claim above can run more than once per row,
+		// because resuming a paused scan puts it back to `queued` instead of
+		// creating a new one, and rewriting the recipe then would replace the
+		// state at first pickup with the state at the latest resume — losing
+		// exactly the provenance the column exists to keep. `backend` is a
+		// standing example: it is re-resolved on every claim, so a scan
+		// paused before a -backend switch and resumed after would have its
+		// recipe silently restamped with the new one.
+		recipe, err := buildScanRecipe(scan, backend, repo.ThreatModel, repo.ScanConfig)
+		if err != nil {
+			return err
+		}
+		sealed := tx.Model(&db.Scan{}).
+			Where("id = ? AND (recipe IS NULL OR recipe = '')", scan.ID).
+			Update("recipe", recipe)
+		if sealed.Error != nil {
+			return sealed.Error
+		}
+		if sealed.RowsAffected > 0 {
+			scan.Recipe = recipe
 		}
 		scan.Status = db.ScanRunning
 		scan.StatusPriority = db.StatusPriorityFor(db.ScanRunning)


### PR DESCRIPTION
Closes #773.

Adds `Scan.Recipe` — an immutable JSON snapshot of the inputs the worker was handed — written once inside the transaction that claims the scan, plus `Scan.ParentScanID` so a chain of reruns can be walked hop by hop.

### Three things the issue's design collides with in the current code

**1. The claim can run more than once per row, so "written once at pickup" needs a guard.**

Resuming a paused scan puts the *same row* back to `queued` — operator resume (`scans.go:532`), bulk resume-all (`scans.go:431`), and the account-pause auto-resume (`worker.go:1173`) — rather than enqueuing a new one. So `startScan` claims some rows twice, and an unguarded write would replace the first pickup's snapshot with the state at the latest resume: exactly the history the column exists to keep.

`backend` is the sharpest case, because the claim re-resolves it from the runner on every pass. Proven rather than argued — with only the SQL guard removed, `TestStartScan_recipeSurvivesAPausedScanResuming` reports:

```
backend = "codex" after resume, want the first pickup's "claude"
threat model digest = "2a6d9d5c..." after resume, want the first pickup's "e593c4db..."
```

A scan paused before a `-backend` switch and resumed after would have its provenance silently restamped. The guard is `WHERE id = ? AND (recipe IS NULL OR recipe = '')` — enforced in SQL rather than on the in-memory value, since the row can be claimed by a pass whose struct never carried the recipe.

**2. `commit` cannot be in a recipe written at pickup.** The issue lists it first, but `Scan.Commit` is set from `gitHead` after the clone (`skill.go:174`), well after the claim, so a recipe written at pickup can only ever pin the empty string. `Recipe.Ref` records what was *asked for*; `Scan.Commit` stays the record of what it resolved to. `TestStartScan_commitIsNotKnownAtClaimTime` pins that premise, so if the commit ever becomes known at claim time the test fails and the omission gets revisited rather than quietly outliving its reason. Same reasoning drops `runner_image_digest`, `allowed_tools` and `egress_policy` from your follow-up comment — all properties of a container that does not exist yet at claim — and `preflight_probe_id`, which waits on #772.

**3. `ResumedFromScanID` looks like `parent_scan_id` but cannot do its job.** It is pinned to the lineage *root* (deliberately — it addresses one workspace across N retries), and `resumeOpts` only sets it when the retry actually resumes a harness session, so a retry of a `done` or `cancelled` scan has a parent and no link at all. Walking a chain "each hop diffed against its parent's recipe" needs the immediate parent on every rerun, so `ParentScanID` is a separate column set by both retry paths (`scanRetry`, `scansRetryFailed`), and the doc comments on each say why they are not one field.

### Recipe contents

`kind`, `ref`, `backend` (resolved at claim), `model`, `effort`, `skill`/`skill_version`/`skill_schema_version`/`skills_repo_sha`, `profile`, `sub_path`, `scope_mode`, `focus_area`, `rescan_mode`, `diff_base_scan_id`, `parent_scan_id`, and `threat_model_sha256` / `scan_config_sha256` for the `Repository` text in effect inside the claiming transaction — the part nothing else records, and the reason a rerun before and after a threat-model edit is currently indistinguishable.

`focus_area` embeds as parsed JSON rather than an escaped string so a recipe diff shows which focus fields moved instead of one opaque blob; malformed JSON is dropped rather than failing the claim. Unset threat model / scan config are *absent* rather than recorded as the digest of the empty string, so "none set" cannot be misread as a real digest.

The claim's existing `Repository` read widens from `id, federation_opt_out_at` to include `threat_model, scan_config` — still two more columns rather than loading the row.

### Tests

Five, all in `internal/worker`: the snapshot written at claim (asserting the resolved backend wins over the enqueued one); the resume guard above, **verified failing on unguarded code first**; the commit-at-claim premise; and digest/optional-field behaviour (edit changes the digest, unset is absent, embedded and malformed focus areas). `go build ./...`, `go vet ./internal/...`, `gofmt` clean.

### Droppable if you'd rather

- **`ParentScanID`** is separable — if you'd prefer to widen `ResumedFromScanID` to every retry and keep the root separately, say so and I'll cut this half; I went the other way because changing it would move the workspace-pinning behaviour that field's comment is explicit about.
- **`focus_area` as embedded JSON** could just as well be the raw string if you want the recipe byte-comparable against the column.
- Nothing here reads the recipe back yet — no UI or API surface — since #773 scopes it to recording. Happy to add a scan-page row or a recipe diff between a scan and its parent in a follow-up.
