### PR TITLE
Structured `controls` in the threat-model contract

### DIFF
--- a/internal/threatmodel/threatmodel.go
+++ b/internal/threatmodel/threatmodel.go
@@ -1,0 +1,210 @@
+// Package threatmodel parses the parts of a threat-model report that the Go
+// side has to act on, rather than hand through to a skill verbatim.
+//
+// Until now nothing in Go read a field out of a threat model: the document
+// moves from Repository.ThreatModel through stageThreatModel to
+// ./threat_model.json as opaque text, and only skills look inside it. Controls
+// are the first part that the worker itself has to interpret, because matching
+// a finding's file against a control's paths is a decision about that finding,
+// made before any skill runs.
+//
+// Parsing is deliberately partial. A Model unmarshals only the fields declared
+// here and ignores everything else in the document, so a threat model that
+// grows new sections — or that predates controls entirely — still parses. The
+// package never rejects a model for what it does not understand; the only
+// errors it returns are for controls that are present and malformed.
+package threatmodel
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"scrutineer/internal/skills"
+)
+
+// Provenance values follow the convention the rest of the threat-model schema
+// uses: a documented claim cites a file:line or URL that can be re-read, an
+// inferred one is the model's own reading of the code.
+const (
+	ProvenanceDocumented = "documented"
+	ProvenanceInferred   = "inferred"
+)
+
+// Kind is an open enum. These are the kinds the schema names, but a model may
+// carry one this build has never heard of, and that is not an error: an
+// unknown kind still matches paths and still tells a verifier that the author
+// believed something guards this code. Consumers that special-case a kind
+// (an authorization control implying an authenticated-user prerequisite, say)
+// must treat every other value as "a control, effect unknown".
+const (
+	KindAuthorization   = "authorization"
+	KindSandbox         = "sandbox"
+	KindInputValidation = "input-validation"
+	KindCSRF            = "csrf"
+	KindRateLimit       = "rate-limit"
+	KindOther           = "other"
+)
+
+// Control is one design-level mitigation the threat model claims is in force.
+//
+// It is a claim, not a proof. A matched control does not make a finding a
+// false positive; it names something a verifier has to either demonstrate a
+// bypass of or explain away before the finding stands.
+type Control struct {
+	// ID is unique within a model and is what downstream records cite.
+	ID string `json:"id"`
+	// Kind is an open enum; see the Kind constants.
+	Kind string `json:"kind"`
+	// Protects is what this control sits in front of.
+	Protects Protects `json:"protects"`
+	// Assumptions are the conditions under which the control actually
+	// holds — "requests reach this package only through the authenticated
+	// router". They are the first thing a bypass argument attacks.
+	Assumptions []string `json:"assumptions,omitempty"`
+	Provenance  string   `json:"provenance"`
+	// Source backs a documented claim: file:line or a URL.
+	Source string `json:"source,omitempty"`
+}
+
+// Protects is a control's scope. Paths are globs in the same dialect the rest
+// of the product uses for path patterns (skills.Match); EntryPoints name
+// entries in the model's own entry_points table.
+//
+// A control with neither is not scoped to anything and cannot be matched. That
+// is a defect in the model rather than a control that protects everything, and
+// Validate says so.
+type Protects struct {
+	Paths       []string `json:"paths,omitempty"`
+	EntryPoints []string `json:"entry_points,omitempty"`
+}
+
+// Model is the subset of a threat-model report this package reads.
+type Model struct {
+	Controls []Control `json:"controls,omitempty"`
+}
+
+// Parse reads a threat-model document. An empty document is not an error: a
+// repository with no operator override, or a model written before controls
+// existed, yields a Model with no controls and no complaint.
+//
+// Parse does not validate. Callers that are about to act on the controls call
+// Validate; callers that only want to know whether any exist do not have to.
+func Parse(raw string) (*Model, error) {
+	if strings.TrimSpace(raw) == "" {
+		return &Model{}, nil
+	}
+	var m Model
+	if err := json.Unmarshal([]byte(raw), &m); err != nil {
+		return nil, fmt.Errorf("parse threat model: %w", err)
+	}
+	return &m, nil
+}
+
+// Validate reports the first structural problem in the model's controls.
+//
+// The checks are the ones a matcher depends on and JSON Schema cannot express
+// on its own: unique ids, at least one scope, and globs the shared matcher can
+// actually evaluate. An unrecognised kind is deliberately not an error.
+func (m *Model) Validate() error {
+	if m == nil {
+		return nil
+	}
+	seen := make(map[string]int, len(m.Controls))
+	for i, c := range m.Controls {
+		if strings.TrimSpace(c.ID) == "" {
+			return fmt.Errorf("controls[%d]: id is required", i)
+		}
+		if first, dup := seen[c.ID]; dup {
+			return fmt.Errorf("controls[%d]: duplicate id %q, first used by controls[%d]", i, c.ID, first)
+		}
+		seen[c.ID] = i
+		if strings.TrimSpace(c.Kind) == "" {
+			return fmt.Errorf("controls[%d] (%s): kind is required", i, c.ID)
+		}
+		switch c.Provenance {
+		case ProvenanceDocumented, ProvenanceInferred:
+		default:
+			return fmt.Errorf("controls[%d] (%s): provenance must be %q or %q, got %q",
+				i, c.ID, ProvenanceDocumented, ProvenanceInferred, c.Provenance)
+		}
+		if len(c.Protects.Paths) == 0 && len(c.Protects.EntryPoints) == 0 {
+			return fmt.Errorf("controls[%d] (%s): protects needs at least one of paths or entry_points", i, c.ID)
+		}
+		for j, p := range c.Protects.Paths {
+			if strings.TrimSpace(p) == "" {
+				return fmt.Errorf("controls[%d] (%s): protects.paths[%d] is empty", i, c.ID, j)
+			}
+			if err := skills.ValidateGlob(p); err != nil {
+				return fmt.Errorf("controls[%d] (%s): protects.paths[%d] %q is not a valid glob: %w", i, c.ID, j, p, err)
+			}
+		}
+	}
+	return nil
+}
+
+// MatchPath returns the controls whose protects.paths cover the given
+// repository-relative file, in the order they appear in the model.
+//
+// The path must be relative to the repository root, in the same namespace the
+// globs are authored in. Callers holding a path from a subpath-scoped scan
+// have to rebase it first; this package cannot tell the two apart, and
+// matching a subpath-relative path against root-relative globs returns an
+// empty set rather than an error, which is the quiet failure worth avoiding.
+func (m *Model) MatchPath(path string) []Control {
+	if m == nil || path == "" {
+		return nil
+	}
+	path = strings.TrimPrefix(path, "./")
+	var out []Control
+	for _, c := range m.Controls {
+		for _, pattern := range c.Protects.Paths {
+			if skills.Match(pattern, path) {
+				out = append(out, c)
+				break
+			}
+		}
+	}
+	return out
+}
+
+// MatchEntryPoint returns the controls that name the given entry point. The
+// comparison is exact: entry-point names come from the model's own
+// entry_points table, not from user input, so a near miss is an authoring
+// error worth surfacing rather than smoothing over.
+func (m *Model) MatchEntryPoint(name string) []Control {
+	if m == nil || name == "" {
+		return nil
+	}
+	var out []Control
+	for _, c := range m.Controls {
+		for _, ep := range c.Protects.EntryPoints {
+			if ep == name {
+				out = append(out, c)
+				break
+			}
+		}
+	}
+	return out
+}
+
+// IDs returns the sorted, de-duplicated ids of a control set. It exists so
+// that anything recording "which controls matched" — a note, a rubric row, a
+// log line — is stable across runs rather than reflecting model ordering.
+func IDs(controls []Control) []string {
+	if len(controls) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(controls))
+	out := make([]string, 0, len(controls))
+	for _, c := range controls {
+		if _, dup := seen[c.ID]; dup {
+			continue
+		}
+		seen[c.ID] = struct{}{}
+		out = append(out, c.ID)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/threatmodel/threatmodel_test.go
+++ b/internal/threatmodel/threatmodel_test.go
@@ -1,0 +1,244 @@
+package threatmodel
+
+import (
+	"strings"
+	"testing"
+)
+
+const modelWithControls = `{
+  "spec_version": 1,
+  "repository": "https://example.test/repo",
+  "controls": [
+    {
+      "id": "admin-auth",
+      "kind": "authorization",
+      "protects": {
+        "paths": ["internal/admin/**"],
+        "entry_points": ["admin-api"]
+      },
+      "assumptions": ["requests reach this package only through the authenticated router"],
+      "provenance": "documented",
+      "source": "docs/SECURITY.md:12"
+    },
+    {
+      "id": "parser-sandbox",
+      "kind": "sandbox",
+      "protects": { "paths": ["internal/parse/*.go"] },
+      "provenance": "inferred"
+    }
+  ]
+}`
+
+func mustParse(t *testing.T, raw string) *Model {
+	t.Helper()
+	m, err := Parse(raw)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	return m
+}
+
+// A threat model that predates controls, or one from a repository with no
+// override at all, has to parse clean. The package is additive to documents
+// nothing else in Go has ever read.
+func TestParseModelWithoutControls(t *testing.T) {
+	for name, raw := range map[string]string{
+		"empty string":     "",
+		"whitespace":       "   \n\t ",
+		"no controls key":  `{"spec_version": 1, "entry_points": []}`,
+		"controls omitted": `{"spec_version": 1, "trust_boundaries": [{"component": "c"}]}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			m := mustParse(t, raw)
+			if len(m.Controls) != 0 {
+				t.Fatalf("got %d controls, want 0", len(m.Controls))
+			}
+			if err := m.Validate(); err != nil {
+				t.Fatalf("Validate: %v", err)
+			}
+			if got := m.MatchPath("internal/admin/users.go"); got != nil {
+				t.Fatalf("MatchPath on empty model = %v, want nil", got)
+			}
+		})
+	}
+}
+
+// Unknown top-level sections must not break parsing: the document is owned by
+// the skill's schema, and this package reads one field out of it.
+func TestParseIgnoresUnknownFields(t *testing.T) {
+	m := mustParse(t, modelWithControls)
+	if len(m.Controls) != 2 {
+		t.Fatalf("got %d controls, want 2", len(m.Controls))
+	}
+	admin := m.Controls[0]
+	if admin.ID != "admin-auth" || admin.Kind != KindAuthorization {
+		t.Fatalf("first control = %+v", admin)
+	}
+	if admin.Source != "docs/SECURITY.md:12" || admin.Provenance != ProvenanceDocumented {
+		t.Fatalf("provenance/source not parsed: %+v", admin)
+	}
+	if len(admin.Assumptions) != 1 {
+		t.Fatalf("assumptions = %v", admin.Assumptions)
+	}
+	if got := m.Controls[1].Protects.EntryPoints; len(got) != 0 {
+		t.Fatalf("second control entry_points = %v, want none", got)
+	}
+}
+
+func TestParseRejectsMalformedJSON(t *testing.T) {
+	if _, err := Parse(`{"controls": [`); err == nil {
+		t.Fatal("want error for truncated document")
+	}
+}
+
+func TestMatchPath(t *testing.T) {
+	m := mustParse(t, modelWithControls)
+	for name, tc := range map[string]struct {
+		path string
+		want []string
+	}{
+		"file under doublestar":     {"internal/admin/users.go", []string{"admin-auth"}},
+		"nested under doublestar":   {"internal/admin/roles/grant.go", []string{"admin-auth"}},
+		"directory itself":          {"internal/admin", []string{"admin-auth"}},
+		"leading ./ is tolerated":   {"./internal/admin/users.go", []string{"admin-auth"}},
+		"single star stays shallow": {"internal/parse/json.go", []string{"parser-sandbox"}},
+		"single star not nested":    {"internal/parse/deep/json.go", nil},
+		"unprotected path":          {"internal/web/server.go", nil},
+		"empty path":                {"", nil},
+	} {
+		t.Run(name, func(t *testing.T) {
+			got := IDs(m.MatchPath(tc.path))
+			if strings.Join(got, ",") != strings.Join(tc.want, ",") {
+				t.Fatalf("MatchPath(%q) = %v, want %v", tc.path, got, tc.want)
+			}
+		})
+	}
+}
+
+// A path matched by two of a control's own globs yields that control once:
+// the matched set is a set of controls, not of pattern hits.
+func TestMatchPathDoesNotDuplicateOneControl(t *testing.T) {
+	m := mustParse(t, `{"controls": [{
+	  "id": "c1", "kind": "other", "provenance": "inferred",
+	  "protects": {"paths": ["internal/**", "internal/admin/*.go"]}
+	}]}`)
+	got := m.MatchPath("internal/admin/users.go")
+	if len(got) != 1 || got[0].ID != "c1" {
+		t.Fatalf("MatchPath = %v, want exactly one c1", IDs(got))
+	}
+}
+
+func TestMatchEntryPoint(t *testing.T) {
+	m := mustParse(t, modelWithControls)
+	if got := IDs(m.MatchEntryPoint("admin-api")); len(got) != 1 || got[0] != "admin-auth" {
+		t.Fatalf("MatchEntryPoint(admin-api) = %v", got)
+	}
+	// Exact comparison: a near miss is an authoring error, not a match.
+	for _, name := range []string{"admin-API", "admin", "admin-api ", ""} {
+		if got := m.MatchEntryPoint(name); got != nil {
+			t.Fatalf("MatchEntryPoint(%q) = %v, want nil", name, IDs(got))
+		}
+	}
+}
+
+// A control scoped only by entry point must not match a path, and vice versa.
+// The two scopes are independent inputs to different consumers.
+func TestScopesDoNotLeakIntoEachOther(t *testing.T) {
+	m := mustParse(t, `{"controls": [
+	  {"id": "ep-only", "kind": "csrf", "provenance": "inferred", "protects": {"entry_points": ["mutating-routes"]}},
+	  {"id": "path-only", "kind": "sandbox", "provenance": "inferred", "protects": {"paths": ["internal/wasm/**"]}}
+	]}`)
+	if got := m.MatchPath("internal/wasm/run.go"); len(got) != 1 || got[0].ID != "path-only" {
+		t.Fatalf("MatchPath = %v", IDs(got))
+	}
+	if got := m.MatchEntryPoint("mutating-routes"); len(got) != 1 || got[0].ID != "ep-only" {
+		t.Fatalf("MatchEntryPoint = %v", IDs(got))
+	}
+}
+
+func TestValidate(t *testing.T) {
+	for name, tc := range map[string]struct {
+		raw     string
+		wantErr string
+	}{
+		"valid": {modelWithControls, ""},
+		"missing id": {
+			`{"controls": [{"kind": "other", "provenance": "inferred", "protects": {"paths": ["a/**"]}}]}`,
+			"id is required",
+		},
+		"duplicate id": {
+			`{"controls": [
+			  {"id": "c", "kind": "other", "provenance": "inferred", "protects": {"paths": ["a/**"]}},
+			  {"id": "c", "kind": "other", "provenance": "inferred", "protects": {"paths": ["b/**"]}}
+			]}`,
+			"duplicate id",
+		},
+		"missing kind": {
+			`{"controls": [{"id": "c", "provenance": "inferred", "protects": {"paths": ["a/**"]}}]}`,
+			"kind is required",
+		},
+		"bad provenance": {
+			`{"controls": [{"id": "c", "kind": "other", "provenance": "guessed", "protects": {"paths": ["a/**"]}}]}`,
+			"provenance must be",
+		},
+		"no scope": {
+			`{"controls": [{"id": "c", "kind": "other", "provenance": "inferred", "protects": {}}]}`,
+			"at least one of paths or entry_points",
+		},
+		"empty path": {
+			`{"controls": [{"id": "c", "kind": "other", "provenance": "inferred", "protects": {"paths": [""]}}]}`,
+			"is empty",
+		},
+		"malformed glob": {
+			`{"controls": [{"id": "c", "kind": "other", "provenance": "inferred", "protects": {"paths": ["internal/[admin/**"]}}]}`,
+			"is not a valid glob",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			err := mustParse(t, tc.raw).Validate()
+			switch {
+			case tc.wantErr == "" && err != nil:
+				t.Fatalf("Validate: %v", err)
+			case tc.wantErr != "" && err == nil:
+				t.Fatalf("Validate = nil, want error containing %q", tc.wantErr)
+			case tc.wantErr != "" && !strings.Contains(err.Error(), tc.wantErr):
+				t.Fatalf("Validate = %q, want it to contain %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+// An unrecognised kind is explicitly allowed: the schema calls kind an open
+// enum, and a control this build cannot interpret still scopes and matches.
+func TestValidateAllowsUnknownKind(t *testing.T) {
+	m := mustParse(t, `{"controls": [{"id": "c", "kind": "attestation", "provenance": "documented",
+	  "source": "docs/SECURITY.md:1", "protects": {"paths": ["internal/**"]}}]}`)
+	if err := m.Validate(); err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if got := IDs(m.MatchPath("internal/x.go")); len(got) != 1 {
+		t.Fatalf("MatchPath = %v", got)
+	}
+}
+
+func TestIDsAreSortedAndDeduped(t *testing.T) {
+	got := IDs([]Control{{ID: "b"}, {ID: "a"}, {ID: "b"}})
+	if strings.Join(got, ",") != "a,b" {
+		t.Fatalf("IDs = %v", got)
+	}
+	if IDs(nil) != nil {
+		t.Fatal("IDs(nil) should be nil")
+	}
+}
+
+// Validate tolerates a nil receiver so callers can validate whatever Parse
+// handed back without a nil check at every call site.
+func TestNilModel(t *testing.T) {
+	var m *Model
+	if err := m.Validate(); err != nil {
+		t.Fatalf("Validate on nil: %v", err)
+	}
+	if m.MatchPath("a.go") != nil || m.MatchEntryPoint("e") != nil {
+		t.Fatal("matching on nil model should return nil")
+	}
+}

--- a/skills/threat-model/SKILL.md
+++ b/skills/threat-model/SKILL.md
@@ -131,6 +131,14 @@ What the caller (for a library) or operator (for a service) must do for the assu
 
 Ways the API permits being called that violate the assumptions. Passing untrusted data to a trusted-only parameter, using the project as a security boundary it is not, exceeding documented limits, mixing modes that are not synchronised. For each: what it looks like, why it is unsafe, what to do instead.
 
+### Controls
+
+Optional. Design-level mitigations that sit in front of code: an authenticated router ahead of an admin package, a sandbox around a parser, CSRF middleware on all mutating routes. Today these appear only as prose on trust boundaries, which means nothing downstream can tell which mitigation applies to a given finding's file.
+
+For each: an `id` unique in this report, a `kind` (`authorization`, `sandbox`, `input-validation`, `csrf`, `rate-limit`, `other` — an open enum, use a better word if you have one), what it `protects` (repository-root-relative path globs, entry-point names from your own table, or both — at least one), the `assumptions` under which it actually holds, and the usual `provenance`/`source`.
+
+The assumptions matter more than the control. "Requests reach this package only through the authenticated router" is the sentence a reviewer attacks; a control with no stated assumption cannot be argued with. Record a control only where you can point at the mechanism in code or docs — an aspiration ("the service should require auth") is an open question, not a control. Record it as `inferred` when you read it out of the code rather than out of documentation.
+
 ### Known non-findings
 
 Patterns that scanners, fuzzers, or reviewers repeatedly flag against this project that are not bugs given the model. For each: what the tool reports (function, file, message pattern), why it is safe (cite the entry-point row or property that discharges it), and where applicable a suppression hint. Sources: comments in the code that say "this is safe because", `// nolint` / `# noqa` / `// NOSONAR` annotations with reasons, closed issues where a maintainer explained why a scanner hit is not a bug, prior advisories that were rejected. This list is fed back to semgrep and deep-dive as a negative filter; populate it even if short.

--- a/skills/threat-model/schema.json
+++ b/skills/threat-model/schema.json
@@ -56,6 +56,7 @@
     "downstream_responsibilities": { "type": "array", "items": { "type": "string" } },
     "known_misuse":      { "$ref": "#/$defs/misuse_or_na" },
     "known_non_findings": { "type": "array", "items": { "$ref": "#/$defs/non_finding" } },
+    "controls":          { "type": "array", "items": { "$ref": "#/$defs/control" } },
 
     "dispositions": {
       "type": "array",
@@ -255,6 +256,49 @@
         "why_safe":    { "type": "string" },
         "cites":       { "type": "string", "description": "JSON pointer-ish reference into this report, e.g. out_of_scope[0]" },
         "suppression": { "type": "string" }
+      }
+    },
+
+    "control": {
+      "type": "object",
+      "description": "A design-level mitigation the model claims is in force over some code or entry point: an authenticated router, a sandbox, CSRF middleware. A claim, not a proof — downstream a matched control has to be bypassed or explained away, not treated as making a finding safe.",
+      "required": ["id", "kind", "protects", "provenance"],
+      "additionalProperties": false,
+      "properties": {
+        "id":   { "type": "string", "description": "unique within this report; downstream records cite it" },
+        "kind": { "type": "string", "minLength": 1, "description": "open enum: authorization, sandbox, input-validation, csrf, rate-limit, other — a kind not listed here is allowed and means the effect is unknown to consumers" },
+        "protects": { "$ref": "#/$defs/control_scope" },
+        "assumptions": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "conditions under which the control actually holds, e.g. 'requests reach this package only through the authenticated router'"
+        },
+        "provenance": { "$ref": "#/$defs/provenance" },
+        "source":     { "$ref": "#/$defs/source" }
+      }
+    },
+    "control_scope": {
+      "type": "object",
+      "description": "What the control sits in front of. At least one of paths or entry_points is required: a control scoped to nothing cannot be matched, and is an authoring error rather than a control over everything.",
+      "additionalProperties": false,
+      "minProperties": 1,
+      "anyOf": [
+        { "required": ["paths"] },
+        { "required": ["entry_points"] }
+      ],
+      "properties": {
+        "paths": {
+          "type": "array",
+          "items": { "type": "string" },
+          "minItems": 1,
+          "description": "globs matched against a finding's file, repository-root-relative, in the same dialect as scan_config.focus_areas[].paths"
+        },
+        "entry_points": {
+          "type": "array",
+          "items": { "type": "string" },
+          "minItems": 1,
+          "description": "names from this report's entry_points[].entry_point"
+        }
       }
     },
 


### PR DESCRIPTION
Slice 1 of #779: the schema field and a way to read it back. Nothing consumes it yet, and that is deliberate — the two consumers the issue names don't have a channel to reach today, which I wrote up in https://github.com/alpha-omega-security/scrutineer/issues/779#issuecomment-5227710735. Rather than land a field with an inert consumer story, this lands the contract and the matcher, and leaves the transport to a follow-up.

**Schema.** Optional top-level `controls[]` on the threat-model report: `id`, `kind`, `protects` (root-relative path globs and/or entry-point names), `assumptions`, and the existing `provenance`/`source`. Two shape decisions worth flagging:

- `protects` requires at least one of `paths` / `entry_points`. A control scoped to nothing can't be matched, and reading it as "protects everything" is the wrong default for something that will feed severity caps.
- `kind` is a `minLength: 1` string, not an enum, per the issue's "open enum". A consumer that meets a kind it doesn't know still learns that the author claimed a mitigation here; an enum would have made an unfamiliar control a validation failure.

`SKILL.md` gains the authoring guidance, including the part I think carries the weight: the `assumptions` are what a reviewer attacks, and a control with no stated assumption can't be argued with. An aspiration ("the service should require auth") is an open question, not a control.

**`internal/threatmodel`.** Reads `controls[]` back out of a model document and matches a finding path or entry-point name against it.

This is the first Go code in the tree that reads *any* field out of a threat model — until now the document goes from `Repository.ThreatModel` through `stageThreatModel` to `./threat_model.json` as opaque text, and only skills look inside. So parsing is partial on purpose: unknown sections are ignored, and a model written before controls existed (or an empty override) parses clean and matches nothing. `Validate` only complains about controls that are present and malformed — duplicate ids, missing scope, a glob the matcher can't evaluate.

Matching goes through `skills.Match`, the same dialect `repoconfig` validates `focus_areas[].paths` with, so `internal/admin/**` means one thing across the product rather than two.

**The subpath question, stated rather than papered over.** `MatchPath` documents that it needs a repository-root-relative path. Subpath-scoped scans prune `./src` and report locations relative to the sub-folder, while `protects.paths` is authored against the root — matching one against the other returns an empty set, silently. I've left that as a documented precondition on this function instead of guessing a rebase here, because the right answer depends on where the matched set gets computed, which is slice 2. Whoever wires it either rebases at that call site or declares controls out of scope for subpath scans; both are defensible, silently matching nothing isn't.

**Tests.** `internal/threatmodel` covers: models without controls (empty, whitespace, pre-controls documents), unknown top-level fields surviving, malformed JSON rejected, `**` vs `*` depth, `./` prefixes, a path hit by two of one control's globs yielding that control once, path and entry-point scopes not leaking into each other, every `Validate` failure, an unknown `kind` accepted and still matching, and nil-receiver safety.

`gofmt`/`go vet`/`go build ./...` clean; `internal/threatmodel`, `internal/skills`, `internal/repoconfig` and `internal/worker` green locally.
