### PR TITLE
Add CONTRIBUTING.md with changelog guidance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,5 @@
+# Contributing
+
+## Changelog
+
+Don't edit `CHANGELOG.md` in a pull request. Entries are written when a release is cut, not per change, so a PR that touches the changelog just creates a merge conflict for the next one.


### PR DESCRIPTION
Changelog entries are written at release-cut time, not per PR, so a PR that edits `CHANGELOG.md` just conflicts with the next one. Put that in writing so contributors and tooling stop adding entries.