### PR TITLE
Stage matched threat-model controls for verify

### DIFF
--- a/internal/findingnorm/normalize.go
+++ b/internal/findingnorm/normalize.go
@@ -52,3 +52,28 @@ func allDigits(s string) bool {
 	}
 	return true
 }
+
+// FindingPath rebases a finding's reported location into the repository-root
+// namespace that repository-wide documents — control globs, git pathspecs —
+// are authored in.
+//
+// A finding from a subpath-scoped scan reports its location relative to the
+// sub-folder, because the skill treats that folder as the project root. The
+// sub-folder is denormalised onto the finding row, so the two are joined
+// here rather than at each call site.
+//
+// An absolute path or a parent-segment escape yields "" rather than being
+// cleaned: a malformed location must produce no match instead of a match
+// against the wrong file.
+func FindingPath(subPath, location string) string {
+	file := LocationFile(location)
+	subPath = RepoPath(subPath)
+	if !validFindingPath(file) || (subPath != "" && !validFindingPath(subPath)) {
+		return ""
+	}
+	return path.Join(subPath, file)
+}
+
+func validFindingPath(p string) bool {
+	return p != "" && p != "." && !strings.HasPrefix(p, "/") && !HasParentPathSegment(p)
+}

--- a/internal/findingnorm/normalize_test.go
+++ b/internal/findingnorm/normalize_test.go
@@ -1,0 +1,34 @@
+package findingnorm
+
+import "testing"
+
+// FindingPath is the single rebase step behind both the novelty check and the
+// threat-model control match, so the namespace join and the rejection contract
+// are pinned here rather than only through its callers.
+func TestFindingPath(t *testing.T) {
+	for name, tc := range map[string]struct {
+		subPath  string
+		location string
+		want     string
+	}{
+		"root-scoped keeps the location's file": {"", "internal/web/server.go:120", "internal/web/server.go"},
+		"subpath is prefixed onto the location": {"internal", "web/server.go:120", "internal/web/server.go"},
+		"nested subpath joins in order":         {"services/api", "handler.go:8:3", "services/api/handler.go"},
+		"leading ./ is normalised away":         {"./internal", "./web/server.go", "internal/web/server.go"},
+
+		// A malformed location must produce no match rather than a match
+		// against the wrong file, so these yield "" instead of being cleaned.
+		"parent escape in location is rejected": {"", "../../etc/passwd:1", ""},
+		"parent escape in subpath is rejected":  {"../etc", "passwd", ""},
+		"absolute location is rejected":         {"", "/etc/passwd", ""},
+		"absolute subpath is rejected":          {"/srv", "server.go", ""},
+		"empty location is rejected":            {"internal", "", ""},
+		"bare dot is rejected":                  {"", ".", ""},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if got := FindingPath(tc.subPath, tc.location); got != tc.want {
+				t.Errorf("FindingPath(%q, %q) = %q, want %q", tc.subPath, tc.location, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/worker/controls.go
+++ b/internal/worker/controls.go
@@ -2,7 +2,6 @@ package worker
 
 import (
 	"fmt"
-	"path"
 
 	"scrutineer/internal/db"
 	"scrutineer/internal/findingnorm"
@@ -70,11 +69,14 @@ func (w *Worker) controlsContext(scan *db.Scan, skill *db.Skill) (*skillContextC
 	}
 
 	var finding db.Finding
-	if err := w.DB.Select("location").First(&finding, *scan.FindingID).Error; err != nil {
+	if err := w.DB.Select("location", "sub_path").First(&finding, *scan.FindingID).Error; err != nil {
 		return nil, fmt.Errorf("load finding for controls match: %w", err)
 	}
 
-	file := controlsFindingPath(scan.SubPath, finding.Location)
+	// The subpath comes from the finding, never from this scan: a verify scan
+	// is enqueued with no SubPath of its own, while the finding's Location is
+	// relative to the audit scan that produced it, denormalised onto the row.
+	file := findingnorm.FindingPath(finding.SubPath, finding.Location)
 	if file == "" {
 		return &skillContextControls{UnavailableWhy: controlsNoLocation}, nil
 	}
@@ -85,28 +87,4 @@ func (w *Worker) controlsContext(scan *db.Scan, skill *db.Skill) (*skillContextC
 		Matched:     matched,
 		IDs:         threatmodel.IDs(matched),
 	}, nil
-}
-
-// controlsFindingPath rebases a finding's location into the namespace the
-// control globs are authored in.
-//
-// Control paths are repository-root-relative, because the threat model is a
-// single document for the whole repository. A finding from a subpath-scoped
-// scan reports its location relative to the sub-folder (the skill treats it
-// as project root; see pruneToSubPath), so matching it against root-relative
-// globs without the subpath prefix silently matches nothing. That is why the
-// rebase happens here and not in threatmodel.MatchPath, which is handed a
-// path and cannot tell the two namespaces apart.
-//
-// This is the same normalisation noveltyFindingPath performs for the same
-// reason; both reject absolute paths and parent-segment escapes rather than
-// cleaning them, so a malformed location produces no match instead of a match
-// against the wrong file.
-func controlsFindingPath(subPath, location string) string {
-	file := findingnorm.LocationFile(location)
-	subPath = findingnorm.RepoPath(subPath)
-	if !validNoveltyPath(file) || (subPath != "" && !validNoveltyPath(subPath)) {
-		return ""
-	}
-	return path.Join(subPath, file)
 }

--- a/internal/worker/controls.go
+++ b/internal/worker/controls.go
@@ -1,0 +1,112 @@
+package worker
+
+import (
+	"fmt"
+	"path"
+
+	"scrutineer/internal/db"
+	"scrutineer/internal/findingnorm"
+	"scrutineer/internal/threatmodel"
+)
+
+const (
+	controlsNoLocation  = "the finding has no repository-relative location to match against"
+	controlsModelBroken = "the repository threat model could not be read"
+)
+
+// skillContextControls is the set of threat-model controls that claim to
+// protect the file a finding lives in, resolved on the host and staged into
+// context.json for the verify skill.
+//
+// Like novelty, this is deterministic host-side evidence rather than a
+// verdict. The worker decides which controls match, because matching is a
+// glob evaluation with a namespace precondition that the skill has no way to
+// get right from inside the container; what the controls *mean* for the
+// finding is the skill's job.
+//
+// Only matched controls are staged, never the whole model. A verify run is
+// scoped to one finding, and handing it every control in the repository
+// invites it to re-derive the match in prose — the exact non-determinism
+// resolving it on the host is meant to remove.
+type skillContextControls struct {
+	// FindingFile is the repository-root-relative path the match was
+	// performed against, after any subpath rebase. Staged so a report can
+	// cite what was actually matched rather than what the finding row says.
+	FindingFile string `json:"finding_file,omitempty"`
+	// Matched are the controls whose protects.paths cover FindingFile, in
+	// model order. Empty means the model declares controls but none claims
+	// this file — which is itself worth knowing, and is not the same as a
+	// repository with no controls at all.
+	Matched []threatmodel.Control `json:"matched"`
+	// IDs is the sorted, de-duplicated id set of Matched, for citing.
+	IDs []string `json:"ids,omitempty"`
+	// UnavailableWhy explains a block that could not be resolved. It is set
+	// instead of failing the scan: a verify run answers whether a
+	// reproduction still triggers, and refusing to run it because the
+	// operator's threat model has a duplicate control id would trade a
+	// useful answer for an unrelated authoring error. The skill reports the
+	// reason rather than treating an empty match as "nothing protects this".
+	UnavailableWhy string `json:"unavailable_reason,omitempty"`
+}
+
+// controlsContext resolves the matched-controls block for a finding-scoped
+// verify run. It returns nil for every other skill, and for repositories
+// whose threat model declares no controls, so context.json does not grow a
+// block that carries no information.
+func (w *Worker) controlsContext(scan *db.Scan, skill *db.Skill) (*skillContextControls, error) {
+	if skill.Name != verifySkillName || scan.FindingID == nil {
+		return nil, nil
+	}
+
+	model, err := threatmodel.Parse(scan.Repository.ThreatModel)
+	if err != nil {
+		return &skillContextControls{UnavailableWhy: controlsModelBroken + ": " + err.Error()}, nil
+	}
+	if len(model.Controls) == 0 {
+		return nil, nil
+	}
+	if err := model.Validate(); err != nil {
+		return &skillContextControls{UnavailableWhy: controlsModelBroken + ": " + err.Error()}, nil
+	}
+
+	var finding db.Finding
+	if err := w.DB.Select("location").First(&finding, *scan.FindingID).Error; err != nil {
+		return nil, fmt.Errorf("load finding for controls match: %w", err)
+	}
+
+	file := controlsFindingPath(scan.SubPath, finding.Location)
+	if file == "" {
+		return &skillContextControls{UnavailableWhy: controlsNoLocation}, nil
+	}
+
+	matched := model.MatchPath(file)
+	return &skillContextControls{
+		FindingFile: file,
+		Matched:     matched,
+		IDs:         threatmodel.IDs(matched),
+	}, nil
+}
+
+// controlsFindingPath rebases a finding's location into the namespace the
+// control globs are authored in.
+//
+// Control paths are repository-root-relative, because the threat model is a
+// single document for the whole repository. A finding from a subpath-scoped
+// scan reports its location relative to the sub-folder (the skill treats it
+// as project root; see pruneToSubPath), so matching it against root-relative
+// globs without the subpath prefix silently matches nothing. That is why the
+// rebase happens here and not in threatmodel.MatchPath, which is handed a
+// path and cannot tell the two namespaces apart.
+//
+// This is the same normalisation noveltyFindingPath performs for the same
+// reason; both reject absolute paths and parent-segment escapes rather than
+// cleaning them, so a malformed location produces no match instead of a match
+// against the wrong file.
+func controlsFindingPath(subPath, location string) string {
+	file := findingnorm.LocationFile(location)
+	subPath = findingnorm.RepoPath(subPath)
+	if !validNoveltyPath(file) || (subPath != "" && !validNoveltyPath(subPath)) {
+		return ""
+	}
+	return path.Join(subPath, file)
+}

--- a/internal/worker/controls_test.go
+++ b/internal/worker/controls_test.go
@@ -40,6 +40,15 @@ type controlsFixture struct {
 
 func newControlsFixture(t *testing.T, model, location string) controlsFixture {
 	t.Helper()
+	return newControlsFixtureInSubPath(t, model, location, "")
+}
+
+// newControlsFixtureInSubPath builds the finding the way a subpath-scoped
+// audit does: the originating scan carries the sub-folder and the finding row
+// denormalises it (db.Finding.SubPath, "set at finding-create time and never
+// changed"). The verify scan that later reads it has no SubPath of its own.
+func newControlsFixtureInSubPath(t *testing.T, model, location, subPath string) controlsFixture {
+	t.Helper()
 	gdb, err := db.Open(filepath.Join(t.TempDir(), "controls.db"))
 	if err != nil {
 		t.Fatal(err)
@@ -48,13 +57,14 @@ func newControlsFixture(t *testing.T, model, location string) controlsFixture {
 	if err := gdb.Create(&repo).Error; err != nil {
 		t.Fatal(err)
 	}
-	scan := db.Scan{RepositoryID: repo.ID, Kind: JobSkill, Status: db.ScanDone}
+	scan := db.Scan{RepositoryID: repo.ID, Kind: JobSkill, Status: db.ScanDone, SubPath: subPath}
 	if err := gdb.Create(&scan).Error; err != nil {
 		t.Fatal(err)
 	}
 	finding := db.Finding{
 		ScanID: scan.ID, RepositoryID: repo.ID, Title: "handler issue",
 		Severity: "High", Status: db.FindingNew, Location: location,
+		SubPath: subPath,
 	}
 	if err := gdb.Create(&finding).Error; err != nil {
 		t.Fatal(err)
@@ -62,14 +72,18 @@ func newControlsFixture(t *testing.T, model, location string) controlsFixture {
 	return controlsFixture{gdb: gdb, repo: repo, finding: finding}
 }
 
-func (f controlsFixture) resolve(t *testing.T, skillName, subPath string) *skillContextControls {
+// resolve runs controlsContext against the scan production actually enqueues:
+// finding-scoped, and with SubPath unset. Neither
+// enqueueFindingScopedSkillIfIdle nor enqueueValidateFixVerify sets one, so a
+// verify scan can never carry the sub-folder its finding was audited under --
+// the finding row is the only source of it.
+func (f controlsFixture) resolve(t *testing.T, skillName string) *skillContextControls {
 	t.Helper()
 	fid := f.finding.ID
 	scan := &db.Scan{
 		RepositoryID: f.repo.ID,
 		Repository:   f.repo,
 		FindingID:    &fid,
-		SubPath:      subPath,
 	}
 	got, err := (&Worker{DB: f.gdb}).controlsContext(scan, &db.Skill{Name: skillName})
 	if err != nil {
@@ -81,7 +95,7 @@ func (f controlsFixture) resolve(t *testing.T, skillName, subPath string) *skill
 func TestControlsContextMatchesFindingFile(t *testing.T) {
 	fixture := newControlsFixture(t, controlsModel, "internal/web/server.go:120")
 
-	got := fixture.resolve(t, verifySkillName, "")
+	got := fixture.resolve(t, verifySkillName)
 	if got == nil {
 		t.Fatal("controls = nil, want a resolved block")
 	}
@@ -107,7 +121,7 @@ func TestControlsContextMatchesFindingFile(t *testing.T) {
 func TestControlsContextReportsAnUnprotectedFile(t *testing.T) {
 	fixture := newControlsFixture(t, controlsModel, "internal/worker/skill.go:42")
 
-	got := fixture.resolve(t, verifySkillName, "")
+	got := fixture.resolve(t, verifySkillName)
 	if got == nil {
 		t.Fatal("controls = nil, want a block recording that nothing matched")
 	}
@@ -123,9 +137,9 @@ func TestControlsContextReportsAnUnprotectedFile(t *testing.T) {
 // control globs are authored against the repository root. The rebase is what
 // makes the two meet; this test fails without it, which is the point.
 func TestControlsContextRebasesSubpathLocation(t *testing.T) {
-	fixture := newControlsFixture(t, controlsModel, "web/server.go:120")
+	fixture := newControlsFixtureInSubPath(t, controlsModel, "web/server.go:120", "internal")
 
-	got := fixture.resolve(t, verifySkillName, "internal")
+	got := fixture.resolve(t, verifySkillName)
 	if got == nil {
 		t.Fatal("controls = nil, want a resolved block")
 	}
@@ -150,7 +164,7 @@ func TestControlsContextRebasesSubpathLocation(t *testing.T) {
 func TestControlsContextRejectsEscapingLocation(t *testing.T) {
 	fixture := newControlsFixture(t, controlsModel, "../../etc/passwd:1")
 
-	got := fixture.resolve(t, verifySkillName, "")
+	got := fixture.resolve(t, verifySkillName)
 	if got == nil || got.UnavailableWhy != controlsNoLocation {
 		t.Fatalf("controls = %+v, want the no-location reason for a parent-escaping path", got)
 	}
@@ -162,7 +176,7 @@ func TestControlsContextRejectsEscapingLocation(t *testing.T) {
 func TestControlsContextSkipsSkillsThatAreNotVerify(t *testing.T) {
 	fixture := newControlsFixture(t, controlsModel, "internal/web/server.go:120")
 
-	if got := fixture.resolve(t, "revalidate", ""); got != nil {
+	if got := fixture.resolve(t, "revalidate"); got != nil {
 		t.Fatalf("controls = %+v for revalidate, want nil", got)
 	}
 }
@@ -170,7 +184,7 @@ func TestControlsContextSkipsSkillsThatAreNotVerify(t *testing.T) {
 func TestControlsContextSkipsModelWithoutControls(t *testing.T) {
 	fixture := newControlsFixture(t, `{"entry_points": [{"name": "http"}]}`, "internal/web/server.go:120")
 
-	if got := fixture.resolve(t, verifySkillName, ""); got != nil {
+	if got := fixture.resolve(t, verifySkillName); got != nil {
 		t.Fatalf("controls = %+v for a model with no controls, want nil", got)
 	}
 }
@@ -185,7 +199,7 @@ func TestControlsContextDegradesOnMalformedModel(t *testing.T) {
 	} {
 		t.Run(name, func(t *testing.T) {
 			fixture := newControlsFixture(t, model, "internal/web/server.go:120")
-			got := fixture.resolve(t, verifySkillName, "")
+			got := fixture.resolve(t, verifySkillName)
 			if got == nil || got.UnavailableWhy == "" {
 				t.Fatalf("controls = %+v, want a reported unavailable reason", got)
 			}
@@ -198,7 +212,7 @@ func TestControlsContextDegradesOnMalformedModel(t *testing.T) {
 
 func TestControlsContextStagesIntoContextJSON(t *testing.T) {
 	fixture := newControlsFixture(t, controlsModel, "internal/web/server.go:120")
-	got := fixture.resolve(t, verifySkillName, "")
+	got := fixture.resolve(t, verifySkillName)
 
 	dir := t.TempDir()
 	scan := &db.Scan{ID: 11, RepositoryID: fixture.repo.ID, APIToken: "tok"}

--- a/internal/worker/controls_test.go
+++ b/internal/worker/controls_test.go
@@ -1,0 +1,255 @@
+package worker
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gorm.io/gorm"
+
+	"scrutineer/internal/db"
+	"scrutineer/internal/threatmodel"
+)
+
+const controlsModel = `{
+  "controls": [
+    {
+      "id": "web-authz",
+      "kind": "authorization",
+      "protects": {"paths": ["internal/web/**"]},
+      "assumptions": ["requests reach these handlers only through the authenticated router"],
+      "provenance": "documented",
+      "source": "internal/web/server.go:120"
+    },
+    {
+      "id": "parser-sandbox",
+      "kind": "sandbox",
+      "protects": {"paths": ["internal/parser/**"]},
+      "provenance": "inferred"
+    }
+  ]
+}`
+
+type controlsFixture struct {
+	gdb     *gorm.DB
+	repo    db.Repository
+	finding db.Finding
+}
+
+func newControlsFixture(t *testing.T, model, location string) controlsFixture {
+	t.Helper()
+	gdb, err := db.Open(filepath.Join(t.TempDir(), "controls.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo := db.Repository{URL: "file:///fixture", Name: "fixture", ThreatModel: model}
+	if err := gdb.Create(&repo).Error; err != nil {
+		t.Fatal(err)
+	}
+	scan := db.Scan{RepositoryID: repo.ID, Kind: JobSkill, Status: db.ScanDone}
+	if err := gdb.Create(&scan).Error; err != nil {
+		t.Fatal(err)
+	}
+	finding := db.Finding{
+		ScanID: scan.ID, RepositoryID: repo.ID, Title: "handler issue",
+		Severity: "High", Status: db.FindingNew, Location: location,
+	}
+	if err := gdb.Create(&finding).Error; err != nil {
+		t.Fatal(err)
+	}
+	return controlsFixture{gdb: gdb, repo: repo, finding: finding}
+}
+
+func (f controlsFixture) resolve(t *testing.T, skillName, subPath string) *skillContextControls {
+	t.Helper()
+	fid := f.finding.ID
+	scan := &db.Scan{
+		RepositoryID: f.repo.ID,
+		Repository:   f.repo,
+		FindingID:    &fid,
+		SubPath:      subPath,
+	}
+	got, err := (&Worker{DB: f.gdb}).controlsContext(scan, &db.Skill{Name: skillName})
+	if err != nil {
+		t.Fatalf("controlsContext: %v", err)
+	}
+	return got
+}
+
+func TestControlsContextMatchesFindingFile(t *testing.T) {
+	fixture := newControlsFixture(t, controlsModel, "internal/web/server.go:120")
+
+	got := fixture.resolve(t, verifySkillName, "")
+	if got == nil {
+		t.Fatal("controls = nil, want a resolved block")
+	}
+	if got.UnavailableWhy != "" {
+		t.Fatalf("unavailable_reason = %q, want empty", got.UnavailableWhy)
+	}
+	if got.FindingFile != "internal/web/server.go" {
+		t.Errorf("finding_file = %q, want the location's file", got.FindingFile)
+	}
+	if len(got.IDs) != 1 || got.IDs[0] != "web-authz" {
+		t.Fatalf("ids = %v, want only the control scoped to internal/web", got.IDs)
+	}
+	if len(got.Matched) != 1 || got.Matched[0].Kind != threatmodel.KindAuthorization {
+		t.Fatalf("matched = %+v, want the authorization control", got.Matched)
+	}
+	// The assumption is the thing a bypass argument attacks, so it has to
+	// survive into the staged block rather than being reduced to an id.
+	if len(got.Matched[0].Assumptions) != 1 {
+		t.Errorf("matched control lost its assumptions: %+v", got.Matched[0])
+	}
+}
+
+func TestControlsContextReportsAnUnprotectedFile(t *testing.T) {
+	fixture := newControlsFixture(t, controlsModel, "internal/worker/skill.go:42")
+
+	got := fixture.resolve(t, verifySkillName, "")
+	if got == nil {
+		t.Fatal("controls = nil, want a block recording that nothing matched")
+	}
+	if len(got.Matched) != 0 || len(got.IDs) != 0 {
+		t.Fatalf("matched = %+v, want empty for a file no control claims", got.Matched)
+	}
+	if got.FindingFile != "internal/worker/skill.go" {
+		t.Errorf("finding_file = %q, want the file that was matched against", got.FindingFile)
+	}
+}
+
+// A subpath-scoped scan reports locations relative to the sub-folder, while
+// control globs are authored against the repository root. The rebase is what
+// makes the two meet; this test fails without it, which is the point.
+func TestControlsContextRebasesSubpathLocation(t *testing.T) {
+	fixture := newControlsFixture(t, controlsModel, "web/server.go:120")
+
+	got := fixture.resolve(t, verifySkillName, "internal")
+	if got == nil {
+		t.Fatal("controls = nil, want a resolved block")
+	}
+	if got.FindingFile != "internal/web/server.go" {
+		t.Fatalf("finding_file = %q, want the subpath-rebased root-relative path", got.FindingFile)
+	}
+	if len(got.IDs) != 1 || got.IDs[0] != "web-authz" {
+		t.Fatalf("ids = %v, want the control matched after the rebase", got.IDs)
+	}
+
+	// Demonstrate the rebase is load-bearing rather than incidental: the raw
+	// subpath-relative location matches nothing against the same model.
+	model, err := threatmodel.Parse(controlsModel)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if unrebased := model.MatchPath("web/server.go"); len(unrebased) != 0 {
+		t.Fatalf("unrebased path matched %+v; the rebase would be redundant", unrebased)
+	}
+}
+
+func TestControlsContextRejectsEscapingLocation(t *testing.T) {
+	fixture := newControlsFixture(t, controlsModel, "../../etc/passwd:1")
+
+	got := fixture.resolve(t, verifySkillName, "")
+	if got == nil || got.UnavailableWhy != controlsNoLocation {
+		t.Fatalf("controls = %+v, want the no-location reason for a parent-escaping path", got)
+	}
+	if len(got.Matched) != 0 {
+		t.Errorf("matched = %+v, want no match for a rejected path", got.Matched)
+	}
+}
+
+func TestControlsContextSkipsSkillsThatAreNotVerify(t *testing.T) {
+	fixture := newControlsFixture(t, controlsModel, "internal/web/server.go:120")
+
+	if got := fixture.resolve(t, "revalidate", ""); got != nil {
+		t.Fatalf("controls = %+v for revalidate, want nil", got)
+	}
+}
+
+func TestControlsContextSkipsModelWithoutControls(t *testing.T) {
+	fixture := newControlsFixture(t, `{"entry_points": [{"name": "http"}]}`, "internal/web/server.go:120")
+
+	if got := fixture.resolve(t, verifySkillName, ""); got != nil {
+		t.Fatalf("controls = %+v for a model with no controls, want nil", got)
+	}
+}
+
+// A malformed model must not cost the operator the verify run: the reason is
+// reported in the block instead of failing the scan.
+func TestControlsContextDegradesOnMalformedModel(t *testing.T) {
+	for name, model := range map[string]string{
+		"unparseable":  `{"controls": [`,
+		"duplicate id": `{"controls":[{"id":"a","kind":"sandbox","protects":{"paths":["x/**"]},"provenance":"inferred"},{"id":"a","kind":"sandbox","protects":{"paths":["y/**"]},"provenance":"inferred"}]}`,
+		"unscoped":     `{"controls":[{"id":"a","kind":"sandbox","protects":{},"provenance":"inferred"}]}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			fixture := newControlsFixture(t, model, "internal/web/server.go:120")
+			got := fixture.resolve(t, verifySkillName, "")
+			if got == nil || got.UnavailableWhy == "" {
+				t.Fatalf("controls = %+v, want a reported unavailable reason", got)
+			}
+			if len(got.Matched) != 0 {
+				t.Errorf("matched = %+v, want no match from a model that could not be read", got.Matched)
+			}
+		})
+	}
+}
+
+func TestControlsContextStagesIntoContextJSON(t *testing.T) {
+	fixture := newControlsFixture(t, controlsModel, "internal/web/server.go:120")
+	got := fixture.resolve(t, verifySkillName, "")
+
+	dir := t.TempDir()
+	scan := &db.Scan{ID: 11, RepositoryID: fixture.repo.ID, APIToken: "tok"}
+	if err := stageContextWithInputs(
+		dir, "", "http://127.0.0.1:8080/api", "", DefaultMetadataDir,
+		scan, &fixture.repo, nil, nil, got,
+	); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(filepath.Join(dir, "context.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var staged skillContext
+	if err := json.Unmarshal(data, &staged); err != nil {
+		t.Fatal(err)
+	}
+	if staged.Scrutineer.Controls == nil {
+		t.Fatal("staged context.json has no controls block")
+	}
+	if staged.Scrutineer.Controls.FindingFile != got.FindingFile {
+		t.Errorf("staged finding_file = %q, want %q",
+			staged.Scrutineer.Controls.FindingFile, got.FindingFile)
+	}
+	if len(staged.Scrutineer.Controls.Matched) != 1 {
+		t.Fatalf("staged matched = %+v, want the host-resolved control",
+			staged.Scrutineer.Controls.Matched)
+	}
+	if staged.Scrutineer.Controls.Matched[0].ID != "web-authz" {
+		t.Errorf("staged control id = %q, want web-authz", staged.Scrutineer.Controls.Matched[0].ID)
+	}
+}
+
+// A skill other than verify must not gain a controls block just because the
+// repository has a threat model; the whole point of resolving on the host is
+// that the block is finding-scoped.
+func TestStagedContextOmitsControlsWhenUnresolved(t *testing.T) {
+	dir := t.TempDir()
+	repo := db.Repository{URL: "file:///fixture", ThreatModel: controlsModel}
+	scan := &db.Scan{ID: 12, RepositoryID: 3, APIToken: "tok"}
+	if err := stageContextWithInputs(
+		dir, "", "http://127.0.0.1:8080/api", "", DefaultMetadataDir,
+		scan, &repo, nil, nil, nil,
+	); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(filepath.Join(dir, "context.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(data), `"controls"`) {
+		t.Fatalf("context.json carries a controls key with nothing resolved:\n%s", data)
+	}
+}

--- a/internal/worker/novelty.go
+++ b/internal/worker/novelty.go
@@ -3,7 +3,6 @@ package worker
 import (
 	"context"
 	"fmt"
-	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -93,7 +92,7 @@ func checkFindingNovelty(
 		ScannedCommit: strings.TrimSpace(finding.Commit),
 		CheckedCommit: strings.TrimSpace(headCommit),
 	}
-	result.FindingFile = noveltyFindingPath(finding.SubPath, finding.Location)
+	result.FindingFile = findingnorm.FindingPath(finding.SubPath, finding.Location)
 	if result.FindingFile == "" {
 		result.NotCheckedWhy = "finding location is not a repository-relative file"
 		return result
@@ -145,19 +144,6 @@ func checkFindingNovelty(
 	result.CommitLog, bytesTruncated = truncateNoveltyLog(logOutput)
 	result.LogTruncated = bytesTruncated || commitCount > noveltyLogMaxCommits
 	return result
-}
-
-func noveltyFindingPath(subPath, location string) string {
-	file := findingnorm.LocationFile(location)
-	subPath = findingnorm.RepoPath(subPath)
-	if !validNoveltyPath(file) || (subPath != "" && !validNoveltyPath(subPath)) {
-		return ""
-	}
-	return path.Join(subPath, file)
-}
-
-func validNoveltyPath(p string) bool {
-	return p != "" && p != "." && !strings.HasPrefix(p, "/") && !findingnorm.HasParentPathSegment(p)
 }
 
 func validGitOID(value string) bool {

--- a/internal/worker/novelty_test.go
+++ b/internal/worker/novelty_test.go
@@ -50,7 +50,7 @@ func TestNoveltyContextStagesBoundedChangedFileEvidence(t *testing.T) {
 	scan := fixture.scan(head)
 	if err := stageContextWithInputs(
 		fixture.workRoot, "", "http://127.0.0.1:8080/api", "", DefaultMetadataDir,
-		scan, &fixture.repo, nil, got,
+		scan, &fixture.repo, nil, got, nil,
 	); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/worker/skill.go
+++ b/internal/worker/skill.go
@@ -93,6 +93,10 @@ type skillContextScrutineer struct {
 	// Novelty is a bounded host-side git history check staged for revalidate.
 	// It keeps deterministic evidence separate from the model's verdict.
 	Novelty *skillContextNovelty `json:"novelty,omitempty"`
+	// Controls are the threat-model controls that claim to protect the
+	// finding's file, resolved host-side and staged for verify. Absent when
+	// the repository's threat model declares no controls.
+	Controls *skillContextControls `json:"controls,omitempty"`
 }
 
 type skillContextRecon struct {
@@ -1290,7 +1294,7 @@ func (w *Worker) metadataDir() string {
 }
 
 func stageContext(workRoot, skillDir, apiBase, forkOrg, metadataDir string, scan *db.Scan, repo *db.Repository) error {
-	return stageContextWithInputs(workRoot, skillDir, apiBase, forkOrg, metadataDir, scan, repo, nil, nil)
+	return stageContextWithInputs(workRoot, skillDir, apiBase, forkOrg, metadataDir, scan, repo, nil, nil, nil)
 }
 
 func stageContextWithInputs(
@@ -1299,6 +1303,7 @@ func stageContextWithInputs(
 	repo *db.Repository,
 	recon *skillContextRecon,
 	novelty *skillContextNovelty,
+	controls *skillContextControls,
 ) error {
 	if err := os.MkdirAll(workRoot, dirPerm); err != nil {
 		return err
@@ -1334,6 +1339,7 @@ func stageContextWithInputs(
 	ctx.Scrutineer.FocusArea = focusArea
 	ctx.Scrutineer.Recon = recon
 	ctx.Scrutineer.Novelty = novelty
+	ctx.Scrutineer.Controls = controls
 	if scan.SkillID != nil {
 		ctx.Scrutineer.SkillID = *scan.SkillID
 	}
@@ -1408,8 +1414,12 @@ func (w *Worker) stageWorkspace(ctx context.Context, workRoot, skillDir string, 
 	if err != nil {
 		return err
 	}
+	controls, err := w.controlsContext(scan, skill)
+	if err != nil {
+		return err
+	}
 	return stageWorkspaceWithInputs(
-		workRoot, skillDir, w.APIBase, w.ForkOrg, w.metadataDir(), scan, skill, recon, novelty,
+		workRoot, skillDir, w.APIBase, w.ForkOrg, w.metadataDir(), scan, skill, recon, novelty, controls,
 	)
 }
 
@@ -1418,7 +1428,7 @@ func (w *Worker) stageWorkspace(ctx context.Context, workRoot, skillDir string, 
 // rendered skill bundle, and optional import payloads. Production adds recon
 // context for threat-model in Worker.stageWorkspace.
 func StageWorkspace(workRoot, skillDir, apiBase, forkOrg, metadataDir string, scan *db.Scan, skill *db.Skill) error {
-	return stageWorkspaceWithInputs(workRoot, skillDir, apiBase, forkOrg, metadataDir, scan, skill, nil, nil)
+	return stageWorkspaceWithInputs(workRoot, skillDir, apiBase, forkOrg, metadataDir, scan, skill, nil, nil, nil)
 }
 
 func stageWorkspaceWithInputs(
@@ -1427,6 +1437,7 @@ func stageWorkspaceWithInputs(
 	skill *db.Skill,
 	recon *skillContextRecon,
 	novelty *skillContextNovelty,
+	controls *skillContextControls,
 ) error {
 	// stageSkill clears skillDir, so it runs before stageContext, which
 	// writes context.json into that directory (#499).
@@ -1434,7 +1445,7 @@ func stageWorkspaceWithInputs(
 		return fmt.Errorf("stage skill: %w", err)
 	}
 	if err := stageContextWithInputs(
-		workRoot, skillDir, apiBase, forkOrg, metadataDir, scan, &scan.Repository, recon, novelty,
+		workRoot, skillDir, apiBase, forkOrg, metadataDir, scan, &scan.Repository, recon, novelty, controls,
 	); err != nil {
 		return fmt.Errorf("stage context: %w", err)
 	}

--- a/internal/worker/skill_test.go
+++ b/internal/worker/skill_test.go
@@ -350,7 +350,7 @@ func TestStageContext_includesReconFocusAreas(t *testing.T) {
 		Notes: []string{"Examples excluded."},
 	}
 	if err := stageContextWithInputs(
-		dir, "", "http://127.0.0.1:8080/api", "", "", scan, repo, recon, nil,
+		dir, "", "http://127.0.0.1:8080/api", "", "", scan, repo, recon, nil, nil,
 	); err != nil {
 		t.Fatal(err)
 	}

--- a/skills/verify/SKILL.md
+++ b/skills/verify/SKILL.md
@@ -16,7 +16,7 @@ Take an existing finding produced by a prior audit skill and independently grade
 ## Workspace and provenance
 
 - `./src` is a fresh per-scan checkout at the requested ref. It is not the originating audit's workspace and must remain the only target code you execute.
-- `./context.json` has `scrutineer.api_base`, `scrutineer.token`, `scrutineer.repository_id`, and `scrutineer.finding_id`.
+- `./context.json` has `scrutineer.api_base`, `scrutineer.token`, `scrutineer.repository_id`, and `scrutineer.finding_id`. It also has `scrutineer.controls` when the repository's threat model declares controls covering this finding (see [Declared controls](#declared-controls)).
 - `./report.json` is the structured verification record.
 - `./schema.json` is the required output shape.
 
@@ -90,6 +90,36 @@ Every criterion records `verdict`, `method`, `evidence`, `counterevidence`, `pro
 - `deferred`: preflight found external reach or credential access, so execution was intentionally skipped.
 
 For resource-exhaustion findings, a timeout or memory limit is confirmation only when that is the claimed class and the evidence ties it to the expected first-party path. An unrelated setup hang, compiler OOM, or test-runner timeout is not confirmation.
+
+## Declared controls
+
+`scrutineer.controls` in `./context.json` lists the threat-model controls whose `protects.paths` cover this finding's file. The host resolved the match before the container started — the globs are repository-root-relative and a subpath-scoped scan reports locations relative to its sub-folder, so re-deriving the match here would get it wrong. Match the ids, do not recompute them.
+
+```json
+"controls": {
+  "finding_file": "internal/web/server.go",
+  "matched": [
+    {
+      "id": "web-authz",
+      "kind": "authorization",
+      "protects": {"paths": ["internal/web/**"]},
+      "assumptions": ["requests reach these handlers only through the authenticated router"],
+      "provenance": "documented",
+      "source": "internal/web/server.go:120"
+    }
+  ],
+  "ids": ["web-authz"]
+}
+```
+
+A control is a **claim by the threat model's author**, not a proof and not a verdict. It never changes what you run — the reproduction is still the reproduction. It changes what you have to say about the outcome:
+
+- **The reproduction still triggers** (`confirmed`) and a control claims to protect the file: the control did not hold. Say so in `notes`, citing the id, and name whichever of its `assumptions` your reproduction violated — that is the finding's most useful sentence for the analyst, because it points at a design claim that needs revisiting rather than only at a line of code.
+- **The reproduction does not trigger** and a control claims to protect the file: the control is a *candidate* explanation, not the answer. `fixed` still requires citing the guard you actually found in the code (step 6). "Control `web-authz` covers this path" is not a citation; `internal/web/server.go:214 rejects the unauthenticated case` is. If the control is the only thing you can point at, that is `inconclusive`.
+- **`matched` is empty**: the model declares controls but none claims this file. Worth one line in `notes` — an unprotected path is a weaker prior for `fixed`.
+- **`unavailable_reason` is set**: the model could not be read (or the finding has no usable path). Treat it as no information at all, not as "nothing protects this", and pass the reason through to `notes` so the operator can fix the model.
+
+The block is absent entirely when the repository declares no controls. That is the normal case; do not mention it.
 
 ## Output
 


### PR DESCRIPTION
Second slice of #779, on top of #830 (contract, merged). #779 names `verify` as a consumer, but it had no channel to receive a control — this adds it.

- `internal/worker/controls.go` resolves the controls whose globs match the finding's file and stages them into `context.json`, gated on `verify` + finding-scoped runs.
- `skills/verify/SKILL.md` documents what a matched control does and does not license.

Two choices worth flagging:

- Matching happens host-side, mirroring `skillContextNovelty` — it needs the finding-path rebase (`noveltyFindingPath`, reused here) that a container-side skill can't do reliably. Only matched controls are staged, not the whole model, so a finding-scoped run can't re-derive the match in prose.
- A malformed controls block reports `unavailable_reason` instead of failing the scan; SKILL.md tells the skill to read that as *no information*, not as "nothing protects this".

No persistence and no new report field, so no `openapi.yaml`/`docs/database.md` change. The #111 rubric row I'd sketched as slice 3 landed in #831, so this stays clear of it.

`gofmt`/`build`/`vet` clean; `internal/worker`, `internal/skills`, `internal/threatmodel`, `internal/repoconfig` pass.