### PR TITLE
fix(worker): check the unhandled DB writes in the maintainer and skill-metadata paths

### DIFF
--- a/internal/worker/exposure.go
+++ b/internal/worker/exposure.go
@@ -137,10 +137,15 @@ func (w *Worker) doExposure(ctx context.Context, scan *db.Scan, emit func(Event)
 	}
 	scan.SkillName = skill.Name
 	scan.SkillVersion = skill.Version
-	w.DB.Model(scan).Updates(map[string]any{
+	// Non-fatal: the in-memory scan already carries both fields and finalizeScan
+	// saves the whole row at the end, so a failure here only leaves the columns
+	// stale for readers watching the table while the scan runs.
+	if err := w.DB.Model(scan).Updates(map[string]any{
 		"skill_name":    skill.Name,
 		"skill_version": skill.Version,
-	})
+	}).Error; err != nil {
+		w.Log.Warn("update scan skill metadata", "scan", scan.ID, "skill", skill.Name, "err", err)
+	}
 
 	workRoot := w.scanWorkRoot(scan)
 	if err := validateSkillPaths(skill.Name, skill.OutputFile); err != nil {

--- a/internal/worker/skill.go
+++ b/internal/worker/skill.go
@@ -933,20 +933,44 @@ func (w *Worker) markRetracted(scan *db.Scan, seen map[string]bool) int {
 	return retracted
 }
 
+// reportedMaintainer is one entry of a maintainers skill report.
+type reportedMaintainer struct {
+	Login    string `json:"login"`
+	Name     string `json:"name"`
+	Email    string `json:"email"`
+	Role     string `json:"role"`
+	Status   string `json:"status"`
+	Evidence string `json:"evidence"`
+}
+
+// applyTo copies the fields this report entry refreshes onto the stored row.
+// An absent or unrecognised field leaves the stored value alone, so a partial
+// report never blanks what an earlier scan established.
+func (rm reportedMaintainer) applyTo(m *db.Maintainer) {
+	if rm.Name != "" {
+		m.Name = rm.Name
+	}
+	if validEmail(rm.Email) {
+		m.Email = rm.Email
+	}
+	switch rm.Status {
+	case "active":
+		m.Status = db.MaintainerActive
+	case "inactive":
+		m.Status = db.MaintainerInactive
+	}
+	if rm.Evidence != "" {
+		m.Notes = rm.Role + ": " + rm.Evidence
+	}
+}
+
 // parseMaintainersOutput upserts Maintainer rows and links them to the
 // scanned repo. Mirrors the legacy doMaintainerAnalysis logic so the
 // maintainers skill and the old Go handler stay interchangeable.
 func (w *Worker) parseMaintainersOutput(scan *db.Scan, report string, emit func(Event)) error {
 	var result struct {
-		Maintainers []struct {
-			Login    string `json:"login"`
-			Name     string `json:"name"`
-			Email    string `json:"email"`
-			Role     string `json:"role"`
-			Status   string `json:"status"`
-			Evidence string `json:"evidence"`
-		} `json:"maintainers"`
-		DisclosureChannel string `json:"disclosure_channel"`
+		Maintainers       []reportedMaintainer `json:"maintainers"`
+		DisclosureChannel string               `json:"disclosure_channel"`
 		// Subprojects optionally carries a per-sub-package disclosure channel
 		// for a monorepo, so a report against one gem in rails/rails routes to
 		// that gem's maintainers rather than the repo-wide channel. Additive:
@@ -1007,21 +1031,7 @@ func (w *Worker) parseMaintainersOutput(scan *db.Scan, report string, emit func(
 			w.Log.Warn("upsert maintainer", "scan", scan.ID, "login", rm.Login, "err", err)
 			continue
 		}
-		if rm.Name != "" {
-			m.Name = rm.Name
-		}
-		if validEmail(rm.Email) {
-			m.Email = rm.Email
-		}
-		switch rm.Status {
-		case "active":
-			m.Status = db.MaintainerActive
-		case "inactive":
-			m.Status = db.MaintainerInactive
-		}
-		if rm.Evidence != "" {
-			m.Notes = rm.Role + ": " + rm.Evidence
-		}
+		rm.applyTo(&m)
 		if err := w.DB.Save(&m).Error; err != nil {
 			// Only the field refresh was lost; m still identifies a row that
 			// exists, so it stays in linked. Dropping it would remove a real

--- a/internal/worker/skill.go
+++ b/internal/worker/skill.go
@@ -154,10 +154,15 @@ func (w *Worker) doSkill(ctx context.Context, scan *db.Scan, emit func(Event)) (
 	}
 	scan.SkillName = skill.Name
 	scan.SkillVersion = skill.Version
-	w.DB.Model(scan).Updates(map[string]any{
+	// Non-fatal: the in-memory scan already carries both fields and finalizeScan
+	// saves the whole row at the end, so a failure here only leaves the columns
+	// stale for readers watching the table while the scan runs.
+	if err := w.DB.Model(scan).Updates(map[string]any{
 		"skill_name":    skill.Name,
 		"skill_version": skill.Version,
-	})
+	}).Error; err != nil {
+		w.Log.Warn("update scan skill metadata", "scan", scan.ID, "skill", skill.Name, "err", err)
+	}
 
 	// Per-scan workspace keeps concurrent skills on the same repo from
 	// clobbering each other's src/ and report.json. wrap() removes it on
@@ -994,7 +999,14 @@ func (w *Worker) parseMaintainersOutput(scan *db.Scan, report string, emit func(
 			continue
 		}
 		var m db.Maintainer
-		w.DB.Where(db.Maintainer{Login: rm.Login}).FirstOrCreate(&m)
+		if err := w.DB.Where(db.Maintainer{Login: rm.Login}).FirstOrCreate(&m).Error; err != nil {
+			// m is a zero value here: nothing was found and nothing was
+			// created. Falling through would Save() a record with no primary
+			// key and an empty Login, inserting a second, blank maintainer row
+			// and linking the repository to that instead of the real one.
+			w.Log.Warn("upsert maintainer", "scan", scan.ID, "login", rm.Login, "err", err)
+			continue
+		}
 		if rm.Name != "" {
 			m.Name = rm.Name
 		}
@@ -1010,11 +1022,19 @@ func (w *Worker) parseMaintainersOutput(scan *db.Scan, report string, emit func(
 		if rm.Evidence != "" {
 			m.Notes = rm.Role + ": " + rm.Evidence
 		}
-		w.DB.Save(&m)
+		if err := w.DB.Save(&m).Error; err != nil {
+			// Only the field refresh was lost; m still identifies a row that
+			// exists, so it stays in linked. Dropping it would remove a real
+			// maintainer from the repository via the Replace below, which is a
+			// larger loss than a stale name or note.
+			w.Log.Warn("save maintainer", "scan", scan.ID, "login", rm.Login, "err", err)
+		}
 		linked = append(linked, m)
 	}
 	if repoWide && len(linked) > 0 {
-		_ = w.DB.Model(&repo).Association("Maintainers").Replace(linked)
+		if err := w.DB.Model(&repo).Association("Maintainers").Replace(linked); err != nil {
+			w.Log.Warn("replace repository maintainers", "scan", scan.ID, "repository", repo.ID, "err", err)
+		}
 	}
 	emit(Event{Kind: KindText, Text: fmt.Sprintf("identified %d maintainer(s)", len(result.Maintainers))})
 	return nil

--- a/internal/worker/skill.go
+++ b/internal/worker/skill.go
@@ -1012,12 +1012,15 @@ func (w *Worker) parseMaintainersOutput(scan *db.Scan, report string, emit func(
 			}
 			// Best-effort: only touches an existing subproject row, and only
 			// the reconcile/skill-owned channel field.
-			w.DB.Model(&db.Subproject{}).
+			if err := w.DB.Model(&db.Subproject{}).
 				Where("repository_id = ? AND path = ?", scan.RepositoryID, path).
-				Update("disclosure_channel", ch)
+				Update("disclosure_channel", ch).Error; err != nil {
+				w.Log.Warn("update subproject disclosure channel", "scan", scan.ID, "path", path, "err", err)
+			}
 		}
 	}
 	var linked []db.Maintainer
+	partial := false
 	for _, rm := range result.Maintainers {
 		if rm.Login == "" {
 			continue
@@ -1029,6 +1032,7 @@ func (w *Worker) parseMaintainersOutput(scan *db.Scan, report string, emit func(
 			// key and an empty Login, inserting a second, blank maintainer row
 			// and linking the repository to that instead of the real one.
 			w.Log.Warn("upsert maintainer", "scan", scan.ID, "login", rm.Login, "err", err)
+			partial = true
 			continue
 		}
 		rm.applyTo(&m)
@@ -1041,7 +1045,15 @@ func (w *Worker) parseMaintainersOutput(scan *db.Scan, report string, emit func(
 		}
 		linked = append(linked, m)
 	}
-	if repoWide && len(linked) > 0 {
+	switch {
+	case !repoWide:
+	case partial:
+		// Replace(linked) with a partial set would unlink every maintainer whose
+		// lookup transiently failed. Leave the association as it was; the next
+		// successful run rewrites it.
+		w.Log.Warn("skipping maintainer association replace: set is partial after lookup failure",
+			"scan", scan.ID, "repository", repo.ID, "resolved", len(linked))
+	case len(linked) > 0:
 		if err := w.DB.Model(&repo).Association("Maintainers").Replace(linked); err != nil {
 			w.Log.Warn("replace repository maintainers", "scan", scan.ID, "repository", repo.ID, "err", err)
 		}

--- a/internal/worker/skill_parsers_test.go
+++ b/internal/worker/skill_parsers_test.go
@@ -2750,7 +2750,9 @@ func TestParseMaintainers_lookupFailureSkipsRecord(t *testing.T) {
 	}
 
 	// Fail only the first lookup, the way a timeout or a dropped connection
-	// would: the writes that follow still succeed.
+	// would: the writes that follow still succeed. A two-maintainer report
+	// exercises the Replace path — with a one-maintainer report the sole
+	// failure leaves linked empty and Replace is never reached.
 	fired := false
 	const name = "test:fail_maintainer_lookup"
 	if err := gdb.Callback().Query().Before("gorm:query").Register(name, func(d *gorm.DB) {
@@ -2761,7 +2763,7 @@ func TestParseMaintainers_lookupFailureSkipsRecord(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-	report := `{"maintainers":[{"login":"alice","name":"Alice","role":"lead","status":"active","evidence":"commits"}]}`
+	report := `{"maintainers":[{"login":"alice","status":"active"},{"login":"bob","status":"active"}]}`
 	if err := w.parseMaintainersOutput(&scan, report, func(Event) {}); err != nil {
 		t.Fatalf("a per-maintainer failure must not fail the whole report: %v", err)
 	}
@@ -2778,8 +2780,11 @@ func TestParseMaintainers_lookupFailureSkipsRecord(t *testing.T) {
 	if err := gdb.Model(&repo).Association("Maintainers").Find(&linked); err != nil {
 		t.Fatal(err)
 	}
+	// alice's lookup failed and bob's succeeded, so linked=[bob]. Replacing
+	// with a partial set would unlink alice; the guard skips Replace instead
+	// and leaves the seeded association untouched.
 	if len(linked) != 1 || linked[0].Login != "alice" {
-		t.Errorf("repository maintainers = %+v, want the real alice still linked", linked)
+		t.Errorf("repository maintainers = %+v, want alice still linked (Replace skipped on partial set)", linked)
 	}
 }
 

--- a/internal/worker/skill_parsers_test.go
+++ b/internal/worker/skill_parsers_test.go
@@ -2728,3 +2728,98 @@ func writeFile(t *testing.T, path, body string) {
 		t.Fatal(err)
 	}
 }
+
+// A failed maintainer lookup must skip the record, not fall through into the
+// Save below. FirstOrCreate leaves the destination zero on a query error, so
+// saving it inserts a second maintainer row with an empty login and hands the
+// repository's association to that row instead of the real one.
+func TestParseMaintainers_lookupFailureSkipsRecord(t *testing.T) {
+	gdb, err := db.Open(filepath.Join(t.TempDir(), "m.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo := db.Repository{URL: "https://github.com/rails/rails", Name: "rails"}
+	gdb.Create(&repo)
+	scan := db.Scan{RepositoryID: repo.ID}
+	gdb.Create(&scan)
+
+	w := &Worker{DB: gdb, Log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	seed := `{"maintainers":[{"login":"alice","name":"Real Alice","role":"lead","status":"active"}]}`
+	if err := w.parseMaintainersOutput(&scan, seed, func(Event) {}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Fail only the first lookup, the way a timeout or a dropped connection
+	// would: the writes that follow still succeed.
+	fired := false
+	const name = "test:fail_maintainer_lookup"
+	if err := gdb.Callback().Query().Before("gorm:query").Register(name, func(d *gorm.DB) {
+		if d.Statement.Table == "maintainers" && !fired {
+			fired = true
+			_ = d.AddError(errors.New("injected lookup failure"))
+		}
+	}); err != nil {
+		t.Fatal(err)
+	}
+	report := `{"maintainers":[{"login":"alice","name":"Alice","role":"lead","status":"active","evidence":"commits"}]}`
+	if err := w.parseMaintainersOutput(&scan, report, func(Event) {}); err != nil {
+		t.Fatalf("a per-maintainer failure must not fail the whole report: %v", err)
+	}
+	if err := gdb.Callback().Query().Remove(name); err != nil {
+		t.Fatal(err)
+	}
+
+	var blank int64
+	gdb.Model(&db.Maintainer{}).Where("login = ?", "").Count(&blank)
+	if blank != 0 {
+		t.Errorf("failed lookup inserted %d blank-login maintainer row(s), want 0", blank)
+	}
+	var linked []db.Maintainer
+	if err := gdb.Model(&repo).Association("Maintainers").Find(&linked); err != nil {
+		t.Fatal(err)
+	}
+	if len(linked) != 1 || linked[0].Login != "alice" {
+		t.Errorf("repository maintainers = %+v, want the real alice still linked", linked)
+	}
+}
+
+// The opposite case, and the reason the failed Save is NOT skipped: the row
+// exists and is correctly identified, only its field refresh was lost. Dropping
+// it from linked would unlink a real maintainer through the wholesale
+// Association.Replace, which loses more than a stale name does.
+func TestParseMaintainers_saveFailureKeepsMaintainerLinked(t *testing.T) {
+	gdb, err := db.Open(filepath.Join(t.TempDir(), "m.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo := db.Repository{URL: "https://github.com/rails/rails", Name: "rails"}
+	gdb.Create(&repo)
+	scan := db.Scan{RepositoryID: repo.ID}
+	gdb.Create(&scan)
+	gdb.Create(&db.Maintainer{Login: "alice", Name: "Real Alice"})
+
+	const name = "test:fail_maintainer_save"
+	if err := gdb.Callback().Update().Before("gorm:update").Register(name, func(d *gorm.DB) {
+		if d.Statement.Table == "maintainers" {
+			_ = d.AddError(errors.New("injected save failure"))
+		}
+	}); err != nil {
+		t.Fatal(err)
+	}
+	w := &Worker{DB: gdb, Log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	report := `{"maintainers":[{"login":"alice","name":"Updated Alice","role":"lead","status":"active"}]}`
+	if err := w.parseMaintainersOutput(&scan, report, func(Event) {}); err != nil {
+		t.Fatalf("a failed save must not fail the whole report: %v", err)
+	}
+	if err := gdb.Callback().Update().Remove(name); err != nil {
+		t.Fatal(err)
+	}
+
+	var linked []db.Maintainer
+	if err := gdb.Model(&repo).Association("Maintainers").Find(&linked); err != nil {
+		t.Fatal(err)
+	}
+	if len(linked) != 1 || linked[0].Login != "alice" {
+		t.Errorf("repository maintainers = %+v, want alice linked despite the failed save", linked)
+	}
+}


### PR DESCRIPTION
Closes #863, closes #864.

`parseMaintainersOutput` discards the error from `FirstOrCreate` (`internal/worker/skill.go:959`), which leaves `m` zero-valued when the *lookup* fails rather than the create. The `Save` at `:975` then inserts a second maintainer with an empty `Login`, and `Association("Maintainers").Replace` at `:979` links the repository to that blank row instead of the real one — so the failure mode is a wrong association, not only the lost field update the issue describes. `TestParseMaintainers_lookupFailureSkipsRecord` reproduces it against main: `inserted 1 blank-login maintainer row(s), want 0`, with the association holding `{ID:2 Login:}`.

The failed `Save` is deliberately **not** skipped, which is where this departs from #863's suggested fix. There the row exists and is correctly identified — only its field refresh was lost — so dropping it from `linked` would unlink a real maintainer through the wholesale `Replace`. Applying the suggestion turns `TestParseMaintainers_saveFailureKeepsMaintainerLinked` red with an empty association. The `Replace` error itself is now logged rather than returned, keeping the existing non-fatal behaviour of the explicit `_ =`.

For #864, the two `Updates` calls (`internal/worker/exposure.go:140`, `internal/worker/skill.go:155`) are checked and logged, non-fatal: both fields are already set in memory and `finalizeScan` re-saves the whole row, so a failure only leaves the columns stale for readers watching the table mid-scan. No test there — the failure path needs a full scan harness and its only observable effect is the log line.

`gofmt`, `go build ./...` and `go vet` clean; `internal/worker` green.
