### PR TITLE
Let focus-area deep-dives use the skill's max tier

### DIFF
--- a/internal/web/focus_area_deep_dive.go
+++ b/internal/web/focus_area_deep_dive.go
@@ -82,7 +82,12 @@ func (s *Server) enqueueFocusAreaDeepDive(parent *db.Scan, skillID uint, group, 
 		return
 	}
 	if _, err := s.enqueueSkillWith(context.Background(), parent.RepositoryID, skillID, ScanOpts{
-		Model:          parent.Model,
+		// Model is intentionally not inherited: parent.Model is the
+		// threat-model scan's already-resolved concrete id (high tier
+		// by default), and passing it would win precedence over the
+		// deep-dive skill's own scrutineer.model: max declaration.
+		// Leaving it empty lets enqueueSkillWith fall through to the
+		// skill's tier so focus-area deep-dives run on max as intended.
 		Effort:         parent.Effort,
 		Profile:        parent.Profile,
 		SubPath:        parent.SubPath,

--- a/internal/web/focus_area_deep_dive_test.go
+++ b/internal/web/focus_area_deep_dive_test.go
@@ -9,8 +9,15 @@ import (
 )
 
 func TestAutoEnqueueFocusAreaDeepDives(t *testing.T) {
+	withTestModels(t, []Model{
+		{Name: "Test High", ID: "test-high"},
+		{Name: "Test Max", ID: "test-max"},
+	})
 	s, done := newTestServer(t)
 	defer done()
+	if err := db.SetSetting(s.DB, db.SettingModelTierMax, "test-max"); err != nil {
+		t.Fatal(err)
+	}
 	repo := db.Repository{
 		URL: "https://example.com/focus", Name: "focus", ScanConfig: `focus_areas:
   - name: XML parser
@@ -22,9 +29,12 @@ func TestAutoEnqueueFocusAreaDeepDives(t *testing.T) {
 `,
 	}
 	s.DB.Create(&repo)
-	deepDive := db.Skill{Name: deepDiveSkillName, Body: "b", OutputFile: "r.json", OutputKind: "findings", Active: true, Source: "ui"}
+	deepDive := db.Skill{Name: deepDiveSkillName, Body: "b", OutputFile: "r.json", OutputKind: "findings", Active: true, Source: "ui", Model: ModelTierMax}
 	s.DB.Create(&deepDive)
-	parent := db.Scan{RepositoryID: repo.ID, Status: db.ScanDone, SkillName: threatModelSkillName, ScanGroup: "triage-1", Effort: "high"}
+	// The parent threat-model scan stores a resolved concrete model id (high
+	// tier). The fan-out must not inherit it — the deep-dive skill declares
+	// max, and that is what focus-area scans should run on. #879.
+	parent := db.Scan{RepositoryID: repo.ID, Status: db.ScanDone, SkillName: threatModelSkillName, ScanGroup: "triage-1", Effort: "high", Model: "test-high"}
 	s.DB.Create(&parent)
 
 	s.autoEnqueueFocusAreaDeepDives(&parent)
@@ -46,6 +56,9 @@ func TestAutoEnqueueFocusAreaDeepDives(t *testing.T) {
 		got[area.Name] = scan
 		if scan.ScanGroup != parent.ScanGroup || scan.Effort != parent.Effort {
 			t.Errorf("scan = %+v, want parent effort and group", scan)
+		}
+		if scan.Model != "test-max" {
+			t.Errorf("scan.Model = %q, want deep-dive skill's max tier (test-max), not parent's %q", scan.Model, parent.Model)
 		}
 	}
 	if got["XML parser"].FocusArea == "" || got["CLI parser"].FocusArea == "" {


### PR DESCRIPTION
## Problem

Focus-area deep-dive scans spawned by a completed threat-model scan were running on the **high** tier instead of the configured **max** tier, even though `skills/security-deep-dive/SKILL.md` declares `scrutineer.model: max`.

## Root cause

`enqueueFocusAreaDeepDive` passed `Model: parent.Model` into the child `ScanOpts`. Since `parent.Model` is the threat-model scan's already-resolved *concrete* model id (stored post-`resolveModelPreference`), it satisfied `ValidModelPreference` in `enqueueSkillWith` and won precedence over the deep-dive skill's own `sk.Model = "max"` — which was therefore never consulted.

Manually launched deep-dives (empty `Model`) correctly fell through to `max`, so behavior differed by launch path.

## Fix

Drop model inheritance in the focus-area fan-out so the child skill's declared tier applies. Effort, scope, ref, and scan-group inheritance are unchanged.

## Test

`TestAutoEnqueueFocusAreaDeepDives` now sets a concrete high-tier model on the parent, gives the deep-dive skill `Model: ModelTierMax`, pins `SettingModelTierMax`, and asserts each spawned focus-area scan resolves to the max-tier model rather than inheriting the parent's.

Fixes #879

🤖 Generated with [Claude Code](https://claude.com/claude-code)