### PR TITLE
feat(web): consolidate the repository tab menu

### DIFF
--- a/internal/web/static/app.js
+++ b/internal/web/static/app.js
@@ -17,19 +17,55 @@
     }
   }
 
+  // A panel can be opened from a tab in the tablist or from an entry in an
+  // overflow ("More") menu beside it, and a panel may hold a nested tab bar of
+  // its own. Basecoat only knows about the tabs of a single tablist, so
+  // selection is settled here; it runs after basecoat's own handler and
+  // reconciles whatever that missed.
+  function tabBar(tabs) {
+    return tabs.querySelector(':scope > .tab-bar') ||
+           tabs.querySelector(':scope > [role="tablist"]');
+  }
+
+  function selectTab(el) {
+    var tabs = el.closest('.tabs');
+    var bar = tabs && tabBar(tabs);
+    if (!bar) return;
+    var id = el.getAttribute('aria-controls');
+    tabs.querySelectorAll(':scope > [role="tabpanel"]').forEach(function (p) {
+      p.hidden = p.id !== id;
+    });
+    bar.querySelectorAll('[role="tab"]').forEach(function (t) {
+      var sel = t === el;
+      t.setAttribute('aria-selected', sel);
+      t.setAttribute('tabindex', sel ? '0' : '-1');
+    });
+    bar.querySelectorAll('[role="menuitem"][aria-controls]').forEach(function (m) {
+      if (m === el) m.setAttribute('aria-current', 'true');
+      else m.removeAttribute('aria-current');
+    });
+    // The overflow trigger stands in for whichever of its panels is showing.
+    bar.querySelectorAll('.dropdown-menu > button').forEach(function (b) {
+      var owns = !!b.parentElement.querySelector('[role="menuitem"][aria-current="true"]');
+      b.toggleAttribute('data-active', owns);
+    });
+  }
+
+  // Deep links name a tab or menu entry by id; a nested one has to open its
+  // ancestors on the way down.
   function restoreTab() {
     var h = location.hash.slice(1);
     if (!h) return;
-    var tab = document.getElementById(h);
-    if (!tab || tab.getAttribute('role') !== 'tab') return;
-    var list = tab.closest('[role="tablist"]');
-    if (!list) return;
-    list.querySelectorAll('[role="tab"]').forEach(function (t) {
-      var sel = t.id === h;
-      t.setAttribute('aria-selected', sel);
-      var p = document.getElementById(t.getAttribute('aria-controls'));
-      if (p) p.hidden = !sel;
-    });
+    var el = document.getElementById(h);
+    if (!el || !el.hasAttribute('aria-controls')) return;
+    var role = el.getAttribute('role');
+    if (role !== 'tab' && role !== 'menuitem') return;
+    while (el) {
+      selectTab(el);
+      var tabs = el.closest('.tabs');
+      var panel = tabs && tabs.parentElement && tabs.parentElement.closest('[role="tabpanel"]');
+      el = panel ? document.querySelector('[aria-controls="' + panel.id + '"]') : null;
+    }
   }
 
   // The message list is the only thing that scrolls on a conversation page, so
@@ -57,6 +93,14 @@
   document.addEventListener('htmx:historyRestore', init);
   document.addEventListener('htmx:oobAfterSwap', function () { icons(); highlight(); });
 
+  // Arrow keys inside a tablist are basecoat's to handle, and it selects the
+  // new tab before focusing it — so reconcile from the focus that follows,
+  // otherwise a panel opened from the overflow menu stays on screen alongside.
+  document.addEventListener('focusin', function (e) {
+    var tab = e.target.closest && e.target.closest('[role="tab"]');
+    if (tab && tab.getAttribute('aria-selected') === 'true') selectTab(tab);
+  });
+
   document.body.addEventListener('htmx:sseMessage', function (e) {
     var el = e.target.closest('[data-reload-on-sse]');
     if (el && e.detail.type === el.getAttribute('data-reload-on-sse')) location.reload();
@@ -80,8 +124,11 @@
       if (a) { a.click(); return; }
     }
 
-    var tab = e.target.closest('[role="tab"]');
-    if (tab && tab.id) history.replaceState(null, '', '#' + tab.id);
+    var picker = e.target.closest('[role="tab"], [role="menuitem"][aria-controls]');
+    if (picker && picker.closest('.tabs')) {
+      selectTab(picker);
+      if (picker.id) history.replaceState(null, '', '#' + picker.id);
+    }
 
     if (e.target.nodeName === 'DIALOG') e.target.close();
 

--- a/internal/web/static/theme.css
+++ b/internal/web/static/theme.css
@@ -469,6 +469,39 @@ pre.skill-src code { background: none; padding: 0; }
 }
 .alert-warning > svg { color: oklch(0.66 0.15 60); }
 
