### PR TITLE
perf: stop loading blob columns on the skill API hot path

### DIFF
--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -38,6 +39,24 @@ func NewAPIToken() string {
 
 type apiCtxKey struct{}
 
+// scanBlobColumns are the wide columns on a scan row. A running scan's log
+// grows for the length of the run, so endpoints serving only a scan's identity
+// or summary omit them; apiGetScan, which returns the report and log, does not.
+var scanBlobColumns = []string{"Log", "Prompt", "Report", "RefusalAudit", "ImportPayload"}
+
+// authScanOmitColumns additionally drops the scoping blobs, which nothing
+// reachable from scanFromRequest reads.
+var authScanOmitColumns = slices.Concat(scanBlobColumns,
+	[]string{"FocusArea", "DiffStats", "Coverage"})
+
+// repositoryBlobColumns are the wide columns on a repository row, dominated by
+// the cached ecosyste.ms payloads.
+var repositoryBlobColumns = []string{
+	"Metadata", "ThreatModel", "ScanConfig",
+	"EcosystemsRepoData", "EcosystemsPackagesData", "EcosystemsAdvisoriesData",
+	"EcosystemsCommitsData", "EcosystemsIssuesData", "EcosystemsDependentsData",
+}
+
 // apiAuth validates bearer tokens against the currently running scan rows
 // and puts the scan on the request context so handlers can apply the
 // "skills only touch their own repo" rule.
@@ -49,7 +68,8 @@ func (s *Server) apiAuth(next http.Handler) http.Handler {
 			return
 		}
 		var scan db.Scan
-		if err := s.DB.Where("api_token = ? AND status = ?", token, db.ScanRunning).
+		if err := s.DB.Omit(authScanOmitColumns...).
+			Where("api_token = ? AND status = ?", token, db.ScanRunning).
 			First(&scan).Error; err != nil {
 			if errors.Is(err, gorm.ErrRecordNotFound) {
 				writeAPIError(w, http.StatusUnauthorized, "token invalid or scan not running")
@@ -157,7 +177,7 @@ func (s *Server) apiGetRepository(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	var repo db.Repository
-	if err := s.DB.First(&repo, id).Error; err != nil {
+	if err := s.DB.Omit(repositoryBlobColumns...).First(&repo, id).Error; err != nil {
 		writeAPIError(w, http.StatusNotFound, "repository not found")
 		return
 	}
@@ -261,7 +281,7 @@ func (s *Server) apiListScans(w http.ResponseWriter, r *http.Request) {
 		q = q.Where("skill_name = ?", skill)
 	}
 	var rows []db.Scan
-	q.Find(&rows)
+	q.Omit(scanBlobColumns...).Find(&rows)
 	out := make([]map[string]any, 0, len(rows))
 	for _, sc := range rows {
 		out = append(out, scanSummary(sc))

--- a/internal/web/api_hot_path_test.go
+++ b/internal/web/api_hot_path_test.go
@@ -1,0 +1,218 @@
+package web
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"scrutineer/internal/db"
+)
+
+// A column missing from findingSummaryColumns serves a zero value instead.
+func TestAPIListFindings_summaryColumnsCoverEveryField(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	repo, scan := seedRunningScan(t, s)
+
+	checkedAt := time.Now().UTC().Truncate(time.Second)
+	seeded := db.Finding{
+		ScanID: scan.ID, RepositoryID: repo.ID,
+		FindingID: "F1", Commit: "abcdef1", Sinks: "S1",
+		Title: "OS command injection", Severity: "High", Status: db.FindingEnriched,
+		CWE: "CWE-78", Location: "main.go:12", VID: "vid-1", Affected: ">=1.0,<1.4",
+		Reachability: "reachable", QualityTier: "tier-1",
+		CVEID: "CVE-2026-1", GHSAID: "GHSA-xxxx", CVSSVector: "CVSS:3.1/AV:N",
+		CVSSScore: 9.8, FixVersion: "1.4.0", FixCommit: "abcd123",
+		Resolution: db.ResolutionFix, Assignee: "alice", MissedCount: 3,
+		DupCheck: "distinct from F2", Novelty: db.FindingNoveltyUnfixed,
+		NoveltyCheckedCommit: "abcdef1", NoveltyCheckedAt: &checkedAt,
+		// Prose the summary must not carry, and whose columns are excluded.
+		Trace: "long trace", Snippet: "long snippet", SuggestedFix: "long diff",
+	}
+	if err := s.DB.Create(&seeded).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	w := apiReq(t, s, "GET", fmt.Sprintf("/api/repositories/%d/findings", repo.ID), scan.APIToken, "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+	var got []map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d findings, want 1", len(got))
+	}
+
+	// An unprojected row is the reference.
+	var full db.Finding
+	if err := s.DB.First(&full, seeded.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	want := findingSummary(full)
+	for key, wantVal := range want {
+		wantJSON, _ := json.Marshal(wantVal)
+		gotJSON, _ := json.Marshal(got[0][key])
+		if string(gotJSON) != string(wantJSON) {
+			t.Errorf("%s = %s, want %s (missing from findingSummaryColumns?)", key, gotJSON, wantJSON)
+		}
+	}
+}
+
+// The summary omits the cached ecosyste.ms blobs but must still serve the rest.
+func TestAPIGetRepository_omitsBlobsKeepsSummary(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	repo, scan := seedRunningScan(t, s)
+	blob := strings.Repeat("x", 1<<16)
+	if err := s.DB.Model(&repo).Updates(map[string]any{
+		"full_name": "acme/thing", "default_branch": "main",
+		"html_url": "https://github.com/acme/thing", "stars": 42, "forks": 7,
+		"archived": true, "languages": "Go", "license": "MIT", "fork": "acme/staging",
+		"posture": "ready", "posture_summary": "SECURITY.md present",
+		"health":                   db.RepositoryHealthActive,
+		"metadata":                 blob,
+		"ecosystems_repo_data":     blob,
+		"ecosystems_packages_data": blob,
+	}).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	w := apiReq(t, s, "GET", fmt.Sprintf("/api/repositories/%d", repo.ID), scan.APIToken, "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	for key, want := range map[string]any{
+		"full_name": "acme/thing", "default_branch": "main",
+		"html_url": "https://github.com/acme/thing", "stars": float64(42),
+		"forks": float64(7), "archived": true, "languages": "Go", "license": "MIT",
+		"fork": "acme/staging", "posture": "ready",
+		"posture_summary": "SECURITY.md present", "health": "active",
+	} {
+		if got[key] != want {
+			t.Errorf("%s = %v, want %v", key, got[key], want)
+		}
+	}
+}
+
+// scanSummary still reads diff_stats, coverage, and error past the projection.
+func TestAPIListScans_omitsBlobsKeepsSummary(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	repo, auth := seedRunningScan(t, s)
+	prior := db.Scan{
+		RepositoryID: repo.ID, Kind: "skill", Status: db.ScanDone,
+		SkillName: deepDiveSkillName, Commit: "abcdef1", Model: "fake",
+		RescanMode: "diff", DiffBaseCommit: "0000001",
+		DiffStats: `{"files":3}`, Coverage: `{"mode":"diff"}`, Error: "none",
+		Log:    strings.Repeat("x", 1<<16),
+		Report: `{"findings":[]}`,
+	}
+	if err := s.DB.Create(&prior).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	w := apiReq(t, s, "GET", fmt.Sprintf("/api/repositories/%d/scans?skill=%s", repo.ID, deepDiveSkillName),
+		auth.APIToken, "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+	var got []map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d scans, want 1", len(got))
+	}
+	var full db.Scan
+	if err := s.DB.First(&full, prior.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	for key, wantVal := range scanSummary(full) {
+		wantJSON, _ := json.Marshal(wantVal)
+		gotJSON, _ := json.Marshal(got[0][key])
+		if string(gotJSON) != string(wantJSON) {
+			t.Errorf("%s = %s, want %s (omitted column scanSummary reads?)", key, gotJSON, wantJSON)
+		}
+	}
+}
+
+// apiGetScan does serve the report and log; the listing's projection must not
+// have leaked into it.
+func TestAPIGetScan_stillServesReportAndLog(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	repo, auth := seedRunningScan(t, s)
+	prior := db.Scan{
+		RepositoryID: repo.ID, Kind: "skill", Status: db.ScanDone,
+		SkillName: deepDiveSkillName,
+		Report:    `{"findings":[]}`, Log: "line one\nline two",
+	}
+	if err := s.DB.Create(&prior).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	w := apiReq(t, s, "GET", fmt.Sprintf("/api/scans/%d", prior.ID), auth.APIToken, "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	if got["report"] != `{"findings":[]}` || got["log"] != "line one\nline two" {
+		t.Errorf("report = %v, log = %v", got["report"], got["log"])
+	}
+}
+
+// apiAuth drops the blob columns but must keep the fields handlers read off the
+// request context.
+func TestAPIAuth_omitsBlobsKeepsIdentity(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	repo, scan := seedRunningScan(t, s)
+	if err := s.DB.Model(&scan).Updates(map[string]any{
+		"log":        strings.Repeat("x", 1<<16),
+		"prompt":     "prompt text",
+		"report":     `{"findings":[]}`,
+		"commit":     "abcdef1",
+		"sub_path":   "packages/core",
+		"skill_name": deepDiveSkillName,
+	}).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	var seen *db.Scan
+	probe := s.apiAuth(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		seen = scanFromRequest(r)
+	}))
+	r := localReq("GET", "/api/repositories/1")
+	r.Header.Set("Authorization", "Bearer "+scan.APIToken)
+	probe.ServeHTTP(httptest.NewRecorder(), r)
+
+	if seen == nil {
+		t.Fatal("no scan on context")
+	}
+	if seen.ID != scan.ID || seen.RepositoryID != repo.ID {
+		t.Errorf("identity = scan %d repo %d, want scan %d repo %d",
+			seen.ID, seen.RepositoryID, scan.ID, repo.ID)
+	}
+	// Fields the streamed-finding and validate-report paths stamp from context.
+	if seen.Commit != "abcdef1" || seen.SubPath != "packages/core" || seen.SkillName != deepDiveSkillName {
+		t.Errorf("identity fields dropped: commit=%q sub_path=%q skill_name=%q",
+			seen.Commit, seen.SubPath, seen.SkillName)
+	}
+	if seen.Log != "" || seen.Prompt != "" || seen.Report != "" {
+		t.Errorf("blob columns loaded: log=%d prompt=%d report=%d bytes",
+			len(seen.Log), len(seen.Prompt), len(seen.Report))
+	}
+}

--- a/internal/web/api_hot_path_test.go
+++ b/internal/web/api_hot_path_test.go
@@ -104,7 +104,7 @@ func TestAPIGetRepository_omitsBlobsKeepsSummary(t *testing.T) {
 	}
 }
 
-// scanSummary still reads diff_stats, coverage, and error past the projection.
+// scanSummary reads many non-blob columns; apiListScans must omit only the large blobs without dropping any scanSummary fields.
 func TestAPIListScans_omitsBlobsKeepsSummary(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()

--- a/internal/web/api_reads.go
+++ b/internal/web/api_reads.go
@@ -314,7 +314,7 @@ func (s *Server) apiListFindings(w http.ResponseWriter, r *http.Request) {
 		q = q.Where("status = ?", status)
 	}
 	var rows []db.Finding
-	q.Find(&rows)
+	q.Select(findingSummaryColumns).Find(&rows)
 	out := make([]map[string]any, 0, len(rows))
 	for _, f := range rows {
 		out = append(out, findingSummary(f))
@@ -375,6 +375,16 @@ func (s *Server) apiGetFinding(w http.ResponseWriter, r *http.Request) {
 	summary["suggested_fix"] = f.SuggestedFix
 	summary["suggested_fix_commit"] = f.SuggestedFixCommit
 	writeJSON(w, http.StatusOK, summary)
+}
+
+// findingSummaryColumns lists what findingSummary reads, leaving out the prose
+// blobs it never emits. Keep in sync with findingSummary.
+var findingSummaryColumns = []string{
+	"id", "scan_id", "repository_id", "finding_id", "commit", "sinks", "title",
+	"severity", "status", "cwe", "location", "vid", "affected", "reachability",
+	"quality_tier", "cve_id", "ghsa_id", "cvss_vector", "cvss_score",
+	"fix_version", "fix_commit", "resolution", "assignee", "missed_count",
+	"dup_check", "novelty", "novelty_checked_commit", "novelty_checked_at",
 }
 
 func findingSummary(f db.Finding) map[string]any {


### PR DESCRIPTION
AI Disclosure: Generated with Claude Code, Opus 5. Reviewed and tested by me. 

This focuses on a few endpoints that get called a lot during scans. This won't really have any noticeable impact, as the endpoints are already quite fast, but it should generally speed things up a bit and avoid unnecessary DB load/allocations in many cases. This should _somewhat_ reduce GC frequency when running many scans simultaneously (especially above the default parallelism value of 4), though again I don't expect this to be a noticeable difference.

`apiAuth` is notable because it runs on every request and was reading the entire scan row (including the log field) just to get the bearer token, which meant reading far more data than necessary for the same check.

This may not be worth the trouble of maintaining the list of the specific fields for some of these, though I would strongly argue in favor of keeping the `apiAuth` change regardless.

---

## Changes

Each hot endpoint is projected to what it actually emits:

- `apiAuth` omits log, prompt, report, refusal audit, import payload, and the JSON scoping blobs. Nothing reachable from `scanFromRequest` reads them.
- `apiListFindings` selects the columns `findingSummary` reads, skipping the prose (`trace`, `snippet`, `suggested_fix`, `mitigation`, …).
- `apiGetRepository` omits the cached ecosyste.ms payloads.
- `apiListScans` omits the same blobs as `apiAuth`.

Endpoint ranking came from counting `{api_base}` references across `skills/`: `/repositories/{id}/findings` (18 skills), `/findings/{id}` (14), `/repositories/{id}/scans` (9), `/repositories/{id}` (7).

## Measurements

Benchmarked against one relatively ordinary repository mid-scan: a 2 MB live log, 3 finished scans behind it, 10 findings, and 40 KB per cached ecosyste.ms source. Every figure includes `apiAuth`, which runs first on each request and accounts for most of the saving.

| endpoint | before | after | alloc/op |
|---|---|---|---|
| `apiAuth` (64 KB log) | 102 µs | 88 µs | 212 KB → 39 KB |
| `apiAuth` (2 MB log) | 454 µs | 91 µs | 4.3 MB → 39 KB |
| `GET /repositories/{id}` | 646 µs | 112 µs | 5.0 MB → 50 KB |
| `GET /repositories/{id}/scans` | 2.09 ms | 368 µs | 21.7 MB → 92 KB |
| `GET /repositories/{id}/findings` | 852 µs | 178 µs | 5.1 MB → 160 KB |

The auth cost no longer drifts with the caller's own log: 64 KB of logs and 2 MB of logs now cost the same.

🤖 Generated with [Claude Code](https://claude.com/claude-code)