### PR TITLE
fix(skills): accept release_watch in the triage report schema

### DIFF
--- a/internal/worker/schema_bundled_test.go
+++ b/internal/worker/schema_bundled_test.go
@@ -66,7 +66,7 @@ func TestBundledSchemas_compileAndAcceptSamples(t *testing.T) {
 			    "native_signals":["language:Go","language:C"]},
 			  "triggered":["packages","advisories","security-deep-dive"],
 			  "skipped":["semgrep"],"gated":[],"already_done":["metadata"],
-			  "verify":[12,34],"errors":[]}`,
+			  "verify":[12,34],"release_watch":[55,56],"errors":[]}`,
 		},
 		{
 			"../../skills/triage/schema.json",
@@ -547,6 +547,7 @@ func TestBundledSchemas_rejectBadShapes(t *testing.T) {
 	}{
 		{"../../skills/triage/schema.json", `{"triggered":"not-a-list"}`, "/triggered"},
 		{"../../skills/triage/schema.json", `{"triggered":["Bad Name"]}`, "/triggered/0"},
+		{"../../skills/triage/schema.json", `{"release_watch":["55"]}`, "/release_watch/0"},
 		{"../../skills/bandit/schema.json",
 			`{"findings":[{"id":"F1","title":"B608","severity":"Severe","location":"app.py:9"}]}`,
 			"/findings/0/severity"},

--- a/skills/triage/SKILL.md
+++ b/skills/triage/SKILL.md
@@ -111,7 +111,7 @@ Do not verify findings in `new`, `enriched`, `triaged`, `ready`, `published`, `r
 
 ## Watch fixed findings for an upstream release
 
-When a finding reaches `fixed` the maintainer has landed a patch, but consumers cannot pin to a commit — they need a tagged release. For findings in `status=fixed`, enqueue release-watch the same way: `POST {api_base}/findings/{id}/skills/release-watch/run`. Record the ids in a `release_watch` field of your report. If the endpoint returns `404 skill not found or inactive`, leave the field empty and carry on. Release-watch is idempotent: a finding that already has a release recorded re-confirms the existing value rather than flapping.
+When a finding reaches `fixed` the maintainer has landed a patch, but consumers cannot pin to a commit — they need a tagged release. For findings in `status=fixed`, enqueue release-watch the same way: `POST {api_base}/findings/{id}/skills/release-watch/run`. Record the ids in a `release_watch` field of your report; if there are none, write an empty list. If the endpoint returns `404 skill not found or inactive`, write an empty list and carry on. Release-watch is idempotent: a finding that already has a release recorded re-confirms the existing value rather than flapping.
 
 ## Output
 

--- a/skills/triage/schema.json
+++ b/skills/triage/schema.json
@@ -29,6 +29,11 @@
       "items": { "type": "integer", "minimum": 1 },
       "description": "Finding ids that had a verify run enqueued."
     },
+    "release_watch": {
+      "type": "array",
+      "items": { "type": "integer", "minimum": 1 },
+      "description": "Finding ids that had a release-watch run enqueued."
+    },
     "errors": {
       "type": "array",
       "items": { "type": "string" },


### PR DESCRIPTION
`skills/triage/SKILL.md` tells the model to record ids in a `release_watch` field, but `schema.json` sets `additionalProperties: false` without declaring it, so `ValidateSkillReport` rejects any triage run that enqueues one. The schema declares the key with the same shape as `verify`, and the release-watch paragraph spells out the empty case the way the `verify` one does.