+/* ── repository tab bar ── */
+/* Underlined tabs instead of basecoat's segmented pills: this page carries far
+   more sections than the other tabbed ones, and a flat row lets the "More"
+   overflow trigger read as one of them. That trigger sits next to the tablist
+   rather than inside it — role="tablist" admits only tabs — so it is styled
+   alongside them here, and app.js sets data-active on it while one of the
+   sections behind it is the one showing. Scoped to this bar: the nested
+   supply-chain tabs keep the pill look, which keeps the two levels apart.
+   Selection reads from colour and the rule rather than a heavier weight, so
+   moving between tabs cannot shift the row. */
+#repo-tabs { gap: 1.25rem; }
+#repo-tabs > .tab-bar { display: flex; flex-wrap: wrap; align-items: flex-end;
+                        border-bottom: 1px solid var(--border); }
+#repo-tabs > .tab-bar > [role="tablist"] { height: auto; padding: 0;
+                                           background: transparent; border-radius: 0; }
+#repo-tabs > .tab-bar [role="tab"], .tab-more {
+  flex: none; display: inline-flex; align-items: center; gap: 0.375rem;
+  height: auto; padding: 0.5rem 0.875rem; margin-bottom: -1px; white-space: nowrap;
+  border: 0; border-bottom: 2px solid transparent; border-radius: 0;
+  background: transparent; box-shadow: none;
+  font-size: 0.875rem; font-weight: 500; color: var(--muted-foreground);
+}
+#repo-tabs > .tab-bar [role="tab"]:hover, .tab-more:hover,
+.tab-more[aria-expanded="true"] {
+  color: var(--foreground); border-bottom-color: var(--border);
+}
+#repo-tabs > .tab-bar [role="tab"][aria-selected="true"], .tab-more[data-active] {
+  color: var(--foreground); border-bottom-color: var(--foreground);
+  background: transparent; box-shadow: none;
+}
+/* Group labels are quieter than the entries they head. */
+[data-popover] [role="menu"] [role="heading"] { font-weight: 400; }
+
 /* ── copy-to-clipboard button ── */
 /* Holds two stacked lucide icons; app.js sets data-copied for ~1s after a copy,
    which swaps the clipboard glyph for a green check as transient confirmation. */

--- a/internal/web/templates/repo_show.html
+++ b/internal/web/templates/repo_show.html
@@ -67,68 +67,82 @@
   </div>
 </div>
 
+{{/* The supply-chain sections share one tab; its first available sub-tab opens
+     with it, since any of the four can be missing for a given repository. */}}
+{{$supply := or .Pkgs .Deps .HiddenDeps .Dependents .ShowAlternatives}}
+{{$sub := ""}}
+{{if .Pkgs}}{{$sub = "rt6"}}{{else if or .Deps .HiddenDeps}}{{$sub = "rt5"}}{{else if .Dependents}}{{$sub = "rt7"}}{{else if .ShowAlternatives}}{{$sub = "rt15"}}{{end}}
+
 <div class="tabs w-full" id="repo-tabs">
