### PR TITLE
fix(worker): don't hand the API validation route to a skill with no shell

### DIFF
--- a/internal/skills/parse_test.go
+++ b/internal/skills/parse_test.go
@@ -963,7 +963,7 @@ func TestBundledReconPipelineMetadata(t *testing.T) {
 	if err != nil {
 		t.Fatalf("parse recon: %v", err)
 	}
-	if recon.OutputKind != "freeform" || recon.MaxTurns != 12 || recon.Model != "mid" {
+	if recon.OutputKind != "freeform" || recon.MaxTurns != 30 || recon.Model != "mid" {
 		t.Errorf("recon metadata = kind %q, turns %d, model %q", recon.OutputKind, recon.MaxTurns, recon.Model)
 	}
 	if !strings.Contains(recon.AllowedTools, "Write") || !strings.Contains(recon.AllowedTools, "Grep") {

--- a/internal/worker/claude.go
+++ b/internal/worker/claude.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"syscall"
 
 	"github.com/alpha-omega-security/harness"
@@ -138,7 +139,7 @@ func (sj SkillJob) toJob(effort string, maxTurns int, baseURL string) harness.Jo
 		Effort:          effectiveEffort(sj.Effort, effort),
 		MaxTurns:        effectiveMaxTurns(sj.MaxTurns, maxTurns),
 		OutputFile:      sj.OutputFile,
-		ValidationHint:  scrutineerValidationHint(sj.OutputFile),
+		ValidationHint:  scrutineerValidationHint(sj.OutputFile, sj.AllowedTools),
 		AllowedTools:    sj.AllowedTools,
 		BaseURL:         baseURL,
 		ResumeSessionID: sj.ResumeSessionID,
@@ -354,6 +355,24 @@ func effectiveEffort(perScan, runnerDefault string) string {
 	return runnerDefault
 }
 
+// toolsAllowShell reports whether a skill's allowed-tools list lets the agent
+// run shell commands, which is what the API validation route needs. An empty
+// list is the unrestricted case (see Job.AllowedTools), so it allows Bash.
+// Entries may carry a scope qualifier ("Bash(git:*)"), so only the tool name
+// in front of the parenthesis is compared.
+func toolsAllowShell(allowedTools string) bool {
+	if strings.TrimSpace(allowedTools) == "" {
+		return true
+	}
+	for _, tool := range strings.Split(allowedTools, ",") {
+		name, _, _ := strings.Cut(tool, "(")
+		if strings.EqualFold(strings.TrimSpace(name), "Bash") {
+			return true
+		}
+	}
+	return false
+}
+
 // scrutineerValidationHint is the ValidationHint scrutineer supplies on every
 // harness.Job so the agent validates its JSON output via scrutineer's API
 // instead of installing a JSON Schema library inside the runner container.
@@ -362,9 +381,19 @@ func effectiveEffort(perScan, runnerDefault string) string {
 // the endpoint reuses scrutineer's own validator, so a pass here means the
 // post-scan check will also pass. The harness module appends this after the
 // OutputFile clause when OutputFile ends in .json.
-func scrutineerValidationHint(outputFile string) string {
+//
+// The POST route needs Bash, so a skill whose allowed-tools omits it gets the
+// read-based wording instead (#834): recon was told to POST on every run and
+// burned its turn budget failing to. Returning "" for those skills is not an
+// option -- the harness substitutes its own generic "Validate ./x against
+// ./schema.json before finishing" for an empty hint on any .json output, which
+// is the same unexecutable instruction minus the don't-install guard.
+func scrutineerValidationHint(outputFile, allowedTools string) string {
 	if outputFile == "" {
 		return ""
+	}
+	if !toolsAllowShell(allowedTools) {
+		return fmt.Sprintf("To check ./%s against ./schema.json, read both files and compare them yourself; your tool set has no shell, so don't install a schema validator.", outputFile)
 	}
 	return fmt.Sprintf("To check ./%s against ./schema.json, POST it to {scrutineer.api_base}/scans/{scrutineer.scan_id}/validate-report (header \"Authorization: Bearer {scrutineer.token}\", values in ./context.json); {\"valid\":true} means it conforms. Don't install a schema validator.", outputFile)
 }
@@ -381,7 +410,7 @@ func buildLoggedPrompt(skill *db.Skill, backend string) string {
 	prompt := h.Prompt(harness.Job{
 		SkillName:      skill.Name,
 		OutputFile:     skill.OutputFile,
-		ValidationHint: scrutineerValidationHint(skill.OutputFile),
+		ValidationHint: scrutineerValidationHint(skill.OutputFile, skill.AllowedTools),
 	})
 	return prompt +
 		"\n\n--- SKILL.md ---\n\n" + renderSkillMD(skill)

--- a/internal/worker/harness_test.go
+++ b/internal/worker/harness_test.go
@@ -269,14 +269,78 @@ func TestInjectProfileGuide_noopWithoutProfile(t *testing.T) {
 // TestScrutineerValidationHint pins the exact API-endpoint text so a
 // wording change is deliberate.
 func TestScrutineerValidationHint(t *testing.T) {
-	got := scrutineerValidationHint("report.json")
+	got := scrutineerValidationHint("report.json", "")
 	if !strings.Contains(got, "{scrutineer.api_base}/scans/{scrutineer.scan_id}/validate-report") {
 		t.Errorf("hint missing endpoint: %q", got)
 	}
 	if !strings.Contains(got, "Don't install a schema validator") {
 		t.Errorf("hint missing no-install instruction: %q", got)
 	}
-	if scrutineerValidationHint("") != "" {
+	if scrutineerValidationHint("", "") != "" {
 		t.Error("empty output file should give empty hint")
+	}
+}
+
+// TestScrutineerValidationHintWithoutShell covers #834: recon declares
+// allowed-tools without Bash, so the POST route it was being handed is
+// unexecutable and it burned its turn budget failing at it. The hint must stay
+// NON-EMPTY -- an empty ValidationHint makes the harness module substitute its
+// own generic "Validate ./report.json against ./schema.json before finishing"
+// for any .json output, which is the same impossible instruction with the
+// don't-install guard dropped.
+func TestScrutineerValidationHintWithoutShell(t *testing.T) {
+	got := scrutineerValidationHint("report.json", "Read,Write,Grep,Glob")
+	if got == "" {
+		t.Fatal("empty hint lets the harness substitute its generic one")
+	}
+	if strings.Contains(got, "POST") || strings.Contains(got, "validate-report") {
+		t.Errorf("shell-less skill still told to POST: %q", got)
+	}
+	if !strings.Contains(got, "schema.json") {
+		t.Errorf("hint should still name the schema: %q", got)
+	}
+	if !strings.Contains(got, "don't install a schema validator") {
+		t.Errorf("hint missing no-install instruction: %q", got)
+	}
+}
+
+func TestToolsAllowShell(t *testing.T) {
+	cases := []struct {
+		tools string
+		want  bool
+	}{
+		{"", true},                          // unrestricted
+		{"   ", true},                       // unrestricted
+		{"Read,Write,Bash,Grep,Glob", true}, // every bundled skill but recon
+		{"Read,Write,Grep,Glob", false},     // recon
+		{" read , bash ", true},             // spacing and case
+		{"Read,Bash(git:*)", true},          // scoped entry
+		{"Read,BashOutput", false},          // prefix must not match
+	}
+	for _, tc := range cases {
+		if got := toolsAllowShell(tc.tools); got != tc.want {
+			t.Errorf("toolsAllowShell(%q) = %v, want %v", tc.tools, got, tc.want)
+		}
+	}
+}
+
+// TestSkillJobPromptHonoursToolSet is the wiring half: the two tests above
+// exercise the helper directly and so cannot catch a call site that never
+// passes AllowedTools through. This one goes SkillJob -> toJob -> the real
+// harness prompt, which is the path the agent actually receives.
+func TestSkillJobPromptHonoursToolSet(t *testing.T) {
+	recon := SkillJob{Name: "recon", OutputFile: "report.json", AllowedTools: "Read,Write,Grep,Glob"}
+	prompt := ClaudeHarness{}.Prompt(recon.toJob("", 0, ""))
+	if strings.Contains(prompt, "validate-report") {
+		t.Errorf("recon prompt still carries the POST route:\n%s", prompt)
+	}
+	if strings.Contains(prompt, "Validate ./report.json against ./schema.json before finishing") {
+		t.Errorf("recon prompt fell back to the harness generic hint:\n%s", prompt)
+	}
+
+	audit := SkillJob{Name: "audit-authz", OutputFile: "report.json", AllowedTools: "Read,Write,Bash,Grep,Glob"}
+	auditPrompt := ClaudeHarness{}.Prompt(audit.toJob("", 0, ""))
+	if !strings.Contains(auditPrompt, "validate-report") {
+		t.Errorf("shell-capable skill lost the API route:\n%s", auditPrompt)
 	}
 }

--- a/skills/recon/SKILL.md
+++ b/skills/recon/SKILL.md
@@ -8,7 +8,7 @@ metadata:
   scrutineer.version: 1
   scrutineer.output_file: report.json
   scrutineer.output_kind: freeform
-  scrutineer.max_turns: 12
+  scrutineer.max_turns: 30
   scrutineer.model: mid
 ---
 


### PR DESCRIPTION
Closes #834.

`scrutineerValidationHint` (`internal/worker/claude.go:365`) emitted the POST-to-`validate-report` instruction for any job with a non-empty `OutputFile` and never consulted the tool set. `recon` is the only bundled skill whose `allowed-tools` omits `Bash` (`skills/recon/SKILL.md:6`), so it was told on every run to make a request it cannot make, and burned turns failing at it. `toJob` already carries both inputs on adjacent lines (`claude.go:141-142`), so the gate is local.

**Why the hint is replaced rather than dropped.** An empty `ValidationHint` does not silence anything — `schemaValidationHint` (harness v0.1.6 `prompt.go:92`) substitutes its own generic `Validate ./report.json against ./schema.json before finishing.` for any `.json` output. That is the same unexecutable instruction with the `Don't install a schema validator` guard removed, i.e. strictly worse for recon. A shell-less skill now gets read-based wording its `Read` grant can actually carry out.

**Turn limit.** Per your comment, `scrutineer.max_turns: 12` → `30`. The 12 was the only per-skill cap below `DefaultSkillMaxTurns` (`claude.go:20`, also 30), and 30 is the value @connorshea reported working. Say the word and I'll split it into its own PR if you'd rather take the hint fix alone.

**Tests.** `TestSkillJobPromptHonoursToolSet` goes `SkillJob` → `toJob` → the real harness prompt instead of calling the helper: a helper-level test is structurally blind to a call site that never passes `AllowedTools`. Reverting only the `claude.go:141` argument leaves the helper tests green and turns that one red, printing the exact prompt from the issue body.

`internal/worker` and `internal/skills` green locally.
