### PR TITLE
Fix copilot backend failing on the runner's noexec /tmp

### DIFF
--- a/.github/workflows/runner-image.yml
+++ b/.github/workflows/runner-image.yml
@@ -75,6 +75,13 @@ jobs:
       - name: Smoke test image
         run: |
           docker run --rm scrutineer-runner:ci claude --version
+          docker run --rm \
+            --read-only \
+            --cap-drop ALL \
+            --user 12345:12345 \
+            -e HOME=/tmp \
+            --tmpfs /tmp:rw,noexec,nosuid,size=256m \
+            scrutineer-runner:ci copilot --version
           docker run --rm scrutineer-runner:ci curl --version
           docker run --rm scrutineer-runner:ci semgrep --version
           docker run --rm scrutineer-runner:ci zizmor --version

--- a/Dockerfile.runner
+++ b/Dockerfile.runner
@@ -119,6 +119,18 @@ RUN set -eux; \
 # GitHub Copilot CLI (-backend copilot). The glibc tarball contains a single
 # `copilot` binary; it links libstdc++ dynamically (same as opencode's bun
 # runtime), which is why libstdc++6 is already in the apt install list above.
+#
+# The binary is a self-extracting bundle: on first run it unpacks a package
+# containing a native addon (runtime.node) into a cache dir and dlopen()s it.
+# The default cache dir is $XDG_CACHE_HOME/copilot or $HOME/.cache/copilot,
+# and the runner sets HOME=/tmp where /tmp is a noexec tmpfs, so that dlopen
+# fails with "failed to map segment from shared object". Unpacking here at
+# build time into an exec-capable rootfs path and pointing
+# COPILOT_PKG_CACHE_HOME (first entry in copilot's package search order) at it
+# keeps the runtime lookup off the noexec tmpfs. A read-only rootfs is fine:
+# the package is already unpacked, and the harness passes --no-auto-update so
+# copilot never tries to write a newer one.
+ENV COPILOT_PKG_CACHE_HOME=/usr/local/lib/copilot
 RUN set -eux; \
     case "${TARGETARCH}" in \
       amd64) cparch=x64;   sha=039933c9247686131c4406abb1d439bdbf68103edc1ff585bd70d5b0dc940f72 ;; \
@@ -130,7 +142,10 @@ RUN set -eux; \
     echo "${sha}  /tmp/copilot.tgz" | sha256sum -c -; \
     tar -xzf /tmp/copilot.tgz -C /usr/local/bin copilot; \
     rm /tmp/copilot.tgz; \
