### PR TITLE
Typed coverage contract for Scan.Coverage

### DIFF
--- a/internal/coverage/coverage.go
+++ b/internal/coverage/coverage.go
@@ -1,0 +1,259 @@
+// Package coverage defines the typed contract stored in Scan.Coverage: what
+// a scan did and did not reach, and how confident the worker is in that.
+//
+// The column was an ad-hoc JSON blob with two owners writing different shapes
+// into it (the diff-rescan staging path in internal/worker and the
+// threat-model update path in internal/web), so a consumer could not tell
+// "no findings after a complete scan" from "no findings in the part that
+// finished". A Record is that distinction, written by every scan mode.
+//
+// Completeness is derived by the worker from receipt reconciliation against
+// the scope it staged itself, never from the skill's own claim about how much
+// it covered. Where the worker has no independently known scope, the honest
+// answer is CompletenessUnknown, not CompletenessComplete.
+package coverage
+
+import (
+	"encoding/json"
+	"sort"
+	"strings"
+)
+
+// Version is the contract version stamped on every Record written. Consumers
+// that need to reason about older rows compare against it; rows written
+// before the typed contract carry 0.
+const Version = 1
+
+// Completeness states how much of the intended scope this scan actually
+// reached. Anything other than Complete requires a Reason.
+const (
+	// CompletenessComplete means every work item in the staged scope has a
+	// receipt. Only the worker may assign it, and only for a mode where it
+	// enumerated the scope itself.
+	CompletenessComplete = "complete"
+	// CompletenessPartial means the scope was known and some of it was not
+	// reached.
+	CompletenessPartial = "partial"
+	// CompletenessUnknown means no scope was enumerable, so no claim can be
+	// made. This is the correct value for a full-repository scan until a
+	// work manifest exists, and it is deliberately not a synonym for
+	// "probably fine".
+	CompletenessUnknown = "unknown"
+)
+
+// Dispositions record what happened to one work item. reviewed_clean and
+// reviewed_findings are both completed work; the rest are all reasons a unit
+// did not produce a verdict, kept apart so a partial scan can say which kind
+// of gap it means.
+const (
+	DispositionReviewedClean    = "reviewed_clean"
+	DispositionReviewedFindings = "reviewed_findings"
+	DispositionSupporting       = "supporting"
+	DispositionDeferred         = "deferred"
+	DispositionExcluded         = "excluded"
+	DispositionFailed           = "failed"
+	DispositionCostCapped       = "cost_capped"
+)
+
+// Record is the whole coverage contract for one scan.
+type Record struct {
+	Version int `json:"version"`
+
+	// RequestedMode and ActualMode carry the rescan mode the operator asked
+	// for and the one that ran; they differ when the worker fell back, and
+	// FallbackReason says why.
+	RequestedMode  string `json:"requested_mode,omitempty"`
+	ActualMode     string `json:"actual_mode,omitempty"`
+	FallbackReason string `json:"fallback_reason,omitempty"`
+
+	// Completeness is one of the constants above. Reason is required
+	// whenever Completeness is not Complete.
+	Completeness string `json:"completeness"`
+	Reason       string `json:"reason,omitempty"`
+
+	// IncludedPaths is the scope the worker staged. ExcludedPaths and
+	// DeferredPaths carry a reason each, since a bare path list does not
+	// say whether the omission was a policy decision or a shortfall.
+	IncludedPaths []string     `json:"included_paths,omitempty"`
+	ExcludedPaths []PathReason `json:"excluded_paths,omitempty"`
+	DeferredPaths []PathReason `json:"deferred_paths,omitempty"`
+
+	// Receipts is the per-work-item record reconciled against
+	// IncludedPaths. Produced by the skill; the worker only reconciles.
+	Receipts []Receipt `json:"receipts,omitempty"`
+
+	// Surfaces, OpenQuestions and DroppedFindings are declared by this
+	// contract but have no producer yet: they arrive with the skill-side
+	// reporting channel. They are listed here so the shape is fixed before
+	// several skills start inventing their own.
+	Surfaces        []Surface         `json:"surfaces,omitempty"`
+	OpenQuestions   []string          `json:"open_questions,omitempty"`
+	DroppedFindings []DroppedFinding  `json:"dropped_findings,omitempty"`
+	ThreatModel     *ThreatModelState `json:"threat_model,omitempty"`
+}
+
+// PathReason is a path plus why it is not in the reviewed set.
+type PathReason struct {
+	Path   string `json:"path"`
+	Reason string `json:"reason,omitempty"`
+}
+
+// Receipt is one work item's outcome.
+type Receipt struct {
+	Path        string `json:"path"`
+	Disposition string `json:"disposition"`
+	Reason      string `json:"reason,omitempty"`
+}
+
+// Reviewed reports whether this receipt represents work that ran to
+// completion, whatever it concluded. A failed or cost-capped unit did not.
+func (r Receipt) Reviewed() bool {
+	return r.Disposition == DispositionReviewedClean || r.Disposition == DispositionReviewedFindings
+}
+
+// Surface is an attack surface the scan reports having looked at.
+type Surface struct {
+	Name        string `json:"name"`
+	Disposition string `json:"disposition,omitempty"`
+	EvidenceRef string `json:"evidence_ref,omitempty"`
+}
+
+// DroppedFinding is a candidate discarded before verify ran, kept so a clean
+// report can be told apart from a filtered one.
+type DroppedFinding struct {
+	Fingerprint string `json:"fingerprint,omitempty"`
+	Path        string `json:"path,omitempty"`
+	Reason      string `json:"reason"`
+	Detail      string `json:"detail,omitempty"`
+}
+
+// ThreatModelState carries what the diff threat-model path used to merge into
+// the untyped blob as threat_model_update / threat_model_material /
+// threat_model_update_reason. It is a completeness statement — "the
+// repository model was not updated because the diff was too small" — so it
+// belongs in the record rather than beside it.
+type ThreatModelState struct {
+	Update   string `json:"update"`
+	Material bool   `json:"material"`
+	Reason   string `json:"reason,omitempty"`
+}
+
+// Parse reads a stored coverage value. It accepts rows written before this
+// contract existed: the legacy keys are read into their typed homes, and a
+// row that carries no completeness claim is reported as Unknown rather than
+// being guessed at. An empty or unparseable value yields a zero Record and
+// ok=false, so callers can tell "nothing recorded" from "recorded nothing".
+func Parse(raw string) (Record, bool) {
+	if strings.TrimSpace(raw) == "" {
+		return Record{}, false
+	}
+	var rec Record
+	if err := json.Unmarshal([]byte(raw), &rec); err != nil {
+		return Record{}, false
+	}
+	if rec.Version == 0 {
+		var legacy struct {
+			Update   *string `json:"threat_model_update"`
+			Material bool    `json:"threat_model_material"`
+			Reason   string  `json:"threat_model_update_reason"`
+		}
+		if json.Unmarshal([]byte(raw), &legacy) == nil && legacy.Update != nil {
+			rec.ThreatModel = &ThreatModelState{
+				Update:   *legacy.Update,
+				Material: legacy.Material,
+				Reason:   legacy.Reason,
+			}
+		}
+	}
+	if rec.Completeness == "" {
+		rec.Completeness = CompletenessUnknown
+	}
+	return rec, true
+}
+
+// Marshal renders a record for storage, stamping the current version.
+func Marshal(rec Record) (string, error) {
+	rec.Version = Version
+	if rec.Completeness == "" {
+		rec.Completeness = CompletenessUnknown
+	}
+	b, err := json.Marshal(rec)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+// settled reports whether a disposition closes out a work item. A unit that
+// was deliberately left out (excluded) is as settled as one that was
+// reviewed; a unit that was deferred, failed, or ran out of budget is not,
+// and keeps the scan partial even though it has a receipt.
+func settled(disposition string) bool {
+	switch disposition {
+	case DispositionReviewedClean, DispositionReviewedFindings,
+		DispositionSupporting, DispositionExcluded:
+		return true
+	}
+	return false
+}
+
+// Reconcile derives Completeness from the receipts against the scope the
+// worker staged, and returns the scoped paths that leave the scan short —
+// both the ones no receipt mentions and the ones whose receipt says the work
+// did not finish.
+//
+// It is deliberately the worker's job and not the skill's: a skill that
+// silently skipped half a diff would otherwise report itself complete. An
+// empty scope means the worker had nothing to reconcile against — a full or
+// focus-area scan today — and yields Unknown, never Complete, however many
+// receipts the skill supplied.
+func (rec *Record) Reconcile(scope []string) []string {
+	if len(scope) == 0 {
+		rec.Completeness = CompletenessUnknown
+		if rec.Reason == "" {
+			rec.Reason = "no enumerable scope for this scan mode"
+		}
+		return nil
+	}
+	byPath := make(map[string]Receipt, len(rec.Receipts))
+	for _, r := range rec.Receipts {
+		if r.Path != "" {
+			byPath[r.Path] = r
+		}
+	}
+	var (
+		gaps        []string
+		unreceipted bool
+		unfinished  bool
+	)
+	for _, path := range scope {
+		receipt, ok := byPath[path]
+		switch {
+		case !ok:
+			unreceipted = true
+		case !settled(receipt.Disposition):
+			unfinished = true
+		default:
+			continue
+		}
+		gaps = append(gaps, path)
+	}
+	sort.Strings(gaps)
+	if len(gaps) == 0 {
+		rec.Completeness = CompletenessComplete
+		rec.Reason = ""
+		return nil
+	}
+	rec.Completeness = CompletenessPartial
+	if rec.Reason == "" {
+		switch {
+		case unreceipted && unfinished:
+			rec.Reason = "staged work items are unreceipted or unfinished"
+		case unreceipted:
+			rec.Reason = "staged work items have no receipt"
+		default:
+			rec.Reason = "staged work items did not finish"
+		}
+	}
+	return gaps
+}

--- a/internal/coverage/coverage_test.go
+++ b/internal/coverage/coverage_test.go
@@ -1,0 +1,179 @@
+package coverage
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+func TestParseEmptyIsNotARecord(t *testing.T) {
+	for _, raw := range []string{"", "   ", "not json"} {
+		if _, ok := Parse(raw); ok {
+			t.Fatalf("Parse(%q) reported a record where none was stored", raw)
+		}
+	}
+}
+
+// The diff-rescan path wrote {requested_mode, actual_mode, fallback_reason}
+// with no version. Those rows must keep their meaning, and must not be read
+// as a completeness claim they never made.
+func TestParseLegacyDiffBlob(t *testing.T) {
+	rec, ok := Parse(`{"requested_mode":"diff","actual_mode":"full","fallback_reason":"baseline commit is unreachable"}`)
+	if !ok {
+		t.Fatal("legacy diff blob did not parse")
+	}
+	if rec.RequestedMode != "diff" || rec.ActualMode != "full" {
+		t.Fatalf("modes lost: %+v", rec)
+	}
+	if rec.FallbackReason != "baseline commit is unreachable" {
+		t.Fatalf("fallback reason lost: %q", rec.FallbackReason)
+	}
+	if rec.Completeness != CompletenessUnknown {
+		t.Fatalf("completeness = %q, want %q — a legacy row makes no claim",
+			rec.Completeness, CompletenessUnknown)
+	}
+}
+
+// markThreatModelUpdate merged three untyped keys into the same column.
+// Those rows exist in every deployment that has run a diff threat-model
+// scan, so the typed record has to read them back rather than drop them.
+func TestParseLegacyThreatModelKeys(t *testing.T) {
+	rec, ok := Parse(`{"threat_model_update":"skipped_small_diff","threat_model_material":false,"threat_model_update_reason":"diff below threshold"}`)
+	if !ok {
+		t.Fatal("legacy threat-model blob did not parse")
+	}
+	if rec.ThreatModel == nil {
+		t.Fatal("threat-model state dropped")
+	}
+	if rec.ThreatModel.Update != "skipped_small_diff" || rec.ThreatModel.Material {
+		t.Fatalf("threat-model state wrong: %+v", *rec.ThreatModel)
+	}
+	if rec.ThreatModel.Reason != "diff below threshold" {
+		t.Fatalf("threat-model reason lost: %q", rec.ThreatModel.Reason)
+	}
+}
+
+// A false negative here would be silent: threat_model_material is false on
+// four of the five call sites, so "absent" and "present but false" have to be
+// told apart by the key's presence, not by its value.
+func TestParseWithoutThreatModelKeysLeavesItNil(t *testing.T) {
+	rec, ok := Parse(`{"requested_mode":"diff","actual_mode":"diff"}`)
+	if !ok {
+		t.Fatal("blob did not parse")
+	}
+	if rec.ThreatModel != nil {
+		t.Fatalf("invented threat-model state: %+v", *rec.ThreatModel)
+	}
+}
+
+func TestMarshalStampsVersionAndCompleteness(t *testing.T) {
+	raw, err := Marshal(Record{RequestedMode: "full"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal([]byte(raw), &got); err != nil {
+		t.Fatal(err)
+	}
+	if got["version"] != float64(Version) {
+		t.Fatalf("version = %v, want %d", got["version"], Version)
+	}
+	if got["completeness"] != CompletenessUnknown {
+		t.Fatalf("completeness = %v, want %q", got["completeness"], CompletenessUnknown)
+	}
+}
+
+func TestReconcileCompleteWhenEveryScopedPathIsSettled(t *testing.T) {
+	rec := Record{Receipts: []Receipt{
+		{Path: "a.go", Disposition: DispositionReviewedClean},
+		{Path: "b.go", Disposition: DispositionReviewedFindings},
+		{Path: "vendor/c.go", Disposition: DispositionExcluded, Reason: "vendored"},
+	}}
+	if gaps := rec.Reconcile([]string{"a.go", "b.go", "vendor/c.go"}); gaps != nil {
+		t.Fatalf("gaps = %v, want none", gaps)
+	}
+	if rec.Completeness != CompletenessComplete {
+		t.Fatalf("completeness = %q, want %q", rec.Completeness, CompletenessComplete)
+	}
+	if rec.Reason != "" {
+		t.Fatalf("complete scan carries a reason: %q", rec.Reason)
+	}
+}
+
+func TestReconcileReportsUnreceiptedPaths(t *testing.T) {
+	rec := Record{Receipts: []Receipt{{Path: "a.go", Disposition: DispositionReviewedClean}}}
+	gaps := rec.Reconcile([]string{"a.go", "z.go", "m.go"})
+	if want := []string{"m.go", "z.go"}; !reflect.DeepEqual(gaps, want) {
+		t.Fatalf("gaps = %v, want %v", gaps, want)
+	}
+	if rec.Completeness != CompletenessPartial {
+		t.Fatalf("completeness = %q, want %q", rec.Completeness, CompletenessPartial)
+	}
+	if rec.Reason == "" {
+		t.Fatal("partial scan must carry a reason")
+	}
+}
+
+// The reason the disposition set was split: a receipt is not the same as
+// finished work. A failed or cost-capped unit is fully receipted and still
+// leaves the scan partial.
+func TestReconcileTreatsUnfinishedReceiptsAsGaps(t *testing.T) {
+	for _, disposition := range []string{DispositionFailed, DispositionCostCapped, DispositionDeferred} {
+		rec := Record{Receipts: []Receipt{
+			{Path: "a.go", Disposition: DispositionReviewedClean},
+			{Path: "b.go", Disposition: disposition},
+		}}
+		gaps := rec.Reconcile([]string{"a.go", "b.go"})
+		if want := []string{"b.go"}; !reflect.DeepEqual(gaps, want) {
+			t.Fatalf("%s: gaps = %v, want %v", disposition, gaps, want)
+		}
+		if rec.Completeness != CompletenessPartial {
+			t.Fatalf("%s: completeness = %q, want %q", disposition, rec.Completeness, CompletenessPartial)
+		}
+	}
+}
+
+// The anti-trust property this contract exists for: with no scope of its own
+// to check against, the worker cannot upgrade the skill's word into a
+// completeness claim, however many receipts arrive.
+func TestReconcileWithoutScopeNeverClaimsComplete(t *testing.T) {
+	rec := Record{Receipts: []Receipt{
+		{Path: "a.go", Disposition: DispositionReviewedClean},
+		{Path: "b.go", Disposition: DispositionReviewedClean},
+	}}
+	if gaps := rec.Reconcile(nil); gaps != nil {
+		t.Fatalf("gaps = %v, want none", gaps)
+	}
+	if rec.Completeness != CompletenessUnknown {
+		t.Fatalf("completeness = %q, want %q", rec.Completeness, CompletenessUnknown)
+	}
+	if rec.Reason == "" {
+		t.Fatal("unknown completeness must say why it is unknown")
+	}
+}
+
+func TestRoundTripPreservesRecord(t *testing.T) {
+	want := Record{
+		RequestedMode: "diff",
+		ActualMode:    "diff",
+		Completeness:  CompletenessPartial,
+		Reason:        "staged work items have no receipt",
+		IncludedPaths: []string{"a.go"},
+		ExcludedPaths: []PathReason{{Path: "vendor/x.go", Reason: "vendored"}},
+		Receipts:      []Receipt{{Path: "a.go", Disposition: DispositionReviewedFindings}},
+		OpenQuestions: []string{"is the parser reachable from the CLI?"},
+		ThreatModel:   &ThreatModelState{Update: "updated", Material: true},
+	}
+	raw, err := Marshal(want)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, ok := Parse(raw)
+	if !ok {
+		t.Fatal("marshalled record did not parse")
+	}
+	want.Version = Version
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("round trip lost data:\n got %+v\nwant %+v", got, want)
+	}
+}

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -296,10 +296,16 @@ type Scan struct {
 	// old_threat_model.json for a diff threat-model scan, when available.
 	DiffThreatModelScanID *uint `gorm:"index"`
 	// DiffStats and Coverage are JSON blobs. DiffStats describes changed
-	// files/counts; Coverage describes what this scan did or did not cover,
-	// including automatic fallback reasons.
+	// files/counts; Coverage is the internal/coverage.Record describing what
+	// this scan did or did not reach, including automatic fallback reasons.
 	DiffStats string `gorm:"type:text"`
 	Coverage  string `gorm:"type:text"`
+	// Completeness is Coverage's completeness verdict lifted out into its own
+	// indexed column so the scans list can filter on it without decoding the
+	// record. "complete" / "partial" / "unknown"; empty on rows written
+	// before the typed contract. It is derived by the worker from receipt
+	// reconciliation, never copied from a skill's own claim.
+	Completeness string `gorm:"index"`
 
 	// Profile is the runner profile that ran (or was overridden to run)
 	// this scan. Empty means the default runner image; non-empty names

--- a/internal/web/diff_threat_model.go
+++ b/internal/web/diff_threat_model.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"scrutineer/internal/coverage"
 	"scrutineer/internal/db"
 )
 
@@ -99,23 +100,23 @@ func materialThreatModelPath(paths ...string) (string, bool) {
 	return "", false
 }
 
+// markThreatModelUpdate records why the repository threat model was or was
+// not refreshed from this scan. It is a completeness statement about the
+// scan, so it lands inside the coverage record rather than beside it; a scan
+// staged by the worker already has a record here, and this merges into it
+// without disturbing the worker's own verdict.
 func (s *Server) markThreatModelUpdate(scan *db.Scan, state string, material bool, reason string) {
-	var coverage map[string]any
-	if err := json.Unmarshal([]byte(scan.Coverage), &coverage); err != nil || coverage == nil {
-		coverage = map[string]any{}
-	}
-	coverage["threat_model_update"] = state
-	coverage["threat_model_material"] = material
-	if reason != "" {
-		coverage["threat_model_update_reason"] = reason
-	}
-	b, err := json.Marshal(coverage)
+	rec, _ := coverage.Parse(scan.Coverage)
+	rec.ThreatModel = &coverage.ThreatModelState{Update: state, Material: material, Reason: reason}
+	raw, err := coverage.Marshal(rec)
 	if err != nil {
 		s.Log.Warn("threat-model update: marshal coverage", "scan", scan.ID, "err", err)
 		return
 	}
-	scan.Coverage = string(b)
-	if err := s.DB.Model(&db.Scan{}).Where("id = ?", scan.ID).Update("coverage", scan.Coverage).Error; err != nil {
+	scan.Coverage = raw
+	scan.Completeness = rec.Completeness
+	if err := s.DB.Model(&db.Scan{}).Where("id = ?", scan.ID).
+		Updates(map[string]any{"coverage": scan.Coverage, "completeness": scan.Completeness}).Error; err != nil {
 		s.Log.Warn("threat-model update: save coverage", "scan", scan.ID, "err", err)
 	}
 }

--- a/internal/web/diff_threat_model.go
+++ b/internal/web/diff_threat_model.go
@@ -108,6 +108,12 @@ func materialThreatModelPath(paths ...string) (string, bool) {
 func (s *Server) markThreatModelUpdate(scan *db.Scan, state string, material bool, reason string) {
 	rec, _ := coverage.Parse(scan.Coverage)
 	rec.ThreatModel = &coverage.ThreatModelState{Update: state, Material: material, Reason: reason}
+	// Marshal defaults Completeness on its own copy, so a scan with no prior
+	// coverage would store "unknown" in the blob and leave the column empty.
+	// Default here instead, and both come from this one value.
+	if rec.Completeness == "" {
+		rec.Completeness = coverage.CompletenessUnknown
+	}
 	raw, err := coverage.Marshal(rec)
 	if err != nil {
 		s.Log.Warn("threat-model update: marshal coverage", "scan", scan.ID, "err", err)

--- a/internal/web/diff_threat_model_test.go
+++ b/internal/web/diff_threat_model_test.go
@@ -119,3 +119,42 @@ func TestAutoUpdateThreatModelMaterialDiffUpdates(t *testing.T) {
 		t.Fatalf("threat model = %+v, want updated material diff", *rec.ThreatModel)
 	}
 }
+
+// A full threat-model scan carries no prior coverage, so Parse returns
+// ok=false and a zero Record. Marshal defaults Completeness on its own copy,
+// which used to leave the indexed column empty while the stored blob said
+// "unknown" — the exact drift the typed contract exists to prevent.
+func TestMarkThreatModelUpdateKeepsCompletenessColumnInStep(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	repo := db.Repository{URL: "https://example.com/repo", Name: "repo"}
+	if err := s.DB.Create(&repo).Error; err != nil {
+		t.Fatal(err)
+	}
+	scan := db.Scan{
+		RepositoryID: repo.ID,
+		Status:       db.ScanDone,
+		SkillName:    threatModelSkillName,
+		Report:       `{"spec_version":1}`,
+	}
+	if err := s.DB.Create(&scan).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	s.autoUpdateThreatModel(&scan)
+
+	var got db.Scan
+	if err := s.DB.First(&got, scan.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	rec, ok := coverage.Parse(got.Coverage)
+	if !ok {
+		t.Fatalf("Parse(%q) not ok", got.Coverage)
+	}
+	if rec.Completeness != coverage.CompletenessUnknown {
+		t.Fatalf("record Completeness = %q, want %q", rec.Completeness, coverage.CompletenessUnknown)
+	}
+	if got.Completeness != rec.Completeness {
+		t.Fatalf("column Completeness = %q, record says %q — the two disagree", got.Completeness, rec.Completeness)
+	}
+}

--- a/internal/web/diff_threat_model_test.go
+++ b/internal/web/diff_threat_model_test.go
@@ -1,10 +1,10 @@
 package web
 
 import (
-	"encoding/json"
 	"strings"
 	"testing"
 
+	"scrutineer/internal/coverage"
 	"scrutineer/internal/db"
 )
 
@@ -69,12 +69,12 @@ func TestAutoUpdateThreatModelSmallDiffSkips(t *testing.T) {
 	if err := s.DB.First(&gotScan, scan.ID).Error; err != nil {
 		t.Fatal(err)
 	}
-	var coverage map[string]any
-	if err := json.Unmarshal([]byte(gotScan.Coverage), &coverage); err != nil {
-		t.Fatal(err)
+	rec, ok := coverage.Parse(gotScan.Coverage)
+	if !ok || rec.ThreatModel == nil {
+		t.Fatalf("coverage = %q, want a threat-model state", gotScan.Coverage)
 	}
-	if coverage["threat_model_update"] != "skipped_small_diff" || coverage["threat_model_material"] != false {
-		t.Fatalf("coverage = %#v, want skipped non-material diff", coverage)
+	if rec.ThreatModel.Update != "skipped_small_diff" || rec.ThreatModel.Material {
+		t.Fatalf("threat model = %+v, want skipped non-material diff", *rec.ThreatModel)
 	}
 }
 
@@ -111,11 +111,11 @@ func TestAutoUpdateThreatModelMaterialDiffUpdates(t *testing.T) {
 	if err := s.DB.First(&gotScan, scan.ID).Error; err != nil {
 		t.Fatal(err)
 	}
-	var coverage map[string]any
-	if err := json.Unmarshal([]byte(gotScan.Coverage), &coverage); err != nil {
-		t.Fatal(err)
+	rec, ok := coverage.Parse(gotScan.Coverage)
+	if !ok || rec.ThreatModel == nil {
+		t.Fatalf("coverage = %q, want a threat-model state", gotScan.Coverage)
 	}
-	if coverage["threat_model_update"] != "updated" || coverage["threat_model_material"] != true {
-		t.Fatalf("coverage = %#v, want updated material diff", coverage)
+	if rec.ThreatModel.Update != "updated" || !rec.ThreatModel.Material {
+		t.Fatalf("threat model = %+v, want updated material diff", *rec.ThreatModel)
 	}
 }

--- a/internal/web/scans.go
+++ b/internal/web/scans.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"scrutineer/internal/coverage"
 	"scrutineer/internal/db"
 	"scrutineer/internal/worker"
 
@@ -151,9 +152,13 @@ type scanDiffView struct {
 	RequestedMode  string
 	ActualMode     string
 	FallbackReason string
-	ChangedFiles   int
-	PatchBytes     int64
-	Files          []scanDiffFile
+	// Completeness and CompletenessReason come from the same coverage
+	// record and say how much of the intended scope the scan reached.
+	Completeness       string
+	CompletenessReason string
+	ChangedFiles       int
+	PatchBytes         int64
+	Files              []scanDiffFile
 }
 
 type scanDiffFile struct {
@@ -199,17 +204,12 @@ func parseScanDiffView(scan db.Scan) *scanDiffView {
 		return nil
 	}
 	var v scanDiffView
-	if scan.Coverage != "" {
-		var cov struct {
-			RequestedMode  string `json:"requested_mode"`
-			ActualMode     string `json:"actual_mode"`
-			FallbackReason string `json:"fallback_reason"`
-		}
-		if json.Unmarshal([]byte(scan.Coverage), &cov) == nil {
-			v.RequestedMode = cov.RequestedMode
-			v.ActualMode = cov.ActualMode
-			v.FallbackReason = cov.FallbackReason
-		}
+	if rec, ok := coverage.Parse(scan.Coverage); ok {
+		v.RequestedMode = rec.RequestedMode
+		v.ActualMode = rec.ActualMode
+		v.FallbackReason = rec.FallbackReason
+		v.Completeness = rec.Completeness
+		v.CompletenessReason = rec.Reason
 	}
 	if scan.DiffStats != "" {
 		var stats struct {

--- a/internal/worker/diff_rescan.go
+++ b/internal/worker/diff_rescan.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"scrutineer/internal/coverage"
 	"scrutineer/internal/db"
 )
 
@@ -20,12 +21,6 @@ const (
 	nameStatusMinColumns   = 2
 	nameStatusRenameCols   = 3
 )
-
-type diffCoverage struct {
-	RequestedMode  string `json:"requested_mode"`
-	ActualMode     string `json:"actual_mode"`
-	FallbackReason string `json:"fallback_reason,omitempty"`
-}
 
 type diffStats struct {
 	BaseCommit        string         `json:"base_commit"`
@@ -135,7 +130,17 @@ func (w *Worker) prepareDiffRescan(ctx context.Context, scan *db.Scan, workRoot 
 			"changed_files": maxDiffChangedFileRows,
 		},
 	})
-	scan.Coverage = mustJSON(diffCoverage{RequestedMode: db.ScanRescanModeDiff, ActualMode: db.ScanRescanModeDiff})
+	// The changed-file list the worker staged itself is the only scope it
+	// knows independently of the skill, so it is the only scope a
+	// completeness verdict can honestly be reconciled against. No receipts
+	// exist yet at staging time, so this starts partial and names why.
+	setCoverage(scan, coverage.Record{
+		RequestedMode: db.ScanRescanModeDiff,
+		ActualMode:    db.ScanRescanModeDiff,
+		Completeness:  coverage.CompletenessPartial,
+		Reason:        "scan has not reported receipts for the staged changed files",
+		IncludedPaths: changedPaths(changed),
+	})
 	if err := w.DB.Model(scan).Updates(map[string]any{
 		"rescan_mode":               scan.RescanMode,
 		"diff_base_scan_id":         scan.DiffBaseScanID,
@@ -143,6 +148,7 @@ func (w *Worker) prepareDiffRescan(ctx context.Context, scan *db.Scan, workRoot 
 		"diff_threat_model_scan_id": scan.DiffThreatModelScanID,
 		"diff_stats":                scan.DiffStats,
 		"coverage":                  scan.Coverage,
+		"completeness":              scan.Completeness,
 	}).Error; err != nil {
 		return fmt.Errorf("save diff rescan metadata: %w", err)
 	}
@@ -198,10 +204,15 @@ func (w *Worker) fallbackDiffScan(scan *db.Scan, reason string) {
 	scan.DiffBaseCommit = ""
 	scan.DiffThreatModelScanID = nil
 	scan.DiffStats = ""
-	scan.Coverage = mustJSON(diffCoverage{
+	// A fallback ran as a full scan, and a full scan has no enumerable
+	// scope until #20's work manifest exists, so the honest verdict is
+	// unknown rather than complete.
+	setCoverage(scan, coverage.Record{
 		RequestedMode:  db.ScanRescanModeDiff,
 		ActualMode:     db.ScanRescanModeFull,
 		FallbackReason: reason,
+		Completeness:   coverage.CompletenessUnknown,
+		Reason:         "no enumerable scope for a full scan",
 	})
 	if err := w.DB.Model(scan).Updates(map[string]any{
 		"rescan_mode":               db.ScanRescanModeFull,
@@ -210,6 +221,7 @@ func (w *Worker) fallbackDiffScan(scan *db.Scan, reason string) {
 		"diff_threat_model_scan_id": nil,
 		"diff_stats":                "",
 		"coverage":                  scan.Coverage,
+		"completeness":              scan.Completeness,
 	}).Error; err != nil && w.Log != nil {
 		w.Log.Warn("save diff rescan fallback", "scan", scan.ID, "reason", reason, "err", err)
 	}
@@ -289,4 +301,34 @@ func uintValue(v *uint) uint {
 		return 0
 	}
 	return *v
+}
+
+// setCoverage renders a coverage record onto the scan and keeps the indexed
+// Completeness column in step with it, so the two can never disagree.
+func setCoverage(scan *db.Scan, rec coverage.Record) {
+	raw, err := coverage.Marshal(rec)
+	if err != nil {
+		return
+	}
+	scan.Coverage = raw
+	scan.Completeness = rec.Completeness
+	if scan.Completeness == "" {
+		scan.Completeness = coverage.CompletenessUnknown
+	}
+}
+
+// changedPaths is the staged diff's file set as a plain path list, which is
+// what a receipt reconciliation matches against. Renames are recorded under
+// their new path, matching how the skill sees the tree at the head commit.
+func changedPaths(changed []changedFile) []string {
+	if len(changed) == 0 {
+		return nil
+	}
+	paths := make([]string, 0, len(changed))
+	for _, f := range changed {
+		if f.Path != "" {
+			paths = append(paths, f.Path)
+		}
+	}
+	return paths
 }

--- a/internal/worker/diff_rescan_test.go
+++ b/internal/worker/diff_rescan_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"scrutineer/internal/coverage"
 	"scrutineer/internal/db"
 	"scrutineer/internal/testutil"
 )
@@ -192,12 +193,20 @@ func TestPrepareDiffRescanFallsBackWithoutBaseline(t *testing.T) {
 	if scan.RescanMode != db.ScanRescanModeFull {
 		t.Fatalf("mode = %q, want full fallback", scan.RescanMode)
 	}
-	var cov diffCoverage
-	if err := json.Unmarshal([]byte(scan.Coverage), &cov); err != nil {
-		t.Fatal(err)
+	cov, ok := coverage.Parse(scan.Coverage)
+	if !ok {
+		t.Fatalf("coverage = %q, want a record", scan.Coverage)
 	}
 	if cov.RequestedMode != db.ScanRescanModeDiff || cov.ActualMode != db.ScanRescanModeFull || !strings.Contains(cov.FallbackReason, "baseline") {
 		t.Fatalf("coverage = %+v", cov)
+	}
+	// A fallback ran as a full scan, which has no enumerable scope, so it
+	// must not inherit a completeness claim from the diff it replaced.
+	if cov.Completeness != coverage.CompletenessUnknown {
+		t.Fatalf("completeness = %q, want %q", cov.Completeness, coverage.CompletenessUnknown)
+	}
+	if scan.Completeness != cov.Completeness {
+		t.Fatalf("column = %q, record = %q; the two must agree", scan.Completeness, cov.Completeness)
 	}
 	var stored db.Scan
 	gdb.First(&stored, scan.ID)


### PR DESCRIPTION
Closes part of #771 — the self-contained slice I described in https://github.com/alpha-omega-security/scrutineer/issues/771#issuecomment-5217502449. Happy to reshape it if you'd rather the split ran differently.

`Scan.Coverage` was an ad-hoc JSON blob with **two** writers putting different shapes into it — `diffCoverage` in `internal/worker/diff_rescan.go` and `markThreatModelUpdate` in `internal/web/diff_threat_model.go`, which merged three keys through `map[string]any`. A consumer could not tell "no findings after a complete scan" from "no findings in the part that finished".

**What this does**

- Adds `internal/coverage` with the typed record and an indexed `Scan.Completeness` column, so the scans list can filter without decoding the blob. `setCoverage` writes both together so the column and the record cannot drift apart.
- Moves both existing writers onto the record. The `threat_model_update` / `threat_model_material` / `threat_model_update_reason` keys become a `threat_model` sub-record rather than being dropped: "the model wasn't updated because the diff was too small" is a completeness statement, so it belongs inside the contract. (Those keys had no reader outside their own test, so dropping them was available — I don't think it's right.)
- `Parse` reads **both** legacy shapes back, so rows written before this keep their meaning, and a row that made no completeness claim reads `unknown` instead of being guessed at.
- `Reconcile` derives completeness in the worker from receipts against the scope the worker staged itself. **With no scope of its own it returns `unknown`, never `complete`, however many receipts a skill supplied** — that refusal is the point, and `TestReconcileWithoutScopeNeverClaimsComplete` pins it. A receipt is also not the same as finished work, so `deferred` / `failed` / `cost_capped` keep a scan `partial` while `excluded` settles it.

**What is deliberately not here, and why**

- `surfaces[]`, `dropped_findings[]`, `open_questions[]` and `receipts[]` are **declared but written by nobody**. They can only come from the skill, and per finding (2) in the issue comment, `coverage_metadata_key` is advertised at `skill.go:1351` and never ingested anywhere — making that channel real is slice 2. I'd rather ship the shape fixed and say so than populate these from guesses.
- `preflight` (#772), `reason: cost_cap` (#774) and manifest-derived per-unit receipts (#20) belong to their own issues.
- Diff staging starts at `partial` with `included_paths` set and no receipts, which is the truthful state at staging time. The fallback path records `unknown`, since a full scan has no enumerable scope yet.
- I left `internal/web/api.go` emitting `coverage` as a string. Turning it into an object is right (finding 4) but it's a breaking API change, so I'd rather you called it than have it ride along here.

`go build`, `go vet` and `gofmt` are clean. `internal/coverage` passes, as do the `Diff`/`Rescan`/`ThreatModel`/`Scan` tests in `internal/worker` and `internal/web`. One caveat I'd rather state than paper over: `internal/db`'s `TestWriteFindingField_concurrentUpdatesKeepHistoryChain` failed for me with `SQLITE_BUSY` — but it also fails intermittently on unmodified `main` on this machine (1 failure in 4 runs there, 3 in 4 on the branch), so I can't tell from here whether that's my change or an underactuated box. Nothing in the diff touches findings or that write path; CI is the authority. If it's red there I'll fix it in this PR.
