### PR TITLE
Leave repository health empty until required skills have run

### DIFF
--- a/internal/db/repository_health.go
+++ b/internal/db/repository_health.go
@@ -190,7 +190,8 @@ func healthAge(age time.Duration) string {
 func RepositoryHealthEvidenceComplete(gdb *gorm.DB, repositoryID uint) (bool, error) {
 	var done []string
 	if err := gdb.Model(&Scan{}).
-		Where("repository_id = ? AND status = ? AND skill_name IN ?", repositoryID, ScanDone, repositoryHealthSkills).
+		Where("repository_id = ? AND kind = ? AND status = ? AND skill_name IN ?",
+			repositoryID, "skill", ScanDone, repositoryHealthSkills).
 		Distinct("skill_name").Pluck("skill_name", &done).Error; err != nil {
 		return false, err
 	}

--- a/internal/db/repository_health.go
+++ b/internal/db/repository_health.go
@@ -26,6 +26,13 @@ const (
 	healthZombieDependents   = 100
 )
 
+// repositoryHealthSkills are the skills whose output the classification reads.
+// A repository is left unassessed until every one of them has a completed run,
+// so a partial pipeline (metadata done, maintainers still manual) cannot stamp
+// a misleading verdict. packages is deliberately absent: its absence softens
+// the verdict (no zombie/stale-release signal) but never inverts it.
+var repositoryHealthSkills = []string{"metadata", "maintainers"}
+
 // RepositoryHealthAssessment is the durable classification plus the evidence
 // used to reach it. Summary is derived at read time for detailed views; only
 // Health is stored on the repository row.
@@ -52,11 +59,17 @@ type RepositoryHealthAssessment struct {
 }
 
 // AssessRepositoryHealth classifies a repository from persisted evidence.
+// evidenceComplete reports whether every skill in repositoryHealthSkills has a
+// finished run for this repository; when it is false the assessment carries the
+// evidence collected so far (counts, flags) but leaves Health empty so the
+// table shows nothing rather than a fall-through "stale". Archived is the one
+// exception: it is a definitive upstream signal that needs no corroboration.
+//
 // An old push alone can make a repository stale, but abandonment additionally
 // requires an explicit archived flag or maintainer evidence showing no active
 // owner. That avoids treating repositories which have not yet run maintainers
 // as abandoned.
-func AssessRepositoryHealth(repo Repository, packages []Package, maintainers []Maintainer, now time.Time) RepositoryHealthAssessment {
+func AssessRepositoryHealth(repo Repository, packages []Package, maintainers []Maintainer, evidenceComplete bool, now time.Time) RepositoryHealthAssessment {
 	assessment := RepositoryHealthAssessment{}
 	var flags []string
 	for _, pkg := range packages {
@@ -89,7 +102,7 @@ func AssessRepositoryHealth(repo Repository, packages []Package, maintainers []M
 		staleRelease = releaseAge >= healthStaleReleaseWindow
 	}
 
-	if !repo.Archived && repo.PushedAt == nil && assessment.KnownMaintainers == 0 {
+	if !repo.Archived && !evidenceComplete {
 		return assessment
 	}
 
@@ -170,6 +183,20 @@ func healthAge(age time.Duration) string {
 	return "less than a month"
 }
 
+// RepositoryHealthEvidenceComplete reports whether every skill the health
+// classification depends on has at least one finished run for the repository.
+// It answers "did the skill run", not "did it produce rows", so a maintainers
+// scan that legitimately found nobody still counts as complete.
+func RepositoryHealthEvidenceComplete(gdb *gorm.DB, repositoryID uint) (bool, error) {
+	var done []string
+	if err := gdb.Model(&Scan{}).
+		Where("repository_id = ? AND status = ? AND skill_name IN ?", repositoryID, ScanDone, repositoryHealthSkills).
+		Distinct("skill_name").Pluck("skill_name", &done).Error; err != nil {
+		return false, err
+	}
+	return len(done) == len(repositoryHealthSkills), nil
+}
+
 // RefreshRepositoryHealth recalculates and persists the health classification.
 // It does not manufacture a status when the evidence is incomplete; legacy
 // rows therefore remain empty until enough source data exists.
@@ -187,8 +214,12 @@ func RefreshRepositoryHealth(gdb *gorm.DB, repositoryID uint, now time.Time) (Re
 		Where("repository_maintainers.repository_id = ?", repositoryID).Find(&maintainers).Error; err != nil {
 		return RepositoryHealthAssessment{}, fmt.Errorf("load maintainers for repository health: %w", err)
 	}
+	complete, err := RepositoryHealthEvidenceComplete(gdb, repositoryID)
+	if err != nil {
+		return RepositoryHealthAssessment{}, fmt.Errorf("load repository health scan evidence: %w", err)
+	}
 
-	assessment := AssessRepositoryHealth(repo, packages, maintainers, now)
+	assessment := AssessRepositoryHealth(repo, packages, maintainers, complete, now)
 	if repo.Health == assessment.Health {
 		return assessment, nil
 	}

--- a/internal/db/repository_health_test.go
+++ b/internal/db/repository_health_test.go
@@ -19,42 +19,49 @@ func TestAssessRepositoryHealth(t *testing.T) {
 		repo     Repository
 		packages []Package
 		people   []Maintainer
+		complete bool
 		want     RepositoryHealth
 	}{
 		{
-			name:   "recent push with active maintainer is active",
-			repo:   Repository{PushedAt: ptrTime(now.Add(-30 * 24 * time.Hour))},
-			people: []Maintainer{active},
-			want:   RepositoryHealthActive,
+			name:     "recent push with active maintainer is active",
+			repo:     Repository{PushedAt: ptrTime(now.Add(-30 * 24 * time.Hour))},
+			people:   []Maintainer{active},
+			complete: true,
+			want:     RepositoryHealthActive,
 		},
 		{
-			name: "old push remains stale without maintainer evidence",
-			repo: Repository{PushedAt: ptrTime(now.Add(-3 * 365 * 24 * time.Hour))},
-			want: RepositoryHealthStale,
+			name:     "old push with maintainers scan finding nobody is stale",
+			repo:     Repository{PushedAt: ptrTime(now.Add(-3 * 365 * 24 * time.Hour))},
+			complete: true,
+			want:     RepositoryHealthStale,
 		},
 		{
-			name:   "legacy empty maintainer status does not imply abandonment",
-			repo:   Repository{PushedAt: ptrTime(now.Add(-3 * 365 * 24 * time.Hour))},
-			people: []Maintainer{{}},
-			want:   RepositoryHealthStale,
+			name:     "legacy empty maintainer status does not imply abandonment",
+			repo:     Repository{PushedAt: ptrTime(now.Add(-3 * 365 * 24 * time.Hour))},
+			people:   []Maintainer{{}},
+			complete: true,
+			want:     RepositoryHealthStale,
 		},
 		{
-			name:   "old push and inactive maintainers is abandoned",
-			repo:   Repository{PushedAt: ptrTime(now.Add(-3 * 365 * 24 * time.Hour))},
-			people: []Maintainer{inactive},
-			want:   RepositoryHealthAbandoned,
+			name:     "old push and inactive maintainers is abandoned",
+			repo:     Repository{PushedAt: ptrTime(now.Add(-3 * 365 * 24 * time.Hour))},
+			people:   []Maintainer{inactive},
+			complete: true,
+			want:     RepositoryHealthAbandoned,
 		},
 		{
 			name:     "highly used abandoned package is zombie",
 			repo:     Repository{PushedAt: ptrTime(now.Add(-3 * 365 * 24 * time.Hour))},
 			packages: []Package{{DependentRepos: healthZombieDependents - 1}, {DependentRepos: healthZombieDependents}},
 			people:   []Maintainer{inactive},
+			complete: true,
 			want:     RepositoryHealthZombie,
 		},
 		{
 			name:     "archived package is zombie with downstream use",
 			repo:     Repository{Archived: true},
 			packages: []Package{{DependentRepos: healthZombieDependents}},
+			complete: true,
 			want:     RepositoryHealthZombie,
 		},
 		{
@@ -62,6 +69,7 @@ func TestAssessRepositoryHealth(t *testing.T) {
 			repo:     Repository{PushedAt: ptrTime(now.Add(-30 * 24 * time.Hour))},
 			packages: []Package{{LatestReleaseAt: ptrTime(now.Add(-19 * 30 * 24 * time.Hour))}},
 			people:   []Maintainer{active},
+			complete: true,
 			want:     RepositoryHealthStale,
 		},
 		{
@@ -71,15 +79,27 @@ func TestAssessRepositoryHealth(t *testing.T) {
 				{LatestReleaseAt: ptrTime(now.Add(-19 * 30 * 24 * time.Hour))},
 				{LatestReleaseAt: ptrTime(now.Add(-30 * 24 * time.Hour))},
 			},
-			people: []Maintainer{active},
-			want:   RepositoryHealthActive,
+			people:   []Maintainer{active},
+			complete: true,
+			want:     RepositoryHealthActive,
 		},
 		{
 			name:     "stale_release flag alone does not move classification with a recent release",
 			repo:     Repository{PushedAt: ptrTime(now.Add(-30 * 24 * time.Hour))},
 			packages: []Package{{RiskFlags: string(PackageRiskStaleRelease), LatestReleaseAt: ptrTime(now.Add(-30 * 24 * time.Hour))}},
 			people:   []Maintainer{active},
+			complete: true,
 			want:     RepositoryHealthActive,
+		},
+		{
+			name: "recent push without required scans is unassessed",
+			repo: Repository{PushedAt: ptrTime(now.Add(-30 * 24 * time.Hour))},
+			want: "",
+		},
+		{
+			name: "archived is classified without full evidence",
+			repo: Repository{Archived: true},
+			want: RepositoryHealthAbandoned,
 		},
 		{
 			name: "missing evidence is unassessed",
@@ -90,7 +110,7 @@ func TestAssessRepositoryHealth(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := AssessRepositoryHealth(tt.repo, tt.packages, tt.people, now)
+			got := AssessRepositoryHealth(tt.repo, tt.packages, tt.people, tt.complete, now)
 			if got.Health != tt.want {
 				t.Errorf("health = %q, want %q (%+v)", got.Health, tt.want, got)
 			}
@@ -110,7 +130,7 @@ func TestAssessRepositoryHealth_unionsAndOrdersRiskFlags(t *testing.T) {
 	}
 	people := []Maintainer{{Status: MaintainerActive}}
 
-	got := AssessRepositoryHealth(repo, packages, people, now)
+	got := AssessRepositoryHealth(repo, packages, people, true, now)
 
 	want := []string{string(PackageRiskSingleMaintainer), string(PackageRiskStaleRelease)}
 	if !reflect.DeepEqual(got.RiskFlags, want) {
@@ -127,7 +147,7 @@ func TestAssessRepositoryHealth_summaryNamesLastReleaseAge(t *testing.T) {
 	packages := []Package{{LatestReleaseAt: ptrTime(now.Add(-60 * 24 * time.Hour))}}
 	people := []Maintainer{{Status: MaintainerActive}}
 
-	got := AssessRepositoryHealth(repo, packages, people, now)
+	got := AssessRepositoryHealth(repo, packages, people, true, now)
 
 	if !strings.Contains(got.Summary, "last release ") {
 		t.Errorf("summary should name the last release age, got %q", got.Summary)
@@ -139,10 +159,10 @@ func TestAssessRepositoryHealth_flagsSurviveEarlyReturn(t *testing.T) {
 	repo := Repository{}
 	packages := []Package{{RiskFlags: string(PackageRiskNativeExtension)}}
 
-	got := AssessRepositoryHealth(repo, packages, nil, now)
+	got := AssessRepositoryHealth(repo, packages, nil, false, now)
 
 	if got.Health != "" {
-		t.Errorf("Health = %q, want empty (no push, no maintainer evidence)", got.Health)
+		t.Errorf("Health = %q, want empty (evidence incomplete)", got.Health)
 	}
 	want := []string{string(PackageRiskNativeExtension)}
 	if !reflect.DeepEqual(got.RiskFlags, want) {
@@ -170,6 +190,7 @@ func TestRefreshRepositoryHealth_persistsProjection(t *testing.T) {
 	if err := gdb.Model(&repo).Association("Maintainers").Append(&maintainer); err != nil {
 		t.Fatal(err)
 	}
+	seedHealthScans(t, gdb, repo.ID)
 
 	assessment, err := RefreshRepositoryHealth(gdb, repo.ID, now)
 	if err != nil {
@@ -225,6 +246,7 @@ func TestRefreshRepositoryHealthSkipsUnchangedProjection(t *testing.T) {
 	if err := gdb.Model(&repo).Association("Maintainers").Append(&maintainer); err != nil {
 		t.Fatal(err)
 	}
+	seedHealthScans(t, gdb, repo.ID)
 	updates = 0
 
 	assessment, err := RefreshRepositoryHealth(gdb, repo.ID, now)
@@ -236,6 +258,52 @@ func TestRefreshRepositoryHealthSkipsUnchangedProjection(t *testing.T) {
 	}
 	if updates != 0 {
 		t.Fatalf("repository updates = %d, want 0", updates)
+	}
+}
+
+func TestRefreshRepositoryHealth_leavesHealthEmptyWithoutRequiredScans(t *testing.T) {
+	gdb, err := Open(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC)
+	repo := Repository{
+		URL:      "https://example.com/curl",
+		Name:     "curl",
+		Health:   RepositoryHealthStale,
+		PushedAt: ptrTime(now.Add(-7 * 24 * time.Hour)),
+	}
+	if err := gdb.Create(&repo).Error; err != nil {
+		t.Fatal(err)
+	}
+	// Only metadata has run; maintainers is still manual, so the verdict must
+	// stay empty rather than fall through to stale.
+	if err := gdb.Create(&Scan{RepositoryID: repo.ID, Kind: "skill", SkillName: "metadata", Status: ScanDone}).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	assessment, err := RefreshRepositoryHealth(gdb, repo.ID, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if assessment.Health != "" {
+		t.Fatalf("assessment.Health = %q, want empty until every health skill has run", assessment.Health)
+	}
+	var got Repository
+	if err := gdb.First(&got, repo.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if got.Health != "" {
+		t.Errorf("stored health = %q, want cleared back to empty", got.Health)
+	}
+}
+
+func seedHealthScans(t *testing.T, gdb *gorm.DB, repoID uint) {
+	t.Helper()
+	for _, name := range repositoryHealthSkills {
+		if err := gdb.Create(&Scan{RepositoryID: repoID, Kind: "skill", SkillName: name, Status: ScanDone}).Error; err != nil {
+			t.Fatal(err)
+		}
 	}
 }
 

--- a/internal/db/repository_health_test.go
+++ b/internal/db/repository_health_test.go
@@ -298,6 +298,40 @@ func TestRefreshRepositoryHealth_leavesHealthEmptyWithoutRequiredScans(t *testin
 	}
 }
 
+func TestRepositoryHealthEvidenceComplete_ignoresImportScans(t *testing.T) {
+	gdb, err := Open(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo := Repository{URL: "https://example.com/r", Name: "r"}
+	if err := gdb.Create(&repo).Error; err != nil {
+		t.Fatal(err)
+	}
+	// An import row copies the uploaded tool name into skill_name; it must not
+	// satisfy the gate for the same-named skill.
+	for _, name := range repositoryHealthSkills {
+		if err := gdb.Create(&Scan{RepositoryID: repo.ID, Kind: "import", SkillName: name, Status: ScanDone}).Error; err != nil {
+			t.Fatal(err)
+		}
+	}
+	complete, err := RepositoryHealthEvidenceComplete(gdb, repo.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if complete {
+		t.Fatal("import-kind scans satisfied the health-evidence gate")
+	}
+
+	seedHealthScans(t, gdb, repo.ID)
+	complete, err = RepositoryHealthEvidenceComplete(gdb, repo.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !complete {
+		t.Fatal("skill-kind scans did not satisfy the health-evidence gate")
+	}
+}
+
 func seedHealthScans(t *testing.T, gdb *gorm.DB, repoID uint) {
 	t.Helper()
 	for _, name := range repositoryHealthSkills {

--- a/internal/web/repository_health_test.go
+++ b/internal/web/repository_health_test.go
@@ -27,6 +27,7 @@ func TestRepositoryHealthTickRefreshesStoredHealth(t *testing.T) {
 	if err := s.DB.Model(&repo).Association("Maintainers").Append(&maintainer); err != nil {
 		t.Fatal(err)
 	}
+	seedHealthScans(t, s, repo.ID)
 
 	s.repositoryHealthTick(now)
 
@@ -56,6 +57,7 @@ func TestRepositoryHealthTickAgesRepositoriesWithoutParserRuns(t *testing.T) {
 	if err := s.DB.Model(&repo).Association("Maintainers").Append(&maintainer); err != nil {
 		t.Fatal(err)
 	}
+	seedHealthScans(t, s, repo.ID)
 
 	s.repositoryHealthTick(now)
 	var got db.Repository
@@ -72,5 +74,18 @@ func TestRepositoryHealthTickAgesRepositoriesWithoutParserRuns(t *testing.T) {
 	}
 	if got.Health != db.RepositoryHealthStale {
 		t.Fatalf("aged health = %q, want %q", got.Health, db.RepositoryHealthStale)
+	}
+}
+
+// seedHealthScans creates finished metadata + maintainers scan rows so
+// RepositoryHealthEvidenceComplete reports true and the tick under test can
+// reach a verdict. The db package keeps the authoritative skill list; these
+// tests only exercise the tick loop, so hard-coding the two names is fine.
+func seedHealthScans(t *testing.T, s *Server, repoID uint) {
+	t.Helper()
+	for _, name := range []string{"metadata", "maintainers"} {
+		if err := s.DB.Create(&db.Scan{RepositoryID: repoID, Kind: "skill", SkillName: name, Status: db.ScanDone}).Error; err != nil {
+			t.Fatal(err)
+		}
 	}
 }

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -2445,7 +2445,11 @@ func (s *Server) loadRepoShowView(
 	deps := s.loadRepoDependencyView(repo.ID, query.Get("deps") == "all")
 	inventory := s.loadRepoInventoryView(repo.ID, deps.Groups)
 	maintainers := s.repoMaintainers(repo.ID)
-	health := db.AssessRepositoryHealth(repo, inventory.Packages, maintainers, time.Now())
+	evidenceComplete, err := db.RepositoryHealthEvidenceComplete(s.DB, repo.ID)
+	if err != nil {
+		s.Log.Error("repository health evidence", "repo", repo.ID, "err", err)
+	}
+	health := db.AssessRepositoryHealth(repo, inventory.Packages, maintainers, evidenceComplete, time.Now())
 	alternatives, err := loadPackageAlternatives(s.DB, repo.ID)
 	if err != nil {
 		s.Log.Error("load package alternatives", "repo", repo.ID, "err", err)


### PR DESCRIPTION
Fixes #888.

## Problem

`repositoryHealth` returns `stale` as the fall-through default. The `maintainers` skill is currently manual-only, so any repo that has run `metadata` but not `maintainers` gets `ActiveMaintainers == 0` and is stamped **stale** — including very active projects like curl.

The old escape hatch (`PushedAt == nil && KnownMaintainers == 0`) was bypassed as soon as `metadata` set `pushed_at`.

## Change

- `repositoryHealthSkills` names the skills the classification reads from (`metadata`, `maintainers`).
- New `RepositoryHealthEvidenceComplete(gdb, repoID)` reports whether every one of those skills has a `status = done` scan row. This answers "did the skill run", not "did it produce rows", so a maintainers scan that legitimately found nobody still counts.
- `AssessRepositoryHealth` takes an `evidenceComplete` flag; when false it returns the collected evidence (counts, risk flags) with `Health` left empty. `Archived` remains a short-circuit — it's a definitive upstream signal on its own.
- `RefreshRepositoryHealth` and the live repo view both compute the flag from scan rows. The hourly rescore will now also clear a previously-stored verdict back to empty when evidence is incomplete.
- `packages` is deliberately not gated on: its absence softens the verdict (no zombie/stale-release signal) but never inverts it.

## Tests

- New table cases: `recent push without required scans is unassessed` (the curl scenario) and `archived is classified without full evidence`.
- New `TestRefreshRepositoryHealth_leavesHealthEmptyWithoutRequiredScans` covers the persisted path, including clearing a stale value that was already stored.
- Existing `Refresh*` tests seed the required scan rows via a helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
