### PR TITLE
fix: reject cron schedules without future runs

### DIFF
--- a/internal/web/schedule.go
+++ b/internal/web/schedule.go
@@ -43,7 +43,11 @@ func ScheduleNext(expr string, after time.Time) (time.Time, error) {
 	if err != nil {
 		return time.Time{}, err
 	}
-	return sched.Next(after), nil
+	next := sched.Next(after)
+	if next.IsZero() {
+		return time.Time{}, errors.New("schedule has no future occurrence")
+	}
+	return next, nil
 }
 
 // StartScheduler runs the recurring-scan loop until ctx is cancelled.

--- a/internal/web/schedule_test.go
+++ b/internal/web/schedule_test.go
@@ -27,7 +27,7 @@ func TestScheduleNext(t *testing.T) {
 			t.Errorf("ScheduleNext(%q) = %v, want a time after %v", expr, next, now)
 		}
 	}
-	for _, expr := range []string{"", "yearly-ish", "* * *", "61 * * * *"} {
+	for _, expr := range []string{"", "yearly-ish", "* * *", "61 * * * *", "0 0 31 2 *"} {
 		if _, err := ScheduleNext(expr, now); err == nil {
 			t.Errorf("ScheduleNext(%q) = nil error, want error", expr)
 		}
@@ -145,6 +145,38 @@ func TestScheduleTick_notDueYet(t *testing.T) {
 	s.DB.First(&got, repo.ID)
 	if got.NextScheduledScanAt == nil || got.NextScheduledScanAt.Sub(future).Abs() > time.Second {
 		t.Fatalf("NextScheduledScanAt = %v, want untouched %v", got.NextScheduledScanAt, future)
+	}
+}
+
+func TestScheduleTick_invalidScheduleDoesNotFireOrStoreZero(t *testing.T) {
+	s, synced, done := scheduleTestServer(t, "abc", nil)
+	defer done()
+	due := time.Now().Add(-time.Minute)
+	repo := scheduledRepo(t, s, "0 0 31 2 *", due)
+	if err := s.DB.Model(&db.Repository{}).Where("id = ?", repo.ID).
+		Update("upstream_url", "https://example.com/upstream").Error; err != nil {
+		t.Fatal(err)
+	}
+
+	s.scheduleTick(context.Background(), time.Now())
+
+	if len(*synced) != 0 {
+		t.Fatalf("syncUpstream calls = %v, want none for an invalid schedule", *synced)
+	}
+	var got db.Repository
+	if err := s.DB.First(&got, repo.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if got.NextScheduledScanAt == nil || got.NextScheduledScanAt.IsZero() ||
+		got.NextScheduledScanAt.Sub(due).Abs() > time.Second {
+		t.Fatalf("NextScheduledScanAt = %v, want original non-zero due time %v", got.NextScheduledScanAt, due)
+	}
+	var scans int64
+	if err := s.DB.Model(&db.Scan{}).Where("repository_id = ?", repo.ID).Count(&scans).Error; err != nil {
+		t.Fatal(err)
+	}
+	if scans != 0 {
+		t.Fatalf("invalid schedule created %d scan(s), want 0", scans)
 	}
 }
 
@@ -332,12 +364,14 @@ func TestRepoScheduleUpdate_rejectsInvalidCron(t *testing.T) {
 	defer done()
 	repo := scheduledRepo(t, s, "", time.Now())
 
-	w := postForm(t, s, "/repositories/"+strconv.FormatUint(uint64(repo.ID), 10)+"/schedule", url.Values{
-		"scan_schedule":      {"custom"},
-		"scan_schedule_cron": {"not a cron"},
-	})
-	if w.Code != http.StatusUnprocessableEntity {
-		t.Fatalf("status %d, want 422", w.Code)
+	for _, expr := range []string{"not a cron", "0 0 31 2 *"} {
+		w := postForm(t, s, "/repositories/"+strconv.FormatUint(uint64(repo.ID), 10)+"/schedule", url.Values{
+			"scan_schedule":      {"custom"},
+			"scan_schedule_cron": {expr},
+		})
+		if w.Code != http.StatusUnprocessableEntity {
+			t.Errorf("schedule %q: status %d, want 422", expr, w.Code)
+		}
 	}
 }
 
@@ -448,12 +482,14 @@ func TestSettingsUpdateScanSchedule_rejectsInvalidCron(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()
 
-	w := postForm(t, s, "/settings/scan-schedule", url.Values{
-		"scan_schedule":      {"custom"},
-		"scan_schedule_cron": {"every other tuesday"},
-	})
-	if w.Code != http.StatusUnprocessableEntity {
-		t.Fatalf("status %d, want 422", w.Code)
+	for _, expr := range []string{"every other tuesday", "0 0 31 2 *"} {
+		w := postForm(t, s, "/settings/scan-schedule", url.Values{
+			"scan_schedule":      {"custom"},
+			"scan_schedule_cron": {expr},
+		})
+		if w.Code != http.StatusUnprocessableEntity {
+			t.Errorf("schedule %q: status %d, want 422", expr, w.Code)
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes #811

## Summary

Rejects syntactically valid cron expressions that can never produce a future occurrence, preventing impossible schedules from being stored and repeatedly treated as due.

For example, `0 0 31 2 *` parses successfully but asks for February 31. The cron library returns `time.Time{}` for this expression after exhausting its search window.

## Changes

- Update `ScheduleNext` to return an error when the parsed schedule produces a zero next occurrence.
- Make repository schedule validation reject impossible cron expressions.
- Make global schedule validation reject impossible cron expressions.
- Prevent `scheduleTick` from firing scans or contacting upstream repositories for invalid persisted schedules.
- Prevent the scheduler from replacing an existing due time with a zero timestamp.
- Add regression coverage for syntactically invalid and valid-but-impossible schedules.

## Tests

- `go test -race ./...`
- `go test -race -tags evals ./internal/evals/...`
- `go vet ./...`
- `go vet -tags evals ./internal/evals/...`
- `go vet -tags podman ./...`
- `golangci-lint run`
- `git diff --check`