### PR TITLE
fix(web): make the disclosure draft reviewable before a finding is ready

### DIFF
--- a/internal/web/finding_disclosure.go
+++ b/internal/web/finding_disclosure.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 
 	"scrutineer/internal/db"
 )
@@ -86,4 +87,49 @@ func (s *Server) findingDisclosureHTML(w http.ResponseWriter, r *http.Request) {
 	title := template.HTMLEscapeString(fmt.Sprintf("Disclosure draft — finding #%d: %s", f.ID, f.Title))
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	_, _ = fmt.Fprintf(w, disclosureHTMLPage, title, body)
+}
+
+// findingDisclosureMarkdown exports the current saved draft.
+func (s *Server) findingDisclosureMarkdown(w http.ResponseWriter, r *http.Request) {
+	var f db.Finding
+	id, err := strconv.Atoi(r.PathValue("id"))
+	if err != nil {
+		http.NotFound(w, r)
+		return
+	}
+	if err := s.DB.First(&f, id).Error; err != nil {
+		http.NotFound(w, r)
+		return
+	}
+	body := renderFindingDisclosureMarkdown(&f)
+	if body == "" {
+		http.Error(w, "no disclosure draft stored for this finding", http.StatusNotFound)
+		return
+	}
+	var repo db.Repository
+	s.DB.First(&repo, f.RepositoryID)
+	w.Header().Set("Content-Type", "text/markdown; charset=utf-8")
+	w.Header().Set("Content-Disposition", `attachment; filename="`+findingDisclosureMarkdownFilename(&repo, &f)+`"`)
+	_, _ = w.Write([]byte(body))
+}
+
+func findingDisclosureMarkdownFilename(repo *db.Repository, f *db.Finding) string {
+	return fmt.Sprintf("scrutineer-%s-finding-%d-disclosure-%s.md",
+		sanitiseFilename(repo.Name),
+		f.ID,
+		time.Now().UTC().Format("20060102"))
+}
+
+func renderFindingDisclosureMarkdown(f *db.Finding) string {
+	draft := strings.TrimSpace(f.DisclosureDraft)
+	if draft == "" {
+		return ""
+	}
+	var b strings.Builder
+	if title := strings.TrimSpace(escapeMD(f.Title)); title != "" {
+		fmt.Fprintf(&b, "# %s\n\n", title)
+	}
+	b.WriteString(draft)
+	b.WriteString("\n")
+	return b.String()
 }

--- a/internal/web/finding_disclosure_test.go
+++ b/internal/web/finding_disclosure_test.go
@@ -1,6 +1,7 @@
 package web
 
 import (
+	"net/http"
 	"net/http/httptest"
 	"strconv"
 	"strings"
@@ -133,5 +134,74 @@ func TestFindingDisclosureHTML_missingFinding(t *testing.T) {
 	s.Handler().ServeHTTP(w, localReq("GET", "/findings/999999/disclosure.html"))
 	if w.Code != 404 {
 		t.Errorf("status = %d, want 404", w.Code)
+	}
+}
+
+func TestFindingDisclosureMarkdown_exportsLatestSavedDraft(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	repo := db.Repository{Name: "thing", FullName: "acme/thing"}
+	s.DB.Create(&repo)
+	scan := db.Scan{
+		RepositoryID: repo.ID, Kind: "skill", SkillName: discloseSkillName, Status: db.ScanDone,
+		Report: `{"ghsa":{"summary":"Stale generated title","description":"old generated draft"}}`,
+	}
+	s.DB.Create(&scan)
+	const latest = "## Summary\n\nLatest analyst edit with `inline code`.\n\n- item\n  - nested\n\n```go\nfmt.Println(\"kept\")\n```"
+	f := db.Finding{
+		ScanID: scan.ID, RepositoryID: repo.ID, FindingID: "F1", Title: "Current finding title",
+		DisclosureDraft: latest,
+	}
+	s.DB.Create(&f)
+
+	path := "/findings/" + strconv.FormatUint(uint64(f.ID), 10) + "/disclosure.md"
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq("GET", path))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+	if got := w.Header().Get("Content-Type"); got != "text/markdown; charset=utf-8" {
+		t.Errorf("Content-Type = %q", got)
+	}
+	if got := w.Header().Get("Content-Disposition"); !strings.Contains(got, "attachment") || !strings.Contains(got, "disclosure") || !strings.Contains(got, ".md") {
+		t.Errorf("Content-Disposition = %q", got)
+	}
+	want := "# Current finding title\n\n" + latest + "\n"
+	if got := w.Body.String(); got != want {
+		t.Errorf("markdown export did not preserve the latest saved draft\nwant:\n%s\ngot:\n%s", want, got)
+	}
+	for _, stale := range []string{"Stale generated title", "old generated draft", "Scan metadata", "patched", "preserved"} {
+		if strings.Contains(w.Body.String(), stale) {
+			t.Errorf("export contains stale or internal generation data %q:\n%s", stale, w.Body)
+		}
+	}
+
+	const revised = "## Summary\n\nSaved again after generation.\n"
+	if err := db.WriteFindingField(s.DB, f.ID, "disclosure_draft", revised, db.SourceAnalyst, ""); err != nil {
+		t.Fatal(err)
+	}
+	w = httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq("GET", path))
+	if !strings.Contains(w.Body.String(), revised) || strings.Contains(w.Body.String(), latest) {
+		t.Errorf("export did not read the latest persisted edit:\n%s", w.Body)
+	}
+}
+
+func TestFindingDisclosureMarkdown_emptyDraftNotFound(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	repo := db.Repository{Name: "thing"}
+	s.DB.Create(&repo)
+	scan := db.Scan{RepositoryID: repo.ID, Status: db.ScanDone}
+	s.DB.Create(&scan)
+	f := db.Finding{ScanID: scan.ID, RepositoryID: repo.ID, Title: "No saved draft", DisclosureDraft: "  "}
+	s.DB.Create(&f)
+
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq("GET", "/findings/"+strconv.FormatUint(uint64(f.ID), 10)+"/disclosure.md"))
+	if w.Code != http.StatusNotFound || !strings.Contains(w.Body.String(), "no disclosure draft") {
+		t.Errorf("status/body = %d %q, want explicit 404", w.Code, w.Body.String())
 	}
 }

--- a/internal/web/finding_forms.go
+++ b/internal/web/finding_forms.go
@@ -51,6 +51,25 @@ func (s *Server) findingFields(w http.ResponseWriter, r *http.Request) {
 	s.redirect(w, r, fmt.Sprintf("/findings/%d", f.ID))
 }
 