-  <nav role="tablist" aria-orientation="horizontal">
-    <button type="button" role="tab" id="rt1" aria-controls="rp1" aria-selected="true">Summary</button>
-    {{if or .Findings .Category}}
-      <button type="button" role="tab" id="rt4" aria-controls="rp4" aria-selected="false">
-        Findings <span class="badge-destructive ml-1">{{len .Findings}}</span>
+  {{/* The everyday sections stay in the tab bar and the long tail moves into
+       the "More" menu, which sits beside the tablist rather than inside it
+       because role="tablist" admits only tabs. app.js drives both. */}}
+  <div class="tab-bar">
+    <nav role="tablist" aria-orientation="horizontal" aria-label="Repository sections">
+      <button type="button" role="tab" id="rt1" aria-controls="rp1" aria-selected="true">Summary</button>
+      {{if or .Findings .Category}}
+        <button type="button" role="tab" id="rt4" aria-controls="rp4" aria-selected="false">
+          Findings <span class="badge-destructive ml-1">{{len .Findings}}</span>
+        </button>
+      {{end}}
+      {{if .ScannerFindings}}
+        <button type="button" role="tab" id="rt11" aria-controls="rp11" aria-selected="false">
+          Scanners <span class="badge-outline ml-1">{{len .ScannerFindings}}</span>
+        </button>
+      {{end}}
+      {{if $supply}}
+        <button type="button" role="tab" id="rt17" aria-controls="rp17" aria-selected="false">
+          Supply chain
+        </button>
+      {{end}}
+      <button type="button" role="tab" id="rt3" aria-controls="rp3" aria-selected="false">Scans</button>
+      <button type="button" role="tab" id="rt16" aria-controls="rp16" aria-selected="false">
+        Chat{{if .Conversations}} <span class="badge-outline ml-1">{{len .Conversations}}</span>{{end}}
       </button>
-    {{end}}
-    {{if .ScannerFindings}}
-      <button type="button" role="tab" id="rt11" aria-controls="rp11" aria-selected="false">
-        Scanners <span class="badge-outline ml-1">{{len .ScannerFindings}}</span>
+    </nav>
+
+    <div class="dropdown-menu">
+      <button type="button" class="tab-more" aria-haspopup="menu" aria-expanded="false"
+              aria-controls="repo-more-menu">
+        More <i data-lucide="chevron-down"></i>
       </button>
-    {{end}}
-    {{if .Pkgs}}
-    <button type="button" role="tab" id="rt6" aria-controls="rp6" aria-selected="false">
-      Packages
-    </button>
-    {{end}}
-    {{if .ShowAlternatives}}
-    <button type="button" role="tab" id="rt15" aria-controls="rp15" aria-selected="false">
-      Alternatives{{if .Alternatives}} <span class="badge-outline ml-1">{{len .Alternatives}}</span>{{end}}
-    </button>
-    {{end}}
-    {{if or .Deps .HiddenDeps}}
-      <button type="button" role="tab" id="rt5" aria-controls="rp5" aria-selected="false">
-        Dependencies
-      </button>
-    {{end}}
-    {{if .ThreatModel}}
-    <button type="button" role="tab" id="rt10" aria-controls="rp10" aria-selected="false">
-      Threat Model
-    </button>
-    {{end}}
-    <button type="button" role="tab" id="rt12" aria-controls="rp12" aria-selected="false">
-      Workbench
-      {{if .Workbench.HasOverride}}<span class="badge-outline ml-1">override</span>{{end}}
-    </button>
-    <button type="button" role="tab" id="rt14" aria-controls="rp14" aria-selected="false">
-      Scan config{{if .Repo.ScanConfig}} <span class="badge-outline ml-1">set</span>{{end}}
-    </button>
-    <button type="button" role="tab" id="rt13" aria-controls="rp13" aria-selected="false">
-      Benchmark{{if .ExpectedFindings}} <span class="badge-outline ml-1">{{.ExpectedMatched}}/{{len .ExpectedFindings}}</span>{{end}}
-    </button>
-    {{if .Advisories}}
-    <button type="button" role="tab" id="rt8" aria-controls="rp8" aria-selected="false">
-      Advisories
-    </button>
-    {{end}}
-    {{if .Dependents}}
-    <button type="button" role="tab" id="rt7" aria-controls="rp7" aria-selected="false">
-      Dependents
-    </button>
-    {{end}}
-    <button type="button" role="tab" id="rt9" aria-controls="rp9" aria-selected="false">
-      Maintainers
-    </button>
-    <button type="button" role="tab" id="rt2" aria-controls="rp2" aria-selected="false">Data</button>
-    <button type="button" role="tab" id="rt3" aria-controls="rp3" aria-selected="false">Scans</button>
-    <button type="button" role="tab" id="rt15" aria-controls="rp15" aria-selected="false">
-      Chat{{if .Conversations}} <span class="badge-outline ml-1">{{len .Conversations}}</span>{{end}}
-    </button>
-  </nav>
+      <div data-popover aria-hidden="true">
+        <div role="menu" id="repo-more-menu">
+          <div role="group" aria-label="Analysis">
+            <div role="heading" aria-level="3" class="text-muted-foreground text-xs">Analysis</div>
+            {{if .ThreatModel}}
+            <button type="button" role="menuitem" id="rt10" aria-controls="rp10">Threat model</button>
+            {{end}}
+            <button type="button" role="menuitem" id="rt12" aria-controls="rp12">
+              Workbench
+              {{if .Workbench.HasOverride}}<span class="text-muted-foreground text-xs">override</span>{{end}}
+            </button>
+            <button type="button" role="menuitem" id="rt13" aria-controls="rp13">
+              Benchmark
+              {{if .ExpectedFindings}}<span class="text-muted-foreground text-xs">{{.ExpectedMatched}}/{{len .ExpectedFindings}}</span>{{end}}
+            </button>
+          </div>
+          <hr role="separator">
+          <div role="group" aria-label="Disclosure">
+            <div role="heading" aria-level="3" class="text-muted-foreground text-xs">Disclosure</div>
+            <button type="button" role="menuitem" id="rt9" aria-controls="rp9">Maintainers</button>
+            {{if .Advisories}}
+            <button type="button" role="menuitem" id="rt8" aria-controls="rp8">Advisories</button>
+            {{end}}
+          </div>
+          <hr role="separator">
+          <div role="group" aria-label="Config">
+            <div role="heading" aria-level="3" class="text-muted-foreground text-xs">Config</div>
+            <button type="button" role="menuitem" id="rt14" aria-controls="rp14">
+              Scan config
+              {{if .Repo.ScanConfig}}<span class="text-muted-foreground text-xs">set</span>{{end}}
+            </button>
+            <button type="button" role="menuitem" id="rt2" aria-controls="rp2">Data</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
 
   <div role="tabpanel" id="rp1" aria-labelledby="rt1">
     {{if .Repo.FetchedAt}}
