### PR TITLE
fix(worker): don't count sibling focus-area scans as missed observations

### DIFF
--- a/docs/database.md
+++ b/docs/database.md
@@ -203,7 +203,7 @@ One row per vulnerability. Lifecycle columns are mutated through `db.WriteFindin
 | last_seen_scan_id | integer | Most recent scan that re-observed this fingerprint. |
 | last_seen_commit | text | Commit at re-observation. |
 | seen_count | integer | Total times re-observed across rescans. |
-| missed_count | integer | Consecutive same-skill rescans where the fingerprint did not reappear; reset on next re-observation. Non-zero is a hint the issue may be fixed upstream. |
+| missed_count | integer | Consecutive same-skill full-repo rescans where the fingerprint did not reappear; reset on next re-observation. Focus-area scans never increment it — they only look at their own slice, so a miss there is not evidence of anything. Non-zero is a hint the issue may be fixed upstream. |
 | last_missed_scan_id | integer | Scan where it most recently went missing. |
 | finding_id | text | ID within the originating report, e.g. `F1`. |
 | sinks | text | Comma-joined sink IDs. Links to the threat model tab. |

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -761,10 +761,13 @@ type Finding struct {
 	LastSeenCommit string
 	SeenCount      int
 	// MissedCount/LastMissedScanID track the inverse: consecutive
-	// same-skill rescans of this repo+subpath where the fingerprint did
-	// NOT reappear. Reset to zero on the next re-observation. A non-zero
-	// MissedCount is a hint the finding may have been fixed upstream; it
-	// is not proof since model-driven audits are nondeterministic.
+	// same-skill full-repo rescans of this repo+subpath where the
+	// fingerprint did NOT reappear. Reset to zero on the next
+	// re-observation. Focus-area scans never increment it: they are only
+	// in scope for their own slice, so a miss there says nothing. A
+	// non-zero MissedCount is a hint the finding may have been fixed
+	// upstream; it is not proof since model-driven audits are
+	// nondeterministic.
 	MissedCount      int
 	LastMissedScanID uint
 

--- a/internal/web/templates/findings.html
+++ b/internal/web/templates/findings.html
@@ -140,7 +140,7 @@
           <a href="/findings/{{.ID}}" class="font-medium">{{.Title}}</a>
           {{if gt .MissedCount 0}}
             <span class="badge-outline text-xs"
-                  data-tooltip="Not observed in the last {{.MissedCount}} rescan(s) of this repository">
+                  data-tooltip="Not observed in the last {{.MissedCount}} full-repo rescan(s) of this repository">
               not seen {{.MissedCount}}x
             </span>
           {{end}}

--- a/internal/worker/findings_dedup_test.go
+++ b/internal/worker/findings_dedup_test.go
@@ -868,3 +868,87 @@ func TestParseFindingsOutput_notObservedSkipsClosedFindings(t *testing.T) {
 		t.Errorf("closed finding should not accrue missed count: missed=%d", f.MissedCount)
 	}
 }
+
+func TestParseFindingsOutput_focusAreaScanDoesNotMarkOtherAreasMissed(t *testing.T) {
+	gdb, err := db.Open(filepath.Join(t.TempDir(), "p.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo := db.Repository{URL: "https://x/r", Name: "r"}
+	gdb.Create(&repo)
+	w := &Worker{DB: gdb, Log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	emit := func(Event) {}
+
+	// Focus-area deep-dive on auth finds F1.
+	s1 := &db.Scan{RepositoryID: repo.ID, Kind: JobSkill, SkillName: "security-deep-dive",
+		SubPath: "", FocusArea: `{"name":"auth"}`, Status: db.ScanDone, Commit: "abc"}
+	gdb.Create(s1)
+	if err := w.parseFindingsOutput(&db.Skill{}, s1,
+		`{"findings":[{"id":"F1","title":"x","severity":"High","cwe":"CWE-89","location":"a.rb:1"}]}`, emit); err != nil {
+		t.Fatal(err)
+	}
+
+	// A sibling focus area finds its own finding and nothing from auth. It
+	// was never in scope to re-observe F1, so it must not count as a miss.
+	s2 := &db.Scan{RepositoryID: repo.ID, Kind: JobSkill, SkillName: "security-deep-dive",
+		SubPath: "", FocusArea: `{"name":"deserialization"}`, Status: db.ScanDone, Commit: "abc"}
+	gdb.Create(s2)
+	if err := w.parseFindingsOutput(&db.Skill{}, s2,
+		`{"findings":[{"id":"F2","title":"y","severity":"High","cwe":"CWE-502","location":"b.rb:2"}]}`, emit); err != nil {
+		t.Fatal(err)
+	}
+
+	var f1 db.Finding
+	gdb.Where("title = ?", "x").First(&f1)
+	if f1.MissedCount != 0 {
+		t.Errorf("sibling focus-area scan marked F1 missed: missed=%d last_missed=%d",
+			f1.MissedCount, f1.LastMissedScanID)
+	}
+
+	// A full-repo rescan of the same skill IS in scope for everything, so it
+	// still counts as a miss. Guards against disabling the signal outright.
+	s3 := &db.Scan{RepositoryID: repo.ID, Kind: JobSkill, SkillName: "security-deep-dive",
+		SubPath: "", Status: db.ScanDone, Commit: "def"}
+	gdb.Create(s3)
+	if err := w.parseFindingsOutput(&db.Skill{}, s3, `{"findings":[]}`, emit); err != nil {
+		t.Fatal(err)
+	}
+
+	gdb.Where("title = ?", "x").First(&f1)
+	if f1.MissedCount != 1 || f1.LastMissedScanID != s3.ID {
+		t.Errorf("full-repo rescan should mark F1 missed: missed=%d last_missed=%d",
+			f1.MissedCount, f1.LastMissedScanID)
+	}
+}
+
+func TestParseFindingsOutput_focusAreaScanDoesNotAutoReject(t *testing.T) {
+	gdb, err := db.Open(filepath.Join(t.TempDir(), "p.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo := db.Repository{URL: "https://x/r", Name: "r"}
+	gdb.Create(&repo)
+	w := &Worker{DB: gdb, Log: slog.New(slog.NewTextHandler(io.Discard, nil)), AutoRejectMissedCount: 1}
+	emit := func(Event) {}
+
+	s1 := &db.Scan{RepositoryID: repo.ID, Kind: JobSkill, SkillName: "security-deep-dive",
+		SubPath: "", FocusArea: `{"name":"auth"}`, Status: db.ScanDone, Commit: "abc"}
+	gdb.Create(s1)
+	if err := w.parseFindingsOutput(&db.Skill{}, s1,
+		`{"findings":[{"id":"F1","title":"x","severity":"High","cwe":"CWE-89","location":"a.rb:1"}]}`, emit); err != nil {
+		t.Fatal(err)
+	}
+
+	s2 := &db.Scan{RepositoryID: repo.ID, Kind: JobSkill, SkillName: "security-deep-dive",
+		SubPath: "", FocusArea: `{"name":"ssrf"}`, Status: db.ScanDone, Commit: "abc"}
+	gdb.Create(s2)
+	if err := w.parseFindingsOutput(&db.Skill{}, s2, `{"findings":[]}`, emit); err != nil {
+		t.Fatal(err)
+	}
+
+	var f1 db.Finding
+	gdb.Where("title = ?", "x").First(&f1)
+	if f1.Status == db.FindingRejected {
+		t.Errorf("sibling focus-area scan auto-rejected a valid finding (missed=%d)", f1.MissedCount)
+	}
+}

--- a/internal/worker/findings_dedup_test.go
+++ b/internal/worker/findings_dedup_test.go
@@ -899,7 +899,9 @@ func TestParseFindingsOutput_focusAreaScanDoesNotMarkOtherAreasMissed(t *testing
 	}
 
 	var f1 db.Finding
-	gdb.Where("title = ?", "x").First(&f1)
+	if err := gdb.Where("title = ?", "x").First(&f1).Error; err != nil {
+		t.Fatal(err)
+	}
 	if f1.MissedCount != 0 {
 		t.Errorf("sibling focus-area scan marked F1 missed: missed=%d last_missed=%d",
 			f1.MissedCount, f1.LastMissedScanID)
@@ -914,7 +916,9 @@ func TestParseFindingsOutput_focusAreaScanDoesNotMarkOtherAreasMissed(t *testing
 		t.Fatal(err)
 	}
 
-	gdb.Where("title = ?", "x").First(&f1)
+	if err := gdb.Where("title = ?", "x").First(&f1).Error; err != nil {
+		t.Fatal(err)
+	}
 	if f1.MissedCount != 1 || f1.LastMissedScanID != s3.ID {
 		t.Errorf("full-repo rescan should mark F1 missed: missed=%d last_missed=%d",
 			f1.MissedCount, f1.LastMissedScanID)
@@ -947,8 +951,13 @@ func TestParseFindingsOutput_focusAreaScanDoesNotAutoReject(t *testing.T) {
 	}
 
 	var f1 db.Finding
-	gdb.Where("title = ?", "x").First(&f1)
+	if err := gdb.Where("title = ?", "x").First(&f1).Error; err != nil {
+		t.Fatal(err)
+	}
 	if f1.Status == db.FindingRejected {
 		t.Errorf("sibling focus-area scan auto-rejected a valid finding (missed=%d)", f1.MissedCount)
+	}
+	if f1.MissedCount != 0 {
+		t.Errorf("sibling focus-area scan marked F1 missed: missed=%d", f1.MissedCount)
 	}
 }

--- a/internal/worker/skill.go
+++ b/internal/worker/skill.go
@@ -810,7 +810,21 @@ func (e *FailOnThresholdError) Error() string {
 // fingerprint did not appear in the scan output. Closed findings (fixed,
 // published, rejected, duplicate) are left alone. Returns the number of
 // rows touched so the scan log can report it.
+//
+// A focus-area scan only looks at its own slice of the repo, so it is not
+// in scope to re-observe findings from sibling areas and never counts as a
+// miss: with N parallel focus-area deep-dives each one would otherwise bump
+// MissedCount on every open finding from the other N-1, which also drives
+// AutoRejectMissedCount below and would auto-reject valid findings. Only
+// full-repo rescans count. Finding denormalizes RepositoryID/Commit/SubPath
+// from Scan but not FocusArea, and a finding can legitimately be observed
+// under more than one area, so scoping the query by focus area instead is
+// not available without joining back through a scan.
 func (w *Worker) markNotObserved(scan *db.Scan, seen map[string]bool) int {
+	if scan.FocusArea != "" {
+		return 0
+	}
+
 	sameSkill := w.DB.Model(&db.Scan{}).Select("id").
 		Where("repository_id = ? AND skill_name = ?", scan.RepositoryID, scan.SkillName)
 	var prior []db.Finding


### PR DESCRIPTION
Closes #835 by fixing the count rather than removing the marker, per your comment.

`markNotObserved` (`internal/worker/skill.go:813`) scoped by `(repository_id, skill_name, sub_path)` with no `focus_area` term, so each of N parallel focus-area deep-dives bumped `MissedCount` on every open finding from the other N-1. With `AutoRejectMissedCount` set, one batch auto-rejects valid findings — `TestParseFindingsOutput_focusAreaScanDoesNotAutoReject` fails that way on main.

Took the second option (skip when `scan.FocusArea != ""`). The first isn't available without joining back through a scan: `Finding` denormalizes `RepositoryID`/`Commit`/`SubPath` but not `FocusArea`, and a finding can be observed under more than one area, so neither `ScanID` (first-seen) nor `LastSeenScanID` (re-observation) is a safe stand-in.

Both new tests fail on main and pass here; the second asserts a full-repo rescan still counts, so the signal isn't disabled. Full `internal/worker` green (763s).