+// findingDisclosureDraftSave persists edits from the disclosure editor.
+func (s *Server) findingDisclosureDraftSave(w http.ResponseWriter, r *http.Request) {
+	f, ok := loadByID[db.Finding](s, w, r)
+	if !ok {
+		return
+	}
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	draft := strings.TrimSpace(strings.ReplaceAll(r.FormValue("disclosure_draft"), "\r\n", "\n"))
+	if err := db.WriteFindingField(s.DB, f.ID, "disclosure_draft", draft, db.SourceAnalyst, ""); err != nil {
+		http.Error(w, err.Error(), http.StatusUnprocessableEntity)
+		return
+	}
+	setFlash(w, Flash{Category: successKey, Title: "Disclosure draft saved"})
+	s.redirect(w, r, fmt.Sprintf("/findings/%d#disclosure", f.ID))
+}
+
 func (s *Server) findingCommunications(w http.ResponseWriter, r *http.Request) {
 	f, ok := loadByID[db.Finding](s, w, r)
 	if !ok {

--- a/internal/web/finding_forms_test.go
+++ b/internal/web/finding_forms_test.go
@@ -80,6 +80,72 @@ func TestFindingFields(t *testing.T) {
 	}
 }
 
+func TestFindingDisclosureDraftSavePersistsEditedMarkdown(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	f := seedFindingForForm(t, s)
+	const draft = "## Summary\n\nEdited text with `inline code`.\n\n- one\n  - two\n\n```ruby\nputs :ok\n```"
+
+	w := postForm(t, s, fmt.Sprintf("/findings/%d/disclosure-draft", f.ID), url.Values{
+		"disclosure_draft": {draft},
+	})
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("status = %d, want 303; body=%s", w.Code, w.Body)
+	}
+	if got := w.Header().Get("Location"); got != fmt.Sprintf("/findings/%d#disclosure", f.ID) {
+		t.Errorf("Location = %q, want disclosure anchor", got)
+	}
+
+	var got db.Finding
+	s.DB.First(&got, f.ID)
+	if got.DisclosureDraft != draft {
+		t.Errorf("saved disclosure draft changed\nwant:\n%s\ngot:\n%s", draft, got.DisclosureDraft)
+	}
+	var history db.FindingHistory
+	if err := s.DB.Where("finding_id = ? AND field = ?", f.ID, "disclosure_draft").First(&history).Error; err != nil {
+		t.Fatalf("load disclosure history: %v", err)
+	}
+	if history.Source != db.SourceAnalyst || history.NewValue != draft {
+		t.Errorf("history = %+v, want analyst edit with saved markdown", history)
+	}
+
+	if w := postForm(t, s, "/findings/999999/disclosure-draft", url.Values{
+		"disclosure_draft": {draft},
+	}); w.Code != http.StatusNotFound {
+		t.Errorf("missing finding status = %d, want 404", w.Code)
+	}
+}
+
+func TestFindingDisclosureDraftSaveNormalizesBrowserNewlines(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	f := seedFindingForForm(t, s)
+	const saved = "first line\nsecond line"
+	if err := s.DB.Model(&f).Update("disclosure_draft", saved).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	w := postForm(t, s, fmt.Sprintf("/findings/%d/disclosure-draft", f.ID), url.Values{
+		"disclosure_draft": {"first line\r\nsecond line"},
+	})
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("status = %d, want 303; body=%s", w.Code, w.Body)
+	}
+
+	var got db.Finding
+	s.DB.First(&got, f.ID)
+	if got.DisclosureDraft != saved {
+		t.Errorf("saved disclosure newlines = %q, want %q", got.DisclosureDraft, saved)
+	}
+	var historyCount int64
+	s.DB.Model(&db.FindingHistory{}).
+		Where("finding_id = ? AND field = ?", f.ID, "disclosure_draft").
+		Count(&historyCount)
+	if historyCount != 0 {
+		t.Errorf("history rows = %d, want 0 for an unchanged browser submission", historyCount)
+	}
+}
+
 func TestFindingFieldsAtomicRollback(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()

--- a/internal/web/scan_report.go
+++ b/internal/web/scan_report.go
@@ -34,10 +34,8 @@ func (s *Server) scanReport(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Skill is looked up separately rather than via Preload because Scan.SkillID
-	// is nullable and Preload on a nullable FK is fiddly across GORM versions;
-	// a missing skill row (e.g. skill deleted after the scan ran) is non-fatal
-	// here, we just lose the OutputKind dispatch and fall back to raw.
+	// SkillID is nullable, so load the skill separately rather than with Preload.
+	// Missing rows are non-fatal; disclose scans can still dispatch by name.
 	var skill *db.Skill
 	if scan.SkillID != nil {
 		var sk db.Skill
@@ -46,7 +44,16 @@ func (s *Server) scanReport(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	body := renderScanReport(s.DB, &scan, skill)
+	var body string
+	if isDiscloseScanReport(&scan, skill) {
+		body = renderSavedDisclosureScanReport(s.DB, &scan)
+		if body == "" {
+			http.Error(w, "no saved disclosure draft to export", http.StatusNotFound)
+			return
+		}
+	} else {
+		body = renderScanReport(s.DB, &scan, skill)
+	}
 
 	w.Header().Set("Content-Type", "text/markdown; charset=utf-8")
 	w.Header().Set("Content-Disposition", `attachment; filename="`+scanReportFilename(&scan)+`"`)
@@ -62,14 +69,13 @@ func scanReportFilename(scan *db.Scan) string {
 }
 
 func renderScanReport(gdb *gorm.DB, scan *db.Scan, skill *db.Skill) string {
-	var b strings.Builder
-	writeScanReportHeader(&b, scan)
-	writeScanReportMetadata(&b, scan, skill)
-
 	kind := ""
 	if skill != nil {
 		kind = skill.OutputKind
 	}
+	var b strings.Builder
+	writeScanReportHeader(&b, scan)
+	writeScanReportMetadata(&b, scan, skill)
 	switch kind {
 	case "findings", "advisory_audit":
 		// advisory_audit persists ordinary Finding rows alongside its
@@ -80,6 +86,24 @@ func renderScanReport(gdb *gorm.DB, scan *db.Scan, skill *db.Skill) string {
 		writeScanReportFreeform(&b, scan, kind)
 	}
 	return b.String()
+}
+
+func isDiscloseScanReport(scan *db.Scan, skill *db.Skill) bool {
+	if skill != nil {
+		return skill.OutputKind == "disclose"
+	}
+	return scan.SkillName == discloseSkillName
+}
+
+func renderSavedDisclosureScanReport(gdb *gorm.DB, scan *db.Scan) string {
+	if gdb == nil || scan.FindingID == nil {
+		return ""
+	}
+	var finding db.Finding
+	if err := gdb.First(&finding, *scan.FindingID).Error; err != nil {
+		return ""
+	}
+	return renderFindingDisclosureMarkdown(&finding)
 }
 
 func writeScanReportHeader(b *strings.Builder, scan *db.Scan) {

--- a/internal/web/scan_report_test.go
+++ b/internal/web/scan_report_test.go
@@ -1,6 +1,7 @@
 package web
 
 import (
+	"net/http"
 	"net/http/httptest"
 	"strconv"
 	"strings"
@@ -153,6 +154,88 @@ func TestScanReport_findingsDispatch(t *testing.T) {
 	if indexAt >= topnav33At || topnav33At >= topnav110At {
 		t.Errorf("additional locations not naturally sorted: index=%d t33=%d t110=%d",
 			indexAt, topnav33At, topnav110At)
+	}
+}
+
+func TestScanReport_discloseUsesLatestSavedFindingDraft(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	repo := db.Repository{URL: "https://github.com/acme/thing", Name: "thing", FullName: "acme/thing"}
+	s.DB.Create(&repo)
+	origin := db.Scan{RepositoryID: repo.ID, Kind: worker.JobSkill, Status: db.ScanDone, SkillName: deepDiveSkillName}
+	s.DB.Create(&origin)
+	const saved = "## Summary\n\nThe latest saved disclosure.\n\n```ruby\nputs :saved\n```"
+	f := db.Finding{
+		ScanID: origin.ID, RepositoryID: repo.ID, FindingID: "F1", Title: "Saved advisory title",
+		DisclosureDraft: saved,
+	}
+	s.DB.Create(&f)
+	skill := db.Skill{
+		Name: discloseSkillName, OutputKind: "disclose", OutputFile: "report.json",
+		Version: 1, Active: true, Source: "ui",
+	}
+	s.DB.Create(&skill)
+	discloseScan := db.Scan{
+		RepositoryID: repo.ID, Kind: worker.JobSkill, Status: db.ScanDone,
+		SkillID: &skill.ID, SkillName: skill.Name, FindingID: &f.ID,
+		Report: `{"ghsa":{"summary":"Generated title","description":"stale generated body"},"patched":["disclosure_draft"]}`,
+	}
+	s.DB.Create(&discloseScan)
+
+	path := "/scans/" + strconv.FormatUint(uint64(discloseScan.ID), 10) + "/report.md"
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq("GET", path))
+	if w.Code != 200 {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+	if got := w.Body.String(); got != "# Saved advisory title\n\n"+saved+"\n" {
+		t.Errorf("disclose scan export did not use saved finding draft:\n%s", got)
+	}
+	for _, unwanted := range []string{"Generated title", "stale generated body", "Scan metadata", "patched"} {
+		if strings.Contains(w.Body.String(), unwanted) {
+			t.Errorf("disclose export contains %q:\n%s", unwanted, w.Body)
+		}
+	}
+}
+
+func TestScanReport_discloseWithoutSavedDraftReturnsNotFound(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		createFinding bool
+	}{
+		{name: "finding association missing"},
+		{name: "draft empty", createFinding: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s, done := newTestServer(t)
+			defer done()
+			repo := db.Repository{URL: "https://github.com/acme/thing", Name: "thing"}
+			s.DB.Create(&repo)
+			skill := db.Skill{Name: discloseSkillName, OutputKind: "disclose", Active: true, Version: 1, Source: "ui"}
+			s.DB.Create(&skill)
+			var findingID *uint
+			if tc.createFinding {
+				origin := db.Scan{RepositoryID: repo.ID, Kind: worker.JobSkill, Status: db.ScanDone}
+				s.DB.Create(&origin)
+				finding := db.Finding{ScanID: origin.ID, RepositoryID: repo.ID, Title: "No draft"}
+				s.DB.Create(&finding)
+				findingID = &finding.ID
+			}
+			scan := db.Scan{
+				RepositoryID: repo.ID, Kind: worker.JobSkill, Status: db.ScanDone,
+				SkillID: &skill.ID, SkillName: skill.Name, FindingID: findingID,
+			}
+			s.DB.Create(&scan)
+
+			w := httptest.NewRecorder()
+			s.Handler().ServeHTTP(w, localReq("GET", "/scans/"+strconv.FormatUint(uint64(scan.ID), 10)+"/report.md"))
+			if w.Code != http.StatusNotFound || !strings.Contains(w.Body.String(), "no saved disclosure draft") {
+				t.Errorf("status/body = %d %q, want explicit 404", w.Code, w.Body.String())
+			}
+			if got := w.Header().Get("Content-Disposition"); got != "" {
+				t.Errorf("missing draft should not download an attachment: %q", got)
+			}
+		})
 	}
 }
 

--- a/internal/web/scans.go
+++ b/internal/web/scans.go
@@ -207,9 +207,21 @@ func (s *Server) scanShow(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	s.render(w, r, "scan_show.html", map[string]any{
-		"Scan": scan,
-		"Diff": parseScanDiffView(scan),
+		"Scan":               scan,
+		"Diff":               parseScanDiffView(scan),
+		"DisclosureReviewID": s.disclosureReviewFindingID(scan),
 	})
+}
+
+func (s *Server) disclosureReviewFindingID(scan db.Scan) uint {
+	if scan.Status != db.ScanDone || !discloseScanGeneratedDraft(scan) {
+		return 0
+	}
+	var finding db.Finding
+	if err := s.DB.Select("id", "disclosure_draft").First(&finding, *scan.FindingID).Error; err != nil || strings.TrimSpace(finding.DisclosureDraft) == "" {
+		return 0
+	}
+	return finding.ID
 }
 
 // scanDiffView is the parsed diff-rescan metadata for the scan page,

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -419,6 +419,9 @@ func New(gdb *gorm.DB, q *queue.Queue, log *slog.Logger, broker *Broker, w *work
 		"findingReportFilename": func(repo db.Repository, f db.Finding) string {
 			return findingReportFilename(&repo, &f)
 		},
+		"findingDisclosureMarkdownFilename": func(repo db.Repository, f db.Finding) string {
+			return findingDisclosureMarkdownFilename(&repo, &f)
+		},
 	}
 	t, err := template.New("").Funcs(funcs).ParseFS(tmplFS, "templates/*.html")
 	if err != nil {
@@ -522,6 +525,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("POST /findings/{id}/reviews", s.findingReviewCreate)
 	mux.HandleFunc("GET /findings/{id}", s.findingShow)
 	mux.HandleFunc("GET /findings/{id}/report.md", s.findingReport)
+	mux.HandleFunc("GET /findings/{id}/disclosure.md", s.findingDisclosureMarkdown)
 	mux.HandleFunc("GET /findings/{id}/csaf.json", s.findingCSAF)
 	mux.HandleFunc("GET /findings/{id}/osv.json", s.findingOSV)
 	mux.HandleFunc("GET /findings/{id}/disclosure.html", s.findingDisclosureHTML)
@@ -541,6 +545,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("GET /findings/{id}/bundle.tar.gz", s.findingBundleDownload)
 	mux.HandleFunc("POST /findings/{id}/notes", s.findingNotes)
 	mux.HandleFunc("POST /findings/{id}/fields", s.findingFields)
+	mux.HandleFunc("POST /findings/{id}/disclosure-draft", s.findingDisclosureDraftSave)
 	mux.HandleFunc("POST /findings/{id}/communications", s.findingCommunications)
 	mux.HandleFunc("POST /findings/{id}/references", s.findingReferences)
 	mux.HandleFunc("POST /findings/{id}/labels", s.findingLabels)
@@ -1497,6 +1502,10 @@ func (s *Server) findingStatus(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	status := db.FindingLifecycle(r.FormValue(statusKey))
+	if status == db.FindingReady && strings.TrimSpace(f.DisclosureDraft) == "" {
+		http.Error(w, "a saved disclosure draft is required before marking ready", http.StatusUnprocessableEntity)
+		return
+	}
 	switch status {
 	case db.FindingNew, db.FindingEnriched, db.FindingTriaged, db.FindingReady,
 		db.FindingReported, db.FindingAcknowledged, db.FindingFixed, db.FindingPublished,
@@ -1563,7 +1572,7 @@ func (s *Server) findingVerify(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) findingDisclose(w http.ResponseWriter, r *http.Request) {
-	s.runFindingSkill(w, r, discloseSkillName, false)
+	s.runFindingSkill(w, r, discloseSkillName, true)
 }
 
 func (s *Server) findingPublicIssue(w http.ResponseWriter, r *http.Request) {
@@ -1822,8 +1831,10 @@ func (s *Server) advisoriesList(w http.ResponseWriter, r *http.Request) {
 
 type findingWorkflowData struct {
 	db.Finding
-	VerifyInFlight bool
-	HasDependents  bool
+	VerifyInFlight     bool
+	DiscloseInFlight   bool
+	HasDependents      bool
+	HasDisclosureDraft bool
 }
 
 func (s *Server) findingShow(w http.ResponseWriter, r *http.Request) {
@@ -1865,6 +1876,7 @@ func (s *Server) findingShow(w http.ResponseWriter, r *http.Request) {
 		selected[l.Name] = true
 	}
 	_, verifyInFlight := s.openFindingSkillScan(f.ID, verifySkillName)
+	_, discloseInFlight := s.openFindingSkillScan(f.ID, discloseSkillName)
 	hasDependents, err := repoHasDependents(s.DB, scan.RepositoryID)
 	if err != nil {
 		s.Log.Warn("count dependents", "repo", scan.RepositoryID, "err", err)
@@ -1904,23 +1916,26 @@ func (s *Server) findingShow(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := map[string]any{
-		"F":                f,
-		"Scan":             scan,
-		"Repo":             repo,
-		"Notes":            notes,
-		"Communications":   comms,
-		"References":       refs,
-		"History":          history,
-		"HistoryTotal":     historyTotal,
-		"Reviews":          reviews,
-		"Verifications":    verifications,
-		"LatestRevalidate": latestRevalidate,
-		"AllLabels":        labels,
-		"Selected":         selected,
+		"F":                  f,
+		"HasDisclosureDraft": strings.TrimSpace(f.DisclosureDraft) != "",
+		"Scan":               scan,
+		"Repo":               repo,
+		"Notes":              notes,
+		"Communications":     comms,
+		"References":         refs,
+		"History":            history,
+		"HistoryTotal":       historyTotal,
+		"Reviews":            reviews,
+		"Verifications":      verifications,
+		"LatestRevalidate":   latestRevalidate,
+		"AllLabels":          labels,
+		"Selected":           selected,
 		"Workflow": findingWorkflowData{
-			Finding:        f,
-			VerifyInFlight: verifyInFlight,
-			HasDependents:  hasDependents,
+			Finding:            f,
+			VerifyInFlight:     verifyInFlight,
+			DiscloseInFlight:   discloseInFlight,
+			HasDependents:      hasDependents,
+			HasDisclosureDraft: strings.TrimSpace(f.DisclosureDraft) != "",
 		},
 		"Exposures":     exposures,
 		"HasDependents": hasDependents,

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"slices"
 	"sort"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -1809,7 +1810,7 @@ func TestFindingShow_dependentWorkflowWhenDependentsExist(t *testing.T) {
 	s.DB.Create(&scan)
 	s.DB.Create(&db.Dependent{RepositoryID: repo.ID, Name: "downstream", Ecosystem: "npm"})
 	f := db.Finding{ScanID: scan.ID, RepositoryID: repo.ID, Title: "ready finding",
-		Severity: "High", Status: db.FindingReady}
+		Severity: "High", Status: db.FindingReady, DisclosureDraft: "## Summary\n\nReviewed draft."}
 	s.DB.Create(&f)
 
 	w := httptest.NewRecorder()
@@ -1827,6 +1828,199 @@ func TestFindingShow_dependentWorkflowWhenDependentsExist(t *testing.T) {
 		if strings.Contains(body, gone) {
 			t.Errorf("dependent workflow should not render no-dependent text %q", gone)
 		}
+	}
+}
+
+func TestFindingShow_disclosureWorkflowStates(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	repo := db.Repository{URL: "https://github.com/foo/lib", Name: "lib"}
+	s.DB.Create(&repo)
+	scan := db.Scan{RepositoryID: repo.ID, Kind: "skill", Status: db.ScanDone, SkillName: deepDiveSkillName}
+	s.DB.Create(&scan)
+	s.DB.Create(&db.Dependent{RepositoryID: repo.ID, Name: "downstream", Ecosystem: "npm"})
+
+	noDraft := db.Finding{
+		ScanID: scan.ID, RepositoryID: repo.ID, Title: "awaiting draft",
+		Severity: "High", Status: db.FindingTriaged,
+	}
+	withDraft := db.Finding{
+		ScanID: scan.ID, RepositoryID: repo.ID, Title: "drafted finding",
+		Severity: "High", Status: db.FindingTriaged,
+		DisclosureDraft: "## Summary\n\nA saved **disclosure** with `inline code`.\n",
+	}
+	s.DB.Create(&noDraft)
+	s.DB.Create(&withDraft)
+
+	renderFinding := func(id uint) string {
+		w := httptest.NewRecorder()
+		s.Handler().ServeHTTP(w, localReq("GET", fmt.Sprintf("/findings/%d", id)))
+		if w.Code != http.StatusOK {
+			t.Fatalf("finding %d status %d: %s", id, w.Code, w.Body)
+		}
+		return w.Body.String()
+	}
+
+	before := renderFinding(noDraft.ID)
+	if !strings.Contains(before, "Draft disclosure") {
+		t.Errorf("finding without a draft is missing the generation action:\n%s", before)
+	}
+	if !strings.Contains(before, "Export report") || strings.Contains(before, "Export disclosure") {
+		t.Errorf("finding without a draft should retain the generic report export:\n%s", before)
+	}
+	for _, want := range []string{
+		`id="disclosure"`,
+		`data-disclosure-editor`,
+		`action="/findings/` + strconv.FormatUint(uint64(noDraft.ID), 10) + `/disclosure-draft"`,
+		`name="disclosure_draft"`,
+		`data-disclosure-form>`,
+		`data-disclosure-preview hidden>`,
+		`<div id="disclosure-edit-panel-`,
+		`role="tab"`,
+		`role="tabpanel"`,
+		`data-disclosure-preview-stale`,
+		"Nothing saved yet. Save your draft to preview it.",
+		"Write or paste a disclosure draft below",
+	} {
+		if !strings.Contains(before, want) {
+			t.Errorf("finding without a draft is missing manual editor state %q:\n%s", want, before)
+		}
+	}
+	if strings.Contains(before, "Review disclosure") || strings.Contains(before, "Needs review") {
+		t.Errorf("finding without a draft rendered generated-draft affordances:\n%s", before)
+	}
+	if strings.Contains(before, "Showing the saved draft. Save your edits to update this preview.") {
+		t.Errorf("finding without a draft claims it is previewing saved text:\n%s", before)
+	}
+	if strings.Contains(before, `<form id="disclosure-edit-panel-`) {
+		t.Errorf("edit form must not override its native ARIA role:\n%s", before)
+	}
+	if !strings.Contains(before, `disabled title="A saved disclosure draft is required before marking ready"`) {
+		t.Errorf("finding without a draft does not visibly gate Mark ready:\n%s", before)
+	}
+
+	after := renderFinding(withDraft.ID)
+	for _, want := range []string{
+		"Draft generated",
+		"Needs review",
+		"Export disclosure",
+		`href="#disclosure"`,
+		"Review disclosure",
+		"Regenerate draft",
+		`hx-confirm="Regenerating may overwrite the latest saved disclosure edits. Continue?"`,
+		`id="disclosure"`,
+		`data-disclosure-preview`,
+		`data-disclosure-preview-stale`,
+		`data-disclosure-editor`,
+		`data-disclosure-form hidden>`,
+		`role="tab"`,
+		`role="tabpanel"`,
+		"Showing the saved draft. Save your edits to update this preview.",
+		`action="/findings/` + strconv.FormatUint(uint64(withDraft.ID), 10) + `/disclosure-draft"`,
+		`name="disclosure_draft"`,
+		">Preview<",
+		">Edit<",
+		">Save<",
+		">Cancel<",
+		`href="/findings/` + strconv.FormatUint(uint64(withDraft.ID), 10) + `/disclosure.md"`,
+		`href="/findings/` + strconv.FormatUint(uint64(withDraft.ID), 10) + `/report.md"`,
+		"Export finding report",
+	} {
+		if !strings.Contains(after, want) {
+			t.Errorf("finding with a draft is missing %q:\n%s", want, after)
+		}
+	}
+	if strings.Count(after, `name="disclosure_draft"`) != 1 {
+		t.Errorf("disclosure draft should have one obvious editor, got %d:\n%s",
+			strings.Count(after, `name="disclosure_draft"`), after)
+	}
+	if strings.Contains(after, "Nothing saved yet. Save your draft to preview it.") {
+		t.Errorf("finding with a draft rendered empty-draft preview copy:\n%s", after)
+	}
+
+	queued := db.Scan{
+		RepositoryID: repo.ID, Kind: worker.JobSkill, SkillName: discloseSkillName,
+		FindingID: &noDraft.ID, Status: db.ScanQueued, StatusPriority: db.StatusPriorityFor(db.ScanQueued),
+	}
+	s.DB.Create(&queued)
+	drafting := renderFinding(noDraft.ID)
+	if !strings.Contains(drafting, "Drafting disclosure") || strings.Contains(drafting, `hx-post="/findings/`+strconv.FormatUint(uint64(noDraft.ID), 10)+`/disclose"`) {
+		t.Errorf("queued first draft did not disable disclosure enqueue: %s", drafting)
+	}
+
+	running := db.Scan{
+		RepositoryID: repo.ID, Kind: worker.JobSkill, SkillName: discloseSkillName,
+		FindingID: &withDraft.ID, Status: db.ScanRunning, StatusPriority: db.StatusPriorityFor(db.ScanRunning),
+	}
+	s.DB.Create(&running)
+	regenerating := renderFinding(withDraft.ID)
+	if !strings.Contains(regenerating, "Regeneration in progress") || !strings.Contains(regenerating, "Review disclosure") ||
+		strings.Contains(regenerating, `hx-post="/findings/`+strconv.FormatUint(uint64(withDraft.ID), 10)+`/disclose"`) {
+		t.Errorf("running regeneration did not preserve review and disable enqueue: %s", regenerating)
+	}
+}
+
+func TestFindingShow_readyWithoutDraftOffersEditor(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	repo := db.Repository{URL: "https://github.com/foo/lib", Name: "lib"}
+	s.DB.Create(&repo)
+	scan := db.Scan{RepositoryID: repo.ID, Kind: "skill", Status: db.ScanDone, SkillName: deepDiveSkillName}
+	s.DB.Create(&scan)
+	s.DB.Create(&db.Dependent{RepositoryID: repo.ID, Name: "downstream", Ecosystem: "npm"})
+	finding := db.Finding{
+		ScanID: scan.ID, RepositoryID: repo.ID, Title: "historical ready finding",
+		Severity: "High", Status: db.FindingReady,
+	}
+	s.DB.Create(&finding)
+
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq("GET", fmt.Sprintf("/findings/%d", finding.ID)))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+	body := w.Body.String()
+	for _, want := range []string{`id="disclosure"`, `data-disclosure-form>`, "No saved disclosure draft", "Write or paste a disclosure draft below"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("historical ready finding missing %q: %s", want, body)
+		}
+	}
+	if strings.Contains(body, "The saved draft is prepared") || strings.Contains(body, "Review disclosure") {
+		t.Errorf("historical ready finding claims a saved draft exists: %s", body)
+	}
+}
+
+func TestFindingStatus_readyRequiresDisclosureDraft(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	f := seedFindingForForm(t, s)
+	if err := s.DB.Model(&f).Update("status", db.FindingTriaged).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	path := fmt.Sprintf("/findings/%d/status", f.ID)
+	w := postForm(t, s, path, url.Values{"status": {string(db.FindingReady)}})
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status without draft = %d, want 422; body=%s", w.Code, w.Body)
+	}
+	var got db.Finding
+	s.DB.First(&got, f.ID)
+	if got.Status != db.FindingTriaged {
+		t.Errorf("status changed without a draft: %q", got.Status)
+	}
+
+	if err := db.WriteFindingField(s.DB, f.ID, "disclosure_draft", "## Reviewed draft", db.SourceAnalyst, ""); err != nil {
+		t.Fatal(err)
+	}
+	w = postForm(t, s, path, url.Values{"status": {string(db.FindingReady)}})
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("status with draft = %d, want 303; body=%s", w.Code, w.Body)
+	}
+	s.DB.First(&got, f.ID)
+	if got.Status != db.FindingReady {
+		t.Errorf("status = %q, want ready", got.Status)
 	}
 }
 
@@ -2383,7 +2577,8 @@ func TestFindingDiscloseEnqueuesDiscloseSkill(t *testing.T) {
 	if w.Code != http.StatusSeeOther {
 		t.Fatalf("status %d: %s", w.Code, w.Body)
 	}
-	if !strings.HasPrefix(w.Header().Get("Location"), "/scans/") {
+	firstLocation := w.Header().Get("Location")
+	if !strings.HasPrefix(firstLocation, "/scans/") {
 		t.Errorf("expected redirect to scan, got %q", w.Header().Get("Location"))
 	}
 
@@ -2394,6 +2589,17 @@ func TestFindingDiscloseEnqueuesDiscloseSkill(t *testing.T) {
 	}
 	if row.APIToken == "" {
 		t.Error("scan missing api token")
+	}
+
+	w = httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req.Clone(req.Context()))
+	if w.Code != http.StatusSeeOther || w.Header().Get("Location") != firstLocation {
+		t.Errorf("duplicate disclose = %d redirect %q, want existing scan %q", w.Code, w.Header().Get("Location"), firstLocation)
+	}
+	var count int64
+	s.DB.Model(&db.Scan{}).Where("finding_id = ? AND skill_name = ?", finding.ID, discloseSkillName).Count(&count)
+	if count != 1 {
+		t.Errorf("disclose scans = %d, want one in-flight scan", count)
 	}
 }
 
@@ -4826,6 +5032,54 @@ func TestScanShowRenders(t *testing.T) {
 	}
 	if !strings.Contains(body, "triaged") {
 		t.Errorf("finding status not rendered in scan results table")
+	}
+}
+
+func TestScanShow_discloseCompletionLinksToSavedDraft(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	repo := db.Repository{URL: "u", Name: "n"}
+	s.DB.Create(&repo)
+	origin := db.Scan{RepositoryID: repo.ID, Kind: "skill", Status: db.ScanDone, SkillName: deepDiveSkillName}
+	s.DB.Create(&origin)
+	finding := db.Finding{
+		ScanID: origin.ID, RepositoryID: repo.ID, Title: "drafted", Status: db.FindingTriaged,
+		DisclosureDraft: "## Summary\n\nSaved draft.",
+	}
+	s.DB.Create(&finding)
+	scan := db.Scan{
+		RepositoryID: repo.ID, Kind: "skill", Status: db.ScanDone, SkillName: discloseSkillName,
+		FindingID: &finding.ID,
+		Report:    `{"ghsa":{"summary":"Drafted","description":"## Summary\n\nSaved draft."}}`,
+	}
+	s.DB.Create(&scan)
+
+	render := func() string {
+		w := httptest.NewRecorder()
+		s.Handler().ServeHTTP(w, localReq("GET", fmt.Sprintf("/scans/%d", scan.ID)))
+		if w.Code != http.StatusOK {
+			t.Fatalf("status %d: %s", w.Code, w.Body)
+		}
+		return w.Body.String()
+	}
+
+	body := render()
+	for _, want := range []string{
+		"Disclosure draft generated",
+		"The saved draft is ready for analyst review and editing.",
+		fmt.Sprintf(`/findings/%d#disclosure`, finding.ID),
+		"Review disclosure",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("completed disclose scan missing %q: %s", want, body)
+		}
+	}
+
+	scan.Report = `{"error":"insufficient prose"}`
+	s.DB.Save(&scan)
+	if body = render(); strings.Contains(body, "Disclosure draft generated") {
+		t.Errorf("refused disclose scan rendered a generation success message: %s", body)
 	}
 }
 

--- a/internal/web/sse.go
+++ b/internal/web/sse.go
@@ -1,6 +1,7 @@
 package web
 
 import (
+	"encoding/json"
 	"fmt"
 	"html"
 	"io"
@@ -193,13 +194,19 @@ func (s *Server) renderScanStatus(scanID uint) string {
 		if scan.Status != db.ScanDone {
 			cat = errorKey
 		}
-		data["Flash"] = Flash{
+		flash := Flash{
 			Category:    cat,
 			Title:       fmt.Sprintf("%s %s", scan.SkillName, scan.Status),
 			Description: scan.Repository.Name,
 			Href:        fmt.Sprintf("/scans/%d", scan.ID),
 			Label:       "View",
 		}
+		if findingID := s.disclosureReviewFindingID(scan); findingID != 0 {
+			flash.Title = "Disclosure draft generated"
+			flash.Href = fmt.Sprintf("/findings/%d#disclosure", findingID)
+			flash.Label = "Review disclosure"
+		}
+		data["Flash"] = flash
 	}
 	var buf strings.Builder
 	if err := s.tmpl.ExecuteTemplate(&buf, "scan-status-sse", data); err != nil {
@@ -207,6 +214,23 @@ func (s *Server) renderScanStatus(scanID uint) string {
 		return ""
 	}
 	return buf.String()
+}
+
+// discloseScanGeneratedDraft excludes refused or malformed runs.
+func discloseScanGeneratedDraft(scan db.Scan) bool {
+	if scan.SkillName != discloseSkillName || scan.FindingID == nil {
+		return false
+	}
+	var result struct {
+		GHSA struct {
+			Description string `json:"description"`
+		} `json:"ghsa"`
+		Error string `json:"error"`
+	}
+	if err := json.Unmarshal([]byte(scan.Report), &result); err != nil {
+		return false
+	}
+	return strings.TrimSpace(result.Error) == "" && strings.TrimSpace(result.GHSA.Description) != ""
 }
 
 // writeSSEEvent emits one SSE event per the spec. Embedded newlines in data

--- a/internal/web/sse_test.go
+++ b/internal/web/sse_test.go
@@ -154,6 +154,49 @@ func TestRenderScanStatus_runningPushesRowWithoutToast(t *testing.T) {
 	}
 }
 
+func TestRenderScanStatus_discloseDoneLinksToSavedDraft(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	repo := db.Repository{URL: "https://example.com/disclosure", Name: "disclosure"}
+	s.DB.Create(&repo)
+	origin := db.Scan{RepositoryID: repo.ID, Kind: "skill", SkillName: deepDiveSkillName, Status: db.ScanDone}
+	s.DB.Create(&origin)
+	f := db.Finding{
+		ScanID: origin.ID, RepositoryID: repo.ID, Title: "drafted", Status: db.FindingTriaged,
+		DisclosureDraft: "## Summary\n\nSaved draft.",
+	}
+	s.DB.Create(&f)
+	scan := db.Scan{
+		RepositoryID: repo.ID, Kind: "skill", SkillName: discloseSkillName, Status: db.ScanDone,
+		FindingID: &f.ID,
+		Report:    `{"ghsa":{"summary":"Drafted","description":"## Summary\n\nSaved draft."}}`,
+	}
+	s.DB.Create(&scan)
+
+	out := s.renderScanStatus(scan.ID)
+	for _, want := range []string{
+		"Disclosure draft generated",
+		fmt.Sprintf(`/findings/%d#disclosure`, f.ID),
+		"Review disclosure",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("disclose completion toast missing %q: %s", want, out)
+		}
+	}
+	if strings.Contains(out, fmt.Sprintf(`/scans/%d`, scan.ID)) && strings.Contains(out, ">View<") {
+		t.Errorf("successful disclose toast still points only at the scan: %s", out)
+	}
+
+	// A refused rerun must not claim it generated the older saved draft.
+	scan.Report = `{"error":"insufficient prose"}`
+	s.DB.Save(&scan)
+	out = s.renderScanStatus(scan.ID)
+	if strings.Contains(out, "Disclosure draft generated") {
+		t.Errorf("refused disclose rerun reported success: %s", out)
+	}
+}
+
 // The list pages refresh off scan-status, so every action that changes a scan
 // row has to publish one or the tables stay stale in any tab that did not
 // trigger the action.

--- a/internal/web/static/app.js
+++ b/internal/web/static/app.js
@@ -140,8 +140,16 @@
       var disclosureRoot = disclosureCancel.closest('[data-disclosure-editor]');
       if (disclosureForm) disclosureForm.reset();
       if (disclosureRoot) {
-        var previewButton = disclosureRoot.querySelector('[data-disclosure-mode="preview"]');
-        if (previewButton) previewButton.click();
+        // Cancel returns to the saved draft, so with nothing saved the editor
+        // stays open rather than dropping the analyst on an empty preview.
+        // Focus follows the tab, which the panel it came from just hid.
+        var draft = disclosureRoot.querySelector('[data-disclosure-form] textarea');
+        var saved = draft && draft.defaultValue.trim() !== '';
+        var target = disclosureRoot.querySelector('[data-disclosure-mode="' + (saved ? 'preview' : 'edit') + '"]');
+        if (target) {
+          activateDisclosureMode(target, false);
+          target.focus();
+        }
       }
       return;
     }

--- a/internal/web/static/app.js
+++ b/internal/web/static/app.js
@@ -93,7 +93,59 @@
     if (el && e.detail.type === el.getAttribute('data-reload-on-sse')) location.reload();
   });
 
+  function activateDisclosureMode(button, focusEditor) {
+    var disclosure = button.closest('[data-disclosure-editor]');
+    if (!disclosure) return;
+    var editing = button.getAttribute('data-disclosure-mode') === 'edit';
+    var preview = disclosure.querySelector('[data-disclosure-preview]');
+    var editor = disclosure.querySelector('[data-disclosure-form]');
+    var textarea = editor && editor.querySelector('textarea');
+    var stale = preview && preview.querySelector('[data-disclosure-preview-stale]');
+    if (preview) preview.hidden = editing;
+    if (editor) editor.hidden = !editing;
+    if (stale && !editing) stale.hidden = !textarea || textarea.value === textarea.defaultValue;
+    disclosure.querySelectorAll('[data-disclosure-mode]').forEach(function (candidate) {
+      var selected = candidate === button;
+      candidate.setAttribute('aria-selected', selected ? 'true' : 'false');
+      candidate.setAttribute('tabindex', selected ? '0' : '-1');
+      candidate.className = selected ? 'btn-sm' : 'btn-sm-outline';
+    });
+    if (editing && focusEditor && textarea) textarea.focus();
+  }
+
+  document.addEventListener('keydown', function (e) {
+    var tab = e.target.closest('[data-disclosure-mode][role="tab"]');
+    if (!tab || !['ArrowLeft', 'ArrowRight', 'Home', 'End'].includes(e.key)) return;
+    var tabs = Array.from(tab.closest('[role="tablist"]').querySelectorAll('[role="tab"]'));
+    var index = tabs.indexOf(tab);
+    if (e.key === 'Home') index = 0;
+    else if (e.key === 'End') index = tabs.length - 1;
+    else index = (index + (e.key === 'ArrowRight' ? 1 : -1) + tabs.length) % tabs.length;
+    e.preventDefault();
+    activateDisclosureMode(tabs[index], false);
+    tabs[index].focus();
+  });
+
   document.addEventListener('click', function (e) {
+    var disclosureMode = e.target.closest('[data-disclosure-mode]');
+    if (disclosureMode) {
+      e.preventDefault();
+      activateDisclosureMode(disclosureMode, true);
+      return;
+    }
+
+    var disclosureCancel = e.target.closest('[data-disclosure-cancel]');
+    if (disclosureCancel) {
+      var disclosureForm = disclosureCancel.closest('form');
+      var disclosureRoot = disclosureCancel.closest('[data-disclosure-editor]');
+      if (disclosureForm) disclosureForm.reset();
+      if (disclosureRoot) {
+        var previewButton = disclosureRoot.querySelector('[data-disclosure-mode="preview"]');
+        if (previewButton) previewButton.click();
+      }
+      return;
+    }
+
     var copyBtn = e.target.closest('[data-copy]');
     if (copyBtn && navigator.clipboard) {
       e.preventDefault();

--- a/internal/web/templates/finding_show.html
+++ b/internal/web/templates/finding_show.html
@@ -24,9 +24,15 @@
       <i data-lucide="send"></i> Submit to VINCE
     </button>
     {{end}}
+    {{if .HasDisclosureDraft}}
+    <a href="/findings/{{$f.ID}}/disclosure.md" class="btn-outline" download="{{findingDisclosureMarkdownFilename $repo $f}}">
+      <i data-lucide="download"></i> Export disclosure
+    </a>
+    {{else}}
     <a href="/findings/{{$f.ID}}/report.md" class="btn-outline" download="{{findingReportFilename $repo $f}}">
       <i data-lucide="download"></i> Export report
     </a>
+    {{end}}
     <a href="/findings/{{$f.ID}}/bundle.tar.gz" class="btn-outline"
        title="{{if .HasDependents}}OSV + CSAF VEX + markdown report + patch + manifest{{else}}OSV + markdown report + patch + manifest{{end}}, packaged for a disclosure recipient"
        download>
@@ -44,6 +50,75 @@
 {{end}}
 
 {{template "finding_workflow" .Workflow}}
+
+<section id="disclosure" class="card mb-6 scroll-mt-6" data-disclosure-editor>
+  <header class="flex items-start justify-between gap-4 mb-4">
+    <div>
+      <div class="flex items-center gap-2">
+        <h3 class="text-lg font-semibold">Disclosure draft</h3>
+        {{if .HasDisclosureDraft}}
+        <span class="badge-secondary">Needs review</span>
+        {{else}}
+        <span class="badge-outline">No saved draft</span>
+        {{end}}
+      </div>
+      {{if .HasDisclosureDraft}}
+      <p class="text-sm text-muted-foreground mt-1">This is the latest saved maintainer-facing draft.</p>
+      {{else}}
+      <p class="text-sm text-muted-foreground mt-1">Write or paste a disclosure draft below, or use Draft disclosure to generate one.</p>
+      {{end}}
+    </div>
+    <div class="flex items-center gap-1" role="tablist" aria-label="Disclosure draft view">
+      <button type="button" id="disclosure-preview-tab-{{$f.ID}}" role="tab"
+              aria-controls="disclosure-preview-panel-{{$f.ID}}" aria-selected="{{if .HasDisclosureDraft}}true{{else}}false{{end}}"
+              tabindex="{{if .HasDisclosureDraft}}0{{else}}-1{{end}}"
+              class="{{if .HasDisclosureDraft}}btn-sm{{else}}btn-sm-outline{{end}}" data-disclosure-mode="preview">Preview</button>
+      <button type="button" id="disclosure-edit-tab-{{$f.ID}}" role="tab"
+              aria-controls="disclosure-edit-panel-{{$f.ID}}" aria-selected="{{if .HasDisclosureDraft}}false{{else}}true{{end}}"
+              tabindex="{{if .HasDisclosureDraft}}-1{{else}}0{{end}}"
+              class="{{if .HasDisclosureDraft}}btn-sm-outline{{else}}btn-sm{{end}}" data-disclosure-mode="edit">Edit</button>
+    </div>
+  </header>
+
+  <div id="disclosure-preview-panel-{{$f.ID}}" role="tabpanel" tabindex="0"
+       aria-labelledby="disclosure-preview-tab-{{$f.ID}}" class="prose max-w-none"
+       data-disclosure-preview{{if not .HasDisclosureDraft}} hidden{{end}}>
+    <div class="alert mb-4 not-prose" data-disclosure-preview-stale hidden>
+      <i data-lucide="info"></i>
+      <section>{{if .HasDisclosureDraft}}Showing the saved draft. Save your edits to update this preview.{{else}}Nothing saved yet. Save your draft to preview it.{{end}}</section>
+    </div>
+    {{if .HasDisclosureDraft}}{{md $f.DisclosureDraft}}{{else}}<p class="text-muted-foreground">No saved disclosure draft.</p>{{end}}
+  </div>
+  <div id="disclosure-edit-panel-{{$f.ID}}" role="tabpanel" tabindex="0"
+       aria-labelledby="disclosure-edit-tab-{{$f.ID}}"
+       data-disclosure-form{{if .HasDisclosureDraft}} hidden{{end}}>
+    <form method="post" action="/findings/{{$f.ID}}/disclosure-draft" class="form grid gap-3">
+      <label class="text-xs text-muted-foreground" for="disclosure-draft-{{$f.ID}}">Markdown disclosure</label>
+      <textarea id="disclosure-draft-{{$f.ID}}" class="input font-mono text-xs min-h-96"
+                name="disclosure_draft" rows="24">{{$f.DisclosureDraft}}</textarea>
+      <div class="flex justify-end gap-2">
+        <button type="reset" class="btn-sm-outline" data-disclosure-cancel>Cancel</button>
+        <button type="submit" class="btn-sm">Save</button>
+      </div>
+    </form>
+  </div>
+
+  {{if .HasDisclosureDraft}}
+  <footer class="flex flex-wrap gap-3 mt-4 pt-3 border-t text-xs">
+    <a href="/findings/{{$f.ID}}/disclosure.md" class="text-muted-foreground hover:text-foreground hover:underline inline-flex items-center gap-1">
+      <i data-lucide="download" class="size-3.5"></i> Export saved Markdown
+    </a>
+    <a href="/findings/{{$f.ID}}/report.md" class="text-muted-foreground hover:text-foreground hover:underline inline-flex items-center gap-1">
+      <i data-lucide="file-text" class="size-3.5"></i> Export finding report
+    </a>
+    <a href="/findings/{{$f.ID}}/disclosure.html" target="_blank" rel="noopener"
+       class="text-muted-foreground hover:text-foreground hover:underline inline-flex items-center gap-1"
+       title="Open the draft as styled HTML, then select-all and paste into a Gmail compose window">
+      <i data-lucide="external-link" class="size-3.5"></i> Open Gmail-ready HTML
+    </a>
+  </footer>
+  {{end}}
+</section>
 
 <dl class="grid grid-cols-2 sm:grid-cols-6 gap-4 mb-6 text-sm">
   <div>
@@ -613,17 +688,6 @@ git commit -m "fix: {{$f.Title}}"</pre>
           <label class="text-xs text-muted-foreground"
                  title="File-level owners of the finding's location, from CODEOWNERS or recent non-bot committers">Suggested recipients</label>
           <input class="input" name="suggested_recipients" value="{{$f.SuggestedRecipients}}">
-        </div>
-        <div class="grid gap-1 col-span-2">
-          <label class="text-xs text-muted-foreground">Disclosure draft</label>
-          <textarea class="input font-mono text-xs" name="disclosure_draft" rows="6">{{$f.DisclosureDraft}}</textarea>
-          {{if $f.DisclosureDraft}}
-          <a href="/findings/{{$f.ID}}/disclosure.html" target="_blank" rel="noopener"
-             class="text-xs text-muted-foreground hover:text-foreground hover:underline inline-flex items-center gap-1 justify-self-start"
-             title="Open the draft as styled HTML, then select-all and paste into a Gmail compose window">
-            <i data-lucide="external-link" class="size-3.5"></i> Open Gmail-ready HTML
-          </a>
-          {{end}}
         </div>
         <div class="col-span-2 flex justify-end">
           <button type="submit" class="btn-sm">Save</button>

--- a/internal/web/templates/finding_workflow.html
+++ b/internal/web/templates/finding_workflow.html
@@ -12,17 +12,27 @@
         <p class="text-sm mb-1 font-medium">Verification complete</p>
         <p class="text-sm text-muted-foreground">The confirm job ran and validated this finding. Review the evidence and triage.</p>
       {{else if eq $s "triaged"}}
-        {{if .HasDependents}}
+        {{if .HasDisclosureDraft}}
+          <p class="text-sm mb-1 font-medium flex items-center gap-2">
+            Draft generated <span class="badge-secondary">Needs review</span>
+          </p>
+          <p class="text-sm text-muted-foreground">A saved disclosure draft exists. Review and edit it before marking this finding ready.</p>
+        {{else if .HasDependents}}
           <p class="text-sm mb-1 font-medium">Triaged, ready to prepare disclosure</p>
           <p class="text-sm text-muted-foreground">You've confirmed this is a real finding. Run the disclose skill to get a GHSA-shaped draft, review and edit, then mark ready.</p>
         {{else}}
           <p class="text-sm mb-1 font-medium">Triaged, ready for operator handoff</p>
-          <p class="text-sm text-muted-foreground">You've confirmed this is a real finding. No dependents are recorded, so prepare an operator handoff with a patch or mitigation, then mark ready.</p>
+          <p class="text-sm text-muted-foreground">You've confirmed this is a real finding. No dependents are recorded, so save the disclosure draft and prepare an operator handoff with a patch or mitigation before marking ready.</p>
         {{end}}
       {{else if eq $s "ready"}}
         {{if .HasDependents}}
-          <p class="text-sm mb-1 font-medium">Disclosure draft ready</p>
-          <p class="text-sm text-muted-foreground">The draft is prepared. Review it in the notes, edit if needed, then send to the maintainer.</p>
+          {{if .HasDisclosureDraft}}
+            <p class="text-sm mb-1 font-medium">Disclosure draft ready</p>
+            <p class="text-sm text-muted-foreground">The saved draft is prepared. Review it below, edit if needed, then send to the maintainer.</p>
+          {{else}}
+            <p class="text-sm mb-1 font-medium">No saved disclosure draft</p>
+            <p class="text-sm text-muted-foreground">This finding predates the draft requirement. Write or paste a disclosure draft below before sending it to the maintainer.</p>
+          {{end}}
         {{else}}
           <p class="text-sm mb-1 font-medium">Remediation handoff ready</p>
           <p class="text-sm text-muted-foreground">Review the patch or mitigation notes, edit if needed, then share with the operator or remediation owner.</p>
@@ -100,10 +110,31 @@
         </button>
 
       {{else if eq $s "triaged"}}
-        <button type="submit" class="btn" formaction="/findings/{{$id}}/disclose"
-                hx-post="/findings/{{$id}}/disclose">
-          <i data-lucide="file-pen"></i> Draft disclosure
-        </button>
+        {{if .HasDisclosureDraft}}
+          <a href="#disclosure" class="btn">
+            <i data-lucide="file-check-2"></i> Review disclosure
+          </a>
+          {{if .DiscloseInFlight}}
+            <button type="button" class="btn-outline" disabled title="A disclosure regeneration scan is already queued or running">
+              <i data-lucide="loader-circle" class="animate-spin"></i> Regeneration in progress
+            </button>
+          {{else}}
+            <button type="submit" class="btn-outline" formaction="/findings/{{$id}}/disclose"
+                    hx-post="/findings/{{$id}}/disclose"
+                    hx-confirm="Regenerating may overwrite the latest saved disclosure edits. Continue?">
+              <i data-lucide="refresh-cw"></i> Regenerate draft
+            </button>
+          {{end}}
+        {{else if .DiscloseInFlight}}
+          <button type="button" class="btn" disabled title="A disclosure scan is already queued or running for this finding">
+            <i data-lucide="loader-circle" class="animate-spin"></i> Drafting disclosure
+          </button>
+        {{else}}
+          <button type="submit" class="btn" formaction="/findings/{{$id}}/disclose"
+                  hx-post="/findings/{{$id}}/disclose">
+            <i data-lucide="file-pen"></i> Draft disclosure
+          </button>
+        {{end}}
         <button type="submit" class="btn-outline" formaction="/findings/{{$id}}/patch"
                 hx-post="/findings/{{$id}}/patch">
           <i data-lucide="wrench"></i> Propose patch
@@ -112,16 +143,27 @@
                 hx-post="/findings/{{$id}}/mitigate">
           <i data-lucide="shield"></i> Draft mitigation
         </button>
-        <button type="submit" name="status" value="ready" class="btn-outline"
-                hx-post="/findings/{{$id}}/status">
-          Mark ready
-        </button>
+        {{if .HasDisclosureDraft}}
+          <button type="submit" name="status" value="ready" class="btn-outline"
+                  hx-post="/findings/{{$id}}/status">
+            Mark ready
+          </button>
+        {{else}}
+          <button type="button" class="btn-outline" disabled title="A saved disclosure draft is required before marking ready">
+            Mark ready
+          </button>
+        {{end}}
         <button type="submit" name="status" value="rejected" class="btn-ghost"
                 hx-post="/findings/{{$id}}/status">
           Reject
         </button>
 
       {{else if eq $s "ready"}}
+        {{if .HasDisclosureDraft}}
+          <a href="#disclosure" class="btn-outline">
+            <i data-lucide="file-check-2"></i> Review disclosure
+          </a>
+        {{end}}
         {{if not (or (eq .Severity "High") (eq .Severity "Critical"))}}
           <button type="submit" class="btn-outline" formaction="/findings/{{$id}}/public-issue"
                   hx-post="/findings/{{$id}}/public-issue">

--- a/internal/web/templates/scan_show.html
+++ b/internal/web/templates/scan_show.html
@@ -170,6 +170,17 @@
   </div>
 {{end}}
 
+{{with $.DisclosureReviewID}}
+  <div class="alert mb-6">
+    <i data-lucide="circle-check"></i>
+    <section>
+      <strong>Disclosure draft generated</strong>
+      <p>The saved draft is ready for analyst review and editing.</p>
+      <a href="/findings/{{.}}#disclosure" class="btn-sm mt-1">Review disclosure</a>
+    </section>
+  </div>
+{{end}}
+
 {{$live := and (not .Status.Terminal) (ne (status .Status) "paused")}}
 {{$default := 1}}{{if $live}}{{$default = 2}}{{end}}
 <div class="tabs w-full" id="scan-tabs">


### PR DESCRIPTION
The disclose skill writes a GHSA-shaped draft to the finding's disclosure_draft column, but the finding page had nowhere to put it. The workflow kept offering "Draft disclosure" after a draft already existed, the only editor was a six-row textarea buried in the analyst fields form, and the Markdown exports rebuilt generic scan metadata instead of reading what was saved.

The finding page now carries a disclosure section with a preview/edit toggle, save and cancel, writing through the usual finding-field history. "Review disclosure" becomes the primary action once a draft is saved and "Mark ready" is gated on one in both the UI and the handler, regeneration drops to a secondary action that confirms before overwriting analyst edits and no longer enqueues a duplicate scan, and the finding and disclose-scan exports serve the saved draft, returning 404 when there is none.

Opus 5 was used to implement this.