@@ -430,8 +444,36 @@
   </div>
   {{end}}
 
+  {{/* The four panels below belong to this nested tab bar; they keep the outer
+       indentation so the move stays reviewable. It closes after Alternatives. */}}
+  {{if $supply}}
+  <div role="tabpanel" id="rp17" aria-labelledby="rt17" hidden>
+  <div class="tabs w-full">
+    <nav role="tablist" aria-orientation="horizontal" aria-label="Supply chain sections">
+      {{if .Pkgs}}
+      <button type="button" role="tab" id="rt6" aria-controls="rp6" aria-selected="{{eq $sub "rt6"}}">
+        Packages
+      </button>
+      {{end}}
+      {{if or .Deps .HiddenDeps}}
+      <button type="button" role="tab" id="rt5" aria-controls="rp5" aria-selected="{{eq $sub "rt5"}}">
+        Dependencies
+      </button>
+      {{end}}
+      {{if .Dependents}}
+      <button type="button" role="tab" id="rt7" aria-controls="rp7" aria-selected="{{eq $sub "rt7"}}">
+        Dependents
+      </button>
+      {{end}}
+      {{if .ShowAlternatives}}
+      <button type="button" role="tab" id="rt15" aria-controls="rp15" aria-selected="{{eq $sub "rt15"}}">
+        Alternatives{{if .Alternatives}} <span class="badge-outline ml-1">{{len .Alternatives}}</span>{{end}}
+      </button>
+      {{end}}
+    </nav>
+
   {{if .Pkgs}}
-  <div role="tabpanel" id="rp6" aria-labelledby="rt6" hidden>
+  <div role="tabpanel" id="rp6" aria-labelledby="rt6"{{if ne $sub "rt6"}} hidden{{end}}>
     <table class="table w-full">
       <thead><tr>
         <th>Name</th><th>Ecosystem</th><th>Registry</th>
@@ -454,8 +496,75 @@
   </div>
   {{end}}
 
