### PR TITLE
Add supply-chain risk flags to the packages report

### DIFF
--- a/docs/database.md
+++ b/docs/database.md
@@ -45,7 +45,7 @@ The central entity. One row per git URL.
 | federation_opt_out_reason | text | Optional reason the maintainer gave; it travels with the `optout` record. |
 | posture | text | Disclosure-readiness tier from the `posture` skill: `ready`, `partial`, `unprepared`. |
 | posture_summary | text | One-line explanation that goes with `posture`. |
-| health | text | Evidence-based maintenance classification: `active`, `stale`, `abandoned`, or `zombie`. Empty until metadata or maintainer evidence is available. |
+| health | text | Evidence-based maintenance classification: `active`, `stale`, `abandoned`, or `zombie`. Empty until metadata or maintainer evidence is available. A package carrying `stale_release` holds the repository at `stale`. |
 | fork | text | `owner/name` of the staging fork inside `-fork-org`. Written by the `fork` skill. |
 | clone_error | text | Last clone/fetch failure message; non-empty means the repo is currently unreachable. Cleared on next successful clone. |
 | disk_bytes | integer | Cached on-disk size of the persistent clone cache, so the repo list renders the disk badge from a column instead of walking each repo's cache per row. Refreshed by the worker after each scan and backfilled once at startup; 0 for local repos and remote repos not scanned since the column was added. |
@@ -431,6 +431,7 @@ Registry entries from the `packages` skill. Replaced each run.
 | latest_release_at | datetime | |
 | dependent_packages_url | text | ecosyste.ms API URL for fetching dependents. |
 | metadata | text | Full upstream JSON for this package. |
+| risk_flags | text | Comma-joined supply-chain hygiene flags from the packages skill: `single_maintainer`, `no_security_policy`, `native_extension`, `stale_release`, `maintainer_domain_expired`. Each flag's evidence sentence stays in the scan report. |
 | created_at | datetime | |
 
 ## dependents

--- a/docs/database.md
+++ b/docs/database.md
@@ -45,7 +45,7 @@ The central entity. One row per git URL.
 | federation_opt_out_reason | text | Optional reason the maintainer gave; it travels with the `optout` record. |
 | posture | text | Disclosure-readiness tier from the `posture` skill: `ready`, `partial`, `unprepared`. |
 | posture_summary | text | One-line explanation that goes with `posture`. |
-| health | text | Evidence-based maintenance classification: `active`, `stale`, `abandoned`, or `zombie`. Empty until metadata or maintainer evidence is available. A package carrying `stale_release` holds the repository at `stale`. |
+| health | text | Evidence-based maintenance classification: `active`, `stale`, `abandoned`, or `zombie`. Empty until metadata or maintainer evidence is available. A repository whose newest package release is more than eighteen months old is held at `stale`. |
 | fork | text | `owner/name` of the staging fork inside `-fork-org`. Written by the `fork` skill. |
 | clone_error | text | Last clone/fetch failure message; non-empty means the repo is currently unreachable. Cleared on next successful clone. |
 | disk_bytes | integer | Cached on-disk size of the persistent clone cache, so the repo list renders the disk badge from a column instead of walking each repo's cache per row. Refreshed by the worker after each scan and backfilled once at startup; 0 for local repos and remote repos not scanned since the column was added. |
@@ -431,7 +431,7 @@ Registry entries from the `packages` skill. Replaced each run.
 | latest_release_at | datetime | |
 | dependent_packages_url | text | ecosyste.ms API URL for fetching dependents. |
 | metadata | text | Full upstream JSON for this package. |
-| risk_flags | text | Comma-joined supply-chain hygiene flags from the packages skill: `single_maintainer`, `no_security_policy`, `native_extension`, `stale_release`, `maintainer_domain_expired`. Each flag's evidence sentence stays in the scan report. |
+| risk_flags | text | Comma-joined supply-chain hygiene flags from the packages skill: `single_maintainer`, `no_security_policy`, `native_extension`, `stale_release`, `maintainer_domain_expired`. Each flag's evidence sentence stays in the scan report. The flags are advisory and do not move `health`. |
 | created_at | datetime | |
 
 ## dependents

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -13,7 +13,7 @@ These live in `skills/` and are embedded in the Scrutineer executable. At startu
 | `triage` | Default pipeline orchestrator. Classifies the repo, enqueues the appropriate scan set via the scrutineer API, and re-verifies any findings already reported upstream. Edit its body to change what runs by default. |
 | `metadata` | Fetches description, default branch, languages, license, stars, archived status, and icon from repos.ecosyste.ms. |
 | `repo-overview` | Runs `brief --json` for a structured project summary used by other skills as orientation. |
