### PR TITLE
Bundle GitHub Copilot CLI in the runner image and document the backend

### DIFF
--- a/Dockerfile.runner
+++ b/Dockerfile.runner
@@ -11,6 +11,7 @@ ARG CLAUDE_AMD64_LOCK=v2.1.223@sha256:0b516307190edfb776501e5c12a32d7d0c0b01d111
 ARG CLAUDE_ARM64_LOCK=v2.1.223@sha256:e6a7ce80f57317c9121d429fe2bcc7b5b82cd901863c3f33754589dcc99d0460
 ARG CODEX_VERSION=0.142.5
 ARG OPENCODE_VERSION=1.17.12
+ARG COPILOT_VERSION=1.0.80
 ARG SEMGREP_VERSION=1.167.0
 
 FROM golang:1.26.5-trixie@sha256:4ee9ffa999b4583ce281939cdff828763083610292f252279a0cee77473bd9a7 AS go-tools
@@ -38,6 +39,7 @@ ARG CLAUDE_AMD64_LOCK
 ARG CLAUDE_ARM64_LOCK
 ARG CODEX_VERSION
 ARG OPENCODE_VERSION
+ARG COPILOT_VERSION
 ARG SEMGREP_VERSION
 
 ENV DEBIAN_FRONTEND=noninteractive
@@ -113,6 +115,22 @@ RUN set -eux; \
     tar -xzf /tmp/opencode.tgz -C /usr/local/bin opencode; \
     rm /tmp/opencode.tgz; \
     opencode --version
