### PR TITLE
Reap orphaned scan workspaces on startup

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -419,6 +419,16 @@ type Scan struct {
 	UpdatedAt time.Time
 }
 
+// Resumable reports whether a retry can reuse this scan's harness session and
+// workspace state. Failed scans and partial successful scans that exhausted
+// their turn budget are resumable only when the harness recorded a session.
+func (s *Scan) Resumable() bool {
+	if s == nil || s.SessionID == "" {
+		return false
+	}
+	return s.Status == ScanFailed || (s.Status == ScanDone && s.MaxTurnsHit)
+}
+
 // Package is one registry entry from packages.ecosyste.ms linked to this repo.
 type Package struct {
 	ID           uint `gorm:"primarykey"`

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -422,8 +422,8 @@ type Scan struct {
 // Resumable reports whether a retry can reuse this scan's harness session and
 // workspace state. Failed scans and partial successful scans that exhausted
 // their turn budget are resumable only when the harness recorded a session.
-func (s *Scan) Resumable() bool {
-	if s == nil || s.SessionID == "" {
+func (s Scan) Resumable() bool {
+	if s.SessionID == "" {
 		return false
 	}
 	return s.Status == ScanFailed || (s.Status == ScanDone && s.MaxTurnsHit)

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -817,3 +817,26 @@ func TestStatusPriority_sortOrder(t *testing.T) {
 		t.Logf("id=%d status=%s priority=%d", sc.ID, sc.Status, sc.StatusPriority)
 	}
 }
+
+func TestScanResumable(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		scan *Scan
+		want bool
+	}{
+		{name: "failed with session", scan: &Scan{Status: ScanFailed, SessionID: "session"}, want: true},
+		{name: "done at max turns with session", scan: &Scan{Status: ScanDone, MaxTurnsHit: true, SessionID: "session"}, want: true},
+		{name: "failed without session", scan: &Scan{Status: ScanFailed}},
+		{name: "done at max turns without session", scan: &Scan{Status: ScanDone, MaxTurnsHit: true}},
+		{name: "ordinary done with session", scan: &Scan{Status: ScanDone, SessionID: "session"}},
+		{name: "cancelled with session", scan: &Scan{Status: ScanCancelled, SessionID: "session"}},
+		{name: "running with session", scan: &Scan{Status: ScanRunning, SessionID: "session"}},
+		{name: "nil scan", scan: nil},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.scan.Resumable(); got != tc.want {
+				t.Fatalf("Resumable() = %t, want %t", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -821,17 +821,16 @@ func TestStatusPriority_sortOrder(t *testing.T) {
 func TestScanResumable(t *testing.T) {
 	for _, tc := range []struct {
 		name string
-		scan *Scan
+		scan Scan
 		want bool
 	}{
-		{name: "failed with session", scan: &Scan{Status: ScanFailed, SessionID: "session"}, want: true},
-		{name: "done at max turns with session", scan: &Scan{Status: ScanDone, MaxTurnsHit: true, SessionID: "session"}, want: true},
-		{name: "failed without session", scan: &Scan{Status: ScanFailed}},
-		{name: "done at max turns without session", scan: &Scan{Status: ScanDone, MaxTurnsHit: true}},
-		{name: "ordinary done with session", scan: &Scan{Status: ScanDone, SessionID: "session"}},
-		{name: "cancelled with session", scan: &Scan{Status: ScanCancelled, SessionID: "session"}},
-		{name: "running with session", scan: &Scan{Status: ScanRunning, SessionID: "session"}},
-		{name: "nil scan", scan: nil},
+		{name: "failed with session", scan: Scan{Status: ScanFailed, SessionID: "session"}, want: true},
+		{name: "done at max turns with session", scan: Scan{Status: ScanDone, MaxTurnsHit: true, SessionID: "session"}, want: true},
+		{name: "failed without session", scan: Scan{Status: ScanFailed}},
+		{name: "done at max turns without session", scan: Scan{Status: ScanDone, MaxTurnsHit: true}},
+		{name: "ordinary done with session", scan: Scan{Status: ScanDone, SessionID: "session"}},
+		{name: "cancelled with session", scan: Scan{Status: ScanCancelled, SessionID: "session"}},
+		{name: "running with session", scan: Scan{Status: ScanRunning, SessionID: "session"}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			if got := tc.scan.Resumable(); got != tc.want {

--- a/internal/web/scans.go
+++ b/internal/web/scans.go
@@ -366,8 +366,7 @@ func (s *Server) scanRetry(w http.ResponseWriter, r *http.Request) {
 // since claude was the only backend before the column existed and the local
 // runner is claude-only.
 func (s *Server) resumeOpts(scan db.Scan) (sessionID string, resumeOf *uint) {
-	resumableStatus := scan.Status == db.ScanFailed || (scan.Status == db.ScanDone && scan.MaxTurnsHit)
-	if !resumableStatus || scan.SessionID == "" {
+	if !scan.Resumable() {
 		return "", nil
 	}
 	scanBackend := scan.Backend

--- a/internal/worker/artifact_sweep.go
+++ b/internal/worker/artifact_sweep.go
@@ -1,0 +1,95 @@
+package worker
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"scrutineer/internal/db"
+)
+
+// sweepOrphanScanArtifacts removes workspaces left behind when a process exits
+// before finalizeScan reaches its terminal cleanup. A workspace that still
+// backs an active resume must survive so the resumed harness can find its
+// source tree and session store.
+func (w *Worker) sweepOrphanScanArtifacts() (int, error) {
+	if w.DB == nil || w.DataDir == "" {
+		return 0, nil
+	}
+	entries, err := os.ReadDir(w.DataDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, nil
+		}
+		return 0, fmt.Errorf("read scan workspace root: %w", err)
+	}
+
+	var removed int
+	var sweepErr error
+	for _, entry := range entries {
+		scanID, ok := scanWorkspaceEntryID(entry)
+		if !ok {
+			continue
+		}
+		reap, err := w.scanArtifactsReapable(scanID)
+		if err != nil {
+			sweepErr = errors.Join(sweepErr, err)
+			continue
+		}
+		if !reap {
+			continue
+		}
+		if err := w.RemoveScanArtifacts(scanID); err != nil {
+			sweepErr = errors.Join(sweepErr, fmt.Errorf("remove scan %d artifacts: %w", scanID, err))
+			continue
+		}
+		removed++
+	}
+	return removed, sweepErr
+}
+
+func scanWorkspaceEntryID(entry os.DirEntry) (uint, bool) {
+	if !entry.IsDir() {
+		return 0, false
+	}
+	rawID, ok := strings.CutPrefix(entry.Name(), "scan-")
+	if !ok || rawID == "" {
+		return 0, false
+	}
+	id, err := strconv.ParseUint(rawID, 10, strconv.IntSize)
+	if err != nil || id == 0 {
+		return 0, false
+	}
+	return uint(id), true
+}
+
+func (w *Worker) scanArtifactsReapable(scanID uint) (bool, error) {
+	var scan struct {
+		ID     uint
+		Status db.ScanStatus
+	}
+	if err := w.DB.Model(&db.Scan{}).
+		Select("id, status").
+		Where("id = ?", scanID).
+		Limit(1).
+		Find(&scan).Error; err != nil {
+		return false, fmt.Errorf("load scan %d for artifact sweep: %w", scanID, err)
+	}
+	if scan.ID == 0 || !scan.Status.Terminal() {
+		return false, nil
+	}
+
+	var activeResumes int64
+	if err := w.DB.Model(&db.Scan{}).
+		Where("resumed_from_scan_id = ? AND status IN ?", scanID, []db.ScanStatus{
+			db.ScanQueued,
+			db.ScanRunning,
+			db.ScanPaused,
+		}).
+		Count(&activeResumes).Error; err != nil {
+		return false, fmt.Errorf("check scan %d resume references: %w", scanID, err)
+	}
+	return activeResumes == 0, nil
+}

--- a/internal/worker/artifact_sweep.go
+++ b/internal/worker/artifact_sweep.go
@@ -94,12 +94,7 @@ func scanArtifactEntryID(entry os.DirEntry) (uint, bool) {
 }
 
 func (w *Worker) scanArtifactSweepDecision(scanID uint) (reap, preserveState bool, err error) {
-	var scan struct {
-		ID          uint
-		Status      db.ScanStatus
-		SessionID   string
-		MaxTurnsHit bool
-	}
+	var scan db.Scan
 	if err := w.DB.Model(&db.Scan{}).
 		Select("id, status, session_id, max_turns_hit").
 		Where("id = ?", scanID).
@@ -128,6 +123,5 @@ func (w *Worker) scanArtifactSweepDecision(scanID uint) (reap, preserveState boo
 		return true, false, nil
 	}
 
-	resumable := scan.Status == db.ScanFailed || (scan.Status == db.ScanDone && scan.MaxTurnsHit)
-	return true, resumable && scan.SessionID != "", nil
+	return true, scan.Resumable(), nil
 }

--- a/internal/worker/artifact_sweep.go
+++ b/internal/worker/artifact_sweep.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -19,27 +20,30 @@ func (w *Worker) sweepOrphanScanArtifacts() (int, error) {
 	if w.DB == nil || w.DataDir == "" {
 		return 0, nil
 	}
-	entries, err := os.ReadDir(w.DataDir)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return 0, nil
+	workspaceIDs, workspaceErr := scanArtifactIDs(w.DataDir)
+	stateIDs, stateErr := scanArtifactIDs(filepath.Join(w.DataDir, harnessStateDirName))
+	candidates := make(map[uint]bool, len(workspaceIDs)+len(stateIDs))
+	for scanID := range workspaceIDs {
+		candidates[scanID] = true
+	}
+	for scanID := range stateIDs {
+		if _, ok := candidates[scanID]; !ok {
+			candidates[scanID] = false
 		}
-		return 0, fmt.Errorf("read scan workspace root: %w", err)
 	}
 
 	var removed int
-	var sweepErr error
-	for _, entry := range entries {
-		scanID, ok := scanWorkspaceEntryID(entry)
-		if !ok {
-			continue
-		}
+	sweepErr := errors.Join(workspaceErr, stateErr)
+	for scanID, hasWorkspace := range candidates {
 		reap, preserveState, err := w.scanArtifactSweepDecision(scanID)
 		if err != nil {
 			sweepErr = errors.Join(sweepErr, err)
 			continue
 		}
 		if !reap {
+			continue
+		}
+		if preserveState && !hasWorkspace {
 			continue
 		}
 		var removeErr error
@@ -57,7 +61,24 @@ func (w *Worker) sweepOrphanScanArtifacts() (int, error) {
 	return removed, sweepErr
 }
 
-func scanWorkspaceEntryID(entry os.DirEntry) (uint, bool) {
+func scanArtifactIDs(root string) (map[uint]struct{}, error) {
+	ids := make(map[uint]struct{})
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return ids, nil
+		}
+		return ids, fmt.Errorf("read scan artifact root %s: %w", root, err)
+	}
+	for _, entry := range entries {
+		if scanID, ok := scanArtifactEntryID(entry); ok {
+			ids[scanID] = struct{}{}
+		}
+	}
+	return ids, nil
+}
+
+func scanArtifactEntryID(entry os.DirEntry) (uint, bool) {
 	if !entry.IsDir() {
 		return 0, false
 	}
@@ -86,7 +107,7 @@ func (w *Worker) scanArtifactSweepDecision(scanID uint) (reap, preserveState boo
 		Find(&scan).Error; err != nil {
 		return false, false, fmt.Errorf("load scan %d for artifact sweep: %w", scanID, err)
 	}
-	if scan.ID == 0 || !scan.Status.Terminal() {
+	if scan.ID != 0 && !scan.Status.Terminal() {
 		return false, false, nil
 	}
 
@@ -102,6 +123,9 @@ func (w *Worker) scanArtifactSweepDecision(scanID uint) (reap, preserveState boo
 	}
 	if activeResumes > 0 {
 		return false, false, nil
+	}
+	if scan.ID == 0 {
+		return true, false, nil
 	}
 
 	resumable := scan.Status == db.ScanFailed || (scan.Status == db.ScanDone && scan.MaxTurnsHit)

--- a/internal/worker/artifact_sweep.go
+++ b/internal/worker/artifact_sweep.go
@@ -13,7 +13,8 @@ import (
 // sweepOrphanScanArtifacts removes workspaces left behind when a process exits
 // before finalizeScan reaches its terminal cleanup. A workspace that still
 // backs an active resume must survive so the resumed harness can find its
-// source tree and session store.
+// source tree and session store. A resumable terminal scan can shed its stale
+// workspace, but keeps the harness state needed by a future retry.
 func (w *Worker) sweepOrphanScanArtifacts() (int, error) {
 	if w.DB == nil || w.DataDir == "" {
 		return 0, nil
@@ -33,7 +34,7 @@ func (w *Worker) sweepOrphanScanArtifacts() (int, error) {
 		if !ok {
 			continue
 		}
-		reap, err := w.scanArtifactsReapable(scanID)
+		reap, preserveState, err := w.scanArtifactSweepDecision(scanID)
 		if err != nil {
 			sweepErr = errors.Join(sweepErr, err)
 			continue
@@ -41,8 +42,14 @@ func (w *Worker) sweepOrphanScanArtifacts() (int, error) {
 		if !reap {
 			continue
 		}
-		if err := w.RemoveScanArtifacts(scanID); err != nil {
-			sweepErr = errors.Join(sweepErr, fmt.Errorf("remove scan %d artifacts: %w", scanID, err))
+		var removeErr error
+		if preserveState {
+			removeErr = os.RemoveAll(w.workRoot(scanID))
+		} else {
+			removeErr = w.RemoveScanArtifacts(scanID)
+		}
+		if removeErr != nil {
+			sweepErr = errors.Join(sweepErr, fmt.Errorf("remove scan %d artifacts: %w", scanID, removeErr))
 			continue
 		}
 		removed++
@@ -65,20 +72,22 @@ func scanWorkspaceEntryID(entry os.DirEntry) (uint, bool) {
 	return uint(id), true
 }
 
-func (w *Worker) scanArtifactsReapable(scanID uint) (bool, error) {
+func (w *Worker) scanArtifactSweepDecision(scanID uint) (reap, preserveState bool, err error) {
 	var scan struct {
-		ID     uint
-		Status db.ScanStatus
+		ID          uint
+		Status      db.ScanStatus
+		SessionID   string
+		MaxTurnsHit bool
 	}
 	if err := w.DB.Model(&db.Scan{}).
-		Select("id, status").
+		Select("id, status, session_id, max_turns_hit").
 		Where("id = ?", scanID).
 		Limit(1).
 		Find(&scan).Error; err != nil {
-		return false, fmt.Errorf("load scan %d for artifact sweep: %w", scanID, err)
+		return false, false, fmt.Errorf("load scan %d for artifact sweep: %w", scanID, err)
 	}
 	if scan.ID == 0 || !scan.Status.Terminal() {
-		return false, nil
+		return false, false, nil
 	}
 
 	var activeResumes int64
@@ -89,7 +98,12 @@ func (w *Worker) scanArtifactsReapable(scanID uint) (bool, error) {
 			db.ScanPaused,
 		}).
 		Count(&activeResumes).Error; err != nil {
-		return false, fmt.Errorf("check scan %d resume references: %w", scanID, err)
+		return false, false, fmt.Errorf("check scan %d resume references: %w", scanID, err)
 	}
-	return activeResumes == 0, nil
+	if activeResumes > 0 {
+		return false, false, nil
+	}
+
+	resumable := scan.Status == db.ScanFailed || (scan.Status == db.ScanDone && scan.MaxTurnsHit)
+	return true, resumable && scan.SessionID != "", nil
 }

--- a/internal/worker/artifact_sweep_test.go
+++ b/internal/worker/artifact_sweep_test.go
@@ -106,7 +106,6 @@ func TestSweepOrphanScanArtifactsRemovesNonResumableState(t *testing.T) {
 	}
 
 	w := &Worker{DB: gdb, DataDir: t.TempDir()}
-	writeScanArtifact(t, w.workRoot(scan.ID))
 	writeScanArtifact(t, w.harnessStateDirID(scan.ID))
 	removed, err := w.sweepOrphanScanArtifacts()
 	if err != nil {
@@ -115,9 +114,28 @@ func TestSweepOrphanScanArtifactsRemovesNonResumableState(t *testing.T) {
 	if removed != 1 {
 		t.Fatalf("removed = %d, want 1", removed)
 	}
-	for _, path := range []string{w.workRoot(scan.ID), w.harnessStateDirID(scan.ID)} {
-		assertPathMissing(t, path)
+	assertPathMissing(t, w.harnessStateDirID(scan.ID))
+}
+
+func TestSweepOrphanScanArtifactsRemovesMissingScanRow(t *testing.T) {
+	gdb, err := db.Open(filepath.Join(t.TempDir(), "sweep.db"))
+	if err != nil {
+		t.Fatal(err)
 	}
+	w := &Worker{DB: gdb, DataDir: t.TempDir()}
+	const missingScanID = 404
+	writeScanArtifact(t, w.workRoot(missingScanID))
+	writeScanArtifact(t, w.harnessStateDirID(missingScanID))
+
+	removed, err := w.sweepOrphanScanArtifacts()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if removed != 1 {
+		t.Fatalf("removed = %d, want 1", removed)
+	}
+	assertPathMissing(t, w.workRoot(missingScanID))
+	assertPathMissing(t, w.harnessStateDirID(missingScanID))
 }
 
 func TestSweepOrphanScanArtifactsMissingRootIsNoop(t *testing.T) {

--- a/internal/worker/artifact_sweep_test.go
+++ b/internal/worker/artifact_sweep_test.go
@@ -19,33 +19,33 @@ func TestSweepOrphanScanArtifacts(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	createScan := func(status db.ScanStatus, resumedFrom *uint) db.Scan {
+	createScan := func(scan db.Scan) db.Scan {
 		t.Helper()
-		scan := db.Scan{
-			RepositoryID:      repo.ID,
-			Kind:              JobSkill,
-			Status:            status,
-			ResumedFromScanID: resumedFrom,
-		}
+		scan.RepositoryID = repo.ID
+		scan.Kind = JobSkill
 		if err := gdb.Create(&scan).Error; err != nil {
 			t.Fatal(err)
 		}
 		return scan
 	}
 
-	crashed := createScan(db.ScanRunning, nil)
-	historical := createScan(db.ScanFailed, nil)
-	queuedRoot := createScan(db.ScanFailed, nil)
-	createScan(db.ScanQueued, &queuedRoot.ID)
-	pausedRoot := createScan(db.ScanFailed, nil)
-	createScan(db.ScanPaused, &pausedRoot.ID)
-	queued := createScan(db.ScanQueued, nil)
-	stateOnly := createScan(db.ScanFailed, nil)
+	crashed := createScan(db.Scan{Status: db.ScanRunning, SessionID: "crashed-session"})
+	historical := createScan(db.Scan{Status: db.ScanFailed})
+	maxTurns := createScan(db.Scan{
+		Status: db.ScanDone, SessionID: "max-turns-session", MaxTurnsHit: true,
+	})
+	queuedRoot := createScan(db.Scan{Status: db.ScanFailed})
+	createScan(db.Scan{Status: db.ScanQueued, ResumedFromScanID: &queuedRoot.ID})
+	pausedRoot := createScan(db.Scan{Status: db.ScanFailed})
+	createScan(db.Scan{Status: db.ScanPaused, ResumedFromScanID: &pausedRoot.ID})
+	queued := createScan(db.Scan{Status: db.ScanQueued})
+	stateOnly := createScan(db.Scan{Status: db.ScanFailed, SessionID: "state-only-session"})
 
 	w := &Worker{DB: gdb, DataDir: t.TempDir()}
 	withArtifacts := []uint{
 		crashed.ID,
 		historical.ID,
+		maxTurns.ID,
 		queuedRoot.ID,
 		pausedRoot.ID,
 		queued.ID,
@@ -67,14 +67,16 @@ func TestSweepOrphanScanArtifacts(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if removed != 2 {
-		t.Fatalf("removed = %d, want 2", removed)
+	if removed != 3 {
+		t.Fatalf("removed = %d, want 3", removed)
 	}
 
-	for _, id := range []uint{crashed.ID, historical.ID} {
+	for _, id := range []uint{crashed.ID, historical.ID, maxTurns.ID} {
 		assertPathMissing(t, w.workRoot(id))
-		assertPathMissing(t, w.harnessStateDirID(id))
 	}
+	assertPathExists(t, w.harnessStateDirID(crashed.ID))
+	assertPathExists(t, w.harnessStateDirID(maxTurns.ID))
+	assertPathMissing(t, w.harnessStateDirID(historical.ID))
 	for _, id := range []uint{queuedRoot.ID, pausedRoot.ID, queued.ID} {
 		assertPathExists(t, w.workRoot(id))
 		assertPathExists(t, w.harnessStateDirID(id))
@@ -82,6 +84,40 @@ func TestSweepOrphanScanArtifacts(t *testing.T) {
 	assertPathExists(t, w.harnessStateDirID(stateOnly.ID))
 	assertPathExists(t, filepath.Join(w.DataDir, "scan-not-an-id"))
 	assertPathExists(t, filepath.Join(w.DataDir, "scan-9999"))
+}
+
+func TestSweepOrphanScanArtifactsRemovesNonResumableState(t *testing.T) {
+	gdb, err := db.Open(filepath.Join(t.TempDir(), "sweep.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo := db.Repository{URL: "https://example.com/repo", Name: "repo"}
+	if err := gdb.Create(&repo).Error; err != nil {
+		t.Fatal(err)
+	}
+	scan := db.Scan{
+		RepositoryID: repo.ID,
+		Kind:         JobSkill,
+		Status:       db.ScanCancelled,
+		SessionID:    "not-resumable",
+	}
+	if err := gdb.Create(&scan).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	w := &Worker{DB: gdb, DataDir: t.TempDir()}
+	writeScanArtifact(t, w.workRoot(scan.ID))
+	writeScanArtifact(t, w.harnessStateDirID(scan.ID))
+	removed, err := w.sweepOrphanScanArtifacts()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if removed != 1 {
+		t.Fatalf("removed = %d, want 1", removed)
+	}
+	for _, path := range []string{w.workRoot(scan.ID), w.harnessStateDirID(scan.ID)} {
+		assertPathMissing(t, path)
+	}
 }
 
 func TestSweepOrphanScanArtifactsMissingRootIsNoop(t *testing.T) {

--- a/internal/worker/artifact_sweep_test.go
+++ b/internal/worker/artifact_sweep_test.go
@@ -1,0 +1,124 @@
+package worker
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"scrutineer/internal/db"
+)
+
+func TestSweepOrphanScanArtifacts(t *testing.T) {
+	gdb, err := db.Open(filepath.Join(t.TempDir(), "sweep.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo := db.Repository{URL: "https://example.com/repo", Name: "repo"}
+	if err := gdb.Create(&repo).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	createScan := func(status db.ScanStatus, resumedFrom *uint) db.Scan {
+		t.Helper()
+		scan := db.Scan{
+			RepositoryID:      repo.ID,
+			Kind:              JobSkill,
+			Status:            status,
+			ResumedFromScanID: resumedFrom,
+		}
+		if err := gdb.Create(&scan).Error; err != nil {
+			t.Fatal(err)
+		}
+		return scan
+	}
+
+	crashed := createScan(db.ScanRunning, nil)
+	historical := createScan(db.ScanFailed, nil)
+	queuedRoot := createScan(db.ScanFailed, nil)
+	createScan(db.ScanQueued, &queuedRoot.ID)
+	pausedRoot := createScan(db.ScanFailed, nil)
+	createScan(db.ScanPaused, &pausedRoot.ID)
+	queued := createScan(db.ScanQueued, nil)
+	stateOnly := createScan(db.ScanFailed, nil)
+
+	w := &Worker{DB: gdb, DataDir: t.TempDir()}
+	withArtifacts := []uint{
+		crashed.ID,
+		historical.ID,
+		queuedRoot.ID,
+		pausedRoot.ID,
+		queued.ID,
+	}
+	for _, id := range withArtifacts {
+		writeScanArtifact(t, w.workRoot(id))
+		writeScanArtifact(t, w.harnessStateDirID(id))
+	}
+	writeScanArtifact(t, w.harnessStateDirID(stateOnly.ID))
+	writeScanArtifact(t, filepath.Join(w.DataDir, "scan-not-an-id"))
+	if err := os.WriteFile(filepath.Join(w.DataDir, "scan-9999"), []byte("not a directory"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := db.SweepRunning(gdb); err != nil {
+		t.Fatal(err)
+	}
+	removed, err := w.sweepOrphanScanArtifacts()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if removed != 2 {
+		t.Fatalf("removed = %d, want 2", removed)
+	}
+
+	for _, id := range []uint{crashed.ID, historical.ID} {
+		assertPathMissing(t, w.workRoot(id))
+		assertPathMissing(t, w.harnessStateDirID(id))
+	}
+	for _, id := range []uint{queuedRoot.ID, pausedRoot.ID, queued.ID} {
+		assertPathExists(t, w.workRoot(id))
+		assertPathExists(t, w.harnessStateDirID(id))
+	}
+	assertPathExists(t, w.harnessStateDirID(stateOnly.ID))
+	assertPathExists(t, filepath.Join(w.DataDir, "scan-not-an-id"))
+	assertPathExists(t, filepath.Join(w.DataDir, "scan-9999"))
+}
+
+func TestSweepOrphanScanArtifactsMissingRootIsNoop(t *testing.T) {
+	gdb, err := db.Open(filepath.Join(t.TempDir(), "sweep.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	w := &Worker{DB: gdb, DataDir: filepath.Join(t.TempDir(), "missing")}
+	removed, err := w.sweepOrphanScanArtifacts()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if removed != 0 {
+		t.Fatalf("removed = %d, want 0", removed)
+	}
+}
+
+func writeScanArtifact(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "artifact"), []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func assertPathExists(t *testing.T, path string) {
+	t.Helper()
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("expected %s to exist: %v", path, err)
+	}
+}
+
+func assertPathMissing(t *testing.T, path string) {
+	t.Helper()
+	if _, err := os.Stat(path); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected %s to be removed, stat error = %v", path, err)
+	}
+}

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -569,6 +569,11 @@ func (w *Worker) clearSessionStore(scan *db.Scan) {
 func (w *Worker) Register(q *queue.Queue) {
 	w.Queue = q
 	w.migrateLegacyState()
+	if removed, err := w.sweepOrphanScanArtifacts(); err != nil {
+		w.Log.Warn("orphan scan artifact sweep failed", "removed", removed, "err", err)
+	} else if removed > 0 {
+		w.Log.Info("removed orphan scan artifacts", "count", removed)
+	}
 	q.Register(JobSkill, w.wrap(w.doSkill))
 	q.Register(JobExposure, w.wrap(w.doExposure))
 	w.scheduleNextAccountResume()


### PR DESCRIPTION
Fixes #933

## Summary

Adds startup cleanup for scan workspaces left behind when _Scrutineer_ exits before a running scan reaches its normal terminal cleanup.

The reaper runs after legacy harness-state migration and before queue handlers are registered.

## Changes

- Inspect exact `scan-<id>` directories under the worker data directory during startup.
- Remove workspaces belonging to terminal scans.
- Remove the corresponding persisted harness-state directory at the same time.
- Preserve workspace roots referenced by queued, running or paused resume scans.
- Preserve state-only directories used by normally failed resumable scans.
- Ignore malformed directory names, unrelated files and scans that are not terminal.
- Continue processing other entries when an individual lookup or removal fails, while reporting the accumulated error.
- Log the number of orphaned scan artifacts removed.

## Tests

- Add coverage for workspaces left by scans that were running during a restart.
- Add coverage for historical failed-scan workspaces.
- Verify queued and paused resume lineages remain intact.
- Verify active scan workspaces and state-only resume stores are preserved.
- Verify malformed entries and regular files are ignored.
- Verify a missing workspace root is a no-op.

## Verification

- `go mod tidy -diff`
- `go test ./...`
- `go test -race ./internal/worker -count=1 -timeout=5m`
- `go test -race ./internal/web -count=1 -timeout=5m`
- `go vet ./...`
- `go vet -tags evals ./internal/evals/...`
- `go test -race -tags evals ./internal/evals/...`
- `go vet -tags podman ./...`
- `golangci-lint v2.12.2`
- `git diff --check`