-| `packages` | Looks up every published package the repository produces across all registries, with download and dependent counts. |
+| `packages` | Looks up every published package the repository produces across all registries, with download and dependent counts, plus supply-chain risk flags. |
 | `advisories` | Fetches published GHSA and CVE records that affect any of those packages. |
 | `dependencies` | Indexes every manifest and lockfile in the tree with `git-pkgs list`. |
 | `sbom` | Generates a CycloneDX SBOM with `git-pkgs sbom`. |

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -446,7 +446,7 @@ type Package struct {
 	// maintainer_domain_expired. The ids are validated and canonically
 	// ordered on write, so a stored value only ever names known flags. Each
 	// flag's evidence sentence stays in the scan report; promoting only the
-	// ids keeps health scoring and the package page free of JSON decoding.
+	// ids keeps the health summary and the package page free of JSON decoding.
 	RiskFlags string
 
 	CreatedAt time.Time

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -440,6 +440,14 @@ type Package struct {
 	LatestReleaseAt      *time.Time
 	DependentPackagesURL string
 	Metadata             string `gorm:"type:text"`
+	// RiskFlags is the comma-joined set of supply-chain hygiene warnings the
+	// packages skill reported for this package: single_maintainer,
+	// no_security_policy, native_extension, stale_release,
+	// maintainer_domain_expired. The ids are validated and canonically
+	// ordered on write, so a stored value only ever names known flags. Each
+	// flag's evidence sentence stays in the scan report; promoting only the
+	// ids keeps health scoring and the package page free of JSON decoding.
+	RiskFlags string
 
 	CreatedAt time.Time
 }

--- a/internal/db/package_risk.go
+++ b/internal/db/package_risk.go
@@ -29,6 +29,41 @@ var packageRiskFlagOrder = []PackageRiskFlag{
 	PackageRiskMaintainerDomainExpired,
 }
 
+// packageRiskFlagLabels maps each known flag id to the phrase shown on the
+// package page and in health summaries. The stored column, the API and the
+// skill contract all keep the ids, so only display goes through here.
+var packageRiskFlagLabels = map[PackageRiskFlag]string{
+	PackageRiskSingleMaintainer:        "single maintainer",
+	PackageRiskNoSecurityPolicy:        "no security policy",
+	PackageRiskNativeExtension:         "ships native code",
+	PackageRiskStaleRelease:            "no recent release",
+	PackageRiskMaintainerDomainExpired: "maintainer domain expired",
+}
+
+// PackageRiskFlagLabel returns the display label for a risk-flag id, falling
+// back to the id itself when there is none, so a value written before a
+// label existed still renders.
+func PackageRiskFlagLabel(id string) string {
+	if label, ok := packageRiskFlagLabels[PackageRiskFlag(id)]; ok {
+		return label
+	}
+	return id
+}
+
+// PackageRiskFlagLabels maps a list of risk-flag ids to their display
+// labels. Returns nil for empty input, consistent with the other helpers in
+// this file.
+func PackageRiskFlagLabels(ids []string) []string {
+	if len(ids) == 0 {
+		return nil
+	}
+	labels := make([]string, len(ids))
+	for i, id := range ids {
+		labels[i] = PackageRiskFlagLabel(id)
+	}
+	return labels
+}
+
 // NormalisePackageRiskFlags validates and canonically orders the risk-flag
 // ids the packages skill reported for one package. kept holds the known ids
 // in packageRiskFlagOrder, deduped, ready to be comma-joined (no space) into

--- a/internal/db/package_risk.go
+++ b/internal/db/package_risk.go
@@ -50,20 +50,6 @@ func PackageRiskFlagLabel(id string) string {
 	return id
 }
 
-// PackageRiskFlagLabels maps a list of risk-flag ids to their display
-// labels. Returns nil for empty input, consistent with the other helpers in
-// this file.
-func PackageRiskFlagLabels(ids []string) []string {
-	if len(ids) == 0 {
-		return nil
-	}
-	labels := make([]string, len(ids))
-	for i, id := range ids {
-		labels[i] = PackageRiskFlagLabel(id)
-	}
-	return labels
-}
-
 // NormalisePackageRiskFlags validates and canonically orders the risk-flag
 // ids the packages skill reported for one package. kept holds the known ids
 // in packageRiskFlagOrder, deduped, ready to be comma-joined (no space) into

--- a/internal/db/package_risk.go
+++ b/internal/db/package_risk.go
@@ -1,0 +1,77 @@
+package db
+
+import (
+	"slices"
+	"strings"
+)
+
+// PackageRiskFlag is one supply-chain hygiene warning the packages skill
+// attaches to a published package. The set is closed: an id the skill
+// reports that is not one of the constants below is dropped on write, so a
+// stored value only ever holds known flags.
+type PackageRiskFlag string
+
+const (
+	PackageRiskSingleMaintainer        PackageRiskFlag = "single_maintainer"
+	PackageRiskNoSecurityPolicy        PackageRiskFlag = "no_security_policy"
+	PackageRiskNativeExtension         PackageRiskFlag = "native_extension"
+	PackageRiskStaleRelease            PackageRiskFlag = "stale_release"
+	PackageRiskMaintainerDomainExpired PackageRiskFlag = "maintainer_domain_expired"
+)
+
+// packageRiskFlagOrder is the canonical order flags are stored and rendered
+// in, independent of the order the skill reported them.
+var packageRiskFlagOrder = []PackageRiskFlag{
+	PackageRiskSingleMaintainer,
+	PackageRiskNoSecurityPolicy,
+	PackageRiskNativeExtension,
+	PackageRiskStaleRelease,
+	PackageRiskMaintainerDomainExpired,
+}
+
+// NormalisePackageRiskFlags validates and canonically orders the risk-flag
+// ids the packages skill reported for one package. kept holds the known ids
+// in packageRiskFlagOrder, deduped, ready to be comma-joined (no space) into
+// Package.RiskFlags. dropped holds the unknown ids, deduped in first-seen
+// order, for callers that want to warn about them. Both are nil when there
+// is nothing to report.
+func NormalisePackageRiskFlags(ids []string) (kept, dropped []string) {
+	seen := make(map[PackageRiskFlag]bool, len(ids))
+	seenDropped := map[string]bool{}
+	for _, raw := range ids {
+		id := strings.TrimSpace(raw)
+		if id == "" {
+			continue
+		}
+		flag := PackageRiskFlag(id)
+		if slices.Contains(packageRiskFlagOrder, flag) {
+			seen[flag] = true
+			continue
+		}
+		if !seenDropped[id] {
+			seenDropped[id] = true
+			dropped = append(dropped, id)
+		}
+	}
+	for _, f := range packageRiskFlagOrder {
+		if seen[f] {
+			kept = append(kept, string(f))
+		}
+	}
+	return kept, dropped
+}
+
+// PackageRiskFlags is the read side of the comma-joined Package.RiskFlags
+// column: it splits on "," and trims each element, dropping empties. Returns
+// nil for an empty or all-blank input.
+func PackageRiskFlags(joined string) []string {
+	var out []string
+	for _, part := range strings.Split(joined, ",") {
+		id := strings.TrimSpace(part)
+		if id == "" {
+			continue
+		}
+		out = append(out, id)
+	}
+	return out
+}

--- a/internal/db/package_risk_test.go
+++ b/internal/db/package_risk_test.go
@@ -77,16 +77,6 @@ func TestPackageRiskFlagLabel(t *testing.T) {
 			}
 		})
 	}