+  {{if or .Deps .HiddenDeps}}
+  <div role="tabpanel" id="rp5" aria-labelledby="rt5"{{if ne $sub "rt5"}} hidden{{end}}>
+    <div class="flex items-center justify-between gap-3 mb-3">
+      <p class="text-sm text-muted-foreground">
+        {{if .ShowAllDeps}}Showing all dependency phases.{{else}}Showing runtime dependencies.{{end}}
+        {{if .HiddenDeps}}{{.HiddenDeps}} test/build/dev row(s) hidden.{{end}}
+      </p>
+      {{if .ShowAllDeps}}
+        <a class="btn-sm-outline" href="/repositories/{{.Repo.ID}}#rt5">Runtime only</a>
+      {{else if .HiddenDeps}}
+        <a class="btn-sm-outline" href="/repositories/{{.Repo.ID}}?deps=all#rt5">Include test/build/dev</a>
+      {{end}}
+    </div>
+    {{if .Deps}}
+      <table class="table w-full">
+        <thead><tr>
+          <th>Name</th><th>Ecosystem</th>
+          <th>Version</th><th>Type</th><th>Manifests</th><th class="w-16"></th>
+        </tr></thead>
+        <tbody>
+        {{range .Deps}}
+          <tr>
+            <td class="whitespace-normal font-medium"><code class="text-sm break-all">{{.Name}}</code></td>
+            <td><span class="badge-outline">{{.Ecosystem}}</span></td>
+            <td class="text-muted-foreground whitespace-normal break-all">{{if .Requirement}}{{.Requirement}}{{else}}-{{end}}{{if .RequirementUnresolved}} <span class="badge-outline" data-tooltip="{{if .RequirementResolution}}{{.RequirementResolution}}{{else}}Requirement contains an unresolved manifest expression{{end}}">unresolved</span>{{end}}</td>
+            <td class="text-muted-foreground">{{.DependencyType}}</td>
+            <td class="whitespace-normal text-muted-foreground text-xs">{{range $i, $m := .Manifests}}{{if $i}}, {{end}}{{$u := locurl $.Repo.ID $.DepsCommit $m}}{{if $u}}<a href="{{$u}}" class="hover:underline break-all">{{$m}}</a>{{else}}{{$m}}{{end}}{{end}}</td>
+            <td>{{if .PURL}}{{$rid := lookup $.KnownPURLs .PURL}}{{if $rid}}<a href="/repositories/{{$rid}}" class="btn-sm-ghost" aria-label="View repository" data-tooltip="View repository"><i data-lucide="external-link"></i></a>{{else}}<form method="post" action="/dependencies/{{.ID}}/scan" hx-post="/dependencies/{{.ID}}/scan" hx-swap="none"><button type="submit" class="btn-sm-ghost" aria-label="Import repository" data-tooltip="Import repository"><i data-lucide="import"></i></button></form>{{end}}{{end}}</td>
+          </tr>
+        {{end}}
+        </tbody>
+      </table>
+      {{if gt .DepsTotal .TabRowCap}}
+      <p class="text-sm text-muted-foreground mt-3">
+        Dependency list capped at the first {{.TabRowCap}} of {{.DepsTotal}} rows.
+      </p>
+      {{end}}
+    {{else if .HiddenDeps}}
+      <p class="text-muted-foreground text-sm p-4">No runtime dependencies in the default view.</p>
+    {{end}}
+  </div>
+  {{end}}
+
+  {{if .Dependents}}
+  <div role="tabpanel" id="rp7" aria-labelledby="rt7"{{if ne $sub "rt7"}} hidden{{end}}>
+    <table class="table w-full">
+      <thead><tr>
+        <th>Name</th><th>Ecosystem</th><th>Latest</th>
+        <th>Downloads</th><th>Dependents</th><th class="w-16"></th>
+      </tr></thead>
+      <tbody>
+      {{range .Dependents}}
+        <tr>
+          <td class="whitespace-normal font-medium">{{.Name}}</td>
+          <td><span class="badge-outline">{{.Ecosystem}}</span></td>
+          <td class="text-muted-foreground">{{.LatestVersion}}</td>
+          <td class="text-muted-foreground">{{bignum .Downloads}}</td>
+          <td class="text-muted-foreground">{{bignum .DependentRepos}} repos</td>
+          <td>{{if .RepositoryURL}}{{$rid := lookup $.KnownURLs .RepositoryURL}}{{if $rid}}<a href="/repositories/{{$rid}}" class="btn-sm-ghost" aria-label="View repository" data-tooltip="View repository"><i data-lucide="external-link"></i></a>{{else}}<form method="post" action="/dependents/{{.ID}}/scan" hx-post="/dependents/{{.ID}}/scan" hx-swap="none"><button type="submit" class="btn-sm-ghost" aria-label="Import repository" data-tooltip="Import repository"><i data-lucide="import"></i></button></form>{{end}}{{end}}</td>
+        </tr>
+      {{end}}
+      </tbody>
+    </table>
+    {{- template "row-cap" (dict "Shown" .Dependents "Total" .DependentsTotal)}}
+  </div>
+  {{end}}
+
   {{if .ShowAlternatives}}
