### PR TITLE
Add provider-specific OpenCode runners

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,12 +404,12 @@ See [docs/codex.md](docs/codex.md) for what differs from claude (argv, skill sta
 
 ## Opencode backend
 
-[opencode](https://opencode.ai) is provider-agnostic, so `-backend opencode` runs whichever model you configure (Anthropic, OpenAI, or anything opencode supports). The runner image bundles the `opencode` binary; set the credential for your provider and the model id in `provider/model` form:
+[OpenCode](https://opencode.ai) can run models from several providers. The stock runner includes OpenCode and its common built-in adapters; select it with `-backend opencode` and use a model id in `provider/model` form:
 
     backend: opencode
     default_model: anthropic/claude-sonnet-5
 
-The egress allowlist covers `models.dev` plus the Anthropic and OpenAI API hosts; other providers go in `egress_allow:`. Like codex, the opencode backend requires the containerised runner. See [docs/opencode.md](docs/opencode.md) for provider-credential handling and what differs from claude.
+Anthropic and OpenAI keep their existing setup. Other providers can use `opencode.providers` to select provider-only credentials, hardened-mode egress hosts, stored OAuth state, OpenCode config, and a derived runner image. Scrutineer checks that the selected model exists in that image before starting the skill, then records the provider image and digest on the scan. Like codex, the OpenCode backend requires the container runner. See [docs/opencode.md](docs/opencode.md) for configuration and image requirements.
 
 ## Copilot backend
 
@@ -443,7 +443,7 @@ See [SECURITY.md](SECURITY.md) for the reporting policy and [threatmodel.md](thr
 - [docs/encrypted-sharing.md](docs/encrypted-sharing.md) -- encrypted findings sharing between contributors (age + SSH keys, team keyring management)
 - [docs/interchange.md](docs/interchange.md) -- federation interchange format: in-toto record envelope, salted finding hashes, the claim-check endpoint, the public and members-only feeds with their export/import jobs (threat surface: T14 in [threatmodel.md](threatmodel.md))
 - [docs/codex.md](docs/codex.md) -- the codex backend: what differs from claude, sandbox interaction, adding another harness
-- [docs/opencode.md](docs/opencode.md) -- the opencode backend: provider-agnostic credentials and egress
+- [docs/opencode.md](docs/opencode.md) -- OpenCode provider credentials, images, auth state, readiness, and egress
 - [docs/copilot.md](docs/copilot.md) -- the copilot backend: GitHub token credential handling and egress
 - [docs/podman.md](docs/podman.md) -- security model and known gaps for the podman / rootless runtime (sandbox isolation, hardened-mode verification)
 - [docs/egress-sidecar.md](docs/egress-sidecar.md) -- operator validation checklist for the rootless `--hardened` egress proxy sidecar

--- a/cmd/scrutineer/main.go
+++ b/cmd/scrutineer/main.go
@@ -987,9 +987,7 @@ func setupRunner(f *flags, cfg *config.Config, log *slog.Logger) (worker.SkillRu
 	if err != nil {
 		return nil, "", err
 	}
-	harnessHosts := append([]string{}, h.EgressHosts()...)
-	harnessHosts = append(harnessHosts, worker.OpencodeProviderEgress(opencodeProviders)...)
-	allow := buildEgressAllow(harnessHosts, f.hardened, cfg, f.modelBaseURL, log)
+	allow := buildEgressAllow(h.EgressHosts(), f.hardened, cfg, f.modelBaseURL, log)
 	if apiHost != worker.HostGatewayAlias {
 		allow = append(allow, apiHost)
 	}
@@ -1045,8 +1043,15 @@ func setupRunner(f *flags, cfg *config.Config, log *slog.Logger) (worker.SkillRu
 		Runtime:             rt,
 		SELinuxRelabel:      relabel,
 		Egress:              egress,
-		OpencodeProviders:   opencodeProviders,
-		OpencodeReadiness:   worker.NewOpencodeReadinessCache(),
+		ProviderProxy: worker.ScopedEgressProxyConfig{
+			Allow:         allow,
+			APIPort:       addrPort(f.addr),
+			APIHosts:      []string{apiHost},
+			ContainerHost: apiHost,
+			Log:           log,
+		},
+		OpencodeProviders: opencodeProviders,
+		OpencodeReadiness: worker.NewOpencodeReadinessCache(),
 	}, apiBase, nil
 }
 

--- a/cmd/scrutineer/main.go
+++ b/cmd/scrutineer/main.go
@@ -979,7 +979,17 @@ func setupRunner(f *flags, cfg *config.Config, log *slog.Logger) (worker.SkillRu
 		return nil, "", err
 	}
 	var egress worker.EgressSidecarConfig
-	allow := buildEgressAllow(h.EgressHosts(), f.hardened, cfg, f.modelBaseURL, log)
+	var configuredProviders map[string]config.OpencodeProvider
+	if cfg != nil {
+		configuredProviders = cfg.Opencode.Providers
+	}
+	opencodeProviders, err := loadOpencodeProviders(h, configuredProviders, cfgPath(f.configPath))
+	if err != nil {
+		return nil, "", err
+	}
+	harnessHosts := append([]string{}, h.EgressHosts()...)
+	harnessHosts = append(harnessHosts, worker.OpencodeProviderEgress(opencodeProviders)...)
+	allow := buildEgressAllow(harnessHosts, f.hardened, cfg, f.modelBaseURL, log)
 	if apiHost != worker.HostGatewayAlias {
 		allow = append(allow, apiHost)
 	}
@@ -1035,7 +1045,64 @@ func setupRunner(f *flags, cfg *config.Config, log *slog.Logger) (worker.SkillRu
 		Runtime:             rt,
 		SELinuxRelabel:      relabel,
 		Egress:              egress,
+		OpencodeProviders:   opencodeProviders,
+		OpencodeReadiness:   worker.NewOpencodeReadinessCache(),
 	}, apiBase, nil
+}
+
+func loadOpencodeProviders(h worker.Harness, providers map[string]config.OpencodeProvider, configPath string) (map[string]worker.OpencodeProviderConfig, error) {
+	if worker.HarnessName(h) != "opencode" || len(providers) == 0 {
+		return nil, nil
+	}
+	absConfig, err := filepath.Abs(configPath)
+	if err != nil {
+		return nil, fmt.Errorf("resolve OpenCode config path: %w", err)
+	}
+	baseDir := filepath.Dir(absConfig)
+	result := make(map[string]worker.OpencodeProviderConfig, len(providers))
+	for id, provider := range providers {
+		configFile, err := resolveOpencodeHostPath(baseDir, provider.ConfigFile)
+		if err != nil {
+			return nil, fmt.Errorf("opencode.providers.%s.config_file: %w", id, err)
+		}
+		stateDir, err := resolveOpencodeHostPath(baseDir, provider.StateDir)
+		if err != nil {
+			return nil, fmt.Errorf("opencode.providers.%s.state_dir: %w", id, err)
+		}
+		var configContent string
+		if configFile != "" {
+			content, err := os.ReadFile(configFile)
+			if err != nil {
+				return nil, fmt.Errorf("read opencode.providers.%s.config_file: %w", id, err)
+			}
+			configContent = string(content)
+		}
+		result[id] = worker.OpencodeProviderConfig{
+			RunnerImage:      provider.RunnerImage,
+			ConfigContent:    configContent,
+			APIKeyEnv:        provider.APIKeyEnv,
+			AuthMetadata:     provider.AuthMetadata,
+			PassEnv:          append([]string(nil), provider.PassEnv...),
+			RequiredBinaries: append([]string(nil), provider.RequiredBinaries...),
+			EgressHosts:      append([]string(nil), provider.EgressAllow...),
+			StateDir:         stateDir,
+		}
+	}
+	return result, nil
+}
+
+func resolveOpencodeHostPath(baseDir, path string) (string, error) {
+	if path == "" {
+		return "", nil
+	}
+	expanded, err := expandHome(path)
+	if err != nil {
+		return "", err
+	}
+	if !filepath.IsAbs(expanded) {
+		expanded = filepath.Join(baseDir, expanded)
+	}
+	return filepath.Clean(expanded), nil
 }
 
 // resolveScanNetworking prepares per-scan networking before the egress proxy

--- a/cmd/scrutineer/main_test.go
+++ b/cmd/scrutineer/main_test.go
@@ -341,6 +341,57 @@ func TestSetupRunner_nonClaudeBackendRejectsNoContainer(t *testing.T) {
 	}
 }
 
+func TestLoadOpencodeProvidersResolvesConfigRelativePaths(t *testing.T) {
+	dir := t.TempDir()
+	providerDir := filepath.Join(dir, "providers")
+	if err := os.MkdirAll(providerDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(providerDir, "kiro.json"), []byte(`{"plugin":["kiro"]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	h, err := worker.HarnessByName("opencode")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := loadOpencodeProviders(h, map[string]config.OpencodeProvider{
+		"kiro": {
+			RunnerImage:      "registry.example/kiro:1",
+			ConfigFile:       "providers/kiro.json",
+			PassEnv:          []string{"KIRO_API_KEY"},
+			RequiredBinaries: []string{"kiro-cli"},
+			EgressAllow:      []string{"q.us-east-1.amazonaws.com"},
+			StateDir:         "state/kiro",
+		},
+	}, filepath.Join(dir, "scrutineer.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	provider := got["kiro"]
+	if provider.ConfigContent != `{"plugin":["kiro"]}` || provider.StateDir != filepath.Join(dir, "state", "kiro") {
+		t.Errorf("loaded provider = %+v", provider)
+	}
+	if !slices.Equal(provider.EgressHosts, []string{"q.us-east-1.amazonaws.com"}) {
+		t.Errorf("egress hosts = %v", provider.EgressHosts)
+	}
+	if !slices.Equal(provider.RequiredBinaries, []string{"kiro-cli"}) {
+		t.Errorf("required binaries = %v", provider.RequiredBinaries)
+	}
+}
+
+func TestLoadOpencodeProvidersIgnoredForOtherHarness(t *testing.T) {
+	h, err := worker.HarnessByName("claude")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := loadOpencodeProviders(h, map[string]config.OpencodeProvider{
+		"kiro": {ConfigFile: "does-not-exist.json"},
+	}, filepath.Join(t.TempDir(), "scrutineer.yaml"))
+	if err != nil || got != nil {
+		t.Fatalf("non-OpenCode provider load = %v, %v", got, err)
+	}
+}
+
 func TestRegisterFlags_noContainerAliasParsesFromArgv(t *testing.T) {
 	// Both the canonical --no-container and the deprecated --no-docker alias
 	// must parse off the command line and set the same noContainer field, so

--- a/docs/database.md
+++ b/docs/database.md
@@ -124,7 +124,10 @@ One row per skill execution or external import. `skill_name` / `skill_version` p
 | scan_group | text | Groups a cohort of scans launched as one batch (Scan-all-subprojects, a single New-scan run, or a Diff rescan group). Each sibling streams a finding to `POST /repositories/{id}/findings` the moment it confirms it and reads `GET /repositories/{id}/findings?scan_group=...` before reporting, so an in-flight skill sees what a sibling has filed so far — not only after that sibling finishes — and can avoid re-filing it. Empty when not part of a batch. |
 | focus_area | text | Normalized JSON snapshot of the input-processing focus area assigned to a split `security-deep-dive`. It keeps queued work reproducible if repository `scan_config` changes. Empty means the scan is unscoped and covers its normal repository or subproject scope. |
 | profile | text | Runner profile that ran the scan (e.g. `php`). Empty = the default runner image. Set explicitly via `?profile=` or auto-detected from the clone by `brief` before launch; persisted so retries reuse the choice. |
-| backend | text | Agent CLI (`-backend`) that ran the scan: `claude` or `codex`. Stamped by the worker so a retry after switching `-backend` starts fresh instead of passing one harness's session id to another's resume command. Empty on rows predating the column or that never reached the runner. |
+| backend | text | Agent CLI (`-backend`) that ran the scan: `claude`, `codex`, `opencode`, or `copilot`. Stamped by the worker so a retry after switching `-backend` starts fresh instead of passing one harness's session id to another's resume command. Empty on rows predating the column or that never reached the runner. |
+| provider | text | Provider prefix selected from an OpenCode model id, such as `groq` or `kiro`. Empty for other backends. |
+| runner_image | text | Provider base image selected for the scan, before the language profile is layered on it. |
+| runner_image_digest | text | Locally resolved registry digest, or immutable local image id when the provider image has no registry digest. |
 | commit | text | Git HEAD at scan time. |
 | started_at | datetime | |
 | finished_at | datetime | |

--- a/docs/opencode.md
+++ b/docs/opencode.md
@@ -161,7 +161,10 @@ must have owner-only permissions such as `0700`. When `state_dir` is the only
 credential source, its auth file must already contain the selected provider. A
 provider using `pass_env` may initialise the file on first use.
 `state_dir` and `api_key_env` cannot be combined because
-`OPENCODE_AUTH_CONTENT` would override the rotating file.
+`OPENCODE_AUTH_CONTENT` would override the rotating file. Scans that share a
+`state_dir` run one at a time so a token refresh from one scan is never
+overwritten by another; use `api_key_env` or `pass_env` for providers where
+concurrent scans matter more than persisted OAuth.
 
 Without `state_dir`, OpenCode's auth data stays with the scan's retry state and
 is deleted after that scan lineage completes. Logs, repository data, and

--- a/docs/opencode.md
+++ b/docs/opencode.md
@@ -1,104 +1,187 @@
-# Opencode backend
+# OpenCode backend
 
-Scrutineer can drive [opencode](https://opencode.ai) instead of claude-code,
-selected with `-backend opencode` (or `backend: opencode` in
-`scrutineer.yaml`). Unlike claude and codex, opencode is provider-agnostic:
-the model you configure determines which API it talks to, so credential and
-egress handling are looser than for the single-provider backends.
+Scrutineer can run [OpenCode](https://opencode.ai) instead of claude-code. Set
+`-backend opencode`, or use `backend: opencode` in `scrutineer.yaml`. Model ids
+use OpenCode's `provider/model` form, and this backend requires the container
+runner. Scrutineer rejects `--no-container` when it is selected.
 
-## Setup
-
-The runner image bundles the `opencode` binary, so there's nothing to install.
-opencode reads provider credentials from its auth config or from the
-provider's own env var; the harness passes through `ANTHROPIC_API_KEY`,
-`OPENAI_API_KEY`, `OPENCODE_CONFIG_CONTENT` and `OPENCODE_AUTH_CONTENT` from
-the host so the common cases work without extra setup:
+The stock runner contains OpenCode and its common built-in providers. Existing
+Anthropic and OpenAI installations can keep using host credentials without a
+provider block:
 
     export ANTHROPIC_API_KEY=sk-ant-...
     go run ./cmd/scrutineer -skills ./skills -backend opencode
 
-or in `scrutineer.yaml`:
-
     backend: opencode
     default_model: anthropic/claude-sonnet-5
     models:
-      - name: Sonnet (via opencode)
-        id:   anthropic/claude-sonnet-5
-      - name: GPT-5 (via opencode)
-        id:   openai/gpt-5
+      - name: Sonnet via OpenCode
+        id: anthropic/claude-sonnet-5
 
-Model ids are in opencode's `provider/model` form. For providers other than
-Anthropic and OpenAI, set `OPENCODE_CONFIG_CONTENT` (an inline JSON config
-opencode reads at startup) with the provider block, and add the provider's
-API host to `egress_allow:` so the proxy lets it through.
+## Provider configuration
 
-The opencode backend requires the containerised runner. `--no-container` with
-`-backend opencode` is rejected at startup.
+Add an `opencode.providers` entry when a provider needs different credentials,
+egress, config, stored auth, or a derived runner image. The map key must match
+the provider prefix in the model id.
 
-## How the harness maps
+    backend: opencode
+    default_model: groq/llama-3.3-70b-versatile
+    models:
+      - name: Llama 3.3 70B via Groq
+        id: groq/llama-3.3-70b-versatile
 
-| Aspect | claude | opencode |
-| --- | --- | --- |
-| Binary | `claude` | `opencode` |
-| Argv | `claude -p --output-format stream-json ...` | `opencode run --format json --auto ...` |
-| Skill staging | `./.claude/skills/{name}/SKILL.md` | `./.opencode/skill/{name}/SKILL.md` |
-| Project memory | `CLAUDE.md` | `AGENTS.md` |
-| Egress hosts | `*.anthropic.com` | `models.dev`, `api.openai.com`, `*.anthropic.com` |
-| Credential env | `ANTHROPIC_API_KEY`, `CLAUDE_CODE_OAUTH_TOKEN` | `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `OPENCODE_CONFIG_CONTENT`, `OPENCODE_AUTH_CONTENT` |
-| State dir env | `CLAUDE_CONFIG_DIR` | `OPENCODE_CONFIG_DIR`, `OPENCODE_DB` |
-| Account-error phrases | claude usage/plan/access messages | union of common provider rate-limit / quota / invalid-key messages |
+    opencode:
+      providers:
+        groq:
+          api_key_env: GROQ_API_KEY
+          egress_allow:
+            - api.groq.com
 
-opencode globs `./.opencode/{skill,skills}/**/SKILL.md` with symlinks enabled,
-so `stageSkill` writes the same files it always has into
-`./.opencode/skill/{name}/`. The activation prompt points at that path
-explicitly (opencode discovers but does not auto-invoke skills in headless
-`run` mode). `PROFILE.md` lands at `AGENTS.md`, which opencode walks from cwd
-up to the project root.
+`api_key_env` names a variable in Scrutineer's host environment. For each
+scan, Scrutineer generates `OPENCODE_AUTH_CONTENT` containing only the selected
+provider and gives the container the variable name rather than putting its
+value in the runtime argv. A configured provider does not inherit
+`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, or a host-wide OpenCode auth document.
 
-`--auto` suppresses opencode's interactive permission prompts; the container
-is the sandbox. A chat turn is therefore held to its prompt
-instruction and that container boundary, not to a permission mode: only claude
-takes the `--allowedTools Read,Grep,Glob` list scrutineer asks for. `OPENCODE_DISABLE_MODELS_FETCH=1` stops opencode fetching
-`models.dev` at
-startup (the host is still on the egress allowlist for runs that do need it).
+Use `auth_metadata` for provider auth fields that accompany an API key:
 
-The session store (`OPENCODE_DB`, a SQLite file) and config
-(`OPENCODE_CONFIG_DIR`) are bind-mounted the same way claude's session store
-is, so a retried scan continues with `--session <id>`.
+    opencode:
+      providers:
+        example:
+          api_key_env: EXAMPLE_API_KEY
+          auth_metadata:
+            accountId: team-1
+          egress_allow:
+            - api.example.com
 
-## Egress
+Some providers use several native environment variables instead of an
+OpenCode API-key record. Name each one under `pass_env`; Scrutineer refuses the
+scan if any named value is absent. Variables such as `GITHUB_TOKEN` are never
+forwarded unless they appear here, which avoids confusing a repository token
+with a Copilot credential.
 
-Because opencode can talk to any provider, the harness's `EgressHosts()`
-returns the two common ones plus opencode's own model registry. That covers
-Anthropic and OpenAI out of the box; anything else (Bedrock, Azure, Ollama on
-another host, Cloudflare Workers AI) needs an `egress_allow:` entry. Under
-`--hardened` only the harness's hosts plus the host skill API are permitted,
-so a third-party provider under hardened mode is a deliberate widening.
+    opencode:
+      providers:
+        amazon-bedrock:
+          pass_env:
+            - AWS_ACCESS_KEY_ID
+            - AWS_SECRET_ACCESS_KEY
+            - AWS_REGION
+          egress_allow:
+            - bedrock-runtime.us-east-1.amazonaws.com
 
-The threat-model T1 residual applies the same: whichever provider credential
-is set passes into the container as an env var and is readable by
-in-container code.
+Credential files are not mounted automatically. Bedrock, Vertex, and similar
+providers need narrowly scoped mounts before file-based host credential chains
+can be supported. Prefer short-lived environment credentials for now.
 
-## Known gaps
+Every configured provider needs at least one `egress_allow` hostname. These
+hosts are added to the resolved OpenCode allowlist, including under
+`--hardened`. The top-level `egress_allow` remains ignored in hardened mode.
+Use hostnames without a scheme, path, or port. Region- and resource-specific
+providers should list the endpoints for the configured region or resource.
 
-opencode has no per-turn cap in `run` mode, so `-max-turns` is ignored. The
-`-scan-timeout` wall-clock limit still applies.
+Local providers such as Ollama are not covered by this option yet. The egress
+proxy permits only Scrutineer's API port on the container host, so allowing a
+hostname does not expose Ollama's port 11434.
 
-Claude's `-effort` setting has no opencode equivalent and is ignored.
+## Provider images and config
 
-`-model-base-url` is accepted for interface symmetry but ignored: opencode
-has no single base-URL override; per-provider endpoints go in
-`OPENCODE_CONFIG_CONTENT`.
+`runner_image` selects a provider base image before Scrutineer resolves the
+repository language profile:
 
-The stream parser (`OpencodeHarness.ParseStream`) maps `step_start`
-(session id), `tool`, `text`/`reasoning`, and `error` events from
-`opencode run --format json` onto the scan log; `step_finish` carries
-per-step cost and token counts and is emitted as a result event so the
-scan row records usage. Unknown event types pass through as raw text.
+    Scrutineer runner -> OpenCode provider image -> language profile
+
+Build provider images from the Scrutineer runner. They must retain `opencode`,
+`brief`, and the `scrutineer` binary, then add any pinned plugin, adapter,
+provider package, or supporting executable. Pin the configured image by digest
+when practical. Scrutineer records both the configured image reference and its
+locally resolved digest or image id on the scan. Readiness checks `brief` and
+`scrutineer` automatically when `runner_image` is set.
+
+List supporting executables under `required_binaries`. The readiness check
+looks them up inside the selected image and names a missing executable in the
+scan error.
+
+`config_file` points to an OpenCode JSON or JSONC config on the host. Relative
+paths are resolved from `scrutineer.yaml`; the file is read at startup and sent
+as `OPENCODE_CONFIG_CONTENT`. Restart Scrutineer after changing it. Keep the
+file limited to the selected provider and do not store credentials in it; code
+inside the scan container can read the resulting environment variable.
+
+    opencode:
+      providers:
+        kiro:
+          runner_image: registry.example/scrutineer-opencode-kiro@sha256:...
+          config_file: ./opencode/kiro.json
+          pass_env:
+            - KIRO_API_KEY
+          required_binaries:
+            - kiro-cli
+          egress_allow:
+            - q.us-east-1.amazonaws.com
+            - runtime.us-east-1.kiro.dev
+            - management.us-east-1.kiro.dev
+            - prod.us-east-1.auth.desktop.kiro.dev
+
+Kiro is an operator-managed image case. The stock OpenCode catalog no longer
+contains `kiro/auto`, so the image and config must supply a pinned adapter and
+`kiro-cli`. The exact config and host list must match the adapter version in
+that image.
+
+Before running the skill, Scrutineer runs `opencode models <provider>` from
+`/tmp` in the selected language-profile image. This keeps repository OpenCode
+files out of the check. The selected `provider/model` must appear exactly in
+the output. Missing OpenCode binaries, adapter packages, supporting binaries,
+and catalog models produce separate errors; other OpenCode startup output is
+kept in the scan error.
+
+## Stored auth
+
+OAuth providers can use `state_dir` instead of `api_key_env`. Scrutineer mounts
+that host directory as OpenCode's XDG data directory, allowing refreshed auth
+to survive separate scans.
+
+    opencode:
+      providers:
+        github-copilot:
+          state_dir: ~/.local/share/scrutineer/opencode/github-copilot
+          egress_allow:
+            - github.com
+            - api.github.com
+            - "*.githubcopilot.com"
+
+The corresponding auth file is
+`<state_dir>/opencode/auth.json`. It may contain only the provider named by the
+configuration block. Scrutineer checks this before mounting it and refuses to
+expose a directory containing another provider's credential. The state
+directory must have owner-only permissions such as `0700`. When `state_dir` is
+the only credential source, its auth file must already contain the selected
+provider. A provider using `pass_env` may initialise the file on first use.
+`state_dir` and `api_key_env` cannot be combined because
+`OPENCODE_AUTH_CONTENT` would override the rotating file.
+
+Without `state_dir`, OpenCode's auth data stays with the scan's retry state and
+is deleted after that scan lineage completes. Session data continues to use
+`OPENCODE_CONFIG_DIR` and `OPENCODE_DB` under the ordinary harness-state mount.
+
+## Harness behaviour
+
+OpenCode receives `opencode run --format json --auto --model
+provider/model`. Skills are staged at `./.opencode/skill/{name}/SKILL.md`, and a
+language profile's project guide is written as `AGENTS.md`. `--auto` suppresses
+interactive permission prompts; the container remains the security boundary.
+
+OpenCode has no `run` option matching Scrutineer's `-max-turns`, and Claude's
+`-effort` setting has no OpenCode equivalent. The wall-clock `-scan-timeout`
+still applies. `-model-base-url` is also ignored because OpenCode endpoints are
+configured per provider.
+
+The stream parser maps OpenCode session, tool, text, reasoning, error, cost,
+and usage events into the scan log and metrics. Unknown event types remain
+visible as raw text.
 
 ## See also
 
-- `docs/codex.md`: the codex backend, including the "Adding another harness"
-  section that opencode follows.
-- `internal/worker/harness_opencode.go`: the `OpencodeHarness` implementation.
-- #211: tracking issue for alternative harnesses.
+- [Runner setup](../README.md#setup)
+- [Hardened egress](egress-sidecar.md)
+- [Codex backend](codex.md)

--- a/docs/opencode.md
+++ b/docs/opencode.md
@@ -73,7 +73,19 @@ controls owned by Scrutineer cannot be named under `pass_env`.
 
 Credential files are not mounted automatically. Bedrock, Vertex, and similar
 providers need narrowly scoped mounts before file-based host credential chains
-can be supported. Prefer short-lived environment credentials for now.
+can be supported.
+
+Whichever of `api_key_env`, `pass_env`, or `state_dir` supplies the credential,
+its value passes into the scan container so opencode can authenticate and is
+readable by any code the scanned repository causes to run there (the T1
+residual in `threatmodel.md`). `pass_env` extends that to whatever native
+chain the provider requires, and the `state_dir` auth file described below is
+mounted read-write so refreshed tokens persist, which also lets in-container
+code overwrite it. Prefer short-lived or narrowly scoped credentials (an
+`AWS_SECRET_ACCESS_KEY` limited to Bedrock model invocation, a per-install
+OAuth app for Copilot) so an exfiltrated value has bounded reach; under
+`--hardened` the provider's `egress_allow` hosts and the skill API are the
+only destinations it can be sent to.
 
 Every configured provider needs at least one `egress_allow` hostname. These
 hosts are added only to scans using that provider, including under `--hardened`.

--- a/docs/opencode.md
+++ b/docs/opencode.md
@@ -58,7 +58,8 @@ Some providers use several native environment variables instead of an
 OpenCode API-key record. Name each one under `pass_env`; Scrutineer refuses the
 scan if any named value is absent. Variables such as `GITHUB_TOKEN` are never
 forwarded unless they appear here, which avoids confusing a repository token
-with a Copilot credential.
+with a Copilot credential. Proxy, state, config, update, model-fetch, and share
+controls owned by Scrutineer cannot be named under `pass_env`.
 
     opencode:
       providers:
@@ -75,10 +76,10 @@ providers need narrowly scoped mounts before file-based host credential chains
 can be supported. Prefer short-lived environment credentials for now.
 
 Every configured provider needs at least one `egress_allow` hostname. These
-hosts are added to the resolved OpenCode allowlist, including under
-`--hardened`. The top-level `egress_allow` remains ignored in hardened mode.
-Use hostnames without a scheme, path, or port. Region- and resource-specific
-providers should list the endpoints for the configured region or resource.
+hosts are added only to scans using that provider, including under `--hardened`.
+The top-level `egress_allow` remains ignored in hardened mode. Use hostnames
+without a scheme, path, or port. Region- and resource-specific providers should
+list the endpoints for the configured region or resource.
 
 Local providers such as Ollama are not covered by this option yet. The egress
 proxy permits only Scrutineer's API port on the container host, so allowing a
@@ -128,18 +129,20 @@ contains `kiro/auto`, so the image and config must supply a pinned adapter and
 `kiro-cli`. The exact config and host list must match the adapter version in
 that image.
 
-Before running the skill, Scrutineer runs `opencode models <provider>` from
-`/tmp` in the selected language-profile image. This keeps repository OpenCode
-files out of the check. The selected `provider/model` must appear exactly in
-the output. Missing OpenCode binaries, adapter packages, supporting binaries,
-and catalog models produce separate errors; other OpenCode startup output is
-kept in the scan error.
+Before running the skill, Scrutineer checks each concrete provider egress host,
+then runs `opencode models <provider>` from `/tmp` in the selected
+language-profile image. This keeps repository OpenCode files out of the check.
+The selected `provider/model` must appear exactly in the output. Missing
+OpenCode binaries, adapter packages, supporting binaries, egress, and catalog
+models produce separate errors. OpenCode errors from the skill run are also
+kept in the scan error instead of being replaced by the container exit status.
 
 ## Stored auth
 
 OAuth providers can use `state_dir` instead of `api_key_env`. Scrutineer mounts
-that host directory as OpenCode's XDG data directory, allowing refreshed auth
-to survive separate scans.
+only its `auth.json` into the scan's OpenCode data directory, allowing refreshed
+auth to survive separate scans without exposing logs or repository data from a
+previous scan.
 
     opencode:
       providers:
@@ -153,16 +156,17 @@ to survive separate scans.
 The corresponding auth file is
 `<state_dir>/opencode/auth.json`. It may contain only the provider named by the
 configuration block. Scrutineer checks this before mounting it and refuses to
-expose a directory containing another provider's credential. The state
-directory must have owner-only permissions such as `0700`. When `state_dir` is
-the only credential source, its auth file must already contain the selected
-provider. A provider using `pass_env` may initialise the file on first use.
+expose a file containing another provider's credential. The state directory
+must have owner-only permissions such as `0700`. When `state_dir` is the only
+credential source, its auth file must already contain the selected provider. A
+provider using `pass_env` may initialise the file on first use.
 `state_dir` and `api_key_env` cannot be combined because
 `OPENCODE_AUTH_CONTENT` would override the rotating file.
 
 Without `state_dir`, OpenCode's auth data stays with the scan's retry state and
-is deleted after that scan lineage completes. Session data continues to use
-`OPENCODE_CONFIG_DIR` and `OPENCODE_DB` under the ordinary harness-state mount.
+is deleted after that scan lineage completes. Logs, repository data, and
+session data remain under the ordinary per-scan harness-state mount in both
+cases.
 
 ## Harness behaviour
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,7 +9,9 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
+	"regexp"
 	"slices"
+	"strings"
 	"time"
 
 	"gopkg.in/yaml.v3"
@@ -42,6 +44,11 @@ type Config struct {
 	// is rejected at startup. Validated against worker.HarnessByName
 	// so the set of accepted values stays in one place.
 	Backend string `yaml:"backend"`
+	// Opencode holds provider-specific runner settings. The map key is the
+	// provider prefix from an OpenCode model id (for example, "groq" in
+	// "groq/llama-3.3-70b-versatile"). It is config-file-only because it can
+	// name credential environment variables and host paths.
+	Opencode Opencode `yaml:"opencode"`
 	// NoContainer disables the containerised runner so claude runs directly on
 	// the host (no isolation). NoDocker is the pre-rename alias, still honoured
 	// so existing configs keep working; no_container wins when both are set
@@ -203,6 +210,124 @@ type Config struct {
 	FederationImportFeeds []string `yaml:"federation_import_feeds"`
 }
 
+// Opencode groups settings that apply only to the OpenCode backend.
+type Opencode struct {
+	Providers map[string]OpencodeProvider `yaml:"providers"`
+}
+
+// OpencodeProvider describes what one OpenCode provider needs in addition to
+// the stock harness. RunnerImage is optional: built-in providers keep the
+// global runner, while plugin or binary-backed providers can select a derived
+// image. APIKeyEnv names a host environment variable whose value is converted
+// to a provider-only OPENCODE_AUTH_CONTENT document. PassEnv is for providers
+// that require their native multi-variable credential chain instead.
+type OpencodeProvider struct {
+	RunnerImage      string            `yaml:"runner_image"`
+	ConfigFile       string            `yaml:"config_file"`
+	APIKeyEnv        string            `yaml:"api_key_env"`
+	AuthMetadata     map[string]string `yaml:"auth_metadata"`
+	PassEnv          []string          `yaml:"pass_env"`
+	RequiredBinaries []string          `yaml:"required_binaries"`
+	EgressAllow      []string          `yaml:"egress_allow"`
+	// StateDir is a provider-specific host directory mounted as OpenCode's
+	// XDG data directory. It keeps rotating OAuth credentials between scans
+	// without exposing another provider's auth.json.
+	StateDir string `yaml:"state_dir"`
+}
+
+var (
+	opencodeProviderID = regexp.MustCompile(`^[a-z0-9][a-z0-9._-]*$`)
+	environmentName    = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+	binaryName         = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._+-]*$`)
+)
+
+var reservedOpencodePassEnv = map[string]bool{
+	"ALL_PROXY":               true,
+	"HOME":                    true,
+	"HTTP_PROXY":              true,
+	"HTTPS_PROXY":             true,
+	"NO_PROXY":                true,
+	"OPENCODE_AUTH_CONTENT":   true,
+	"OPENCODE_CONFIG_CONTENT": true,
+	"OPENCODE_CONFIG_DIR":     true,
+	"OPENCODE_DB":             true,
+	"XDG_DATA_HOME":           true,
+}
+
+// ValidateOpencode checks the provider map before any scan can use it. The
+// fields are later copied into container arguments, so provider ids and env
+// names stay within the formats their consumers accept and network/state
+// variables owned by the sandbox cannot be overridden through pass_env.
+func ValidateOpencode(c Opencode) error {
+	for id, provider := range c.Providers {
+		if err := validateOpencodeProvider(id, provider); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateOpencodeProvider(id string, provider OpencodeProvider) error {
+	if !opencodeProviderID.MatchString(id) {
+		return fmt.Errorf("opencode.providers: invalid provider id %q", id)
+	}
+	if provider.APIKeyEnv != "" && !environmentName.MatchString(provider.APIKeyEnv) {
+		return fmt.Errorf("opencode.providers.%s.api_key_env: invalid environment variable %q", id, provider.APIKeyEnv)
+	}
+	if provider.StateDir != "" && provider.APIKeyEnv != "" {
+		return fmt.Errorf("opencode.providers.%s: state_dir and api_key_env cannot be combined", id)
+	}
+	if len(provider.AuthMetadata) > 0 && provider.APIKeyEnv == "" {
+		return fmt.Errorf("opencode.providers.%s.auth_metadata requires api_key_env", id)
+	}
+	if err := validateOpencodePassEnv(id, provider.PassEnv); err != nil {
+		return err
+	}
+	if err := validateOpencodeBinaries(id, provider.RequiredBinaries); err != nil {
+		return err
+	}
+	if len(provider.EgressAllow) == 0 {
+		return fmt.Errorf("opencode.providers.%s.egress_allow: at least one provider hostname is required", id)
+	}
+	for _, host := range provider.EgressAllow {
+		if strings.TrimSpace(host) != host || host == "" || strings.Contains(host, "://") || strings.ContainsAny(host, "/:") {
+			return fmt.Errorf("opencode.providers.%s.egress_allow: %q must be a hostname without a scheme, path, or port", id, host)
+		}
+	}
+	return nil
+}
+
+func validateOpencodePassEnv(id string, names []string) error {
+	seen := map[string]bool{}
+	for _, name := range names {
+		if !environmentName.MatchString(name) {
+			return fmt.Errorf("opencode.providers.%s.pass_env: invalid environment variable %q", id, name)
+		}
+		if reservedOpencodePassEnv[name] {
+			return fmt.Errorf("opencode.providers.%s.pass_env: %s is managed by scrutineer", id, name)
+		}
+		if seen[name] {
+			return fmt.Errorf("opencode.providers.%s.pass_env: duplicate environment variable %q", id, name)
+		}
+		seen[name] = true
+	}
+	return nil
+}
+
+func validateOpencodeBinaries(id string, names []string) error {
+	seen := map[string]bool{}
+	for _, name := range names {
+		if !binaryName.MatchString(name) {
+			return fmt.Errorf("opencode.providers.%s.required_binaries: invalid executable name %q", id, name)
+		}
+		if seen[name] {
+			return fmt.Errorf("opencode.providers.%s.required_binaries: duplicate executable name %q", id, name)
+		}
+		seen[name] = true
+	}
+	return nil
+}
+
 // ParseScanTimeout validates and parses a scan_timeout string. Empty
 // returns 0 (caller keeps its default); anything else must be a positive
 // time.Duration.
@@ -352,6 +477,9 @@ func Load(path string) (*Config, error) {
 		return nil, fmt.Errorf("parse config %s: %w", path, err)
 	}
 	if err := ValidateSubprojectScope(c.SubprojectScope); err != nil {
+		return nil, fmt.Errorf("parse config %s: %w", path, err)
+	}
+	if err := ValidateOpencode(c.Opencode); err != nil {
 		return nil, fmt.Errorf("parse config %s: %w", path, err)
 	}
 	if c.VINCE.Enabled() {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -242,16 +242,19 @@ var (
 )
 
 var reservedOpencodePassEnv = map[string]bool{
-	"ALL_PROXY":               true,
-	"HOME":                    true,
-	"HTTP_PROXY":              true,
-	"HTTPS_PROXY":             true,
-	"NO_PROXY":                true,
-	"OPENCODE_AUTH_CONTENT":   true,
-	"OPENCODE_CONFIG_CONTENT": true,
-	"OPENCODE_CONFIG_DIR":     true,
-	"OPENCODE_DB":             true,
-	"XDG_DATA_HOME":           true,
+	"ALL_PROXY":                     true,
+	"HOME":                          true,
+	"HTTP_PROXY":                    true,
+	"HTTPS_PROXY":                   true,
+	"NO_PROXY":                      true,
+	"OPENCODE_AUTH_CONTENT":         true,
+	"OPENCODE_CONFIG_CONTENT":       true,
+	"OPENCODE_CONFIG_DIR":           true,
+	"OPENCODE_DB":                   true,
+	"OPENCODE_DISABLE_AUTOUPDATE":   true,
+	"OPENCODE_DISABLE_MODELS_FETCH": true,
+	"OPENCODE_DISABLE_SHARE":        true,
+	"XDG_DATA_HOME":                 true,
 }
 
 // ValidateOpencode checks the provider map before any scan can use it. The

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -202,6 +202,11 @@ func TestLoad_rejectsInvalidOpencodeProviders(t *testing.T) {
 			want: "managed by scrutineer",
 		},
 		{
+			name: "harness safety env",
+			yaml: "opencode:\n  providers:\n    groq:\n      pass_env: [OPENCODE_DISABLE_AUTOUPDATE]\n",
+			want: "managed by scrutineer",
+		},
+		{
 			name: "state and inline key",
 			yaml: "opencode:\n  providers:\n    xai:\n      api_key_env: XAI_API_KEY\n      state_dir: ./xai-state\n",
 			want: "cannot be combined",
@@ -226,6 +231,23 @@ func TestLoad_rejectsInvalidOpencodeProviders(t *testing.T) {
 			_, err := Load(write(t, tc.yaml))
 			if err == nil || !strings.Contains(err.Error(), tc.want) {
 				t.Fatalf("Load error = %v, want text %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestValidateOpencodeRejectsHarnessSafetyEnvironment(t *testing.T) {
+	for _, name := range []string{
+		"OPENCODE_DISABLE_AUTOUPDATE",
+		"OPENCODE_DISABLE_MODELS_FETCH",
+		"OPENCODE_DISABLE_SHARE",
+	} {
+		t.Run(name, func(t *testing.T) {
+			err := ValidateOpencode(Opencode{Providers: map[string]OpencodeProvider{
+				"groq": {PassEnv: []string{name}, EgressAllow: []string{"api.groq.com"}},
+			}})
+			if err == nil || !strings.Contains(err.Error(), "managed by scrutineer") {
+				t.Fatalf("ValidateOpencode error = %v", err)
 			}
 		})
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 	"testing"
 	"time"
 )
@@ -145,6 +146,88 @@ vince:
 		c.VINCE.Reporter.Phone != "+44 20 7946 0958" ||
 		c.VINCE.Reporter.PGPKey != "https://example.com/alice.asc" {
 		t.Errorf("vince reporter config: %+v", c.VINCE.Reporter)
+	}
+}
+
+func TestLoad_parsesOpencodeProviders(t *testing.T) {
+	c, err := Load(write(t, `
+opencode:
+  providers:
+    groq:
+      api_key_env: GROQ_API_KEY
+      egress_allow:
+        - api.groq.com
+    kiro:
+      runner_image: registry.example/kiro@sha256:abc
+      config_file: ./opencode/kiro.json
+      pass_env:
+        - KIRO_API_KEY
+      required_binaries:
+        - kiro-cli
+      egress_allow:
+        - q.us-east-1.amazonaws.com
+      state_dir: /var/lib/scrutineer/opencode/kiro
+`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := c.Opencode.Providers["groq"]; got.APIKeyEnv != "GROQ_API_KEY" || !slices.Equal(got.EgressAllow, []string{"api.groq.com"}) {
+		t.Errorf("opencode groq provider: %+v", got)
+	}
+	if got := c.Opencode.Providers["kiro"]; got.RunnerImage == "" || got.ConfigFile != "./opencode/kiro.json" ||
+		!slices.Equal(got.PassEnv, []string{"KIRO_API_KEY"}) || !slices.Equal(got.RequiredBinaries, []string{"kiro-cli"}) || got.StateDir == "" {
+		t.Errorf("opencode kiro provider: %+v", got)
+	}
+}
+
+func TestLoad_rejectsInvalidOpencodeProviders(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		yaml string
+		want string
+	}{
+		{
+			name: "provider id",
+			yaml: "opencode:\n  providers:\n    'bad/provider': {}\n",
+			want: "invalid provider id",
+		},
+		{
+			name: "api key env",
+			yaml: "opencode:\n  providers:\n    groq:\n      api_key_env: 'BAD=VALUE'\n",
+			want: "invalid environment variable",
+		},
+		{
+			name: "reserved env",
+			yaml: "opencode:\n  providers:\n    groq:\n      pass_env: [HTTPS_PROXY]\n",
+			want: "managed by scrutineer",
+		},
+		{
+			name: "state and inline key",
+			yaml: "opencode:\n  providers:\n    xai:\n      api_key_env: XAI_API_KEY\n      state_dir: ./xai-state\n",
+			want: "cannot be combined",
+		},
+		{
+			name: "egress url",
+			yaml: "opencode:\n  providers:\n    groq:\n      egress_allow: [https://api.groq.com]\n",
+			want: "must be a hostname",
+		},
+		{
+			name: "missing egress",
+			yaml: "opencode:\n  providers:\n    groq:\n      api_key_env: GROQ_API_KEY\n",
+			want: "at least one provider hostname",
+		},
+		{
+			name: "binary path",
+			yaml: "opencode:\n  providers:\n    kiro:\n      required_binaries: [/usr/bin/kiro-cli]\n      egress_allow: [api.example.com]\n",
+			want: "invalid executable name",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := Load(write(t, tc.yaml))
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("Load error = %v, want text %q", err, tc.want)
+			}
+		})
 	}
 }
 

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -323,6 +323,12 @@ type Scan struct {
 	// pass one harness's session/thread id to another's resume command.
 	// Empty on rows that predate the column or never reached the runner.
 	Backend string `gorm:"index"`
+	// Provider is the model id prefix selected by OpenCode. RunnerImage is the
+	// provider base image, and RunnerImageDigest is its resolved content digest
+	// or local image id. They make runs reproducible when an image tag moves.
+	Provider          string `gorm:"index"`
+	RunnerImage       string
+	RunnerImageDigest string
 
 	// SessionID is the harness session this scan's run belongs to,
 	// captured from the harness's own event stream. Its meaning depends

--- a/internal/worker/claude.go
+++ b/internal/worker/claude.go
@@ -168,6 +168,12 @@ type SkillResult struct {
 	// belongs to a different agent CLI and starts fresh instead of passing
 	// e.g. a codex thread id to claude --resume.
 	Backend string
+	// Provider is the provider prefix selected from an OpenCode model id.
+	// RunnerImage and RunnerImageDigest identify the provider base image before
+	// any repository language profile is layered on it.
+	Provider          string
+	RunnerImage       string
+	RunnerImageDigest string
 	// SessionID is the harness session this run belonged to, as seen in
 	// the stream. The worker already persists it live via the emit callback;
 	// this is a backstop so the final save reflects the latest value (e.g.

--- a/internal/worker/container.go
+++ b/internal/worker/container.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"syscall"
@@ -83,6 +84,11 @@ type ContainerRunner struct {
 	// zero value keeps the host-proxy path (docker, rootful podman, and all
 	// non-hardened scans). See usesEgressSidecar.
 	Egress EgressSidecarConfig
+	// OpencodeProviders contains provider-scoped images, credentials, state,
+	// config, and egress resolved from the operator's YAML configuration.
+	OpencodeProviders map[string]OpencodeProviderConfig
+	// OpencodeReadiness caches successful provider/model catalog probes.
+	OpencodeReadiness *OpencodeReadinessCache
 	// detectProfile lets tests stub profile auto-detection without a container
 	// runtime. nil means DetectProfile.
 	detectProfile func(ctx context.Context, rt ContainerRuntime, runnerImage, srcDir string, relabel bool) Profile
@@ -215,6 +221,11 @@ const HardenedWorkspaceCapBytes int64 = 2 << 30
 // Egress is routed through scrutineer's allowlisting proxy on the host;
 // see EgressProxy. tmpfs/cap-drop rules mirror the local runner's intent.
 func (d ContainerRunner) RunSkill(ctx context.Context, sj SkillJob, emit func(Event)) (SkillResult, error) {
+	d, provider, result, err := d.prepareOpencodeRun(ctx, sj.Model)
+	if err != nil {
+		return result, err
+	}
+
 	var src string
 	if sj.SrcReady {
 		src = filepath.Join(sj.WorkRoot, "src")
@@ -222,30 +233,31 @@ func (d ContainerRunner) RunSkill(ctx context.Context, sj SkillJob, emit func(Ev
 		var err error
 		src, err = ensureClone(ctx, sj.Repo, sj.WorkRoot, d.FullClone, sj.Ref, emit)
 		if err != nil {
-			return SkillResult{}, err
+			return result, err
 		}
 	}
 	if err := d.checkHardenedWorkspace(sj.WorkRoot); err != nil {
-		return SkillResult{}, err
+		return result, err
 	}
 	commit := gitHead(src)
+	result.Commit = commit
 	work := sj.WorkRoot
 	absWork, _ := filepath.Abs(work)
 
 	profile, image := d.resolveProfile(ctx, sj.Profile, src, sj.SubPath, emit)
-	backend := HarnessName(d.harness())
+	result.Profile = profile
 	if sj.RequiresProfile != "" && profile != sj.RequiresProfile {
 		got := profile
 		if got == "" {
 			got = "default"
 		}
-		return SkillResult{Commit: commit, Profile: profile, Backend: backend}, fmt.Errorf("skill %q requires profile %q, resolved %q", sj.Name, sj.RequiresProfile, got)
+		return result, fmt.Errorf("skill %q requires profile %q, resolved %q", sj.Name, sj.RequiresProfile, got)
 	}
 	d.injectProfileGuide(profile, absWork, emit)
 
 	hnet, cleanupNetwork, err := d.setupHardenedNetwork(sj, image)
 	if err != nil {
-		return SkillResult{Commit: commit, Profile: profile, Backend: backend}, err
+		return result, err
 	}
 	// Capture the sidecar's egress decisions (allowlist denials) into the scan
 	// record before teardown removes the ephemeral sidecar.
@@ -263,10 +275,15 @@ func (d ContainerRunner) RunSkill(ctx context.Context, sj SkillJob, emit func(Ev
 	if sj.StateDir != "" {
 		absConfig, _ = filepath.Abs(sj.StateDir)
 		if err := os.MkdirAll(absConfig, dirPerm); err != nil {
-			return SkillResult{Commit: commit, Profile: profile, Backend: backend}, fmt.Errorf("create harness state dir: %w", err)
+			return result, fmt.Errorf("create harness state dir: %w", err)
 		}
 	}
-	runBase := d.buildRunArgs(absWork, image, hnet, absConfig)
+	readinessErr := d.checkOpencodeReadiness(ctx, provider, absWork, image, hnet, absConfig)
+	result.RunnerImageDigest = d.opencodeRunnerImageDigest(ctx, d.image())
+	if readinessErr != nil {
+		return result, readinessErr
+	}
+	runBase := d.buildSkillRunArgs(absWork, image, hnet, absConfig, provider)
 
 	logLine := "$ " + d.Runtime.bin() + " run --rm " + image + " <skill:" + sj.Name + ">"
 	if d.ModelBaseURL != "" {
@@ -284,7 +301,7 @@ func (d ContainerRunner) RunSkill(ctx context.Context, sj SkillJob, emit func(Ev
 		}
 		emit(e)
 	}
-	hitMaxTurns, sessionID, waitErr := d.runContainerOnce(ctx, runBase, sj, wrappedEmit)
+	hitMaxTurns, sessionID, waitErr := d.runContainerOnce(ctx, runBase, sj, provider.Env, wrappedEmit)
 
 	if waitErr != nil && sj.ResumeSessionID != "" && sessionID == "" && accountErrText == "" {
 		if sj.ResumePrompt != "" && sj.Prompt == "" {
@@ -292,7 +309,7 @@ func (d ContainerRunner) RunSkill(ctx context.Context, sj SkillJob, emit func(Ev
 			// report.json") that means nothing to a fresh agent, and there is
 			// no fresh framing to fall back on.
 			emit(Event{Kind: KindText, Text: "resume of session " + sj.ResumeSessionID + " failed; " + resumePromptNoFreshFallbackText})
-			return SkillResult{Commit: commit, Profile: profile, Backend: backend}, fmt.Errorf("%s exited: %w", d.Runtime.bin(), waitErr)
+			return result, fmt.Errorf("%s exited: %w", d.Runtime.bin(), waitErr)
 		}
 		// The resume produced no session event, so claude could not load the
 		// saved conversation (gone from the mounted store). Restart fresh in
@@ -301,10 +318,11 @@ func (d ContainerRunner) RunSkill(ctx context.Context, sj SkillJob, emit func(Ev
 		emit(Event{Kind: KindText, Text: "resume of session " + sj.ResumeSessionID + " failed; restarting fresh"})
 		fresh := sj
 		fresh.ResumeSessionID = ""
-		hitMaxTurns, sessionID, waitErr = d.runContainerOnce(ctx, runBase, fresh, wrappedEmit)
+		hitMaxTurns, sessionID, waitErr = d.runContainerOnce(ctx, runBase, fresh, provider.Env, wrappedEmit)
 	}
 
-	res := SkillResult{Commit: commit, Profile: profile, Backend: backend, SessionID: sessionID}
+	res := result
+	res.SessionID = sessionID
 	if outPath != "" {
 		res.Report = readCappedReport(outPath, emit)
 	}
@@ -325,14 +343,14 @@ func (d ContainerRunner) RunSkill(ctx context.Context, sj SkillJob, emit func(Ev
 // through emit, and reporting the wait error, whether the run hit the
 // max-turns cap, and the session id from the init event (empty when no init
 // event arrived, e.g. a --resume that could not find the conversation).
-func (d ContainerRunner) runContainerOnce(ctx context.Context, runBase []string, sj SkillJob, emit func(Event)) (hitMaxTurns bool, sessionID string, waitErr error) {
+func (d ContainerRunner) runContainerOnce(ctx context.Context, runBase []string, sj SkillJob, processEnv map[string]string, emit func(Event)) (hitMaxTurns bool, sessionID string, waitErr error) {
 	h := d.harness()
 	harnessArgs := append([]string{h.Binary()}, h.Args(sj.toJob(d.Effort, d.MaxTurns, d.ModelBaseURL))...)
 	runArgs := append(append([]string{}, runBase...), harnessArgs...)
 
 	cmd := exec.CommandContext(ctx, d.Runtime.bin(), runArgs...)
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-	cmd.Env = os.Environ()
+	cmd.Env = environmentWith(os.Environ(), processEnv)
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
@@ -366,6 +384,17 @@ func (d ContainerRunner) runContainerOnce(ctx context.Context, runBase []string,
 // complexity manageable as new toggles (hardened mode, proxy, profiles)
 // accumulate.
 func (d ContainerRunner) buildRunArgs(absWork, image string, hnet hardenedNet, harnessStateDir string) []string {
+	return d.buildRunArgsForProvider(absWork, image, hnet, harnessStateDir, opencodeProvider{}, "/work")
+}
+
+func (d ContainerRunner) buildSkillRunArgs(absWork, image string, hnet hardenedNet, harnessStateDir string, provider opencodeProvider) []string {
+	if !provider.Configured {
+		return d.buildRunArgs(absWork, image, hnet, harnessStateDir)
+	}
+	return d.buildRunArgsForProvider(absWork, image, hnet, harnessStateDir, provider, "/work")
+}
+
+func (d ContainerRunner) buildRunArgsForProvider(absWork, image string, hnet hardenedNet, harnessStateDir string, provider opencodeProvider, workdir string) []string {
 	gwTarget := "host-gateway"
 	if d.Hardened {
 		// setupHardenedNetwork resolved the gateway once against this per-scan
@@ -386,12 +415,23 @@ func (d ContainerRunner) buildRunArgs(absWork, image string, hnet hardenedNet, h
 		"-e", "SEMGREP_SEND_METRICS=off",
 		"--tmpfs", "/tmp:rw,noexec,nosuid,size=256m",
 		"-v", bindMount(absWork, "/work", d.SELinuxRelabel),
-		"-w", "/work",
+		"-w", workdir,
 	)
 	// Harness-specific env: model-API credential, base URL, and the
 	// harness's own telemetry / autoupdate suppressors.
 	for _, e := range d.harness().Env(d.ModelBaseURL) {
+		if provider.Configured && opencodeInheritedCredential(e) {
+			continue
+		}
 		args = append(args, "-e", e)
+	}
+	keys := make([]string, 0, len(provider.Env))
+	for key := range provider.Env {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		args = append(args, "-e", key)
 	}
 	if d.Runtime.supportsHostGatewayAddHost() {
 		args = append(args, "--add-host", HostGatewayAlias+":"+gwTarget)
@@ -413,6 +453,19 @@ func (d ContainerRunner) buildRunArgs(absWork, image string, hnet hardenedNet, h
 		args = append(args, "-v", bindMount(harnessStateDir, "/harness-state", d.SELinuxRelabel))
 		for _, e := range d.harness().StateEnv("/harness-state") {
 			args = append(args, "-e", e)
+		}
+	}
+	if HarnessName(d.harness()) == "opencode" {
+		if provider.StateDir != "" {
+			args = append(args,
+				"-v", bindMount(provider.StateDir, "/opencode-provider-state", d.SELinuxRelabel),
+				"-e", "XDG_DATA_HOME=/opencode-provider-state",
+			)
+		} else if harnessStateDir != "" {
+			// Keep OpenCode's auth state alongside the retry session while this
+			// scan lineage is alive. A configured state_dir above extends that
+			// lifetime across independent scans.
+			args = append(args, "-e", "XDG_DATA_HOME=/harness-state/data")
 		}
 	}
 	if d.Hardened || d.HardenedRuntimeOnly {
@@ -467,6 +520,16 @@ func (d ContainerRunner) buildRunArgs(absWork, image string, hnet hardenedNet, h
 		args = append(args, "--network", "none")
 	}
 	return append(args, "--", image)
+}
+
+func opencodeInheritedCredential(env string) bool {
+	key, _, _ := strings.Cut(env, "=")
+	switch key {
+	case "OPENAI_API_KEY", "ANTHROPIC_API_KEY", "OPENCODE_CONFIG_CONTENT", "OPENCODE_AUTH_CONTENT":
+		return true
+	default:
+		return false
+	}
 }
 
 // resolveProfile picks the runner image for this scan. When requested

--- a/internal/worker/container.go
+++ b/internal/worker/container.go
@@ -247,8 +247,12 @@ func (s *containerRunErrorState) observe(event Event, h Harness, configuredProvi
 	}
 }
 
+// resumeRetryable gates the "session gone, restart fresh" fallback. Only an
+// account error (auth/quota) blocks it: a configured-provider error event may
+// be the harness reporting the missing session itself, which is exactly the
+// condition the fallback exists for.
 func (s containerRunErrorState) resumeRetryable() bool {
-	return s.accountText == "" && s.providerText == ""
+	return s.accountText == ""
 }
 
 func (s containerRunErrorState) failure(provider opencodeProvider, runtimeName string, waitErr error) error {
@@ -321,7 +325,7 @@ func (d ContainerRunner) RunSkill(ctx context.Context, sj SkillJob, emit func(Ev
 	if err != nil {
 		return result, err
 	}
-	runBase := d.buildSkillRunArgs(absWork, image, hnet, absConfig, provider)
+	runBase := d.buildRunArgsForProvider(absWork, image, hnet, absConfig, provider, "/work")
 
 	logLine := "$ " + d.Runtime.bin() + " run --rm " + image + " <skill:" + sj.Name + ">"
 	if d.ModelBaseURL != "" {
@@ -409,22 +413,11 @@ func (d ContainerRunner) runContainerOnce(ctx context.Context, runBase []string,
 	return hitMaxTurns, sessionID, waitErr
 }
 
-// buildRunArgs assembles the container run flags for a skill invocation.
+// buildRunArgsForProvider assembles the container run flags for a skill invocation.
 // Returns the args up to and including the image name; the caller appends
 // the in-container command. Split out of RunSkill to keep its cognitive
 // complexity manageable as new toggles (hardened mode, proxy, profiles)
 // accumulate.
-func (d ContainerRunner) buildRunArgs(absWork, image string, hnet hardenedNet, harnessStateDir string) []string {
-	return d.buildRunArgsForProvider(absWork, image, hnet, harnessStateDir, opencodeProvider{}, "/work")
-}
-
-func (d ContainerRunner) buildSkillRunArgs(absWork, image string, hnet hardenedNet, harnessStateDir string, provider opencodeProvider) []string {
-	if !provider.Configured {
-		return d.buildRunArgs(absWork, image, hnet, harnessStateDir)
-	}
-	return d.buildRunArgsForProvider(absWork, image, hnet, harnessStateDir, provider, "/work")
-}
-
 func (d ContainerRunner) buildRunArgsForProvider(absWork, image string, hnet hardenedNet, harnessStateDir string, provider opencodeProvider, workdir string) []string {
 	gwTarget := "host-gateway"
 	if d.Hardened {
@@ -831,7 +824,7 @@ func EnsureHardenedNetwork(rt ContainerRuntime, name string) error {
 
 // hardenedNet bundles a per-scan --internal network name with the host-gateway
 // IPv4 resolved against it. setupHardenedNetwork resolves the gateway once and
-// threads it through both verifyHardenedNetwork and buildRunArgs, so a
+// threads it through both verifyHardenedNetwork and buildRunArgsForProvider, so a
 // hardened scan probes for it a single time instead of once per consumer. The
 // zero value (both fields "") is the non-hardened case.
 type hardenedNet struct {
@@ -1218,7 +1211,7 @@ curl -s -m 5 -o /dev/null http://1.1.1.1 && echo REACHED || echo BLOCKED`
 // (the proxy answers, e.g. 407 without auth) means the TCP path to the host is
 // open. docker/podman wire the host-gateway alias with --add-host exactly as the
 // real run does; Apple's CLI has no --add-host, so the probe targets the
-// resolved gateway IP directly -- the same address buildRunArgs points the proxy
+// resolved gateway IP directly -- the same address buildRunArgsForProvider points the proxy
 // env at for an Apple hardened scan.
 func (rt ContainerRuntime) hardenedProxyReachArgs(network, gatewayIP, proxyPort, image string) []string {
 	args := rt.runArgs("--rm", "--cap-drop", "ALL", "--network", network)

--- a/internal/worker/container.go
+++ b/internal/worker/container.go
@@ -10,6 +10,7 @@ package worker
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"net"
 	"net/url"
 	"os"
@@ -84,6 +85,10 @@ type ContainerRunner struct {
 	// zero value keeps the host-proxy path (docker, rootful podman, and all
 	// non-hardened scans). See usesEgressSidecar.
 	Egress EgressSidecarConfig
+	// ProviderProxy contains the base allowlist and host endpoint used to start
+	// a short-lived in-process proxy for one configured OpenCode provider. The
+	// process-wide proxy never receives provider-specific hosts.
+	ProviderProxy ScopedEgressProxyConfig
 	// OpencodeProviders contains provider-scoped images, credentials, state,
 	// config, and egress resolved from the operator's YAML configuration.
 	OpencodeProviders map[string]OpencodeProviderConfig
@@ -111,6 +116,17 @@ type EgressSidecarConfig struct {
 	// reach the host skill API. Required: an empty value means the sidecar
 	// cannot reach the host, so setupHardenedNetwork fails the scan closed.
 	GatewayIP string
+}
+
+// ScopedEgressProxyConfig is the non-secret startup information needed to
+// create a provider-scoped host proxy. Each scan gets a fresh token and
+// listener, which are closed when the scan finishes.
+type ScopedEgressProxyConfig struct {
+	Allow         []string
+	APIPort       string
+	APIHosts      []string
+	ContainerHost string
+	Log           *slog.Logger
 }
 
 // hardenedNetworkPrefix is the common prefix used to name the per-scan
@@ -215,16 +231,47 @@ func proxyURLWithHost(proxyURL, host string) string {
 // legitimate repos.
 const HardenedWorkspaceCapBytes int64 = 2 << 30
 
+type containerRunErrorState struct {
+	accountText  string
+	providerText string
+	rateLimit    *RateLimitInfo
+}
+
+func (s *containerRunErrorState) observe(event Event, h Harness, configuredProvider bool) {
+	s.accountText = preferAccountErrText(s.accountText, h.AccountErrorText(event.Text))
+	if configuredProvider && event.Kind == KindError && event.Text != "hit max turns" {
+		s.providerText = event.Text
+	}
+	if event.Kind == KindRateLimit && event.RateLimit != nil {
+		s.rateLimit = preferRateLimitReset(s.rateLimit, event.RateLimit)
+	}
+}
+
+func (s containerRunErrorState) resumeRetryable() bool {
+	return s.accountText == "" && s.providerText == ""
+}
+
+func (s containerRunErrorState) failure(provider opencodeProvider, runtimeName string, waitErr error) error {
+	if s.accountText != "" {
+		return &AccountError{Detail: s.accountText, ResetAt: resumableReset(s.accountText, s.rateLimit)}
+	}
+	if s.providerText != "" {
+		return classifyOpencodeProviderRunError(provider, s.providerText, waitErr)
+	}
+	return fmt.Errorf("%s exited: %w", runtimeName, waitErr)
+}
+
 // RunSkill runs a skill inside an ephemeral container. The whole workspace
 // (clone + staged .claude/skills + context.json + output) is mounted at
 // /work read-write so claude can read the skill files and write its output.
 // Egress is routed through scrutineer's allowlisting proxy on the host;
 // see EgressProxy. tmpfs/cap-drop rules mirror the local runner's intent.
 func (d ContainerRunner) RunSkill(ctx context.Context, sj SkillJob, emit func(Event)) (SkillResult, error) {
-	d, provider, result, err := d.prepareOpencodeRun(ctx, sj.Model)
+	d, provider, result, cleanupProviderProxy, err := d.prepareOpencodeExecution(ctx, sj.Model)
 	if err != nil {
 		return result, err
 	}
+	defer cleanupProviderProxy()
 
 	var src string
 	if sj.SrcReady {
@@ -269,19 +316,10 @@ func (d ContainerRunner) RunSkill(ctx context.Context, sj SkillJob, emit func(Ev
 		_ = os.Remove(outPath)
 	}
 
-	// the runtime treats a non-absolute -v source as a named volume (which
-	// rejects '/'), so the config dir must be absolutised like absWork.
-	var absConfig string
-	if sj.StateDir != "" {
-		absConfig, _ = filepath.Abs(sj.StateDir)
-		if err := os.MkdirAll(absConfig, dirPerm); err != nil {
-			return result, fmt.Errorf("create harness state dir: %w", err)
-		}
-	}
-	readinessErr := d.checkOpencodeReadiness(ctx, provider, absWork, image, hnet, absConfig)
-	result.RunnerImageDigest = d.opencodeRunnerImageDigest(ctx, d.image())
-	if readinessErr != nil {
-		return result, readinessErr
+	absConfig, digest, err := d.prepareHarnessState(ctx, sj.StateDir, provider, absWork, image, hnet)
+	result.RunnerImageDigest = digest
+	if err != nil {
+		return result, err
 	}
 	runBase := d.buildSkillRunArgs(absWork, image, hnet, absConfig, provider)
 
@@ -292,24 +330,20 @@ func (d ContainerRunner) RunSkill(ctx context.Context, sj SkillJob, emit func(Ev
 	emit(Event{Kind: KindText, Text: logLine})
 
 	h := d.harness()
-	accountErrText := ""
-	var rateLimitReset *RateLimitInfo
+	runErrors := containerRunErrorState{}
 	wrappedEmit := func(e Event) {
-		accountErrText = preferAccountErrText(accountErrText, h.AccountErrorText(e.Text))
-		if e.Kind == KindRateLimit && e.RateLimit != nil {
-			rateLimitReset = preferRateLimitReset(rateLimitReset, e.RateLimit)
-		}
+		runErrors.observe(e, h, provider.Configured)
 		emit(e)
 	}
 	hitMaxTurns, sessionID, waitErr := d.runContainerOnce(ctx, runBase, sj, provider.Env, wrappedEmit)
 
-	if waitErr != nil && sj.ResumeSessionID != "" && sessionID == "" && accountErrText == "" {
+	if waitErr != nil && sj.ResumeSessionID != "" && sessionID == "" && runErrors.resumeRetryable() {
 		if sj.ResumePrompt != "" && sj.Prompt == "" {
 			// A bare resume prompt is a corrective nudge ("rewrite the invalid
 			// report.json") that means nothing to a fresh agent, and there is
 			// no fresh framing to fall back on.
 			emit(Event{Kind: KindText, Text: "resume of session " + sj.ResumeSessionID + " failed; " + resumePromptNoFreshFallbackText})
-			return result, fmt.Errorf("%s exited: %w", d.Runtime.bin(), waitErr)
+			return result, runErrors.failure(provider, d.Runtime.bin(), waitErr)
 		}
 		// The resume produced no session event, so claude could not load the
 		// saved conversation (gone from the mounted store). Restart fresh in
@@ -330,10 +364,7 @@ func (d ContainerRunner) RunSkill(ctx context.Context, sj SkillJob, emit func(Ev
 		if hitMaxTurns {
 			return res, &MaxTurnsReachedError{}
 		}
-		if accountErrText != "" {
-			return res, &AccountError{Detail: accountErrText, ResetAt: resumableReset(accountErrText, rateLimitReset)}
-		}
-		return res, fmt.Errorf("%s exited: %w", d.Runtime.bin(), waitErr)
+		return res, runErrors.failure(provider, d.Runtime.bin(), waitErr)
 	}
 	return res, nil
 }
@@ -456,17 +487,7 @@ func (d ContainerRunner) buildRunArgsForProvider(absWork, image string, hnet har
 		}
 	}
 	if HarnessName(d.harness()) == "opencode" {
-		if provider.StateDir != "" {
-			args = append(args,
-				"-v", bindMount(provider.StateDir, "/opencode-provider-state", d.SELinuxRelabel),
-				"-e", "XDG_DATA_HOME=/opencode-provider-state",
-			)
-		} else if harnessStateDir != "" {
-			// Keep OpenCode's auth state alongside the retry session while this
-			// scan lineage is alive. A configured state_dir above extends that
-			// lifetime across independent scans.
-			args = append(args, "-e", "XDG_DATA_HOME=/harness-state/data")
-		}
+		args = d.appendOpencodeStateArgs(args, harnessStateDir, provider)
 	}
 	if d.Hardened || d.HardenedRuntimeOnly {
 		// Read-only rootfs + no-new-privileges close the residual paths a

--- a/internal/worker/container_test.go
+++ b/internal/worker/container_test.go
@@ -11,10 +11,17 @@ import (
 	"testing"
 )
 
+// buildRunArgs is the no-provider shorthand tests use so they don't all repeat
+// opencodeProvider{}/"/work". Production code calls buildRunArgsForProvider
+// directly with the resolved provider.
+func (d ContainerRunner) buildRunArgs(image string, hnet hardenedNet, harnessStateDir string) []string {
+	return d.buildRunArgsForProvider("/work/abs", image, hnet, harnessStateDir, opencodeProvider{}, "/work")
+}
+
 func TestBuildRunArgs_ClaudeConfigMount(t *testing.T) {
 	d := ContainerRunner{}
 
-	with := d.buildRunArgs("/work/abs", "img:latest", hardenedNet{}, "/data/harness-state/scan-7")
+	with := d.buildRunArgs("img:latest", hardenedNet{}, "/data/harness-state/scan-7")
 	if !hasAdjacent(with, "-v", "/data/harness-state/scan-7:/harness-state") {
 		t.Errorf("expected the config dir bind mount in %v", with)
 	}
@@ -23,7 +30,7 @@ func TestBuildRunArgs_ClaudeConfigMount(t *testing.T) {
 	}
 
 	// No config dir → no mount and no env, so default scans are unchanged.
-	without := d.buildRunArgs("/work/abs", "img:latest", hardenedNet{}, "")
+	without := d.buildRunArgs("img:latest", hardenedNet{}, "")
 	for _, a := range without {
 		if strings.Contains(a, "/harness-state") || strings.HasPrefix(a, "CLAUDE_CONFIG_DIR=") {
 			t.Errorf("did not expect any harness-state args, got %q in %v", a, without)
@@ -37,7 +44,7 @@ func TestBuildRunArgs_KeepIDGating(t *testing.T) {
 	// byte as before (no --userns token at all), so this also guards against a
 	// regression that would silently alter the container arg vector.
 	rootless := ContainerRunner{Runtime: ContainerRuntime{Bin: "podman", Rootless: true}}
-	if got := rootless.buildRunArgs("/work/abs", "img:latest", hardenedNet{}, ""); !slices.Contains(got, "--userns=keep-id") {
+	if got := rootless.buildRunArgs("img:latest", hardenedNet{}, ""); !slices.Contains(got, "--userns=keep-id") {
 		t.Errorf("rootless podman: expected --userns=keep-id in %v", got)
 	}
 
@@ -46,7 +53,7 @@ func TestBuildRunArgs_KeepIDGating(t *testing.T) {
 		{Runtime: ContainerRuntime{Bin: "docker"}},
 		{Runtime: ContainerRuntime{Bin: "podman"}}, // rootful podman
 	} {
-		got := d.buildRunArgs("/work/abs", "img:latest", hardenedNet{}, "")
+		got := d.buildRunArgs("img:latest", hardenedNet{}, "")
 		for _, a := range got {
 			if strings.HasPrefix(a, "--userns") {
 				t.Errorf("runtime %+v: unexpected %q in %v", d.Runtime, a, got)
@@ -56,7 +63,7 @@ func TestBuildRunArgs_KeepIDGating(t *testing.T) {
 
 	// Rootless podman with a resume config dir keeps BOTH the mount and keep-id
 	// so the persisted session store stays host-owned across container restarts.
-	withCfg := rootless.buildRunArgs("/work/abs", "img:latest", hardenedNet{}, "/data/cfg/scan-1")
+	withCfg := rootless.buildRunArgs("img:latest", hardenedNet{}, "/data/cfg/scan-1")
 	if !slices.Contains(withCfg, "--userns=keep-id") {
 		t.Errorf("rootless+config: expected --userns=keep-id in %v", withCfg)
 	}
@@ -70,7 +77,7 @@ func TestBuildRunArgs_AppleOmitsDockerOnlyFlags(t *testing.T) {
 		Runtime:             ContainerRuntime{Bin: "apple"},
 		HardenedRuntimeOnly: true,
 	}
-	got := d.buildRunArgs("/work/abs", "img:latest", hardenedNet{}, "")
+	got := d.buildRunArgs("img:latest", hardenedNet{}, "")
 	for _, a := range got {
 		if a == "--add-host" {
 			t.Errorf("apple runtime must not receive Docker/Podman --add-host: %v", got)
@@ -100,7 +107,7 @@ func TestBuildRunArgs_AppleHardenedProxyTargetsScanGateway(t *testing.T) {
 		ProxyURL: "http://scrutineer:tok@192.168.64.1:45000", // startup default-network gateway
 	}
 	hnet := hardenedNet{name: "scrutineer-hardened-9", gatewayIP: "192.168.128.1"}
-	got := d.buildRunArgs("/work/abs", "img:latest", hnet, "")
+	got := d.buildRunArgs("img:latest", hnet, "")
 	joined := strings.Join(got, " ")
 
 	if !strings.Contains(joined, "HTTPS_PROXY=http://scrutineer:tok@192.168.128.1:45000") {
@@ -126,7 +133,7 @@ func TestBuildRunArgs_SELinuxRelabel(t *testing.T) {
 	// With relabeling on, every host bind mount must carry the ":z" shared
 	// relabel so the container can access it on an SELinux host.
 	on := ContainerRunner{SELinuxRelabel: true}
-	got := on.buildRunArgs("/work/abs", "img:latest", hardenedNet{}, "/data/cfg/scan-1")
+	got := on.buildRunArgs("img:latest", hardenedNet{}, "/data/cfg/scan-1")
 	if !hasAdjacent(got, "-v", "/work/abs:/work:z") {
 		t.Errorf("expected /work mount relabeled with :z in %v", got)
 	}
@@ -137,7 +144,7 @@ func TestBuildRunArgs_SELinuxRelabel(t *testing.T) {
 	// With relabeling off (the zero value / default), mounts are byte-for-byte
 	// unchanged -- no :z anywhere -- so non-SELinux hosts are unaffected.
 	off := ContainerRunner{}
-	got = off.buildRunArgs("/work/abs", "img:latest", hardenedNet{}, "/data/cfg/scan-1")
+	got = off.buildRunArgs("img:latest", hardenedNet{}, "/data/cfg/scan-1")
 	if !hasAdjacent(got, "-v", "/work/abs:/work") {
 		t.Errorf("expected unrelabeled /work mount in %v", got)
 	}
@@ -161,7 +168,7 @@ func TestBuildRunArgs_ContainerHardening(t *testing.T) {
 	// --hardened-runtime-only: read-only + no-new-privileges, but NOT the
 	// per-scan --internal network -- that network is the part rootless podman
 	// can't route to the host proxy, and is the whole reason this flag exists.
-	roR := ContainerRunner{HardenedRuntimeOnly: true}.buildRunArgs("/work/abs", "img:latest", hardenedNet{name: net}, "")
+	roR := ContainerRunner{HardenedRuntimeOnly: true}.buildRunArgs("img:latest", hardenedNet{name: net}, "")
 	if !slices.Contains(roR, "--read-only") || !hasNoNewPrivs(roR) {
 		t.Errorf("hardened-rootless-runtime: expected --read-only + no-new-privileges in %v", roR)
 	}
@@ -170,7 +177,7 @@ func TestBuildRunArgs_ContainerHardening(t *testing.T) {
 	}
 
 	// --hardened: the container hardening AND the per-scan network.
-	h := ContainerRunner{Hardened: true}.buildRunArgs("/work/abs", "img:latest", hardenedNet{name: net}, "")
+	h := ContainerRunner{Hardened: true}.buildRunArgs("img:latest", hardenedNet{name: net}, "")
 	if !slices.Contains(h, "--read-only") || !hasNoNewPrivs(h) {
 		t.Errorf("hardened: expected --read-only + no-new-privileges in %v", h)
 	}
@@ -188,7 +195,7 @@ func TestBuildRunArgs_ContainerHardening(t *testing.T) {
 	}
 
 	// Default mode: neither container-hardening option (byte-for-byte unchanged).
-	def := ContainerRunner{}.buildRunArgs("/work/abs", "img:latest", hardenedNet{}, "")
+	def := ContainerRunner{}.buildRunArgs("img:latest", hardenedNet{}, "")
 	if slices.Contains(def, "--read-only") || hasNoNewPrivs(def) {
 		t.Errorf("default mode must set neither --read-only nor no-new-privileges: %v", def)
 	}
@@ -196,7 +203,7 @@ func TestBuildRunArgs_ContainerHardening(t *testing.T) {
 	// The baseline -- --cap-drop ALL, non-root --user, the /tmp tmpfs -- is
 	// present in EVERY mode; the new flag must not disturb that invariant.
 	for _, mode := range []ContainerRunner{{}, {HardenedRuntimeOnly: true}, {Hardened: true}} {
-		args := mode.buildRunArgs("/work/abs", "img:latest", hardenedNet{name: net}, "")
+		args := mode.buildRunArgs("img:latest", hardenedNet{name: net}, "")
 		if !hasAdjacent(args, "--cap-drop", "ALL") {
 			t.Errorf("%+v: missing --cap-drop ALL: %v", mode, args)
 		}
@@ -784,7 +791,7 @@ func TestBuildRunArgs_SidecarProxyURL(t *testing.T) {
 		Egress:   EgressSidecarConfig{Token: "tok"},
 	}
 	hn := hardenedNet{name: "scrutineer-hardened-7", proxyEndpoint: "10.89.1.2:3128", proxyName: "scrutineer-proxy-7"}
-	args := d.buildRunArgs("/work/abs", "img:latest", hn, "")
+	args := d.buildRunArgs("img:latest", hn, "")
 
 	// The sidecar path regenerates the proxy URL via ProxyURLForEndpoint
 	// against the sidecar's own IP:port; it does not carry the host-proxy
@@ -810,7 +817,7 @@ func TestBuildRunArgs_HostProxyURLWhenNoSidecar(t *testing.T) {
 	// With no sidecar endpoint the scan uses the process-wide host proxy URL,
 	// exactly as docker/rootful hardened and non-hardened scans do today.
 	d := ContainerRunner{ProxyURL: "http://scrutineer:tok@host.docker.internal:55000"}
-	args := d.buildRunArgs("/work/abs", "img:latest", hardenedNet{}, "")
+	args := d.buildRunArgs("img:latest", hardenedNet{}, "")
 	if !hasAdjacent(args, "-e", "HTTPS_PROXY=http://scrutineer:tok@host.docker.internal:55000") {
 		t.Errorf("expected the host proxy URL in %v", args)
 	}

--- a/internal/worker/egress.go
+++ b/internal/worker/egress.go
@@ -8,6 +8,10 @@ package worker
 
 import (
 	"context"
+	"errors"
+	"net"
+	"net/http"
+	"time"
 
 	"github.com/alpha-omega-security/harness/egress"
 )
@@ -24,6 +28,8 @@ var (
 
 type EgressProxy = egress.Proxy
 
+const scopedEgressReadHeaderTimeout = 10 * time.Second
+
 func StartEgressProxy(p *EgressProxy) (int, error)        { return egress.Start(p) }
 func ServeEgressProxy(p *EgressProxy, addr string) error  { return egress.Serve(p, addr) }
 func NewProxyToken() string                               { return egress.NewToken() }
@@ -37,4 +43,25 @@ func WaitHostAPIReachable(ctx context.Context, host, port string) error {
 
 func VerifyUpstreamDNS(ctx context.Context, allow []string) error {
 	return egress.VerifyUpstreamDNS(ctx, allow)
+}
+
+// StartScopedEgressProxy starts a host proxy whose lifetime is one scan. The
+// harness package's process-wide starter intentionally has no close hook, so
+// provider-specific allowlists use this variant to avoid leaking listeners.
+func StartScopedEgressProxy(p *EgressProxy) (int, func(), error) {
+	noop := func() {}
+	if p == nil {
+		return 0, noop, errors.New("egress: proxy is required")
+	}
+	if p.Token == "" {
+		return 0, noop, errors.New("egress: Token is required")
+	}
+	ln, err := net.Listen("tcp", ":0")
+	if err != nil {
+		return 0, noop, err
+	}
+	srv := &http.Server{Handler: p, ReadHeaderTimeout: scopedEgressReadHeaderTimeout}
+	go func() { _ = srv.Serve(ln) }()
+	closeProxy := func() { _ = srv.Close() }
+	return ln.Addr().(*net.TCPAddr).Port, closeProxy, nil
 }

--- a/internal/worker/egress_test.go
+++ b/internal/worker/egress_test.go
@@ -1,0 +1,30 @@
+package worker
+
+import (
+	"net"
+	"strconv"
+	"testing"
+	"time"
+)
+
+func TestStartScopedEgressProxyClosesListener(t *testing.T) {
+	port, cleanup, err := StartScopedEgressProxy(&EgressProxy{
+		Allow: []string{"example.com"},
+		Token: "scan-token",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	addr := net.JoinHostPort("127.0.0.1", strconv.Itoa(port))
+	conn, err := net.DialTimeout("tcp", addr, time.Second)
+	if err != nil {
+		cleanup()
+		t.Fatalf("dial scoped proxy: %v", err)
+	}
+	_ = conn.Close()
+	cleanup()
+	if conn, err = net.DialTimeout("tcp", addr, 100*time.Millisecond); err == nil {
+		_ = conn.Close()
+		t.Fatal("scoped proxy listener remains open after cleanup")
+	}
+}

--- a/internal/worker/harness_test.go
+++ b/internal/worker/harness_test.go
@@ -159,7 +159,7 @@ func TestHarnessDefaultModels_registryEntriesAreComplete(t *testing.T) {
 
 func TestBuildRunArgs_stateEnvFromHarness(t *testing.T) {
 	d := ContainerRunner{Harness: stubHarness{state: []string{"CODEX_HOME=/harness-state", "CODEX_SQLITE_HOME=/harness-state"}}}
-	got := d.buildRunArgs("/work/abs", "img:latest", hardenedNet{}, "/data/cfg/scan-7")
+	got := d.buildRunArgs("img:latest", hardenedNet{}, "/data/cfg/scan-7")
 
 	if !containsEnvFlag(got, "CODEX_HOME=/harness-state") || !containsEnvFlag(got, "CODEX_SQLITE_HOME=/harness-state") {
 		t.Errorf("harness StateEnv not wired: %v", got)
@@ -177,7 +177,7 @@ func TestBuildRunArgs_stateEnvFromHarness(t *testing.T) {
 		t.Errorf("state dir bind mount missing: %v", got)
 	}
 
-	def := ContainerRunner{}.buildRunArgs("/work/abs", "img:latest", hardenedNet{}, "/data/cfg/scan-7")
+	def := ContainerRunner{}.buildRunArgs("img:latest", hardenedNet{}, "/data/cfg/scan-7")
 	if !containsEnvFlag(def, "CLAUDE_CONFIG_DIR=/harness-state") {
 		t.Errorf("default harness dropped CLAUDE_CONFIG_DIR: %v", def)
 	}
@@ -185,7 +185,7 @@ func TestBuildRunArgs_stateEnvFromHarness(t *testing.T) {
 
 func TestBuildRunArgs_includesHarnessEnv(t *testing.T) {
 	d := ContainerRunner{Harness: stubHarness{env: []string{"CODEX_API_KEY", "STUB_OPT=1"}}}
-	got := d.buildRunArgs("/work/abs", "img:latest", hardenedNet{}, "")
+	got := d.buildRunArgs("img:latest", hardenedNet{}, "")
 
 	if !containsEnvFlag(got, "CODEX_API_KEY") || !containsEnvFlag(got, "STUB_OPT=1") {
 		t.Errorf("harness env not wired into run args: %v", got)
@@ -206,7 +206,7 @@ func TestBuildRunArgs_includesHarnessEnv(t *testing.T) {
 func TestBuildRunArgs_defaultHarnessKeepsClaudeEnv(t *testing.T) {
 	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-test")
 	d := ContainerRunner{ModelBaseURL: "https://proxy.corp.com/v1"}
-	got := d.buildRunArgs("/work/abs", "img:latest", hardenedNet{}, "")
+	got := d.buildRunArgs("img:latest", hardenedNet{}, "")
 	for _, want := range []string{
 		"ANTHROPIC_API_KEY",
 		"ANTHROPIC_BASE_URL=https://proxy.corp.com/v1",

--- a/internal/worker/opencode_provider.go
+++ b/internal/worker/opencode_provider.go
@@ -1,0 +1,334 @@
+package worker
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"slices"
+	"sort"
+	"strings"
+	"sync"
+)
+
+// OpencodeProviderConfig is the runtime portion of one configured OpenCode
+// provider. ConfigContent is loaded from config_file during startup so a scan
+// never reads mutable provider configuration from its repository workspace.
+type OpencodeProviderConfig struct {
+	RunnerImage      string
+	ConfigContent    string
+	APIKeyEnv        string
+	AuthMetadata     map[string]string
+	PassEnv          []string
+	RequiredBinaries []string
+	EgressHosts      []string
+	StateDir         string
+}
+
+// opencodeProvider is the provider configuration resolved for one model. Its
+// environment map contains values only for that provider. Container arguments
+// receive bare variable names so credentials do not appear in the runtime
+// process's argv.
+type opencodeProvider struct {
+	ID                  string
+	Model               string
+	RunnerImage         string
+	StateDir            string
+	Env                 map[string]string
+	RequiredBinaries    []string
+	ExternalCredentials bool
+	Configured          bool
+}
+
+type opencodeAuthEntry struct {
+	Type     string            `json:"type"`
+	Key      string            `json:"key"`
+	Metadata map[string]string `json:"metadata,omitempty"`
+}
+
+const opencodeProviderStatePerm = 0o700
+
+// OpencodeReadinessCache avoids launching the same catalog probe before every
+// scan. Only successful probes are cached; a repaired image or credential can
+// therefore be retried without restarting Scrutineer.
+type OpencodeReadinessCache struct {
+	mu    sync.Mutex
+	ready map[string]bool
+}
+
+func NewOpencodeReadinessCache() *OpencodeReadinessCache {
+	return &OpencodeReadinessCache{ready: make(map[string]bool)}
+}
+
+// OpencodeProviderID returns the provider prefix of an OpenCode model id.
+func OpencodeProviderID(model string) string {
+	id, _, ok := strings.Cut(model, "/")
+	if !ok || id == "" {
+		return ""
+	}
+	return id
+}
+
+// OpencodeProviderEgress returns a stable, de-duplicated union of the hosts
+// needed by configured providers. The proxy is process-wide, while credentials
+// remain selected per scan.
+func OpencodeProviderEgress(providers map[string]OpencodeProviderConfig) []string {
+	seen := make(map[string]bool)
+	var hosts []string
+	for _, provider := range providers {
+		for _, host := range provider.EgressHosts {
+			if !seen[host] {
+				seen[host] = true
+				hosts = append(hosts, host)
+			}
+		}
+	}
+	sort.Strings(hosts)
+	return hosts
+}
+
+func (d ContainerRunner) resolveOpencodeProvider(model string) (opencodeProvider, error) {
+	resolved := opencodeProvider{
+		Model:       model,
+		RunnerImage: d.image(),
+		Env:         make(map[string]string),
+	}
+	if HarnessName(d.harness()) != "opencode" {
+		return resolved, nil
+	}
+	resolved.ID = OpencodeProviderID(model)
+	if resolved.ID == "" {
+		return resolved, nil
+	}
+	cfg, ok := d.OpencodeProviders[resolved.ID]
+	if !ok {
+		return resolved, nil
+	}
+	resolved.Configured = true
+	resolved.StateDir = cfg.StateDir
+	resolved.RequiredBinaries = append([]string(nil), cfg.RequiredBinaries...)
+	if cfg.RunnerImage != "" {
+		resolved.RunnerImage = cfg.RunnerImage
+		resolved.RequiredBinaries = appendMissing(resolved.RequiredBinaries, "brief", "scrutineer")
+	}
+	if cfg.ConfigContent != "" {
+		resolved.Env["OPENCODE_CONFIG_CONTENT"] = cfg.ConfigContent
+	}
+	if cfg.APIKeyEnv != "" {
+		key, ok := os.LookupEnv(cfg.APIKeyEnv)
+		if !ok || key == "" {
+			return resolved, fmt.Errorf("OpenCode provider %q is missing credential environment variable %s", resolved.ID, cfg.APIKeyEnv)
+		}
+		auth, err := json.Marshal(map[string]opencodeAuthEntry{
+			resolved.ID: {Type: "api", Key: key, Metadata: cfg.AuthMetadata},
+		})
+		if err != nil {
+			return resolved, fmt.Errorf("encode OpenCode provider %q auth: %w", resolved.ID, err)
+		}
+		resolved.Env["OPENCODE_AUTH_CONTENT"] = string(auth)
+		resolved.ExternalCredentials = true
+	}
+	for _, name := range cfg.PassEnv {
+		value, ok := os.LookupEnv(name)
+		if !ok || value == "" {
+			return resolved, fmt.Errorf("OpenCode provider %q is missing credential environment variable %s", resolved.ID, name)
+		}
+		resolved.Env[name] = value
+		resolved.ExternalCredentials = true
+	}
+	return resolved, nil
+}
+
+func appendMissing(values []string, additions ...string) []string {
+	for _, addition := range additions {
+		if !slices.Contains(values, addition) {
+			values = append(values, addition)
+		}
+	}
+	return values
+}
+
+func (d ContainerRunner) prepareOpencodeRun(ctx context.Context, model string) (ContainerRunner, opencodeProvider, SkillResult, error) {
+	provider, err := d.resolveOpencodeProvider(model)
+	result := SkillResult{Backend: HarnessName(d.harness())}
+	if result.Backend == "opencode" {
+		result.Provider = provider.ID
+		result.RunnerImage = provider.RunnerImage
+	}
+	if err != nil {
+		result.RunnerImageDigest = d.opencodeRunnerImageDigest(ctx, provider.RunnerImage)
+		return d, provider, result, err
+	}
+	if provider.StateDir != "" {
+		provider.StateDir, _ = filepath.Abs(provider.StateDir)
+		if err := ensureOpencodeProviderState(provider); err != nil {
+			result.RunnerImageDigest = d.opencodeRunnerImageDigest(ctx, provider.RunnerImage)
+			return d, provider, result, err
+		}
+	}
+	// Provider images are bases for the existing language profiles, so replace
+	// the copied runner's default image before profile resolution.
+	d.Image = provider.RunnerImage
+	if result.Backend == "opencode" {
+		result.RunnerImage = d.image()
+	}
+	return d, provider, result, nil
+}
+
+func (d ContainerRunner) opencodeRunnerImageDigest(ctx context.Context, image string) string {
+	if HarnessName(d.harness()) != "opencode" {
+		return ""
+	}
+	return runnerImageContentDigest(ctx, d.Runtime, image)
+}
+
+func ensureOpencodeProviderState(provider opencodeProvider) error {
+	if provider.StateDir == "" {
+		return nil
+	}
+	if err := os.MkdirAll(provider.StateDir, opencodeProviderStatePerm); err != nil {
+		return fmt.Errorf("create OpenCode provider %q state directory: %w", provider.ID, err)
+	}
+	info, err := os.Stat(provider.StateDir)
+	if err != nil {
+		return fmt.Errorf("inspect OpenCode provider %q state directory: %w", provider.ID, err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("OpenCode provider %q state path is not a directory", provider.ID)
+	}
+	if info.Mode().Perm()&0o077 != 0 {
+		return fmt.Errorf("OpenCode provider %q state directory permissions %04o expose credentials; require 0700 or stricter", provider.ID, info.Mode().Perm())
+	}
+	authPath := filepath.Join(provider.StateDir, "opencode", "auth.json")
+	data, err := os.ReadFile(authPath)
+	if os.IsNotExist(err) {
+		if !provider.ExternalCredentials {
+			return fmt.Errorf("OpenCode provider %q is missing stored credentials at %s", provider.ID, authPath)
+		}
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("read OpenCode provider %q auth state: %w", provider.ID, err)
+	}
+	var entries map[string]json.RawMessage
+	if err := json.Unmarshal(data, &entries); err != nil {
+		return fmt.Errorf("parse OpenCode provider %q auth state: %w", provider.ID, err)
+	}
+	for id := range entries {
+		if id != provider.ID {
+			return fmt.Errorf("OpenCode provider %q state contains credentials for provider %q", provider.ID, id)
+		}
+	}
+	if _, ok := entries[provider.ID]; !ok && !provider.ExternalCredentials {
+		return fmt.Errorf("OpenCode provider %q state does not contain its stored credentials", provider.ID)
+	}
+	return nil
+}
+
+func (d ContainerRunner) checkOpencodeReadiness(ctx context.Context, provider opencodeProvider, absWork, image string, hnet hardenedNet, harnessStateDir string) error {
+	if !provider.Configured {
+		return nil
+	}
+	cacheKey := image + "\x00" + provider.Model + "\x00" + provider.Env["OPENCODE_CONFIG_CONTENT"] + "\x00" + provider.StateDir + "\x00" + strings.Join(provider.RequiredBinaries, "\x00")
+	if d.OpencodeReadiness != nil {
+		d.OpencodeReadiness.mu.Lock()
+		ready := d.OpencodeReadiness.ready[cacheKey]
+		d.OpencodeReadiness.mu.Unlock()
+		if ready {
+			return nil
+		}
+	}
+	for _, binary := range provider.RequiredBinaries {
+		args := d.buildRunArgsForProvider(absWork, image, hnet, harnessStateDir, provider, "/tmp")
+		args = append(args, "sh", "-c", `command -v "$1" >/dev/null`, "provider-readiness", binary)
+		cmd := exec.CommandContext(ctx, d.Runtime.bin(), args...)
+		cmd.Env = environmentWith(os.Environ(), provider.Env)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("OpenCode provider %q readiness failed because supporting binary %q is missing: %w: %s", provider.ID, binary, err, cappedProviderOutput(out))
+		}
+	}
+	args := d.buildRunArgsForProvider(absWork, image, hnet, harnessStateDir, provider, "/tmp")
+	args = append(args, "opencode", "models", provider.ID)
+	cmd := exec.CommandContext(ctx, d.Runtime.bin(), args...)
+	cmd.Env = environmentWith(os.Environ(), provider.Env)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return classifyOpencodeReadinessError(provider, strings.TrimSpace(string(out)), err)
+	}
+	models := strings.Fields(string(out))
+	if !slices.Contains(models, provider.Model) {
+		return fmt.Errorf("OpenCode provider %q model %q is unavailable in the selected image catalog: %s", provider.ID, provider.Model, cappedProviderOutput(out))
+	}
+	if d.OpencodeReadiness != nil {
+		d.OpencodeReadiness.mu.Lock()
+		if d.OpencodeReadiness.ready == nil {
+			d.OpencodeReadiness.ready = make(map[string]bool)
+		}
+		d.OpencodeReadiness.ready[cacheKey] = true
+		d.OpencodeReadiness.mu.Unlock()
+	}
+	return nil
+}
+
+func classifyOpencodeReadinessError(provider opencodeProvider, output string, runErr error) error {
+	lower := strings.ToLower(output)
+	switch {
+	case strings.Contains(lower, "executable file not found") || strings.Contains(lower, "opencode: not found"):
+		return fmt.Errorf("OpenCode provider %q readiness failed because the selected image does not contain the opencode binary: %w: %s", provider.ID, runErr, output)
+	case strings.Contains(lower, "module not found"), strings.Contains(lower, "cannot find module"), strings.Contains(lower, "cannot find package"):
+		return fmt.Errorf("OpenCode provider %q readiness failed because a configured adapter or plugin is missing: %w: %s", provider.ID, runErr, output)
+	case strings.Contains(lower, "command not found"), strings.Contains(lower, "no such file or directory"):
+		return fmt.Errorf("OpenCode provider %q readiness failed because a supporting binary is missing: %w: %s", provider.ID, runErr, output)
+	case strings.Contains(lower, "network"), strings.Contains(lower, "connect"), strings.Contains(lower, "econn"), strings.Contains(lower, "timeout"), strings.Contains(lower, "certificate"):
+		return fmt.Errorf("OpenCode provider %q readiness failed while reaching its configured egress hosts: %w: %s", provider.ID, runErr, output)
+	default:
+		return fmt.Errorf("OpenCode provider %q readiness failed: %w: %s", provider.ID, runErr, output)
+	}
+}
+
+func cappedProviderOutput(out []byte) string {
+	const max = 2048
+	text := strings.TrimSpace(string(out))
+	if len(text) > max {
+		return text[:max] + "..."
+	}
+	return text
+}
+
+func environmentWith(base []string, overrides map[string]string) []string {
+	env := append([]string(nil), base...)
+	for key, value := range overrides {
+		prefix := key + "="
+		replaced := false
+		for i := range env {
+			if strings.HasPrefix(env[i], prefix) {
+				env[i] = prefix + value
+				replaced = true
+				break
+			}
+		}
+		if !replaced {
+			env = append(env, prefix+value)
+		}
+	}
+	return env
+}
+
+// runnerImageContentDigest records the locally resolved content identity of
+// the provider base. Registry-backed images use RepoDigests; locally built
+// operator images fall back to their immutable image ID.
+func runnerImageContentDigest(ctx context.Context, rt ContainerRuntime, image string) string {
+	const format = `{{if .RepoDigests}}{{index .RepoDigests 0}}{{else}}{{.Id}}{{end}}`
+	out, err := exec.CommandContext(ctx, rt.bin(), "image", "inspect", "--format", format, "--", image).Output()
+	if err != nil {
+		return ""
+	}
+	value := strings.TrimSpace(string(out))
+	if _, digest, ok := strings.Cut(value, "@"); ok {
+		return digest
+	}
+	return value
+}

--- a/internal/worker/opencode_provider.go
+++ b/internal/worker/opencode_provider.go
@@ -8,7 +8,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"slices"
-	"sort"
 	"strings"
 	"sync"
 )
@@ -38,6 +37,7 @@ type opencodeProvider struct {
 	StateDir            string
 	Env                 map[string]string
 	RequiredBinaries    []string
+	EgressHosts         []string
 	ExternalCredentials bool
 	Configured          bool
 }
@@ -48,7 +48,10 @@ type opencodeAuthEntry struct {
 	Metadata map[string]string `json:"metadata,omitempty"`
 }
 
-const opencodeProviderStatePerm = 0o700
+const (
+	opencodeProviderStatePerm = 0o700
+	opencodeAuthFilePerm      = 0o600
+)
 
 // OpencodeReadinessCache avoids launching the same catalog probe before every
 // scan. Only successful probes are cached; a repaired image or credential can
@@ -71,24 +74,6 @@ func OpencodeProviderID(model string) string {
 	return id
 }
 
-// OpencodeProviderEgress returns a stable, de-duplicated union of the hosts
-// needed by configured providers. The proxy is process-wide, while credentials
-// remain selected per scan.
-func OpencodeProviderEgress(providers map[string]OpencodeProviderConfig) []string {
-	seen := make(map[string]bool)
-	var hosts []string
-	for _, provider := range providers {
-		for _, host := range provider.EgressHosts {
-			if !seen[host] {
-				seen[host] = true
-				hosts = append(hosts, host)
-			}
-		}
-	}
-	sort.Strings(hosts)
-	return hosts
-}
-
 func (d ContainerRunner) resolveOpencodeProvider(model string) (opencodeProvider, error) {
 	resolved := opencodeProvider{
 		Model:       model,
@@ -109,6 +94,7 @@ func (d ContainerRunner) resolveOpencodeProvider(model string) (opencodeProvider
 	resolved.Configured = true
 	resolved.StateDir = cfg.StateDir
 	resolved.RequiredBinaries = append([]string(nil), cfg.RequiredBinaries...)
+	resolved.EgressHosts = append([]string(nil), cfg.EgressHosts...)
 	if cfg.RunnerImage != "" {
 		resolved.RunnerImage = cfg.RunnerImage
 		resolved.RequiredBinaries = appendMissing(resolved.RequiredBinaries, "brief", "scrutineer")
@@ -139,6 +125,96 @@ func (d ContainerRunner) resolveOpencodeProvider(model string) (opencodeProvider
 		resolved.ExternalCredentials = true
 	}
 	return resolved, nil
+}
+
+func (d ContainerRunner) configureOpencodeProviderEgress(provider opencodeProvider) (ContainerRunner, func(), error) {
+	noop := func() {}
+	if !provider.Configured {
+		return d, noop, nil
+	}
+	d.Egress.Allow = appendUniqueStrings(d.Egress.Allow, provider.EgressHosts...)
+	d.ProviderProxy.Allow = appendUniqueStrings(d.ProviderProxy.Allow, provider.EgressHosts...)
+	if d.usesEgressSidecar() {
+		return d, noop, nil
+	}
+	if d.ProviderProxy.ContainerHost == "" {
+		return d, noop, fmt.Errorf("OpenCode provider %q cannot configure scoped egress because the container host endpoint is unavailable", provider.ID)
+	}
+	token := NewProxyToken()
+	port, cleanup, err := StartScopedEgressProxy(&EgressProxy{
+		Allow:    d.ProviderProxy.Allow,
+		Token:    token,
+		APIPort:  d.ProviderProxy.APIPort,
+		APIHosts: d.ProviderProxy.APIHosts,
+		Log:      d.ProviderProxy.Log,
+	})
+	if err != nil {
+		return d, noop, fmt.Errorf("start OpenCode provider %q egress proxy: %w", provider.ID, err)
+	}
+	d.ProxyURL = ProxyURLForHost(token, d.ProviderProxy.ContainerHost, port)
+	return d, cleanup, nil
+}
+
+func (d ContainerRunner) prepareOpencodeExecution(ctx context.Context, model string) (ContainerRunner, opencodeProvider, SkillResult, func(), error) {
+	noop := func() {}
+	d, provider, result, err := d.prepareOpencodeRun(ctx, model)
+	if err != nil {
+		return d, provider, result, noop, err
+	}
+	d, cleanup, err := d.configureOpencodeProviderEgress(provider)
+	if err != nil {
+		return d, provider, result, noop, err
+	}
+	return d, provider, result, cleanup, nil
+}
+
+func (d ContainerRunner) prepareHarnessState(ctx context.Context, stateDir string, provider opencodeProvider, absWork, image string, hnet hardenedNet) (string, string, error) {
+	// A non-absolute bind source is a runtime-managed volume, so resolve the
+	// scan state path the same way as the workspace before building arguments.
+	var absState string
+	if stateDir != "" {
+		absState, _ = filepath.Abs(stateDir)
+		if err := os.MkdirAll(absState, dirPerm); err != nil {
+			return "", "", fmt.Errorf("create harness state dir: %w", err)
+		}
+	}
+	if err := prepareOpencodeScanState(provider, absState); err != nil {
+		return "", "", err
+	}
+	readinessErr := d.checkOpencodeReadiness(ctx, provider, absWork, image, hnet, absState)
+	digest := d.opencodeRunnerImageDigest(ctx, d.image())
+	return absState, digest, readinessErr
+}
+
+func (d ContainerRunner) appendOpencodeStateArgs(args []string, harnessStateDir string, provider opencodeProvider) []string {
+	if harnessStateDir != "" {
+		// Logs, repository metadata, and all other OpenCode data stay scoped to
+		// this scan lineage. A configured provider mounts only auth.json below.
+		args = append(args, "-e", "XDG_DATA_HOME=/harness-state/data")
+	}
+	if provider.StateDir != "" && harnessStateDir != "" {
+		args = append(args, "-v", bindMount(
+			opencodeProviderAuthPath(provider.StateDir),
+			"/harness-state/data/opencode/auth.json",
+			d.SELinuxRelabel,
+		))
+	}
+	return args
+}
+
+func appendUniqueStrings(values []string, additions ...string) []string {
+	out := append([]string(nil), values...)
+	seen := make(map[string]bool, len(out)+len(additions))
+	for _, value := range out {
+		seen[value] = true
+	}
+	for _, addition := range additions {
+		if !seen[addition] {
+			out = append(out, addition)
+			seen[addition] = true
+		}
+	}
+	return out
 }
 
 func appendMissing(values []string, additions ...string) []string {
@@ -201,13 +277,30 @@ func ensureOpencodeProviderState(provider opencodeProvider) error {
 	if info.Mode().Perm()&0o077 != 0 {
 		return fmt.Errorf("OpenCode provider %q state directory permissions %04o expose credentials; require 0700 or stricter", provider.ID, info.Mode().Perm())
 	}
-	authPath := filepath.Join(provider.StateDir, "opencode", "auth.json")
+	authPath := opencodeProviderAuthPath(provider.StateDir)
 	data, err := os.ReadFile(authPath)
 	if os.IsNotExist(err) {
 		if !provider.ExternalCredentials {
 			return fmt.Errorf("OpenCode provider %q is missing stored credentials at %s", provider.ID, authPath)
 		}
-		return nil
+		if err := os.MkdirAll(filepath.Dir(authPath), opencodeProviderStatePerm); err != nil {
+			return fmt.Errorf("create OpenCode provider %q auth directory: %w", provider.ID, err)
+		}
+		file, createErr := os.OpenFile(authPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, opencodeAuthFilePerm)
+		if createErr != nil && !os.IsExist(createErr) {
+			return fmt.Errorf("create OpenCode provider %q auth state: %w", provider.ID, createErr)
+		}
+		if createErr == nil {
+			if _, writeErr := file.WriteString("{}\n"); writeErr != nil {
+				_ = file.Close()
+				return fmt.Errorf("initialise OpenCode provider %q auth state: %w", provider.ID, writeErr)
+			}
+			if closeErr := file.Close(); closeErr != nil {
+				return fmt.Errorf("initialise OpenCode provider %q auth state: %w", provider.ID, closeErr)
+			}
+			return nil
+		}
+		data, err = os.ReadFile(authPath)
 	}
 	if err != nil {
 		return fmt.Errorf("read OpenCode provider %q auth state: %w", provider.ID, err)
@@ -227,11 +320,36 @@ func ensureOpencodeProviderState(provider opencodeProvider) error {
 	return nil
 }
 
+func opencodeProviderAuthPath(stateDir string) string {
+	return filepath.Join(stateDir, "opencode", "auth.json")
+}
+
+func prepareOpencodeScanState(provider opencodeProvider, harnessStateDir string) error {
+	if provider.StateDir == "" {
+		return nil
+	}
+	if harnessStateDir == "" {
+		return fmt.Errorf("OpenCode provider %q stored auth requires a per-scan harness state directory", provider.ID)
+	}
+	target := filepath.Join(harnessStateDir, "data", "opencode", "auth.json")
+	if err := os.MkdirAll(filepath.Dir(target), opencodeProviderStatePerm); err != nil {
+		return fmt.Errorf("prepare OpenCode provider %q scan auth directory: %w", provider.ID, err)
+	}
+	file, err := os.OpenFile(target, os.O_WRONLY|os.O_CREATE, opencodeAuthFilePerm)
+	if err != nil {
+		return fmt.Errorf("prepare OpenCode provider %q scan auth mountpoint: %w", provider.ID, err)
+	}
+	if err := file.Close(); err != nil {
+		return fmt.Errorf("prepare OpenCode provider %q scan auth mountpoint: %w", provider.ID, err)
+	}
+	return nil
+}
+
 func (d ContainerRunner) checkOpencodeReadiness(ctx context.Context, provider opencodeProvider, absWork, image string, hnet hardenedNet, harnessStateDir string) error {
 	if !provider.Configured {
 		return nil
 	}
-	cacheKey := image + "\x00" + provider.Model + "\x00" + provider.Env["OPENCODE_CONFIG_CONTENT"] + "\x00" + provider.StateDir + "\x00" + strings.Join(provider.RequiredBinaries, "\x00")
+	cacheKey := image + "\x00" + provider.Model + "\x00" + provider.Env["OPENCODE_CONFIG_CONTENT"] + "\x00" + provider.StateDir + "\x00" + strings.Join(provider.RequiredBinaries, "\x00") + "\x00" + strings.Join(provider.EgressHosts, "\x00")
 	if d.OpencodeReadiness != nil {
 		d.OpencodeReadiness.mu.Lock()
 		ready := d.OpencodeReadiness.ready[cacheKey]
@@ -248,6 +366,19 @@ func (d ContainerRunner) checkOpencodeReadiness(ctx context.Context, provider op
 		out, err := cmd.CombinedOutput()
 		if err != nil {
 			return fmt.Errorf("OpenCode provider %q readiness failed because supporting binary %q is missing: %w: %s", provider.ID, binary, err, cappedProviderOutput(out))
+		}
+	}
+	for _, host := range provider.EgressHosts {
+		if strings.HasPrefix(host, "*.") {
+			continue
+		}
+		args := d.buildRunArgsForProvider(absWork, image, hnet, harnessStateDir, provider, "/tmp")
+		args = append(args, "curl", "--silent", "--show-error", "--output", "/dev/null", "--connect-timeout", "5", "--max-time", "10", "--", "https://"+host+"/")
+		cmd := exec.CommandContext(ctx, d.Runtime.bin(), args...)
+		cmd.Env = environmentWith(os.Environ(), provider.Env)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("OpenCode provider %q readiness failed while reaching configured egress host %q: %w: %s", provider.ID, host, err, cappedProviderOutput(out))
 		}
 	}
 	args := d.buildRunArgsForProvider(absWork, image, hnet, harnessStateDir, provider, "/tmp")
@@ -271,6 +402,14 @@ func (d ContainerRunner) checkOpencodeReadiness(ctx context.Context, provider op
 		d.OpencodeReadiness.mu.Unlock()
 	}
 	return nil
+}
+
+func classifyOpencodeProviderRunError(provider opencodeProvider, output string, runErr error) error {
+	lower := strings.ToLower(output)
+	if strings.Contains(lower, "network") || strings.Contains(lower, "connect") || strings.Contains(lower, "econn") || strings.Contains(lower, "timeout") || strings.Contains(lower, "certificate") || strings.Contains(lower, "proxy") {
+		return fmt.Errorf("OpenCode provider %q failed while reaching its configured egress hosts: %w: %s", provider.ID, runErr, cappedProviderOutput([]byte(output)))
+	}
+	return fmt.Errorf("OpenCode provider %q failed: %w: %s", provider.ID, runErr, cappedProviderOutput([]byte(output)))
 }
 
 func classifyOpencodeReadinessError(provider opencodeProvider, output string, runErr error) error {

--- a/internal/worker/opencode_provider.go
+++ b/internal/worker/opencode_provider.go
@@ -53,16 +53,39 @@ const (
 	opencodeAuthFilePerm      = 0o600
 )
 
-// OpencodeReadinessCache avoids launching the same catalog probe before every
-// scan. Only successful probes are cached; a repaired image or credential can
-// therefore be retried without restarting Scrutineer.
+// OpencodeReadinessCache holds the OpenCode runtime state that must be shared
+// across concurrent scans: cached successful catalog probes (so a repaired
+// image or credential can be retried without restarting Scrutineer, but a good
+// one is not re-proven before every scan) and per-state_dir locks (so two scans
+// never mount the same rotating auth.json read-write at once).
 type OpencodeReadinessCache struct {
-	mu    sync.Mutex
-	ready map[string]bool
+	mu         sync.Mutex
+	ready      map[string]bool
+	stateLocks map[string]*sync.Mutex
 }
 
 func NewOpencodeReadinessCache() *OpencodeReadinessCache {
-	return &OpencodeReadinessCache{ready: make(map[string]bool)}
+	return &OpencodeReadinessCache{ready: make(map[string]bool), stateLocks: make(map[string]*sync.Mutex)}
+}
+
+// lockState serialises scans that share one provider state_dir. OpenCode can
+// refresh OAuth credentials and rewrite auth.json without cross-process
+// locking, so a second concurrent mount can lose a rotated refresh token. The
+// lock is held for the whole scan (readiness through skill exit) and released
+// by the returned func.
+func (c *OpencodeReadinessCache) lockState(dir string) func() {
+	if c == nil || dir == "" {
+		return func() {}
+	}
+	c.mu.Lock()
+	m, ok := c.stateLocks[dir]
+	if !ok {
+		m = &sync.Mutex{}
+		c.stateLocks[dir] = m
+	}
+	c.mu.Unlock()
+	m.Lock()
+	return m.Unlock
 }
 
 // OpencodeProviderID returns the provider prefix of an OpenCode model id.
@@ -97,7 +120,7 @@ func (d ContainerRunner) resolveOpencodeProvider(model string) (opencodeProvider
 	resolved.EgressHosts = append([]string(nil), cfg.EgressHosts...)
 	if cfg.RunnerImage != "" {
 		resolved.RunnerImage = cfg.RunnerImage
-		resolved.RequiredBinaries = appendMissing(resolved.RequiredBinaries, "brief", "scrutineer")
+		resolved.RequiredBinaries = appendUniqueStrings(resolved.RequiredBinaries, "brief", "scrutineer")
 	}
 	if cfg.ConfigContent != "" {
 		resolved.Env["OPENCODE_CONFIG_CONTENT"] = cfg.ConfigContent
@@ -157,15 +180,36 @@ func (d ContainerRunner) configureOpencodeProviderEgress(provider opencodeProvid
 
 func (d ContainerRunner) prepareOpencodeExecution(ctx context.Context, model string) (ContainerRunner, opencodeProvider, SkillResult, func(), error) {
 	noop := func() {}
-	d, provider, result, err := d.prepareOpencodeRun(ctx, model)
+	provider, err := d.resolveOpencodeProvider(model)
+	result := SkillResult{Backend: HarnessName(d.harness())}
+	if result.Backend == "opencode" {
+		result.Provider = provider.ID
+		result.RunnerImage = provider.RunnerImage
+	}
 	if err != nil {
+		result.RunnerImageDigest = d.opencodeRunnerImageDigest(ctx, provider.RunnerImage)
 		return d, provider, result, noop, err
 	}
-	d, cleanup, err := d.configureOpencodeProviderEgress(provider)
-	if err != nil {
+	if provider.StateDir != "" {
+		provider.StateDir, _ = filepath.Abs(provider.StateDir)
+	}
+	// Lock before ensureOpencodeProviderState so a queued scan never reads
+	// auth.json while a running scan's OpenCode is rewriting it mid-refresh.
+	unlock := d.OpencodeReadiness.lockState(provider.StateDir)
+	if err := ensureOpencodeProviderState(provider); err != nil {
+		unlock()
+		result.RunnerImageDigest = d.opencodeRunnerImageDigest(ctx, provider.RunnerImage)
 		return d, provider, result, noop, err
 	}
-	return d, provider, result, cleanup, nil
+	// Provider images are bases for the existing language profiles, so replace
+	// the copied runner's default image before profile resolution.
+	d.Image = provider.RunnerImage
+	d, closeProxy, err := d.configureOpencodeProviderEgress(provider)
+	if err != nil {
+		unlock()
+		return d, provider, result, noop, err
+	}
+	return d, provider, result, func() { closeProxy(); unlock() }, nil
 }
 
 func (d ContainerRunner) prepareHarnessState(ctx context.Context, stateDir string, provider opencodeProvider, absWork, image string, hnet hardenedNet) (string, string, error) {
@@ -215,42 +259,6 @@ func appendUniqueStrings(values []string, additions ...string) []string {
 		}
 	}
 	return out
-}
-
-func appendMissing(values []string, additions ...string) []string {
-	for _, addition := range additions {
-		if !slices.Contains(values, addition) {
-			values = append(values, addition)
-		}
-	}
-	return values
-}
-
-func (d ContainerRunner) prepareOpencodeRun(ctx context.Context, model string) (ContainerRunner, opencodeProvider, SkillResult, error) {
-	provider, err := d.resolveOpencodeProvider(model)
-	result := SkillResult{Backend: HarnessName(d.harness())}
-	if result.Backend == "opencode" {
-		result.Provider = provider.ID
-		result.RunnerImage = provider.RunnerImage
-	}
-	if err != nil {
-		result.RunnerImageDigest = d.opencodeRunnerImageDigest(ctx, provider.RunnerImage)
-		return d, provider, result, err
-	}
-	if provider.StateDir != "" {
-		provider.StateDir, _ = filepath.Abs(provider.StateDir)
-		if err := ensureOpencodeProviderState(provider); err != nil {
-			result.RunnerImageDigest = d.opencodeRunnerImageDigest(ctx, provider.RunnerImage)
-			return d, provider, result, err
-		}
-	}
-	// Provider images are bases for the existing language profiles, so replace
-	// the copied runner's default image before profile resolution.
-	d.Image = provider.RunnerImage
-	if result.Backend == "opencode" {
-		result.RunnerImage = d.image()
-	}
-	return d, provider, result, nil
 }
 
 func (d ContainerRunner) opencodeRunnerImageDigest(ctx context.Context, image string) string {
@@ -358,36 +366,27 @@ func (d ContainerRunner) checkOpencodeReadiness(ctx context.Context, provider op
 			return nil
 		}
 	}
-	for _, binary := range provider.RequiredBinaries {
+	probe := func(argv ...string) ([]byte, error) {
 		args := d.buildRunArgsForProvider(absWork, image, hnet, harnessStateDir, provider, "/tmp")
-		args = append(args, "sh", "-c", `command -v "$1" >/dev/null`, "provider-readiness", binary)
-		cmd := exec.CommandContext(ctx, d.Runtime.bin(), args...)
+		cmd := exec.CommandContext(ctx, d.Runtime.bin(), append(args, argv...)...)
 		cmd.Env = environmentWith(os.Environ(), provider.Env)
-		out, err := cmd.CombinedOutput()
-		if err != nil {
-			return fmt.Errorf("OpenCode provider %q readiness failed because supporting binary %q is missing: %w: %s", provider.ID, binary, err, cappedProviderOutput(out))
+		return cmd.CombinedOutput()
+	}
+	if len(provider.RequiredBinaries) > 0 {
+		argv := append([]string{"sh", "-c", `for b in "$@"; do command -v "$b" >/dev/null || { echo "scrutineer-readiness-fail: $b"; exit 1; }; done`, "provider-readiness"}, provider.RequiredBinaries...)
+		if out, err := probe(argv...); err != nil {
+			return fmt.Errorf("OpenCode provider %q readiness failed because supporting binary %q is missing: %w: %s", provider.ID, readinessFailTarget(out), err, cappedProviderOutput(out))
 		}
 	}
-	for _, host := range provider.EgressHosts {
-		if strings.HasPrefix(host, "*.") {
-			continue
-		}
-		args := d.buildRunArgsForProvider(absWork, image, hnet, harnessStateDir, provider, "/tmp")
-		args = append(args, "curl", "--silent", "--show-error", "--output", "/dev/null", "--connect-timeout", "5", "--max-time", "10", "--", "https://"+host+"/")
-		cmd := exec.CommandContext(ctx, d.Runtime.bin(), args...)
-		cmd.Env = environmentWith(os.Environ(), provider.Env)
-		out, err := cmd.CombinedOutput()
-		if err != nil {
-			return fmt.Errorf("OpenCode provider %q readiness failed while reaching configured egress host %q: %w: %s", provider.ID, host, err, cappedProviderOutput(out))
+	if hosts := concreteEgressHosts(provider.EgressHosts); len(hosts) > 0 {
+		argv := append([]string{"sh", "-c", `for h in "$@"; do curl --silent --show-error --output /dev/null --connect-timeout 5 --max-time 10 -- "https://$h/" || { echo "scrutineer-readiness-fail: $h"; exit 1; }; done`, "provider-readiness"}, hosts...)
+		if out, err := probe(argv...); err != nil {
+			return fmt.Errorf("OpenCode provider %q readiness failed while reaching configured egress host %q: %w: %s", provider.ID, readinessFailTarget(out), err, cappedProviderOutput(out))
 		}
 	}
-	args := d.buildRunArgsForProvider(absWork, image, hnet, harnessStateDir, provider, "/tmp")
-	args = append(args, "opencode", "models", provider.ID)
-	cmd := exec.CommandContext(ctx, d.Runtime.bin(), args...)
-	cmd.Env = environmentWith(os.Environ(), provider.Env)
-	out, err := cmd.CombinedOutput()
+	out, err := probe("opencode", "models", provider.ID)
 	if err != nil {
-		return classifyOpencodeReadinessError(provider, strings.TrimSpace(string(out)), err)
+		return classifyOpencodeReadinessError(provider, cappedProviderOutput(out), err)
 	}
 	models := strings.Fields(string(out))
 	if !slices.Contains(models, provider.Model) {
@@ -428,6 +427,28 @@ func classifyOpencodeReadinessError(provider opencodeProvider, output string, ru
 	}
 }
 
+func concreteEgressHosts(hosts []string) []string {
+	out := make([]string, 0, len(hosts))
+	for _, h := range hosts {
+		if !strings.HasPrefix(h, "*.") {
+			out = append(out, h)
+		}
+	}
+	return out
+}
+
+// readinessFailTarget extracts the binary or host name a readiness probe
+// script tagged as the failure. The marker is on its own stdout line, so it
+// survives runtime warnings and curl stderr in CombinedOutput.
+func readinessFailTarget(out []byte) string {
+	for line := range strings.SplitSeq(string(out), "\n") {
+		if target, ok := strings.CutPrefix(strings.TrimSpace(line), "scrutineer-readiness-fail: "); ok {
+			return target
+		}
+	}
+	return ""
+}
+
 func cappedProviderOutput(out []byte) string {
 	const max = 2048
 	text := strings.TrimSpace(string(out))
@@ -458,8 +479,13 @@ func environmentWith(base []string, overrides map[string]string) []string {
 
 // runnerImageContentDigest records the locally resolved content identity of
 // the provider base. Registry-backed images use RepoDigests; locally built
-// operator images fall back to their immutable image ID.
+// operator images fall back to their immutable image ID. Apple's container CLI
+// has no --format flag on `image inspect`, so its JSON output is parsed for
+// the equivalent descriptor digest.
 func runnerImageContentDigest(ctx context.Context, rt ContainerRuntime, image string) string {
+	if rt.Bin == runtimeApple {
+		return appleImageContentDigest(ctx, image)
+	}
 	const format = `{{if .RepoDigests}}{{index .RepoDigests 0}}{{else}}{{.Id}}{{end}}`
 	out, err := exec.CommandContext(ctx, rt.bin(), "image", "inspect", "--format", format, "--", image).Output()
 	if err != nil {
@@ -470,4 +496,26 @@ func runnerImageContentDigest(ctx context.Context, rt ContainerRuntime, image st
 		return digest
 	}
 	return value
+}
+
+func appleImageContentDigest(ctx context.Context, image string) string {
+	out, err := exec.CommandContext(ctx, "container", "image", "inspect", image).Output()
+	if err != nil {
+		return ""
+	}
+	var records []struct {
+		ID            string `json:"id"`
+		Configuration struct {
+			Descriptor struct {
+				Digest string `json:"digest"`
+			} `json:"descriptor"`
+		} `json:"configuration"`
+	}
+	if err := json.Unmarshal(out, &records); err != nil || len(records) == 0 {
+		return ""
+	}
+	if d := records[0].Configuration.Descriptor.Digest; d != "" {
+		return d
+	}
+	return records[0].ID
 }

--- a/internal/worker/opencode_provider_test.go
+++ b/internal/worker/opencode_provider_test.go
@@ -1,0 +1,270 @@
+package worker
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestResolveOpencodeProviderBuildsScopedAuth(t *testing.T) {
+	t.Setenv("GROQ_API_KEY", "groq-secret")
+	d := ContainerRunner{
+		Harness: OpencodeHarness{},
+		Image:   "stock:1",
+		OpencodeProviders: map[string]OpencodeProviderConfig{
+			"groq": {
+				RunnerImage:   "groq:1",
+				ConfigContent: `{"provider":{}}`,
+				APIKeyEnv:     "GROQ_API_KEY",
+				AuthMetadata:  map[string]string{"accountId": "team-1"},
+			},
+		},
+	}
+	provider, err := d.resolveOpencodeProvider("groq/llama-3.3-70b-versatile")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !provider.Configured || provider.ID != "groq" || provider.RunnerImage != "groq:1" {
+		t.Fatalf("resolved provider = %+v", provider)
+	}
+	for _, binary := range []string{"brief", "scrutineer"} {
+		if !slices.Contains(provider.RequiredBinaries, binary) {
+			t.Errorf("derived image check does not require %s: %v", binary, provider.RequiredBinaries)
+		}
+	}
+	var auth map[string]opencodeAuthEntry
+	if err := json.Unmarshal([]byte(provider.Env["OPENCODE_AUTH_CONTENT"]), &auth); err != nil {
+		t.Fatal(err)
+	}
+	if len(auth) != 1 || auth["groq"].Key != "groq-secret" || auth["groq"].Metadata["accountId"] != "team-1" {
+		t.Errorf("provider-only auth = %#v", auth)
+	}
+	if provider.Env["OPENCODE_CONFIG_CONTENT"] != `{"provider":{}}` {
+		t.Errorf("config content = %q", provider.Env["OPENCODE_CONFIG_CONTENT"])
+	}
+}
+
+func TestResolveOpencodeProviderRequiresNamedCredentials(t *testing.T) {
+	d := ContainerRunner{
+		Harness: OpencodeHarness{},
+		OpencodeProviders: map[string]OpencodeProviderConfig{
+			"kiro": {PassEnv: []string{"KIRO_API_KEY"}},
+		},
+	}
+	_, err := d.resolveOpencodeProvider("kiro/auto")
+	if err == nil || !strings.Contains(err.Error(), "KIRO_API_KEY") {
+		t.Fatalf("resolve error = %v, want missing KIRO_API_KEY", err)
+	}
+}
+
+func TestResolveOpencodeProviderDoesNotLabelOtherHarnesses(t *testing.T) {
+	provider, err := (ContainerRunner{Harness: ClaudeHarness{}}).resolveOpencodeProvider("anthropic/claude")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if provider.ID != "" || provider.Configured {
+		t.Errorf("Claude model resolved as OpenCode provider: %+v", provider)
+	}
+}
+
+func TestBuildRunArgsForProviderScopesEnvironmentAndState(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "unrelated-openai-secret")
+	t.Setenv("ANTHROPIC_API_KEY", "unrelated-anthropic-secret")
+	d := ContainerRunner{Harness: OpencodeHarness{}, SELinuxRelabel: true}
+	provider := opencodeProvider{
+		ID:         "kiro",
+		StateDir:   "/state/kiro",
+		Configured: true,
+		Env: map[string]string{
+			"KIRO_API_KEY":            "kiro-secret",
+			"OPENCODE_CONFIG_CONTENT": `{"plugin":["kiro"]}`,
+		},
+	}
+	args := d.buildRunArgsForProvider("/work/abs", "kiro:1", hardenedNet{}, "/state/scan-1", provider, "/tmp")
+	joined := strings.Join(args, " ")
+	for _, secret := range []string{"kiro-secret", "unrelated-openai-secret", "unrelated-anthropic-secret"} {
+		if strings.Contains(joined, secret) {
+			t.Errorf("container argv contains secret %q: %v", secret, args)
+		}
+	}
+	for _, key := range []string{"KIRO_API_KEY", "OPENCODE_CONFIG_CONTENT"} {
+		if !hasAdjacent(args, "-e", key) {
+			t.Errorf("container args do not inherit selected key %s: %v", key, args)
+		}
+	}
+	for _, key := range []string{"OPENAI_API_KEY", "ANTHROPIC_API_KEY"} {
+		if slices.Contains(args, key) {
+			t.Errorf("container args inherited unrelated key %s: %v", key, args)
+		}
+	}
+	if !hasAdjacent(args, "-v", "/state/kiro:/opencode-provider-state:z") {
+		t.Errorf("provider state mount missing: %v", args)
+	}
+	if !hasAdjacent(args, "-e", "XDG_DATA_HOME=/opencode-provider-state") {
+		t.Errorf("provider state XDG path missing: %v", args)
+	}
+	if !hasAdjacent(args, "-w", "/tmp") {
+		t.Errorf("readiness working directory is not neutral: %v", args)
+	}
+}
+
+func TestBuildRunArgsForOpencodeKeepsPerScanAuthState(t *testing.T) {
+	d := ContainerRunner{Harness: OpencodeHarness{}}
+	args := d.buildRunArgs("/work/abs", "stock:1", hardenedNet{}, "/state/scan-1")
+	if !hasAdjacent(args, "-e", "XDG_DATA_HOME=/harness-state/data") {
+		t.Errorf("per-scan OpenCode auth state missing: %v", args)
+	}
+}
+
+func TestEnsureOpencodeProviderStateRejectsOtherCredentials(t *testing.T) {
+	state := t.TempDir()
+	if err := os.Chmod(state, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	authDir := filepath.Join(state, "opencode")
+	if err := os.MkdirAll(authDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(authDir, "auth.json"), []byte(`{"kiro":{"type":"api"},"openai":{"type":"api"}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	err := ensureOpencodeProviderState(opencodeProvider{ID: "kiro", StateDir: state})
+	if err == nil || !strings.Contains(err.Error(), `credentials for provider "openai"`) {
+		t.Fatalf("state validation error = %v", err)
+	}
+}
+
+func TestEnsureOpencodeProviderStateRejectsBroadPermissions(t *testing.T) {
+	state := t.TempDir()
+	if err := os.Chmod(state, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	err := ensureOpencodeProviderState(opencodeProvider{ID: "github-copilot", StateDir: state})
+	if err == nil || !strings.Contains(err.Error(), "expose credentials") {
+		t.Fatalf("state permission error = %v", err)
+	}
+}
+
+func TestEnsureOpencodeProviderStateRequiresStoredCredentials(t *testing.T) {
+	state := filepath.Join(t.TempDir(), "oauth-state")
+	err := ensureOpencodeProviderState(opencodeProvider{ID: "github-copilot", StateDir: state})
+	if err == nil || !strings.Contains(err.Error(), "missing stored credentials") {
+		t.Fatalf("missing stored credential error = %v", err)
+	}
+
+	state = filepath.Join(t.TempDir(), "native-state")
+	err = ensureOpencodeProviderState(opencodeProvider{ID: "kiro", StateDir: state, ExternalCredentials: true})
+	if err != nil {
+		t.Fatalf("external credential should be allowed to initialise state: %v", err)
+	}
+}
+
+func TestOpencodeProviderEgressStableAndUnique(t *testing.T) {
+	providers := map[string]OpencodeProviderConfig{
+		"groq": {EgressHosts: []string{"api.groq.com", "auth.example.com"}},
+		"kiro": {EgressHosts: []string{"q.us-east-1.amazonaws.com", "auth.example.com"}},
+	}
+	want := []string{"api.groq.com", "auth.example.com", "q.us-east-1.amazonaws.com"}
+	if got := OpencodeProviderEgress(providers); !slices.Equal(got, want) {
+		t.Errorf("egress hosts = %v, want %v", got, want)
+	}
+}
+
+func TestOpencodeProviderImageFeedsLanguageProfileDetection(t *testing.T) {
+	var detectedImage string
+	d := ContainerRunner{
+		Harness:     OpencodeHarness{},
+		Image:       "provider:1",
+		ProfilesDir: t.TempDir(),
+		detectProfile: func(_ context.Context, _ ContainerRuntime, runnerImage, _ string, _ bool) Profile {
+			detectedImage = runnerImage
+			return Profile{}
+		},
+	}
+	profile, image := d.resolveProfile(t.Context(), "", t.TempDir(), "", func(Event) {})
+	if profile != "" || image != "provider:1" || detectedImage != "provider:1" {
+		t.Errorf("profile=%q image=%q detected base=%q", profile, image, detectedImage)
+	}
+}
+
+func TestCheckOpencodeReadinessFindsExactModel(t *testing.T) {
+	runtime := filepath.Join(t.TempDir(), "fake-runtime")
+	if err := os.WriteFile(runtime, []byte("#!/bin/sh\nprintf 'groq/model-a\\ngroq/model-b\\n'\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	d := ContainerRunner{
+		Harness:           OpencodeHarness{},
+		Runtime:           ContainerRuntime{Bin: runtime},
+		OpencodeReadiness: NewOpencodeReadinessCache(),
+	}
+	provider := opencodeProvider{ID: "groq", Model: "groq/model-b", RunnerImage: "stock:1", Env: map[string]string{}, Configured: true}
+	if err := d.checkOpencodeReadiness(t.Context(), provider, t.TempDir(), "stock:1", hardenedNet{}, ""); err != nil {
+		t.Fatal(err)
+	}
+	provider.Model = "groq/model-c"
+	err := d.checkOpencodeReadiness(t.Context(), provider, t.TempDir(), "stock:1", hardenedNet{}, "")
+	if err == nil || !strings.Contains(err.Error(), "unavailable in the selected image catalog") {
+		t.Fatalf("missing model error = %v", err)
+	}
+}
+
+func TestCheckOpencodeReadinessReportsMissingSupportingBinary(t *testing.T) {
+	runtime := filepath.Join(t.TempDir(), "fake-runtime")
+	if err := os.WriteFile(runtime, []byte("#!/bin/sh\nexit 1\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	d := ContainerRunner{Harness: OpencodeHarness{}, Runtime: ContainerRuntime{Bin: runtime}}
+	provider := opencodeProvider{
+		ID:               "kiro",
+		Model:            "kiro/auto",
+		RunnerImage:      "kiro:1",
+		Env:              map[string]string{},
+		RequiredBinaries: []string{"kiro-cli"},
+		Configured:       true,
+	}
+	err := d.checkOpencodeReadiness(t.Context(), provider, t.TempDir(), "kiro:1", hardenedNet{}, "")
+	if err == nil || !strings.Contains(err.Error(), `supporting binary "kiro-cli" is missing`) {
+		t.Fatalf("missing binary error = %v", err)
+	}
+}
+
+func TestClassifyOpencodeReadinessErrors(t *testing.T) {
+	provider := opencodeProvider{ID: "kiro"}
+	runErr := errors.New("exit status 1")
+	for _, tc := range []struct {
+		output string
+		want   string
+	}{
+		{"Cannot find package kiro-adapter", "adapter or plugin is missing"},
+		{"kiro-cli: command not found", "supporting binary is missing"},
+		{"connect ECONNREFUSED", "configured egress hosts"},
+	} {
+		if got := classifyOpencodeReadinessError(provider, tc.output, runErr); !strings.Contains(got.Error(), tc.want) {
+			t.Errorf("classify %q = %v, want %q", tc.output, got, tc.want)
+		}
+	}
+}
+
+func TestEnvironmentWithReplacesAndAdds(t *testing.T) {
+	got := environmentWith([]string{"A=old", "B=keep"}, map[string]string{"A": "new", "C": "added"})
+	for _, want := range []string{"A=new", "B=keep", "C=added"} {
+		if !slices.Contains(got, want) {
+			t.Errorf("environment = %v, missing %q", got, want)
+		}
+	}
+}
+
+func TestRunnerImageContentDigestPrefersRegistryDigest(t *testing.T) {
+	runtime := filepath.Join(t.TempDir(), "fake-runtime")
+	if err := os.WriteFile(runtime, []byte("#!/bin/sh\nprintf 'registry.example/provider@sha256:abc\\n'\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if got := runnerImageContentDigest(t.Context(), ContainerRuntime{Bin: runtime}, "provider:1"); got != "sha256:abc" {
+		t.Errorf("runner image digest = %q, want sha256:abc", got)
+	}
+}

--- a/internal/worker/opencode_provider_test.go
+++ b/internal/worker/opencode_provider_test.go
@@ -8,7 +8,9 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 )
 
 func TestResolveOpencodeProviderBuildsScopedAuth(t *testing.T) {
@@ -124,7 +126,7 @@ func TestBuildRunArgsForProviderScopesEnvironmentAndState(t *testing.T) {
 
 func TestBuildRunArgsForOpencodeKeepsPerScanAuthState(t *testing.T) {
 	d := ContainerRunner{Harness: OpencodeHarness{}}
-	args := d.buildRunArgs("/work/abs", "stock:1", hardenedNet{}, "/state/scan-1")
+	args := d.buildRunArgs("stock:1", hardenedNet{}, "/state/scan-1")
 	if !hasAdjacent(args, "-e", "XDG_DATA_HOME=/harness-state/data") {
 		t.Errorf("per-scan OpenCode auth state missing: %v", args)
 	}
@@ -257,10 +259,7 @@ func TestOpencodeProviderImageFeedsLanguageProfileDetection(t *testing.T) {
 }
 
 func TestCheckOpencodeReadinessFindsExactModel(t *testing.T) {
-	runtime := filepath.Join(t.TempDir(), "fake-runtime")
-	if err := os.WriteFile(runtime, []byte("#!/bin/sh\ncase \" $* \" in *\" curl \"*) exit 0;; esac\nprintf 'groq/model-a\\ngroq/model-b\\n'\n"), 0o700); err != nil {
-		t.Fatal(err)
-	}
+	runtime := writeFakeRuntime(t, "#!/bin/sh\ncase \" $* \" in *provider-readiness*) exit 0;; esac\nprintf 'groq/model-a\\ngroq/model-b\\n'\n")
 	d := ContainerRunner{
 		Harness:           OpencodeHarness{},
 		Runtime:           ContainerRuntime{Bin: runtime},
@@ -278,36 +277,104 @@ func TestCheckOpencodeReadinessFindsExactModel(t *testing.T) {
 }
 
 func TestCheckOpencodeReadinessReportsBlockedProviderEgress(t *testing.T) {
-	runtime := filepath.Join(t.TempDir(), "fake-runtime")
-	if err := os.WriteFile(runtime, []byte("#!/bin/sh\ncase \" $* \" in *\" curl \"*) echo 'CONNECT tunnel failed, response 403'; exit 1;; esac\nprintf 'groq/model-a\\n'\n"), 0o700); err != nil {
-		t.Fatal(err)
-	}
+	runtime := writeFakeRuntime(t, "#!/bin/sh\ncase \"$*\" in\n"+
+		"*curl*) echo 'warning: platform mismatch' >&2; echo 'curl: (28) Connection timed out' >&2; echo 'scrutineer-readiness-fail: auth.groq.com'; exit 1;;\n"+
+		"*) printf 'groq/model-a\\n';;\nesac\n")
 	d := ContainerRunner{Harness: OpencodeHarness{}, Runtime: ContainerRuntime{Bin: runtime}}
-	provider := opencodeProvider{ID: "groq", Model: "groq/model-a", Env: map[string]string{}, EgressHosts: []string{"api.groq.com"}, Configured: true}
+	provider := opencodeProvider{ID: "groq", Model: "groq/model-a", Env: map[string]string{}, EgressHosts: []string{"api.groq.com", "auth.groq.com", "*.groq.net"}, Configured: true}
 	err := d.checkOpencodeReadiness(t.Context(), provider, t.TempDir(), "stock:1", hardenedNet{}, "")
-	if err == nil || !strings.Contains(err.Error(), `configured egress host "api.groq.com"`) {
+	if err == nil || !strings.Contains(err.Error(), `configured egress host "auth.groq.com"`) {
 		t.Fatalf("blocked egress error = %v", err)
 	}
 }
 
 func TestCheckOpencodeReadinessReportsMissingSupportingBinary(t *testing.T) {
-	runtime := filepath.Join(t.TempDir(), "fake-runtime")
-	if err := os.WriteFile(runtime, []byte("#!/bin/sh\nexit 1\n"), 0o700); err != nil {
-		t.Fatal(err)
-	}
+	runtime := writeFakeRuntime(t, "#!/bin/sh\necho 'scrutineer-readiness-fail: kiro-cli'; exit 1\n")
 	d := ContainerRunner{Harness: OpencodeHarness{}, Runtime: ContainerRuntime{Bin: runtime}}
 	provider := opencodeProvider{
 		ID:               "kiro",
 		Model:            "kiro/auto",
 		RunnerImage:      "kiro:1",
 		Env:              map[string]string{},
-		RequiredBinaries: []string{"kiro-cli"},
+		RequiredBinaries: []string{"brief", "kiro-cli"},
 		Configured:       true,
 	}
 	err := d.checkOpencodeReadiness(t.Context(), provider, t.TempDir(), "kiro:1", hardenedNet{}, "")
 	if err == nil || !strings.Contains(err.Error(), `supporting binary "kiro-cli" is missing`) {
 		t.Fatalf("missing binary error = %v", err)
 	}
+}
+
+func TestCheckOpencodeReadinessProbesOncePerCheck(t *testing.T) {
+	log := filepath.Join(t.TempDir(), "invocations")
+	runtime := writeFakeRuntime(t, "#!/bin/sh\necho x >> "+log+"\ncase \"$*\" in *provider-readiness*) exit 0;; esac\nprintf 'kiro/auto\\n'\n")
+	d := ContainerRunner{Harness: OpencodeHarness{}, Runtime: ContainerRuntime{Bin: runtime}}
+	provider := opencodeProvider{
+		ID:               "kiro",
+		Model:            "kiro/auto",
+		Env:              map[string]string{},
+		RequiredBinaries: []string{"brief", "scrutineer", "kiro-cli"},
+		EgressHosts:      []string{"a.example", "b.example", "*.c.example"},
+		Configured:       true,
+	}
+	if err := d.checkOpencodeReadiness(t.Context(), provider, t.TempDir(), "kiro:1", hardenedNet{}, ""); err != nil {
+		t.Fatal(err)
+	}
+	data, _ := os.ReadFile(log)
+	if n := strings.Count(string(data), "x"); n != 3 {
+		t.Errorf("readiness launched %d containers, want 3 (binaries, hosts, catalog)", n)
+	}
+}
+
+func TestCheckOpencodeReadinessCapsCatalogFailureOutput(t *testing.T) {
+	runtime := writeFakeRuntime(t, "#!/bin/sh\nyes 'Cannot find package kiro-adapter' | head -c 5000; exit 1\n")
+	d := ContainerRunner{Harness: OpencodeHarness{}, Runtime: ContainerRuntime{Bin: runtime}}
+	provider := opencodeProvider{ID: "kiro", Model: "kiro/auto", Env: map[string]string{}, Configured: true}
+	err := d.checkOpencodeReadiness(t.Context(), provider, t.TempDir(), "kiro:1", hardenedNet{}, "")
+	if err == nil || !strings.Contains(err.Error(), "adapter or plugin is missing") {
+		t.Fatalf("catalog failure error = %v", err)
+	}
+	if len(err.Error()) > 3000 {
+		t.Errorf("catalog failure output not capped: %d bytes", len(err.Error()))
+	}
+}
+
+func TestOpencodeStateLockSerialisesSharedStateDir(t *testing.T) {
+	c := NewOpencodeReadinessCache()
+	dir := t.TempDir()
+	held := false
+	overlap := false
+	var wg sync.WaitGroup
+	for range 4 {
+		wg.Go(func() {
+			unlock := c.lockState(dir)
+			if held {
+				overlap = true
+			}
+			held = true
+			time.Sleep(5 * time.Millisecond)
+			held = false
+			unlock()
+		})
+	}
+	wg.Wait()
+	if overlap {
+		t.Error("two callers held the same state_dir lock at once")
+	}
+	// A distinct state_dir must not contend with the first, and empty is a
+	// no-op so a nil cache or a provider without state never blocks.
+	other := c.lockState(t.TempDir())
+	other()
+	(*OpencodeReadinessCache)(nil).lockState("")()
+}
+
+func writeFakeRuntime(t *testing.T, script string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "fake-runtime")
+	if err := os.WriteFile(path, []byte(script), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	return path
 }
 
 func TestClassifyOpencodeReadinessErrors(t *testing.T) {
@@ -324,6 +391,23 @@ func TestClassifyOpencodeReadinessErrors(t *testing.T) {
 		if got := classifyOpencodeReadinessError(provider, tc.output, runErr); !strings.Contains(got.Error(), tc.want) {
 			t.Errorf("classify %q = %v, want %q", tc.output, got, tc.want)
 		}
+	}
+}
+
+func TestContainerRunErrorStateResumeRetryIgnoresProviderErrors(t *testing.T) {
+	h := stubHarness{acctErr: "invalid_api_key"}
+	s := containerRunErrorState{}
+	s.observe(Event{Kind: KindError, Text: "session abc not found"}, h, true)
+	if !s.resumeRetryable() {
+		t.Error("provider error event blocked the fresh-restart resume fallback")
+	}
+	err := s.failure(opencodeProvider{ID: "kiro"}, "docker", errors.New("exit 1"))
+	if !strings.Contains(err.Error(), "session abc not found") {
+		t.Errorf("provider error text lost from failure: %v", err)
+	}
+	s.observe(Event{Kind: KindError, Text: "invalid_api_key: revoked"}, h, true)
+	if s.resumeRetryable() {
+		t.Error("account error event did not block the resume fallback")
 	}
 }
 
@@ -345,11 +429,25 @@ func TestEnvironmentWithReplacesAndAdds(t *testing.T) {
 }
 
 func TestRunnerImageContentDigestPrefersRegistryDigest(t *testing.T) {
-	runtime := filepath.Join(t.TempDir(), "fake-runtime")
-	if err := os.WriteFile(runtime, []byte("#!/bin/sh\nprintf 'registry.example/provider@sha256:abc\\n'\n"), 0o700); err != nil {
-		t.Fatal(err)
-	}
+	runtime := writeFakeRuntime(t, "#!/bin/sh\nprintf 'registry.example/provider@sha256:abc\\n'\n")
 	if got := runnerImageContentDigest(t.Context(), ContainerRuntime{Bin: runtime}, "provider:1"); got != "sha256:abc" {
 		t.Errorf("runner image digest = %q, want sha256:abc", got)
+	}
+}
+
+func TestRunnerImageContentDigestParsesAppleInspectJSON(t *testing.T) {
+	// container image inspect emits a JSON array with no --format support, so
+	// the digest is read from configuration.descriptor.digest with id as the
+	// fallback for locally built images.
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "container"), []byte("#!/bin/sh\ncase \"$*\" in *no-descriptor*) printf '[{\"id\":\"sha256:localid\"}]';; *) printf '[{\"id\":\"sha256:localid\",\"configuration\":{\"descriptor\":{\"digest\":\"sha256:def\"}}}]';; esac\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	if got := runnerImageContentDigest(t.Context(), ContainerRuntime{Bin: runtimeApple}, "provider:1"); got != "sha256:def" {
+		t.Errorf("apple runner image digest = %q, want sha256:def", got)
+	}
+	if got := runnerImageContentDigest(t.Context(), ContainerRuntime{Bin: runtimeApple}, "no-descriptor:1"); got != "sha256:localid" {
+		t.Errorf("apple runner image id fallback = %q, want sha256:localid", got)
 	}
 }

--- a/internal/worker/opencode_provider_test.go
+++ b/internal/worker/opencode_provider_test.go
@@ -22,6 +22,7 @@ func TestResolveOpencodeProviderBuildsScopedAuth(t *testing.T) {
 				ConfigContent: `{"provider":{}}`,
 				APIKeyEnv:     "GROQ_API_KEY",
 				AuthMetadata:  map[string]string{"accountId": "team-1"},
+				EgressHosts:   []string{"api.groq.com"},
 			},
 		},
 	}
@@ -46,6 +47,9 @@ func TestResolveOpencodeProviderBuildsScopedAuth(t *testing.T) {
 	}
 	if provider.Env["OPENCODE_CONFIG_CONTENT"] != `{"provider":{}}` {
 		t.Errorf("config content = %q", provider.Env["OPENCODE_CONFIG_CONTENT"])
+	}
+	if !slices.Equal(provider.EgressHosts, []string{"api.groq.com"}) {
+		t.Errorf("provider egress = %v", provider.EgressHosts)
 	}
 }
 
@@ -102,11 +106,16 @@ func TestBuildRunArgsForProviderScopesEnvironmentAndState(t *testing.T) {
 			t.Errorf("container args inherited unrelated key %s: %v", key, args)
 		}
 	}
-	if !hasAdjacent(args, "-v", "/state/kiro:/opencode-provider-state:z") {
-		t.Errorf("provider state mount missing: %v", args)
+	if !hasAdjacent(args, "-v", "/state/kiro/opencode/auth.json:/harness-state/data/opencode/auth.json:z") {
+		t.Errorf("provider auth mount missing: %v", args)
 	}
-	if !hasAdjacent(args, "-e", "XDG_DATA_HOME=/opencode-provider-state") {
-		t.Errorf("provider state XDG path missing: %v", args)
+	if !hasAdjacent(args, "-e", "XDG_DATA_HOME=/harness-state/data") {
+		t.Errorf("per-scan OpenCode data path missing: %v", args)
+	}
+	for _, arg := range args {
+		if strings.Contains(arg, "/opencode-provider-state") || arg == "/state/kiro:/opencode-provider-state:z" {
+			t.Errorf("whole provider state directory is exposed: %v", args)
+		}
 	}
 	if !hasAdjacent(args, "-w", "/tmp") {
 		t.Errorf("readiness working directory is not neutral: %v", args)
@@ -162,16 +171,71 @@ func TestEnsureOpencodeProviderStateRequiresStoredCredentials(t *testing.T) {
 	if err != nil {
 		t.Fatalf("external credential should be allowed to initialise state: %v", err)
 	}
+	data, err := os.ReadFile(opencodeProviderAuthPath(state))
+	if err != nil || strings.TrimSpace(string(data)) != "{}" {
+		t.Fatalf("initial auth state = %q, %v", data, err)
+	}
 }
 
-func TestOpencodeProviderEgressStableAndUnique(t *testing.T) {
-	providers := map[string]OpencodeProviderConfig{
-		"groq": {EgressHosts: []string{"api.groq.com", "auth.example.com"}},
-		"kiro": {EgressHosts: []string{"q.us-east-1.amazonaws.com", "auth.example.com"}},
+func TestConfigureOpencodeProviderEgressScopesHostProxyToSelectedProvider(t *testing.T) {
+	d := ContainerRunner{
+		Harness: OpencodeHarness{},
+		OpencodeProviders: map[string]OpencodeProviderConfig{
+			"groq": {EgressHosts: []string{"api.groq.com", "auth.example.com"}},
+			"kiro": {EgressHosts: []string{"q.us-east-1.amazonaws.com"}},
+		},
+		Egress: EgressSidecarConfig{Allow: []string{"models.dev"}},
+		ProviderProxy: ScopedEgressProxyConfig{
+			Allow:         []string{"models.dev"},
+			APIPort:       "8080",
+			APIHosts:      []string{HostGatewayAlias},
+			ContainerHost: HostGatewayAlias,
+		},
 	}
-	want := []string{"api.groq.com", "auth.example.com", "q.us-east-1.amazonaws.com"}
-	if got := OpencodeProviderEgress(providers); !slices.Equal(got, want) {
-		t.Errorf("egress hosts = %v, want %v", got, want)
+	provider, err := d.resolveOpencodeProvider("groq/model")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, cleanup, err := d.configureOpencodeProviderEgress(provider)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+	for _, allow := range [][]string{got.Egress.Allow, got.ProviderProxy.Allow} {
+		if !slices.Contains(allow, "api.groq.com") || !slices.Contains(allow, "auth.example.com") {
+			t.Errorf("selected provider hosts missing from %v", allow)
+		}
+		if slices.Contains(allow, "q.us-east-1.amazonaws.com") {
+			t.Errorf("unselected provider host leaked into %v", allow)
+		}
+	}
+	if got.ProxyURL == "" || got.ProxyURL == d.ProxyURL {
+		t.Errorf("provider-scoped proxy URL = %q", got.ProxyURL)
+	}
+}
+
+func TestConfigureOpencodeProviderEgressScopesSidecarToSelectedProvider(t *testing.T) {
+	d := ContainerRunner{
+		Harness:  OpencodeHarness{},
+		Hardened: true,
+		Runtime:  ContainerRuntime{Bin: "podman", Rootless: true},
+		Egress:   EgressSidecarConfig{Allow: []string{"models.dev"}},
+	}
+	provider := opencodeProvider{
+		ID:          "kiro",
+		Configured:  true,
+		EgressHosts: []string{"runtime.us-east-1.kiro.dev"},
+	}
+	got, cleanup, err := d.configureOpencodeProviderEgress(provider)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+	if !slices.Equal(got.Egress.Allow, []string{"models.dev", "runtime.us-east-1.kiro.dev"}) {
+		t.Errorf("sidecar allowlist = %v", got.Egress.Allow)
+	}
+	if got.ProxyURL != d.ProxyURL {
+		t.Errorf("sidecar configuration unexpectedly started a host proxy: %q", got.ProxyURL)
 	}
 }
 
@@ -194,7 +258,7 @@ func TestOpencodeProviderImageFeedsLanguageProfileDetection(t *testing.T) {
 
 func TestCheckOpencodeReadinessFindsExactModel(t *testing.T) {
 	runtime := filepath.Join(t.TempDir(), "fake-runtime")
-	if err := os.WriteFile(runtime, []byte("#!/bin/sh\nprintf 'groq/model-a\\ngroq/model-b\\n'\n"), 0o700); err != nil {
+	if err := os.WriteFile(runtime, []byte("#!/bin/sh\ncase \" $* \" in *\" curl \"*) exit 0;; esac\nprintf 'groq/model-a\\ngroq/model-b\\n'\n"), 0o700); err != nil {
 		t.Fatal(err)
 	}
 	d := ContainerRunner{
@@ -202,7 +266,7 @@ func TestCheckOpencodeReadinessFindsExactModel(t *testing.T) {
 		Runtime:           ContainerRuntime{Bin: runtime},
 		OpencodeReadiness: NewOpencodeReadinessCache(),
 	}
-	provider := opencodeProvider{ID: "groq", Model: "groq/model-b", RunnerImage: "stock:1", Env: map[string]string{}, Configured: true}
+	provider := opencodeProvider{ID: "groq", Model: "groq/model-b", RunnerImage: "stock:1", Env: map[string]string{}, EgressHosts: []string{"api.groq.com"}, Configured: true}
 	if err := d.checkOpencodeReadiness(t.Context(), provider, t.TempDir(), "stock:1", hardenedNet{}, ""); err != nil {
 		t.Fatal(err)
 	}
@@ -210,6 +274,19 @@ func TestCheckOpencodeReadinessFindsExactModel(t *testing.T) {
 	err := d.checkOpencodeReadiness(t.Context(), provider, t.TempDir(), "stock:1", hardenedNet{}, "")
 	if err == nil || !strings.Contains(err.Error(), "unavailable in the selected image catalog") {
 		t.Fatalf("missing model error = %v", err)
+	}
+}
+
+func TestCheckOpencodeReadinessReportsBlockedProviderEgress(t *testing.T) {
+	runtime := filepath.Join(t.TempDir(), "fake-runtime")
+	if err := os.WriteFile(runtime, []byte("#!/bin/sh\ncase \" $* \" in *\" curl \"*) echo 'CONNECT tunnel failed, response 403'; exit 1;; esac\nprintf 'groq/model-a\\n'\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	d := ContainerRunner{Harness: OpencodeHarness{}, Runtime: ContainerRuntime{Bin: runtime}}
+	provider := opencodeProvider{ID: "groq", Model: "groq/model-a", Env: map[string]string{}, EgressHosts: []string{"api.groq.com"}, Configured: true}
+	err := d.checkOpencodeReadiness(t.Context(), provider, t.TempDir(), "stock:1", hardenedNet{}, "")
+	if err == nil || !strings.Contains(err.Error(), `configured egress host "api.groq.com"`) {
+		t.Fatalf("blocked egress error = %v", err)
 	}
 }
 
@@ -247,6 +324,14 @@ func TestClassifyOpencodeReadinessErrors(t *testing.T) {
 		if got := classifyOpencodeReadinessError(provider, tc.output, runErr); !strings.Contains(got.Error(), tc.want) {
 			t.Errorf("classify %q = %v, want %q", tc.output, got, tc.want)
 		}
+	}
+}
+
+func TestClassifyOpencodeProviderRunErrorPreservesUnderlyingMessage(t *testing.T) {
+	provider := opencodeProvider{ID: "kiro"}
+	err := classifyOpencodeProviderRunError(provider, "proxy CONNECT failed for runtime.us-east-1.kiro.dev", errors.New("exit status 1"))
+	if !strings.Contains(err.Error(), "configured egress hosts") || !strings.Contains(err.Error(), "runtime.us-east-1.kiro.dev") {
+		t.Fatalf("provider run error = %v", err)
 	}
 }
 

--- a/internal/worker/skill.go
+++ b/internal/worker/skill.go
@@ -290,8 +290,9 @@ func dependencyResolutionFailed(streamed bool, res SkillResult, err error) bool 
 // itself (as opposed to the skill's report) onto the scan row: session id
 // and commit onto the in-memory struct (persisted by wrap()'s closing Save),
 // and Profile/Backend to the DB immediately so a retry sees them even if the
-// scan later fails hard. Called from every RunSkill call site so the four
-// fields stay in one place.
+// scan later fails hard. Provider and runner image provenance use the same
+// immediate path. Called from every RunSkill call site so the fields stay in
+// one place.
 func (w *Worker) applySkillResult(scan *db.Scan, res SkillResult) {
 	if res.SessionID != "" && res.SessionID != scan.SessionID {
 		scan.SessionID = res.SessionID
@@ -306,6 +307,18 @@ func (w *Worker) applySkillResult(scan *db.Scan, res SkillResult) {
 	if res.Backend != "" && res.Backend != scan.Backend {
 		scan.Backend = res.Backend
 		w.DB.Model(scan).Update("backend", res.Backend)
+	}
+	if res.Provider != "" && res.Provider != scan.Provider {
+		scan.Provider = res.Provider
+		w.DB.Model(scan).Update("provider", res.Provider)
+	}
+	if res.RunnerImage != "" && res.RunnerImage != scan.RunnerImage {
+		scan.RunnerImage = res.RunnerImage
+		w.DB.Model(scan).Update("runner_image", res.RunnerImage)
+	}
+	if res.RunnerImageDigest != "" && res.RunnerImageDigest != scan.RunnerImageDigest {
+		scan.RunnerImageDigest = res.RunnerImageDigest
+		w.DB.Model(scan).Update("runner_image_digest", res.RunnerImageDigest)
 	}
 }
 

--- a/internal/worker/skill_test.go
+++ b/internal/worker/skill_test.go
@@ -47,6 +47,35 @@ func TestStageThreatModel(t *testing.T) {
 	}
 }
 
+func TestApplySkillResultPersistsProviderImageProvenance(t *testing.T) {
+	gdb, err := db.Open(filepath.Join(t.TempDir(), "provider.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo := db.Repository{URL: "https://example.com/provider", Name: "provider"}
+	if err := gdb.Create(&repo).Error; err != nil {
+		t.Fatal(err)
+	}
+	scan := db.Scan{RepositoryID: repo.ID, Kind: JobSkill, Status: db.ScanRunning}
+	if err := gdb.Create(&scan).Error; err != nil {
+		t.Fatal(err)
+	}
+	w := Worker{DB: gdb}
+	w.applySkillResult(&scan, SkillResult{
+		Backend:           "opencode",
+		Provider:          "kiro",
+		RunnerImage:       "registry.example/kiro:1",
+		RunnerImageDigest: "sha256:abc",
+	})
+	var got db.Scan
+	if err := gdb.First(&got, scan.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if got.Provider != "kiro" || got.RunnerImage != "registry.example/kiro:1" || got.RunnerImageDigest != "sha256:abc" {
+		t.Errorf("persisted provider provenance = %+v", got)
+	}
+}
+
 const maintainersReport = `{"maintainers":[
   {"login":"alice","name":"Alice","email":"alice@example.com","role":"lead","status":"active","evidence":"80% of past-year commits"},
   {"login":"bob","role":"contributor","status":"inactive","evidence":"last commit 2022"}

--- a/scrutineer.sample.yaml
+++ b/scrutineer.sample.yaml
@@ -119,7 +119,8 @@
 # it must be based on the Scrutineer runner so language profiles still compose.
 # config_file and state_dir are host paths; relative paths start beside this
 # config file. Every configured provider must declare its API/auth hostnames.
-# These provider hosts remain allowed under hardened mode.
+# Only the selected provider's hosts are added to a scan, including in hardened
+# mode.
 # opencode:
 #   providers:
 #     groq:

--- a/scrutineer.sample.yaml
+++ b/scrutineer.sample.yaml
@@ -112,6 +112,39 @@
 # Container image used for per-scan containers.
 # runner_image: ghcr.io/alpha-omega-security/scrutineer-runner:latest
 
+# Provider-scoped OpenCode settings. The key matches the provider prefix in a
+# model id. api_key_env is read from Scrutineer's host environment and converted
+# to provider-only OpenCode auth. pass_env names native provider variables
+# instead. A derived runner_image can add a pinned adapter or supporting binary;
+# it must be based on the Scrutineer runner so language profiles still compose.
+# config_file and state_dir are host paths; relative paths start beside this
+# config file. Every configured provider must declare its API/auth hostnames.
+# These provider hosts remain allowed under hardened mode.
+# opencode:
+#   providers:
+#     groq:
+#       api_key_env: GROQ_API_KEY
+#       egress_allow:
+#         - api.groq.com
+#     kiro:
+#       runner_image: registry.example/scrutineer-opencode-kiro@sha256:...
+#       config_file: ./opencode/kiro.json
+#       pass_env:
+#         - KIRO_API_KEY
+#       required_binaries:
+#         - kiro-cli
+#       egress_allow:
+#         - q.us-east-1.amazonaws.com
+#         - runtime.us-east-1.kiro.dev
+#         - management.us-east-1.kiro.dev
+#         - prod.us-east-1.auth.desktop.kiro.dev
+#     github-copilot:
+#       state_dir: ~/.local/share/scrutineer/opencode/github-copilot
+#       egress_allow:
+#         - github.com
+#         - api.github.com
+#         - "*.githubcopilot.com"
+
 # Directory containing per-ecosystem runner profiles. Each profile is a
 # Dockerfile under <dir>/<name>/Dockerfile; the worker auto-detects the
 # right profile from the cloned source via `brief` and builds the image


### PR DESCRIPTION
Adds provider-scoped OpenCode configuration for credentials, custom runner images, config files, OAuth state, required binaries, and hardened egress.

Provider images compose with the existing language profiles. Each configured provider is checked with `opencode models` before a skill runs, and scans record the selected provider, image, and resolved digest. The operator docs and sample config cover stock providers and operator-managed images such as Kiro.

Closes #877.
