### PR TITLE
Fix duplicate finding references

### DIFF
--- a/internal/db/finding_helpers.go
+++ b/internal/db/finding_helpers.go
@@ -528,12 +528,30 @@ func AddFindingReference(gdb *gorm.DB, findingID uint, url, tags, summary string
 	r := &FindingReference{
 		FindingID: findingID,
 		URL:       url,
-		Tags:      tags,
-		Summary:   summary,
-		CreatedAt: time.Now(),
 	}
-	if err := gdb.Create(r).Error; err != nil {
+	if err := gdb.Where("finding_id = ? AND url = ?", findingID, url).
+		Attrs(FindingReference{Tags: tags, Summary: summary, CreatedAt: time.Now()}).
+		FirstOrCreate(r).Error; err != nil {
 		return nil, err
+	}
+	updates := map[string]any{}
+	if strings.TrimSpace(tags) != "" && tags != r.Tags {
+		updates["tags"] = tags
+	}
+	if strings.TrimSpace(summary) != "" && summary != r.Summary {
+		updates["summary"] = summary
+	}
+	if len(updates) == 0 {
+		return r, nil
+	}
+	if err := gdb.Model(r).Updates(updates).Error; err != nil {
+		return nil, err
+	}
+	if tags, ok := updates["tags"].(string); ok {
+		r.Tags = tags
+	}
+	if summary, ok := updates["summary"].(string); ok {
+		r.Summary = summary
 	}
 	return r, nil
 }

--- a/internal/db/finding_helpers.go
+++ b/internal/db/finding_helpers.go
@@ -522,7 +522,10 @@ func AddFindingCommunication(gdb *gorm.DB, findingID uint, channel, direction, a
 
 // AddFindingReference records an external URL related to the finding.
 func AddFindingReference(gdb *gorm.DB, findingID uint, url, tags, summary string) (*FindingReference, error) {
-	if strings.TrimSpace(url) == "" {
+	url = strings.TrimSpace(url)
+	tags = strings.TrimSpace(tags)
+	summary = strings.TrimSpace(summary)
+	if url == "" {
 		return nil, fmt.Errorf("reference url is empty")
 	}
 	r := &FindingReference{
@@ -535,10 +538,10 @@ func AddFindingReference(gdb *gorm.DB, findingID uint, url, tags, summary string
 		return nil, err
 	}
 	updates := map[string]any{}
-	if strings.TrimSpace(tags) != "" && tags != r.Tags {
+	if tags != "" && tags != r.Tags {
 		updates["tags"] = tags
 	}
-	if strings.TrimSpace(summary) != "" && summary != r.Summary {
+	if summary != "" && summary != r.Summary {
 		updates["summary"] = summary
 	}
 	if len(updates) == 0 {

--- a/internal/db/finding_helpers.go
+++ b/internal/db/finding_helpers.go
@@ -540,21 +540,17 @@ func AddFindingReference(gdb *gorm.DB, findingID uint, url, tags, summary string
 	updates := map[string]any{}
 	if tags != "" && tags != r.Tags {
 		updates["tags"] = tags
+		r.Tags = tags
 	}
 	if summary != "" && summary != r.Summary {
 		updates["summary"] = summary
+		r.Summary = summary
 	}
 	if len(updates) == 0 {
 		return r, nil
 	}
 	if err := gdb.Model(r).Updates(updates).Error; err != nil {
 		return nil, err
-	}
-	if tags, ok := updates["tags"].(string); ok {
-		r.Tags = tags
-	}
-	if summary, ok := updates["summary"].(string); ok {
-		r.Summary = summary
 	}
 	return r, nil
 }

--- a/internal/db/finding_helpers_test.go
+++ b/internal/db/finding_helpers_test.go
@@ -749,6 +749,25 @@ func TestAddFindingReference(t *testing.T) {
 	if ref.ID == 0 || ref.URL != "https://example.com/advisory" || ref.Tags != "advisory,upstream" {
 		t.Errorf("reference = %+v", ref)
 	}
+	if ref.Summary != "Upstream advisory" {
+		t.Errorf("reference summary = %q, want initial summary", ref.Summary)
+	}
+
+	unchanged, err := AddFindingReference(gdb, f.ID, ref.URL, "", "")
+	if err != nil {
+		t.Fatalf("AddFindingReference unchanged: %v", err)
+	}
+	if unchanged.ID != ref.ID || unchanged.Tags != ref.Tags || unchanged.Summary != ref.Summary {
+		t.Errorf("unchanged reference = %+v, want %+v", unchanged, ref)
+	}
+
+	updated, err := AddFindingReference(gdb, f.ID, ref.URL, "advisory,patch", "Patch proposal")
+	if err != nil {
+		t.Fatalf("AddFindingReference update: %v", err)
+	}
+	if updated.ID != ref.ID || updated.Tags != "advisory,patch" || updated.Summary != "Patch proposal" {
+		t.Errorf("updated reference = %+v", updated)
+	}
 
 	if _, err := AddFindingReference(gdb, f.ID, "   ", "", ""); err == nil {
 		t.Error("empty URL should error")
@@ -757,7 +776,7 @@ func TestAddFindingReference(t *testing.T) {
 	var n int64
 	gdb.Model(&FindingReference{}).Where("finding_id = ?", f.ID).Count(&n)
 	if n != 1 {
-		t.Errorf("reference count = %d, want 1 (empty rejected)", n)
+		t.Errorf("reference count = %d, want 1 (duplicates merged; empty rejected)", n)
 	}
 }
 

--- a/internal/db/finding_helpers_test.go
+++ b/internal/db/finding_helpers_test.go
@@ -753,7 +753,7 @@ func TestAddFindingReference(t *testing.T) {
 		t.Errorf("reference summary = %q, want initial summary", ref.Summary)
 	}
 
-	unchanged, err := AddFindingReference(gdb, f.ID, ref.URL, "", "")
+	unchanged, err := AddFindingReference(gdb, f.ID, "  "+ref.URL+"  ", "   ", "   ")
 	if err != nil {
 		t.Fatalf("AddFindingReference unchanged: %v", err)
 	}
@@ -761,7 +761,7 @@ func TestAddFindingReference(t *testing.T) {
 		t.Errorf("unchanged reference = %+v, want %+v", unchanged, ref)
 	}
 
-	updated, err := AddFindingReference(gdb, f.ID, ref.URL, "advisory,patch", "Patch proposal")
+	updated, err := AddFindingReference(gdb, f.ID, ref.URL, " advisory,patch ", " Patch proposal ")
 	if err != nil {
 		t.Fatalf("AddFindingReference update: %v", err)
 	}

--- a/internal/worker/skill.go
+++ b/internal/worker/skill.go
@@ -719,27 +719,11 @@ func (w *Worker) reobserveFinding(existing, f *db.Finding, scan *db.Scan) error 
 	return nil
 }
 
-// upsertFindingReferences inserts any reference URLs not already on the
-// finding. Used in the dedup branch so a re-observed finding picks up new
-// or migration-added references without duplicating ones already present.
+// upsertFindingReferences records skill-emitted references on a re-observed
+// finding. AddFindingReference keeps each URL idempotent and enriches any
+// existing row with non-empty metadata from the new report.
 func (w *Worker) upsertFindingReferences(findingID uint, refs []db.FindingReference) error {
-	if len(refs) == 0 {
-		return nil
-	}
-	var existingURLs []string
-	if err := w.DB.Model(&db.FindingReference{}).
-		Where("finding_id = ?", findingID).
-		Pluck("url", &existingURLs).Error; err != nil {
-		return err
-	}
-	have := make(map[string]bool, len(existingURLs))
-	for _, u := range existingURLs {
-		have[u] = true
-	}
 	for _, r := range refs {
-		if have[r.URL] {
-			continue
-		}
 		if _, err := db.AddFindingReference(w.DB, findingID, r.URL, r.Tags, r.Summary); err != nil {
 			return err
 		}


### PR DESCRIPTION
Fixes #519

## Summary

Makes finding-reference writes idempotent per finding URL, preventing duplicate references from the API, browser form, release-watch and repeated skill ingestion.

## Changes

- Change `AddFindingReference` to reuse an existing `(finding_id, url)` row.
- Preserve existing tags and summary when a repeated write provides empty values.
- Refresh tags and summary when a repeated write provides non-empty metadata.
- Remove the worker-only reference pre-read/deduplication path and reuse the shared database helper.
- Add coverage for repeated writes, metadata preservation and metadata refreshes.

This intentionally does not add a composite unique index yet: existing installations may already contain duplicate rows, so that migration needs a cleanup strategy first.

## Tests

- `go test ./...`
- `go test -race ./internal/db ./internal/worker`
- `go vet ./...`
- `go vet -tags evals ./...`
- `go vet -tags podman ./...`
- `go mod tidy -diff`
- `golangci-lint run`
- `golangci-lint run --build-tags evals`
- `git diff --check`