### PR TITLE
Process scheduled repositories with bounded concurrency

### DIFF
--- a/internal/web/federation_opt_out_test.go
+++ b/internal/web/federation_opt_out_test.go
@@ -74,7 +74,7 @@ func TestRunScheduledScan_skipsOptedOutRepositoryBeforeAnyNetworkCall(t *testing
 		ID: repo.ID, Name: repo.Name, URL: repo.URL,
 		UpstreamURL:        "https://127.0.0.1:1/never/reached.git",
 		FederationOptOutAt: repo.FederationOptOutAt,
-	})
+	}, schedulerRemoteHeadTimeout)
 
 	var skip db.Scan
 	if err := s.DB.Where("repository_id = ?", repo.ID).Order("id desc").First(&skip).Error; err != nil {
@@ -243,9 +243,9 @@ func TestScansResumePaused_skipsOptedOutRepository(t *testing.T) {
 	}
 }
 
-// The tick loads every due repository up front and then fires them one at a
-// time, so a repository still waiting its turn must be re-read rather than
-// trusted from the snapshot.
+// The tick loads every due repository up front and then dispatches them
+// through a bounded pool, so a repository still waiting for a worker must be
+// re-read rather than trusted from the snapshot.
 func TestRunScheduledScan_rereadsOptOutRecordedAfterTheSnapshot(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()
@@ -255,7 +255,7 @@ func TestRunScheduledScan_rereadsOptOutRecordedAfterTheSnapshot(t *testing.T) {
 	s.runScheduledScan(context.Background(), db.Repository{
 		ID: repo.ID, Name: repo.Name, URL: repo.URL,
 		UpstreamURL: "https://127.0.0.1:1/never/reached.git",
-	})
+	}, schedulerRemoteHeadTimeout)
 
 	var skip db.Scan
 	if err := s.DB.Where("repository_id = ?", repo.ID).Order("id desc").First(&skip).Error; err != nil {
@@ -332,7 +332,7 @@ func TestRunScheduledScan_optOutRecordedMidFiringWaitsForItAndStopsTheScans(t *t
 		defer close(fired)
 		s.runScheduledScan(context.Background(), db.Repository{
 			ID: repo.ID, Name: repo.Name, URL: repo.URL, UpstreamURL: upstream,
-		})
+		}, schedulerRemoteHeadTimeout)
 	}()
 	<-reached
 

