### PR TITLE
Speed up DB-backed tests under -race

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -80,8 +80,13 @@ jobs:
       - name: Vet
         run: go vet ./...
 
+      # modernc.org/sqlite is machine-transpiled C and does unsafe.Pointer
+      # arithmetic on every VDBE step; -race enables checkptr, and validating
+      # those conversions dominates the DB-heavy packages' runtime. Disabling
+      # checkptr for that tree keeps TSAN's data-race detection while dropping
+      # the per-op pointer validation the transpiler already guarantees.
       - name: Test
-        run: go test -race ./...
+        run: go test -race -gcflags='modernc.org/...=-d=checkptr=0' ./...
 
       # The deterministic eval harness is behind //go:build evals. Live model
       # runs remain disabled unless SCRUTINEER_RUN_EVALS is explicitly set.

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /data/
 /data-*/
 /scrutineer
+*.test
 *.db
 *.db-shm
 *.db-wal

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -1551,13 +1551,23 @@ func withPragmas(dsn string) string {
 	return dsn + sep + connectionPragmas
 }
 
-func Open(dsn string) (*gorm.DB, error) {
+// Connect opens dsn with the standard pragmas and logger but performs no
+// migration. Open is Connect plus the full migration path.
+func Connect(dsn string) (*gorm.DB, error) {
 	cfg := &gorm.Config{
 		Logger: logger.Default.LogMode(logger.Warn),
 	}
 	gdb, err := gorm.Open(sqlite.Open(withPragmas(dsn)), cfg)
 	if err != nil {
 		return nil, fmt.Errorf("open sqlite: %w", err)
+	}
+	return gdb, nil
+}
+
+func Open(dsn string) (*gorm.DB, error) {
+	gdb, err := Connect(dsn)
+	if err != nil {
+		return nil, err
 	}
 	foundSchemaVersion, err := checkDatabaseSchemaVersion(gdb)
 	if err != nil {

--- a/internal/db/dbtest/dbtest.go
+++ b/internal/db/dbtest/dbtest.go
@@ -35,7 +35,9 @@ var schema = sync.OnceValue(func() string {
 	}()
 	var stmts []string
 	if err := gdb.Raw(
-		"SELECT sql FROM sqlite_schema WHERE sql IS NOT NULL AND name NOT LIKE 'sqlite_%'",
+		"SELECT sql FROM sqlite_schema" +
+			" WHERE sql IS NOT NULL AND name NOT LIKE 'sqlite_%'" +
+			" ORDER BY CASE type WHEN 'table' THEN 0 ELSE 1 END, rowid",
 	).Scan(&stmts).Error; err != nil {
 		panic("dbtest: read schema: " + err.Error())
 	}

--- a/internal/db/dbtest/dbtest.go
+++ b/internal/db/dbtest/dbtest.go
@@ -1,21 +1,21 @@
-// Package dbtest opens per-test in-memory SQLite databases with the schema
-// pre-applied from a cached DDL snapshot, avoiding a full GORM AutoMigrate
-// on every test. AutoMigrate for the ~30 scrutineer models costs ~265ms
-// under -race (checkptr + TSAN over modernc.org/sqlite's transpiled unsafe
-// pointer arithmetic); at ~700 test servers in internal/web that dominates
-// the package's runtime. Replaying the captured DDL as one batch skips the
-// GORM reflection pass.
+// Package dbtest opens per-test SQLite databases from a cached template
+// image, avoiding a full GORM AutoMigrate on every test. AutoMigrate for
+// the ~30 scrutineer models costs ~265ms under -race (checkptr + TSAN over
+// modernc.org/sqlite's transpiled unsafe pointer arithmetic); at ~700 test
+// servers in internal/web that dominates the package's runtime. Writing a
+// pre-migrated database file and opening it per test skips both GORM's
+// reflection and the DDL execution, at ~20ms/call.
 //
-// SQLite-only by design: unit tests run on in-memory SQLite regardless of
-// the production dialect. Postgres coverage lives in the separate opt-in
+// SQLite-only by design: unit tests run on SQLite regardless of the
+// production dialect. Postgres coverage lives in the separate opt-in
 // smoke tests.
 package dbtest
 
 import (
 	"fmt"
-	"strings"
+	"os"
+	"path/filepath"
 	"sync"
-	"sync/atomic"
 	"testing"
 
 	"gorm.io/gorm"
@@ -23,7 +23,9 @@ import (
 	"scrutineer/internal/db"
 )
 
-var schema = sync.OnceValue(func() string {
+const dbFilePerm = 0o600
+
+var template = sync.OnceValue(func() []byte {
 	gdb, err := db.Open("file::memory:")
 	if err != nil {
 		panic("dbtest: capture schema: " + err.Error())
@@ -33,32 +35,32 @@ var schema = sync.OnceValue(func() string {
 			_ = sqldb.Close()
 		}
 	}()
-	var stmts []string
-	if err := gdb.Raw(
-		"SELECT sql FROM sqlite_schema" +
-			" WHERE sql IS NOT NULL AND name NOT LIKE 'sqlite_%'" +
-			" ORDER BY CASE type WHEN 'table' THEN 0 ELSE 1 END, rowid",
-	).Scan(&stmts).Error; err != nil {
-		panic("dbtest: read schema: " + err.Error())
+	path := filepath.Join(os.TempDir(), fmt.Sprintf("dbtest-template-%d.db", os.Getpid()))
+	_ = os.Remove(path)
+	if err := gdb.Exec("VACUUM INTO ?", path).Error; err != nil {
+		panic("dbtest: vacuum template: " + err.Error())
 	}
-	return strings.Join(stmts, ";\n") + ";"
+	buf, err := os.ReadFile(path)
+	if err != nil {
+		panic("dbtest: read template: " + err.Error())
+	}
+	_ = os.Remove(path)
+	return buf
 })
 
-var seq atomic.Uint64
-
-// Open returns a fresh in-memory *gorm.DB with the full scrutineer schema
-// already applied, and registers a cleanup to close it. Each call gets its
-// own named in-memory database so repeated calls within one test, and
-// t.Parallel tests, do not share state.
+// Open returns a fresh file-backed *gorm.DB with the full scrutineer schema
+// already applied, and registers a cleanup to close it. Each call writes
+// its own copy of the template into tb.TempDir, so repeated calls in one
+// test and t.Parallel tests do not share state.
 func Open(tb testing.TB) *gorm.DB {
 	tb.Helper()
-	dsn := fmt.Sprintf("file:dbtest%d?mode=memory&cache=shared", seq.Add(1))
-	gdb, err := db.Connect(dsn)
+	path := filepath.Join(tb.TempDir(), "dbtest.db")
+	if err := os.WriteFile(path, template(), dbFilePerm); err != nil {
+		tb.Fatalf("dbtest: write template: %v", err)
+	}
+	gdb, err := db.Connect(path)
 	if err != nil {
 		tb.Fatalf("dbtest: connect: %v", err)
-	}
-	if err := gdb.Exec(schema()).Error; err != nil {
-		tb.Fatalf("dbtest: apply schema: %v", err)
 	}
 	tb.Cleanup(func() {
 		if sqldb, _ := gdb.DB(); sqldb != nil {

--- a/internal/db/dbtest/dbtest.go
+++ b/internal/db/dbtest/dbtest.go
@@ -1,0 +1,67 @@
+// Package dbtest opens per-test in-memory SQLite databases with the schema
+// pre-applied from a cached DDL snapshot, avoiding a full GORM AutoMigrate
+// on every test. AutoMigrate for the ~30 scrutineer models costs ~265ms
+// under -race (checkptr + TSAN over modernc.org/sqlite's transpiled unsafe
+// pointer arithmetic); at ~700 test servers in internal/web that dominates
+// the package's runtime. Replaying the captured DDL as one batch skips the
+// GORM reflection pass.
+//
+// SQLite-only by design: unit tests run on in-memory SQLite regardless of
+// the production dialect. Postgres coverage lives in the separate opt-in
+// smoke tests.
+package dbtest
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"gorm.io/gorm"
+
+	"scrutineer/internal/db"
+)
+
+var schema = sync.OnceValue(func() string {
+	gdb, err := db.Open("file::memory:")
+	if err != nil {
+		panic("dbtest: capture schema: " + err.Error())
+	}
+	defer func() {
+		if sqldb, _ := gdb.DB(); sqldb != nil {
+			_ = sqldb.Close()
+		}
+	}()
+	var stmts []string
+	if err := gdb.Raw(
+		"SELECT sql FROM sqlite_schema WHERE sql IS NOT NULL AND name NOT LIKE 'sqlite_%'",
+	).Scan(&stmts).Error; err != nil {
+		panic("dbtest: read schema: " + err.Error())
+	}
+	return strings.Join(stmts, ";\n") + ";"
+})
+
+var seq atomic.Uint64
+
+// Open returns a fresh in-memory *gorm.DB with the full scrutineer schema
+// already applied, and registers a cleanup to close it. Each call gets its
+// own named in-memory database so repeated calls within one test, and
+// t.Parallel tests, do not share state.
+func Open(tb testing.TB) *gorm.DB {
+	tb.Helper()
+	dsn := fmt.Sprintf("file:dbtest%d?mode=memory&cache=shared", seq.Add(1))
+	gdb, err := db.Connect(dsn)
+	if err != nil {
+		tb.Fatalf("dbtest: connect: %v", err)
+	}
+	if err := gdb.Exec(schema()).Error; err != nil {
+		tb.Fatalf("dbtest: apply schema: %v", err)
+	}
+	tb.Cleanup(func() {
+		if sqldb, _ := gdb.DB(); sqldb != nil {
+			_ = sqldb.Close()
+		}
+	})
+	return gdb
+}

--- a/internal/db/dbtest/dbtest_test.go
+++ b/internal/db/dbtest/dbtest_test.go
@@ -1,0 +1,53 @@
+package dbtest
+
+import (
+	"testing"
+
+	"scrutineer/internal/db"
+)
+
+func TestOpen_isolatedPerCall(t *testing.T) {
+	a := Open(t)
+	b := Open(t)
+
+	if err := a.Create(&db.Repository{URL: "https://example.com/a", Name: "a"}).Error; err != nil {
+		t.Fatalf("create in a: %v", err)
+	}
+	var n int64
+	if err := b.Model(&db.Repository{}).Count(&n).Error; err != nil {
+		t.Fatalf("count in b: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("second Open sees %d rows from first; want isolated", n)
+	}
+}
+
+func TestOpen_schemaMatchesAutoMigrate(t *testing.T) {
+	fast := Open(t)
+	full, err := db.Open("file::memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if sqldb, _ := full.DB(); sqldb != nil {
+			_ = sqldb.Close()
+		}
+	})
+
+	const q = "SELECT type || ' ' || name FROM sqlite_schema WHERE name NOT LIKE 'sqlite_%' ORDER BY 1"
+	var fromFast, fromFull []string
+	if err := fast.Raw(q).Scan(&fromFast).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := full.Raw(q).Scan(&fromFull).Error; err != nil {
+		t.Fatal(err)
+	}
+	if len(fromFast) != len(fromFull) {
+		t.Fatalf("object count differs: fast=%d full=%d", len(fromFast), len(fromFull))
+	}
+	for i := range fromFull {
+		if fromFast[i] != fromFull[i] {
+			t.Errorf("schema mismatch at %d: fast=%q full=%q", i, fromFast[i], fromFull[i])
+		}
+	}
+}

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -19,16 +19,14 @@ import (
 	"time"
 
 	"scrutineer/internal/db"
+	"scrutineer/internal/db/dbtest"
 	"scrutineer/internal/queue"
 	"scrutineer/internal/worker"
 )
 
 func newTestServer(t testing.TB) (*Server, func()) {
 	t.Helper()
-	gdb, err := db.Open("file::memory:?cache=shared")
-	if err != nil {
-		t.Fatal(err)
-	}
+	gdb := dbtest.Open(t)
 	sqldb, _ := gdb.DB()
 	log := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	q, err := queue.New(sqldb, log, 0)


### PR DESCRIPTION
`newTestServer` runs `db.Open`, and with it a 30-model AutoMigrate, once per test. Under `-race` that is about half of `internal/web`'s runtime because `modernc.org/sqlite` is transpiled C and every VDBE step trips checkptr.

`dbtest.Open` runs `db.Open` once, `VACUUM INTO` a template file, and per test writes a copy of that file into `t.TempDir()` and opens it. No AutoMigrate, no DDL execution. Each call gets its own file so repeated calls in one test and parallel tests are isolated.

`db.Connect` is `db.Open` without the migration, split out so `dbtest` can open bare.

The CI test step also disables checkptr for `modernc.org/...` only. TSAN still runs; the pointer checks it drops validate the transpiler rather than scrutineer.

`internal/web` under `-race` locally: 283s to 100s. Stacking the CI flag: 82s.