### PR TITLE
fix(web): dedup once per scan batch, not once per sibling completion

### DIFF
--- a/internal/web/federation_opt_out.go
+++ b/internal/web/federation_opt_out.go
@@ -63,11 +63,14 @@ func (s *Server) repoFederationOptOut(w http.ResponseWriter, r *http.Request) {
 // re-render from the database rather than over per-scan SSE pushes.
 func (s *Server) stopScansForOptOut(repoID uint) error {
 	now := time.Now()
+	grouped := s.groupedScanIDs("repository_id = ? AND status IN ?",
+		repoID, []db.ScanStatus{db.ScanQueued, db.ScanPaused})
 	if err := s.DB.Model(&db.Scan{}).
 		Where("repository_id = ? AND status IN ?", repoID, []db.ScanStatus{db.ScanQueued, db.ScanPaused}).
 		Updates(scanStatusUpdates(db.ScanCancelled, worker.OptOutCancelReason, &now, nil)).Error; err != nil {
 		return err
 	}
+	s.settleCancelledScanGroups(grouped...)
 	var running []db.Scan
 	if err := s.DB.Select("id, repository_id").
 		Where("repository_id = ? AND status = ?", repoID, db.ScanRunning).

--- a/internal/web/finding_dedup_enqueue.go
+++ b/internal/web/finding_dedup_enqueue.go
@@ -74,7 +74,38 @@ func (s *Server) autoEnqueueFindingDedup(scan *db.Scan) {
 		return
 	}
 
+	// 3. Every other scan in this scan's batch has finished. See
+	//    hasOutstandingBatchSiblings.
+	if s.hasOutstandingBatchSiblings(scan) {
+		return
+	}
+
 	s.enqueueFindingDedupForRepo(context.Background(), scan.RepositoryID)
+}
+
+// hasOutstandingBatchSiblings reports whether any other scan in this scan's
+// ScanGroup is still queued or running. A batch of focus-area deep dives is
+// launched as one cohort (focus_area_deep_dive.go), and dedup compares the
+// repository's open findings pairwise, so running it per sibling completion
+// spends a model pass on a working set that is still filling up.
+//
+// The in-flight guard in enqueueRepoScopedSkillIfIdle does not cover this on
+// its own: it only suppresses while a dedup is queued or running, so the
+// moment one completes between two sibling completions the gate reopens and
+// the next sibling enqueues another. That it usually collapses to a single
+// pass today is incidental — it depends on the dedup still sitting behind the
+// batch in the queue, i.e. on worker saturation rather than on the batch being
+// finished.
+//
+// The scan being finalized is excluded by id: its own terminal status may not
+// be committed yet when the completion hook runs, and counting itself would
+// stall the batch forever. Scans with no ScanGroup were not launched as a
+// batch and keep the previous behaviour.
+func (s *Server) hasOutstandingBatchSiblings(scan *db.Scan) bool {
+	if scan.ScanGroup == "" {
+		return false
+	}
+	return s.hasOpenScan("scan_group = ? AND id <> ?", scan.ScanGroup, scan.ID)
 }
 
 // enqueueFindingDedupForRepo looks up the active finding-dedup skill and

--- a/internal/web/finding_dedup_enqueue.go
+++ b/internal/web/finding_dedup_enqueue.go
@@ -16,21 +16,35 @@ const findingDedupSkillName = "finding-dedup"
 // so it needs at least a pair.
 const dedupMinFindings = 2
 
-// autoEnqueueFindingDedup is wired onto Worker.OnScanFinalized.
+// autoEnqueueFindingDedup is wired onto Worker.OnScanFinalized, and onto
+// Worker.OnScanGroupSettled for scans launched as part of a batch.
 // The worker calls it once after a scan completes and its findings are
-// committed. We enqueue a repository-scoped finding-dedup run only when both
-// conditions the dedup pass needs to be worth its model spend hold:
+// committed. We enqueue a repository-scoped finding-dedup run only when all
+// three conditions the dedup pass needs to be worth its model spend hold:
 //
-//  1. The scan is a curated LLM audit (security-deep-dive or vuln-scan) that
-//     produced at least one *new* finding. Re-observed findings keep the
-//     scan_id of the run that first created them, so counting findings with
-//     scan_id == this scan counts exactly the new rows. Nothing new means
-//     nothing fresh to dedup.
-//  2. The repository now holds at least two open non-scanner findings in
+//  1. The batch this scan belongs to has drained: every other scan sharing
+//     its scan_group has left the in-flight set. See
+//     hasOutstandingBatchSiblings. An ungrouped scan has nothing to wait for.
+//  2. A curated LLM audit (security-deep-dive, vuln-scan or
+//     advisory-deep-dive) that is not a fix-validation anchor produced at
+//     least one *new* finding. Re-observed findings keep the scan_id of the
+//     run that first created them, so counting findings by scan_id counts
+//     exactly the new rows. Nothing new means nothing fresh to dedup.
+//  3. The repository now holds at least two open non-scanner findings in
 //     total (the new rows count toward this). Dedup needs a pair to compare,
 //     but the pair need not predate this scan: a first-ever audit that emits
 //     several findings describing the same bug from different subagent angles
 //     is exactly what dedup exists to collapse.
+//
+// Condition 1 is evaluated first, and for a grouped scan condition 2 is
+// evaluated over the whole cohort rather than over the sibling that happened
+// to arrive last. Which sibling that is carries no meaning, and gating the
+// batch on it turns "run fewer times" into "sometimes never run": it may have
+// produced no new findings, it may not be an LLM audit at all
+// (enqueueDiffRescanGroup puts recon, threat-model and semgrep in the same
+// scan_group as the fanned-out deep dives), or it may have failed or been
+// cancelled. In each case every earlier sibling has already suppressed, so
+// skipping here would drop a pass that main would have run.
 //
 // "Non-scanner" matches the Findings-tab toggle exactly (nonScannerScanFilter):
 // the cheap tool scanners (semgrep, zizmor) and tool imports (CodeQL, Snyk)
@@ -44,19 +58,27 @@ func (s *Server) autoEnqueueFindingDedup(scan *db.Scan) {
 	// A fix-validation anchor (validate_fix.go) re-runs an audit on a fix ref
 	// purely to diff fingerprints; its findings are validation scratch, not a
 	// repo's working set, so they must not trigger a dedup pass.
-	if scan == nil || !isLLMAuditSkill(scan.SkillName) || scan.BaselineScanID != nil {
+	if scan == nil || scan.BaselineScanID != nil {
 		return
 	}
 
-	var newFromScan int64
-	if err := s.DB.Model(&db.Finding{}).
-		Where("scan_id = ?", scan.ID).
-		Count(&newFromScan).Error; err != nil {
+	if s.hasOutstandingBatchSiblings(scan) {
+		return
+	}
+
+	// An ungrouped scan speaks only for itself, so it has to qualify on its
+	// own. A grouped one answers for the cohort and is checked below.
+	if scan.ScanGroup == "" && !isLLMAuditSkill(scan.SkillName) {
+		return
+	}
+
+	newFindings, err := s.countNewAuditFindings(scan)
+	if err != nil {
 		s.Log.Warn("auto-enqueue finding-dedup: count new findings",
 			"scan", scan.ID, "repo", scan.RepositoryID, "err", err)
 		return
 	}
-	if newFromScan == 0 {
+	if newFindings == 0 {
 		return
 	}
 
@@ -74,20 +96,38 @@ func (s *Server) autoEnqueueFindingDedup(scan *db.Scan) {
 		return
 	}
 
-	// 3. Every other scan in this scan's batch has finished. See
-	//    hasOutstandingBatchSiblings.
-	if s.hasOutstandingBatchSiblings(scan) {
-		return
-	}
-
 	s.enqueueFindingDedupForRepo(context.Background(), scan.RepositoryID)
 }
 
+// countNewAuditFindings counts the findings created by the scans entitled to
+// trigger a dedup pass. Re-observed findings keep the scan_id of the run that
+// first created them, so counting rows by scan_id counts exactly the new ones.
+//
+// For an ungrouped scan that is the scan itself. For a grouped one it is every
+// curated LLM audit in the cohort that is not a fix-validation anchor: the
+// batch is one logical unit of work, so what it produced as a whole is what
+// decides whether a pass is worth running.
+func (s *Server) countNewAuditFindings(scan *db.Scan) (int64, error) {
+	q := s.DB.Model(&db.Finding{})
+	if scan.ScanGroup == "" {
+		q = q.Where("scan_id = ?", scan.ID)
+	} else {
+		cohort := s.DB.Model(&db.Scan{}).Select("id").
+			Where("scan_group = ?", scan.ScanGroup).
+			Where("skill_name IN ?", llmAuditSkillNames()).
+			Where("baseline_scan_id IS NULL")
+		q = q.Where("scan_id IN (?)", cohort)
+	}
+	var n int64
+	err := q.Count(&n).Error
+	return n, err
+}
+
 // hasOutstandingBatchSiblings reports whether any other scan in this scan's
-// ScanGroup is still queued or running. A batch of focus-area deep dives is
-// launched as one cohort (focus_area_deep_dive.go), and dedup compares the
-// repository's open findings pairwise, so running it per sibling completion
-// spends a model pass on a working set that is still filling up.
+// ScanGroup is still in flight. A batch of focus-area deep dives is launched
+// as one cohort (focus_area_deep_dive.go), and dedup compares the repository's
+// open findings pairwise, so running it per sibling completion spends a model
+// pass on a working set that is still filling up.
 //
 // The in-flight guard in enqueueRepoScopedSkillIfIdle does not cover this on
 // its own: it only suppresses while a dedup is queued or running, so the
@@ -97,10 +137,12 @@ func (s *Server) autoEnqueueFindingDedup(scan *db.Scan) {
 // batch in the queue, i.e. on worker saturation rather than on the batch being
 // finished.
 //
-// The scan being finalized is excluded by id: its own terminal status may not
-// be committed yet when the completion hook runs, and counting itself would
-// stall the batch forever. Scans with no ScanGroup were not launched as a
-// batch and keep the previous behaviour.
+// "In flight" has to include paused: a sibling parked on a rate limit will
+// resume and file more findings, so treating it as drained fires the pass
+// early against a half-filled working set. The scan being settled is excluded
+// by id — its own terminal status may not be committed yet when the hook runs,
+// and counting itself would stall the batch forever. Scans with no ScanGroup
+// were not launched as a batch and keep the previous behaviour.
 func (s *Server) hasOutstandingBatchSiblings(scan *db.Scan) bool {
 	if scan.ScanGroup == "" {
 		return false

--- a/internal/web/finding_dedup_enqueue_test.go
+++ b/internal/web/finding_dedup_enqueue_test.go
@@ -212,3 +212,64 @@ func TestAutoEnqueueFindingDedup_nilScan(t *testing.T) {
 	defer done()
 	s.autoEnqueueFindingDedup(nil) // must not panic
 }
+
+// newGroupScan creates a focus-area scan belonging to a batch cohort.
+func newGroupScan(t *testing.T, s *Server, repoID uint, group, focus string, status db.ScanStatus) *db.Scan {
+	t.Helper()
+	scan := db.Scan{RepositoryID: repoID, Status: status, SkillName: "security-deep-dive",
+		ScanGroup: group, FocusArea: focus}
+	s.DB.Create(&scan)
+	return &scan
+}
+
+// A batch of focus-area deep dives finishing one at a time must produce one
+// dedup pass, not one per sibling. The in-flight guard alone does not give
+// that: it only suppresses while a dedup is queued or running, so as soon as
+// one completes between two sibling completions the gate reopens.
+func TestAutoEnqueueFindingDedup_waitsForBatchSiblings(t *testing.T) {
+	s, done, repoID, dedupID := dedupTestSetup(t)
+	defer done()
+
+	const group = "batch-1"
+	first := newGroupScan(t, s, repoID, group, `{"name":"auth"}`, db.ScanDone)
+	second := newGroupScan(t, s, repoID, group, `{"name":"ssrf"}`, db.ScanRunning)
+	third := newGroupScan(t, s, repoID, group, `{"name":"deser"}`, db.ScanQueued)
+	for _, sc := range []*db.Scan{first, second, third} {
+		newFindingUnder(t, s, repoID, sc.ID, db.FindingNew)
+	}
+
+	s.autoEnqueueFindingDedup(first)
+	if n := dedupQueued(s, repoID, dedupID); n != 0 {
+		t.Errorf("queued = %d, want 0 while %d batch siblings are still outstanding", n, 2)
+	}
+
+	// Second finishes; the last sibling is still queued, so still too early.
+	s.DB.Model(second).Update("status", db.ScanDone)
+	s.autoEnqueueFindingDedup(second)
+	if n := dedupQueued(s, repoID, dedupID); n != 0 {
+		t.Errorf("queued = %d, want 0 while 1 batch sibling is still outstanding", n)
+	}
+
+	// Last one home enqueues exactly one pass for the whole batch.
+	s.DB.Model(third).Update("status", db.ScanDone)
+	s.autoEnqueueFindingDedup(third)
+	if n := dedupQueued(s, repoID, dedupID); n != 1 {
+		t.Errorf("queued = %d, want 1 once the batch has drained", n)
+	}
+}
+
+// An ungrouped scan keeps the old behaviour: nothing to wait for.
+func TestAutoEnqueueFindingDedup_ungroupedScanEnqueuesImmediately(t *testing.T) {
+	s, done, repoID, dedupID := dedupTestSetup(t)
+	defer done()
+
+	prior := newScan(t, s, repoID, "security-deep-dive")
+	newFindingUnder(t, s, repoID, prior.ID, db.FindingNew)
+	scan := newScan(t, s, repoID, "security-deep-dive")
+	newFindingUnder(t, s, repoID, scan.ID, db.FindingNew)
+
+	s.autoEnqueueFindingDedup(scan)
+	if n := dedupQueued(s, repoID, dedupID); n != 1 {
+		t.Errorf("queued = %d, want 1 for an ungrouped scan", n)
+	}
+}

--- a/internal/web/finding_dedup_enqueue_test.go
+++ b/internal/web/finding_dedup_enqueue_test.go
@@ -379,3 +379,95 @@ func TestAutoEnqueueFindingDedup_ungroupedScanEnqueuesImmediately(t *testing.T) 
 		t.Errorf("queued = %d, want 1 for an ungrouped scan", n)
 	}
 }
+
+// A queued sibling can be cancelled without ever reaching the worker:
+// scanCancel and scansCancelAll flip the row in place, and a federation
+// opt-out sweeps queued and paused rows in bulk. Each is a queued-to-terminal
+// transition the worker never observes, so the cohort hook has to be fired by
+// the path that made the transition. Without that, the earlier siblings have
+// all suppressed on the cancelled one's account and the batch gets no pass at
+// all — andrew's repro on #855: a completed sibling holding two findings,
+// followed by cancellation of its queued sibling, left the dedup queue empty.
+func TestCancelledQueuedSiblingSettlesBatch(t *testing.T) {
+	cases := []struct {
+		name   string
+		cancel func(s *Server, repoID uint, queued *db.Scan)
+	}{{
+		name: "per-row cancel",
+		cancel: func(s *Server, _ uint, queued *db.Scan) {
+			s.cancelScan(queued, "cancelled by user")
+		},
+	}, {
+		name: "federation opt-out sweep",
+		cancel: func(s *Server, repoID uint, _ *db.Scan) {
+			if err := s.stopScansForOptOut(repoID); err != nil {
+				t.Fatalf("stopScansForOptOut: %v", err)
+			}
+		},
+	}}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s, done, repoID, dedupID := dedupTestSetup(t)
+			defer done()
+
+			// The cohort exists in full before any member settles, as it does
+			// in production: a done sibling carrying the batch's findings, and
+			// one still queued that the earlier one is waiting on.
+			finished := newGroupScan(t, s, repoID, `{"name":"auth"}`, db.ScanDone)
+			queued := newGroupScan(t, s, repoID, `{"name":"ssrf"}`, db.ScanQueued)
+			newFindingUnder(t, s, repoID, finished.ID, db.FindingNew)
+			newFindingUnder(t, s, repoID, finished.ID, db.FindingNew)
+
+			s.autoEnqueueFindingDedup(finished)
+			if n := dedupQueued(s, repoID, dedupID); n != 0 {
+				t.Fatalf("queued = %d, want 0 while the sibling is still queued", n)
+			}
+
+			tc.cancel(s, repoID, queued)
+
+			if n := dedupQueued(s, repoID, dedupID); n != 1 {
+				t.Errorf("queued = %d, want 1 after the last outstanding sibling was cancelled", n)
+			}
+		})
+	}
+}
+
+// A bulk cancel settles each cohort once rather than once per row: the handler
+// answers for the whole batch, so firing per sibling would be redundant work
+// on a path that can flip an entire repository's queue in one click.
+func TestCancelledQueuedSiblingsSettleGroupOnce(t *testing.T) {
+	s, done, repoID, dedupID := dedupTestSetup(t)
+	defer done()
+
+	finished := newGroupScan(t, s, repoID, `{"name":"auth"}`, db.ScanDone)
+	newGroupScan(t, s, repoID, `{"name":"ssrf"}`, db.ScanQueued)
+	newGroupScan(t, s, repoID, `{"name":"deser"}`, db.ScanQueued)
+	newFindingUnder(t, s, repoID, finished.ID, db.FindingNew)
+	newFindingUnder(t, s, repoID, finished.ID, db.FindingNew)
+
+	if err := s.stopScansForOptOut(repoID); err != nil {
+		t.Fatalf("stopScansForOptOut: %v", err)
+	}
+	if n := dedupQueued(s, repoID, dedupID); n != 1 {
+		t.Errorf("queued = %d, want 1 for the cohort", n)
+	}
+}
+
+// A scan the worker claimed between the caller's read and its write keeps
+// running, so the row is not flipped and its cohort has not drained. The
+// settle pass must re-read the status rather than assume the update landed.
+func TestSettleCancelledScanGroupsIgnoresUnflippedRows(t *testing.T) {
+	s, done, repoID, dedupID := dedupTestSetup(t)
+	defer done()
+
+	finished := newGroupScan(t, s, repoID, `{"name":"auth"}`, db.ScanDone)
+	running := newGroupScan(t, s, repoID, `{"name":"ssrf"}`, db.ScanRunning)
+	newFindingUnder(t, s, repoID, finished.ID, db.FindingNew)
+	newFindingUnder(t, s, repoID, finished.ID, db.FindingNew)
+
+	s.settleCancelledScanGroups(running.ID)
+	if n := dedupQueued(s, repoID, dedupID); n != 0 {
+		t.Errorf("queued = %d, want 0 while the sibling is still running", n)
+	}
+}

--- a/internal/web/finding_dedup_enqueue_test.go
+++ b/internal/web/finding_dedup_enqueue_test.go
@@ -213,19 +213,23 @@ func TestAutoEnqueueFindingDedup_nilScan(t *testing.T) {
 	s.autoEnqueueFindingDedup(nil) // must not panic
 }
 
+// testScanGroup is the cohort id the batch tests launch their scans under.
+// Production uses uuid.NewString(); the value only has to be shared.
+const testScanGroup = "batch-1"
+
 // newGroupScan creates a focus-area deep dive belonging to a batch cohort.
-func newGroupScan(t *testing.T, s *Server, repoID uint, group, focus string, status db.ScanStatus) *db.Scan {
+func newGroupScan(t *testing.T, s *Server, repoID uint, focus string, status db.ScanStatus) *db.Scan {
 	t.Helper()
-	return newGroupScanOfSkill(t, s, repoID, group, focus, "security-deep-dive", status)
+	return newGroupScanOfSkill(t, s, repoID, focus, "security-deep-dive", status)
 }
 
 // newGroupScanOfSkill is newGroupScan for the cohort members that are not
 // deep dives: enqueueDiffRescanGroup puts recon, threat-model and semgrep in
 // the same scan_group as the fanned-out deep dives.
-func newGroupScanOfSkill(t *testing.T, s *Server, repoID uint, group, focus, skillName string, status db.ScanStatus) *db.Scan {
+func newGroupScanOfSkill(t *testing.T, s *Server, repoID uint, focus, skillName string, status db.ScanStatus) *db.Scan {
 	t.Helper()
 	scan := db.Scan{RepositoryID: repoID, Status: status, SkillName: skillName,
-		ScanGroup: group, FocusArea: focus}
+		ScanGroup: testScanGroup, FocusArea: focus}
 	s.DB.Create(&scan)
 	return &scan
 }
@@ -238,10 +242,9 @@ func TestAutoEnqueueFindingDedup_waitsForBatchSiblings(t *testing.T) {
 	s, done, repoID, dedupID := dedupTestSetup(t)
 	defer done()
 
-	const group = "batch-1"
-	first := newGroupScan(t, s, repoID, group, `{"name":"auth"}`, db.ScanDone)
-	second := newGroupScan(t, s, repoID, group, `{"name":"ssrf"}`, db.ScanRunning)
-	third := newGroupScan(t, s, repoID, group, `{"name":"deser"}`, db.ScanQueued)
+	first := newGroupScan(t, s, repoID, `{"name":"auth"}`, db.ScanDone)
+	second := newGroupScan(t, s, repoID, `{"name":"ssrf"}`, db.ScanRunning)
+	third := newGroupScan(t, s, repoID, `{"name":"deser"}`, db.ScanQueued)
 	for _, sc := range []*db.Scan{first, second, third} {
 		newFindingUnder(t, s, repoID, sc.ID, db.FindingNew)
 	}
@@ -289,19 +292,18 @@ func TestAutoEnqueueFindingDedup_lastSiblingNeedNotQualify(t *testing.T) {
 			s, done, repoID, dedupID := dedupTestSetup(t)
 			defer done()
 
-			const group = "batch-1"
 			// The whole cohort exists up front, as it does in production:
 			// the batch is launched as one unit and its members finish one
 			// at a time.
 			var earlier []*db.Scan
 			for _, focus := range []string{`{"name":"auth"}`, `{"name":"ssrf"}`} {
-				sibling := newGroupScan(t, s, repoID, group, focus, db.ScanDone)
+				sibling := newGroupScan(t, s, repoID, focus, db.ScanDone)
 				// Both found something, so the cohort has new findings and
 				// the repo ends up with a pair to compare.
 				newFindingUnder(t, s, repoID, sibling.ID, db.FindingNew)
 				earlier = append(earlier, sibling)
 			}
-			last := newGroupScanOfSkill(t, s, repoID, group, `{"name":"deser"}`, tc.skill, db.ScanRunning)
+			last := newGroupScanOfSkill(t, s, repoID, `{"name":"deser"}`, tc.skill, db.ScanRunning)
 			if tc.findings {
 				newFindingUnder(t, s, repoID, last.ID, db.FindingNew)
 			}
@@ -329,12 +331,11 @@ func TestAutoEnqueueFindingDedup_pausedSiblingIsOutstanding(t *testing.T) {
 	s, done, repoID, dedupID := dedupTestSetup(t)
 	defer done()
 
-	const group = "batch-1"
-	first := newGroupScan(t, s, repoID, group, `{"name":"auth"}`, db.ScanDone)
+	first := newGroupScan(t, s, repoID, `{"name":"auth"}`, db.ScanDone)
 	newFindingUnder(t, s, repoID, first.ID, db.FindingNew)
-	second := newGroupScan(t, s, repoID, group, `{"name":"ssrf"}`, db.ScanDone)
+	second := newGroupScan(t, s, repoID, `{"name":"ssrf"}`, db.ScanDone)
 	newFindingUnder(t, s, repoID, second.ID, db.FindingNew)
-	newGroupScan(t, s, repoID, group, `{"name":"deser"}`, db.ScanPaused)
+	newGroupScan(t, s, repoID, `{"name":"deser"}`, db.ScanPaused)
 
 	s.autoEnqueueFindingDedup(first)
 	s.autoEnqueueFindingDedup(second)
@@ -349,13 +350,12 @@ func TestAutoEnqueueFindingDedup_emptyBatchEnqueuesNothing(t *testing.T) {
 	s, done, repoID, dedupID := dedupTestSetup(t)
 	defer done()
 
-	const group = "batch-1"
 	prior := newScan(t, s, repoID, "security-deep-dive")
 	newFindingUnder(t, s, repoID, prior.ID, db.FindingNew)
 	newFindingUnder(t, s, repoID, prior.ID, db.FindingNew)
 
-	first := newGroupScan(t, s, repoID, group, `{"name":"auth"}`, db.ScanDone)
-	last := newGroupScan(t, s, repoID, group, `{"name":"ssrf"}`, db.ScanDone)
+	first := newGroupScan(t, s, repoID, `{"name":"auth"}`, db.ScanDone)
+	last := newGroupScan(t, s, repoID, `{"name":"ssrf"}`, db.ScanDone)
 	s.autoEnqueueFindingDedup(first)
 	s.autoEnqueueFindingDedup(last)
 

--- a/internal/web/finding_dedup_enqueue_test.go
+++ b/internal/web/finding_dedup_enqueue_test.go
@@ -213,10 +213,18 @@ func TestAutoEnqueueFindingDedup_nilScan(t *testing.T) {
 	s.autoEnqueueFindingDedup(nil) // must not panic
 }
 
-// newGroupScan creates a focus-area scan belonging to a batch cohort.
+// newGroupScan creates a focus-area deep dive belonging to a batch cohort.
 func newGroupScan(t *testing.T, s *Server, repoID uint, group, focus string, status db.ScanStatus) *db.Scan {
 	t.Helper()
-	scan := db.Scan{RepositoryID: repoID, Status: status, SkillName: "security-deep-dive",
+	return newGroupScanOfSkill(t, s, repoID, group, focus, "security-deep-dive", status)
+}
+
+// newGroupScanOfSkill is newGroupScan for the cohort members that are not
+// deep dives: enqueueDiffRescanGroup puts recon, threat-model and semgrep in
+// the same scan_group as the fanned-out deep dives.
+func newGroupScanOfSkill(t *testing.T, s *Server, repoID uint, group, focus, skillName string, status db.ScanStatus) *db.Scan {
+	t.Helper()
+	scan := db.Scan{RepositoryID: repoID, Status: status, SkillName: skillName,
 		ScanGroup: group, FocusArea: focus}
 	s.DB.Create(&scan)
 	return &scan
@@ -255,6 +263,104 @@ func TestAutoEnqueueFindingDedup_waitsForBatchSiblings(t *testing.T) {
 	s.autoEnqueueFindingDedup(third)
 	if n := dedupQueued(s, repoID, dedupID); n != 1 {
 		t.Errorf("queued = %d, want 1 once the batch has drained", n)
+	}
+}
+
+// The sibling that arrives last is arbitrary, so the batch's pass cannot
+// depend on that sibling qualifying on its own. Each case here is one where
+// main runs a pass and gating on the finalizing scan would run none: the last
+// one home produced nothing, is not an LLM audit at all, or ended failed or
+// cancelled rather than done.
+func TestAutoEnqueueFindingDedup_lastSiblingNeedNotQualify(t *testing.T) {
+	cases := []struct {
+		name     string
+		skill    string
+		status   db.ScanStatus
+		findings bool
+	}{
+		{name: "no new findings", skill: "security-deep-dive", status: db.ScanDone},
+		{name: "not an LLM audit", skill: "semgrep", status: db.ScanDone},
+		{name: "failed", skill: "security-deep-dive", status: db.ScanFailed},
+		{name: "cancelled", skill: "security-deep-dive", status: db.ScanCancelled},
+		{name: "qualifies itself", skill: "security-deep-dive", status: db.ScanDone, findings: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s, done, repoID, dedupID := dedupTestSetup(t)
+			defer done()
+
+			const group = "batch-1"
+			// The whole cohort exists up front, as it does in production:
+			// the batch is launched as one unit and its members finish one
+			// at a time.
+			var earlier []*db.Scan
+			for _, focus := range []string{`{"name":"auth"}`, `{"name":"ssrf"}`} {
+				sibling := newGroupScan(t, s, repoID, group, focus, db.ScanDone)
+				// Both found something, so the cohort has new findings and
+				// the repo ends up with a pair to compare.
+				newFindingUnder(t, s, repoID, sibling.ID, db.FindingNew)
+				earlier = append(earlier, sibling)
+			}
+			last := newGroupScanOfSkill(t, s, repoID, group, `{"name":"deser"}`, tc.skill, db.ScanRunning)
+			if tc.findings {
+				newFindingUnder(t, s, repoID, last.ID, db.FindingNew)
+			}
+
+			for _, sibling := range earlier {
+				s.autoEnqueueFindingDedup(sibling)
+			}
+			if n := dedupQueued(s, repoID, dedupID); n != 0 {
+				t.Fatalf("queued = %d, want 0 while the last sibling is outstanding", n)
+			}
+
+			s.DB.Model(last).Update("status", tc.status)
+			s.autoEnqueueFindingDedup(last)
+			if n := dedupQueued(s, repoID, dedupID); n != 1 {
+				t.Errorf("queued = %d, want 1: the batch produced findings and has drained", n)
+			}
+		})
+	}
+}
+
+// A sibling paused on a rate limit will resume and file more findings, so the
+// cohort has not drained and the pass must not fire against a half-filled
+// working set.
+func TestAutoEnqueueFindingDedup_pausedSiblingIsOutstanding(t *testing.T) {
+	s, done, repoID, dedupID := dedupTestSetup(t)
+	defer done()
+
+	const group = "batch-1"
+	first := newGroupScan(t, s, repoID, group, `{"name":"auth"}`, db.ScanDone)
+	newFindingUnder(t, s, repoID, first.ID, db.FindingNew)
+	second := newGroupScan(t, s, repoID, group, `{"name":"ssrf"}`, db.ScanDone)
+	newFindingUnder(t, s, repoID, second.ID, db.FindingNew)
+	newGroupScan(t, s, repoID, group, `{"name":"deser"}`, db.ScanPaused)
+
+	s.autoEnqueueFindingDedup(first)
+	s.autoEnqueueFindingDedup(second)
+	if n := dedupQueued(s, repoID, dedupID); n != 0 {
+		t.Errorf("queued = %d, want 0 while a sibling is paused on a rate limit", n)
+	}
+}
+
+// A cohort that produced no new findings at all still gets no pass: the batch
+// gate widens which scan may trigger the work, not whether there is any.
+func TestAutoEnqueueFindingDedup_emptyBatchEnqueuesNothing(t *testing.T) {
+	s, done, repoID, dedupID := dedupTestSetup(t)
+	defer done()
+
+	const group = "batch-1"
+	prior := newScan(t, s, repoID, "security-deep-dive")
+	newFindingUnder(t, s, repoID, prior.ID, db.FindingNew)
+	newFindingUnder(t, s, repoID, prior.ID, db.FindingNew)
+
+	first := newGroupScan(t, s, repoID, group, `{"name":"auth"}`, db.ScanDone)
+	last := newGroupScan(t, s, repoID, group, `{"name":"ssrf"}`, db.ScanDone)
+	s.autoEnqueueFindingDedup(first)
+	s.autoEnqueueFindingDedup(last)
+
+	if n := dedupQueued(s, repoID, dedupID); n != 0 {
+		t.Errorf("queued = %d, want 0: the batch found nothing new", n)
 	}
 }
 

--- a/internal/web/revalidate_enqueue.go
+++ b/internal/web/revalidate_enqueue.go
@@ -73,14 +73,15 @@ func (s *Server) hasOpenFindingScopedScan(findingID, skillID uint) bool {
 	return s.hasOpenScan("finding_id = ? AND skill_id = ?", findingID, skillID)
 }
 
-// hasOpenScan reports whether a queued or running scan matching the given
-// scope predicate already exists. Shared by the finding-scoped and
-// repo-scoped open-scan guards so the "open" definition (queued or running)
-// lives in one place.
+// hasOpenScan reports whether an in-flight scan matching the given scope
+// predicate already exists. Shared by the finding-scoped, repo-scoped and
+// batch-cohort guards so the "open" definition lives in one place, and it is
+// inFlightScanStatuses(): a paused scan has not finished and will resume, so
+// every one of these guards wants to treat it as still open.
 func (s *Server) hasOpenScan(scope string, args ...any) bool {
 	var n int64
 	if err := s.DB.Model(&db.Scan{}).
-		Where("status IN ?", []db.ScanStatus{db.ScanQueued, db.ScanRunning}).
+		Where("status IN ?", inFlightScanStatuses()).
 		Where(scope, args...).
 		Count(&n).Error; err != nil {
 		return false

--- a/internal/web/scans.go
+++ b/internal/web/scans.go
@@ -742,7 +742,58 @@ func (s *Server) cancelScan(scan *db.Scan, reason string) (flippedQueued bool) {
 			errorKey:          reason,
 			"finished_at":     &now,
 		})
+	if res.RowsAffected > 0 {
+		s.settleCancelledScanGroups(scan.ID)
+	}
 	return res.RowsAffected > 0
+}
+
+// settleCancelledScanGroups fires the worker's cohort-settled hook for scans
+// this package flipped straight to a terminal state. A queued scan is not in
+// flight, so cancelling it never reaches Worker.finalizeScan and the hook that
+// tells a batch it has drained would never fire: a cohort whose last
+// outstanding sibling is cancelled this way leaves every earlier sibling
+// already suppressed on its account and nothing left to trigger the work.
+//
+// Only rows this call actually flipped are settled — the status is re-read
+// rather than assumed, so a scan the worker claimed between the caller's read
+// and its write is left to the worker. One member per scan_group is enough:
+// the handler answers for the whole cohort, not for the sibling that happened
+// to arrive last.
+func (s *Server) settleCancelledScanGroups(ids ...uint) {
+	if len(ids) == 0 || s.Worker == nil {
+		return
+	}
+	var settled []db.Scan
+	if err := s.DB.
+		Where("id IN ? AND status = ? AND scan_group <> ''", ids, db.ScanCancelled).
+		Find(&settled).Error; err != nil {
+		s.Log.Warn("settle cancelled scan groups", "err", err)
+		return
+	}
+	seen := make(map[string]bool, len(settled))
+	for i := range settled {
+		if seen[settled[i].ScanGroup] {
+			continue
+		}
+		seen[settled[i].ScanGroup] = true
+		s.Worker.SettleScanGroup(&settled[i])
+	}
+}
+
+// groupedScanIDs returns the ids of the scans matching a condition that were
+// launched as part of a batch. Ungrouped scans are dropped here rather than
+// downstream so a bulk cancel of ordinary scans costs no extra work.
+func (s *Server) groupedScanIDs(query string, args ...any) []uint {
+	var ids []uint
+	if err := s.DB.Model(&db.Scan{}).
+		Where(query, args...).
+		Where("scan_group <> ''").
+		Pluck("id", &ids).Error; err != nil {
+		s.Log.Warn("collect grouped scan ids", "err", err)
+		return nil
+	}
+	return ids
 }
 
 // scansCancelAll cancels every queued or running scan on a repository — the
@@ -755,6 +806,10 @@ func (s *Server) scansCancelAll(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	now := time.Now()
+	// Read the batched queued rows before the bulk flip: afterwards their
+	// status no longer identifies them, and they are the ones whose cohort has
+	// to be told the sibling is gone.
+	grouped := s.groupedScanIDs("repository_id = ? AND status = ?", repoID, db.ScanQueued)
 	queued := s.DB.Model(&db.Scan{}).
 		Where("repository_id = ? AND status = ?", repoID, db.ScanQueued).
 		Updates(scanStatusUpdates(db.ScanCancelled, worker.CancelledByUser, &now, nil))
@@ -762,6 +817,7 @@ func (s *Server) scansCancelAll(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, queued.Error.Error(), http.StatusInternalServerError)
 		return
 	}
+	s.settleCancelledScanGroups(grouped...)
 	var scans []db.Scan
 	if err := s.DB.Where("repository_id = ? AND status IN ?",
 		repoID, []db.ScanStatus{db.ScanRunning}).Find(&scans).Error; err != nil {

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -444,6 +444,11 @@ func New(gdb *gorm.DB, q *queue.Queue, log *slog.Logger, broker *Broker, w *work
 		w.OnFindingCreated = s.autoEnqueueRevalidate
 		w.OnRevalidateVerdict = s.autoChainVerifyAfterRevalidate
 		w.OnScanFinalized = s.onScanFinalized
+		// Only the dedup pass, not the whole onScanFinalized fan-out: a scan
+		// that timed out or was cancelled has no committed analysis to update
+		// a threat model or seed a config from. Dedup is the one consumer
+		// that cares purely about the cohort having drained.
+		w.OnScanGroupSettled = s.autoEnqueueFindingDedup
 		w.OnScanFailed = s.autoEnqueueFocusAreaDeepDives
 		if w.Runner != nil {
 			s.chatRunner = &worker.ChatRunner{Runner: w.Runner, DB: gdb, DataDir: w.DataDir, PrepareSrc: w.PrepareSrc}
@@ -1473,9 +1478,14 @@ func findingsScanIDs(gdb *gorm.DB) *gorm.DB {
 // Unlike findingsBucketSkillSQL this deliberately excludes legacy empty/NULL
 // skill_name rows and imports: those are inert, not a live scan that just
 // produced new findings worth triaging.
+// llmAuditSkillNames are the curated model-driven audits: the skills whose
+// findings are a repository's working set rather than scanner output.
+func llmAuditSkillNames() []string {
+	return []string{deepDiveSkillName, vulnScanSkillName, advisoryDeepDiveSkillName}
+}
+
 func isLLMAuditSkill(skillName string) bool {
-	return skillName == deepDiveSkillName || skillName == vulnScanSkillName ||
-		skillName == advisoryDeepDiveSkillName
+	return slices.Contains(llmAuditSkillNames(), skillName)
 }
 
 func findingSupportsExposure(scan db.Scan) bool {

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -98,6 +98,15 @@ type Worker struct {
 	// dedup run sees the full finding set, and the worker has no queue access
 	// of its own so this callback is the seam.
 	OnScanFinalized func(scan *db.Scan)
+	// OnScanGroupSettled, when non-nil, is called for a scan launched as part
+	// of a batch (non-empty ScanGroup) that reached a terminal state without
+	// OnScanFinalized firing — a timeout, a cancel or a runner error. It
+	// exists so a consumer that waits for a whole cohort to drain still hears
+	// about the siblings that produced nothing: the last scan home decides
+	// for the batch, and which one that is has nothing to do with whether it
+	// succeeded. Exactly one of OnScanFinalized and OnScanGroupSettled fires
+	// per scan, so a consumer wired to both is not called twice.
+	OnScanGroupSettled func(scan *db.Scan)
 	// OnScanFailed, when non-nil, is called after a terminal failed scan has
 	// been persisted. Unlike OnScanFinalized it covers runner errors and
 	// timeouts, which do not have a committed analysis result.
@@ -829,7 +838,9 @@ func (w *Worker) finalizeScan(ctx context.Context, scan *db.Scan, report string,
 	} else if saveErr := w.DB.Save(scan).Error; saveErr != nil {
 		return saveErr
 	}
-	w.maybeFireScanFinalized(scan, err)
+	if !w.maybeFireScanFinalized(scan, err) {
+		w.maybeFireScanGroupSettled(scan)
+	}
 	w.maybeFireScanFailed(scan)
 	if accErr, isAccountErr := errors.AsType[*AccountError](err); isAccountErr && scan.Status == db.ScanPaused {
 		w.pauseQueuedOnAccountError(scan.ID)
@@ -887,18 +898,37 @@ func (w *Worker) resolveAccountReset(accErr *AccountError, emit func(Event)) *ti
 }
 
 // maybeFireScanFinalized invokes the OnScanFinalized hook once a scan has
-// finished its analysis with findings committed. A fail_on threshold leaves
-// Status=ScanFailed but the findings are already persisted (see
-// finishErroredScan), so a deep-dive that trips fail_on must still trigger
-// downstream dedup — exactly the high-severity case we most want deduped.
-func (w *Worker) maybeFireScanFinalized(scan *db.Scan, runErr error) {
-	if w.OnScanFinalized == nil {
-		return
-	}
+// finished its analysis with findings committed, and reports whether the scan
+// reached that state. A fail_on threshold leaves Status=ScanFailed but the
+// findings are already persisted (see finishErroredScan), so a deep-dive that
+// trips fail_on must still trigger downstream dedup — exactly the
+// high-severity case we most want deduped.
+//
+// The return value is about the scan, not about the hook: it says the scan
+// finalized, whether or not a hook was installed to hear it. That keeps
+// maybeFireScanGroupSettled the exact complement of this call.
+func (w *Worker) maybeFireScanFinalized(scan *db.Scan, runErr error) bool {
 	_, failOnThreshold := errors.AsType[*FailOnThresholdError](runErr)
-	if scan.Status == db.ScanDone || failOnThreshold {
+	if scan.Status != db.ScanDone && !failOnThreshold {
+		return false
+	}
+	if w.OnScanFinalized != nil {
 		w.OnScanFinalized(scan)
 	}
+	return true
+}
+
+// maybeFireScanGroupSettled invokes the OnScanGroupSettled hook for a batched
+// scan that reached a terminal state the finalized hook does not cover: a
+// timeout, a cancel or a runner error. A consumer waiting for the cohort to
+// drain has to hear these. Without it, the batch whose last sibling fails
+// leaves every earlier sibling already suppressed on its account and nothing
+// left to re-trigger the work — the cohort silently gets no pass at all.
+func (w *Worker) maybeFireScanGroupSettled(scan *db.Scan) {
+	if w.OnScanGroupSettled == nil || scan.ScanGroup == "" || !scan.Status.Terminal() {
+		return
+	}
+	w.OnScanGroupSettled(scan)
 }
 
 func (w *Worker) maybeFireScanFailed(scan *db.Scan) {

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -931,6 +931,19 @@ func (w *Worker) maybeFireScanGroupSettled(scan *db.Scan) {
 	w.OnScanGroupSettled(scan)
 }
 
+// SettleScanGroup reports a scan that reached a terminal state without
+// passing through finalizeScan, so the cohort hook still fires. Cancellation
+// from the web layer flips a queued row in place (scanCancel, scansCancelAll,
+// federation opt-out) — the worker never sees it, so a batch whose last
+// outstanding sibling is cancelled that way would leave every earlier sibling
+// already suppressed and nothing left to trigger the pass.
+//
+// The hook's own preconditions still apply, so a caller may hand over any
+// terminal scan without checking whether it was grouped.
+func (w *Worker) SettleScanGroup(scan *db.Scan) {
+	w.maybeFireScanGroupSettled(scan)
+}
+
 func (w *Worker) maybeFireScanFailed(scan *db.Scan) {
 	if w.OnScanFailed != nil && scan.Status == db.ScanFailed {
 		w.OnScanFailed(scan)

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -34,6 +34,55 @@ func TestMaybeFireScanFailed(t *testing.T) {
 	}
 }
 
+// Exactly one of the two hooks fires per scan. A batched scan that ends in a
+// state the finalized hook does not cover still has to reach a consumer
+// waiting for its cohort to drain, and one that does finalize must not be
+// announced twice.
+func TestMaybeFireScanFinalizedAndGroupSettled(t *testing.T) {
+	failOn := &FailOnThresholdError{}
+	cases := []struct {
+		name     string
+		scan     db.Scan
+		runErr   error
+		finalize bool
+		settle   bool
+	}{
+		{name: "done ungrouped", scan: db.Scan{Status: db.ScanDone}, finalize: true},
+		{name: "done batched", scan: db.Scan{Status: db.ScanDone, ScanGroup: "g"}, finalize: true},
+		{name: "fail_on batched", scan: db.Scan{Status: db.ScanFailed, ScanGroup: "g"}, runErr: failOn, finalize: true},
+		{name: "failed batched", scan: db.Scan{Status: db.ScanFailed, ScanGroup: "g"}, settle: true},
+		{name: "cancelled batched", scan: db.Scan{Status: db.ScanCancelled, ScanGroup: "g"}, settle: true},
+		{name: "failed ungrouped", scan: db.Scan{Status: db.ScanFailed}},
+		{name: "paused batched", scan: db.Scan{Status: db.ScanPaused, ScanGroup: "g"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var finalized, settled int
+			w := &Worker{
+				OnScanFinalized:    func(*db.Scan) { finalized++ },
+				OnScanGroupSettled: func(*db.Scan) { settled++ },
+			}
+			scan := tc.scan
+			if !w.maybeFireScanFinalized(&scan, tc.runErr) {
+				w.maybeFireScanGroupSettled(&scan)
+			}
+			if want := btoi(tc.finalize); finalized != want {
+				t.Errorf("finalized = %d, want %d", finalized, want)
+			}
+			if want := btoi(tc.settle); settled != want {
+				t.Errorf("settled = %d, want %d", settled, want)
+			}
+		})
+	}
+}
+
+func btoi(b bool) int {
+	if b {
+		return 1
+	}
+	return 0
+}
+
 func TestMigrateLegacyState_renamesStateDir(t *testing.T) {
 	dataDir := t.TempDir()
 	oldDir := filepath.Join(dataDir, legacyHarnessStateDirName, "scan-7")


### PR DESCRIPTION
Closes #836.

`autoEnqueueFindingDedup` fires on every focus-area deep dive's completion. The in-flight guard in `enqueueRepoScopedSkillIfIdle` (`internal/web/server.go:3172`) only suppresses while a dedup is *queued or running*, so the moment one completes between two sibling completions the gate reopens and the next sibling enqueues another pass.

@connorshea's asymmetry follows from that: collapsing to a single pass is incidental, not designed — it holds only while the dedup is still sitting behind the batch in the queue, so it depends on worker saturation rather than on the batch being finished.

Gated on the cohort instead: skip while any other scan in the same `ScanGroup` is queued or running, so the last sibling home enqueues exactly one pass. The finalizing scan is excluded by id because its own terminal status may not be committed when the hook runs. Ungrouped scans are unchanged.

`internal/web` green (145.7s); the new batch test fails on main.
