### PR TITLE
fix(db): guard the ecosystem join key against a nil MakePURL result

### DIFF
--- a/internal/db/ecosystem.go
+++ b/internal/db/ecosystem.go
@@ -93,16 +93,23 @@ func ecosystemKey(purlStr, ecosystem, name string) (eco, namespace, pkg string) 
 		return canonicalType(p.Type), p.Namespace, p.Name
 	}
 	built := purl.MakePURL(reconcileEcosystem(ecosystem), name, "")
-	if p, err := purl.Parse(built.String()); err == nil {
-		return canonicalType(p.Type), p.Namespace, p.Name
+	if built != nil {
+		if p, err := purl.Parse(built.String()); err == nil {
+			return canonicalType(p.Type), p.Namespace, p.Name
+		}
 	}
-	// MakePURL produced an invalid PURL: a namespace-required type whose
-	// path-like name it does not split (swift). Split on the last separator the
-	// way purl.Parse splits a path namespace; if there is none, keep it whole.
+	// MakePURL rejected the identifier or produced an invalid PURL: a
+	// namespace-required type whose path-like name it cannot represent (swift).
+	// Split on the last separator the way purl.Parse splits a path namespace; if
+	// there is none, keep it whole.
+	eco = canonicalType(ecosystem)
 	if i := strings.LastIndex(name, "/"); i > 0 {
-		return canonicalType(built.Type), name[:i], name[i+1:]
+		return eco, name[:i], name[i+1:]
 	}
-	return canonicalType(built.Type), built.Namespace, built.Name
+	if built == nil {
+		return eco, "", name
+	}
+	return eco, built.Namespace, built.Name
 }
 
 // EcosystemType returns the canonical PURL-type ecosystem to store on Package

--- a/internal/db/ecosystem_test.go
+++ b/internal/db/ecosystem_test.go
@@ -102,6 +102,27 @@ func TestEcosystemKeyPURL(t *testing.T) {
 	}
 }
 
+// TestEcosystemKeySwiftRegistryFallback guards purl.MakePURL rejecting Swift
+// registry identities that cannot be represented as Swift source-coordinate
+// PURLs. They still need a stable key for matching imported package rows.
+func TestEcosystemKeySwiftRegistryFallback(t *testing.T) {
+	cases := []struct {
+		label, name, wantNamespace, wantPackage string
+	}{
+		{"registry identity without separator", "apple.swift-argument-parser", "", "apple.swift-argument-parser"},
+		{"registry identity with separator", "apple/swift-argument-parser", "apple", "swift-argument-parser"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.label, func(t *testing.T) {
+			eco, namespace, pkg := ecosystemKey("", "swift", tc.name)
+			if eco != "swift" || namespace != tc.wantNamespace || pkg != tc.wantPackage {
+				t.Errorf("got (%q, %q, %q), want (swift, %q, %q)",
+					eco, namespace, pkg, tc.wantNamespace, tc.wantPackage)
+			}
+		})
+	}
+}
+
 // TestDependencyFindingsPURLJoin exercises the primary path end to end: a
 // Dependency and a Package both carrying a namespaced golang PURL join through
 // the parsed PURL, and it guards the packages.p_url column→field mapping.


### PR DESCRIPTION
Renovate's #902 moves `github.com/git-pkgs/purl` to v0.1.17, where `MakePURL` returns nil for a Swift registry identity it cannot express as a source-coordinate PURL. `ecosystemKey` dereferenced that result unconditionally, and since every parser derives a row's stored ecosystem through `EcosystemType` with an empty name, any swift row panics the ingest worker; on CI it surfaces as `TestEcosystemType/eco_swift` failing on both the Linux and macOS jobs.

The nil is now guarded and the existing fallback kept intact: `canonicalType(ecosystem)` is the same value `canonicalType(built.Type)` produced, a declined identity carrying a separator still splits at the last slash the way `purl.Parse` splits a path namespace, and one without keeps its whole name. Join keys come out unchanged on v0.1.16 and identical between the two versions, so #902 can go green without a data migration.

Opus 5 was used to implement this.