--- a/internal/web/federation_opt_out_test.go
+++ b/internal/web/federation_opt_out_test.go
@@ -321,7 +321,7 @@ func TestRunScheduledScan_optOutRecordedMidFiringWaitsForItAndStopsTheScans(t *t
 
 	reached, release := make(chan struct{}), make(chan struct{})
 	s.resolveRemoteHead = func(context.Context, db.Repository) (string, error) { return "deadbeef", nil }
-	s.syncUpstream = func(context.Context, string, string) error {
+	s.syncUpstream = func(context.Context, string, string, time.Duration) error {
 		close(reached)
 		<-release
 		return nil

--- a/internal/web/schedule.go
+++ b/internal/web/schedule.go
@@ -29,10 +29,9 @@ const (
 	// tick interval only bounds the firing latency, not the cadence.
 	schedulerTick = time.Minute
 
-	// Keep remote Git work parallel enough that one slow host does not block
-	// every due repository, but bounded to limit forge and SQLite pressure.
-	schedulerMaxConcurrentRepositories = 5
-	schedulerRepositoryTimeout         = 10 * time.Minute
+	// Bound remote HEAD probes without also placing large first-time mirror
+	// clones under a deadline that would make them restart on every tick.
+	schedulerRemoteHeadTimeout = 10 * time.Minute
 )
 
 // ScheduleNext validates a scan-schedule value, the "daily"/"weekly"
@@ -91,7 +90,17 @@ func (s *Server) scheduleTick(ctx context.Context, now time.Time) {
 		s.Log.Error("scheduler: list repositories", "err", err)
 		return
 	}
-	s.runScheduledRepositories(ctx, now, global, repos, schedulerMaxConcurrentRepositories, schedulerRepositoryTimeout)
+	s.runScheduledRepositories(ctx, now, global, repos, s.schedulerConcurrency(), schedulerRemoteHeadTimeout)
+}
+
+// schedulerConcurrency keeps scheduled Git work under the same operator-set
+// concurrency budget as scan jobs. Tests may construct a Server without a
+// queue, in which case one worker preserves forward progress.
+func (s *Server) schedulerConcurrency() int {
+	if s.Queue == nil {
+		return 1
+	}
+	return max(1, s.Queue.Concurrency())
 }
 
 func (s *Server) runScheduledRepositories(
@@ -100,7 +109,7 @@ func (s *Server) runScheduledRepositories(
 	global string,
 	repos []db.Repository,
 	maxConcurrent int,
-	timeout time.Duration,
+	remoteHeadTimeout time.Duration,
 ) {
 	if len(repos) == 0 {
 		return
@@ -119,16 +128,20 @@ func (s *Server) runScheduledRepositories(
 	for range min(maxConcurrent, len(repos)) {
 		workers.Go(func() {
 			for repo := range jobs {
-				repoCtx, cancel := context.WithTimeout(ctx, timeout)
-				s.processScheduledRepository(repoCtx, now, global, repo)
-				cancel()
+				s.processScheduledRepository(ctx, now, global, repo, remoteHeadTimeout)
 			}
 		})
 	}
 	workers.Wait()
 }
 
-func (s *Server) processScheduledRepository(ctx context.Context, now time.Time, global string, repo db.Repository) {
+func (s *Server) processScheduledRepository(
+	ctx context.Context,
+	now time.Time,
+	global string,
+	repo db.Repository,
+	remoteHeadTimeout time.Duration,
+) {
 	expr := repo.ScanSchedule
 	if expr == "" {
 		expr = global
@@ -150,7 +163,7 @@ func (s *Server) processScheduledRepository(ctx context.Context, now time.Time, 
 		return
 	}
 	if repo.NextScheduledScanAt != nil {
-		s.runScheduledScan(ctx, repo)
+		s.runScheduledScanWithRemoteHeadTimeout(ctx, repo, remoteHeadTimeout)
 	}
 	if err := s.DB.Model(&db.Repository{}).Where("id = ?", repo.ID).
 		UpdateColumn("next_scheduled_scan_at", next).Error; err != nil {
@@ -164,6 +177,14 @@ func (s *Server) processScheduledRepository(ctx context.Context, now time.Time, 
 // diff-rescan group (which falls back to full coverage when no baseline
 // exists, e.g. on a never-scanned repository).
 func (s *Server) runScheduledScan(ctx context.Context, repo db.Repository) {
+	s.runScheduledScanWithRemoteHeadTimeout(ctx, repo, schedulerRemoteHeadTimeout)
+}
+
+func (s *Server) runScheduledScanWithRemoteHeadTimeout(
+	ctx context.Context,
+	repo db.Repository,
+	remoteHeadTimeout time.Duration,
+) {
 	// Held for the whole firing, so the opt-out cannot commit between the check
 	// below and the network calls it gates: recording one waits here, then sweeps
 	// whatever this firing enqueued. See lockRepoFederation.
@@ -198,12 +219,18 @@ func (s *Server) runScheduledScan(ctx context.Context, repo db.Repository) {
 		return
 	}
 	if repo.UpstreamURL != "" {
-		if err := s.syncUpstream(ctx, repo.URL, repo.UpstreamURL); err != nil {
+		if err := s.syncUpstream(ctx, repo.URL, repo.UpstreamURL, remoteHeadTimeout); err != nil {
 			s.recordScheduledSkip(repo, "upstream sync failed: "+err.Error())
 			return
 		}
 	}
-	head, err := s.resolveRemoteHead(ctx, repo)
+	remoteCtx := ctx
+	var cancel context.CancelFunc = func() {}
+	if remoteHeadTimeout > 0 {
+		remoteCtx, cancel = context.WithTimeout(ctx, remoteHeadTimeout)
+	}
+	head, err := s.resolveRemoteHead(remoteCtx, repo)
+	cancel()
 	if err != nil {
 		s.recordScheduledSkip(repo, "remote HEAD lookup failed: "+err.Error())
 		return

--- a/internal/web/schedule.go
+++ b/internal/web/schedule.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/robfig/cron/v3"
@@ -22,10 +23,17 @@ const ScheduleOff = "off"
 // created directly in a terminal status and never enter the queue.
 const scheduleKind = "schedule"
 
-// schedulerTick is how often the scheduler re-evaluates every repository's
-// schedule. Due-ness is driven by the persisted NextScheduledScanAt, so the
-// tick interval only bounds the firing latency, not the cadence.
-const schedulerTick = time.Minute
+const (
+	// schedulerTick is how often the scheduler re-evaluates every repository's
+	// schedule. Due-ness is driven by the persisted NextScheduledScanAt, so the
+	// tick interval only bounds the firing latency, not the cadence.
+	schedulerTick = time.Minute
+
+	// Keep remote Git work parallel enough that one slow host does not block
+	// every due repository, but bounded to limit forge and SQLite pressure.
+	schedulerMaxConcurrentRepositories = 5
+	schedulerRepositoryTimeout         = 10 * time.Minute
+)
 
 // ScheduleNext validates a scan-schedule value, the "daily"/"weekly"
 // presets or anything cron.ParseStandard accepts (5-field cron expressions
@@ -83,34 +91,70 @@ func (s *Server) scheduleTick(ctx context.Context, now time.Time) {
 		s.Log.Error("scheduler: list repositories", "err", err)
 		return
 	}
+	s.runScheduledRepositories(ctx, now, global, repos, schedulerMaxConcurrentRepositories, schedulerRepositoryTimeout)
+}
+
+func (s *Server) runScheduledRepositories(
+	ctx context.Context,
+	now time.Time,
+	global string,
+	repos []db.Repository,
+	maxConcurrent int,
+	timeout time.Duration,
+) {
+	if len(repos) == 0 {
+		return
+	}
+	if maxConcurrent < 1 {
+		maxConcurrent = 1
+	}
+
+	jobs := make(chan db.Repository, len(repos))
 	for _, repo := range repos {
-		expr := repo.ScanSchedule
-		if expr == "" {
-			expr = global
-		}
-		if expr == "" || expr == ScheduleOff {
-			if repo.NextScheduledScanAt != nil {
-				if err := s.DB.Model(&db.Repository{}).Where("id = ?", repo.ID).
-					UpdateColumn("next_scheduled_scan_at", nil).Error; err != nil {
-					s.Log.Error("scheduler: clear next_scheduled_scan_at", "repo", repo.Name, "err", err)
-				}
+		jobs <- repo
+	}
+	close(jobs)
+
+	var workers sync.WaitGroup
+	for range min(maxConcurrent, len(repos)) {
+		workers.Go(func() {
+			for repo := range jobs {
+				repoCtx, cancel := context.WithTimeout(ctx, timeout)
+				s.processScheduledRepository(repoCtx, now, global, repo)
+				cancel()
 			}
-			continue
-		}
-		next, err := ScheduleNext(expr, now)
-		if err != nil {
-			// Save paths validate, so this only happens on hand-edited
-			// data; skip rather than firing on a schedule we can't read.
-			s.Log.Warn("scheduler: invalid schedule", "repo", repo.Name, "schedule", expr, "err", err)
-			continue
-		}
+		})
+	}
+	workers.Wait()
+}
+
+func (s *Server) processScheduledRepository(ctx context.Context, now time.Time, global string, repo db.Repository) {
+	expr := repo.ScanSchedule
+	if expr == "" {
+		expr = global
+	}
+	if expr == "" || expr == ScheduleOff {
 		if repo.NextScheduledScanAt != nil {
-			s.runScheduledScan(ctx, repo)
+			if err := s.DB.Model(&db.Repository{}).Where("id = ?", repo.ID).
+				UpdateColumn("next_scheduled_scan_at", nil).Error; err != nil {
+				s.Log.Error("scheduler: clear next_scheduled_scan_at", "repo", repo.Name, "err", err)
+			}
 		}
-		if err := s.DB.Model(&db.Repository{}).Where("id = ?", repo.ID).
-			UpdateColumn("next_scheduled_scan_at", next).Error; err != nil {
-			s.Log.Error("scheduler: advance next_scheduled_scan_at", "repo", repo.Name, "err", err)
-		}
+		return
+	}
+	next, err := ScheduleNext(expr, now)
+	if err != nil {
+		// Save paths validate, so this only happens on hand-edited
+		// data; skip rather than firing on a schedule we can't read.
+		s.Log.Warn("scheduler: invalid schedule", "repo", repo.Name, "schedule", expr, "err", err)
+		return
+	}
+	if repo.NextScheduledScanAt != nil {
+		s.runScheduledScan(ctx, repo)
+	}
+	if err := s.DB.Model(&db.Repository{}).Where("id = ?", repo.ID).
+		UpdateColumn("next_scheduled_scan_at", next).Error; err != nil {
+		s.Log.Error("scheduler: advance next_scheduled_scan_at", "repo", repo.Name, "err", err)
 	}
 }
 
@@ -130,9 +174,8 @@ func (s *Server) runScheduledScan(ctx context.Context, repo db.Repository) {
 	// and the remote HEAD lookup have already contacted their host, which is
 	// the other half of what the opt-out asks us not to do. Read live rather
 	// than off the tick's snapshot: the tick loads every due repository up
-	// front and then fires them one at a time, each doing its own network I/O,
-	// so an opt-out recorded mid-tick has to be seen by the repositories still
-	// waiting their turn.
+	// front, so an opt-out recorded while its bounded worker is waiting has to
+	// be seen before that repository performs network I/O.
 	optedOut, err := s.repoFederationOptedOut(repo.ID)
 	if err != nil {
 		s.Log.Error("scheduler: read federation opt-out", "repo", repo.Name, "err", err)

--- a/internal/web/schedule.go
+++ b/internal/web/schedule.go
@@ -174,8 +174,9 @@ func (s *Server) runScheduledScan(ctx context.Context, repo db.Repository) {
 	// and the remote HEAD lookup have already contacted their host, which is
 	// the other half of what the opt-out asks us not to do. Read live rather
 	// than off the tick's snapshot: the tick loads every due repository up
-	// front, so an opt-out recorded while its bounded worker is waiting has to
-	// be seen before that repository performs network I/O.
+	// front, so an opt-out recorded while a repository is waiting in the
+	// bounded work queue has to be seen before that repository performs
+	// network I/O.
 	optedOut, err := s.repoFederationOptedOut(repo.ID)
 	if err != nil {
 		s.Log.Error("scheduler: read federation opt-out", "repo", repo.Name, "err", err)

--- a/internal/web/schedule.go
+++ b/internal/web/schedule.go
@@ -29,8 +29,9 @@ const (
 	// tick interval only bounds the firing latency, not the cadence.
 	schedulerTick = time.Minute
 
-	// Bound remote HEAD probes without also placing large first-time mirror
-	// clones under a deadline that would make them restart on every tick.
+	// Ten minutes leaves room for transient retry backoff and slow forge
+	// responses while preventing one unreachable remote from retaining a
+	// scheduler worker indefinitely.
 	schedulerRemoteHeadTimeout = 10 * time.Minute
 )
 
@@ -163,7 +164,7 @@ func (s *Server) processScheduledRepository(
 		return
 	}
 	if repo.NextScheduledScanAt != nil {
-		s.runScheduledScanWithRemoteHeadTimeout(ctx, repo, remoteHeadTimeout)
+		s.runScheduledScan(ctx, repo, remoteHeadTimeout)
 	}
 	if err := s.DB.Model(&db.Repository{}).Where("id = ?", repo.ID).
 		UpdateColumn("next_scheduled_scan_at", next).Error; err != nil {
@@ -176,11 +177,7 @@ func (s *Server) processScheduledRepository(
 // most recent completed scan's commit and either record a skip or enqueue a
 // diff-rescan group (which falls back to full coverage when no baseline
 // exists, e.g. on a never-scanned repository).
-func (s *Server) runScheduledScan(ctx context.Context, repo db.Repository) {
-	s.runScheduledScanWithRemoteHeadTimeout(ctx, repo, schedulerRemoteHeadTimeout)
-}
-
-func (s *Server) runScheduledScanWithRemoteHeadTimeout(
+func (s *Server) runScheduledScan(
 	ctx context.Context,
 	repo db.Repository,
 	remoteHeadTimeout time.Duration,
@@ -225,12 +222,12 @@ func (s *Server) runScheduledScanWithRemoteHeadTimeout(
 		}
 	}
 	remoteCtx := ctx
-	var cancel context.CancelFunc = func() {}
 	if remoteHeadTimeout > 0 {
+		var cancel context.CancelFunc
 		remoteCtx, cancel = context.WithTimeout(ctx, remoteHeadTimeout)
+		defer cancel()
 	}
 	head, err := s.resolveRemoteHead(remoteCtx, repo)
-	cancel()
 	if err != nil {
 		s.recordScheduledSkip(repo, "remote HEAD lookup failed: "+err.Error())
 		return

--- a/internal/web/schedule_test.go
+++ b/internal/web/schedule_test.go
@@ -49,7 +49,7 @@ func scheduleTestServer(t *testing.T, head string, syncErr error) (*Server, *[]s
 		}
 		return head, nil
 	}
-	s.syncUpstream = func(_ context.Context, repoURL, upstreamURL string) error {
+	s.syncUpstream = func(_ context.Context, repoURL, upstreamURL string, _ time.Duration) error {
 		synced = append(synced, repoURL+"<-"+upstreamURL)
 		return syncErr
 	}
@@ -195,9 +195,11 @@ func TestScheduleTick_invalidScheduleDoesNotFireOrStoreZero(t *testing.T) {
 func TestRunScheduledRepositories_boundsConcurrency(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()
+	const maxConcurrent = 3
+	s.Queue.Reconfigure(maxConcurrent)
 	now := time.Now()
-	repos := make([]db.Repository, 0, schedulerMaxConcurrentRepositories+2)
-	for i := range schedulerMaxConcurrentRepositories + 2 {
+	repos := make([]db.Repository, 0, maxConcurrent+2)
+	for i := range maxConcurrent + 2 {
 		repos = append(repos, scheduledNamedRepo(t, s, fmt.Sprintf("repo-%d", i), "daily", now.Add(-time.Minute)))
 	}
 
@@ -227,7 +229,7 @@ func TestRunScheduledRepositories_boundsConcurrency(t *testing.T) {
 	go func() {
 		s.runScheduledRepositories(
 			context.Background(), now, "", repos,
-			schedulerMaxConcurrentRepositories, 5*time.Second,
+			s.schedulerConcurrency(), 5*time.Second,
 		)
 		close(finished)
 	}()
@@ -240,7 +242,7 @@ func TestRunScheduledRepositories_boundsConcurrency(t *testing.T) {
 		<-finished
 	}()
 
-	for range schedulerMaxConcurrentRepositories {
+	for range maxConcurrent {
 		select {
 		case <-started:
 		case <-time.After(time.Second):
@@ -249,7 +251,7 @@ func TestRunScheduledRepositories_boundsConcurrency(t *testing.T) {
 	}
 	select {
 	case <-started:
-		t.Fatalf("more than %d repositories ran concurrently", schedulerMaxConcurrentRepositories)
+		t.Fatalf("more than %d repositories ran concurrently", maxConcurrent)
 	case <-time.After(50 * time.Millisecond):
 	}
 
@@ -259,8 +261,8 @@ func TestRunScheduledRepositories_boundsConcurrency(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("scheduler did not wait for all repository work to finish")
 	}
-	if got := peak.Load(); got != schedulerMaxConcurrentRepositories {
-		t.Fatalf("peak concurrency = %d, want %d", got, schedulerMaxConcurrentRepositories)
+	if got := peak.Load(); got != maxConcurrent {
+		t.Fatalf("peak concurrency = %d, want %d", got, maxConcurrent)
 	}
 }
 

--- a/internal/web/schedule_test.go
+++ b/internal/web/schedule_test.go
@@ -3,10 +3,12 @@ package web
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -56,7 +58,17 @@ func scheduleTestServer(t *testing.T, head string, syncErr error) (*Server, *[]s
 
 func scheduledRepo(t *testing.T, s *Server, schedule string, due time.Time) db.Repository {
 	t.Helper()
-	repo := db.Repository{URL: "https://example.com/r", Name: "r", ScanSchedule: schedule, NextScheduledScanAt: &due}
+	return scheduledNamedRepo(t, s, "r", schedule, due)
+}
+
+func scheduledNamedRepo(t *testing.T, s *Server, name, schedule string, due time.Time) db.Repository {
+	t.Helper()
+	repo := db.Repository{
+		URL:                 "https://example.com/" + name,
+		Name:                name,
+		ScanSchedule:        schedule,
+		NextScheduledScanAt: &due,
+	}
 	if err := s.DB.Create(&repo).Error; err != nil {
 		t.Fatal(err)
 	}
@@ -177,6 +189,190 @@ func TestScheduleTick_invalidScheduleDoesNotFireOrStoreZero(t *testing.T) {
 	}
 	if scans != 0 {
 		t.Fatalf("invalid schedule created %d scan(s), want 0", scans)
+	}
+}
+
+func TestRunScheduledRepositories_boundsConcurrency(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	now := time.Now()
+	repos := make([]db.Repository, 0, schedulerMaxConcurrentRepositories+2)
+	for i := range schedulerMaxConcurrentRepositories + 2 {
+		repos = append(repos, scheduledNamedRepo(t, s, fmt.Sprintf("repo-%d", i), "daily", now.Add(-time.Minute)))
+	}
+
+	var active atomic.Int64
+	var peak atomic.Int64
+	started := make(chan struct{}, len(repos))
+	release := make(chan struct{})
+	s.resolveRemoteHead = func(ctx context.Context, _ db.Repository) (string, error) {
+		running := active.Add(1)
+		defer active.Add(-1)
+		for {
+			previous := peak.Load()
+			if running <= previous || peak.CompareAndSwap(previous, running) {
+				break
+			}
+		}
+		started <- struct{}{}
+		select {
+		case <-release:
+			return "", errors.New("released test remote")
+		case <-ctx.Done():
+			return "", ctx.Err()
+		}
+	}
+
+	finished := make(chan struct{})
+	go func() {
+		s.runScheduledRepositories(
+			context.Background(), now, "", repos,
+			schedulerMaxConcurrentRepositories, 5*time.Second,
+		)
+		close(finished)
+	}()
+	defer func() {
+		select {
+		case <-release:
+		default:
+			close(release)
+		}
+		<-finished
+	}()
+
+	for range schedulerMaxConcurrentRepositories {
+		select {
+		case <-started:
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for the initial scheduler workers")
+		}
+	}
+	select {
+	case <-started:
+		t.Fatalf("more than %d repositories ran concurrently", schedulerMaxConcurrentRepositories)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(release)
+	select {
+	case <-finished:
+	case <-time.After(5 * time.Second):
+		t.Fatal("scheduler did not wait for all repository work to finish")
+	}
+	if got := peak.Load(); got != schedulerMaxConcurrentRepositories {
+		t.Fatalf("peak concurrency = %d, want %d", got, schedulerMaxConcurrentRepositories)
+	}
+}
+
+func TestRunScheduledRepositories_slowRepoDoesNotBlockHealthyRepo(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	now := time.Now()
+	slow := scheduledNamedRepo(t, s, "slow", "daily", now.Add(-time.Minute))
+	healthy := scheduledNamedRepo(t, s, "healthy", "daily", now.Add(-time.Minute))
+
+	slowStarted := make(chan struct{})
+	healthyStarted := make(chan struct{})
+	releaseSlow := make(chan struct{})
+	s.resolveRemoteHead = func(ctx context.Context, repo db.Repository) (string, error) {
+		if repo.ID == slow.ID {
+			close(slowStarted)
+			select {
+			case <-releaseSlow:
+				return "", errors.New("released slow remote")
+			case <-ctx.Done():
+				return "", ctx.Err()
+			}
+		}
+		close(healthyStarted)
+		return "", errors.New("healthy remote checked")
+	}
+
+	finished := make(chan struct{})
+	go func() {
+		s.runScheduledRepositories(context.Background(), now, "", []db.Repository{slow, healthy}, 2, 5*time.Second)
+		close(finished)
+	}()
+	defer func() {
+		select {
+		case <-releaseSlow:
+		default:
+			close(releaseSlow)
+		}
+		<-finished
+	}()
+
+	select {
+	case <-slowStarted:
+	case <-time.After(time.Second):
+		t.Fatal("slow repository did not start")
+	}
+	select {
+	case <-healthyStarted:
+	case <-time.After(time.Second):
+		t.Fatal("healthy repository was blocked behind the slow repository")
+	}
+	close(releaseSlow)
+	select {
+	case <-finished:
+	case <-time.After(5 * time.Second):
+		t.Fatal("scheduler did not finish after the slow repository was released")
+	}
+}
+
+func TestRunScheduledRepositories_timeoutReleasesSlotAndAdvancesSchedules(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	now := time.Now()
+	timedOut := scheduledNamedRepo(t, s, "timeout", "daily", now.Add(-time.Minute))
+	next := scheduledNamedRepo(t, s, "next", "daily", now.Add(-time.Minute))
+
+	var nextStarted atomic.Bool
+	s.resolveRemoteHead = func(ctx context.Context, repo db.Repository) (string, error) {
+		if repo.ID == timedOut.ID {
+			<-ctx.Done()
+			return "", ctx.Err()
+		}
+		nextStarted.Store(true)
+		return "", errors.New("next remote checked")
+	}
+
+	var scheduleUpdates atomic.Int64
+	const callback = "test:count_schedule_advances"
+	if err := s.DB.Callback().Update().Before("gorm:update").Register(callback, func(tx *gorm.DB) {
+		if tx.Statement.Table == "repositories" {
+			scheduleUpdates.Add(1)
+		}
+	}); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := s.DB.Callback().Update().Remove(callback); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	s.runScheduledRepositories(
+		context.Background(), now, "", []db.Repository{timedOut, next},
+		1, 25*time.Millisecond,
+	)
+	if !nextStarted.Load() {
+		t.Fatal("repository after a timeout never acquired the released worker slot")
+	}
+	if got := scheduleUpdates.Load(); got != 2 {
+		t.Fatalf("schedule updates = %d, want exactly one for each repository", got)
+	}
+	for _, repo := range []db.Repository{timedOut, next} {
+		var got db.Repository
+		if err := s.DB.First(&got, repo.ID).Error; err != nil {
+			t.Fatal(err)
+		}
+		if got.NextScheduledScanAt == nil || !got.NextScheduledScanAt.After(now) {
+			t.Fatalf("repo %s next scheduled scan = %v, want after %v", repo.Name, got.NextScheduledScanAt, now)
+		}
+	}
+	if skip := lastSkip(t, s, timedOut.ID); !strings.Contains(skip.Error, context.DeadlineExceeded.Error()) {
+		t.Fatalf("timeout skip reason = %q, want deadline exceeded", skip.Error)
 	}
 }
 

--- a/internal/web/schedule_test.go
+++ b/internal/web/schedule_test.go
@@ -266,62 +266,6 @@ func TestRunScheduledRepositories_boundsConcurrency(t *testing.T) {
 	}
 }
 
-func TestRunScheduledRepositories_slowRepoDoesNotBlockHealthyRepo(t *testing.T) {
-	s, done := newTestServer(t)
-	defer done()
-	now := time.Now()
-	slow := scheduledNamedRepo(t, s, "slow", "daily", now.Add(-time.Minute))
-	healthy := scheduledNamedRepo(t, s, "healthy", "daily", now.Add(-time.Minute))
-
-	slowStarted := make(chan struct{})
-	healthyStarted := make(chan struct{})
-	releaseSlow := make(chan struct{})
-	s.resolveRemoteHead = func(ctx context.Context, repo db.Repository) (string, error) {
-		if repo.ID == slow.ID {
-			close(slowStarted)
-			select {
-			case <-releaseSlow:
-				return "", errors.New("released slow remote")
-			case <-ctx.Done():
-				return "", ctx.Err()
-			}
-		}
-		close(healthyStarted)
-		return "", errors.New("healthy remote checked")
-	}
-
-	finished := make(chan struct{})
-	go func() {
-		s.runScheduledRepositories(context.Background(), now, "", []db.Repository{slow, healthy}, 2, 5*time.Second)
-		close(finished)
-	}()
-	defer func() {
-		select {
-		case <-releaseSlow:
-		default:
-			close(releaseSlow)
-		}
-		<-finished
-	}()
-
-	select {
-	case <-slowStarted:
-	case <-time.After(time.Second):
-		t.Fatal("slow repository did not start")
-	}
-	select {
-	case <-healthyStarted:
-	case <-time.After(time.Second):
-		t.Fatal("healthy repository was blocked behind the slow repository")
-	}
-	close(releaseSlow)
-	select {
-	case <-finished:
-	case <-time.After(5 * time.Second):
-		t.Fatal("scheduler did not finish after the slow repository was released")
-	}
-}
-
 func TestRunScheduledRepositories_timeoutReleasesSlotAndAdvancesSchedules(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -434,7 +434,7 @@ func New(gdb *gorm.DB, q *queue.Queue, log *slog.Logger, broker *Broker, w *work
 		resolvePURL: resolvePURLRepo, listBranches: worker.ListRemoteBranches,
 		fetchOrgRepos:     fetchGitHubOrgRepos,
 		resolveRemoteHead: defaultResolveRemoteHead,
-		syncUpstream:      w.SyncUpstreamWithHeadTimeout}
+		syncUpstream:      w.SyncUpstream}
 	s.prefetchEcosystems = s.ecosystemsPrefetch
 	s.ecosystemsEnrichment = true
 	s.chatActive = map[uint]struct{}{}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -156,7 +156,7 @@ type Server struct {
 	// syncUpstream force-syncs a staging repository from its configured
 	// upstream before the scheduler's new-commit check. Field rather than
 	// a direct worker call so tests can stub the git traffic.
-	syncUpstream func(ctx context.Context, repoURL, upstreamURL string) error
+	syncUpstream func(ctx context.Context, repoURL, upstreamURL string, headTimeout time.Duration) error
 
 	// prefetchEcosystems warms the per-repository ecosyste.ms cache
 	// when a new repo is added, in parallel with the triage enqueue. Field
@@ -434,7 +434,7 @@ func New(gdb *gorm.DB, q *queue.Queue, log *slog.Logger, broker *Broker, w *work
 		resolvePURL: resolvePURLRepo, listBranches: worker.ListRemoteBranches,
 		fetchOrgRepos:     fetchGitHubOrgRepos,
 		resolveRemoteHead: defaultResolveRemoteHead,
-		syncUpstream:      w.SyncUpstream}
+		syncUpstream:      w.SyncUpstreamWithHeadTimeout}
 	s.prefetchEcosystems = s.ecosystemsPrefetch
 	s.ecosystemsEnrichment = true
 	s.chatActive = map[uint]struct{}{}

--- a/internal/worker/upstream.go
+++ b/internal/worker/upstream.go
@@ -62,29 +62,20 @@ func resolveRemoteHead(ctx context.Context, retry gitRetry, cloneURL string) (st
 // the per-URL lock serialises it against the scan cache's clone/fetch on the
 // same repository. Pushing uses the ambient git credentials (credential
 // helper, gh auth); only the terminal prompt is disabled so a missing
-// credential fails fast.
-func (w *Worker) SyncUpstream(ctx context.Context, repoURL, upstreamURL string) error {
-	return w.syncUpstream(ctx, gitRetry{}, repoURL, upstreamURL)
-}
-
-// SyncUpstreamWithHeadTimeout bounds only the remote HEAD probes used to
-// decide whether a sync is needed. Clone, fetch, and push retain the parent
+// credential fails fast. headTimeout bounds only the remote HEAD probes used
+// to decide whether a sync is needed. Clone, fetch, and push retain the parent
 // context so a large first-time mirror is not discarded solely for exceeding
 // a scheduler probe deadline.
-func (w *Worker) SyncUpstreamWithHeadTimeout(
+func (w *Worker) SyncUpstream(
 	ctx context.Context,
 	repoURL string,
 	upstreamURL string,
 	headTimeout time.Duration,
 ) error {
-	return w.syncUpstreamWithHeadTimeout(ctx, gitRetry{}, repoURL, upstreamURL, headTimeout)
+	return w.syncUpstream(ctx, gitRetry{}, repoURL, upstreamURL, headTimeout)
 }
 
-func (w *Worker) syncUpstream(ctx context.Context, retry gitRetry, repoURL, upstreamURL string) error {
-	return w.syncUpstreamWithHeadTimeout(ctx, retry, repoURL, upstreamURL, 0)
-}
-
-func (w *Worker) syncUpstreamWithHeadTimeout(
+func (w *Worker) syncUpstream(
 	ctx context.Context,
 	retry gitRetry,
 	repoURL string,
@@ -99,17 +90,16 @@ func (w *Worker) syncUpstreamWithHeadTimeout(
 	}
 	policy := retry.resolved()
 	headCtx := ctx
-	var cancelHead context.CancelFunc = func() {}
 	if headTimeout > 0 {
+		var cancelHead context.CancelFunc
 		headCtx, cancelHead = context.WithTimeout(ctx, headTimeout)
+		defer cancelHead()
 	}
 	repoHead, err := resolveRemoteHead(headCtx, branchPickerRetry(policy), repoURL)
 	if err != nil {
-		cancelHead()
 		return fmt.Errorf("resolve repo HEAD: %w", err)
 	}
 	upstreamHead, err := resolveRemoteHead(headCtx, branchPickerRetry(policy), upstreamURL)
-	cancelHead()
 	if err != nil {
 		return fmt.Errorf("resolve upstream HEAD: %w", err)
 	}

--- a/internal/worker/upstream.go
+++ b/internal/worker/upstream.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 )
 
 // validateScheduleURL is the scheduler's counterpart to validateGitURL:
@@ -66,7 +67,30 @@ func (w *Worker) SyncUpstream(ctx context.Context, repoURL, upstreamURL string) 
 	return w.syncUpstream(ctx, gitRetry{}, repoURL, upstreamURL)
 }
 
+// SyncUpstreamWithHeadTimeout bounds only the remote HEAD probes used to
+// decide whether a sync is needed. Clone, fetch, and push retain the parent
+// context so a large first-time mirror is not discarded solely for exceeding
+// a scheduler probe deadline.
+func (w *Worker) SyncUpstreamWithHeadTimeout(
+	ctx context.Context,
+	repoURL string,
+	upstreamURL string,
+	headTimeout time.Duration,
+) error {
+	return w.syncUpstreamWithHeadTimeout(ctx, gitRetry{}, repoURL, upstreamURL, headTimeout)
+}
+
 func (w *Worker) syncUpstream(ctx context.Context, retry gitRetry, repoURL, upstreamURL string) error {
+	return w.syncUpstreamWithHeadTimeout(ctx, retry, repoURL, upstreamURL, 0)
+}
+
+func (w *Worker) syncUpstreamWithHeadTimeout(
+	ctx context.Context,
+	retry gitRetry,
+	repoURL string,
+	upstreamURL string,
+	headTimeout time.Duration,
+) error {
 	if err := validateScheduleURL(repoURL); err != nil {
 		return fmt.Errorf("repo: %w", err)
 	}
@@ -74,11 +98,18 @@ func (w *Worker) syncUpstream(ctx context.Context, retry gitRetry, repoURL, upst
 		return fmt.Errorf("upstream: %w", err)
 	}
 	policy := retry.resolved()
-	repoHead, err := resolveRemoteHead(ctx, branchPickerRetry(policy), repoURL)
+	headCtx := ctx
+	var cancelHead context.CancelFunc = func() {}
+	if headTimeout > 0 {
+		headCtx, cancelHead = context.WithTimeout(ctx, headTimeout)
+	}
+	repoHead, err := resolveRemoteHead(headCtx, branchPickerRetry(policy), repoURL)
 	if err != nil {
+		cancelHead()
 		return fmt.Errorf("resolve repo HEAD: %w", err)
 	}
-	upstreamHead, err := resolveRemoteHead(ctx, branchPickerRetry(policy), upstreamURL)
+	upstreamHead, err := resolveRemoteHead(headCtx, branchPickerRetry(policy), upstreamURL)
+	cancelHead()
 	if err != nil {
 		return fmt.Errorf("resolve upstream HEAD: %w", err)
 	}

--- a/internal/worker/upstream_retry_test.go
+++ b/internal/worker/upstream_retry_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestResolveRemoteHeadRetriesTransientFailure(t *testing.T) {
@@ -51,6 +52,37 @@ func TestSyncUpstreamRetriesRemoteCloneAndFetch(t *testing.T) {
 				t.Fatalf("push calls = %d, remote SHA = %q; want 1 and %q", git.pushCalls, git.remoteSHA, git.desiredSHA)
 			}
 		})
+	}
+}
+
+func TestSyncUpstreamHeadTimeoutDoesNotBoundMirrorOperations(t *testing.T) {
+	git := newUpstreamScript()
+	retry := fastRetry()
+	var headProbesWithDeadline int
+	var mirrorOperationWithDeadline bool
+	retry.run = func(ctx context.Context, dir string, env []string, args ...string) (string, error) {
+		_, hasDeadline := ctx.Deadline()
+		if len(args) > 0 && args[0] == "ls-remote" && (len(args) < 2 || args[1] != "--refs") {
+			if hasDeadline {
+				headProbesWithDeadline++
+			}
+		} else if len(args) > 0 {
+			mirrorOperationWithDeadline = mirrorOperationWithDeadline || hasDeadline
+		}
+		return git.run(ctx, dir, env, args...)
+	}
+	worker := &Worker{DataDir: t.TempDir()}
+
+	if err := worker.syncUpstreamWithHeadTimeout(
+		context.Background(), retry, git.repoURL, git.upstreamURL, time.Second,
+	); err != nil {
+		t.Fatalf("syncUpstreamWithHeadTimeout: %v", err)
+	}
+	if headProbesWithDeadline != 2 {
+		t.Fatalf("HEAD probes with deadline = %d, want 2", headProbesWithDeadline)
+	}
+	if mirrorOperationWithDeadline {
+		t.Fatal("clone/fetch/push inherited the remote HEAD deadline")
 	}
 }
 

--- a/internal/worker/upstream_retry_test.go
+++ b/internal/worker/upstream_retry_test.go
@@ -39,7 +39,7 @@ func TestSyncUpstreamRetriesRemoteCloneAndFetch(t *testing.T) {
 			retry.run = git.run
 			worker := &Worker{DataDir: t.TempDir()}
 
-			if err := worker.syncUpstream(context.Background(), retry, git.repoURL, git.upstreamURL); err != nil {
+			if err := worker.syncUpstream(context.Background(), retry, git.repoURL, git.upstreamURL, 0); err != nil {
 				t.Fatalf("syncUpstream: %v", err)
 			}
 			if failOperation == "clone" && (git.cloneCalls != 2 || !git.cloneResetObserved) {
@@ -73,10 +73,10 @@ func TestSyncUpstreamHeadTimeoutDoesNotBoundMirrorOperations(t *testing.T) {
 	}
 	worker := &Worker{DataDir: t.TempDir()}
 
-	if err := worker.syncUpstreamWithHeadTimeout(
+	if err := worker.syncUpstream(
 		context.Background(), retry, git.repoURL, git.upstreamURL, time.Second,
 	); err != nil {
-		t.Fatalf("syncUpstreamWithHeadTimeout: %v", err)
+		t.Fatalf("syncUpstream: %v", err)
 	}
 	if headProbesWithDeadline != 2 {
 		t.Fatalf("HEAD probes with deadline = %d, want 2", headProbesWithDeadline)
@@ -95,7 +95,7 @@ func TestSyncUpstreamCancelledCloneCleansMirrorForNextInvocation(t *testing.T) {
 	retry.run = git.run
 	worker := &Worker{DataDir: t.TempDir()}
 
-	err := worker.syncUpstream(ctx, retry, git.repoURL, git.upstreamURL)
+	err := worker.syncUpstream(ctx, retry, git.repoURL, git.upstreamURL, 0)
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("syncUpstream error = %v, want context.Canceled", err)
 	}
@@ -107,7 +107,7 @@ func TestSyncUpstreamCancelledCloneCleansMirrorForNextInvocation(t *testing.T) {
 	fresh := newUpstreamScript()
 	freshRetry := fastRetry()
 	freshRetry.run = fresh.run
-	if err := worker.syncUpstream(context.Background(), freshRetry, fresh.repoURL, fresh.upstreamURL); err != nil {
+	if err := worker.syncUpstream(context.Background(), freshRetry, fresh.repoURL, fresh.upstreamURL, 0); err != nil {
 		t.Fatalf("fresh sync after cancellation: %v", err)
 	}
 	if fresh.cloneCalls != 1 || fresh.remoteSHA != fresh.desiredSHA {
@@ -125,7 +125,7 @@ func TestSyncUpstreamReconcilesAmbiguousPush(t *testing.T) {
 			retry.run = git.run
 			worker := &Worker{DataDir: t.TempDir()}
 
-			if err := worker.syncUpstream(context.Background(), retry, git.repoURL, git.upstreamURL); err != nil {
+			if err := worker.syncUpstream(context.Background(), retry, git.repoURL, git.upstreamURL, 0); err != nil {
 				t.Fatalf("syncUpstream: %v", err)
 			}
 			wantPushes := 1

--- a/internal/worker/upstream_test.go
+++ b/internal/worker/upstream_test.go
@@ -70,7 +70,7 @@ func TestSyncUpstream(t *testing.T) {
 	want := testGit(t, upstream, "rev-parse", "HEAD")
 
 	w := &Worker{DataDir: t.TempDir()}
-	if err := w.SyncUpstream(context.Background(), staging, upstream); err != nil {
+	if err := w.SyncUpstream(context.Background(), staging, upstream, 0); err != nil {
 		t.Fatalf("SyncUpstream: %v", err)
 	}
 	if got := testGit(t, staging, "rev-parse", "HEAD"); got != want {
@@ -89,7 +89,7 @@ func TestSyncUpstream_reusesMirrorAcrossSyncs(t *testing.T) {
 	for i, msg := range []string{"first upstream move", "second upstream move"} {
 		testGit(t, upstream, "commit", "-q", "--allow-empty", "-m", msg)
 		want := testGit(t, upstream, "rev-parse", "HEAD")
-		if err := w.SyncUpstream(context.Background(), staging, upstream); err != nil {
+		if err := w.SyncUpstream(context.Background(), staging, upstream, 0); err != nil {
 			t.Fatalf("sync %d: %v", i, err)
 		}
 		if got := testGit(t, staging, "rev-parse", "HEAD"); got != want {
@@ -110,7 +110,7 @@ func TestSyncUpstream_noopWhenAlreadyInSync(t *testing.T) {
 	testGit(t, "", "clone", "-q", "--bare", upstream, staging)
 
 	w := &Worker{DataDir: t.TempDir()}
-	if err := w.SyncUpstream(context.Background(), staging, upstream); err != nil {
+	if err := w.SyncUpstream(context.Background(), staging, upstream, 0); err != nil {
 		t.Fatalf("SyncUpstream: %v", err)
 	}
 	if got := testGit(t, staging, "rev-parse", "HEAD"); got != want {
@@ -130,7 +130,7 @@ func TestSyncUpstream_overwritesRewrittenHistory(t *testing.T) {
 	want := testGit(t, upstream, "rev-parse", "HEAD")
 
 	w := &Worker{DataDir: t.TempDir()}
-	if err := w.SyncUpstream(context.Background(), staging, upstream); err != nil {
+	if err := w.SyncUpstream(context.Background(), staging, upstream, 0); err != nil {
 		t.Fatalf("SyncUpstream: %v", err)
 	}
 	if got := testGit(t, staging, "rev-parse", "HEAD"); got != want {
@@ -143,7 +143,7 @@ func TestSyncUpstream_missingUpstream(t *testing.T) {
 	initTestRepo(t, staging)
 
 	w := &Worker{DataDir: t.TempDir()}
-	if err := w.SyncUpstream(context.Background(), staging, filepath.Join(t.TempDir(), "nope")); err == nil {
+	if err := w.SyncUpstream(context.Background(), staging, filepath.Join(t.TempDir(), "nope"), 0); err == nil {
 		t.Fatal("expected error for missing upstream")
 	}
 }


### PR DESCRIPTION
Fixes #815

## Summary

Processes repositories due for scheduled scans through a bounded worker pool so a slow or unavailable Git remote does not delay every subsequent repository in the scheduler tick.

The scheduler derives its worker limit from the operator-configured queue concurrency. Remote HEAD probes receive a scoped timeout, while potentially large mirror clone, fetch and push operations retain the scheduler's parent context.

## Changes

- Process scheduled repositories concurrently using the queue's configured concurrency limit.
- Fall back to one scheduler worker when no queue is configured.
- Apply a 10-minute timeout only to remote HEAD probes.
- Apply the probe timeout to staging/upstream HEAD comparisons and the final repository HEAD lookup.
- Keep mirror clone, fetch and push operations outside the probe timeout so large initial clones are not cancelled and restarted on every tick.
- Preserve existing schedule resolution, firing and advancement behavior.
- Advance each repository's `next_scheduled_scan_at` exactly once after a due run, including skipped and failed runs.
- Preserve repository federation locking and Git cache locking.
- Keep failures and probe timeouts isolated so one repository does not cancel unrelated work.
- Wait for all dispatched repository work before completing the scheduler tick.
- Add deterministic tests covering:
  - Enforcement of the configured queue concurrency.
  - A timed-out remote HEAD probe releasing its worker slot.
  - Remote probe timeout isolation.
  - Mirror operations not inheriting the remote HEAD timeout.
  - Exactly-once schedule advancement.

## Tests

- `go mod tidy -diff`
- `go test ./...`
- `go test -race ./...`
- `go test -race -tags evals ./internal/evals/...`
- `go vet ./...`
- `go vet -tags evals ./internal/evals/...`
- `go vet -tags podman ./...`
- `golangci-lint run`
- `git diff --check`