### PR TITLE
fix: preserve workflow paths in zizmor findings

### DIFF
--- a/internal/worker/zizmor_script_test.go
+++ b/internal/worker/zizmor_script_test.go
@@ -1,0 +1,86 @@
+package worker
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"slices"
+	"testing"
+)
+
+func TestZizmorScriptPreservesWorkflowPaths(t *testing.T) {
+	script, err := filepath.Abs("../../skills/zizmor/scripts/scan.py")
+	if err != nil {
+		t.Fatal(err)
+	}
+	root := t.TempDir()
+	workflows := filepath.Join(root, "src", ".github", "workflows")
+	if err := os.MkdirAll(workflows, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	bin := filepath.Join(root, "bin")
+	if err := os.Mkdir(bin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	fakeZizmor := filepath.Join(bin, "zizmor")
+	if err := os.WriteFile(fakeZizmor, []byte(fakeZizmorScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command("python3", script)
+	cmd.Dir = root
+	cmd.Env = append(os.Environ(), "PATH="+bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("zizmor adapter failed: %v\n%s", err, out)
+	}
+
+	var report struct {
+		Findings []struct {
+			Location  string   `json:"location"`
+			Locations []string `json:"locations"`
+		} `json:"findings"`
+	}
+	if err := json.Unmarshal(out, &report); err != nil {
+		t.Fatalf("decode report: %v\n%s", err, out)
+	}
+	if len(report.Findings) != 1 {
+		t.Fatalf("findings = %d, want 1: %s", len(report.Findings), out)
+	}
+	want := []string{
+		".github/workflows/ci.yml:44",
+		".github/workflows/release.yml:18",
+	}
+	if !slices.Equal(report.Findings[0].Locations, want) {
+		t.Errorf("locations = %q, want %q", report.Findings[0].Locations, want)
+	}
+	if report.Findings[0].Location != want[0] {
+		t.Errorf("location = %q, want %q", report.Findings[0].Location, want[0])
+	}
+}
+
+const fakeZizmorScript = `#!/usr/bin/env bash
+cat <<'JSON'
+[
+  {
+    "ident": "unpinned-uses",
+    "desc": "unpinned action reference",
+    "determinations": {"severity": "high"},
+    "locations": [{
+      "symbolic": {"key": {"Local": {"verbatim_path": ".github/workflows/ci.yml"}}},
+      "concrete": {"location": {"start_point": {"row": 43}}}
+    }]
+  },
+  {
+    "ident": "unpinned-uses",
+    "desc": "unpinned action reference",
+    "determinations": {"severity": "high"},
+    "locations": [{
+      "symbolic": {"key": {"local": {"given_path": ".github/workflows/release.yml"}}},
+      "concrete": {"location": {"start_point": {"row": 17}}}
+    }]
+  }
+]
+JSON
+`

--- a/skills/zizmor/scripts/scan.py
+++ b/skills/zizmor/scripts/scan.py
@@ -90,7 +90,8 @@ def result_location(r):
         return "unknown"
     sym = locations[0].get("symbolic") or {}
     key = sym.get("key") or {}
-    path = key.get("local", {}).get("given_path") or key.get("Local", {}).get("given_path") or "workflow"
+    local = key.get("local") or key.get("Local") or {}
+    path = local.get("given_path") or local.get("verbatim_path") or "workflow"
     row = locations[0].get("concrete", {}).get("location", {}).get("start_point", {}).get("row")
     return f"{path}:{row + 1}" if row is not None else path
 


### PR DESCRIPTION
Fixes #833

## Summary

Fixes zizmor findings incorrectly displaying the generic `workflow` location instead of the repository-relative GitHub Actions workflow path.

Current zizmor versions report local workflow paths through `symbolic.key.Local.verbatim_path`, while the adapter only checked the older `given_path` field. This caused path extraction to fall back to the literal `workflow`.

## Changes

- Read current zizmor `verbatim_path` values when constructing finding locations.
- Retain compatibility with the legacy `given_path` field.
- Support both `Local` and `local` symbolic key variants.
- Preserve the existing zero-based to one-based line-number conversion.
- Add an end-to-end adapter regression test using representative current and legacy zizmor payloads.
- Verify emitted locations such as `.github/workflows/ci.yml:44` instead of `workflow:44`.

## Tests

- `go test ./internal/worker -run TestZizmorScriptPreservesWorkflowPaths -count=1`
- `go test ./internal/worker`
- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `golangci-lint run`
- `git diff --check`