### PR TITLE
renovate: disable dependency dashboard

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,13 +1,12 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"],
+  "extends": ["config:recommended", ":disableDependencyDashboard"],
   "enabledManagers": [
     "gomod",
     "github-actions",
     "dockerfile",
     "custom.regex"
   ],
-  "dependencyDashboard": true,
   "automerge": false,
   "internalChecksFilter": "strict",
   "customManagers": [
@@ -92,12 +91,6 @@
       "enabled": true
     },
     {
-      "description": "Require explicit approval before starting a Go module major-version migration",
-      "matchManagers": ["gomod"],
-      "matchUpdateTypes": ["major"],
-      "dependencyDashboardApproval": true
-    },
-    {
       "description": "An indirect dependency's major version is decided by whatever requires it, never here",
       "matchManagers": ["gomod"],
       "matchDepTypes": ["indirect"],
@@ -125,7 +118,7 @@
       "minimumGroupSize": 3
     },
     {
-      "description": "Keep all four Claude Code pins on one GitHub release; do not approve a partial group in the Dependency Dashboard",
+      "description": "Keep all four Claude Code pins on one GitHub release",
       "matchPackageNames": ["anthropics/claude-code"],
       "groupName": "Claude Code",
       "minimumGroupSize": 4,


### PR DESCRIPTION
The config:recommended preset enables the Dependency Dashboard, and the direct Go-major rule uses it as an approval queue. That makes #657 a required part of the update workflow even though ordinary pull-request review is sufficient here.

This adds :disableDependencyDashboard after config:recommended so the override wins, removes Dashboard approval for direct Go major updates, and removes the Dashboard-specific wording from the Claude Code group. Direct Go majors will now arrive as ordinary PRs; indirect Go majors remain disabled, and minimumGroupSize still keeps all four Claude Code pins together. Renovate will close #657 on its next run after this lands.

The configuration validates successfully against Renovate 44.46.5.

Codex was used to implement this.