### PR TITLE
skills: add a poutine scanner skill for CI/CD pipeline findings

### DIFF
--- a/.github/workflows/runner-image.yml
+++ b/.github/workflows/runner-image.yml
@@ -78,6 +78,7 @@ jobs:
           docker run --rm scrutineer-runner:ci curl --version
           docker run --rm scrutineer-runner:ci semgrep --version
           docker run --rm scrutineer-runner:ci zizmor --version
+          docker run --rm scrutineer-runner:ci poutine version
           docker run --rm scrutineer-runner:ci git-pkgs --version
           docker run --rm scrutineer-runner:ci brief --version
           docker run --rm scrutineer-runner:ci git --version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Entries are grouped by release, newest first. Each entry is a summary written fo
 ## Unreleased
 
 - A `default_model` pinned in the config file but missing from the model pick list is now reported at startup instead of being silently ignored, and the documentation and sample configuration now use current-generation model ids. ([#816](https://github.com/alpha-omega-security/scrutineer/pull/816), [@alexandre-daubois](https://github.com/alexandre-daubois))
+- Added a `poutine` scanner skill, so pipeline supply-chain weaknesses — untrusted-checkout code execution, injection, secrets exposed to a whole job — are reported alongside the existing zizmor workflow lint, and GitLab CI, Azure Pipelines and Tekton repositories get pipeline coverage for the first time. ([#593](https://github.com/alpha-omega-security/scrutineer/issues/593))
 
 ## 2026-08-11
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,10 @@ FROM golang:1.26.5-alpine@sha256:0178a641fbb4858c5f1b48e34bdaabe0350a330a1b1149a
 RUN apk add --no-cache git
 RUN GOBIN=/out go install github.com/git-pkgs/git-pkgs@v0.15.3 && \
     GOBIN=/out go install github.com/git-pkgs/brief/cmd/brief@v0.9.3
+# poutine stamps its version through -ldflags, so a plain `go install` would
+# leave `poutine version` reporting "development" and the settings page blank.
+RUN GOBIN=/out go install -ldflags "-X main.version=1.1.6" \
+    github.com/boostsecurityio/poutine@v1.1.6
 
 # vid links tree-sitter grammars (C), so unlike the main binary it needs
 # cgo; build-base provides gcc and musl headers, matching the musl-based

--- a/Dockerfile.runner
+++ b/Dockerfile.runner
@@ -16,6 +16,10 @@ ARG SEMGREP_VERSION=1.167.0
 FROM golang:1.26.5-trixie@sha256:4ee9ffa999b4583ce281939cdff828763083610292f252279a0cee77473bd9a7 AS go-tools
 RUN GOBIN=/out go install github.com/git-pkgs/git-pkgs@v0.15.3 && \
     GOBIN=/out go install github.com/git-pkgs/brief/cmd/brief@v0.9.3
+# poutine stamps its version through -ldflags, so a plain `go install` would
+# leave `poutine version` reporting "development" and the settings page blank.
+RUN GOBIN=/out go install -ldflags "-X main.version=1.1.6" \
+    github.com/boostsecurityio/poutine@v1.1.6
 
 FROM rust:1.97-trixie@sha256:1bcff4befb740599103a2c7cb51058e14479b2e35e3a34a3f0dc4ede09927488 AS zizmor-build
 ENV CARGO_HTTP_MULTIPLEXING=false

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ To onboard a whole GitHub org at once, open **Add multiple** → **Import a whol
 
 You can also scan a directory on disk, useful before pushing, or for code not hosted on a git forge. Paste an absolute path (`/path/to/project`) in the same **Add repository** field. Scrutineer copies the directory into a per-scan workspace and runs the default skill set; skills that need a forge URL or ecosyste.ms enrichment (`advisories`, `exposure`, `fork`, `maintainers`, `metadata`, `packages`, `public-issue`, `report-upstream`) are skipped automatically. Symlinks are recreated as-is rather than dereferenced during the copy; in container mode their targets then resolve inside the container, so host files reached only through such a link are not visible to skills. Under `--no-container` the kernel dereferences them normally, so only point scrutineer at trees you trust.
 
-The optional analysis tools (semgrep, zizmor, git-pkgs, brief) are bundled in the runner image, so you don't need them installed locally when the container runner is in use.
+The optional analysis tools (semgrep, zizmor, poutine, git-pkgs, brief) are bundled in the runner image, so you don't need them installed locally when the container runner is in use.
 
 ## Git authentication
 
@@ -157,6 +157,7 @@ Adding a repo enqueues the `triage` skill, whose SKILL.md lists the further skil
 | `semgrep` | Static analysis mapped into findings shape |
 | `vuln-scan` | High-recall model-backed static candidate scan adapted from Anthropic's defending-code reference harness |
 | `zizmor` | GitHub Actions workflow audit mapped into findings shape |
+| `poutine` | CI/CD pipeline supply-chain audit (GitHub Actions, GitLab CI, Azure Pipelines, Tekton) mapped into findings shape |
 | `ingest` | Normalizes external reports in arbitrary formats into findings when `/v1/import` cannot recognise the payload |
 | `security-deep-dive` | The model-backed audit producing structured findings |
 | `advisory-deep-dive` | Re-audits every past advisory against its fix commit for a fix bypass, an incomplete fix, or the same bug class in sibling code the patch never touched; the deep-dive scoped to the advisory space |

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -31,6 +31,7 @@ These live in `skills/` and are embedded in the Scrutineer executable. At startu
 | `semgrep` | Runs semgrep with the `p/security-audit` and `p/secrets` rulesets and maps hits into the findings shape. |
 | `vuln-scan` | High-recall model-backed static source-code candidate scan adapted from Anthropic's defending-code reference harness. |
 | `zizmor` | Audits GitHub Actions workflows and maps hits into the findings shape. |
+| `poutine` | Audits CI/CD pipelines for supply-chain weaknesses and maps hits into the findings shape. Overlaps `zizmor` on GitHub Actions but targets high-risk pipeline findings over lint, and also reads GitLab CI, Azure Pipelines and Tekton. |
 | `ingest` | Normalizes an externally-produced security report in an arbitrary format into findings. Runs when `/v1/import` cannot recognise the payload; the raw report is staged at `import/report`. |
 | `recon` | Maps the repository's distinct externally reachable input-processing subsystems into focus areas that threat-model carries into later deep-dive audits. |
 | `threat-model` | Derives the project's security contract from source and docs: components, entry-point trust table, claimed and disclaimed properties, and disposition labels. Loaded by `security-deep-dive` so it does not re-derive boundaries per run. |

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -1405,6 +1405,7 @@ const (
 	threatModelSkillName = "threat-model"
 	reconSkillName       = "recon"
 	zizmorSkillName      = "zizmor"
+	poutineSkillName     = "poutine"
 )
 
 // The Findings-bucket filters are vars rather than consts because they splice
@@ -1478,8 +1479,12 @@ func isLLMAuditSkill(skillName string) bool {
 		skillName == advisoryDeepDiveSkillName
 }
 
+// Exposure asks whether a finding is reachable from outside; a workflow-level
+// finding has no such answer, so the pipeline scanners are excluded. poutine
+// joins zizmor here for that reason rather than because of anything specific
+// to either tool.
 func findingSupportsExposure(scan db.Scan) bool {
-	return scan.SkillName != zizmorSkillName
+	return scan.SkillName != zizmorSkillName && scan.SkillName != poutineSkillName
 }
 
 func (s *Server) addRepoAndScan(w http.ResponseWriter, r *http.Request, repoURL string) {

--- a/internal/web/templates/settings.html
+++ b/internal/web/templates/settings.html
@@ -216,6 +216,7 @@
       {{template "metarow" (dict "Label" (printf "Backend (%s)" .Meta.Backend) "Value" .Meta.Harness)}}
       {{template "metarow" (dict "Label" "Semgrep" "Value" .Meta.Semgrep)}}
       {{template "metarow" (dict "Label" "Zizmor" "Value" .Meta.Zizmor)}}
+      {{template "metarow" (dict "Label" "Poutine" "Value" .Meta.Poutine)}}
       {{template "metarow" (dict "Label" "Container runtime" "Value" .Meta.Runtime)}}
       {{template "metarow" (dict "Label" "Runner image" "Value" .Meta.RunnerImageRef)}}
     </div>

--- a/internal/worker/poutine_script_test.go
+++ b/internal/worker/poutine_script_test.go
@@ -1,0 +1,123 @@
+package worker
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"slices"
+	"testing"
+)
+
+func TestPoutineScriptGroupsByRule(t *testing.T) {
+	script, err := filepath.Abs("../../skills/poutine/scripts/scan.py")
+	if err != nil {
+		t.Fatal(err)
+	}
+	root := t.TempDir()
+	workflows := filepath.Join(root, "src", ".github", "workflows")
+	if err := os.MkdirAll(workflows, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	bin := filepath.Join(root, "bin")
+	if err := os.Mkdir(bin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	fakePoutine := filepath.Join(bin, "poutine")
+	if err := os.WriteFile(fakePoutine, []byte(fakePoutineScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command("python3", script)
+	cmd.Dir = root
+	cmd.Env = append(os.Environ(), "PATH="+bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("poutine adapter failed: %v\n%s", err, out)
+	}
+
+	var report struct {
+		Findings []struct {
+			Title     string   `json:"title"`
+			Severity  string   `json:"severity"`
+			Location  string   `json:"location"`
+			Locations []string `json:"locations"`
+		} `json:"findings"`
+	}
+	if err := json.Unmarshal(out, &report); err != nil {
+		t.Fatalf("decode report: %v\n%s", err, out)
+	}
+	// Three hits over two rules: the pair sharing untrusted_checkout_exec
+	// collapses into one finding carrying both locations.
+	if len(report.Findings) != 2 {
+		t.Fatalf("findings = %d, want 2: %s", len(report.Findings), out)
+	}
+
+	// Findings come out ordered by rule id, so debug_enabled precedes
+	// untrusted_checkout_exec regardless of the order poutine emitted them.
+	checkout := report.Findings[1]
+	if checkout.Title != "Arbitrary Code Execution from Untrusted Code Checkout" {
+		t.Errorf("title = %q, want the rule's title", checkout.Title)
+	}
+	if checkout.Severity != "High" {
+		t.Errorf("severity = %q, want High for a poutine error", checkout.Severity)
+	}
+	want := []string{
+		".github/workflows/ci.yml:44",
+		".github/workflows/release.yml:18",
+	}
+	if !slices.Equal(checkout.Locations, want) {
+		t.Errorf("locations = %q, want %q", checkout.Locations, want)
+	}
+	if checkout.Location != want[0] {
+		t.Errorf("location = %q, want %q", checkout.Location, want[0])
+	}
+
+	// A finding poutine reports with no line is about the file as a whole, so
+	// the bare path is the location rather than a fabricated `:0`.
+	debug := report.Findings[0]
+	if debug.Severity != "Low" {
+		t.Errorf("severity = %q, want Low for a poutine note", debug.Severity)
+	}
+	if !slices.Equal(debug.Locations, []string{".gitlab-ci.yml"}) {
+		t.Errorf("locations = %q, want the bare path", debug.Locations)
+	}
+}
+
+const fakePoutineScript = `#!/usr/bin/env bash
+cat <<'JSON'
+{
+  "findings": [
+    {
+      "rule_id": "untrusted_checkout_exec",
+      "purl": "pkg:localrepo/localrepo/local?repository_url=.",
+      "meta": {"path": ".github/workflows/ci.yml", "line": 44, "job": "build"}
+    },
+    {
+      "rule_id": "untrusted_checkout_exec",
+      "purl": "pkg:localrepo/localrepo/local?repository_url=.",
+      "meta": {"path": ".github/workflows/release.yml", "line": 18, "job": "publish"}
+    },
+    {
+      "rule_id": "debug_enabled",
+      "purl": "pkg:localrepo/localrepo/local?repository_url=.",
+      "meta": {"path": ".gitlab-ci.yml"}
+    }
+  ],
+  "rules": {
+    "untrusted_checkout_exec": {
+      "id": "untrusted_checkout_exec",
+      "title": "Arbitrary Code Execution from Untrusted Code Checkout",
+      "description": "The workflow checks out untrusted code and executes it.",
+      "level": "error"
+    },
+    "debug_enabled": {
+      "id": "debug_enabled",
+      "title": "CI Runner Debug Enabled",
+      "description": "The workflow increases the verbosity of the runner.",
+      "level": "note"
+    }
+  }
+}
+JSON
+`

--- a/internal/worker/versions.go
+++ b/internal/worker/versions.go
@@ -96,6 +96,7 @@ func RunnerImageRevision(ctx context.Context, rt ContainerRuntime, image string)
 // change here.
 type RunnerToolVersions struct {
 	Zizmor  string
+	Poutine string
 	Semgrep string
 	Harness string
 }
@@ -107,7 +108,11 @@ type RunnerToolVersions struct {
 // "claude", "codex"); it is a code-supplied constant from Harness.Binary(),
 // never user input, so plain interpolation is fine.
 func queryToolsScript(harnessBin string) string {
+	// poutine has no --version flag; `poutine version` prints a three-line
+	// block whose first dotted-numeric token is the version, which is what
+	// versionRe picks out once the subshell has flattened the newlines.
 	return `echo "zizmor=$(zizmor --version 2>/dev/null)"; ` +
+		`echo "poutine=$(poutine version 2>/dev/null)"; ` +
 		`echo "semgrep=$(semgrep --version 2>/dev/null)"; ` +
 		`echo "harness=$(` + harnessBin + ` --version 2>/dev/null)"`
 }
@@ -156,6 +161,8 @@ func parseToolVersions(out string) RunnerToolVersions {
 		switch key {
 		case "zizmor":
 			v.Zizmor = val
+		case "poutine":
+			v.Poutine = val
 		case "semgrep":
 			v.Semgrep = val
 		case "harness":

--- a/internal/worker/versions.go
+++ b/internal/worker/versions.go
@@ -109,8 +109,10 @@ type RunnerToolVersions struct {
 // never user input, so plain interpolation is fine.
 func queryToolsScript(harnessBin string) string {
 	// poutine has no --version flag; `poutine version` prints a three-line
-	// block whose first dotted-numeric token is the version, which is what
-	// versionRe picks out once the subshell has flattened the newlines.
+	// block ("Version:", "Commit:", "Built At:"). Command substitution strips
+	// only the trailing newline, so the two extra lines reach parseToolVersions
+	// on their own -- neither carries an "=", so both are skipped, and the
+	// version rides the first line where versionRe finds it.
 	return `echo "zizmor=$(zizmor --version 2>/dev/null)"; ` +
 		`echo "poutine=$(poutine version 2>/dev/null)"; ` +
 		`echo "semgrep=$(semgrep --version 2>/dev/null)"; ` +

--- a/internal/worker/versions_test.go
+++ b/internal/worker/versions_test.go
@@ -36,6 +36,30 @@ func TestQueryToolsScript_usesHarnessBinary(t *testing.T) {
 	}
 }
 
+func TestParseToolVersions_poutineVersionBlock(t *testing.T) {
+	// Unlike every other tool here, `poutine version` prints three lines, and
+	// the substitution in queryToolsScript does not flatten them. The two
+	// trailing lines therefore arrive as their own lines; they carry no "="
+	// and are skipped, and the version rides the first one. The poutine value
+	// below is verbatim output from poutine v1.1.6.
+	out := "zizmor=zizmor 1.26.1\n" +
+		"poutine=Version: 1.1.6\nCommit: none\nBuilt At: unknown\n" +
+		"semgrep=1.167.0\n" +
+		"harness=2.1.123 (Claude Code)\n"
+	got := parseToolVersions(out)
+	if got.Poutine != "1.1.6" {
+		t.Errorf("Poutine = %q, want 1.1.6", got.Poutine)
+	}
+	// The point of the case: poutine's extra lines must not swallow the keys
+	// echoed after it.
+	if got.Semgrep != "1.167.0" {
+		t.Errorf("Semgrep = %q, want 1.167.0", got.Semgrep)
+	}
+	if got.Harness != "2.1.123" {
+		t.Errorf("Harness = %q, want 2.1.123", got.Harness)
+	}
+}
+
 func TestParseToolVersions_missingTools(t *testing.T) {
 	// A tool that is absent prints an empty value after the "=".
 	got := parseToolVersions("zizmor=\nsemgrep=\nharness=\n")

--- a/renovate.json
+++ b/renovate.json
@@ -77,6 +77,22 @@
       "depNameTemplate": "zizmor",
       "datasourceTemplate": "crate",
       "versioningTemplate": "semver"
+    },
+    {
+      "customType": "regex",
+      "description": "Update the poutine container-image pins. Both halves of the install line carry the version — the module pin and the -ldflags stamp — so both are matched and move together.",
+      "managerFilePatterns": [
+        "/^Dockerfile$/",
+        "/^Dockerfile\\.runner$/"
+      ],
+      "matchStrings": [
+        "-X main\\.version=(?<currentValue>\\d+\\.\\d+\\.\\d+)",
+        "github\\.com/boostsecurityio/poutine@v(?<currentValue>\\d+\\.\\d+\\.\\d+)"
+      ],
+      "packageNameTemplate": "github.com/boostsecurityio/poutine",
+      "depNameTemplate": "poutine",
+      "datasourceTemplate": "go",
+      "versioningTemplate": "semver"
     }
   ],
   "packageRules": [
@@ -123,6 +139,12 @@
       "matchPackageNames": ["zizmor"],
       "groupName": "zizmor",
       "minimumGroupSize": 3
+    },
+    {
+      "description": "Keep the poutine container-image pins synchronized: two per Dockerfile, the module pin and the -ldflags stamp",
+      "matchPackageNames": ["github.com/boostsecurityio/poutine"],
+      "groupName": "poutine",
+      "minimumGroupSize": 4
     },
     {
       "description": "Keep all four Claude Code pins on one GitHub release; do not approve a partial group in the Dependency Dashboard",

--- a/skills/poutine/SKILL.md
+++ b/skills/poutine/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: poutine
+description: Audit CI/CD pipelines with poutine and map hits into the findings shape.
+license: MIT
+compatibility: Requires `poutine` (https://github.com/boostsecurityio/poutine) and `python3` on PATH.
+metadata:
+  scrutineer.version: 1
+  scrutineer.output_file: report.json
+  scrutineer.output_kind: findings
+  scrutineer.model: mid
+---
+
+# poutine
+
+Run poutine against `./src` and map each finding into scrutineer's findings shape.
+
+poutine is a supply-chain scanner for build pipelines. It overlaps the zizmor skill on
+GitHub Actions but is aimed at high-risk pipeline findings rather than lint — the rules
+that fire at `error` are things like arbitrary code execution from an untrusted checkout —
+and it also reads GitLab CI, Azure Pipelines and Tekton, which zizmor does not.
+
+## Workspace
+
+- `./src` — the cloned repository
+- `./scripts/scan.py` — the wrapper
+- `./report.json` — write the findings report here
+- `./schema.json` — output shape
+
+## Available scripts
+
+- `scripts/scan.py` — invokes `poutine analyze_local . --format json` and converts the output. If the repo has no CI pipeline definitions it writes an empty result so the scan succeeds cleanly. Findings are grouped by rule, so one rule firing across several jobs becomes one finding carrying every `file:line` in `locations`. poutine's levels are mapped to scrutineer's: `note` → `Low`, `warning` → `Medium`, `error` → `High`.
+
+## What to do
+
+```bash
+python3 scripts/scan.py > ./report.json
+```
+
+The script handles a repo with no pipelines, a missing poutine binary and malformed output
+gracefully — don't add retry or error handling on top.

--- a/skills/poutine/schema.json
+++ b/skills/poutine/schema.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "poutine findings report",
+  "type": "object",
+  "required": ["findings"],
+  "additionalProperties": true,
+  "properties": {
+    "findings": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id", "title", "severity", "location"],
+        "additionalProperties": true,
+        "properties": {
+          "id":       { "type": "string" },
+          "title":    { "type": "string" },
+          "severity": { "type": "string", "enum": ["Critical", "High", "Medium", "Low"] },
+          "cwe":      { "type": "string" },
+          "location": { "type": "string" },
+          "locations": { "type": "array", "items": { "type": "string" } },
+          "trace":    { "type": "string" },
+          "rating":   { "type": "string" },
+          "references": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["url"],
+              "properties": {
+                "url":     { "type": "string", "format": "uri" },
+                "summary": { "type": "string" },
+                "tags":    { "type": "string" }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/skills/poutine/scripts/scan.py
+++ b/skills/poutine/scripts/scan.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Run poutine against ./src and emit findings in scrutineer's shape.
+Requires poutine on PATH. Writes JSON to stdout.
+
+Results are grouped by rule so the same rule firing on every job in a
+pipeline becomes one finding with the full set of file:line positions in
+`locations`, matching the zizmor adapter's behaviour (#191).
+
+poutine reports the rule metadata once, in a top-level `rules` map keyed by
+rule id, and each finding carries only `rule_id` plus its own location. The
+title, severity and references therefore come from that map rather than from
+the finding, and a finding naming a rule the map does not describe still
+yields a finding — a location we drop is a vulnerability we did not report.
+"""
+import json
+import os
+import shutil
+import subprocess
+import sys
+from collections import defaultdict
+
+# poutine levels are SARIF's (`error`/`warning`/`note`); scrutineer's scale has
+# a fourth step above them. Nothing in poutine emits `critical`, so nothing maps
+# to `Critical` — inventing that step here would let a rule the tool calls an
+# error outrank one another scanner genuinely rated critical.
+SEVERITY_MAP = {
+    "error": "High",
+    "warning": "Medium",
+    "note": "Low",
+}
+
+# poutine reads GitHub Actions, GitLab CI, Azure Pipelines and Tekton. Skipping
+# the run when a repo has none of them keeps the scan cheap on the many repos
+# that ship no pipeline at all, the way the zizmor adapter skips a repo with no
+# workflows directory.
+PIPELINE_PATHS = [
+    (".github", "workflows"),
+    (".gitlab-ci.yml",),
+    (".gitlab", "ci"),
+    ("azure-pipelines.yml",),
+    (".tekton",),
+]
+
+
+def has_pipelines(src):
+    return any(os.path.exists(os.path.join(src, *parts)) for parts in PIPELINE_PATHS)
+
+
+def main():
+    src = "./src"
+    if not os.path.isdir(src):
+        print(json.dumps({"findings": [], "error": "no ./src dir"}))
+        return
+
+    if not has_pipelines(src):
+        print(json.dumps({"findings": [], "error": "no CI pipeline definitions"}))
+        return
+
+    if shutil.which("poutine") is None:
+        print(json.dumps({"findings": [], "error": "poutine not on PATH"}))
+        return
+
+    # --quiet drops the progress bar from stdout and --disable-version-check
+    # stops the once-a-day release check, which would otherwise reach the
+    # network from inside the sandbox and stall behind the egress proxy.
+    proc = subprocess.run(
+        ["poutine", "analyze_local", ".", "--format", "json",
+         "--quiet", "--disable-version-check"],
+        cwd=src,
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0:
+        print(json.dumps({"findings": [], "error": proc.stderr.strip()[:2000]}))
+        return
+
+    try:
+        data = json.loads(proc.stdout) if proc.stdout else {}
+    except json.JSONDecodeError as exc:
+        print(json.dumps({"findings": [], "error": f"poutine json: {exc}"}))
+        return
+
+    rules = data.get("rules") or {}
+    groups = defaultdict(list)
+    for f in data.get("findings") or []:
+        groups[f.get("rule_id") or "poutine finding"].append(f)
+
+    findings = []
+    for i, (rule_id, hits) in enumerate(sorted(groups.items()), start=1):
+        rule = rules.get(rule_id) or {}
+        severity = SEVERITY_MAP.get(str(rule.get("level", "")).lower(), "Medium")
+        locations = sorted({finding_location(h) for h in hits})
+        n = len(locations)
+        suffix = f" ({n} locations)" if n > 1 else ""
+        findings.append({
+            "id": f"F{i}",
+            "title": rule.get("title") or rule_id,
+            "severity": severity,
+            "location": locations[0],
+            "locations": locations,
+            "trace": (rule.get("description") or "").strip() or rule_id,
+            "rating": f"{severity} from poutine rule {rule_id}{suffix}",
+            "references": references(rule_id, rule),
+        })
+
+    print(json.dumps({"findings": findings}))
+
+
+def references(rule_id, rule):
+    """The rule's own doc page, then whatever references the rule carries."""
+    refs = [{
+        "url": f"https://boostsecurityio.github.io/poutine/rules/{rule_id}/",
+        "summary": f"poutine docs: {rule_id}",
+        "tags": "docs",
+    }]
+    for r in rule.get("refs") or []:
+        url = (r.get("ref") or "").strip()
+        if url:
+            refs.append({"url": url, "summary": (r.get("description") or "").strip()})
+    return refs
+
+
+def finding_location(f):
+    meta = f.get("meta") or {}
+    path = meta.get("path") or "pipeline"
+    line = meta.get("line")
+    # poutine omits `line` rather than sending 0 when a finding is about the
+    # file as a whole, so a bare path is a real answer and not a missing one.
+    return f"{path}:{line}" if line else path
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #593.

The `zizmor` skill covers GitHub Actions workflows and is, as the issue puts it, closer to a pedantic linter than a way to spot high-risk issues quickly. poutine is aimed at the other end — its `error`-level rules are things like arbitrary code execution from an untrusted checkout — and it also reads GitLab CI, Azure Pipelines and Tekton, which nothing here covers today.

I'm not the poutine maintainer; @fproulx-boostsecurity was asked in the thread and the issue has sat unassigned for a month, so this is offered as a starting point rather than as the canonical version. Happy to hand it over or rework it.

### Shape

It mirrors the zizmor skill rather than inventing a second shape: same frontmatter, same `schema.json`, same `scripts/scan.py` layout, same grouping behaviour. `scan.py` runs `poutine analyze_local . --format json` and groups by rule, so one rule firing across several jobs becomes a single finding carrying every `file:line` in `locations` — the behaviour added for zizmor in #191.

### Two decisions worth a reviewer's attention

**Rule metadata lives outside the finding.** poutine emits rule metadata once in a top-level `rules` map and each finding carries only `rule_id`. Title, severity and references are read from that map. A finding naming a rule the map doesn't describe still produces a finding (titled with the raw rule id) rather than being dropped — a location silently discarded is a vulnerability not reported.

**Nothing maps to `Critical`.** poutine's levels are SARIF's, so `error`/`warning`/`note` → `High`/`Medium`/`Low`. poutine never emits `critical`, and promoting its `error` into scrutineer's `Critical` would let it outrank a finding another scanner genuinely rated critical. Easy to change if you'd rather it did.

### Verification

Against poutine's own `scanner/testdata` fixtures, the adapter turns 50 raw findings into 11 grouped ones:

| severity | rule | locations |
|---|---|---|
| High | Arbitrary Code Execution from Untrusted Code Checkout | 13 |
| High | If condition always evaluates to true | 1 |
| Medium | Injection with Arbitrary External Contributor | 8 |
| Medium | Workflow job exposes all secrets | 2 |
| Medium | Default permissions used on risky events | 3 |
| Medium | Build Component with a Known Vulnerability used | 3 |
| Medium | Pull Request Runs on Self-Hosted GitHub Actions Runner | 3 |
| Low | CI Runner Debug Enabled | 5 |
| Low | Github Action from Unverified Creator used | 5 |
| Low | Unpinnable CI component used | 2 |
| Low | Unverified Script Execution | 3 |

That output validates against `skills/poutine/schema.json`. Run against this repository, poutine reports one finding (`github_action_from_unverified_creator_used`, `note`, on the `golangci-lint-action` pin in `tests.yml`).

`internal/worker/poutine_script_test.go` follows `zizmor_script_test.go`: a fake `poutine` on `PATH`, asserting the rule grouping, the title and severity lookup through the `rules` map, and that a finding poutine reports with no line keeps a bare path instead of a fabricated `:0`. The empty paths — no `./src`, no pipeline files, poutine missing from `PATH`, malformed output, non-zero exit — were each exercised by hand and all return an empty findings set with an `error` string rather than failing the scan.

### Wiring

- Installed in the `go-tools` stage of both Dockerfiles; the existing `COPY --from=go-tools /out/*` picks it up, so no new `COPY` line.
- poutine stamps its version through `-ldflags`, so a plain `go install` would leave `poutine version` reporting `development` and the settings row blank. The install line sets it, and the renovate rule matches **both** halves (module pin and ldflags stamp) with `minimumGroupSize: 4` so they can't drift apart.
- `poutine version` rather than `--version` — there is no such flag. In a subshell the three-line block flattens and `versionRe` picks the version out of the first token, which is why it slots into `queryToolsScript` unchanged.
- Findings are excluded from exposure analysis alongside zizmor's: exposure asks whether a finding is reachable from outside, and a pipeline-level finding has no answer to that.

### CI, run locally

When I opened this the caveat here was that I had no Go toolchain and could not run the test suite. That is no longer true, so replacing it with results. Everything below was run against `b7edb8f` on go1.26.5, the version `go.mod` and both Dockerfiles pin.

| CI step | result |
|---|---|
| `scripts/release-resolver_test.sh` | 13/13 |
| `scripts/wait-for-runner-image_test.sh` | 42/42 |
| `go mod tidy -diff` | clean |
| `go vet ./...` | clean |
| `go test ./...` | 16 packages ok, 0 fail |
| `go test -race ./...` | 16 packages ok, 0 data races |
| `go vet -tags evals ./internal/evals/...` | clean |
| `go test -race -tags evals ./internal/evals/...` | ok |
| `go vet -tags podman ./...` | clean |
| `golangci-lint run` | 0 issues |
| `govulncheck ./...` | 0 called; 1 in a required module this code doesn't reach |
| `zizmor --persona auditor .github/` | no findings |

`zizmor` is the one worth calling out, since this PR edits `runner-image.yml` and that job would be the first to object.

**Still not verified by me: the two image builds.** No container runtime here. The part of that diff that can actually fail is the one `go install` line, so I ran it directly rather than leaving it as an assertion — `GOBIN=/out go install -ldflags "-X main.version=1.1.6" github.com/boostsecurityio/poutine@v1.1.6` succeeds on go1.26.5 and the resulting binary reports `Version: 1.1.6`, so the `main.version` ldflags path is right and the settings row won't read `development`.

### One thing I had wrong

Running it turned up an error in my own comment. I wrote that the subshell flattens `poutine version`'s three-line output. It doesn't — command substitution strips only the *trailing* newline, so `Commit:` and `Built At:` arrive at `parseToolVersions` as their own lines. The parsed result is still correct, because neither line carries an `=` so both are skipped and the version rides the first line, but that is a different mechanism than the one I documented and nothing tested it.

`b7edb8f` corrects the comment and adds `TestParseToolVersions_poutineVersionBlock`, built from verbatim poutine v1.1.6 output. It asserts the version parses *and* that poutine's extra lines don't swallow the `semgrep` and `harness` keys echoed after it — which is the failure that would actually have mattered.