### PR TITLE
Add usage cost-driver correlations and outlier analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ When the containerised runner is active (the default when a container runtime is
 - **Skill HTTP API** -- running skills can call back into scrutineer to list prior scans and enqueue further skills; see the [HTTP API overview](docs/api.md) for authentication boundaries and [openapi.yaml](openapi.yaml) for the full route specification
 - **Live updates** -- SSE streaming of scan logs and status changes, pushed rather than polled; the jobs list, the repositories list and a repository's Scans tab refresh their own table when a scan starts, finishes, or is cancelled, paused, resumed or queued, keeping the current scroll, filters and sort. Elapsed times ("started 3m ago") count up on their own, recomputed in the page rather than fetched
 - **Organisation rollup** -- repos, findings, and maintainers grouped by owning org, with per-org markdown exports
-- **Usage tracking** -- per-scan token and cost figures plus a `/usage` page totalling spend per skill; on a Claude subscription token, a rate-limit wall auto-pauses the batch and resumes it after the reported reset, with per-window status shown on `/usage`. Optionally (`downgrade_on_overage`), once the account crosses into overage the model tier falls back from max/high to the mid tier for new scans until overage clears (typically when the window resets) -- announced in the log, on the jobs page, and on `/usage`
+- **Usage tracking** -- per-scan token and cost figures plus a `/usage` page totalling spend per skill, correlating cost with repository workload proxies and linking runs that cost at least ten times their skill median; see [docs/usage.md](docs/usage.md). On a Claude subscription token, a rate-limit wall auto-pauses the batch and resumes it after the reported reset, with per-window status shown on `/usage`. Optionally (`downgrade_on_overage`), once the account crosses into overage the model tier falls back from max/high to the mid tier for new scans until overage clears (typically when the window resets) -- announced in the log, on the jobs page, and on `/usage`
 - **Themes** -- six colour themes plus a light/dark/system toggle, set on the Settings page
 
 ## The default pipeline
@@ -438,6 +438,7 @@ See [SECURITY.md](SECURITY.md) for the reporting policy and [threatmodel.md](thr
 - [docs/import.md](docs/import.md) -- importing findings from other tools (SARIF, CSV, markdown, minimal JSON) and adding new formats
 - [docs/api.md](docs/api.md) -- HTTP API surfaces, callers, authentication boundaries, and links to the full [OpenAPI specification](openapi.yaml)
 - [docs/database.md](docs/database.md) -- full database schema reference
+- [docs/usage.md](docs/usage.md) -- per-skill cost ranges, workload correlations and 10x-median outliers
 - [docs/backup.md](docs/backup.md) -- backing up and restoring the database (built-in `scrutineer backup`/`restore`, `sqlite3`, Litestream)
 - [docs/development.md](docs/development.md) -- project layout, regenerating embedded data, running tests
 - [docs/encrypted-sharing.md](docs/encrypted-sharing.md) -- encrypted findings sharing between contributors (age + SSH keys, team keyring management)

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -6,11 +6,11 @@ Scrutineer records model usage on each scan and aggregates completed and failed 
 
 The **Cost drivers** view compares scan cost with three inexpensive workload proxies:
 
-- **SLOC** is `lines.total_lines` from a successful `repo-overview` report for the same repository and commit.
-- **Dependency manifests** is the number of distinct non-empty `manifest_path` values in a successful `dependencies` inventory for the same repository and commit.
-- **Phase 1 sinks** is the number of entries in the `security-deep-dive` scan's own `inventory`.
+- **SLOC** is `lines.total_lines` from the latest successful `repo-overview` report for the repository.
+- **Dependency manifests** is the current number of distinct non-empty `Dependency.ManifestPath` values stored for the repository.
+- **Phase 1 sinks** is the number of entries in the latest positive-cost completed `security-deep-dive` report for the repository.
 
-Repository-wide SLOC and manifest measurements are not attached to subpath or focus-area scans because the full-repository value would overstate their scope. Reports without an exact non-empty commit match are also excluded. This makes the table intentionally sparse when the prerequisite measurement skills have not run at the same commit.
+Repository-wide SLOC and manifest measurements are not attached to subpath or focus-area scans because the full-repository value would overstate their scope. They are deliberately coarse, inexpensive current-corpus proxies rather than historical commit snapshots: SLOC can lag until `repo-overview` runs again, and dependency rows reflect the latest successful inventory. Phase 1 sink counts are attached only to the selected deep-dive scan, which avoids loading and parsing the repository's complete deep-dive history on every page view.
 
 Correlations are calculated independently per skill over positive-cost runs. A row appears once at least three matched observations exist and both cost and the driver vary. The reported value is Pearson's correlation coefficient (`r`): values near `1` indicate that cost tends to rise with the proxy, values near `-1` indicate an inverse relationship and values near `0` indicate little linear relationship. Correlation describes the stored corpus and does not prove that a proxy caused the cost.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,21 @@
+# Scan usage and cost
+
+Scrutineer records model usage on each scan and aggregates completed and failed skill runs on the `/usage` page. The **By skill** view is the instance's observed cost range: min, median, p90, max, total, token totals and turn-count percentiles are calculated from the scans stored in that instance. These corpus measurements are more useful than a fixed price estimate because model, effort, repository content and provider pricing all affect cost.
+
+## Cost drivers
+
+The **Cost drivers** view compares scan cost with three inexpensive workload proxies:
+
+- **SLOC** is `lines.total_lines` from a successful `repo-overview` report for the same repository and commit.
+- **Dependency manifests** is the number of distinct non-empty `manifest_path` values in a successful `dependencies` inventory for the same repository and commit.
+- **Phase 1 sinks** is the number of entries in the `security-deep-dive` scan's own `inventory`.
+
+Repository-wide SLOC and manifest measurements are not attached to subpath or focus-area scans because the full-repository value would overstate their scope. Reports without an exact non-empty commit match are also excluded. This makes the table intentionally sparse when the prerequisite measurement skills have not run at the same commit.
+
+Correlations are calculated independently per skill over positive-cost runs. A row appears once at least three matched observations exist and both cost and the driver vary. The reported value is Pearson's correlation coefficient (`r`): values near `1` indicate that cost tends to rise with the proxy, values near `-1` indicate an inverse relationship and values near `0` indicate little linear relationship. Correlation describes the stored corpus and does not prove that a proxy caused the cost.
+
+## Outliers
+
+The outlier table lists every positive-cost scan whose cost is at least ten times the positive-cost median for that skill. Each row links to the scan and repository and includes model, runner profile, turns and any matched driver measurements. Inspect the linked scan's transcript, report and runtime settings before assigning a cause; common explanations include a larger-than-usual analysis surface, a large sink inventory, repeated tool work, retries or a different model configuration.
+
+Zero-cost rows are retained in the normal usage totals but excluded from correlation and outlier baselines. This prevents historical rows without captured billing data and genuinely free runs from forcing the outlier median to zero.

--- a/internal/web/templates/usage.html
+++ b/internal/web/templates/usage.html
@@ -17,6 +17,7 @@
   <div class="flex items-center gap-1 shrink-0 ml-4">
     <a href="/usage?view=skill" class="{{if eq .View "skill"}}btn-outline{{else}}btn-sm-ghost{{end}}">By skill</a>
     <a href="/usage?view=day" class="{{if eq .View "day"}}btn-outline{{else}}btn-sm-ghost{{end}}">By day</a>
+    <a href="/usage?view=drivers" class="{{if eq .View "drivers"}}btn-outline{{else}}btn-sm-ghost{{end}}">Cost drivers</a>
   </div>
 </div>
 
@@ -50,7 +51,75 @@
 </div>
 {{end}}
 
-{{if eq .View "day"}}
+{{if eq .View "drivers"}}
+  <h3 class="text-lg font-semibold mb-3">Cost correlations</h3>
+  {{if .DriverCorrelations}}
+    <div class="overflow-x-auto mb-8">
+      <table class="table w-full">
+        <thead><tr>
+          <th>Skill</th>
+          <th>Driver</th>
+          <th class="text-right">Matched runs</th>
+          <th class="text-right">Pearson r</th>
+          <th>Relationship</th>
+        </tr></thead>
+        <tbody>
+        {{range .DriverCorrelations}}
+          <tr>
+            <td class="font-medium">{{.Skill}}</td>
+            <td>{{.Driver}}</td>
+            <td class="text-right text-muted-foreground">{{.Samples}}</td>
+            <td class="text-right font-medium">{{printf "%.2f" .R}}</td>
+            <td class="text-muted-foreground">{{.Summary}}</td>
+          </tr>
+        {{end}}
+        </tbody>
+      </table>
+    </div>
+  {{else}}
+    {{template "empty" (dict "Icon" "chart-scatter" "Title" "Not enough matched runs" "Body" "A correlation appears after three positive-cost runs share a repository and commit with the relevant measurement.")}}
+  {{end}}
+
+  <h3 class="text-lg font-semibold mt-8 mb-3">Cost outliers</h3>
+  {{if .Outliers}}
+    <div class="overflow-x-auto">
+      <table class="table w-full">
+        <thead><tr>
+          <th>Scan</th>
+          <th>Repository</th>
+          <th>Skill</th>
+          <th>Model / profile</th>
+          <th class="text-right">Cost</th>
+          <th class="text-right">Skill median</th>
+          <th class="text-right">vs median</th>
+          <th class="text-right">Turns</th>
+          <th class="text-right">SLOC</th>
+          <th class="text-right">Manifests</th>
+          <th class="text-right">Sinks</th>
+        </tr></thead>
+        <tbody>
+        {{range .Outliers}}
+          <tr>
+            <td><a href="/scans/{{.ScanID}}" class="link">#{{.ScanID}}</a></td>
+            <td><a href="/repositories/{{.RepositoryID}}" class="link">{{.Repository}}</a></td>
+            <td class="font-medium">{{.Skill}}</td>
+            <td class="text-muted-foreground">{{if .Model}}{{.Model}}{{else}}—{{end}}{{if .Profile}} / {{.Profile}}{{end}}</td>
+            <td class="text-right font-medium">{{usd .Cost}}</td>
+            <td class="text-right text-muted-foreground">{{usd .Median}}</td>
+            <td class="text-right">{{printf "%.1f×" .Multiple}}</td>
+            <td class="text-right text-muted-foreground">{{.Turns}}</td>
+            <td class="text-right text-muted-foreground">{{if .SLOC}}{{.SLOC}}{{else}}—{{end}}</td>
+            <td class="text-right text-muted-foreground">{{if .Manifests}}{{.Manifests}}{{else}}—{{end}}</td>
+            <td class="text-right text-muted-foreground">{{if .Sinks}}{{.Sinks}}{{else}}—{{end}}</td>
+          </tr>
+        {{end}}
+        </tbody>
+      </table>
+    </div>
+  {{else}}
+    {{template "empty" (dict "Icon" "circle-check" "Title" "No 10× cost outliers" "Body" "No positive-cost run is at least ten times its skill median.")}}
+  {{end}}
+{{else if eq .View "day"}}
   {{if .DayRows}}
     <table class="table w-full">
       <thead><tr>

--- a/internal/web/templates/usage.html
+++ b/internal/web/templates/usage.html
@@ -77,7 +77,7 @@
       </table>
     </div>
   {{else}}
-    {{template "empty" (dict "Icon" "chart-scatter" "Title" "Not enough matched runs" "Body" "A correlation appears after three positive-cost runs share a repository and commit with the relevant measurement.")}}
+    {{template "empty" (dict "Icon" "chart-scatter" "Title" "Not enough matched runs" "Body" "A correlation appears after three positive-cost runs of one skill have a relevant measurement, with variation in both cost and measurement.")}}
   {{end}}
 
   <h3 class="text-lg font-semibold mt-8 mb-3">Cost outliers</h3>

--- a/internal/web/templates/usage.html
+++ b/internal/web/templates/usage.html
@@ -103,7 +103,7 @@
             <td><a href="/scans/{{.ScanID}}" class="link">#{{.ScanID}}</a></td>
             <td><a href="/repositories/{{.RepositoryID}}" class="link">{{.Repository}}</a></td>
             <td class="font-medium">{{.Skill}}</td>
-            <td class="text-muted-foreground">{{if .Model}}{{.Model}}{{else}}—{{end}}{{if .Profile}} / {{.Profile}}{{end}}</td>
+            <td class="text-muted-foreground">{{if .Model}}{{.Model}}{{if .Profile}} / {{.Profile}}{{end}}{{else if .Profile}}{{.Profile}}{{else}}—{{end}}</td>
             <td class="text-right font-medium">{{usd .Cost}}</td>
             <td class="text-right text-muted-foreground">{{usd .Median}}</td>
             <td class="text-right">{{printf "%.1f×" .Multiple}}</td>

--- a/internal/web/usage.go
+++ b/internal/web/usage.go
@@ -54,7 +54,7 @@ func (s *Server) usage(w http.ResponseWriter, r *http.Request) {
 		"cache_read_tokens", "cache_write_tokens", "finished_at", "created_at",
 	}
 	if view == "drivers" {
-		columns = append(columns, "id", "repository_id", "model", "profile", "commit", "sub_path", "focus_area")
+		columns = append(columns, "id", "repository_id", "model", "profile", "sub_path", "focus_area")
 	}
 	s.DB.Select(columns).
 		Where("status IN ?", []db.ScanStatus{db.ScanDone, db.ScanFailed}).

--- a/internal/web/usage.go
+++ b/internal/web/usage.go
@@ -41,7 +41,7 @@ type Stats struct {
 
 func (s *Server) usage(w http.ResponseWriter, r *http.Request) {
 	view := r.URL.Query().Get("view")
-	if view != "day" {
+	if view != "day" && view != "drivers" {
 		view = "skill"
 	}
 
@@ -49,7 +49,8 @@ func (s *Server) usage(w http.ResponseWriter, r *http.Request) {
 	// rows have zero cost and would drag the floor down, and failed runs
 	// did still spend tokens so they stay in.
 	var scans []db.Scan
-	s.DB.Select("skill_name", "cost_usd", "turns",
+	s.DB.Select("id", "repository_id", "skill_name", "model", "profile", "commit",
+		"sub_path", "focus_area", "cost_usd", "turns",
 		"input_tokens", "output_tokens", "cache_read_tokens", "cache_write_tokens",
 		"finished_at", "created_at").
 		Where("status IN ?", []db.ScanStatus{db.ScanDone, db.ScanFailed}).
@@ -114,13 +115,19 @@ func (s *Server) usage(w http.ResponseWriter, r *http.Request) {
 
 	rl := buildRateLimitPanel(s.Worker.RateLimitStatus())
 	rl.Downgrading = s.Worker.ShouldDowngradeModel()
+	drivers := usageDriverAnalysis{}
+	if view == "drivers" {
+		drivers = s.loadUsageDriverAnalysis(scans)
+	}
 	s.render(w, r, "usage.html", map[string]any{
-		"Rows":      rows,
-		"DayRows":   dayRows,
-		"TotalCost": totalCost,
-		"TotalRuns": totalRuns,
-		"View":      view,
-		"RateLimit": rl,
+		"Rows":               rows,
+		"DayRows":            dayRows,
+		"DriverCorrelations": drivers.Correlations,
+		"Outliers":           drivers.Outliers,
+		"TotalCost":          totalCost,
+		"TotalRuns":          totalRuns,
+		"View":               view,
+		"RateLimit":          rl,
 	})
 }
 

--- a/internal/web/usage.go
+++ b/internal/web/usage.go
@@ -49,10 +49,14 @@ func (s *Server) usage(w http.ResponseWriter, r *http.Request) {
 	// rows have zero cost and would drag the floor down, and failed runs
 	// did still spend tokens so they stay in.
 	var scans []db.Scan
-	s.DB.Select("id", "repository_id", "skill_name", "model", "profile", "commit",
-		"sub_path", "focus_area", "cost_usd", "turns",
-		"input_tokens", "output_tokens", "cache_read_tokens", "cache_write_tokens",
-		"finished_at", "created_at").
+	columns := []string{
+		"skill_name", "cost_usd", "turns", "input_tokens", "output_tokens",
+		"cache_read_tokens", "cache_write_tokens", "finished_at", "created_at",
+	}
+	if view == "drivers" {
+		columns = append(columns, "id", "repository_id", "model", "profile", "commit", "sub_path", "focus_area")
+	}
+	s.DB.Select(columns).
 		Where("status IN ?", []db.ScanStatus{db.ScanDone, db.ScanFailed}).
 		Where("skill_name != ''").
 		Find(&scans)

--- a/internal/web/usage_drivers.go
+++ b/internal/web/usage_drivers.go
@@ -74,15 +74,20 @@ type usageDriverPair struct {
 }
 
 func (s *Server) loadUsageDriverAnalysis(scans []db.Scan) usageDriverAnalysis {
+	repositoryIDs := usageRepositoryIDs(scans)
+	if len(repositoryIDs) == 0 {
+		return usageDriverAnalysis{}
+	}
 	var sources []db.Scan
 	s.DB.Select("id", "repository_id", "skill_name", "commit", "report").
 		Where("status = ?", db.ScanDone).
+		Where("repository_id IN ?", repositoryIDs).
 		Where("skill_name IN ?", []string{"repo-overview", "dependencies", "security-deep-dive"}).
 		Where("report != ''").
 		Find(&sources)
 
 	var repos []db.Repository
-	s.DB.Select("id", "name", "full_name").Find(&repos)
+	s.DB.Select("id", "name", "full_name").Where("id IN ?", repositoryIDs).Find(&repos)
 	repoNames := make(map[uint]string, len(repos))
 	for _, repo := range repos {
 		repoNames[repo.ID] = usageRepositoryName(repo)
@@ -93,6 +98,21 @@ func (s *Server) loadUsageDriverAnalysis(scans []db.Scan) usageDriverAnalysis {
 		Correlations: usageCorrelations(scans, values),
 		Outliers:     usageOutliers(scans, values, repoNames),
 	}
+}
+
+func usageRepositoryIDs(scans []db.Scan) []uint {
+	seen := make(map[uint]struct{}, len(scans))
+	for _, scan := range scans {
+		if scan.RepositoryID != 0 {
+			seen[scan.RepositoryID] = struct{}{}
+		}
+	}
+	ids := make([]uint, 0, len(seen))
+	for id := range seen {
+		ids = append(ids, id)
+	}
+	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+	return ids
 }
 
 func usageDriverValuesByScan(scans, sources []db.Scan) map[uint]usageDriverValues {

--- a/internal/web/usage_drivers.go
+++ b/internal/web/usage_drivers.go
@@ -135,16 +135,16 @@ func usageDriverValuesByScan(scans []db.Scan, slocByRepo, manifestsByRepo map[ui
 	for _, scan := range scans {
 		v := usageDriverValues{}
 		if sinks, ok := sinksByScan[scan.ID]; ok {
-			v.Sinks = intPointer(sinks)
+			v.Sinks = new(sinks)
 		}
 		// repo-overview and dependencies describe the repository root. Applying
 		// those values to narrower scans would overstate their actual scope.
 		if scan.SubPath == "" && scan.FocusArea == "" {
 			if sloc, ok := slocByRepo[scan.RepositoryID]; ok && scan.SkillName != "repo-overview" {
-				v.SLOC = intPointer(sloc)
+				v.SLOC = new(sloc)
 			}
 			if manifests, ok := manifestsByRepo[scan.RepositoryID]; ok && scan.SkillName != "dependencies" {
-				v.Manifests = intPointer(manifests)
+				v.Manifests = new(manifests)
 			}
 		}
 		values[scan.ID] = v
@@ -352,8 +352,4 @@ func usageDriverDisplay(value *int) string {
 		return ""
 	}
 	return strconv.Itoa(*value)
-}
-
-func intPointer(value int) *int {
-	return &value
 }

--- a/internal/web/usage_drivers.go
+++ b/internal/web/usage_drivers.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"math"
 	"sort"
-	"strings"
+	"strconv"
 
 	"scrutineer/internal/db"
 )
@@ -52,20 +52,10 @@ type usageCostOutlier struct {
 	Sinks        string
 }
 
-type usageSnapshotKey struct {
-	RepositoryID uint
-	Commit       string
-}
-
-type usageSnapshotValue struct {
-	ScanID uint
-	Value  float64
-}
-
 type usageDriverValues struct {
-	SLOC      *float64
-	Manifests *float64
-	Sinks     *float64
+	SLOC      *int
+	Manifests *int
+	Sinks     *int
 }
 
 type usageDriverPair struct {
@@ -74,88 +64,87 @@ type usageDriverPair struct {
 }
 
 func (s *Server) loadUsageDriverAnalysis(scans []db.Scan) usageDriverAnalysis {
-	repositoryIDs := usageRepositoryIDs(scans)
-	if len(repositoryIDs) == 0 {
-		return usageDriverAnalysis{}
-	}
-	var sources []db.Scan
-	s.DB.Select("id", "repository_id", "skill_name", "commit", "report").
-		Where("status = ?", db.ScanDone).
-		Where("repository_id IN ?", repositoryIDs).
-		Where("skill_name IN ?", []string{"repo-overview", "dependencies", "security-deep-dive"}).
-		Where("report != ''").
-		Find(&sources)
-
-	var repos []db.Repository
-	s.DB.Select("id", "name", "full_name").Where("id IN ?", repositoryIDs).Find(&repos)
-	repoNames := make(map[uint]string, len(repos))
-	for _, repo := range repos {
-		repoNames[repo.ID] = usageRepositoryName(repo)
-	}
-
-	values := usageDriverValuesByScan(scans, sources)
-	return usageDriverAnalysis{
+	values := usageDriverValuesByScan(
+		scans,
+		s.loadUsageSLOC(),
+		s.loadUsageManifestCounts(),
+		s.loadUsageDeepDiveSinks(),
+	)
+	analysis := usageDriverAnalysis{
 		Correlations: usageCorrelations(scans, values),
-		Outliers:     usageOutliers(scans, values, repoNames),
+		Outliers:     usageOutliers(scans, values),
 	}
+	s.loadUsageOutlierRepositoryNames(analysis.Outliers)
+	return analysis
 }
 
-func usageRepositoryIDs(scans []db.Scan) []uint {
-	seen := make(map[uint]struct{}, len(scans))
-	for _, scan := range scans {
-		if scan.RepositoryID != 0 {
-			seen[scan.RepositoryID] = struct{}{}
-		}
-	}
-	ids := make([]uint, 0, len(seen))
-	for id := range seen {
-		ids = append(ids, id)
-	}
-	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
-	return ids
-}
+func (s *Server) loadUsageSLOC() map[uint]int {
+	latest := s.DB.Model(&db.Scan{}).
+		Select("MAX(id)").
+		Where("status = ? AND skill_name = ? AND report != ''", db.ScanDone, "repo-overview").
+		Group("repository_id")
+	var sources []db.Scan
+	s.DB.Select("id", "repository_id", "report").Where("id IN (?)", latest).Find(&sources)
 
-func usageDriverValuesByScan(scans, sources []db.Scan) map[uint]usageDriverValues {
-	slocBySnapshot := map[usageSnapshotKey]usageSnapshotValue{}
-	manifestsBySnapshot := map[usageSnapshotKey]usageSnapshotValue{}
-	values := map[uint]usageDriverValues{}
+	values := make(map[uint]int, len(sources))
 	for _, source := range sources {
-		key := usageSnapshotKey{RepositoryID: source.RepositoryID, Commit: source.Commit}
-		switch source.SkillName {
-		case "repo-overview":
-			if sloc, ok := repoOverviewSLOC(source.Report); ok {
-				setLatestUsageSnapshot(slocBySnapshot, key, source.ID, sloc)
-				v := values[source.ID]
-				v.SLOC = floatPointer(sloc)
-				values[source.ID] = v
-			}
-		case "dependencies":
-			if manifests, ok := dependencyManifestCount(source.Report); ok {
-				setLatestUsageSnapshot(manifestsBySnapshot, key, source.ID, manifests)
-				v := values[source.ID]
-				v.Manifests = floatPointer(manifests)
-				values[source.ID] = v
-			}
-		case "security-deep-dive":
-			if sinks, ok := deepDiveSinkCount(source.Report); ok {
-				v := values[source.ID]
-				v.Sinks = floatPointer(sinks)
-				values[source.ID] = v
-			}
+		if sloc, ok := repoOverviewSLOC(source.Report); ok {
+			values[source.RepositoryID] = sloc
 		}
 	}
+	return values
+}
 
+func (s *Server) loadUsageManifestCounts() map[uint]int {
+	var rows []struct {
+		RepositoryID  uint
+		ManifestCount int
+	}
+	s.DB.Model(&db.Dependency{}).
+		Select("repository_id, COUNT(DISTINCT TRIM(manifest_path)) AS manifest_count").
+		Where("TRIM(manifest_path) != ''").
+		Group("repository_id").
+		Scan(&rows)
+
+	values := make(map[uint]int, len(rows))
+	for _, row := range rows {
+		values[row.RepositoryID] = row.ManifestCount
+	}
+	return values
+}
+
+func (s *Server) loadUsageDeepDiveSinks() map[uint]int {
+	latest := s.DB.Model(&db.Scan{}).
+		Select("MAX(id)").
+		Where("status = ? AND skill_name = ? AND cost_usd > 0 AND report != ''", db.ScanDone, "security-deep-dive").
+		Group("repository_id")
+	var sources []db.Scan
+	s.DB.Select("id", "report").Where("id IN (?)", latest).Find(&sources)
+
+	values := make(map[uint]int, len(sources))
+	for _, source := range sources {
+		if sinks, ok := deepDiveSinkCount(source.Report); ok {
+			values[source.ID] = sinks
+		}
+	}
+	return values
+}
+
+func usageDriverValuesByScan(scans []db.Scan, slocByRepo, manifestsByRepo map[uint]int, sinksByScan map[uint]int) map[uint]usageDriverValues {
+	values := make(map[uint]usageDriverValues, len(scans))
 	for _, scan := range scans {
-		v := values[scan.ID]
+		v := usageDriverValues{}
+		if sinks, ok := sinksByScan[scan.ID]; ok {
+			v.Sinks = intPointer(sinks)
+		}
 		// repo-overview and dependencies describe the repository root. Applying
 		// those values to narrower scans would overstate their actual scope.
-		if scan.SubPath == "" && scan.FocusArea == "" && scan.Commit != "" {
-			key := usageSnapshotKey{RepositoryID: scan.RepositoryID, Commit: scan.Commit}
-			if snapshot, ok := slocBySnapshot[key]; ok {
-				v.SLOC = floatPointer(snapshot.Value)
+		if scan.SubPath == "" && scan.FocusArea == "" {
+			if sloc, ok := slocByRepo[scan.RepositoryID]; ok && scan.SkillName != "repo-overview" {
+				v.SLOC = intPointer(sloc)
 			}
-			if snapshot, ok := manifestsBySnapshot[key]; ok {
-				v.Manifests = floatPointer(snapshot.Value)
+			if manifests, ok := manifestsByRepo[scan.RepositoryID]; ok && scan.SkillName != "dependencies" {
+				v.Manifests = intPointer(manifests)
 			}
 		}
 		values[scan.ID] = v
@@ -163,17 +152,7 @@ func usageDriverValuesByScan(scans, sources []db.Scan) map[uint]usageDriverValue
 	return values
 }
 
-func setLatestUsageSnapshot(values map[usageSnapshotKey]usageSnapshotValue, key usageSnapshotKey, scanID uint, value float64) {
-	if key.Commit == "" {
-		return
-	}
-	current, ok := values[key]
-	if !ok || scanID > current.ScanID {
-		values[key] = usageSnapshotValue{ScanID: scanID, Value: value}
-	}
-}
-
-func repoOverviewSLOC(report string) (float64, bool) {
+func repoOverviewSLOC(report string) (int, bool) {
 	var result struct {
 		Lines struct {
 			TotalLines *int `json:"total_lines"`
@@ -182,40 +161,17 @@ func repoOverviewSLOC(report string) (float64, bool) {
 	if json.Unmarshal([]byte(report), &result) != nil || result.Lines.TotalLines == nil || *result.Lines.TotalLines < 0 {
 		return 0, false
 	}
-	return float64(*result.Lines.TotalLines), true
+	return *result.Lines.TotalLines, true
 }
 
-func dependencyManifestCount(report string) (float64, bool) {
-	var result struct {
-		Analyses struct {
-			Inventory *struct {
-				Status string `json:"status"`
-				Result []struct {
-					ManifestPath string `json:"manifest_path"`
-				} `json:"result"`
-			} `json:"inventory"`
-		} `json:"analyses"`
-	}
-	if json.Unmarshal([]byte(report), &result) != nil || result.Analyses.Inventory == nil || result.Analyses.Inventory.Status != "ok" {
-		return 0, false
-	}
-	paths := map[string]struct{}{}
-	for _, row := range result.Analyses.Inventory.Result {
-		if path := strings.TrimSpace(row.ManifestPath); path != "" {
-			paths[path] = struct{}{}
-		}
-	}
-	return float64(len(paths)), true
-}
-
-func deepDiveSinkCount(report string) (float64, bool) {
+func deepDiveSinkCount(report string) (int, bool) {
 	var result struct {
 		Inventory []json.RawMessage `json:"inventory"`
 	}
 	if json.Unmarshal([]byte(report), &result) != nil || result.Inventory == nil {
 		return 0, false
 	}
-	return float64(len(result.Inventory)), true
+	return len(result.Inventory), true
 }
 
 func usageCorrelations(scans []db.Scan, values map[uint]usageDriverValues) []usageDriverCorrelation {
@@ -259,14 +215,14 @@ func usageCorrelations(scans []db.Scan, values map[uint]usageDriverValues) []usa
 	return rows
 }
 
-func appendUsagePair(pairs map[string]map[string][]usageDriverPair, skill, driver string, value *float64, cost float64) {
+func appendUsagePair(pairs map[string]map[string][]usageDriverPair, skill, driver string, value *int, cost float64) {
 	if value == nil {
 		return
 	}
 	if pairs[skill] == nil {
 		pairs[skill] = map[string][]usageDriverPair{}
 	}
-	pairs[skill][driver] = append(pairs[skill][driver], usageDriverPair{Driver: *value, Cost: cost})
+	pairs[skill][driver] = append(pairs[skill][driver], usageDriverPair{Driver: float64(*value), Cost: cost})
 }
 
 func pearsonCorrelation(pairs []usageDriverPair) (float64, bool) {
@@ -310,7 +266,7 @@ func correlationSummary(r float64) string {
 	return strength + " " + direction
 }
 
-func usageOutliers(scans []db.Scan, values map[uint]usageDriverValues, repoNames map[uint]string) []usageCostOutlier {
+func usageOutliers(scans []db.Scan, values map[uint]usageDriverValues) []usageCostOutlier {
 	costsBySkill := map[string][]float64{}
 	for _, scan := range scans {
 		if scan.CostUSD > 0 {
@@ -332,7 +288,6 @@ func usageOutliers(scans []db.Scan, values map[uint]usageDriverValues, repoNames
 		rows = append(rows, usageCostOutlier{
 			ScanID:       scan.ID,
 			RepositoryID: scan.RepositoryID,
-			Repository:   repoNames[scan.RepositoryID],
 			Skill:        scan.SkillName,
 			Model:        scan.Model,
 			Profile:      scan.Profile,
@@ -354,6 +309,34 @@ func usageOutliers(scans []db.Scan, values map[uint]usageDriverValues, repoNames
 	return rows
 }
 
+func (s *Server) loadUsageOutlierRepositoryNames(outliers []usageCostOutlier) {
+	if len(outliers) == 0 {
+		return
+	}
+	seen := make(map[uint]struct{}, len(outliers))
+	ids := make([]uint, 0, len(outliers))
+	for _, outlier := range outliers {
+		if _, ok := seen[outlier.RepositoryID]; ok {
+			continue
+		}
+		seen[outlier.RepositoryID] = struct{}{}
+		ids = append(ids, outlier.RepositoryID)
+	}
+	var repos []db.Repository
+	s.DB.Select("id", "name", "full_name").Where("id IN ?", ids).Find(&repos)
+	names := make(map[uint]string, len(repos))
+	for _, repo := range repos {
+		names[repo.ID] = usageRepositoryName(repo)
+	}
+	for i := range outliers {
+		if name := names[outliers[i].RepositoryID]; name != "" {
+			outliers[i].Repository = name
+		} else {
+			outliers[i].Repository = fmt.Sprintf("repository #%d", outliers[i].RepositoryID)
+		}
+	}
+}
+
 func usageRepositoryName(repo db.Repository) string {
 	if repo.FullName != "" {
 		return repo.FullName
@@ -364,13 +347,13 @@ func usageRepositoryName(repo db.Repository) string {
 	return fmt.Sprintf("repository #%d", repo.ID)
 }
 
-func usageDriverDisplay(value *float64) string {
+func usageDriverDisplay(value *int) string {
 	if value == nil {
 		return ""
 	}
-	return fmt.Sprintf("%.0f", *value)
+	return strconv.Itoa(*value)
 }
 
-func floatPointer(value float64) *float64 {
+func intPointer(value int) *int {
 	return &value
 }

--- a/internal/web/usage_drivers.go
+++ b/internal/web/usage_drivers.go
@@ -1,0 +1,356 @@
+package web
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"sort"
+	"strings"
+
+	"scrutineer/internal/db"
+)
+
+const (
+	usageOutlierMultiple              = 10
+	usageCorrelationMinSamples        = 3
+	usageCorrelationStrongThreshold   = 0.7
+	usageCorrelationModerateThreshold = 0.4
+)
+
+const (
+	usageDriverSLOC      = "SLOC"
+	usageDriverManifests = "Dependency manifests"
+	usageDriverSinks     = "Phase 1 sinks"
+)
+
+type usageDriverAnalysis struct {
+	Correlations []usageDriverCorrelation
+	Outliers     []usageCostOutlier
+}
+
+type usageDriverCorrelation struct {
+	Skill   string
+	Driver  string
+	Samples int
+	R       float64
+	Summary string
+}
+
+type usageCostOutlier struct {
+	ScanID       uint
+	RepositoryID uint
+	Repository   string
+	Skill        string
+	Model        string
+	Profile      string
+	Cost         float64
+	Median       float64
+	Multiple     float64
+	Turns        int
+	SLOC         string
+	Manifests    string
+	Sinks        string
+}
+
+type usageSnapshotKey struct {
+	RepositoryID uint
+	Commit       string
+}
+
+type usageSnapshotValue struct {
+	ScanID uint
+	Value  float64
+}
+
+type usageDriverValues struct {
+	SLOC      *float64
+	Manifests *float64
+	Sinks     *float64
+}
+
+type usageDriverPair struct {
+	Driver float64
+	Cost   float64
+}
+
+func (s *Server) loadUsageDriverAnalysis(scans []db.Scan) usageDriverAnalysis {
+	var sources []db.Scan
+	s.DB.Select("id", "repository_id", "skill_name", "commit", "report").
+		Where("status = ?", db.ScanDone).
+		Where("skill_name IN ?", []string{"repo-overview", "dependencies", "security-deep-dive"}).
+		Where("report != ''").
+		Find(&sources)
+
+	var repos []db.Repository
+	s.DB.Select("id", "name", "full_name").Find(&repos)
+	repoNames := make(map[uint]string, len(repos))
+	for _, repo := range repos {
+		repoNames[repo.ID] = usageRepositoryName(repo)
+	}
+
+	values := usageDriverValuesByScan(scans, sources)
+	return usageDriverAnalysis{
+		Correlations: usageCorrelations(scans, values),
+		Outliers:     usageOutliers(scans, values, repoNames),
+	}
+}
+
+func usageDriverValuesByScan(scans, sources []db.Scan) map[uint]usageDriverValues {
+	slocBySnapshot := map[usageSnapshotKey]usageSnapshotValue{}
+	manifestsBySnapshot := map[usageSnapshotKey]usageSnapshotValue{}
+	values := map[uint]usageDriverValues{}
+	for _, source := range sources {
+		key := usageSnapshotKey{RepositoryID: source.RepositoryID, Commit: source.Commit}
+		switch source.SkillName {
+		case "repo-overview":
+			if sloc, ok := repoOverviewSLOC(source.Report); ok {
+				setLatestUsageSnapshot(slocBySnapshot, key, source.ID, sloc)
+				v := values[source.ID]
+				v.SLOC = floatPointer(sloc)
+				values[source.ID] = v
+			}
+		case "dependencies":
+			if manifests, ok := dependencyManifestCount(source.Report); ok {
+				setLatestUsageSnapshot(manifestsBySnapshot, key, source.ID, manifests)
+				v := values[source.ID]
+				v.Manifests = floatPointer(manifests)
+				values[source.ID] = v
+			}
+		case "security-deep-dive":
+			if sinks, ok := deepDiveSinkCount(source.Report); ok {
+				v := values[source.ID]
+				v.Sinks = floatPointer(sinks)
+				values[source.ID] = v
+			}
+		}
+	}
+
+	for _, scan := range scans {
+		v := values[scan.ID]
+		// repo-overview and dependencies describe the repository root. Applying
+		// those values to narrower scans would overstate their actual scope.
+		if scan.SubPath == "" && scan.FocusArea == "" && scan.Commit != "" {
+			key := usageSnapshotKey{RepositoryID: scan.RepositoryID, Commit: scan.Commit}
+			if snapshot, ok := slocBySnapshot[key]; ok {
+				v.SLOC = floatPointer(snapshot.Value)
+			}
+			if snapshot, ok := manifestsBySnapshot[key]; ok {
+				v.Manifests = floatPointer(snapshot.Value)
+			}
+		}
+		values[scan.ID] = v
+	}
+	return values
+}
+
+func setLatestUsageSnapshot(values map[usageSnapshotKey]usageSnapshotValue, key usageSnapshotKey, scanID uint, value float64) {
+	if key.Commit == "" {
+		return
+	}
+	current, ok := values[key]
+	if !ok || scanID > current.ScanID {
+		values[key] = usageSnapshotValue{ScanID: scanID, Value: value}
+	}
+}
+
+func repoOverviewSLOC(report string) (float64, bool) {
+	var result struct {
+		Lines struct {
+			TotalLines *int `json:"total_lines"`
+		} `json:"lines"`
+	}
+	if json.Unmarshal([]byte(report), &result) != nil || result.Lines.TotalLines == nil || *result.Lines.TotalLines < 0 {
+		return 0, false
+	}
+	return float64(*result.Lines.TotalLines), true
+}
+
+func dependencyManifestCount(report string) (float64, bool) {
+	var result struct {
+		Analyses struct {
+			Inventory *struct {
+				Status string `json:"status"`
+				Result []struct {
+					ManifestPath string `json:"manifest_path"`
+				} `json:"result"`
+			} `json:"inventory"`
+		} `json:"analyses"`
+	}
+	if json.Unmarshal([]byte(report), &result) != nil || result.Analyses.Inventory == nil || result.Analyses.Inventory.Status != "ok" {
+		return 0, false
+	}
+	paths := map[string]struct{}{}
+	for _, row := range result.Analyses.Inventory.Result {
+		if path := strings.TrimSpace(row.ManifestPath); path != "" {
+			paths[path] = struct{}{}
+		}
+	}
+	return float64(len(paths)), true
+}
+
+func deepDiveSinkCount(report string) (float64, bool) {
+	var result struct {
+		Inventory []json.RawMessage `json:"inventory"`
+	}
+	if json.Unmarshal([]byte(report), &result) != nil || result.Inventory == nil {
+		return 0, false
+	}
+	return float64(len(result.Inventory)), true
+}
+
+func usageCorrelations(scans []db.Scan, values map[uint]usageDriverValues) []usageDriverCorrelation {
+	pairs := map[string]map[string][]usageDriverPair{}
+	for _, scan := range scans {
+		if scan.CostUSD <= 0 {
+			continue
+		}
+		v := values[scan.ID]
+		appendUsagePair(pairs, scan.SkillName, usageDriverSLOC, v.SLOC, scan.CostUSD)
+		appendUsagePair(pairs, scan.SkillName, usageDriverManifests, v.Manifests, scan.CostUSD)
+		appendUsagePair(pairs, scan.SkillName, usageDriverSinks, v.Sinks, scan.CostUSD)
+	}
+
+	var rows []usageDriverCorrelation
+	for skill, byDriver := range pairs {
+		for driver, observations := range byDriver {
+			r, ok := pearsonCorrelation(observations)
+			if !ok {
+				continue
+			}
+			rows = append(rows, usageDriverCorrelation{
+				Skill:   skill,
+				Driver:  driver,
+				Samples: len(observations),
+				R:       r,
+				Summary: correlationSummary(r),
+			})
+		}
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		left, right := math.Abs(rows[i].R), math.Abs(rows[j].R)
+		if left != right {
+			return left > right
+		}
+		if rows[i].Skill != rows[j].Skill {
+			return rows[i].Skill < rows[j].Skill
+		}
+		return rows[i].Driver < rows[j].Driver
+	})
+	return rows
+}
+
+func appendUsagePair(pairs map[string]map[string][]usageDriverPair, skill, driver string, value *float64, cost float64) {
+	if value == nil {
+		return
+	}
+	if pairs[skill] == nil {
+		pairs[skill] = map[string][]usageDriverPair{}
+	}
+	pairs[skill][driver] = append(pairs[skill][driver], usageDriverPair{Driver: *value, Cost: cost})
+}
+
+func pearsonCorrelation(pairs []usageDriverPair) (float64, bool) {
+	if len(pairs) < usageCorrelationMinSamples {
+		return 0, false
+	}
+	var driverMean, costMean float64
+	for _, pair := range pairs {
+		driverMean += pair.Driver
+		costMean += pair.Cost
+	}
+	driverMean /= float64(len(pairs))
+	costMean /= float64(len(pairs))
+
+	var covariance, driverVariance, costVariance float64
+	for _, pair := range pairs {
+		driverDelta := pair.Driver - driverMean
+		costDelta := pair.Cost - costMean
+		covariance += driverDelta * costDelta
+		driverVariance += driverDelta * driverDelta
+		costVariance += costDelta * costDelta
+	}
+	if driverVariance == 0 || costVariance == 0 {
+		return 0, false
+	}
+	return covariance / math.Sqrt(driverVariance*costVariance), true
+}
+
+func correlationSummary(r float64) string {
+	strength := "weak"
+	abs := math.Abs(r)
+	if abs >= usageCorrelationStrongThreshold {
+		strength = "strong"
+	} else if abs >= usageCorrelationModerateThreshold {
+		strength = "moderate"
+	}
+	direction := "positive"
+	if r < 0 {
+		direction = "negative"
+	}
+	return strength + " " + direction
+}
+
+func usageOutliers(scans []db.Scan, values map[uint]usageDriverValues, repoNames map[uint]string) []usageCostOutlier {
+	costsBySkill := map[string][]float64{}
+	for _, scan := range scans {
+		if scan.CostUSD > 0 {
+			costsBySkill[scan.SkillName] = append(costsBySkill[scan.SkillName], scan.CostUSD)
+		}
+	}
+	medians := map[string]float64{}
+	for skill, costs := range costsBySkill {
+		medians[skill] = summarise(costs).Median
+	}
+
+	var rows []usageCostOutlier
+	for _, scan := range scans {
+		median := medians[scan.SkillName]
+		if median <= 0 || scan.CostUSD < usageOutlierMultiple*median {
+			continue
+		}
+		v := values[scan.ID]
+		rows = append(rows, usageCostOutlier{
+			ScanID:       scan.ID,
+			RepositoryID: scan.RepositoryID,
+			Repository:   repoNames[scan.RepositoryID],
+			Skill:        scan.SkillName,
+			Model:        scan.Model,
+			Profile:      scan.Profile,
+			Cost:         scan.CostUSD,
+			Median:       median,
+			Multiple:     scan.CostUSD / median,
+			Turns:        scan.Turns,
+			SLOC:         usageDriverDisplay(v.SLOC),
+			Manifests:    usageDriverDisplay(v.Manifests),
+			Sinks:        usageDriverDisplay(v.Sinks),
+		})
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		if rows[i].Multiple != rows[j].Multiple {
+			return rows[i].Multiple > rows[j].Multiple
+		}
+		return rows[i].Cost > rows[j].Cost
+	})
+	return rows
+}
+
+func usageRepositoryName(repo db.Repository) string {
+	if repo.FullName != "" {
+		return repo.FullName
+	}
+	if repo.Name != "" {
+		return repo.Name
+	}
+	return fmt.Sprintf("repository #%d", repo.ID)
+}
+
+func usageDriverDisplay(value *float64) string {
+	if value == nil {
+		return ""
+	}
+	return fmt.Sprintf("%.0f", *value)
+}
+
+func floatPointer(value float64) *float64 {
+	return &value
+}

--- a/internal/web/usage_test.go
+++ b/internal/web/usage_test.go
@@ -1,6 +1,7 @@
 package web
 
 import (
+	"fmt"
 	"math"
 	"net/http/httptest"
 	"strings"
@@ -41,6 +42,85 @@ func TestSummarise(t *testing.T) {
 	}
 	if z := summarise(nil); z != (Stats{}) {
 		t.Errorf("empty summarise = %+v", z)
+	}
+}
+
+func TestUsageDriverReportParsing(t *testing.T) {
+	t.Run("repo overview SLOC", func(t *testing.T) {
+		got, ok := repoOverviewSLOC(`{"lines":{"total_lines":1234}}`)
+		if !ok || got != 1234 {
+			t.Fatalf("repoOverviewSLOC = %v, %v, want 1234, true", got, ok)
+		}
+		if _, ok := repoOverviewSLOC(`{"lines":{"total_files":12}}`); ok {
+			t.Fatal("repoOverviewSLOC accepted report without total_lines")
+		}
+	})
+
+	t.Run("distinct dependency manifests", func(t *testing.T) {
+		report := `{"analyses":{"inventory":{"status":"ok","result":[` +
+			`{"manifest_path":"package.json"},{"manifest_path":"package.json"},` +
+			`{"manifest_path":"cmd/go.mod"},{"manifest_path":""}]}}}`
+		got, ok := dependencyManifestCount(report)
+		if !ok || got != 2 {
+			t.Fatalf("dependencyManifestCount = %v, %v, want 2, true", got, ok)
+		}
+		if _, ok := dependencyManifestCount(`{"analyses":{"inventory":{"status":"error"}}}`); ok {
+			t.Fatal("dependencyManifestCount accepted failed inventory")
+		}
+	})
+
+	t.Run("deep dive sinks", func(t *testing.T) {
+		got, ok := deepDiveSinkCount(`{"inventory":[{"id":"S1"},{"id":"S2"}]}`)
+		if !ok || got != 2 {
+			t.Fatalf("deepDiveSinkCount = %v, %v, want 2, true", got, ok)
+		}
+		if _, ok := deepDiveSinkCount(`{"findings":[]}`); ok {
+			t.Fatal("deepDiveSinkCount accepted report without inventory")
+		}
+	})
+}
+
+func TestPearsonCorrelation(t *testing.T) {
+	positive := []usageDriverPair{{Driver: 1, Cost: 2}, {Driver: 2, Cost: 4}, {Driver: 3, Cost: 6}}
+	if got, ok := pearsonCorrelation(positive); !ok || !almostEq(got, 1) {
+		t.Fatalf("positive correlation = %v, %v, want 1, true", got, ok)
+	}
+	negative := []usageDriverPair{{Driver: 1, Cost: 6}, {Driver: 2, Cost: 4}, {Driver: 3, Cost: 2}}
+	if got, ok := pearsonCorrelation(negative); !ok || !almostEq(got, -1) {
+		t.Fatalf("negative correlation = %v, %v, want -1, true", got, ok)
+	}
+	if _, ok := pearsonCorrelation(positive[:2]); ok {
+		t.Fatal("two samples produced a correlation")
+	}
+	constant := []usageDriverPair{{Driver: 1, Cost: 2}, {Driver: 1, Cost: 3}, {Driver: 1, Cost: 4}}
+	if _, ok := pearsonCorrelation(constant); ok {
+		t.Fatal("constant driver produced a correlation")
+	}
+}
+
+func TestUsageDriverValuesByScan_matchesExactRootSnapshot(t *testing.T) {
+	sources := []db.Scan{
+		{ID: 10, RepositoryID: 1, SkillName: "repo-overview", Commit: "abc", Report: `{"lines":{"total_lines":100}}`},
+		{ID: 11, RepositoryID: 1, SkillName: "dependencies", Commit: "abc", Report: `{"analyses":{"inventory":{"status":"ok","result":[{"manifest_path":"go.mod"}]}}}`},
+		{ID: 12, RepositoryID: 1, SkillName: "security-deep-dive", Commit: "abc", Report: `{"inventory":[{},{}]}`},
+	}
+	scans := []db.Scan{
+		{ID: 20, RepositoryID: 1, Commit: "abc"},
+		{ID: 21, RepositoryID: 1, Commit: "abc", SubPath: "cmd/tool"},
+		{ID: 22, RepositoryID: 1, Commit: "abc", FocusArea: `{"name":"parser"}`},
+		{ID: 23, RepositoryID: 1, Commit: "def"},
+	}
+	got := usageDriverValuesByScan(scans, sources)
+	if got[20].SLOC == nil || *got[20].SLOC != 100 || got[20].Manifests == nil || *got[20].Manifests != 1 {
+		t.Fatalf("root values = %+v, want SLOC 100 and manifests 1", got[20])
+	}
+	for _, id := range []uint{21, 22, 23} {
+		if got[id].SLOC != nil || got[id].Manifests != nil {
+			t.Errorf("scan %d inherited root-only values: %+v", id, got[id])
+		}
+	}
+	if got[12].Sinks == nil || *got[12].Sinks != 2 {
+		t.Fatalf("deep-dive sink count = %+v, want 2", got[12])
 	}
 }
 
@@ -200,6 +280,66 @@ func TestUsage_perDay(t *testing.T) {
 	}
 	if !strings.Contains(body, "3 runs") {
 		t.Errorf("missing 3 runs count")
+	}
+}
+
+func TestUsage_costDriversAndOutliers(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	repo := db.Repository{URL: "https://x/drivers", Name: "drivers", FullName: "owner/drivers"}
+	s.DB.Create(&repo)
+
+	commits := []string{"a", "b", "c"}
+	sloc := []int{100, 200, 300}
+	costs := []float64{1, 2, 30}
+	var outlier db.Scan
+	for i, commit := range commits {
+		s.DB.Create(&db.Scan{
+			RepositoryID: repo.ID,
+			Kind:         "skill",
+			SkillName:    "repo-overview",
+			Status:       db.ScanDone,
+			Commit:       commit,
+			Report:       `{"lines":{"total_lines":` + fmt.Sprint(sloc[i]) + `}}`,
+		})
+		scan := db.Scan{
+			RepositoryID: repo.ID,
+			Kind:         "skill",
+			SkillName:    "audit",
+			Status:       db.ScanDone,
+			Commit:       commit,
+			Model:        "test-model",
+			Profile:      "go",
+			CostUSD:      costs[i],
+			Turns:        5 + i,
+		}
+		s.DB.Create(&scan)
+		if i == 2 {
+			outlier = scan
+		}
+	}
+
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq("GET", "/usage?view=drivers"))
+	if w.Code != 200 {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+	body := w.Body.String()
+	for _, want := range []string{
+		"Cost correlations",
+		"audit",
+		"SLOC",
+		"3",
+		"Cost outliers",
+		fmt.Sprintf("/scans/%d", outlier.ID),
+		"owner/drivers",
+		"test-model / go",
+		"15.0×",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("usage drivers page missing %q", want)
+		}
 	}
 }
 

--- a/internal/web/usage_test.go
+++ b/internal/web/usage_test.go
@@ -56,19 +56,6 @@ func TestUsageDriverReportParsing(t *testing.T) {
 		}
 	})
 
-	t.Run("distinct dependency manifests", func(t *testing.T) {
-		report := `{"analyses":{"inventory":{"status":"ok","result":[` +
-			`{"manifest_path":"package.json"},{"manifest_path":"package.json"},` +
-			`{"manifest_path":"cmd/go.mod"},{"manifest_path":""}]}}}`
-		got, ok := dependencyManifestCount(report)
-		if !ok || got != 2 {
-			t.Fatalf("dependencyManifestCount = %v, %v, want 2, true", got, ok)
-		}
-		if _, ok := dependencyManifestCount(`{"analyses":{"inventory":{"status":"error"}}}`); ok {
-			t.Fatal("dependencyManifestCount accepted failed inventory")
-		}
-	})
-
 	t.Run("deep dive sinks", func(t *testing.T) {
 		got, ok := deepDiveSinkCount(`{"inventory":[{"id":"S1"},{"id":"S2"}]}`)
 		if !ok || got != 2 {
@@ -98,41 +85,66 @@ func TestPearsonCorrelation(t *testing.T) {
 	}
 }
 
-func TestUsageDriverValuesByScan_matchesExactRootSnapshot(t *testing.T) {
-	sources := []db.Scan{
-		{ID: 10, RepositoryID: 1, SkillName: "repo-overview", Commit: "abc", Report: `{"lines":{"total_lines":100}}`},
-		{ID: 11, RepositoryID: 1, SkillName: "dependencies", Commit: "abc", Report: `{"analyses":{"inventory":{"status":"ok","result":[{"manifest_path":"go.mod"}]}}}`},
-		{ID: 12, RepositoryID: 1, SkillName: "security-deep-dive", Commit: "abc", Report: `{"inventory":[{},{}]}`},
-	}
+func TestUsageDriverValuesByScan_appliesRootMeasurements(t *testing.T) {
 	scans := []db.Scan{
-		{ID: 20, RepositoryID: 1, Commit: "abc"},
+		{ID: 10, RepositoryID: 1, SkillName: "repo-overview"},
+		{ID: 11, RepositoryID: 1, SkillName: "dependencies"},
+		{ID: 12, RepositoryID: 1, SkillName: "security-deep-dive"},
+		{ID: 20, RepositoryID: 1},
 		{ID: 21, RepositoryID: 1, Commit: "abc", SubPath: "cmd/tool"},
 		{ID: 22, RepositoryID: 1, Commit: "abc", FocusArea: `{"name":"parser"}`},
-		{ID: 23, RepositoryID: 1, Commit: "def"},
 	}
-	got := usageDriverValuesByScan(scans, sources)
+	got := usageDriverValuesByScan(scans, map[uint]int{1: 100}, map[uint]int{1: 1}, map[uint]int{12: 2})
 	if got[20].SLOC == nil || *got[20].SLOC != 100 || got[20].Manifests == nil || *got[20].Manifests != 1 {
 		t.Fatalf("root values = %+v, want SLOC 100 and manifests 1", got[20])
 	}
-	for _, id := range []uint{21, 22, 23} {
+	for _, id := range []uint{21, 22} {
 		if got[id].SLOC != nil || got[id].Manifests != nil {
 			t.Errorf("scan %d inherited root-only values: %+v", id, got[id])
 		}
+	}
+	if got[10].SLOC != nil {
+		t.Errorf("repo-overview correlated against its own output: %+v", got[10])
+	}
+	if got[11].Manifests != nil {
+		t.Errorf("dependencies correlated against its own output: %+v", got[11])
 	}
 	if got[12].Sinks == nil || *got[12].Sinks != 2 {
 		t.Fatalf("deep-dive sink count = %+v, want 2", got[12])
 	}
 }
 
-func TestUsageRepositoryIDs(t *testing.T) {
-	got := usageRepositoryIDs([]db.Scan{
-		{RepositoryID: 3},
-		{RepositoryID: 1},
-		{RepositoryID: 3},
-		{},
-	})
-	if len(got) != 2 || got[0] != 1 || got[1] != 3 {
-		t.Fatalf("repository IDs = %v, want [1 3]", got)
+func TestUsageDriverLoaders(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	repo := db.Repository{URL: "https://x/loaders", Name: "loaders"}
+	s.DB.Create(&repo)
+	for _, path := range []string{"go.mod", "go.mod", " cmd/go.mod ", ""} {
+		s.DB.Create(&db.Dependency{RepositoryID: repo.ID, Name: path, ManifestPath: path})
+	}
+	s.DB.Create(&db.Scan{RepositoryID: repo.ID, SkillName: "repo-overview", Status: db.ScanDone, Report: `{"lines":{"total_lines":100}}`})
+	s.DB.Create(&db.Scan{RepositoryID: repo.ID, SkillName: "repo-overview", Status: db.ScanDone, Report: `{"lines":{"total_lines":200}}`})
+	s.DB.Create(&db.Scan{RepositoryID: repo.ID, SkillName: "repo-overview", Status: db.ScanFailed, Report: `{"lines":{"total_lines":300}}`})
+	oldDeepDive := db.Scan{RepositoryID: repo.ID, SkillName: "security-deep-dive", Status: db.ScanDone, CostUSD: 1, Report: `{"inventory":[{}]}`}
+	s.DB.Create(&oldDeepDive)
+	deepDive := db.Scan{RepositoryID: repo.ID, SkillName: "security-deep-dive", Status: db.ScanDone, CostUSD: 1, Report: `{"inventory":[{},{}]}`}
+	s.DB.Create(&deepDive)
+	s.DB.Create(&db.Scan{RepositoryID: repo.ID, SkillName: "security-deep-dive", Status: db.ScanDone, Report: `{"inventory":[{},{},{}]}`})
+	s.DB.Create(&db.Scan{RepositoryID: repo.ID, SkillName: "security-deep-dive", Status: db.ScanFailed, CostUSD: 2, Report: `{"inventory":[{},{},{},{}]}`})
+
+	if got := s.loadUsageSLOC()[repo.ID]; got != 200 {
+		t.Fatalf("latest SLOC = %d, want 200", got)
+	}
+	if got := s.loadUsageManifestCounts()[repo.ID]; got != 2 {
+		t.Fatalf("manifest count = %d, want 2", got)
+	}
+	sinks := s.loadUsageDeepDiveSinks()
+	if got := sinks[deepDive.ID]; got != 2 {
+		t.Fatalf("deep-dive sink count = %d, want 2", got)
+	}
+	if len(sinks) != 1 {
+		t.Fatalf("sink measurements = %v, want only latest positive-cost completed scan per repository", sinks)
 	}
 }
 

--- a/internal/web/usage_test.go
+++ b/internal/web/usage_test.go
@@ -311,20 +311,21 @@ func TestUsage_costDriversAndOutliers(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()
 
-	repo := db.Repository{URL: "https://x/drivers", Name: "drivers", FullName: "owner/drivers"}
-	s.DB.Create(&repo)
-
-	commits := []string{"a", "b", "c"}
 	sloc := []int{100, 200, 300}
 	costs := []float64{1, 2, 30}
 	var outlier db.Scan
-	for i, commit := range commits {
+	for i := range sloc {
+		repo := db.Repository{
+			URL:      fmt.Sprintf("https://x/drivers-%d", i+1),
+			Name:     fmt.Sprintf("drivers-%d", i+1),
+			FullName: fmt.Sprintf("owner/drivers-%d", i+1),
+		}
+		s.DB.Create(&repo)
 		s.DB.Create(&db.Scan{
 			RepositoryID: repo.ID,
 			Kind:         "skill",
 			SkillName:    "repo-overview",
 			Status:       db.ScanDone,
-			Commit:       commit,
 			Report:       `{"lines":{"total_lines":` + fmt.Sprint(sloc[i]) + `}}`,
 		})
 		scan := db.Scan{
@@ -332,7 +333,6 @@ func TestUsage_costDriversAndOutliers(t *testing.T) {
 			Kind:         "skill",
 			SkillName:    "audit",
 			Status:       db.ScanDone,
-			Commit:       commit,
 			Model:        "test-model",
 			Profile:      "go",
 			CostUSD:      costs[i],
@@ -355,9 +355,11 @@ func TestUsage_costDriversAndOutliers(t *testing.T) {
 		"audit",
 		"SLOC",
 		"3",
+		"0.88",
+		"strong positive",
 		"Cost outliers",
 		fmt.Sprintf("/scans/%d", outlier.ID),
-		"owner/drivers",
+		"owner/drivers-3",
 		"test-model / go",
 		"15.0×",
 	} {

--- a/internal/web/usage_test.go
+++ b/internal/web/usage_test.go
@@ -91,8 +91,8 @@ func TestUsageDriverValuesByScan_appliesRootMeasurements(t *testing.T) {
 		{ID: 11, RepositoryID: 1, SkillName: "dependencies"},
 		{ID: 12, RepositoryID: 1, SkillName: "security-deep-dive"},
 		{ID: 20, RepositoryID: 1},
-		{ID: 21, RepositoryID: 1, Commit: "abc", SubPath: "cmd/tool"},
-		{ID: 22, RepositoryID: 1, Commit: "abc", FocusArea: `{"name":"parser"}`},
+		{ID: 21, RepositoryID: 1, SubPath: "cmd/tool"},
+		{ID: 22, RepositoryID: 1, FocusArea: `{"name":"parser"}`},
 	}
 	got := usageDriverValuesByScan(scans, map[uint]int{1: 100}, map[uint]int{1: 1}, map[uint]int{12: 2})
 	if got[20].SLOC == nil || *got[20].SLOC != 100 || got[20].Manifests == nil || *got[20].Manifests != 1 {

--- a/internal/web/usage_test.go
+++ b/internal/web/usage_test.go
@@ -124,6 +124,18 @@ func TestUsageDriverValuesByScan_matchesExactRootSnapshot(t *testing.T) {
 	}
 }
 
+func TestUsageRepositoryIDs(t *testing.T) {
+	got := usageRepositoryIDs([]db.Scan{
+		{RepositoryID: 3},
+		{RepositoryID: 1},
+		{RepositoryID: 3},
+		{},
+	})
+	if len(got) != 2 || got[0] != 1 || got[1] != 3 {
+		t.Fatalf("repository IDs = %v, want [1 3]", got)
+	}
+}
+
 func TestFormatUSD(t *testing.T) {
 	cases := []struct {
 		v    float64
@@ -340,6 +352,37 @@ func TestUsage_costDriversAndOutliers(t *testing.T) {
 		if !strings.Contains(body, want) {
 			t.Errorf("usage drivers page missing %q", want)
 		}
+	}
+}
+
+func TestUsage_costOutlierRendersProfileWithoutMissingModelMarker(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+
+	repo := db.Repository{URL: "https://x/profile-only", Name: "profile-only"}
+	s.DB.Create(&repo)
+	for _, cost := range []float64{1, 1, 30} {
+		s.DB.Create(&db.Scan{
+			RepositoryID: repo.ID,
+			Kind:         "skill",
+			SkillName:    "profile-only",
+			Status:       db.ScanDone,
+			Profile:      "go",
+			CostUSD:      cost,
+		})
+	}
+
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq("GET", "/usage?view=drivers"))
+	if w.Code != 200 {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, ">go</td>") {
+		t.Error("profile-only outlier did not render its profile")
+	}
+	if strings.Contains(body, "— / go") {
+		t.Error("profile-only outlier rendered a missing-model marker")
 	}
 }
 


### PR DESCRIPTION
Part of #37

## Summary

Extends the Usage dashboard with corpus-backed cost-driver analysis so operators can understand how scan cost relates to repository size and audit workload.

The new view calculates per-skill correlations and identifies scans costing at least ten times their skill's median, with direct links and supporting runtime measurements for investigation.

## Changes

- Add a `Cost drivers` view to `/usage`.
- Correlate scan cost with:
  - Source lines of code from the latest successful `repo-overview` scan for each repository.
  - The current count of distinct non-empty dependency manifest paths stored for each repository.
  - Phase 1 sink inventory size from the latest positive-cost completed `security-deep-dive` scan for each repository.
- Treat repository-level measurements as coarse latest/current corpus proxies rather than historical commit snapshots.
- Exclude subpath and focus-area scans from root-level size measurements.
- Avoid correlating `repo-overview` and `dependencies` costs against their own produced measurements.
- Calculate Pearson correlations independently per skill.
- Require at least three positive-cost observations with non-zero variance before displaying a correlation.
- Identify positive-cost scans costing at least 10x their skill median.
- Show each outlier's repository, model, profile, turns, cost baseline and available workload measurements.
- Link outlier rows directly to their scan and repository.
- Limit report parsing to the latest eligible `repo-overview` and `security-deep-dive` scan per repository, and derive manifest counts from grouped dependency rows.
- Document usage ranges, measurement provenance, outlier interpretation and analysis limitations.

## Tests

- `go test ./...`
- `go test -race ./...`
- `go test -tags evals ./...`
- `go vet ./...`
- `go vet -tags evals ./...`
- `golangci-lint run`
- `golangci-lint run --build-tags evals`
- `git diff --check`
