### PR TITLE
Support multi-skill filtering on the scans dashboard

### DIFF
--- a/internal/web/scans.go
+++ b/internal/web/scans.go
@@ -19,11 +19,9 @@ import (
 )
 
 func (s *Server) jobs(w http.ResponseWriter, r *http.Request) {
-	q := s.DB.Model(&db.Scan{})
-	skillName := r.URL.Query().Get("skill")
-	if skillName != "" {
-		q = q.Where("skill_name = ?", skillName)
-	}
+	skillFilter := parseScanSkillFilter(r.URL.Query().Get("skill"))
+	r = requestWithScanSkillFilter(r, skillFilter.value())
+	q := skillFilter.apply(s.DB.Model(&db.Scan{}))
 	status := r.URL.Query().Get(statusKey)
 	if status != "" {
 		q = q.Where("status = ?", status)
@@ -68,12 +66,75 @@ func (s *Server) jobs(w http.ResponseWriter, r *http.Request) {
 	}
 	s.render(w, r, "jobs.html", map[string]any{
 		"Scans": scans, "Page": page,
-		"Skill": skillName, "Status": status, "Sort": sort, "Skills": skillNames,
+		"Skill": skillFilter.value(), "SkillLabel": skillFilter.label(),
+		"Status": status, "Sort": sort, "Skills": skillNames,
 		"AnySubPath": anySubPath, "QueuedCount": stats.QueuedCount, "PausedCount": stats.PausedCount,
 		"AccountPausedCount": stats.AccountPausedCount,
 		"NextAccountResume":  stats.NextAccountResume,
 		"ModelDowngraded":    s.Worker.ShouldDowngradeModel(),
 	})
+}
+
+type scanSkillFilter struct {
+	names []string
+}
+
+func parseScanSkillFilter(raw string) scanSkillFilter {
+	seen := make(map[string]struct{})
+	names := make([]string, 0)
+	for _, name := range strings.Split(raw, ",") {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
+		names = append(names, name)
+	}
+	return scanSkillFilter{names: names}
+}
+
+func (f scanSkillFilter) apply(q *gorm.DB) *gorm.DB {
+	switch len(f.names) {
+	case 0:
+		return q
+	case 1:
+		return q.Where("skill_name = ?", f.names[0])
+	default:
+		return q.Where("skill_name IN ?", f.names)
+	}
+}
+
+func (f scanSkillFilter) value() string {
+	return strings.Join(f.names, ",")
+}
+
+func (f scanSkillFilter) label() string {
+	if len(f.names) == 1 {
+		return f.names[0]
+	}
+	if len(f.names) > 1 {
+		return fmt.Sprintf("%d skills", len(f.names))
+	}
+	return ""
+}
+
+// requestWithScanSkillFilter gives pagination and sortable headers the same
+// canonical filter used by the SQL query. Clone before rewriting RawQuery so
+// middleware and callers retaining the original request do not observe a
+// handler-local normalization.
+func requestWithScanSkillFilter(r *http.Request, value string) *http.Request {
+	r = r.Clone(r.Context())
+	query := r.URL.Query()
+	if value == "" {
+		query.Del("skill")
+	} else {
+		query.Set("skill", value)
+	}
+	r.URL.RawQuery = query.Encode()
+	return r
 }
 
 type scanListStats struct {
@@ -299,13 +360,10 @@ func (s *Server) resumeOpts(scan db.Scan) (sessionID string, resumeOf *uint) {
 }
 
 func (s *Server) scansRetryFailed(w http.ResponseWriter, r *http.Request) {
-	skillName := r.URL.Query().Get("skill")
+	skillFilter := parseScanSkillFilter(r.URL.Query().Get("skill"))
 	repoID, _ := strconv.Atoi(r.URL.Query().Get("repository"))
-	q := s.DB.Model(&db.Scan{}).
-		Where("status = ? AND kind = ? AND skill_id IS NOT NULL", db.ScanFailed, worker.JobSkill)
-	if skillName != "" {
-		q = q.Where("skill_name = ?", skillName)
-	}
+	q := skillFilter.apply(s.DB.Model(&db.Scan{}).
+		Where("status = ? AND kind = ? AND skill_id IS NOT NULL", db.ScanFailed, worker.JobSkill))
 	if repoID > 0 {
 		q = q.Where("repository_id = ?", repoID)
 	}
@@ -370,8 +428,8 @@ func (s *Server) scansRetryFailed(w http.ResponseWriter, r *http.Request) {
 	target := "/scans?status=failed"
 	if repoID > 0 {
 		target = fmt.Sprintf("/repositories/%d#rt3", repoID)
-	} else if skillName != "" {
-		target += "&skill=" + url.QueryEscape(skillName)
+	} else if skillFilter.value() != "" {
+		target += "&skill=" + url.QueryEscape(skillFilter.value())
 	}
 	s.redirect(w, r, target)
 }

--- a/internal/web/scans_filter_test.go
+++ b/internal/web/scans_filter_test.go
@@ -1,0 +1,183 @@
+package web
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"strings"
+	"testing"
+
+	"scrutineer/internal/db"
+	"scrutineer/internal/worker"
+)
+
+func TestParseScanSkillFilter(t *testing.T) {
+	tests := []struct {
+		name      string
+		raw       string
+		wantNames []string
+		wantValue string
+		wantLabel string
+	}{
+		{name: "empty", raw: "", wantNames: []string{}},
+		{name: "only separators", raw: " , , ", wantNames: []string{}},
+		{name: "single", raw: " security-deep-dive ", wantNames: []string{"security-deep-dive"}, wantValue: "security-deep-dive", wantLabel: "security-deep-dive"},
+		{name: "multiple normalized", raw: " alpha, bravo,,alpha, charlie ", wantNames: []string{"alpha", "bravo", "charlie"}, wantValue: "alpha,bravo,charlie", wantLabel: "3 skills"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := parseScanSkillFilter(test.raw)
+			if !slices.Equal(got.names, test.wantNames) {
+				t.Errorf("names = %v, want %v", got.names, test.wantNames)
+			}
+			if got.value() != test.wantValue {
+				t.Errorf("value() = %q, want %q", got.value(), test.wantValue)
+			}
+			if got.label() != test.wantLabel {
+				t.Errorf("label() = %q, want %q", got.label(), test.wantLabel)
+			}
+		})
+	}
+}
+
+func TestJobs_filtersBySingleSkill(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	repo := db.Repository{URL: "https://example.com/single-filter", Name: "single-filter"}
+	if err := s.DB.Create(&repo).Error; err != nil {
+		t.Fatal(err)
+	}
+	makeScan := func(name string) db.Scan {
+		scan := db.Scan{RepositoryID: repo.ID, Kind: worker.JobSkill, SkillName: name, Status: db.ScanDone,
+			StatusPriority: db.StatusPriorityFor(db.ScanDone)}
+		if err := s.DB.Create(&scan).Error; err != nil {
+			t.Fatal(err)
+		}
+		return scan
+	}
+	alpha := makeScan("alpha")
+	bravo := makeScan("bravo")
+
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq("GET", "/scans?skill=alpha"))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body)
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, fmt.Sprintf(`/scans/%d"`, alpha.ID)) {
+		t.Errorf("matching alpha scan %d is missing", alpha.ID)
+	}
+	if strings.Contains(body, fmt.Sprintf(`/scans/%d"`, bravo.ID)) {
+		t.Errorf("non-matching bravo scan %d was rendered", bravo.ID)
+	}
+	if !strings.Contains(body, `aria-current="true">alpha</a>`) {
+		t.Error("single skill filter is not marked as current")
+	}
+}
+
+func TestJobs_filtersByMultipleSkillsAndPreservesNormalizedQuery(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	repo := db.Repository{URL: "https://example.com/filter", Name: "filter"}
+	if err := s.DB.Create(&repo).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	var alphaID, bravoID uint
+	for i := range 21 {
+		name := "alpha"
+		if i >= 11 {
+			name = "bravo"
+		}
+		scan := db.Scan{RepositoryID: repo.ID, Kind: worker.JobSkill, SkillName: name, Status: db.ScanDone,
+			StatusPriority: db.StatusPriorityFor(db.ScanDone)}
+		if err := s.DB.Create(&scan).Error; err != nil {
+			t.Fatal(err)
+		}
+		if name == "alpha" {
+			alphaID = scan.ID
+		} else {
+			bravoID = scan.ID
+		}
+	}
+	charlie := db.Scan{RepositoryID: repo.ID, Kind: worker.JobSkill, SkillName: "charlie", Status: db.ScanDone,
+		StatusPriority: db.StatusPriorityFor(db.ScanDone)}
+	if err := s.DB.Create(&charlie).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq("GET", "/scans?skill=%20alpha%20,%20bravo,,alpha&status=done&sort=skill"))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body)
+	}
+	body := w.Body.String()
+	for _, id := range []uint{alphaID, bravoID} {
+		if !strings.Contains(body, fmt.Sprintf(`/scans/%d"`, id)) {
+			t.Errorf("matching scan %d is missing", id)
+		}
+	}
+	if strings.Contains(body, fmt.Sprintf(`/scans/%d"`, charlie.ID)) {
+		t.Errorf("non-matching charlie scan %d was rendered", charlie.ID)
+	}
+	if !strings.Contains(body, "2 skills") {
+		t.Error("combined filter label is missing")
+	}
+	if !strings.Contains(body, `aria-label="Skills: alpha,bravo"`) {
+		t.Error("combined filter accessible label does not list the selected skills")
+	}
+	if !strings.Contains(body, "skill=alpha%2Cbravo") {
+		t.Error("normalized skill filter is missing from sort or pagination links")
+	}
+	if strings.Contains(body, `aria-current="true">alpha</a>`) || strings.Contains(body, `aria-current="true">bravo</a>`) {
+		t.Error("combined filter marked an individual skill as current")
+	}
+}
+
+func TestScansRetryFailed_filtersByMultipleSkills(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	repo := db.Repository{URL: "https://example.com/retry-filter", Name: "retry-filter"}
+	if err := s.DB.Create(&repo).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	skills := make(map[string]db.Skill)
+	for _, name := range []string{"alpha", "bravo", "charlie"} {
+		skill := db.Skill{Name: name, Description: name, Body: "b", OutputFile: "report.json",
+			OutputKind: "freeform", Version: 1, Active: true, Source: "ui"}
+		if err := s.DB.Create(&skill).Error; err != nil {
+			t.Fatal(err)
+		}
+		skills[name] = skill
+		scan := db.Scan{RepositoryID: repo.ID, Kind: worker.JobSkill, SkillID: &skill.ID, SkillName: name,
+			Status: db.ScanFailed, StatusPriority: db.StatusPriorityFor(db.ScanFailed)}
+		if err := s.DB.Create(&scan).Error; err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq("POST", "/scans/retry-failed?skill=%20alpha%20,bravo,,alpha"))
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("status = %d, want 303; body=%s", w.Code, w.Body)
+	}
+	if got := w.Header().Get("Location"); got != "/scans?status=failed&skill=alpha%2Cbravo" {
+		t.Errorf("redirect = %q, want normalized combined filter", got)
+	}
+	for _, test := range []struct {
+		name string
+		want int64
+	}{{"alpha", 1}, {"bravo", 1}, {"charlie", 0}} {
+		var queued int64
+		if err := s.DB.Model(&db.Scan{}).
+			Where("status = ? AND skill_id = ?", db.ScanQueued, skills[test.name].ID).
+			Count(&queued).Error; err != nil {
+			t.Fatal(err)
+		}
+		if queued != test.want {
+			t.Errorf("queued %s scans = %d, want %d", test.name, queued, test.want)
+		}
+	}
+}