-    copilot --version
+    mkdir -p "${COPILOT_PKG_CACHE_HOME}"; \
+    copilot --version; \
+    test -d "${COPILOT_PKG_CACHE_HOME}/pkg"; \
+    chmod -R a+rX "${COPILOT_PKG_CACHE_HOME}"
 
 COPY --from=go-tools /out/* /usr/local/bin/
 COPY --from=zizmor-build /out/bin/zizmor /usr/local/bin/zizmor

--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ Or with a Claude Code OAuth token instead of an API key:
       -e CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-... \
       scrutineer
 
-For codex or opencode, pass `-e CODEX_API_KEY=...` / `-e OPENAI_API_KEY=...` (or `ANTHROPIC_API_KEY` for opencode with an Anthropic model) and add `-backend codex` / `-backend opencode` to the command. For copilot, pass `-e GH_TOKEN=...` and add `-backend copilot`.
+For codex or opencode, pass `-e CODEX_API_KEY=...` / `-e OPENAI_API_KEY=...` (or `ANTHROPIC_API_KEY` for opencode with an Anthropic model) and add `-backend codex` / `-backend opencode` to the command. For copilot, pass `-e GH_TOKEN=...` (a fine-grained PAT or `gh auth token` value; classic `ghp_` PATs are rejected by Copilot CLI) and add `-backend copilot`.
 
 Always bind to `127.0.0.1`: the UI has no authentication, so binding to `0.0.0.0` exposes your findings database to anyone on the network.
 
@@ -413,9 +413,9 @@ The egress allowlist covers `models.dev` plus the Anthropic and OpenAI API hosts
 
 ## Copilot backend
 
-Scrutineer can drive [GitHub Copilot CLI](https://docs.github.com/en/copilot/how-tos/copilot-cli) instead of claude-code. The runner image bundles the `copilot` binary, so switching is the flag (or `backend: copilot` in `scrutineer.yaml`) plus a credential -- a GitHub token with Copilot access:
+Scrutineer can drive [GitHub Copilot CLI](https://docs.github.com/en/copilot/how-tos/copilot-cli) instead of claude-code. The runner image bundles the `copilot` binary, so switching is the flag (or `backend: copilot` in `scrutineer.yaml`) plus a credential -- a GitHub token with Copilot access. Copilot CLI rejects classic (`ghp_`) PATs, so use a fine-grained PAT or the OAuth token `gh auth login` already stored:
 
-    export GH_TOKEN=github_pat_...
+    export GH_TOKEN=$(gh auth token)
     go run ./cmd/scrutineer -skills ./skills -backend copilot
 
 The container, egress proxy, language profiles and skill staging stay the same; only the agent CLI inside the container changes. The default egress allowlist is entirely GitHub infrastructure (`github.com`, `api.github.com`, `api.mcp.github.com`, `*.githubcopilot.com`), since Copilot CLI proxies every model through GitHub's own API; setting `-model-base-url` overrides that endpoint and adds the override host to the allowlist. The model pick list defaults to Copilot's own catalog (Claude and GPT models) with tier tags already set; override with `models:` in the config for a different set. Unlike codex and opencode, `-max-turns` is honoured by this backend. The copilot backend requires the containerised runner; `--no-container` with `-backend copilot` is rejected at startup. See [docs/copilot.md](docs/copilot.md) for the full credential and event-mapping details.

--- a/docs/copilot.md
+++ b/docs/copilot.md
@@ -12,7 +12,7 @@ The runner image bundles the `copilot` binary (a glibc build, sha256-pinned
 in `Dockerfile.runner`), so there's nothing to install. Authenticate with a
 GitHub token that has Copilot access and start scrutineer:
 
-    export GH_TOKEN=github_pat_...
+    export GH_TOKEN=$(gh auth token)
     go run ./cmd/scrutineer -skills ./skills -backend copilot
 
 or in `scrutineer.yaml`:
@@ -42,13 +42,19 @@ backends.
 
 Any of `COPILOT_GITHUB_TOKEN`, `GH_TOKEN`, or `GITHUB_TOKEN` on the host is
 passed through to the container as a credential; Copilot CLI accepts the
-first one it finds. Copilot CLI does not accept classic personal access
-tokens (`ghp_...`): use a fine-grained PAT with the Copilot Requests
-permission, or export the OAuth token from an existing `gh` login with
-`export GH_TOKEN=$(gh auth token)`. Only the environment variables above
-reach the container -- the host's `~/.config/gh` is not mounted -- so the
-token must be exported explicitly. Whichever token you export is the one
-billed against your Copilot entitlement.
+first one it finds. There is no separate API-key concept here: whichever
+token you export is the one billed against your Copilot entitlement.
+
+Copilot CLI rejects **classic personal access tokens** (`ghp_...`) outright
+with "Classic Personal Access Tokens (ghp_) are not supported by Copilot",
+before any network call. Use one of:
+
+- the OAuth token `gh auth login` already stores -- `export GH_TOKEN=$(gh auth token)`
+- a fine-grained PAT (`github_pat_...`) on an account with Copilot access
+
+The token is validated against the GitHub API on startup, so an expired or
+insufficiently scoped token fails the scan with "Authentication token found
+but could not be validated" rather than hanging.
 
 The copilot backend requires the containerised runner. `--no-container` with
 `-backend copilot` is rejected at startup: the `copilot` binary is in the
@@ -83,6 +89,44 @@ discovers skills but does not auto-invoke them in headless `-p` mode.
 `-model-base-url` maps to `COPILOT_PROVIDER_BASE_URL`; there is no
 `-effort` equivalent, and it is ignored for this backend, same as codex and
 opencode.
+
+## The package cache and the noexec /tmp
+
+The `copilot` binary is a self-extracting bundle: on first run it unpacks a
+package containing a native addon (`runtime.node`) into a cache directory and
+`dlopen()`s it. Its default cache location is `$XDG_CACHE_HOME/copilot`, or
+`$HOME/.cache/copilot` when that is unset.
+
+That default does not work inside a scan container. The container runner sets
+`HOME=/tmp` and mounts `/tmp` as a `noexec` tmpfs
+(`--tmpfs /tmp:rw,noexec,nosuid,size=256m`, `internal/worker/container.go`),
+so the extracted addon lands on a filesystem the kernel refuses to map
+executable and the CLI dies before doing any work:
+
+    Failed to load package index: /tmp/.cache/copilot/pkg/linux-x64/1.0.80/index.js
+    Error: Native addon "runtime" not found for linux-x64. Tried:
+      .../prebuilds/linux-x64/runtime.node: failed to map segment from shared object
+
+`Dockerfile.runner` avoids this by unpacking the package at **build** time
+into `/usr/local/lib/copilot` and setting `COPILOT_PKG_CACHE_HOME` to that
+path. It is the first entry in copilot's package search order (ahead of
+`COPILOT_CACHE_HOME`, `$XDG_CACHE_HOME/copilot`, `COPILOT_HOME`, and
+`~/.copilot`), so the runtime lookup resolves on the exec-capable rootfs and
+never touches the tmpfs. The build asserts the package actually materialised
+(`test -d $COPILOT_PKG_CACHE_HOME/pkg`) so a future CLI release that changes
+this layout fails the image build rather than every scan.
+
+A read-only rootfs (`--hardened`) is compatible: the package is already
+unpacked, and the harness passes `--no-auto-update` (plus
+`COPILOT_AUTO_UPDATE=false`), so copilot never tries to fetch or write a
+newer one. Profile images inherit both the directory and the environment
+variable because they are built `FROM ${RUNNER_IMAGE}`.
+
+Keep this in mind when bumping `COPILOT_VERSION`: the version is part of the
+cache path, so the build-time unpack and the runtime lookup have to come from
+the same image layer -- which they do, but a hand-copied `copilot` binary
+dropped into a derived image without re-running the unpack step would fall
+back to the noexec default and fail.
 
 ## Egress
 


### PR DESCRIPTION
This PR fixes a bug that causes the copilot backend to fail due to noexec /tmp mounts. It also clarifies that `ghp_` PATs aren't valid for the Copilot backend.

**Runner Image Updates**

* Modified `Dockerfile.runner` to bundle the Copilot CLI binary (`copilot`), set up a package cache (`/usr/local/lib/copilot`), and ensure compatibility with containerized execution by unpacking the binary at build time and setting the necessary environment variable (`COPILOT_PKG_CACHE_HOME`). This avoids runtime failures due to noexec `/tmp` mounts.

**Reference Documentation**

* Added `docs/copilot.md`, providing comprehensive details on Copilot backend setup, credential handling, technical differences, event mapping, and known gaps.
