### PR TITLE
feat: show Disclosure title

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -873,6 +873,13 @@ type Finding struct {
 	ReleaseURL      string
 	Resolution      FindingResolution `gorm:"index"`
 	DisclosureDraft string            `gorm:"type:text"`
+	// DisclosureTitle is the disclose skill's drafted GHSA summary
+	// (report.json's ghsa.summary), which may differ from Finding.Title:
+	// the finding's own title is set at audit time and preserved across
+	// disclose re-runs, while this is the disclosure-specific headline
+	// meant for the GHSA/VINCE form. Analyst-editable like the rest of
+	// this block.
+	DisclosureTitle string `gorm:"type:text"`
 	// SuggestedRecipients routes the disclosure to the file-level owners
 	// of Location (CODEOWNERS entries or, absent those, recent non-bot
 	// committers) because the repo-level maintainers list is too coarse

--- a/internal/db/finding_helpers.go
+++ b/internal/db/finding_helpers.go
@@ -429,74 +429,48 @@ func SeverityAtLeast(got, threshold string) bool {
 	return rank(SeverityLevels, got) >= rank(SeverityLevels, threshold)
 }
 
-// findingFieldAccessor maps the API-facing field name to the current
-// value and the DB column name. It is the single list of mutable fields;
-// adding a new editable field means adding it here.
+// findingFieldAccessors maps every API-facing editable field name to a getter
+// on Finding. It is the single list of mutable fields; adding a new editable
+// field means adding it here. The DB column name is always the API field name.
+var findingFieldAccessors = map[string]func(*Finding) string{
+	"title":                      func(f *Finding) string { return f.Title },
+	"severity":                   func(f *Finding) string { return f.Severity },
+	"status":                     func(f *Finding) string { return string(f.Status) },
+	"cwe":                        func(f *Finding) string { return f.CWE },
+	"location":                   func(f *Finding) string { return f.Location },
+	"affected":                   func(f *Finding) string { return f.Affected },
+	"reachability":               func(f *Finding) string { return f.Reachability },
+	"quality_tier":               func(f *Finding) string { return f.QualityTier },
+	"cve_id":                     func(f *Finding) string { return f.CVEID },
+	"ghsa_id":                    func(f *Finding) string { return f.GHSAID },
+	"cvss_vector":                func(f *Finding) string { return f.CVSSVector },
+	"cvss_v4_vector":             func(f *Finding) string { return f.CVSSv4Vector },
+	"fix_version":                func(f *Finding) string { return f.FixVersion },
+	"fix_commit":                 func(f *Finding) string { return f.FixCommit },
+	"resolution":                 func(f *Finding) string { return string(f.Resolution) },
+	"disclosure_draft":           func(f *Finding) string { return f.DisclosureDraft },
+	"disclosure_title":           func(f *Finding) string { return f.DisclosureTitle },
+	"suggested_recipients":       func(f *Finding) string { return f.SuggestedRecipients },
+	"assignee":                   func(f *Finding) string { return f.Assignee },
+	"suggested_fix":              func(f *Finding) string { return f.SuggestedFix },
+	"suggested_fix_commit":       func(f *Finding) string { return f.SuggestedFixCommit },
+	"breaking_change":            func(f *Finding) string { return f.BreakingChange },
+	"breaking_change_rationale":  func(f *Finding) string { return f.BreakingChangeRationale },
+	"exploited_in_wild":          func(f *Finding) string { return f.ExploitedInWild },
+	"exploited_in_wild_evidence": func(f *Finding) string { return f.ExploitedInWildEvidence },
+	"mitigation":                 func(f *Finding) string { return f.Mitigation },
+	"mitigation_semgrep":         func(f *Finding) string { return f.MitigationSemgrep },
+	"release_tag":                func(f *Finding) string { return f.ReleaseTag },
+	"release_url":                func(f *Finding) string { return f.ReleaseURL },
+	"last_revalidate_verdict":    func(f *Finding) string { return f.LastRevalidateVerdict },
+}
+
 func findingFieldAccessor(f *Finding, field string) (current, column string, err error) {
-	switch field {
-	case "title":
-		return f.Title, "title", nil
-	case "severity":
-		return f.Severity, "severity", nil
-	case "status":
-		return string(f.Status), "status", nil
-	case "cwe":
-		return f.CWE, "cwe", nil
-	case "location":
-		return f.Location, "location", nil
-	case "affected":
-		return f.Affected, "affected", nil
-	case "reachability":
-		return f.Reachability, "reachability", nil
-	case "quality_tier":
-		return f.QualityTier, "quality_tier", nil
-	case "cve_id":
-		return f.CVEID, "cve_id", nil
-	case "ghsa_id":
-		return f.GHSAID, "ghsa_id", nil
-	case "cvss_vector":
-		return f.CVSSVector, "cvss_vector", nil
-	case "cvss_v4_vector":
-		return f.CVSSv4Vector, "cvss_v4_vector", nil
-	case "fix_version":
-		return f.FixVersion, "fix_version", nil
-	case "fix_commit":
-		return f.FixCommit, "fix_commit", nil
-	case "resolution":
-		return string(f.Resolution), "resolution", nil
-	case "disclosure_draft":
-		return f.DisclosureDraft, "disclosure_draft", nil
-	case "disclosure_title":
-		return f.DisclosureTitle, "disclosure_title", nil
-	case "suggested_recipients":
-		return f.SuggestedRecipients, "suggested_recipients", nil
-	case "assignee":
-		return f.Assignee, "assignee", nil
-	case "suggested_fix":
-		return f.SuggestedFix, "suggested_fix", nil
-	case "suggested_fix_commit":
-		return f.SuggestedFixCommit, "suggested_fix_commit", nil
-	case "breaking_change":
-		return f.BreakingChange, "breaking_change", nil
-	case "breaking_change_rationale":
-		return f.BreakingChangeRationale, "breaking_change_rationale", nil
-	case "exploited_in_wild":
-		return f.ExploitedInWild, "exploited_in_wild", nil
-	case "exploited_in_wild_evidence":
-		return f.ExploitedInWildEvidence, "exploited_in_wild_evidence", nil
-	case "mitigation":
-		return f.Mitigation, "mitigation", nil
-	case "mitigation_semgrep":
-		return f.MitigationSemgrep, "mitigation_semgrep", nil
-	case "release_tag":
-		return f.ReleaseTag, "release_tag", nil
-	case "release_url":
-		return f.ReleaseURL, "release_url", nil
-	case "last_revalidate_verdict":
-		return f.LastRevalidateVerdict, "last_revalidate_verdict", nil
-	default:
+	get, ok := findingFieldAccessors[field]
+	if !ok {
 		return "", "", fmt.Errorf("field %q is not editable", field)
 	}
+	return get(f), field, nil
 }
 
 // AddFindingNote appends a timestamped note.

--- a/internal/db/finding_helpers.go
+++ b/internal/db/finding_helpers.go
@@ -466,6 +466,8 @@ func findingFieldAccessor(f *Finding, field string) (current, column string, err
 		return string(f.Resolution), "resolution", nil
 	case "disclosure_draft":
 		return f.DisclosureDraft, "disclosure_draft", nil
+	case "disclosure_title":
+		return f.DisclosureTitle, "disclosure_title", nil
 	case "suggested_recipients":
 		return f.SuggestedRecipients, "suggested_recipients", nil
 	case "assignee":

--- a/internal/db/finding_helpers_test.go
+++ b/internal/db/finding_helpers_test.go
@@ -628,7 +628,7 @@ var editableFindingFields = []string{
 	"title", "severity", "status", "cwe", "location", "affected",
 	"reachability", "quality_tier", "cve_id", "ghsa_id",
 	"cvss_vector", "cvss_v4_vector", "fix_version", "fix_commit",
-	"resolution", "disclosure_draft", "assignee",
+	"resolution", "disclosure_draft", "disclosure_title", "assignee",
 	"suggested_fix", "suggested_fix_commit",
 	"breaking_change", "breaking_change_rationale",
 	"exploited_in_wild", "exploited_in_wild_evidence",

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -123,6 +123,7 @@ type Finding struct {
 	BreakingChangeRationale string
 	DupCheck                string
 	DisclosureDraft         string
+	DisclosureTitle         string
 	SuggestedRecipients     string
 	ExploitedInWild         string
 	ExploitedInWildEvidence string

--- a/internal/ingest/minimal.go
+++ b/internal/ingest/minimal.go
@@ -61,6 +61,7 @@ type minimalFinding struct {
 	BreakingChangeRationale string `json:"breaking_change_rationale"`
 	DupCheck                string `json:"dup_check"`
 	DisclosureDraft         string `json:"disclosure_draft"`
+	DisclosureTitle         string `json:"disclosure_title"`
 	SuggestedRecipients     string `json:"suggested_recipients"`
 	ExploitedInWild         string `json:"exploited_in_wild"`
 	ExploitedInWildEvidence string `json:"exploited_in_wild_evidence"`
@@ -148,6 +149,7 @@ func parseMinimal(data []byte) ([]Result, error) {
 			BreakingChangeRationale: f.BreakingChangeRationale,
 			DupCheck:                f.DupCheck,
 			DisclosureDraft:         f.DisclosureDraft,
+			DisclosureTitle:         f.DisclosureTitle,
 			SuggestedRecipients:     f.SuggestedRecipients,
 			ExploitedInWild:         f.ExploitedInWild,
 			ExploitedInWildEvidence: f.ExploitedInWildEvidence,

--- a/internal/web/api_export.go
+++ b/internal/web/api_export.go
@@ -321,6 +321,7 @@ type sharingFinding struct {
 	BreakingChangeRationale string `json:"breaking_change_rationale,omitempty"`
 	DupCheck                string `json:"dup_check,omitempty"`
 	DisclosureDraft         string `json:"disclosure_draft,omitempty"`
+	DisclosureTitle         string `json:"disclosure_title,omitempty"`
 	SuggestedRecipients     string `json:"suggested_recipients,omitempty"`
 	ExploitedInWild         string `json:"exploited_in_wild,omitempty"`
 	ExploitedInWildEvidence string `json:"exploited_in_wild_evidence,omitempty"`
@@ -441,6 +442,7 @@ func (s *Server) apiExportRepoBundle(w http.ResponseWriter, r *http.Request, rep
 			sf.BreakingChangeRationale = f.BreakingChangeRationale
 			sf.DupCheck = f.DupCheck
 			sf.DisclosureDraft = f.DisclosureDraft
+			sf.DisclosureTitle = f.DisclosureTitle
 			sf.SuggestedRecipients = f.SuggestedRecipients
 			sf.ExploitedInWild = f.ExploitedInWild
 			sf.ExploitedInWildEvidence = f.ExploitedInWildEvidence

--- a/internal/web/api_export.go
+++ b/internal/web/api_export.go
@@ -792,6 +792,7 @@ func findingExport(f db.Finding) map[string]any {
 		"fix_commit":           f.FixCommit,
 		"resolution":           string(f.Resolution),
 		"disclosure_draft":     f.DisclosureDraft,
+		"disclosure_title":     f.DisclosureTitle,
 		"suggested_recipients": f.SuggestedRecipients,
 		"assignee":             f.Assignee,
 		"trace":                f.Trace,

--- a/internal/web/api_export_test.go
+++ b/internal/web/api_export_test.go
@@ -1353,7 +1353,7 @@ func TestExportFindings_carriesDBFields(t *testing.T) {
 		"finding_id", "sinks", "title", "severity", "status", "cwe", "location", "affected",
 		"reachability", "quality_tier",
 		"cve_id", "cvss_vector", "cvss_score", "fix_version", "fix_commit",
-		"resolution", "disclosure_draft", "suggested_recipients", "assignee",
+		"resolution", "disclosure_draft", "disclosure_title", "suggested_recipients", "assignee",
 		"trace", "boundary", "validation", "prior_art", "reach", "rating",
 		"created_at", "updated_at",
 	}
@@ -1464,6 +1464,7 @@ func seedRichFinding(t *testing.T, s *Server, url string) db.Repository {
 		BreakingChangeRationale: "no public API change",
 		DupCheck:                "distinct from F2: different sink",
 		DisclosureDraft:         "## Advisory\nPath traversal in download()",
+		DisclosureTitle:         "Path traversal in download()",
 		SuggestedRecipients:     "@alice (CODEOWNERS: crypto/*)",
 		ExploitedInWild:         "no",
 		ExploitedInWildEvidence: "no reports as of 2026-07",
@@ -1844,7 +1845,8 @@ func TestExportBundle_includeAllCarriesArchival(t *testing.T) {
 		t.Errorf("default sinks = %q, want path.join,os.Open", def.Sinks)
 	}
 	if def.Snippet != "" || def.Affected != "" || def.CVEID != "" || def.CVSSVector != "" ||
-		def.DisclosureDraft != "" || def.SuggestedRecipients != "" || def.ExploitedInWild != "" || def.UpstreamFixCommit != "" {
+		def.DisclosureDraft != "" || def.DisclosureTitle != "" || def.SuggestedRecipients != "" ||
+		def.ExploitedInWild != "" || def.UpstreamFixCommit != "" {
 		t.Errorf("default bundle carried archival scalars: %+v", def)
 	}
 	if len(def.Notes) != 0 || len(def.Communications) != 0 || len(def.References) != 0 {
@@ -1868,6 +1870,7 @@ func TestExportBundle_includeAllCarriesArchival(t *testing.T) {
 		{"breaking_change_rationale", all.BreakingChangeRationale, "no public API change"},
 		{"dup_check", all.DupCheck, "distinct from F2: different sink"},
 		{"disclosure_draft", all.DisclosureDraft, "## Advisory\nPath traversal in download()"},
+		{"disclosure_title", all.DisclosureTitle, "Path traversal in download()"},
 		{"suggested_recipients", all.SuggestedRecipients, "@alice (CODEOWNERS: crypto/*)"},
 		{"exploited_in_wild", all.ExploitedInWild, "no"},
 		{"exploited_in_wild_evidence", all.ExploitedInWildEvidence, "no reports as of 2026-07"},
@@ -1943,6 +1946,7 @@ func TestExportBundleRoundTrip_includeAll(t *testing.T) {
 		{"breaking_change_rationale", got.BreakingChangeRationale, "no public API change"},
 		{"dup_check", got.DupCheck, "distinct from F2: different sink"},
 		{"disclosure_draft", got.DisclosureDraft, "## Advisory\nPath traversal in download()"},
+		{"disclosure_title", got.DisclosureTitle, "Path traversal in download()"},
 		{"suggested_recipients", got.SuggestedRecipients, "@alice (CODEOWNERS: crypto/*)"},
 		{"exploited_in_wild", got.ExploitedInWild, "no"},
 		{"exploited_in_wild_evidence", got.ExploitedInWildEvidence, "no reports as of 2026-07"},

--- a/internal/web/api_reads.go
+++ b/internal/web/api_reads.go
@@ -375,6 +375,7 @@ func (s *Server) apiGetFinding(w http.ResponseWriter, r *http.Request) {
 	summary["reach"] = f.Reach
 	summary["rating"] = f.Rating
 	summary["disclosure_draft"] = f.DisclosureDraft
+	summary["disclosure_title"] = f.DisclosureTitle
 	summary["suggested_recipients"] = f.SuggestedRecipients
 	summary["suggested_fix"] = f.SuggestedFix
 	summary["suggested_fix_commit"] = f.SuggestedFixCommit

--- a/internal/web/finding_forms.go
+++ b/internal/web/finding_forms.go
@@ -21,7 +21,7 @@ import (
 var analystFields = []string{
 	"title", "severity", "cwe", "location", "affected",
 	"cve_id", "ghsa_id", "cvss_vector", "cvss_v4_vector", "fix_version", "fix_commit",
-	"resolution", "disclosure_draft", "suggested_recipients", "assignee",
+	"resolution", "disclosure_draft", "disclosure_title", "suggested_recipients", "assignee",
 }
 
 func (s *Server) findingFields(w http.ResponseWriter, r *http.Request) {

--- a/internal/web/finding_forms_test.go
+++ b/internal/web/finding_forms_test.go
@@ -32,6 +32,7 @@ func TestFindingFields(t *testing.T) {
 		"severity":             {"Critical"},
 		"cve_id":               {" CVE-2026-12345 "},
 		"affected":             {">=1.0.0 <2.0.0"},
+		"disclosure_title":     {"Analyst-set advisory summary"},
 		"suggested_recipients": {"@alice (CODEOWNERS: crypto/*)"},
 		"ignored":              {"x"}, // not in analystFields, dropped
 		"resolution":           {""},  // present but unchanged, no-op
@@ -46,14 +47,15 @@ func TestFindingFields(t *testing.T) {
 	var got db.Finding
 	s.DB.First(&got, f.ID)
 	if got.Severity != "Critical" || got.CVEID != "CVE-2026-12345" || got.Affected != ">=1.0.0 <2.0.0" ||
+		got.DisclosureTitle != "Analyst-set advisory summary" ||
 		got.SuggestedRecipients != "@alice (CODEOWNERS: crypto/*)" {
-		t.Errorf("after edit: severity=%q cve=%q affected=%q recipients=%q",
-			got.Severity, got.CVEID, got.Affected, got.SuggestedRecipients)
+		t.Errorf("after edit: severity=%q cve=%q affected=%q disclosure_title=%q recipients=%q",
+			got.Severity, got.CVEID, got.Affected, got.DisclosureTitle, got.SuggestedRecipients)
 	}
 	var hist []db.FindingHistory
 	s.DB.Where("finding_id = ?", f.ID).Find(&hist)
-	if len(hist) != 4 {
-		t.Errorf("history rows = %d, want 4 (severity, cve_id, affected, suggested_recipients)", len(hist))
+	if len(hist) != 5 {
+		t.Errorf("history rows = %d, want 5 (severity, cve_id, affected, disclosure_title, suggested_recipients)", len(hist))
 	}
 	for _, h := range hist {
 		if h.Source != db.SourceAnalyst {
@@ -71,8 +73,8 @@ func TestFindingFields(t *testing.T) {
 		t.Errorf("GHSAID = %q, want empty (rejected value should not be stored)", got.GHSAID)
 	}
 	s.DB.Where("finding_id = ?", f.ID).Find(&hist)
-	if len(hist) != 4 {
-		t.Errorf("history rows after rejected write = %d, want still 4", len(hist))
+	if len(hist) != 5 {
+		t.Errorf("history rows after rejected write = %d, want still 5", len(hist))
 	}
 
 	if w := postForm(t, s, "/findings/999999/fields", url.Values{"severity": {"Low"}}); w.Code != http.StatusNotFound {

--- a/internal/web/import.go
+++ b/internal/web/import.go
@@ -587,6 +587,7 @@ func buildImportFindings(scan *db.Scan, res ingest.Result) ([]db.Finding, []impo
 		f.BreakingChangeRationale = in.BreakingChangeRationale
 		f.DupCheck = in.DupCheck
 		f.DisclosureDraft = in.DisclosureDraft
+		f.DisclosureTitle = in.DisclosureTitle
 		f.SuggestedRecipients = in.SuggestedRecipients
 		f.ExploitedInWild = in.ExploitedInWild
 		f.ExploitedInWildEvidence = in.ExploitedInWildEvidence

--- a/internal/web/templates/finding_show.html
+++ b/internal/web/templates/finding_show.html
@@ -674,6 +674,10 @@ git commit -m "fix: {{$f.Title}}"</pre>
     </summary>
     <section class="pb-4">
       <form method="post" action="/findings/{{$f.ID}}/fields" class="form grid grid-cols-2 gap-3">
+        <div class="grid gap-1 col-span-2">
+          <label class="text-xs text-muted-foreground">Title</label>
+          <input class="input" name="title" value="{{$f.Title}}">
+        </div>
         <div class="grid gap-1">
           <label class="text-xs text-muted-foreground">Severity</label>
           <input class="input" name="severity" value="{{$f.Severity}}" list="severity-options">

--- a/internal/web/templates/finding_show.html
+++ b/internal/web/templates/finding_show.html
@@ -675,8 +675,9 @@ git commit -m "fix: {{$f.Title}}"</pre>
     <section class="pb-4">
       <form method="post" action="/findings/{{$f.ID}}/fields" class="form grid grid-cols-2 gap-3">
         <div class="grid gap-1 col-span-2">
-          <label class="text-xs text-muted-foreground">Title</label>
-          <input class="input" name="title" value="{{$f.Title}}">
+          <label class="text-xs text-muted-foreground"
+                 title="The disclose skill's drafted GHSA summary. May differ from the finding's own title above, which is set at audit time and left untouched by disclose re-runs.">Disclosure title</label>
+          <input class="input" name="disclosure_title" value="{{$f.DisclosureTitle}}">
         </div>
         <div class="grid gap-1">
           <label class="text-xs text-muted-foreground">Severity</label>

--- a/internal/worker/skill_parsers.go
+++ b/internal/worker/skill_parsers.go
@@ -1299,14 +1299,18 @@ func (w *Worker) parseMitigationOutput(scan *db.Scan, report string, emit func(E
 	return nil
 }
 
-// parseDiscloseOutput posts a FindingNote summarising a disclose run so the
-// finding's Notes panel records that a draft was prepared, alongside the
-// verify/revalidate/patch entries (#482). The draft itself is on
-// Finding.DisclosureDraft (PATCHed by the skill via the API); this note is
-// the audit trail pointing at it: the GHSA summary, which fields were
-// patched/preserved, the suggested recipients, references added, and
-// the report's notes prose. An error-only report records why the skill
-// refused to draft.
+// parseDiscloseOutput records the drafted GHSA summary on
+// Finding.DisclosureTitle and posts a FindingNote summarising the run so
+// the finding's Notes panel records that a draft was prepared, alongside
+// the verify/revalidate/patch entries (#482). DisclosureTitle is distinct
+// from Finding.Title: the skill's own PATCH only touches Title when it
+// was empty, so a re-run against a finding with an existing title would
+// otherwise lose the freshly drafted summary entirely. The disclosure
+// draft body itself is on Finding.DisclosureDraft (PATCHed by the skill
+// via the API); this note is the audit trail pointing at it: the GHSA
+// summary, which fields were patched/preserved, the suggested
+// recipients, references added, and the report's notes prose. An
+// error-only report records why the skill refused to draft.
 func (w *Worker) parseDiscloseOutput(scan *db.Scan, report string, emit func(Event)) error {
 	if scan.FindingID == nil {
 		return fmt.Errorf("disclose scan has no finding_id")
@@ -1331,6 +1335,11 @@ func (w *Worker) parseDiscloseOutput(scan *db.Scan, report string, emit func(Eve
 	if result.Error != "" {
 		fmt.Fprintf(&b, "disclose: refused\n\n%s\n", strings.TrimSpace(result.Error))
 	} else {
+		if summary := strings.TrimSpace(result.GHSA.Summary); summary != "" {
+			if err := db.WriteFindingField(w.DB, *scan.FindingID, "disclosure_title", summary, db.SourceModel, "disclose"); err != nil {
+				return fmt.Errorf("update disclosure_title: %w", err)
+			}
+		}
 		b.WriteString("disclose: drafted")
 		if result.GHSA.Summary != "" {
 			fmt.Fprintf(&b, " %q", result.GHSA.Summary)

--- a/internal/worker/skill_parsers_test.go
+++ b/internal/worker/skill_parsers_test.go
@@ -1951,6 +1951,19 @@ func TestParseDisclose_postsSummaryNote(t *testing.T) {
 	}`
 	f, gdb := runSkillWithFinding(t, "disclose", report, db.FindingTriaged)
 
+	var stored db.Finding
+	gdb.First(&stored, f.ID)
+	if stored.DisclosureTitle != "Command injection in run()" {
+		t.Errorf("DisclosureTitle = %q, want the ghsa.summary", stored.DisclosureTitle)
+	}
+	var hist db.FindingHistory
+	if err := gdb.Where("finding_id = ? AND field = ?", f.ID, "disclosure_title").First(&hist).Error; err != nil {
+		t.Fatalf("missing disclosure_title history: %v", err)
+	}
+	if hist.Source != db.SourceModel || hist.By != "disclose" {
+		t.Errorf("disclosure_title history source/by = %q/%q, want model/disclose", hist.Source, hist.By)
+	}
+
 	var notes []db.FindingNote
 	gdb.Where(map[string]any{"finding_id": f.ID, "by": "disclose"}).Find(&notes)
 	if len(notes) != 1 {

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -526,7 +526,7 @@ paths:
                     Map of field name to new value. Allowed fields:
                     title, severity, status, cwe, location, affected, reachability, quality_tier,
                     cve_id, ghsa_id, cvss_vector, cvss_v4_vector, fix_version, fix_commit,
-                    resolution, disclosure_draft, suggested_recipients, assignee,
+                    resolution, disclosure_draft, disclosure_title, suggested_recipients, assignee,
                     suggested_fix, suggested_fix_commit, breaking_change, breaking_change_rationale,
                     exploited_in_wild, exploited_in_wild_evidence, mitigation, mitigation_semgrep,
                     release_tag, release_url, last_revalidate_verdict.
@@ -1624,6 +1624,7 @@ components:
             reach:            { type: string }
             rating:           { type: string }
             disclosure_draft: { type: string }
+            disclosure_title: { type: string, description: "The disclose skill's drafted GHSA summary; may differ from the finding's own title." }
             suggested_recipients: { type: string, description: "File-level owners for the finding's location, from CODEOWNERS or recent non-bot committers." }
             sub_path:         { type: string, description: "Monorepo sub-folder the producing scan was scoped to. The finding's location is relative to it; empty means the repo root." }
             verification:
@@ -1839,6 +1840,7 @@ components:
               breaking_change_rationale:  { type: string }
               dup_check:                  { type: string }
               disclosure_draft:           { type: string }
+              disclosure_title:           { type: string, description: "The disclose skill's drafted GHSA summary; may differ from the finding's own title." }
               suggested_recipients:       { type: string, description: "File-level owners for the finding's location, from CODEOWNERS or recent non-bot committers." }
               exploited_in_wild:          { type: string, enum: [yes, no] }
               exploited_in_wild_evidence: { type: string }


### PR DESCRIPTION
The title of the Finding may be different to the resulting Disclosure,
so we should make sure it's visible under 'Disclosure fields', otherwise
the user needs to find the scan and/or check the Notes.

Co-authored-by: Claude Sonnet 5 <jamie.tanna+claude-code@mend.io>
