### PR TITLE
Use clone.Cache for exposure and repo-cache checkouts

### DIFF
--- a/internal/worker/clone.go
+++ b/internal/worker/clone.go
@@ -142,12 +142,7 @@ func cloneOrFetch(
 	if recurseSubmodules {
 		emit(Event{Kind: KindText, Text: "$ git submodule update --init --recursive --depth 1 (best effort)"})
 	}
-	r := retry.resolved().toClone()
-	r.Notify = func(n clone.Notice) {
-		emit(Event{Kind: KindText, Text: fmt.Sprintf(
-			"git %s failed with a transient error (attempt %d/%d), retrying in %s",
-			n.Label, n.Attempt, n.Attempts, n.Delay.Round(time.Millisecond))})
-	}
+	r := retry.toCloneWithNotify(emit)
 	options := clone.EnsureOptions{Full: fullClone, RecurseSubmodules: recurseSubmodules}
 	if err := clone.EnsureWithOptions(ctx, r, url, dst, ref, options); err != nil {
 		// Unwrap so ensureClone's own UnreachableError wrap does not

--- a/internal/worker/exposure.go
+++ b/internal/worker/exposure.go
@@ -2,8 +2,6 @@ package worker
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -12,18 +10,10 @@ import (
 	"path/filepath"
 	"sync"
 
+	"github.com/git-pkgs/clone"
+
 	"scrutineer/internal/db"
 )
-
-// dependentCacheRoot returns the shared on-disk path scrutineer reuses
-// across exposure scans of the same dependent URL. Keyed by sha256 of the
-// URL so different URLs cannot collide and the path is filesystem-safe.
-// The directory survives wrap()'s per-scan workspace cleanup, so the
-// second exposure scan on the same dependent only fetches the delta.
-func dependentCacheRoot(dataDir, url string) string {
-	sum := sha256.Sum256([]byte(url))
-	return filepath.Join(dataDir, "dependent-cache", hex.EncodeToString(sum[:]))
-}
 
 // cacheMutex returns the per-URL mutex used to serialise fetch+copy on
 // the dependent cache. Lazily created on first use.
@@ -42,23 +32,16 @@ func (w *Worker) prepareDependentSrc(ctx context.Context, url, ref, workRoot str
 	mu.Lock()
 	defer mu.Unlock()
 
-	cacheRoot := dependentCacheRoot(w.DataDir, url)
-	if err := os.MkdirAll(cacheRoot, dirPerm); err != nil {
-		return "", err
+	cache := clone.Cache{
+		Root:  filepath.Join(w.DataDir, "dependent-cache"),
+		Retry: gitRetry{}.toCloneWithNotify(emit),
 	}
-	cacheSrc, err := ensureClone(ctx, db.Repository{URL: url}, cacheRoot, false, ref, emit)
-	if err != nil {
-		return "", err
+	if _, err := os.Stat(filepath.Join(cache.Dir(url), "src", ".git")); err == nil {
+		emit(Event{Kind: KindText, Text: "$ git fetch origin " + fetchTarget(ref) + " && reset"})
+	} else {
+		emit(Event{Kind: KindText, Text: "$ git clone " + url + " (shallow)"})
 	}
-	commit := gitHead(cacheSrc)
-	dst := filepath.Join(workRoot, "src")
-	if err := os.RemoveAll(dst); err != nil {
-		return "", err
-	}
-	if err := CopyTree(cacheSrc, dst); err != nil {
-		return "", fmt.Errorf("copy dependent cache: %w", err)
-	}
-	return commit, nil
+	return cache.Prepare(ctx, url, ref, filepath.Join(workRoot, "src"))
 }
 
 // CopyTree recursively copies src to dst, preserving permissions but not

--- a/internal/worker/exposure.go
+++ b/internal/worker/exposure.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"sync"
@@ -28,6 +27,14 @@ func (w *Worker) cacheMutex(url string) *sync.Mutex {
 // is whatever the skill leaves behind. Returns the HEAD commit of the
 // freshly-synced cache.
 func (w *Worker) prepareDependentSrc(ctx context.Context, url, ref, workRoot string, emit func(Event)) (string, error) {
+	// Validate before emitting so a bad URL or ref does not log a
+	// "$ git clone" line for a command that will never run.
+	if err := clone.ValidateURL(url); err != nil {
+		return "", &RepoUnreachableError{URL: url, Err: err}
+	}
+	if err := clone.ValidateRef(ref); err != nil {
+		return "", err
+	}
 	mu := w.cacheMutex(url)
 	mu.Lock()
 	defer mu.Unlock()
@@ -47,47 +54,7 @@ func (w *Worker) prepareDependentSrc(ctx context.Context, url, ref, workRoot str
 // CopyTree recursively copies src to dst, preserving permissions but not
 // ownership or timestamps. Symlinks are recreated; everything else is
 // copied byte-for-byte. Fast enough for git trees up to a few hundred MB.
-func CopyTree(src, dst string) error {
-	return filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-		rel, err := filepath.Rel(src, path)
-		if err != nil {
-			return err
-		}
-		target := filepath.Join(dst, rel)
-		switch {
-		case info.IsDir():
-			return os.MkdirAll(target, info.Mode().Perm())
-		case info.Mode()&os.ModeSymlink != 0:
-			link, err := os.Readlink(path)
-			if err != nil {
-				return err
-			}
-			return os.Symlink(link, target)
-		default:
-			return copyFile(path, target, info.Mode().Perm())
-		}
-	})
-}
-
-func copyFile(src, dst string, perm os.FileMode) error {
-	in, err := os.Open(src)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = in.Close() }()
-	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, perm)
-	if err != nil {
-		return err
-	}
-	if _, err := io.Copy(out, in); err != nil {
-		_ = out.Close()
-		return err
-	}
-	return out.Close()
-}
+func CopyTree(src, dst string) error { return clone.CopyTree(src, dst) }
 
 // doExposure runs the exposure skill for one (finding, dependent) pair.
 // The scan's Repository stays the library being audited; ./src in the

--- a/internal/worker/exposure_test.go
+++ b/internal/worker/exposure_test.go
@@ -161,15 +161,3 @@ func TestParseExposureOutput_upsertsExistingRow(t *testing.T) {
 		t.Errorf("scan fields = %+v", row)
 	}
 }
-
-func TestDependentCacheRoot_keyedByURL(t *testing.T) {
-	a := dependentCacheRoot("/data", "https://github.com/a/b")
-	b := dependentCacheRoot("/data", "https://github.com/a/b")
-	c := dependentCacheRoot("/data", "https://github.com/c/d")
-	if a != b {
-		t.Errorf("same URL must yield same path: %s vs %s", a, b)
-	}
-	if a == c {
-		t.Errorf("different URLs must yield different paths")
-	}
-}

--- a/internal/worker/git_retry.go
+++ b/internal/worker/git_retry.go
@@ -63,14 +63,7 @@ func (r gitRetry) toClone() clone.Retry {
 	}
 }
 
-func branchPickerRetry(r gitRetry) gitRetry {
-	r.attempts = branchPickerAttempts
-	r.baseDelay = branchPickerDelay
-	r.maxDelay = branchPickerDelay
-	return r
-}
-
-func (r gitRetry) do(ctx context.Context, cmd gitCommand, emit func(Event)) (string, error) {
+func (r gitRetry) toCloneWithNotify(emit func(Event)) clone.Retry {
 	retry := r.resolved().toClone()
 	if emit != nil {
 		retry.Notify = func(n clone.Notice) {
@@ -79,7 +72,18 @@ func (r gitRetry) do(ctx context.Context, cmd gitCommand, emit func(Event)) (str
 				n.Label, n.Attempt, n.Attempts, n.Delay.Round(time.Millisecond))})
 		}
 	}
-	return retry.Do(ctx, clone.Command{
+	return retry
+}
+
+func branchPickerRetry(r gitRetry) gitRetry {
+	r.attempts = branchPickerAttempts
+	r.baseDelay = branchPickerDelay
+	r.maxDelay = branchPickerDelay
+	return r
+}
+
+func (r gitRetry) do(ctx context.Context, cmd gitCommand, emit func(Event)) (string, error) {
+	return r.toCloneWithNotify(emit).Do(ctx, clone.Command{
 		Label:   cmd.label,
 		Dir:     cmd.dir,
 		Env:     cmd.env,

--- a/internal/worker/novelty_test.go
+++ b/internal/worker/novelty_test.go
@@ -150,6 +150,10 @@ func TestPrepareNoveltyHistoryDeepensSharedCache(t *testing.T) {
 	scan := fixture.scan(head)
 	scan.Repository.URL = repoURL
 	w := &Worker{DB: fixture.gdb, DataDir: dataDir}
+	// clone.Cache.EnsureCommit hardens fetch to https-only unless the
+	// caller's env already sets GIT_ALLOW_PROTOCOL; this test's cache
+	// origin is a file:// path.
+	t.Setenv("GIT_ALLOW_PROTOCOL", "file")
 	w.prepareNoveltyHistory(context.Background(), scan, &db.Skill{Name: revalidateSkillName})
 
 	if !commitReachable(context.Background(), cacheSrc, fixture.base) {

--- a/internal/worker/repo_cache.go
+++ b/internal/worker/repo_cache.go
@@ -15,7 +15,14 @@ import (
 )
 
 func repoCache(dataDir string) *clone.Cache {
-	return &clone.Cache{Root: filepath.Join(dataDir, "repo-cache")}
+	// One attempt via gitWithEnv, matching the pre-delegation git() call.
+	// The default clone.Retry policy is 3 attempts with backoff, which would
+	// hold w.cacheMutex(url) inside the code-browser HTTP handler for the
+	// whole retry budget while a scan on the same repo waits.
+	return &clone.Cache{
+		Root:  filepath.Join(dataDir, "repo-cache"),
+		Retry: gitRetry{attempts: 1}.toCloneWithNotify(nil),
+	}
 }
 
 // RepoCacheRoot returns the persistent per-URL clone directory under

--- a/internal/worker/repo_cache.go
+++ b/internal/worker/repo_cache.go
@@ -2,26 +2,28 @@ package worker
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 
+	"github.com/git-pkgs/clone"
 	"gorm.io/gorm"
 
 	"scrutineer/internal/db"
 )
+
+func repoCache(dataDir string) *clone.Cache {
+	return &clone.Cache{Root: filepath.Join(dataDir, "repo-cache")}
+}
 
 // RepoCacheRoot returns the persistent per-URL clone directory under
 // dataDir. The cache survives scan cleanup so subsequent scans only
 // fetch the delta; EnsureCommit deepens it on demand when the code
 // browser asks for a commit that the shallow clone doesn't have.
 func RepoCacheRoot(dataDir, url string) string {
-	sum := sha256.Sum256([]byte(url))
-	return filepath.Join(dataDir, "repo-cache", hex.EncodeToString(sum[:]))
+	return repoCache(dataDir).Dir(url)
 }
 
 // RepoDiskUsage returns the on-disk size in bytes of the persistent
@@ -32,8 +34,7 @@ func RepoDiskUsage(dataDir string, repo db.Repository) int64 {
 	if repo.IsLocal() {
 		return 0
 	}
-	n, _ := dirSize(RepoCacheRoot(dataDir, repo.URL))
-	return n
+	return repoCache(dataDir).DiskBytes(repo.URL)
 }
 
 // refreshRepoDiskUsage recomputes the clone-cache size for one repository
@@ -151,22 +152,7 @@ func (w *Worker) EnsureCommit(ctx context.Context, url, commit string) error {
 	mu := w.cacheMutex(url)
 	mu.Lock()
 	defer mu.Unlock()
-
-	cacheSrc := filepath.Join(RepoCacheRoot(w.DataDir, url), "src")
-	if _, err := os.Stat(filepath.Join(cacheSrc, ".git")); err != nil {
-		return nil
-	}
-	if commitReachable(ctx, cacheSrc, commit) {
-		return nil
-	}
-	out, _ := git(ctx, "-C", cacheSrc, "rev-parse", "--is-shallow-repository")
-	if strings.TrimSpace(out) != "true" {
-		return nil
-	}
-	if out, err := git(ctx, "-C", cacheSrc, "fetch", "--unshallow", "--quiet", "origin"); err != nil {
-		return fmt.Errorf("unshallow %s: %s: %w", url, strings.TrimSpace(out), err)
-	}
-	return nil
+	return repoCache(w.DataDir).EnsureCommit(ctx, url, strings.ToLower(commit))
 }
 
 func commitReachable(ctx context.Context, dir, commit string) bool {

--- a/internal/worker/repo_cache_test.go
+++ b/internal/worker/repo_cache_test.go
@@ -377,6 +377,9 @@ func TestEnsureCommit_reachableCommitIsNoOp(t *testing.T) {
 	if err := w.EnsureCommit(context.Background(), url, head); err != nil {
 		t.Errorf("EnsureCommit with reachable commit: %v", err)
 	}
+	if err := w.EnsureCommit(context.Background(), url, strings.ToUpper(head)); err != nil {
+		t.Errorf("EnsureCommit with uppercase commit: %v", err)
+	}
 }
 
 func TestEnsureCommit_unreachableNonShallowIsNoOp(t *testing.T) {

--- a/internal/worker/repo_cache_test.go
+++ b/internal/worker/repo_cache_test.go
@@ -113,8 +113,14 @@ func TestRepoCacheRoot(t *testing.T) {
 	if a == c {
 		t.Errorf("different URLs should produce different paths, both %q", a)
 	}
-	if !strings.HasPrefix(a, filepath.Join("/data", "repo-cache")+string(filepath.Separator)) {
-		t.Errorf("path %q not under /data/repo-cache/", a)
+	// Pin the sha256(url) layout so a clone.Cache release that changes Dir()
+	// fails here rather than silently re-keying every existing cache dir on
+	// disk (docs/skills.md documents this layout, and RemoveAll on the old
+	// path would leave orphans).
+	want := filepath.Join("/data", "repo-cache",
+		"426415da6467c87a94a513112f24b70d4b6adf406b39e4b9e74ac984d9221813")
+	if a != want {
+		t.Errorf("path %q, want %q", a, want)
 	}
 }
 


### PR DESCRIPTION
Replaces the hand-rolled dependent-cache and repo-cache paths with `git-pkgs/clone.Cache`, which already carries the sha256-per-URL layout, `Prepare` (fetch/reset, `RemoveAll(dst)`, `CopyTree`), `EnsureCommit`, and `DiskBytes`.

`prepareDependentSrc` now builds a `clone.Cache` and calls `Prepare` directly; `dependentCacheRoot` and its test are deleted. `RepoCacheRoot`, `RepoDiskUsage`, and `EnsureCommit` delegate to the same helpers under the existing per-URL worker lock. `EnsureCommit` lowercases the commit before delegating since `clone.ValidCommit` is stricter than `validGitOID`.

`prepareRepoSrcWithOptions` is left as-is: its `<sha>/with-submodules/src` layout does not match `Cache.Dir`, so folding it in would move existing submodule caches on disk.

The retry-notify closure duplicated in `cloneOrFetch` and `gitRetry.do` is extracted to `gitRetry.toCloneWithNotify`.