-
-	gotList := PackageRiskFlagLabels([]string{"single_maintainer", "unknown_id"})
-	wantList := []string{"single maintainer", "unknown_id"}
-	if !reflect.DeepEqual(gotList, wantList) {
-		t.Errorf("PackageRiskFlagLabels = %#v, want %#v", gotList, wantList)
-	}
-
-	if got := PackageRiskFlagLabels(nil); got != nil {
-		t.Errorf("PackageRiskFlagLabels(nil) = %#v, want nil", got)
-	}
 }
 
 func TestPackageRiskFlags(t *testing.T) {

--- a/internal/db/package_risk_test.go
+++ b/internal/db/package_risk_test.go
@@ -1,0 +1,91 @@
+package db
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestNormalisePackageRiskFlags(t *testing.T) {
+	tests := []struct {
+		name        string
+		ids         []string
+		wantKept    []string
+		wantDropped []string
+	}{
+		{
+			name:     "canonical reordering",
+			ids:      []string{"stale_release", "single_maintainer"},
+			wantKept: []string{"single_maintainer", "stale_release"},
+		},
+		{
+			name:     "dedup",
+			ids:      []string{"native_extension", "native_extension"},
+			wantKept: []string{"native_extension"},
+		},
+		{
+			name:     "whitespace trimmed",
+			ids:      []string{"  single_maintainer  ", " stale_release"},
+			wantKept: []string{"single_maintainer", "stale_release"},
+		},
+		{
+			name:     "empty strings skipped",
+			ids:      []string{"", "   ", "single_maintainer"},
+			wantKept: []string{"single_maintainer"},
+		},
+		{
+			name:        "unknown ids dropped and deduped",
+			ids:         []string{"bogus", "single_maintainer", "bogus", "also_bogus"},
+			wantKept:    []string{"single_maintainer"},
+			wantDropped: []string{"bogus", "also_bogus"},
+		},
+		{
+			name: "nil for empty input",
+			ids:  nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			kept, dropped := NormalisePackageRiskFlags(tt.ids)
+			if !reflect.DeepEqual(kept, tt.wantKept) {
+				t.Errorf("kept = %#v, want %#v", kept, tt.wantKept)
+			}
+			if !reflect.DeepEqual(dropped, tt.wantDropped) {
+				t.Errorf("dropped = %#v, want %#v", dropped, tt.wantDropped)
+			}
+		})
+	}
+}
+
+func TestPackageRiskFlags(t *testing.T) {
+	tests := []struct {
+		name   string
+		joined string
+		want   []string
+	}{
+		{
+			name:   "split and trim",
+			joined: "single_maintainer, stale_release,native_extension",
+			want:   []string{"single_maintainer", "stale_release", "native_extension"},
+		},
+		{
+			name:   "empty input",
+			joined: "",
+			want:   nil,
+		},
+		{
+			name:   "all-blank input",
+			joined: " , ,  ",
+			want:   nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := PackageRiskFlags(tt.joined)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("PackageRiskFlags(%q) = %#v, want %#v", tt.joined, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/db/package_risk_test.go
+++ b/internal/db/package_risk_test.go
@@ -57,6 +57,38 @@ func TestNormalisePackageRiskFlags(t *testing.T) {
 	}
 }
 
+func TestPackageRiskFlagLabel(t *testing.T) {
+	tests := []struct {
+		id   string
+		want string
+	}{
+		{id: "single_maintainer", want: "single maintainer"},
+		{id: "no_security_policy", want: "no security policy"},
+		{id: "native_extension", want: "ships native code"},
+		{id: "stale_release", want: "no recent release"},
+		{id: "maintainer_domain_expired", want: "maintainer domain expired"},
+		{id: "unknown_id", want: "unknown_id"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.id, func(t *testing.T) {
+			if got := PackageRiskFlagLabel(tt.id); got != tt.want {
+				t.Errorf("PackageRiskFlagLabel(%q) = %q, want %q", tt.id, got, tt.want)
+			}
+		})
+	}
+
+	gotList := PackageRiskFlagLabels([]string{"single_maintainer", "unknown_id"})
+	wantList := []string{"single maintainer", "unknown_id"}
+	if !reflect.DeepEqual(gotList, wantList) {
+		t.Errorf("PackageRiskFlagLabels = %#v, want %#v", gotList, wantList)
+	}
+
+	if got := PackageRiskFlagLabels(nil); got != nil {
+		t.Errorf("PackageRiskFlagLabels(nil) = %#v, want nil", got)
+	}
+}
+
 func TestPackageRiskFlags(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/internal/db/repository_health.go
+++ b/internal/db/repository_health.go
@@ -2,7 +2,6 @@ package db
 
 import (
 	"fmt"
-	"slices"
 	"strings"
 	"time"
 
@@ -20,9 +19,11 @@ const (
 	RepositoryHealthAbandoned RepositoryHealth = "abandoned"
 	RepositoryHealthZombie    RepositoryHealth = "zombie"
 
-	healthActiveWindow     = 365 * 24 * time.Hour
-	healthAbandonedWindow  = 2 * 365 * 24 * time.Hour
-	healthZombieDependents = 100
+	healthActiveWindow    = 365 * 24 * time.Hour
+	healthAbandonedWindow = 2 * 365 * 24 * time.Hour
+	// A month is thirty days here, matching how healthAge renders one.
+	healthStaleReleaseWindow = 18 * 30 * 24 * time.Hour
+	healthZombieDependents   = 100
 )
 
 // RepositoryHealthAssessment is the durable classification plus the evidence
@@ -34,10 +35,19 @@ type RepositoryHealthAssessment struct {
 	DependentRepos    int
 	ActiveMaintainers int
 	KnownMaintainers  int
+	// LastReleaseAt is the most recent release across every package the
+	// repository publishes, so a monorepo counts as shipping while any one
+	// of its packages still ships. Nil when no package records a release
+	// date.
+	LastReleaseAt *time.Time
 	// RiskFlags are the supply-chain hygiene warnings the packages skill
 	// reported, unioned across every package the repository publishes and
-	// canonically ordered. They are evidence carried alongside the
-	// classification; only stale_release actually moves it.
+	// canonically ordered. They are surfaced in the summary as evidence and
+	// never move the classification: an absent flag means "not checked"
+	// rather than "checked and clean" (SKILL.md says so). The package set is
+	// also replaced wholesale on every run, so scoring on a flag would let a
+	// scan that skipped the check flip a stored verdict with no upstream
+	// change behind it.
 	RiskFlags []string
 }
 
@@ -54,6 +64,9 @@ func AssessRepositoryHealth(repo Repository, packages []Package, maintainers []M
 		// feed cannot prove those sets are disjoint, so max is conservative.
 		assessment.DependentRepos = max(assessment.DependentRepos, pkg.DependentRepos)
 		flags = append(flags, PackageRiskFlags(pkg.RiskFlags)...)
+		if pkg.LatestReleaseAt != nil && (assessment.LastReleaseAt == nil || pkg.LatestReleaseAt.After(*assessment.LastReleaseAt)) {
+			assessment.LastReleaseAt = pkg.LatestReleaseAt
+		}
 	}
 	// The dropped return is discarded: values in the RiskFlags column were
 	// already validated when the packages skill's row was written, so
@@ -69,6 +82,13 @@ func AssessRepositoryHealth(repo Repository, packages []Package, maintainers []M
 		}
 	}
 
+	var releaseAge time.Duration
+	staleRelease := false
+	if assessment.LastReleaseAt != nil {
+		releaseAge = now.Sub(*assessment.LastReleaseAt)
+		staleRelease = releaseAge >= healthStaleReleaseWindow
+	}
+
 	if !repo.Archived && repo.PushedAt == nil && assessment.KnownMaintainers == 0 {
 		return assessment
 	}
@@ -78,12 +98,12 @@ func AssessRepositoryHealth(repo Repository, packages []Package, maintainers []M
 		age = now.Sub(*repo.PushedAt)
 	}
 
-	assessment.Health = repositoryHealth(repo.Archived, repo.PushedAt != nil, age, assessment)
-	assessment.Summary = healthSummary(repo.Archived, repo.PushedAt, age, assessment)
+	assessment.Health = repositoryHealth(repo.Archived, repo.PushedAt != nil, staleRelease, age, assessment)
+	assessment.Summary = healthSummary(repo.Archived, repo.PushedAt, age, releaseAge, assessment)
 	return assessment
 }
 
-func repositoryHealth(archived, hasPush bool, age time.Duration, assessment RepositoryHealthAssessment) RepositoryHealth {
+func repositoryHealth(archived, hasPush, staleRelease bool, age time.Duration, assessment RepositoryHealthAssessment) RepositoryHealth {
 	abandoned := archived || (hasPush && age >= healthAbandonedWindow && assessment.KnownMaintainers > 0 && assessment.ActiveMaintainers == 0)
 	if abandoned {
 		if assessment.DependentRepos >= healthZombieDependents {
@@ -91,19 +111,17 @@ func repositoryHealth(archived, hasPush bool, age time.Duration, assessment Repo
 		}
 		return RepositoryHealthAbandoned
 	}
-	// A package that has not shipped a release in eighteen months is not
-	// reaching its consumers however busy the repository looks, so the flag
-	// holds the classification at stale even when commits are recent. It
-	// deliberately does not push the repository towards abandoned, which
-	// still requires archival or maintainer evidence.
-	staleRelease := slices.Contains(assessment.RiskFlags, string(PackageRiskStaleRelease))
+	// A repository whose newest package release is eighteen months old is
+	// not reaching its consumers however busy its commit log looks, so it is
+	// held at stale. Taking the newest release across all packages keeps a
+	// monorepo active while any one of its packages still ships.
 	if hasPush && age <= healthActiveWindow && assessment.ActiveMaintainers > 0 && !staleRelease {
 		return RepositoryHealthActive
 	}
 	return RepositoryHealthStale
 }
 
-func healthSummary(archived bool, pushedAt *time.Time, age time.Duration, assessment RepositoryHealthAssessment) string {
+func healthSummary(archived bool, pushedAt *time.Time, age, releaseAge time.Duration, assessment RepositoryHealthAssessment) string {
 	var parts []string
 	switch {
 	case archived:
@@ -124,8 +142,11 @@ func healthSummary(archived bool, pushedAt *time.Time, age time.Duration, assess
 	if assessment.DependentRepos > 0 {
 		parts = append(parts, fmt.Sprintf("up to %d dependent repos", assessment.DependentRepos))
 	}
+	if assessment.LastReleaseAt != nil {
+		parts = append(parts, fmt.Sprintf("last release %s ago", healthAge(releaseAge)))
+	}
 	if len(assessment.RiskFlags) > 0 {
-		parts = append(parts, "risk flags: "+strings.Join(assessment.RiskFlags, ", "))
+		parts = append(parts, "risk flags: "+strings.Join(PackageRiskFlagLabels(assessment.RiskFlags), ", "))
 	}
 	return strings.Join(parts, "; ")
 }

--- a/internal/db/repository_health.go
+++ b/internal/db/repository_health.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -33,6 +34,11 @@ type RepositoryHealthAssessment struct {
 	DependentRepos    int
 	ActiveMaintainers int
 	KnownMaintainers  int
+	// RiskFlags are the supply-chain hygiene warnings the packages skill
+	// reported, unioned across every package the repository publishes and
+	// canonically ordered. They are evidence carried alongside the
+	// classification; only stale_release actually moves it.
+	RiskFlags []string
 }
 
 // AssessRepositoryHealth classifies a repository from persisted evidence.
@@ -42,11 +48,17 @@ type RepositoryHealthAssessment struct {
 // as abandoned.
 func AssessRepositoryHealth(repo Repository, packages []Package, maintainers []Maintainer, now time.Time) RepositoryHealthAssessment {
 	assessment := RepositoryHealthAssessment{}
+	var flags []string
 	for _, pkg := range packages {
 		// Published packages can share downstream repositories. The package
 		// feed cannot prove those sets are disjoint, so max is conservative.
 		assessment.DependentRepos = max(assessment.DependentRepos, pkg.DependentRepos)
+		flags = append(flags, PackageRiskFlags(pkg.RiskFlags)...)
 	}
+	// The dropped return is discarded: values in the RiskFlags column were
+	// already validated when the packages skill's row was written, so
+	// nothing here should be unknown.
+	assessment.RiskFlags, _ = NormalisePackageRiskFlags(flags)
 	for _, maintainer := range maintainers {
 		switch maintainer.Status {
 		case MaintainerActive:
@@ -79,7 +91,13 @@ func repositoryHealth(archived, hasPush bool, age time.Duration, assessment Repo
 		}
 		return RepositoryHealthAbandoned
 	}
-	if hasPush && age <= healthActiveWindow && assessment.ActiveMaintainers > 0 {
+	// A package that has not shipped a release in eighteen months is not
+	// reaching its consumers however busy the repository looks, so the flag
+	// holds the classification at stale even when commits are recent. It
+	// deliberately does not push the repository towards abandoned, which
+	// still requires archival or maintainer evidence.
+	staleRelease := slices.Contains(assessment.RiskFlags, string(PackageRiskStaleRelease))
+	if hasPush && age <= healthActiveWindow && assessment.ActiveMaintainers > 0 && !staleRelease {
 		return RepositoryHealthActive
 	}
 	return RepositoryHealthStale
@@ -105,6 +123,9 @@ func healthSummary(archived bool, pushedAt *time.Time, age time.Duration, assess
 	}
 	if assessment.DependentRepos > 0 {
 		parts = append(parts, fmt.Sprintf("up to %d dependent repos", assessment.DependentRepos))
+	}
+	if len(assessment.RiskFlags) > 0 {
+		parts = append(parts, "risk flags: "+strings.Join(assessment.RiskFlags, ", "))
 	}
 	return strings.Join(parts, "; ")
 }

--- a/internal/db/repository_health.go
+++ b/internal/db/repository_health.go
@@ -146,7 +146,11 @@ func healthSummary(archived bool, pushedAt *time.Time, age, releaseAge time.Dura
 		parts = append(parts, fmt.Sprintf("last release %s ago", healthAge(releaseAge)))
 	}
 	if len(assessment.RiskFlags) > 0 {
-		parts = append(parts, "risk flags: "+strings.Join(PackageRiskFlagLabels(assessment.RiskFlags), ", "))
+		labels := make([]string, len(assessment.RiskFlags))
+		for i, id := range assessment.RiskFlags {
+			labels[i] = PackageRiskFlagLabel(id)
+		}
+		parts = append(parts, "risk flags: "+strings.Join(labels, ", "))
 	}
 	return strings.Join(parts, "; ")
 }

--- a/internal/db/repository_health_test.go
+++ b/internal/db/repository_health_test.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -57,6 +58,13 @@ func TestAssessRepositoryHealth(t *testing.T) {
 			want:     RepositoryHealthZombie,
 		},
 		{
+			name:     "stale_release flag holds classification at stale despite a recent push",
+			repo:     Repository{PushedAt: ptrTime(now.Add(-30 * 24 * time.Hour))},
+			packages: []Package{{RiskFlags: string(PackageRiskStaleRelease)}},
+			people:   []Maintainer{active},
+			want:     RepositoryHealthStale,
+		},
+		{
 			name: "missing evidence is unassessed",
 			repo: Repository{},
 			want: "",
@@ -73,6 +81,42 @@ func TestAssessRepositoryHealth(t *testing.T) {
 				t.Error("classified health should explain its evidence")
 			}
 		})
+	}
+}
+
+func TestAssessRepositoryHealth_unionsAndOrdersRiskFlags(t *testing.T) {
+	now := time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC)
+	repo := Repository{PushedAt: ptrTime(now.Add(-30 * 24 * time.Hour))}
+	packages := []Package{
+		{RiskFlags: string(PackageRiskStaleRelease) + "," + string(PackageRiskSingleMaintainer)},
+		{RiskFlags: string(PackageRiskSingleMaintainer)},
+	}
+	people := []Maintainer{{Status: MaintainerActive}}
+
+	got := AssessRepositoryHealth(repo, packages, people, now)
+
+	want := []string{string(PackageRiskSingleMaintainer), string(PackageRiskStaleRelease)}
+	if !reflect.DeepEqual(got.RiskFlags, want) {
+		t.Errorf("RiskFlags = %#v, want %#v (deduped, canonically ordered)", got.RiskFlags, want)
+	}
+	if !strings.Contains(got.Summary, "risk flags:") {
+		t.Errorf("summary should mention risk flags, got %q", got.Summary)
+	}
+}
+
+func TestAssessRepositoryHealth_flagsSurviveEarlyReturn(t *testing.T) {
+	now := time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC)
+	repo := Repository{}
+	packages := []Package{{RiskFlags: string(PackageRiskNativeExtension)}}
+
+	got := AssessRepositoryHealth(repo, packages, nil, now)
+
+	if got.Health != "" {
+		t.Errorf("Health = %q, want empty (no push, no maintainer evidence)", got.Health)
+	}
+	want := []string{string(PackageRiskNativeExtension)}
+	if !reflect.DeepEqual(got.RiskFlags, want) {
+		t.Errorf("RiskFlags = %#v, want %#v even on the early-return path", got.RiskFlags, want)
 	}
 }
 

--- a/internal/db/repository_health_test.go
+++ b/internal/db/repository_health_test.go
@@ -58,11 +58,28 @@ func TestAssessRepositoryHealth(t *testing.T) {
 			want:     RepositoryHealthZombie,
 		},
 		{
-			name:     "stale_release flag holds classification at stale despite a recent push",
+			name:     "release older than eighteen months holds classification at stale despite a recent push",
 			repo:     Repository{PushedAt: ptrTime(now.Add(-30 * 24 * time.Hour))},
-			packages: []Package{{RiskFlags: string(PackageRiskStaleRelease)}},
+			packages: []Package{{LatestReleaseAt: ptrTime(now.Add(-19 * 30 * 24 * time.Hour))}},
 			people:   []Maintainer{active},
 			want:     RepositoryHealthStale,
+		},
+		{
+			name: "monorepo stays active while one package still ships",
+			repo: Repository{PushedAt: ptrTime(now.Add(-30 * 24 * time.Hour))},
+			packages: []Package{
+				{LatestReleaseAt: ptrTime(now.Add(-19 * 30 * 24 * time.Hour))},
+				{LatestReleaseAt: ptrTime(now.Add(-30 * 24 * time.Hour))},
+			},
+			people: []Maintainer{active},
+			want:   RepositoryHealthActive,
+		},
+		{
+			name:     "stale_release flag alone does not move classification with a recent release",
+			repo:     Repository{PushedAt: ptrTime(now.Add(-30 * 24 * time.Hour))},
+			packages: []Package{{RiskFlags: string(PackageRiskStaleRelease), LatestReleaseAt: ptrTime(now.Add(-30 * 24 * time.Hour))}},
+			people:   []Maintainer{active},
+			want:     RepositoryHealthActive,
 		},
 		{
 			name: "missing evidence is unassessed",
@@ -101,6 +118,19 @@ func TestAssessRepositoryHealth_unionsAndOrdersRiskFlags(t *testing.T) {
 	}
 	if !strings.Contains(got.Summary, "risk flags:") {
 		t.Errorf("summary should mention risk flags, got %q", got.Summary)
+	}
+}
+
+func TestAssessRepositoryHealth_summaryNamesLastReleaseAge(t *testing.T) {
+	now := time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC)
+	repo := Repository{PushedAt: ptrTime(now.Add(-30 * 24 * time.Hour))}
+	packages := []Package{{LatestReleaseAt: ptrTime(now.Add(-60 * 24 * time.Hour))}}
+	people := []Maintainer{{Status: MaintainerActive}}
+
+	got := AssessRepositoryHealth(repo, packages, people, now)
+
+	if !strings.Contains(got.Summary, "last release ") {
+		t.Errorf("summary should name the last release age, got %q", got.Summary)
 	}
 }
 

--- a/internal/web/api_reads.go
+++ b/internal/web/api_reads.go
@@ -97,6 +97,9 @@ type packageResponse struct {
 	// repo-level package. Lets an API consumer group a monorepo's packages by
 	// sub-package without a second lookup.
 	SubPath string `json:"sub_path,omitempty"`
+	// RiskFlags are the packages skill's supply-chain hygiene warnings for
+	// this package. The evidence for each stays in the scan report.
+	RiskFlags []string `json:"risk_flags,omitempty"`
 }
 
 func (s *Server) apiListPackages(w http.ResponseWriter, r *http.Request) {
@@ -127,6 +130,7 @@ func (s *Server) apiListPackages(w http.ResponseWriter, r *http.Request) {
 			DependentRepos:    p.DependentRepos,
 			RegistryURL:       p.RegistryURL,
 			LatestReleaseAt:   p.LatestReleaseAt,
+			RiskFlags:         db.PackageRiskFlags(p.RiskFlags),
 		}
 		if p.SubprojectID != nil {
 			resp.SubPath = subPaths[*p.SubprojectID]

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -343,10 +343,11 @@ func New(gdb *gorm.DB, q *queue.Queue, log *slog.Logger, broker *Broker, w *work
 			}
 			return m
 		},
-		"list":     func(xs ...string) []string { return xs },
-		"contains": slices.Contains[[]string, string],
-		"len64":    tmplLen64,
-		"sortkey":  sortKey,
+		"list":      func(xs ...string) []string { return xs },
+		"contains":  slices.Contains[[]string, string],
+		"len64":     tmplLen64,
+		"sortkey":   sortKey,
+		"riskflags": db.PackageRiskFlags,
 		"cwename": func(id string) string {
 			if _, c, ok := LookupCWE(id); ok {
 				return c.Name

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -348,6 +348,7 @@ func New(gdb *gorm.DB, q *queue.Queue, log *slog.Logger, broker *Broker, w *work
 		"len64":     tmplLen64,
 		"sortkey":   sortKey,
 		"riskflags": db.PackageRiskFlags,
+		"risklabel": db.PackageRiskFlagLabel,
 		"cwename": func(id string) string {
 			if _, c, ok := LookupCWE(id); ok {
 				return c.Name

--- a/internal/web/templates/package_show.html
+++ b/internal/web/templates/package_show.html
@@ -58,6 +58,13 @@
   {{end}}
 </div>
 
+{{$flags := riskflags $p.RiskFlags}}
+{{if $flags}}
+<div class="flex flex-wrap gap-2 mb-6">
+  {{range $flags}}<span class="badge-secondary">{{.}}</span>{{end}}
+</div>
+{{end}}
+
 {{if .Meta}}
 <section class="accordion">
   <details class="group border-b">

--- a/internal/web/templates/package_show.html
+++ b/internal/web/templates/package_show.html
@@ -61,7 +61,7 @@
 {{$flags := riskflags $p.RiskFlags}}
 {{if $flags}}
 <div class="flex flex-wrap gap-2 mb-6">
-  {{range $flags}}<span class="badge-secondary">{{.}}</span>{{end}}
+  {{range $flags}}<span class="badge-secondary">{{risklabel .}}</span>{{end}}
 </div>
 {{end}}
 

--- a/internal/worker/skill_parsers.go
+++ b/internal/worker/skill_parsers.go
@@ -135,6 +135,13 @@ func (w *Worker) parsePackagesOutput(scan *db.Scan, report string, emit func(Eve
 			LatestReleaseAt      string `json:"latest_release_at"`
 			DependentPackagesURL string `json:"dependent_packages_url"`
 			Metadata             any    `json:"metadata"`
+			RiskFlags            []struct {
+				ID string `json:"id"`
+				// Evidence is not stored on the row; it stays in scan.Report
+				// so the analyst sees why a flag was raised without a second
+				// JSON column to keep in sync.
+				Evidence string `json:"evidence"`
+			} `json:"risk_flags"`
 		} `json:"packages"`
 	}
 	if err := json.Unmarshal([]byte(report), &result); err != nil {
@@ -164,6 +171,11 @@ func (w *Worker) parsePackagesOutput(scan *db.Scan, report string, emit func(Eve
 				row.Metadata = string(b)
 			}
 		}
+		flagIDs := make([]string, 0, len(p.RiskFlags))
+		for _, f := range p.RiskFlags {
+			flagIDs = append(flagIDs, f.ID)
+		}
+		row.RiskFlags = packageRiskFlags(emit, p.Name, flagIDs)
 		rows = append(rows, row)
 	}
 	// Replace the prior row set atomically: a failed insert after the
@@ -185,6 +197,19 @@ func (w *Worker) parsePackagesOutput(scan *db.Scan, report string, emit func(Eve
 	emit(Event{Kind: KindText, Text: fmt.Sprintf("saved %d package(s)", len(rows))})
 	w.reconcileSubprojectLinksIfEnabled(scan.RepositoryID)
 	return nil
+}
+
+// packageRiskFlags validates the risk-flag ids the skill reported for one
+// package and returns them in the comma-joined form Package.RiskFlags stores.
+// An unknown id is dropped with a warning rather than failing the scan: the
+// rest of the package row is still accurate, while a model inventing a
+// sixth flag name should not cost the repository its whole package set.
+func packageRiskFlags(emit func(Event), packageName string, ids []string) string {
+	kept, dropped := db.NormalisePackageRiskFlags(ids)
+	if len(dropped) > 0 {
+		emit(Event{Kind: KindText, Text: fmt.Sprintf("packages: dropping unknown risk flag(s) %s for %s", strings.Join(dropped, ", "), packageName)})
+	}
+	return strings.Join(kept, ",")
 }
 
 // parseAdvisoriesOutput replaces Advisory rows for the scan's repository.

--- a/internal/worker/skill_parsers.go
+++ b/internal/worker/skill_parsers.go
@@ -175,7 +175,7 @@ func (w *Worker) parsePackagesOutput(scan *db.Scan, report string, emit func(Eve
 		for _, f := range p.RiskFlags {
 			flagIDs = append(flagIDs, f.ID)
 		}
-		row.RiskFlags = packageRiskFlags(emit, p.Name, row.Ecosystem, flagIDs)
+		row.RiskFlags = joinPackageRiskFlags(emit, p.Name, row.Ecosystem, flagIDs)
 		rows = append(rows, row)
 	}
 	// Replace the prior row set atomically: a failed insert after the
@@ -199,12 +199,15 @@ func (w *Worker) parsePackagesOutput(scan *db.Scan, report string, emit func(Eve
 	return nil
 }
 
-// packageRiskFlags validates the risk-flag ids the skill reported for one
+// joinPackageRiskFlags validates the risk-flag ids the skill reported for one
 // package and returns them in the comma-joined form Package.RiskFlags stores.
+// It is the write side of db.PackageRiskFlags, which splits the column back
+// into ids on read.
+//
 // An unknown id is dropped with a warning rather than failing the scan: the
 // rest of the package row is still accurate, while a model inventing a
 // sixth flag name should not cost the repository its whole package set.
-func packageRiskFlags(emit func(Event), name, ecosystem string, ids []string) string {
+func joinPackageRiskFlags(emit func(Event), name, ecosystem string, ids []string) string {
 	kept, dropped := db.NormalisePackageRiskFlags(ids)
 	if len(dropped) > 0 {
 		emit(Event{Kind: KindText, Text: fmt.Sprintf("packages: dropping unknown risk flag(s) %s for %s (%s)", strings.Join(dropped, ", "), name, ecosystem)})

--- a/internal/worker/skill_parsers.go
+++ b/internal/worker/skill_parsers.go
@@ -175,7 +175,7 @@ func (w *Worker) parsePackagesOutput(scan *db.Scan, report string, emit func(Eve
 		for _, f := range p.RiskFlags {
 			flagIDs = append(flagIDs, f.ID)
 		}
-		row.RiskFlags = packageRiskFlags(emit, p.Name, flagIDs)
+		row.RiskFlags = packageRiskFlags(emit, p.Name, row.Ecosystem, flagIDs)
 		rows = append(rows, row)
 	}
 	// Replace the prior row set atomically: a failed insert after the
@@ -204,10 +204,10 @@ func (w *Worker) parsePackagesOutput(scan *db.Scan, report string, emit func(Eve
 // An unknown id is dropped with a warning rather than failing the scan: the
 // rest of the package row is still accurate, while a model inventing a
 // sixth flag name should not cost the repository its whole package set.
-func packageRiskFlags(emit func(Event), packageName string, ids []string) string {
+func packageRiskFlags(emit func(Event), name, ecosystem string, ids []string) string {
 	kept, dropped := db.NormalisePackageRiskFlags(ids)
 	if len(dropped) > 0 {
-		emit(Event{Kind: KindText, Text: fmt.Sprintf("packages: dropping unknown risk flag(s) %s for %s", strings.Join(dropped, ", "), packageName)})
+		emit(Event{Kind: KindText, Text: fmt.Sprintf("packages: dropping unknown risk flag(s) %s for %s (%s)", strings.Join(dropped, ", "), name, ecosystem)})
 	}
 	return strings.Join(kept, ",")
 }

--- a/internal/worker/skill_parsers_test.go
+++ b/internal/worker/skill_parsers_test.go
@@ -397,12 +397,12 @@ func TestParsePackagesOutput_dropsUnknownRiskFlagAndWarns(t *testing.T) {
 	}
 	var warned bool
 	for _, e := range events {
-		if strings.Contains(e, "made_up_flag") {
+		if strings.Contains(e, "made_up_flag") && strings.Contains(e, row.Ecosystem) {
 			warned = true
 		}
 	}
 	if !warned {
-		t.Errorf("events = %v, want a warning naming the dropped flag", events)
+		t.Errorf("events = %v, want a warning naming the dropped flag and the ecosystem %q", events, row.Ecosystem)
 	}
 }
 

--- a/internal/worker/skill_parsers_test.go
+++ b/internal/worker/skill_parsers_test.go
@@ -355,6 +355,57 @@ func TestParsePackages_replacesPackageRows(t *testing.T) {
 	}
 }
 
+func TestParsePackages_riskFlagsCanonicallyOrdered(t *testing.T) {
+	report := `{"packages":[
+		{"name":"foo","ecosystem":"rubygems","risk_flags":[{"id":"stale_release","evidence":"latest release 2024-01-01"},{"id":"single_maintainer","evidence":"one owner listed"}]},
+		{"name":"foo-cli","ecosystem":"rubygems"}
+	]}`
+	repo, gdb := runSkillWithReport(t, "packages", report)
+	var rows []db.Package
+	gdb.Where("repository_id = ?", repo.ID).Order("name").Find(&rows)
+	if len(rows) != 2 {
+		t.Fatalf("rows = %d, want 2", len(rows))
+	}
+	if rows[0].Name != "foo" || rows[0].RiskFlags != "single_maintainer,stale_release" {
+		t.Errorf("row foo RiskFlags = %q, want canonically ordered single_maintainer,stale_release", rows[0].RiskFlags)
+	}
+	if rows[1].Name != "foo-cli" || rows[1].RiskFlags != "" {
+		t.Errorf("row foo-cli RiskFlags = %q, want empty (no risk_flags key)", rows[1].RiskFlags)
+	}
+}
+
+// An unknown risk-flag id must not cost the package its known flags: the
+// scan still needs an accurate row for downstream health scoring.
+func TestParsePackagesOutput_dropsUnknownRiskFlagAndWarns(t *testing.T) {
+	repo, gdb := runSkillWithReport(t, "packages", `{"packages":[]}`)
+	scan := db.Scan{RepositoryID: repo.ID}
+	gdb.Create(&scan)
+
+	var events []string
+	w := &Worker{DB: gdb, Log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	report := `{"packages":[{"name":"foo","ecosystem":"rubygems","risk_flags":[{"id":"single_maintainer","evidence":"one owner listed"},{"id":"made_up_flag","evidence":"n/a"}]}]}`
+	if err := w.parsePackagesOutput(&scan, report, func(e Event) { events = append(events, e.Text) }); err != nil {
+		t.Fatal(err)
+	}
+
+	var row db.Package
+	if err := gdb.Where("repository_id = ? AND name = ?", repo.ID, "foo").First(&row).Error; err != nil {
+		t.Fatal(err)
+	}
+	if row.RiskFlags != "single_maintainer" {
+		t.Errorf("RiskFlags = %q, want single_maintainer (unknown flag dropped, known flag kept)", row.RiskFlags)
+	}
+	var warned bool
+	for _, e := range events {
+		if strings.Contains(e, "made_up_flag") {
+			warned = true
+		}
+	}
+	if !warned {
+		t.Errorf("events = %v, want a warning naming the dropped flag", events)
+	}
+}
+
 // A failed insert must not destroy the existing rows: the delete and the
 // re-insert run in one transaction, so a mid-write failure rolls the delete
 // back and the repository keeps the packages from its last good scan.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1471,6 +1471,7 @@ components:
         dependent_repos:    { type: integer }
         registry_url:       { type: string }
         latest_release_at:  { type: string, format: date-time, nullable: true }
+        risk_flags:         { type: array, items: { type: string, enum: [single_maintainer, no_security_policy, native_extension, stale_release, maintainer_domain_expired] }, description: "Supply-chain hygiene warnings from the packages skill. The evidence for each stays in the scan report." }
         sub_path:           { type: string, description: "Monorepo sub-package this package is attributed to (its subproject path). Omitted for a repo-level package." }
 
     Advisory:

--- a/skills/packages/SKILL.md
+++ b/skills/packages/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: packages
-description: Look up every package this repository publishes across all registries via packages.ecosyste.ms, with downloads, dependent counts, latest version, and registry URL.
+description: Look up every package this repository publishes across all registries via packages.ecosyste.ms, with downloads, dependent counts, latest version, registry URL and supply-chain risk flags.
 license: MIT
 compatibility: Prefers the scrutineer API's cached ecosyste.ms payload; needs network access to packages.ecosyste.ms only when nothing is cached.
 metadata:
@@ -39,7 +39,26 @@ One repository can ship multiple packages across multiple ecosystems. Ask packag
    - `latest_release_at` from upstream `latest_release_published_at` (RFC3339)
    - `dependent_packages_url` from upstream `dependent_packages_url`
    - `metadata` — the whole upstream object for this package, verbatim
+   - `risk_flags`, see "Risk flags" below
 
 If upstream answered and this repository genuinely publishes no packages (the lookup returns `[]`), write `{"packages": []}`. That is a valid result, not an error.
 
 Only write that empty array when a source actually answered. If neither source is reachable — the cached endpoint returned 404 *and* the direct fetch failed, which is what `--hardened` looks like on an uncached repository — do not write `./report.json` at all. Exit non-zero instead. The parser replaces the whole package set for the repository, deleting every existing row before inserting what you produced, so an empty array reported as success wipes packages a previous scan recorded rather than leaving them untouched.
+
+## Risk flags
+
+Each entry in `risk_flags` is `{"id": ..., "evidence": ...}`. `id` is one of the five ids listed below. `evidence` is one sentence naming what you actually saw (the file, the field, the date), not a restatement of the flag name.
+
+The five flags and how to check each:
+
+- `single_maintainer`: the registry lists one owner or publisher for this package. Read it from the upstream payload's maintainers/owners field.
+- `no_security_policy`: no `SECURITY.md` (or `.github/SECURITY.md`, `docs/SECURITY.md`) in `./src`.
+- `native_extension`: the package ships compiled code, so installing it runs a toolchain. Examples worth naming: a `binding.gyp` or `node-gyp` dependency, `ext/` with an `extconf.rb`, `setup.py` declaring `ext_modules`, a `build.rs`, cgo directives.
+- `stale_release`: the latest release is more than eighteen months older than today. Compute it from the upstream `latest_release_published_at`.
+- `maintainer_domain_expired`: a maintainer contact's email domain no longer resolves.
+
+Omit a flag you could not check. An absent flag means "not checked or not found", never "checked and clean". Guessing is worse than silence here, because these ids feed the repository's health classification.
+
+`./src` is the repository checkout, available to this skill, so the source-derived checks read from there. Under `--hardened` the DNS check for `maintainer_domain_expired` is unavailable, so that flag is simply omitted rather than guessed.
+
+Write `risk_flags` as an empty array or omit it entirely when nothing applies; both are valid.

--- a/skills/packages/SKILL.md
+++ b/skills/packages/SKILL.md
@@ -57,7 +57,7 @@ The five flags and how to check each:
 - `stale_release`: the latest release is more than eighteen months older than today. Compute it from the upstream `latest_release_published_at`.
 - `maintainer_domain_expired`: a maintainer contact's email domain no longer resolves.
 
-Omit a flag you could not check. An absent flag means "not checked or not found", never "checked and clean". Guessing is worse than silence here, because these ids feed the repository's health classification.
+Omit a flag you could not check. An absent flag means "not checked or not found", never "checked and clean". Guessing is worse than silence here, because an analyst reads every flag as something you actually verified.
 
 `./src` is the repository checkout, available to this skill, so the source-derived checks read from there. Under `--hardened` the DNS check for `maintainer_domain_expired` is unavailable, so that flag is simply omitted rather than guessed.
 

--- a/skills/packages/schema.json
+++ b/skills/packages/schema.json
@@ -24,7 +24,22 @@
           "registry_url":           { "type": "string" },
           "latest_release_at":      { "type": "string" },
           "dependent_packages_url": { "type": "string" },
-          "metadata":               {}
+          "metadata":               {},
+          "risk_flags": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["id", "evidence"],
+              "additionalProperties": false,
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "enum": ["single_maintainer", "no_security_policy", "native_extension", "stale_release", "maintainer_domain_expired"]
+                },
+                "evidence": { "type": "string" }
+              }
+            }
+          }
         }
       }
     }

--- a/skills/packages/schema.json
+++ b/skills/packages/schema.json
@@ -36,7 +36,7 @@
                   "type": "string",
                   "enum": ["single_maintainer", "no_security_policy", "native_extension", "stale_release", "maintainer_domain_expired"]
                 },
-                "evidence": { "type": "string" }
+                "evidence": { "type": "string", "minLength": 1 }
               }
             }
           }


### PR DESCRIPTION
Part of #106: folds the [Trail of Bits supply-chain-risk-auditor](https://github.com/trailofbits/skills/tree/main/plugins/supply-chain-risk-auditor) heuristic checklist into the existing `packages` skill as a `risk_flags` array, rather than adding a separate skill.

Five flags, exactly the ones the issue names, no more:

| Flag | Raised when |
|---|---|
| `single_maintainer` | the registry lists one owner or publisher |
| `no_security_policy` | no `SECURITY.md` anywhere in the checkout |
| `native_extension` | the package ships compiled code, so installing it runs a toolchain |
| `stale_release` | the latest release is more than eighteen months old |
| `maintainer_domain_expired` | a maintainer contact's email domain no longer resolves |

## Report shape

Each entry is `{"id": ..., "evidence": ...}`, where the evidence is one sentence naming what the skill actually saw: the file, the field, the date. The schema requires it to be non-empty. The skill is told to omit any flag it could not check and SKILL.md says so in as many words: an absent flag means "not checked or not found", never "checked and clean". Guessing is worse than silence, because an analyst reads every flag as something the skill actually verified. Under `--hardened` the DNS lookup behind `maintainer_domain_expired` is unavailable, so that flag is simply left off.

## Storage

Only the validated ids reach the new `packages.risk_flags` column, comma-joined and canonically ordered. The evidence sentences stay in `scan.Report`. That is the split `posture` already uses, where the full check list stays in the report while only the tier is promoted to a column, and it keeps the health summary and the package page free of JSON decoding.

`internal/db/package_risk.go` owns the closed set plus `NormalisePackageRiskFlags`, `PackageRiskFlags` and a label map for display, so the parser and the health scorer share one definition instead of repeating flag names. `joinPackageRiskFlags` in the worker is the write side of that pair. An id outside the set is dropped with a warning event naming the package and its ecosystem rather than failing the scan: the rest of the package row is still accurate, while a model inventing a sixth flag name should not cost the repository its whole package set.

New nullable text column, so `AutoMigrate` adds it. No `preMigrate` work, nothing to backfill.

## Health

`RepositoryHealthAssessment` gains a `RiskFlags` union across the repository's packages, deduped and canonically ordered, computed before the unassessed early return so the flags are still carried when there is not enough evidence to classify. `healthSummary` names them in human form, so a classification explains itself.

The flags are advisory and never move the classification. An absent flag means "not checked", not "checked and clean", and `parsePackagesOutput` replaces the whole package set on every run while the health scorer recomputes hourly. Scoring on a flag would therefore let a single scan that skipped the check silently flip a stored verdict back with no upstream change behind it.

Release staleness is instead derived host-side from `Package.LatestReleaseAt`, authoritative upstream data already in a column. The assessment carries `LastReleaseAt`, the newest release across every package the repository publishes, and a repository whose newest release is more than eighteen months old is held at `stale`. Taking the newest release rather than any one package's keeps a monorepo `active` while any of its packages still ships, which matters now that #806 gave sub-packages their own identity. It deliberately does **not** push anything towards `abandoned`, which still requires archival or maintainer evidence. The summary gained a `last release N ago` clause so a stale verdict says why.

## Also

- `risk_flags` on the packages API response plus `openapi.yaml`, so a skill can read back what the last run recorded.
- Badges on the package page, hidden when there are none. Both the badges and the health summary render labels (`ships native code`, `no recent release`) while the column, the API and the skill contract keep the ids.
- `docs/database.md` and `docs/skills.md`.

## Testing

- `NormalisePackageRiskFlags` and `PackageRiskFlags`: canonical reordering, dedup, trimming, empty and unknown ids, nil on empty input. Labels for all five ids plus the fallback for an unrecognised one.
- Parser: flags land comma-joined and canonically ordered whatever order the skill reported them in, a package with no `risk_flags` key gets an empty column, an unknown id is dropped while the known flags on the same package survive and the warning names both the flag and the ecosystem.
- Health: a release older than eighteen months holds a recently-pushed repository at `stale`; a monorepo stays `active` while one package still ships; a `stale_release` flag alongside a recent release date moves nothing; flags union and order across two packages with the summary naming them; the summary names the last release age; flags survive the early-return path while `Health` stays empty.

`gofmt -l`, `go build`, `go vet` (including the `evals` and `podman` tags), `go mod tidy -diff`, `go test -race ./...`, `go test -race -tags evals` and `golangci-lint` are all clean. The one `golangci-lint` hit, `goconst` on `internal/web/audit_test.go:57`, is present on an unmodified `main`.

Remaining on #106 after this: the `security-deep-dive` upgrade (convention-not-bug rule plus the sharp-edges API-misuse probes).

**Note: The `verify` attack-tree line on the tracking comment is already done by #851, just not ticked.**