+
+# GitHub Copilot CLI (-backend copilot). The glibc tarball contains a single
+# `copilot` binary; it links libstdc++ dynamically (same as opencode's bun
+# runtime), which is why libstdc++6 is already in the apt install list above.
+RUN set -eux; \
+    case "${TARGETARCH}" in \
+      amd64) cparch=x64;   sha=039933c9247686131c4406abb1d439bdbf68103edc1ff585bd70d5b0dc940f72 ;; \
+      arm64) cparch=arm64; sha=3ed85e711955e13be523bf492bc6c93b40b69925bcb7f817c9d08abf4839cf89 ;; \
+      *) echo "unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;; \
+    esac; \
+    curl -fsSL -o /tmp/copilot.tgz \
+      "https://github.com/github/copilot-cli/releases/download/v${COPILOT_VERSION}/copilot-linux-${cparch}.tar.gz"; \
+    echo "${sha}  /tmp/copilot.tgz" | sha256sum -c -; \
+    tar -xzf /tmp/copilot.tgz -C /usr/local/bin copilot; \
+    rm /tmp/copilot.tgz; \
+    copilot --version
 
 COPY --from=go-tools /out/* /usr/local/bin/
 COPY --from=zizmor-build /out/bin/zizmor /usr/local/bin/zizmor

--- a/README.md
+++ b/README.md
@@ -415,10 +415,10 @@ The egress allowlist covers `models.dev` plus the Anthropic and OpenAI API hosts
 
 Scrutineer can drive [GitHub Copilot CLI](https://docs.github.com/en/copilot/how-tos/copilot-cli) instead of claude-code. The runner image bundles the `copilot` binary, so switching is the flag (or `backend: copilot` in `scrutineer.yaml`) plus a credential -- a GitHub token with Copilot access:
 
-    export GH_TOKEN=ghp_...
+    export GH_TOKEN=github_pat_...
     go run ./cmd/scrutineer -skills ./skills -backend copilot
 
-The container, egress proxy, language profiles and skill staging stay the same; only the agent CLI inside the container changes. The egress allowlist is entirely GitHub infrastructure (`github.com`, `api.github.com`, `api.mcp.github.com`, `*.githubcopilot.com`) -- no third-party model provider host is contacted directly, since Copilot CLI proxies every model through GitHub's own API. The model pick list defaults to Copilot's own catalog (Claude and GPT models) with tier tags already set; override with `models:` in the config for a different set. Unlike codex and opencode, `-max-turns` is honoured by this backend. The copilot backend requires the containerised runner; `--no-container` with `-backend copilot` is rejected at startup. See [docs/copilot.md](docs/copilot.md) for the full credential and event-mapping details.
+The container, egress proxy, language profiles and skill staging stay the same; only the agent CLI inside the container changes. The default egress allowlist is entirely GitHub infrastructure (`github.com`, `api.github.com`, `api.mcp.github.com`, `*.githubcopilot.com`), since Copilot CLI proxies every model through GitHub's own API; setting `-model-base-url` overrides that endpoint and adds the override host to the allowlist. The model pick list defaults to Copilot's own catalog (Claude and GPT models) with tier tags already set; override with `models:` in the config for a different set. Unlike codex and opencode, `-max-turns` is honoured by this backend. The copilot backend requires the containerised runner; `--no-container` with `-backend copilot` is rejected at startup. See [docs/copilot.md](docs/copilot.md) for the full credential and event-mapping details.
 
 ## Sandboxed Claude Code configs
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # scrutineer
 
-A local tool for scanning open source repositories for security vulnerabilities and managing the disclosure process. You add a repo by URL, scrutineer runs a pipeline of [agent skills](https://agentskills.io) against it inside a container, and presents the results in a web UI where you can triage findings, identify maintainers, and track disclosures. The agent CLI is pluggable: [claude-code](https://claude.com/code) by default, or [codex](https://github.com/openai/codex) or [opencode](https://opencode.ai) with `-backend`.
+A local tool for scanning open source repositories for security vulnerabilities and managing the disclosure process. You add a repo by URL, scrutineer runs a pipeline of [agent skills](https://agentskills.io) against it inside a container, and presents the results in a web UI where you can triage findings, identify maintainers, and track disclosures. The agent CLI is pluggable: [claude-code](https://claude.com/code) by default, or [codex](https://github.com/openai/codex), [opencode](https://opencode.ai), or [GitHub Copilot CLI](https://docs.github.com/en/copilot/how-tos/copilot-cli) with `-backend`.
 
 ## Quick start
 
@@ -50,9 +50,9 @@ You can also build a checkout-independent executable and run it from another dir
 
 Precompiled binaries cover Linux and macOS on `amd64` and `arm64`. Run `scrutineer --version` (or `scrutineer version`) to see the application version, source commit, build timestamp, and exact runner-image digest paired with that release.
 
-The executable does not bundle Docker, Podman, or Apple's `container` CLI. Scrutineer remains a host application that asks the selected external runtime to launch an ephemeral runner container for each scan; it materialises the embedded profile Dockerfiles under the data directory when `docker/profiles` is not available from a source checkout. Content-addressed skill and profile bundles from older versions are retained because existing skill records may still reference their auxiliary files; incomplete extraction directories older than 24 hours are removed automatically. To run under codex or opencode instead, see the [Codex backend](#codex-backend) and [Opencode backend](#opencode-backend) sections; only the credential and `-backend` flag change.
+The executable does not bundle Docker, Podman, or Apple's `container` CLI. Scrutineer remains a host application that asks the selected external runtime to launch an ephemeral runner container for each scan; it materialises the embedded profile Dockerfiles under the data directory when `docker/profiles` is not available from a source checkout. Content-addressed skill and profile bundles from older versions are retained because existing skill records may still reference their auxiliary files; incomplete extraction directories older than 24 hours are removed automatically. To run under codex, opencode, or copilot instead, see the [Codex backend](#codex-backend), [Opencode backend](#opencode-backend), and [Copilot backend](#copilot-backend) sections; only the credential and `-backend` flag change.
 
-Large batches pause automatically at an account-level rate limit or quota wall. When claude-code is running on a subscription token it emits a `rate_limit_event` carrying the reset time, and scrutineer re-queues the paused batch after that reset; API-key accounts and the codex/opencode backends report the error without a reset time, so those batches stay paused for manual resume from the `/usage` page, which also shows the most recent per-window status.
+Large batches pause automatically at an account-level rate limit or quota wall. When claude-code is running on a subscription token it emits a `rate_limit_event` carrying the reset time, and scrutineer re-queues the paused batch after that reset; API-key accounts and the codex/opencode/copilot backends report the error without a reset time, so those batches stay paused for manual resume from the `/usage` page, which also shows the most recent per-window status.
 
 Scrutineer uses Docker by default: each scan runs in an ephemeral container with a read-only source mount and an egress allowlist proxy. The paired runner image (`ghcr.io/alpha-omega-security/scrutineer-runner`) is pulled on first use, so the first scan is slower while it downloads. A host without the selected runtime fails startup rather than silently weakening isolation; `--no-container` is the explicit, Claude-only escape hatch for running directly on a trusted host.
 
@@ -252,7 +252,7 @@ Or with a Claude Code OAuth token instead of an API key:
       -e CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-... \
       scrutineer
 
-For codex or opencode, pass `-e CODEX_API_KEY=...` / `-e OPENAI_API_KEY=...` (or `ANTHROPIC_API_KEY` for opencode with an Anthropic model) and add `-backend codex` / `-backend opencode` to the command.
+For codex or opencode, pass `-e CODEX_API_KEY=...` / `-e OPENAI_API_KEY=...` (or `ANTHROPIC_API_KEY` for opencode with an Anthropic model) and add `-backend codex` / `-backend opencode` to the command. For copilot, pass `-e GH_TOKEN=...` and add `-backend copilot`.
 
 Always bind to `127.0.0.1`: the UI has no authentication, so binding to `0.0.0.0` exposes your findings database to anyone on the network.
 
@@ -338,7 +338,7 @@ The `docker build` commands shown for the runner image and profiles can be run a
 | `-effort` | `high` | Claude effort level (claude backend only) |
 | `-skills` | - | Additional local directory to load SKILL.md files from; same-named skills override the bundled copies (repeatable) |
 | `-skills-repo` | - | `owner/repo[@ref]` or credential-free git HTTPS URL `https://host/path[@ref]` to clone skills from on startup; `@ref` pins a branch, tag or commit and the resolved SHA is recorded on every scan; private repositories use config-file-only `skills_repo_token` |
-| `-backend` | `claude` | Agent CLI the container runner execs: `claude`, `codex`, or `opencode`. Non-claude backends require the containerised runner |
+| `-backend` | `claude` | Agent CLI the container runner execs: `claude`, `codex`, `opencode`, or `copilot`. Non-claude backends require the containerised runner |
 | `--runtime` | `docker` | Container runtime: `docker`, `podman` (rootless podman supported), or `apple` (Apple, experimental) |
 | `--selinux` | `auto` | Bind-mount SELinux relabeling: `auto` (relabel when SELinux is detected), `on`, or `off` |
 | `--no-container` | false | Disable the containerised runner; run claude directly on the host (no isolation). Deprecated alias: `--no-docker` |
@@ -348,7 +348,7 @@ The `docker build` commands shown for the runner image and profiles can be run a
 | `-concurrency` | `4` | Number of scans to run in parallel. Chat turns run from a separate pool sized at half this value, so a busy host can reach 1.5x this many agent containers |
 | `-clone` | `shallow` | Clone depth: `shallow` (`--depth 1`) or `full` |
 | `-scan-timeout` | `1h` | Wall-clock limit per scan; exceeded scans fail |
-| `-max-turns` | `0` | Per-scan turn cap (0 = unlimited); claude backend only, codex and opencode have no turn cap |
+| `-max-turns` | `0` | Per-scan turn cap (0 = unlimited); claude and copilot backends only, codex and opencode have no turn cap |
 | `-schema-strict` | `false` | Fail a scan when its `report.json` does not validate against the skill's `schema.json` (default: warn in the scan log and parse anyway) |
 | `-model-base-url` | - | Custom model API base URL for the active backend (env fallback: `ANTHROPIC_BASE_URL` for claude). `-anthropic-base-url` is a deprecated alias. |
 | `-ecosystems-enrichment` | `true` | Enrich repositories from ecosyste.ms: the per-repository cache, the warm on repo add, and the PURL-to-repository resolution behind SBOM and dependency import. `=false` stops every lookup scrutineer's own process makes, leaves `egress_allow` untouched (the bundled skills still fetch ecosyste.ms themselves), and leaves the Dependents tab and dependent-exposure analysis with no data |
@@ -411,6 +411,15 @@ See [docs/codex.md](docs/codex.md) for what differs from claude (argv, skill sta
 
 The egress allowlist covers `models.dev` plus the Anthropic and OpenAI API hosts; other providers go in `egress_allow:`. Like codex, the opencode backend requires the containerised runner. See [docs/opencode.md](docs/opencode.md) for provider-credential handling and what differs from claude.
 
+## Copilot backend
+
+Scrutineer can drive [GitHub Copilot CLI](https://docs.github.com/en/copilot/how-tos/copilot-cli) instead of claude-code. The runner image bundles the `copilot` binary, so switching is the flag (or `backend: copilot` in `scrutineer.yaml`) plus a credential -- a GitHub token with Copilot access:
+
+    export GH_TOKEN=ghp_...
+    go run ./cmd/scrutineer -skills ./skills -backend copilot
+
+The container, egress proxy, language profiles and skill staging stay the same; only the agent CLI inside the container changes. The egress allowlist is entirely GitHub infrastructure (`github.com`, `api.github.com`, `api.mcp.github.com`, `*.githubcopilot.com`) -- no third-party model provider host is contacted directly, since Copilot CLI proxies every model through GitHub's own API. The model pick list defaults to Copilot's own catalog (Claude and GPT models) with tier tags already set; override with `models:` in the config for a different set. Unlike codex and opencode, `-max-turns` is honoured by this backend. The copilot backend requires the containerised runner; `--no-container` with `-backend copilot` is rejected at startup. See [docs/copilot.md](docs/copilot.md) for the full credential and event-mapping details.
+
 ## Sandboxed Claude Code configs
 
 In `--no-container` mode the `claude` subprocess inherits your `~/.claude/settings.json`, so [sandbox settings](https://code.claude.com/docs/en/sandboxing) that restrict network or filesystem access there will fail skills that need them. Point `claude` at a separate config directory just for scrutineer runs:
@@ -435,6 +444,7 @@ See [SECURITY.md](SECURITY.md) for the reporting policy and [threatmodel.md](thr
 - [docs/interchange.md](docs/interchange.md) -- federation interchange format: in-toto record envelope, salted finding hashes, the claim-check endpoint, the public and members-only feeds with their export/import jobs (threat surface: T14 in [threatmodel.md](threatmodel.md))
 - [docs/codex.md](docs/codex.md) -- the codex backend: what differs from claude, sandbox interaction, adding another harness
 - [docs/opencode.md](docs/opencode.md) -- the opencode backend: provider-agnostic credentials and egress
+- [docs/copilot.md](docs/copilot.md) -- the copilot backend: GitHub token credential handling and egress
 - [docs/podman.md](docs/podman.md) -- security model and known gaps for the podman / rootless runtime (sandbox isolation, hardened-mode verification)
 - [docs/egress-sidecar.md](docs/egress-sidecar.md) -- operator validation checklist for the rootless `--hardened` egress proxy sidecar
 

--- a/docs/copilot.md
+++ b/docs/copilot.md
@@ -1,0 +1,123 @@
+# Copilot backend
+
+Scrutineer can drive [GitHub Copilot CLI](https://docs.github.com/en/copilot/how-tos/copilot-cli)
+instead of claude-code, selected with `-backend copilot` (or `backend:
+copilot` in `scrutineer.yaml`). The container, egress proxy, language
+profiles and workspace layout stay the same; only the agent CLI exec'd inside
+the per-scan container changes.
+
+## Setup
+
+The runner image bundles the `copilot` binary (a glibc build, sha256-pinned
+in `Dockerfile.runner`), so there's nothing to install. Authenticate with a
+GitHub token that has Copilot access and start scrutineer:
+
+    export GH_TOKEN=ghp_...
+    go run ./cmd/scrutineer -skills ./skills -backend copilot
+
+or in `scrutineer.yaml`:
+
+    backend: copilot
+    default_model: claude-sonnet-4.6
+    models:
+      - name: Claude Sonnet 4.6
+        id:   claude-sonnet-4.6
+        tier: high
+      - name: Claude Haiku 4.5
+        id:   claude-haiku-4.5
+        tier: mid
+      - name: Claude Opus 4.6
+        id:   claude-opus-4.6
+        tier: max
+      - name: GPT-5.3 Codex
+        id:   gpt-5.3-codex
+      - name: GPT-5.4
+        id:   gpt-5.4
+
+The `models:` block is optional; without it the pick list is the harness's
+built-in default set above. Model ids are Copilot CLI's own (dotted, e.g.
+`claude-sonnet-4.6`), which differ from claude-code's hyphenated ids
+(`claude-sonnet-4-6`) -- don't copy ids between the claude and copilot
+backends.
+
+Any of `COPILOT_GITHUB_TOKEN`, `GH_TOKEN`, or `GITHUB_TOKEN` on the host is
+passed through to the container as a credential; Copilot CLI accepts the
+first one it finds. A token from `gh auth login` (or a fine-grained PAT with
+Copilot access) works the same way `gh` itself authenticates. There is no
+separate API-key concept here: whichever token you export is the one billed
+against your Copilot entitlement.
+
+The copilot backend requires the containerised runner. `--no-container` with
+`-backend copilot` is rejected at startup: the `copilot` binary lives in the
+runner image, not on the host, and the local fallback (`LocalClaude`) is
+claude-only.
+
+## How the harness maps
+
+| Aspect | claude | copilot |
+| --- | --- | --- |
+| Binary | `claude` | `copilot` |
+| Argv | `claude -p --output-format stream-json ...` | `copilot -p ... --output-format json --autopilot --max-autopilot-continues N --allow-all --no-ask-user --no-auto-update --no-color` |
+| Skill staging | `./.claude/skills/{name}/SKILL.md` | `./.github/skills/{name}/SKILL.md` |
+| Project memory | `CLAUDE.md` | `./.github/copilot-instructions.md` |
+| Egress hosts | `*.anthropic.com` | `github.com`, `api.github.com`, `api.mcp.github.com`, `*.githubcopilot.com` |
+| Credential env | `ANTHROPIC_API_KEY`, `CLAUDE_CODE_OAUTH_TOKEN` | `COPILOT_GITHUB_TOKEN`, `GH_TOKEN`, `GITHUB_TOKEN` |
+| State dir env | `CLAUDE_CONFIG_DIR` | `COPILOT_HOME` |
+| Account-error phrases | claude usage/plan/access messages | rate limit / quota / entitlement / auth failure messages |
+
+`--allow-all` grants the CLI every tool it exposes without interactive
+confirmation; the container is the sandbox, the same posture codex and
+opencode run under. `--no-ask-user` stops copilot from blocking on a prompt
+scrutineer can't answer. `-resume=<id>` is appended when a scan is retried, so
+the session store (bind-mounted at `/harness-state`, `COPILOT_HOME`) picks up
+where a previous attempt left off, the same as the other backends.
+
+The activation prompt points explicitly at
+`./.github/skills/{name}/SKILL.md`: like codex and opencode, copilot
+discovers skills but does not auto-invoke them in headless `-p` mode.
+
+`-model-base-url` maps to `COPILOT_PROVIDER_BASE_URL`; there is no
+`-effort` equivalent, and it is ignored for this backend, same as codex and
+opencode.
+
+## Egress
+
+Copilot CLI talks to GitHub for authentication, MCP, and the model API
+itself (`githubcopilot.com`), so the egress allowlist is entirely GitHub
+infrastructure -- no third-party model provider host is ever contacted
+directly. Under `--hardened` only these hosts plus the host skill API are
+permitted.
+
+The threat-model T1 residual applies the same: whichever GitHub token is set
+passes into the container as an env var and is readable by in-container code.
+Scope the token narrowly (a fine-grained PAT rather than a broad classic
+token) if that residual matters for your deployment.
+
+## Known gaps
+
+Copilot CLI has no per-turn cap distinct from `--max-autopilot-continues`
+(mapped from `-max-turns`, defaulting to `DefaultMaxTurns` when unset), so
+unlike codex and opencode this backend does honour `-max-turns`. The
+`-scan-timeout` wall-clock limit still applies regardless.
+
+Claude's `-effort` setting has no copilot equivalent and is ignored.
+
+The stream parser (`CopilotHarness.ParseStream`) maps Copilot CLI's
+`--output-format json` events onto the scan log, based on CLI 1.0.75:
+`assistant.message` and `assistant.reasoning` become text/thinking events,
+`tool.execution_start` becomes a tool call, `assistant.usage` and
+`assistant.turn_end` are combined into a single result event emitted after
+the stream ends (Copilot reports turns and token usage as separate records),
+`result` carries the session id and a non-zero exit code as an error, and
+`abort` / `session.error` / `error` surface as errors. Unknown event types
+pass through as raw text so a CLI update remains visible.
+
+## See also
+
+- `docs/codex.md`: the codex backend, including the "Adding another harness"
+  section that copilot follows.
+- `docs/opencode.md`: the opencode backend.
+- `internal/worker/harness.go`: the `Harness` interface aliases; the
+  concrete `CopilotHarness` implementation lives in the
+  `github.com/alpha-omega-security/harness` module (`copilot.go`).
+- #211: tracking issue for alternative harnesses.

--- a/docs/copilot.md
+++ b/docs/copilot.md
@@ -12,7 +12,7 @@ The runner image bundles the `copilot` binary (a glibc build, sha256-pinned
 in `Dockerfile.runner`), so there's nothing to install. Authenticate with a
 GitHub token that has Copilot access and start scrutineer:
 
-    export GH_TOKEN=ghp_...
+    export GH_TOKEN=github_pat_...
     go run ./cmd/scrutineer -skills ./skills -backend copilot
 
 or in `scrutineer.yaml`:
@@ -42,13 +42,16 @@ backends.
 
 Any of `COPILOT_GITHUB_TOKEN`, `GH_TOKEN`, or `GITHUB_TOKEN` on the host is
 passed through to the container as a credential; Copilot CLI accepts the
-first one it finds. A token from `gh auth login` (or a fine-grained PAT with
-Copilot access) works the same way `gh` itself authenticates. There is no
-separate API-key concept here: whichever token you export is the one billed
-against your Copilot entitlement.
+first one it finds. Copilot CLI does not accept classic personal access
+tokens (`ghp_...`): use a fine-grained PAT with the Copilot Requests
+permission, or export the OAuth token from an existing `gh` login with
+`export GH_TOKEN=$(gh auth token)`. Only the environment variables above
+reach the container -- the host's `~/.config/gh` is not mounted -- so the
+token must be exported explicitly. Whichever token you export is the one
+billed against your Copilot entitlement.
 
 The copilot backend requires the containerised runner. `--no-container` with
-`-backend copilot` is rejected at startup: the `copilot` binary lives in the
+`-backend copilot` is rejected at startup: the `copilot` binary is in the
 runner image, not on the host, and the local fallback (`LocalClaude`) is
 claude-only.
 
@@ -67,10 +70,11 @@ claude-only.
 
 `--allow-all` grants the CLI every tool it exposes without interactive
 confirmation; the container is the sandbox, the same posture codex and
-opencode run under. `--no-ask-user` stops copilot from blocking on a prompt
-scrutineer can't answer. `-resume=<id>` is appended when a scan is retried, so
-the session store (bind-mounted at `/harness-state`, `COPILOT_HOME`) picks up
-where a previous attempt left off, the same as the other backends.
+opencode run under. `--no-ask-user` stops copilot from blocking on an
+interactive prompt (scrutineer runs it headless). `--resume=<id>` is appended
+when a scan is retried, so the session store (bind-mounted at
+`/harness-state`, `COPILOT_HOME`) resumes the previous attempt, the same as
+the other backends.
 
 The activation prompt points explicitly at
 `./.github/skills/{name}/SKILL.md`: like codex and opencode, copilot
@@ -82,28 +86,22 @@ opencode.
 
 ## Egress
 
-Copilot CLI talks to GitHub for authentication, MCP, and the model API
-itself (`githubcopilot.com`), so the egress allowlist is entirely GitHub
-infrastructure -- no third-party model provider host is ever contacted
-directly. Under `--hardened` only these hosts plus the host skill API are
-permitted.
+Copilot CLI connects to GitHub for authentication, MCP, and the model API
+itself (`githubcopilot.com`), so the default egress allowlist is entirely
+GitHub infrastructure. Under `--hardened` only these hosts plus the host
+skill API are permitted. The exception is `-model-base-url`: Copilot CLI
+contacts that provider host directly, and scrutineer adds it to the
+allowlist in both normal and `--hardened` modes.
 
 The threat-model T1 residual applies the same: whichever GitHub token is set
-passes into the container as an env var and is readable by in-container code.
-Scope the token narrowly (a fine-grained PAT rather than a broad classic
-token) if that residual matters for your deployment.
+passes into the container as an env var and is readable by in-container
+code. Scope the token to the minimum (fine-grained PAT with only the Copilot
+Requests permission) if that residual matters for your deployment.
 
 ## Known gaps
 
-Copilot CLI has no per-turn cap distinct from `--max-autopilot-continues`
-(mapped from `-max-turns`, defaulting to `DefaultMaxTurns` when unset), so
-unlike codex and opencode this backend does honour `-max-turns`. The
-`-scan-timeout` wall-clock limit still applies regardless.
-
-Claude's `-effort` setting has no copilot equivalent and is ignored.
-
 The stream parser (`CopilotHarness.ParseStream`) maps Copilot CLI's
-`--output-format json` events onto the scan log, based on CLI 1.0.75:
+`--output-format json` events onto the scan log:
 `assistant.message` and `assistant.reasoning` become text/thinking events,
 `tool.execution_start` becomes a tool call, `assistant.usage` and
 `assistant.turn_end` are combined into a single result event emitted after
@@ -118,6 +116,6 @@ pass through as raw text so a CLI update remains visible.
   section that copilot follows.
 - `docs/opencode.md`: the opencode backend.
 - `internal/worker/harness.go`: the `Harness` interface aliases; the
-  concrete `CopilotHarness` implementation lives in the
+  concrete `CopilotHarness` implementation is in the
   `github.com/alpha-omega-security/harness` module (`copilot.go`).
 - #211: tracking issue for alternative harnesses.


### PR DESCRIPTION
The harness library (v0.1.6) already implements CopilotHarness, but the runner image never installed the copilot binary and there was no docs page for it, so -backend copilot was unusable.

- Dockerfile.runner: add a sha256-pinned install stage for the copilot Linux binary (amd64/arm64), matching the codex/opencode pattern.
- docs/copilot.md: new page covering setup, credential env vars, the harness argv/egress/skill-staging mapping, and known gaps.
- README.md: mention the copilot backend in the intro, flags table, Docker run example, rate-limit note, and add a "Copilot backend" section plus a docs-index entry.