-  <div role="tabpanel" id="rp15" aria-labelledby="rt15" hidden>
+  <div role="tabpanel" id="rp15" aria-labelledby="rt15"{{if ne $sub "rt15"}} hidden{{end}}>
     <div class="grid gap-4">
       <section>
         <h3 class="text-sm font-medium mb-2">Migration alternatives</h3>
@@ -516,48 +625,8 @@
     </div>
   </div>
   {{end}}
-
-  {{if or .Deps .HiddenDeps}}
-  <div role="tabpanel" id="rp5" aria-labelledby="rt5" hidden>
-    <div class="flex items-center justify-between gap-3 mb-3">
-      <p class="text-sm text-muted-foreground">
-        {{if .ShowAllDeps}}Showing all dependency phases.{{else}}Showing runtime dependencies.{{end}}
-        {{if .HiddenDeps}}{{.HiddenDeps}} test/build/dev row(s) hidden.{{end}}
-      </p>
-      {{if .ShowAllDeps}}
-        <a class="btn-sm-outline" href="/repositories/{{.Repo.ID}}#rt5">Runtime only</a>
-      {{else if .HiddenDeps}}
-        <a class="btn-sm-outline" href="/repositories/{{.Repo.ID}}?deps=all#rt5">Include test/build/dev</a>
-      {{end}}
-    </div>
-    {{if .Deps}}
-      <table class="table w-full">
-        <thead><tr>
-          <th>Name</th><th>Ecosystem</th>
-          <th>Version</th><th>Type</th><th>Manifests</th><th class="w-16"></th>
-        </tr></thead>
-        <tbody>
-        {{range .Deps}}
-          <tr>
-            <td class="whitespace-normal font-medium"><code class="text-sm break-all">{{.Name}}</code></td>
-            <td><span class="badge-outline">{{.Ecosystem}}</span></td>
-            <td class="text-muted-foreground whitespace-normal break-all">{{if .Requirement}}{{.Requirement}}{{else}}-{{end}}{{if .RequirementUnresolved}} <span class="badge-outline" data-tooltip="{{if .RequirementResolution}}{{.RequirementResolution}}{{else}}Requirement contains an unresolved manifest expression{{end}}">unresolved</span>{{end}}</td>
-            <td class="text-muted-foreground">{{.DependencyType}}</td>
-            <td class="whitespace-normal text-muted-foreground text-xs">{{range $i, $m := .Manifests}}{{if $i}}, {{end}}{{$u := locurl $.Repo.ID $.DepsCommit $m}}{{if $u}}<a href="{{$u}}" class="hover:underline break-all">{{$m}}</a>{{else}}{{$m}}{{end}}{{end}}</td>
-            <td>{{if .PURL}}{{$rid := lookup $.KnownPURLs .PURL}}{{if $rid}}<a href="/repositories/{{$rid}}" class="btn-sm-ghost" aria-label="View repository" data-tooltip="View repository"><i data-lucide="external-link"></i></a>{{else}}<form method="post" action="/dependencies/{{.ID}}/scan" hx-post="/dependencies/{{.ID}}/scan" hx-swap="none"><button type="submit" class="btn-sm-ghost" aria-label="Import repository" data-tooltip="Import repository"><i data-lucide="import"></i></button></form>{{end}}{{end}}</td>
-          </tr>
-        {{end}}
-        </tbody>
-      </table>
-      {{if gt .DepsTotal .TabRowCap}}
-      <p class="text-sm text-muted-foreground mt-3">
-        Dependency list capped at the first {{.TabRowCap}} of {{.DepsTotal}} rows.
-      </p>
-      {{end}}
-    {{else if .HiddenDeps}}
-      <p class="text-muted-foreground text-sm p-4">No runtime dependencies in the default view.</p>
-    {{end}}
-  </div>
+  </div>{{/* .tabs */}}
+  </div>{{/* #rp17 */}}
   {{end}}
 
   {{if .ThreatModel}}
@@ -658,30 +727,6 @@
   </div>
   {{end}}
 
