### PR TITLE
update git-pkgs to 0.19.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN pip install --no-cache-dir semgrep==1.167.0 "setuptools<81"
 
 FROM golang:1.27.0-alpine@sha256:4c9fe60190a2a3350ddc51de80d0224b8a6698d12bdfc999fee45ea9d6c46dbc AS go-tools
 RUN apk add --no-cache git
-RUN GOBIN=/out go install github.com/git-pkgs/git-pkgs@v0.15.3 && \
+RUN GOBIN=/out go install github.com/git-pkgs/git-pkgs@v0.19.0 && \
     GOBIN=/out go install github.com/git-pkgs/brief/cmd/brief@v0.12.0
 
 # vid links tree-sitter grammars (C), so unlike the main binary it needs

--- a/Dockerfile.runner
+++ b/Dockerfile.runner
@@ -15,7 +15,7 @@ ARG COPILOT_VERSION=1.0.80
 ARG SEMGREP_VERSION=1.167.0
 
 FROM golang:1.26.6-trixie@sha256:b75d466dd608587fd66cca705a307ba65b889827d06ad61d6a75f0482b51b7c7 AS go-tools
-RUN GOBIN=/out go install github.com/git-pkgs/git-pkgs@v0.15.3 && \
+RUN GOBIN=/out go install github.com/git-pkgs/git-pkgs@v0.19.0 && \
     GOBIN=/out go install github.com/git-pkgs/brief/cmd/brief@v0.12.0
 
 FROM rust:1.97-trixie@sha256:3382bd20aa942806c533e9a73cd000474fb3ef173f71e684cc9b942675781769 AS zizmor-build

--- a/threatmodel.md
+++ b/threatmodel.md
@@ -120,7 +120,7 @@ No rate limiting on `POST /repositories`, no cap on clone size, no timeout on th
 
 ### T11: Image supply chain (partially mitigated)
 
-Tool versions are pinned: `claude-code@2.1.241`, `semgrep==1.167.0`, `git-pkgs@v0.15.3`, `zizmor@1.26.1`. The final stage is `debian:trixie-slim`; the `golang:1.27.0-trixie` and `rust:1.96-trixie` builder stages are pinned by sha256 digest. The container runs as non-root user `runner`. The runner image is built in CI, smoke-tested, and published to GHCR; users pull a known-good artifact rather than rebuilding against live registries.
+Tool versions are pinned: `claude-code@2.1.241`, `semgrep==1.167.0`, `git-pkgs@v0.19.0`, `zizmor@1.26.1`. The final stage is `debian:trixie-slim`; the `golang:1.27.0-trixie` and `rust:1.96-trixie` builder stages are pinned by sha256 digest. The container runs as non-root user `runner`. The runner image is built in CI, smoke-tested, and published to GHCR; users pull a known-good artifact rather than rebuilding against live registries.
 
 Supply-chain surface in the final stage:
 - `apt` pulls from Debian's official mirrors plus the GitHub CLI repo at `cli.github.com/packages` (signed-by keyring under `/etc/apt/keyrings/`). `gh` is used at scan time by the `fork` and `report-upstream` skills.


### PR DESCRIPTION
With this bumped i can get opam dependencies in my ocaml project! yay!

<img width="1512" height="773" alt="image" src="https://github.com/user-attachments/assets/d0a2f559-0070-4b77-8283-448e57f1100f" />
