### PR TITLE
fix(web): hide the scan export action without a saved disclosure draft

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -1315,24 +1315,11 @@ func (s Scan) CacheHitRatio() float64 {
 	return float64(s.CacheReadTokens) / float64(total)
 }
 
-// HasExportableReport tells the UI whether to offer a "download as
-// markdown" button for this scan. A scan that has produced findings is
-// always worth exporting. Otherwise we parse the report and look for any
-// substantive content: at least one top-level value that isn't an empty
-// string, empty array, empty object, or null. That lets through real
-// reports of any size — a single-package result is just as worth
-// exporting as a 10K-line SBOM — while filtering out structurally
-// empty scans like {"subprojects": []} or {"packages": [], "advisories":
-// []}. For non-JSON-object reports (bare array, plain text, malformed
-// JSON) we accept anything past a small trimmed length so freeform skills
-// emitting non-object output aren't accidentally hidden. The
-// /scans/{id}/report.md route is unaffected and remains reachable by
-// URL regardless of this signal.
+// HasExportableReport reports whether a scan's own result has substantive
+// content for generic Markdown export. Disclosure availability is checked
+// separately against the saved finding draft.
 func (s Scan) HasExportableReport() bool {
-	// nonObjectReportMinLen is the trimmed-length floor below which a
-	// non-JSON-object report (bare array, plain text, malformed JSON) is
-	// treated as too thin to bother exporting. JSON-object reports get
-	// the structural check instead and ignore this.
+	// Non-object reports use a size floor; JSON objects are checked structurally.
 	const nonObjectReportMinLen = 20
 	if s.FindingsCount > 0 {
 		return true

--- a/internal/web/scan_report.go
+++ b/internal/web/scan_report.go
@@ -34,15 +34,7 @@ func (s *Server) scanReport(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// SkillID is nullable, so load the skill separately rather than with Preload.
-	// Missing rows are non-fatal; disclose scans can still dispatch by name.
-	var skill *db.Skill
-	if scan.SkillID != nil {
-		var sk db.Skill
-		if err := s.DB.First(&sk, *scan.SkillID).Error; err == nil {
-			skill = &sk
-		}
-	}
+	skill := loadScanReportSkill(s.DB, &scan)
 
 	var body string
 	if isDiscloseScanReport(&scan, skill) {
@@ -66,6 +58,24 @@ func scanReportFilename(scan *db.Scan) string {
 		scan.ID,
 		sanitiseFilename(firstNonEmpty(scan.SkillName, scan.Kind, "scan")),
 		time.Now().UTC().Format("20060102"))
+}
+
+func loadScanReportSkill(gdb *gorm.DB, scan *db.Scan) *db.Skill {
+	if scan.SkillID == nil {
+		return nil
+	}
+	var skill db.Skill
+	if err := gdb.Select("id", "output_kind").First(&skill, *scan.SkillID).Error; err != nil {
+		return nil
+	}
+	return &skill
+}
+
+func hasExportableScanReport(gdb *gorm.DB, scan *db.Scan, skill *db.Skill) bool {
+	if isDiscloseScanReport(scan, skill) {
+		return renderSavedDisclosureScanReport(gdb, scan) != ""
+	}
+	return scan.HasExportableReport()
 }
 
 func renderScanReport(gdb *gorm.DB, scan *db.Scan, skill *db.Skill) string {
@@ -100,7 +110,7 @@ func renderSavedDisclosureScanReport(gdb *gorm.DB, scan *db.Scan) string {
 		return ""
 	}
 	var finding db.Finding
-	if err := gdb.First(&finding, *scan.FindingID).Error; err != nil {
+	if err := gdb.Select("id", "title", "disclosure_draft").First(&finding, *scan.FindingID).Error; err != nil {
 		return ""
 	}
 	return renderFindingDisclosureMarkdown(&finding)

--- a/internal/web/scan_report_test.go
+++ b/internal/web/scan_report_test.go
@@ -202,9 +202,13 @@ func TestScanReport_discloseWithoutSavedDraftReturnsNotFound(t *testing.T) {
 	for _, tc := range []struct {
 		name          string
 		createFinding bool
+		draft         string
+		omitSkillID   bool
 	}{
 		{name: "finding association missing"},
 		{name: "draft empty", createFinding: true},
+		{name: "draft whitespace only", createFinding: true, draft: "  \n\t"},
+		{name: "skill name fallback", createFinding: true, omitSkillID: true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			s, done := newTestServer(t)
@@ -217,13 +221,21 @@ func TestScanReport_discloseWithoutSavedDraftReturnsNotFound(t *testing.T) {
 			if tc.createFinding {
 				origin := db.Scan{RepositoryID: repo.ID, Kind: worker.JobSkill, Status: db.ScanDone}
 				s.DB.Create(&origin)
-				finding := db.Finding{ScanID: origin.ID, RepositoryID: repo.ID, Title: "No draft"}
+				finding := db.Finding{
+					ScanID: origin.ID, RepositoryID: repo.ID, Title: "No draft",
+					DisclosureDraft: tc.draft,
+				}
 				s.DB.Create(&finding)
 				findingID = &finding.ID
 			}
+			var skillID *uint
+			if !tc.omitSkillID {
+				skillID = &skill.ID
+			}
 			scan := db.Scan{
 				RepositoryID: repo.ID, Kind: worker.JobSkill, Status: db.ScanDone,
-				SkillID: &skill.ID, SkillName: skill.Name, FindingID: findingID,
+				SkillID: skillID, SkillName: skill.Name, FindingID: findingID,
+				Report: `{"ghsa":{"summary":"stale generated output"}}`,
 			}
 			s.DB.Create(&scan)
 
@@ -234,6 +246,88 @@ func TestScanReport_discloseWithoutSavedDraftReturnsNotFound(t *testing.T) {
 			}
 			if got := w.Header().Get("Content-Disposition"); got != "" {
 				t.Errorf("missing draft should not download an attachment: %q", got)
+			}
+			if strings.Contains(w.Body.String(), "Scan metadata") {
+				t.Errorf("missing draft fell back to generic scan export: %s", w.Body)
+			}
+		})
+	}
+}
+
+func TestScanShow_disclosureExportVisibility(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	repo := db.Repository{URL: "https://github.com/acme/thing", Name: "thing"}
+	s.DB.Create(&repo)
+	discloseSkill := db.Skill{Name: discloseSkillName, OutputKind: "disclose", Active: true, Version: 1, Source: "ui"}
+	s.DB.Create(&discloseSkill)
+	genericSkill := db.Skill{Name: "maintainers", OutputKind: "maintainers", Active: true, Version: 1, Source: "ui"}
+	s.DB.Create(&genericSkill)
+
+	origin := db.Scan{RepositoryID: repo.ID, Kind: worker.JobSkill, Status: db.ScanDone}
+	s.DB.Create(&origin)
+	withoutDraft := db.Finding{
+		ScanID: origin.ID, RepositoryID: repo.ID, Title: "No draft",
+		DisclosureDraft: "  \n\t",
+	}
+	s.DB.Create(&withoutDraft)
+	withDraft := db.Finding{
+		ScanID: origin.ID, RepositoryID: repo.ID, Title: "Saved draft",
+		DisclosureDraft: "## Summary\n\nSaved disclosure.",
+	}
+	s.DB.Create(&withDraft)
+
+	draftlessScan := db.Scan{
+		RepositoryID: repo.ID, Kind: worker.JobSkill, Status: db.ScanDone,
+		SkillID: &discloseSkill.ID, SkillName: discloseSkill.Name, FindingID: &withoutDraft.ID,
+		Report: `{"refused":true,"reason":"analysis unavailable"}`,
+	}
+	s.DB.Create(&draftlessScan)
+	nameFallbackScan := db.Scan{
+		RepositoryID: repo.ID, Kind: worker.JobSkill, Status: db.ScanDone,
+		SkillName: discloseSkill.Name, FindingID: &withoutDraft.ID,
+		Report: `{"ghsa":{"summary":"stale generated output"}}`,
+	}
+	s.DB.Create(&nameFallbackScan)
+	savedDraftScan := db.Scan{
+		RepositoryID: repo.ID, Kind: worker.JobSkill, Status: db.ScanDone,
+		SkillID: &discloseSkill.ID, SkillName: discloseSkill.Name, FindingID: &withDraft.ID,
+	}
+	s.DB.Create(&savedDraftScan)
+	genericScan := db.Scan{
+		RepositoryID: repo.ID, Kind: worker.JobSkill, Status: db.ScanDone,
+		SkillID: &genericSkill.ID, SkillName: genericSkill.Name,
+		Report: `{"maintainers":[{"login":"alice"}]}`,
+	}
+	s.DB.Create(&genericScan)
+	emptyGenericScan := db.Scan{
+		RepositoryID: repo.ID, Kind: worker.JobSkill, Status: db.ScanDone,
+		SkillID: &genericSkill.ID, SkillName: genericSkill.Name,
+		Report: `{"maintainers":[]}`,
+	}
+	s.DB.Create(&emptyGenericScan)
+
+	for _, tc := range []struct {
+		name       string
+		scan       db.Scan
+		wantExport bool
+	}{
+		{name: "disclose scan without saved draft", scan: draftlessScan},
+		{name: "disclose scan using skill name fallback", scan: nameFallbackScan},
+		{name: "disclose scan with saved draft", scan: savedDraftScan, wantExport: true},
+		{name: "non-disclose scan with report", scan: genericScan, wantExport: true},
+		{name: "non-disclose scan with structurally empty report", scan: emptyGenericScan},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			s.Handler().ServeHTTP(w, localReq("GET", "/scans/"+strconv.FormatUint(uint64(tc.scan.ID), 10)))
+			if w.Code != http.StatusOK {
+				t.Fatalf("status %d: %s", w.Code, w.Body)
+			}
+			href := "/scans/" + strconv.FormatUint(uint64(tc.scan.ID), 10) + "/report.md"
+			if got := strings.Contains(w.Body.String(), href); got != tc.wantExport {
+				t.Errorf("export link present = %v, want %v", got, tc.wantExport)
 			}
 		})
 	}

--- a/internal/web/scans.go
+++ b/internal/web/scans.go
@@ -207,10 +207,12 @@ func (s *Server) scanShow(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 		return
 	}
+	skill := loadScanReportSkill(s.DB, &scan)
 	s.render(w, r, "scan_show.html", map[string]any{
 		"Scan":               scan,
 		"Diff":               parseScanDiffView(scan),
 		"DisclosureReviewID": s.disclosureReviewFindingID(scan),
+		"CanExportReport":    hasExportableScanReport(s.DB, &scan, skill),
 	})
 }
 

--- a/internal/web/templates/scan_show.html
+++ b/internal/web/templates/scan_show.html
@@ -14,7 +14,7 @@
   </h2>
   {{if and (eq .Kind "skill") .SkillID}}
     <div class="flex items-center gap-2">
-      {{if .HasExportableReport}}
+      {{if $.CanExportReport}}
       <a href="/scans/{{.ID}}/report.md" class="btn-outline" download="{{scanReportFilename .}}">
         <i data-lucide="download"></i> Export as markdown
       </a>
@@ -36,7 +36,7 @@
       </form>
       {{end}}
     </div>
-  {{else if .HasExportableReport}}
+  {{else if $.CanExportReport}}
     <a href="/scans/{{.ID}}/report.md" class="btn-outline" download="{{scanReportFilename .}}">
       <i data-lucide="download"></i> Export as markdown
     </a>


### PR DESCRIPTION
#849 pointed the disclose-scan Markdown export at the finding's saved draft and made it return 404 when there is none, but the scan page kept deciding the "Export as markdown" button from the scan's own report JSON. A disclose scan holding a refusal or stale generated output advertised an export that could only fail.

The page now asks the same question the route does, a non-empty saved draft on the linked finding for disclose scans and the existing report check for everything else, so the two cannot disagree. Generic scan exports are unchanged, and the skill row is read for output_kind alone rather than pulling its full Markdown body on every scan view.

Opus 5 was used to implement this.