-  {{if .Dependents}}
-  <div role="tabpanel" id="rp7" aria-labelledby="rt7" hidden>
-    <table class="table w-full">
-      <thead><tr>
-        <th>Name</th><th>Ecosystem</th><th>Latest</th>
-        <th>Downloads</th><th>Dependents</th><th class="w-16"></th>
-      </tr></thead>
-      <tbody>
-      {{range .Dependents}}
-        <tr>
-          <td class="whitespace-normal font-medium">{{.Name}}</td>
-          <td><span class="badge-outline">{{.Ecosystem}}</span></td>
-          <td class="text-muted-foreground">{{.LatestVersion}}</td>
-          <td class="text-muted-foreground">{{bignum .Downloads}}</td>
-          <td class="text-muted-foreground">{{bignum .DependentRepos}} repos</td>
-          <td>{{if .RepositoryURL}}{{$rid := lookup $.KnownURLs .RepositoryURL}}{{if $rid}}<a href="/repositories/{{$rid}}" class="btn-sm-ghost" aria-label="View repository" data-tooltip="View repository"><i data-lucide="external-link"></i></a>{{else}}<form method="post" action="/dependents/{{.ID}}/scan" hx-post="/dependents/{{.ID}}/scan" hx-swap="none"><button type="submit" class="btn-sm-ghost" aria-label="Import repository" data-tooltip="Import repository"><i data-lucide="import"></i></button></form>{{end}}{{end}}</td>
-        </tr>
-      {{end}}
-      </tbody>
-    </table>
-    {{- template "row-cap" (dict "Shown" .Dependents "Total" .DependentsTotal)}}
-  </div>
-  {{end}}
-
   <div role="tabpanel" id="rp9" aria-labelledby="rt9" hidden>
     {{if .Maintainers}}
     <table class="table w-full">
@@ -754,7 +799,7 @@
     </table>
   </div>
 
-  <div role="tabpanel" id="rp15" aria-labelledby="rt15" hidden>
+  <div role="tabpanel" id="rp16" aria-labelledby="rt16" hidden>
     {{template "chat-panel" (dict "Action" (printf "/repositories/%d/conversations" .Repo.ID) "Conversations" .Conversations "Placeholder" "Ask about this repository's code or findings...")}}
   </div>
 


### PR DESCRIPTION
AI Disclosure: Generated with Claude Code, Opus 5. Reviewed and tested by me. Needs a bit more review before I mark it undraft.

The repository page had grown to 15 tabs in a single flat row. This reshapes that into six tabs plus a grouped **More** overflow menu. Fixes #838.

| | |
|---|---|
| Tab bar | Summary · Findings ③ · Scanners ⑥ · Supply chain · Scans · Chat · More ⌄ |
| More › Analysis | Threat model · Workbench *override* · Benchmark |
| More › Disclosure | Maintainers · Advisories |
| More › Config | Scan config *set* · Data |

<img width="1228" height="672" alt="Screenshot 2026-08-09 at 3 22 03 PM" src="https://github.com/user-attachments/assets/af2b3a26-c127-49ba-86dd-336f66e5ce0b" />

**Supply chain** is one tab holding a nested bar for Packages / Dependencies / Dependents / Alternatives. The panels move verbatim — the only edit is the `hidden` attribute, since any of the four can be absent and the first available one has to open with the parent. They keep their original indentation so the move reads as a move rather than a rewrite.

**Selection logic.** basecoat only tracks the tabs of a single tablist, so a panel opened from the More menu would have lingered on screen next to the next tab clicked. `selectTab()` in `app.js` now settles selection for tabs, menu entries, and nested bars alike, running after basecoat and reconciling what it missed — including the arrow-key path, hooked via the `focusin` that follows basecoat's own move. Deep links resolve through nesting, so `#rt15` opens Supply chain *and* its Alternatives sub-tab.

**Styling.** The bar moves from basecoat's segmented pills to underlined tabs, scoped to this page. The nested supply-chain bar keeps the pill look so the two levels stay distinguishable. Selection reads from colour and the rule rather than a heavier font weight, so moving between tabs cannot shift the row.

**Drive-by fix.** `rt15`/`rp15` was serving as the id for both Alternatives and Chat — a duplicate that made the `/repositories/N/alternatives` redirect ambiguous. Chat moves to `rt16`/`rp16`; every existing `#rt*` redirect in the Go handlers still lands correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)