### PR TITLE
Refuse unconfigured OpenCode providers and keep their error text

### DIFF
--- a/docs/opencode.md
+++ b/docs/opencode.md
@@ -93,9 +93,12 @@ The top-level `egress_allow` remains ignored in hardened mode. Use hostnames
 without a scheme, path, or port. Region- and resource-specific providers should
 list the endpoints for the configured region or resource.
 
-Local providers such as Ollama are not covered by this option yet. The egress
-proxy permits only Scrutineer's API port on the container host, so allowing a
-hostname does not expose Ollama's port 11434.
+Local providers such as Ollama and LM Studio are not covered by this option
+yet. The egress proxy permits only Scrutineer's API port on the container host,
+so allowing a hostname does not expose a host-local model server's port.
+
+A model whose provider prefix is neither `anthropic`, `openai`, nor a key under
+`opencode.providers` is refused before the container starts.
 
 ## Provider images and config
 

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.26.6
 
 require (
 	filippo.io/age v1.3.1
-	github.com/alpha-omega-security/harness v0.1.6
+	github.com/alpha-omega-security/harness v0.1.7
 	github.com/ecosyste-ms/ecosystems-go v0.4.0
 	github.com/git-pkgs/clone v0.5.0
 	github.com/git-pkgs/clone/gogit v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -13,8 +13,8 @@ github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA
 github.com/ProtonMail/go-crypto v1.1.6 h1:ZcV+Ropw6Qn0AX9brlQLAUXfqLBc7Bl+f/DmNxpLfdw=
 github.com/ProtonMail/go-crypto v1.1.6/go.mod h1:rA3QumHc/FZ8pAHreoekgiAbzpNsfQAosU5td4SnOrE=
 github.com/RaveNoX/go-jsoncommentstrip v1.0.0/go.mod h1:78ihd09MekBnJnxpICcwzCMzGrKSKYe4AqU6PDYYpjk=
-github.com/alpha-omega-security/harness v0.1.6 h1:K4QpjpBw+cQ/2r7N0j0LAAacfQXHw5CBP8JnUFr5AZs=
-github.com/alpha-omega-security/harness v0.1.6/go.mod h1:/nym/38ro7lLq4jVmQhYqblV+0uMo3YpeueqaXNMpOs=
+github.com/alpha-omega-security/harness v0.1.7 h1:nPeQDA1wLFLJeVTHTs58qndMl7vRfQNbNYf8ADHD0MQ=
+github.com/alpha-omega-security/harness v0.1.7/go.mod h1:/nym/38ro7lLq4jVmQhYqblV+0uMo3YpeueqaXNMpOs=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0 h1:axGnT1gRIfimI7gJifB699GoE/oq+F2MU7Dml6nw9rQ=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0/go.mod h1:lvDnEdqiQrp0O42VQGgmlKpxL1AP2+08jFMw88y4klk=
 github.com/bmatcuk/doublestar v1.1.1/go.mod h1:UD6OnuiIn0yFxxA2le/rnRU1G4RaI4UvFv1sNto9p6w=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -254,6 +254,8 @@ var reservedOpencodePassEnv = map[string]bool{
 	"OPENCODE_DISABLE_AUTOUPDATE":   true,
 	"OPENCODE_DISABLE_MODELS_FETCH": true,
 	"OPENCODE_DISABLE_SHARE":        true,
+	"OPENCODE_LOG_LEVEL":            true,
+	"OPENCODE_PRINT_LOGS":           true,
 	"XDG_DATA_HOME":                 true,
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -241,6 +241,8 @@ func TestValidateOpencodeRejectsHarnessSafetyEnvironment(t *testing.T) {
 		"OPENCODE_DISABLE_AUTOUPDATE",
 		"OPENCODE_DISABLE_MODELS_FETCH",
 		"OPENCODE_DISABLE_SHARE",
+		"OPENCODE_PRINT_LOGS",
+		"OPENCODE_LOG_LEVEL",
 	} {
 		t.Run(name, func(t *testing.T) {
 			err := ValidateOpencode(Opencode{Providers: map[string]OpencodeProvider{

--- a/internal/worker/container.go
+++ b/internal/worker/container.go
@@ -237,9 +237,9 @@ type containerRunErrorState struct {
 	rateLimit    *RateLimitInfo
 }
 
-func (s *containerRunErrorState) observe(event Event, h Harness, configuredProvider bool) {
+func (s *containerRunErrorState) observe(event Event, h Harness, opencodeProviderID string) {
 	s.accountText = preferAccountErrText(s.accountText, h.AccountErrorText(event.Text))
-	if configuredProvider && event.Kind == KindError && event.Text != "hit max turns" {
+	if opencodeProviderID != "" && event.Kind == KindError && event.Text != "hit max turns" {
 		s.providerText = event.Text
 	}
 	if event.Kind == KindRateLimit && event.RateLimit != nil {
@@ -336,7 +336,7 @@ func (d ContainerRunner) RunSkill(ctx context.Context, sj SkillJob, emit func(Ev
 	h := d.harness()
 	runErrors := containerRunErrorState{}
 	wrappedEmit := func(e Event) {
-		runErrors.observe(e, h, provider.Configured)
+		runErrors.observe(e, h, provider.ID)
 		emit(e)
 	}
 	hitMaxTurns, sessionID, waitErr := d.runContainerOnce(ctx, runBase, sj, provider.Env, wrappedEmit)

--- a/internal/worker/egress.go
+++ b/internal/worker/egress.go
@@ -62,6 +62,11 @@ func StartScopedEgressProxy(p *EgressProxy) (int, func(), error) {
 	}
 	srv := &http.Server{Handler: p, ReadHeaderTimeout: scopedEgressReadHeaderTimeout}
 	go func() { _ = srv.Serve(ln) }()
-	closeProxy := func() { _ = srv.Close() }
+	// srv.Close only closes listeners Serve has already tracked; if the Serve
+	// goroutine has not been scheduled yet, srv.listeners is empty and ln stays
+	// open until Serve eventually runs. Closing ln directly makes the returned
+	// cleanup synchronous regardless of goroutine scheduling; the second close
+	// on an already-closed listener is a discarded error.
+	closeProxy := func() { _ = srv.Close(); _ = ln.Close() }
 	return ln.Addr().(*net.TCPAddr).Port, closeProxy, nil
 }

--- a/internal/worker/opencode_provider.go
+++ b/internal/worker/opencode_provider.go
@@ -97,6 +97,17 @@ func OpencodeProviderID(model string) string {
 	return id
 }
 
+// opencodeStockProviders are the OpenCode provider ids that work in the stock
+// runner without an opencode.providers block: OpencodeHarness.Env passes their
+// API-key variables through and OpencodeHarness.EgressHosts already allows
+// their endpoints. Any other prefix needs an explicit provider block so it
+// gets config, credentials, and egress; without one OpenCode fails inside its
+// server with a generic message and no readiness check runs.
+var opencodeStockProviders = map[string]bool{
+	"anthropic": true,
+	"openai":    true,
+}
+
 func (d ContainerRunner) resolveOpencodeProvider(model string) (opencodeProvider, error) {
 	resolved := opencodeProvider{
 		Model:       model,
@@ -112,7 +123,10 @@ func (d ContainerRunner) resolveOpencodeProvider(model string) (opencodeProvider
 	}
 	cfg, ok := d.OpencodeProviders[resolved.ID]
 	if !ok {
-		return resolved, nil
+		if opencodeStockProviders[resolved.ID] {
+			return resolved, nil
+		}
+		return resolved, fmt.Errorf("OpenCode model %q uses provider %q, which has no opencode.providers.%s entry; see docs/opencode.md", model, resolved.ID, resolved.ID)
 	}
 	resolved.Configured = true
 	resolved.StateDir = cfg.StateDir

--- a/internal/worker/opencode_provider_test.go
+++ b/internal/worker/opencode_provider_test.go
@@ -78,6 +78,25 @@ func TestResolveOpencodeProviderDoesNotLabelOtherHarnesses(t *testing.T) {
 	}
 }
 
+func TestResolveOpencodeProviderRejectsUnconfiguredNonStockProvider(t *testing.T) {
+	d := ContainerRunner{
+		Harness: OpencodeHarness{},
+		OpencodeProviders: map[string]OpencodeProviderConfig{
+			"kiro": {EgressHosts: []string{"runtime.kiro.dev"}},
+		},
+	}
+	_, err := d.resolveOpencodeProvider("lmstudio/qwen/qwen3.5-9b")
+	if err == nil || !strings.Contains(err.Error(), "opencode.providers.lmstudio") {
+		t.Fatalf("unconfigured provider error = %v, want opencode.providers.lmstudio", err)
+	}
+	for _, model := range []string{"anthropic/claude-sonnet-5", "openai/gpt-6"} {
+		provider, err := d.resolveOpencodeProvider(model)
+		if err != nil || provider.Configured || provider.ID != OpencodeProviderID(model) {
+			t.Errorf("stock model %q: provider=%+v err=%v, want unconfigured pass-through", model, provider, err)
+		}
+	}
+}
+
 func TestBuildRunArgsForProviderScopesEnvironmentAndState(t *testing.T) {
 	t.Setenv("OPENAI_API_KEY", "unrelated-openai-secret")
 	t.Setenv("ANTHROPIC_API_KEY", "unrelated-anthropic-secret")
@@ -397,7 +416,7 @@ func TestClassifyOpencodeReadinessErrors(t *testing.T) {
 func TestContainerRunErrorStateResumeRetryIgnoresProviderErrors(t *testing.T) {
 	h := stubHarness{acctErr: "invalid_api_key"}
 	s := containerRunErrorState{}
-	s.observe(Event{Kind: KindError, Text: "session abc not found"}, h, true)
+	s.observe(Event{Kind: KindError, Text: "session abc not found"}, h, "kiro")
 	if !s.resumeRetryable() {
 		t.Error("provider error event blocked the fresh-restart resume fallback")
 	}
@@ -405,9 +424,27 @@ func TestContainerRunErrorStateResumeRetryIgnoresProviderErrors(t *testing.T) {
 	if !strings.Contains(err.Error(), "session abc not found") {
 		t.Errorf("provider error text lost from failure: %v", err)
 	}
-	s.observe(Event{Kind: KindError, Text: "invalid_api_key: revoked"}, h, true)
+	s.observe(Event{Kind: KindError, Text: "invalid_api_key: revoked"}, h, "kiro")
 	if s.resumeRetryable() {
 		t.Error("account error event did not block the resume fallback")
+	}
+}
+
+func TestContainerRunErrorStateKeepsStockProviderErrorText(t *testing.T) {
+	// A stock (unconfigured) OpenCode provider still has an ID, so its error
+	// event should reach the scan failure instead of the bare exit status.
+	s := containerRunErrorState{}
+	s.observe(Event{Kind: KindError, Text: "Unexpected server error. Check server logs for details."}, stubHarness{}, "anthropic")
+	err := s.failure(opencodeProvider{ID: "anthropic"}, "docker", errors.New("exit status 1"))
+	if !strings.Contains(err.Error(), "Unexpected server error") || !strings.Contains(err.Error(), `"anthropic"`) {
+		t.Errorf("stock provider failure = %v, want OpenCode provider error text", err)
+	}
+	// A non-opencode backend has no provider ID and keeps the plain exit error.
+	s = containerRunErrorState{}
+	s.observe(Event{Kind: KindError, Text: "some claude error"}, stubHarness{}, "")
+	err = s.failure(opencodeProvider{}, "docker", errors.New("exit status 1"))
+	if strings.Contains(err.Error(), "OpenCode provider") {
+		t.Errorf("non-opencode failure wrapped as provider error: %v", err)
 	}
 }
 


### PR DESCRIPTION
In #876 an OpenCode model with provider prefix `lmstudio` and no `opencode.providers.lmstudio` block fell through `resolveOpencodeProvider` with `Configured=false`: no `OPENCODE_CONFIG_CONTENT`, no readiness probe, no provider egress. opencode then threw inside its server, which its catch-all middleware flattens to `Unexpected server error. Check server logs for details.`, and the scan error was the bare `docker exited: exit status 1` because `containerRunErrorState.observe` only kept error text for configured providers.

`resolveOpencodeProvider` now returns an error naming `opencode.providers.<id>` when the prefix is neither a configured provider nor one of the two that work in the stock runner (`anthropic`, `openai`). `containerRunErrorState` keys on the resolved provider ID instead of `Configured`, so stock-provider error events also reach the scan failure. `docs/opencode.md` adds LM Studio to the local-provider caveat and states the refusal.

Bumps `alpha-omega-security/harness` to v0.1.7, which sets `OPENCODE_PRINT_LOGS=1` and `OPENCODE_LOG_LEVEL=error` so the server-side cause behind `Unexpected server error` reaches stderr and the scan log. Both are added to `reservedOpencodePassEnv` so a provider block cannot re-silence them.

Part of #876.