--- a/internal/web/templates/jobs.html
+++ b/internal/web/templates/jobs.html
@@ -22,14 +22,14 @@
     {{if and (eq .Status "failed") .Page.Total}}
       <form method="post" action="/scans/retry-failed?skill={{.Skill}}"
             hx-post="/scans/retry-failed?skill={{.Skill}}" hx-swap="none"
-            hx-confirm="Re-enqueue every failed{{if .Skill}} {{.Skill}}{{end}} scan?">
+            hx-confirm="Re-enqueue every failed scan{{if .Skill}} for {{.Skill}}{{end}}?">
         <button type="submit" class="btn-outline"><i data-lucide="refresh-cw"></i> Retry all failed</button>
       </form>
     {{end}}
     <div class="dropdown-menu">
-      <button type="button" class="btn-outline" aria-haspopup="menu" aria-expanded="false">
+      <button type="button" class="btn-outline" aria-haspopup="menu" aria-expanded="false"{{if .Skill}} aria-label="Skills: {{.Skill}}" title="{{.Skill}}"{{end}}>
         <i data-lucide="filter"></i>
-        {{if .Skill}}{{.Skill}}{{else}}Skill{{end}}
+        {{if .Skill}}{{.SkillLabel}}{{else}}Skill{{end}}
         <i data-lucide="chevron-down"></i>
       </button>
       <div data-popover aria-hidden="true" data-align="end">


### PR DESCRIPTION
Fixes #812

## Summary

Adds comma-separated multi-skill filtering to the scans dashboard, allowing operators to view and retry several related skill types together.

For example, `/scans?skill=security-deep-dive,vuln-scan,advisory-deep-dive` now returns the union of scans for those exact skill names.

## Changes

- Parse comma-separated values from the `skill` query parameter.
- Trim whitespace, remove empty entries and deduplicate repeated skill names.
- Preserve existing exact-match behavior for a single skill.
- Use an `IN` query when multiple skills are selected.
- Preserve the normalized filter across sorting and pagination links.
- Apply the same filter semantics to bulk retrying of failed scans.
- Preserve the normalized filter in retry redirects.
- Show a compact multi-skill label in the filter control while retaining the full selection in accessible text and confirmation prompts.
- Add focused tests for parsing, single-skill filtering, multi-skill filtering, query preservation and filtered retries.

## Tests

- `go test -race ./...`
- `go test -race -tags evals ./internal/evals/...`
- `go vet ./...`
- `go vet -tags evals ./internal/evals/...`
- `go vet -tags podman ./...`
- `golangci-lint run`
- `git diff --check`