### PR TITLE
Stop scan tokens changing other findings' lifecycle

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -104,7 +104,7 @@ The Scans tab fragment reads a narrowed projection (`scanRowColumns`) rather tha
 
 ## Skill HTTP API
 
-`/api` is a bearer-authenticated surface that running skills call back into. Each scan gets a random token on enqueue; the worker writes it into the workspace's `context.json`. Middleware (`apiAuth`) validates the token against the active scan row and enforces that a scan only touches resources on its own repository.
+`/api` is a bearer-authenticated surface that running skills call back into. Each scan gets a random token on enqueue; the worker writes it into the workspace's `context.json`. Middleware (`apiAuth`) validates the token against the active scan row and enforces that a scan only touches resources on its own repository. Direct finding-field PATCHes additionally require the scan's `FindingID` to match the target; finding child records remain repository-scoped for repository-wide skills.
 
 See `openapi.yaml` at the repo root for the full surface. The `triage` bundled skill is the reference example.
 

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -246,9 +246,9 @@ Bundled skills with typed output kinds carry a schema; skills with `output_kind:
 
 ## Calling scrutineer from a skill
 
-`context.json` carries `scrutineer.api_base` and a per-scan bearer `scrutineer.token`. With those a skill can read prior scan results for the same repository, enqueue further scans, fetch maintainers, packages, advisories, dependents, and findings, and write notes and field updates back to a finding. The full surface is documented in [openapi.yaml](../openapi.yaml) at the repository root. The `triage` skill is the reference example for enqueueing; `disclose` and `patch` are the reference examples for finding writes.
+`context.json` carries `scrutineer.api_base` and a per-scan bearer `scrutineer.token`. With those a skill can read prior scan results for the same repository, enqueue further scans, fetch maintainers, packages, advisories, dependents, and findings, and write notes back to findings. A finding-scoped skill can also update mutable fields on the finding named by `finding_id`. The full surface is documented in [openapi.yaml](../openapi.yaml) at the repository root. The `triage` skill is the reference example for enqueueing; `disclose` and `patch` are the reference examples for finding writes.
 
-The token is scoped to the scan's own repository: a skill cannot read or write rows belonging to other repositories.
+The token is scoped to the scan's own repository: a skill cannot read or write rows belonging to other repositories. Direct field updates are narrower and require the scan's `finding_id` to match the target finding. Notes, communications, references, and labels retain repository scope so repository-wide skills can manage associated context across findings.
 
 ## Loading skills
 

--- a/internal/db/ecosystem.go
+++ b/internal/db/ecosystem.go
@@ -143,14 +143,25 @@ type DependencyFinding struct {
 	Boundary   string           `json:"boundary"`
 }
 
+// dependencyFindingVisibleLifecycles are at or past maintainer notification
+// in the finding workflow. A positive allowlist keeps unpublished, rejected,
+// unknown, and future lifecycle values from crossing repository boundaries.
+var dependencyFindingVisibleLifecycles = []FindingLifecycle{
+	FindingReported,
+	FindingAcknowledged,
+	FindingFixed,
+	FindingPublished,
+}
+
 // DependencyFindings joins an application repository's Dependency rows
 // against every Package row in the database (any repository) and returns
-// the live Findings on the matched library repositories. The join key is the
-// parsed PURL (type, namespace, name) on both sides, so the two sources agree
-// without a write-time alias map. Self-matches and findings already marked
-// fixed/rejected/duplicate are excluded. Dependency phase is returned to the
-// caller but does not filter reachability: build dependencies can still be
-// supply-chain edges, and the UI layer owns phase filtering for display.
+// only notified or published Findings on the matched library repositories.
+// The join key is the parsed PURL (type, namespace, name) on both sides, so the
+// two sources agree without a write-time alias map. Self-matches, unpublished
+// findings, and rejected/duplicate findings are excluded. Dependency phase is
+// returned to the caller but does not filter reachability: build dependencies
+// can still be supply-chain edges, and the UI layer owns phase filtering for
+// display.
 func DependencyFindings(g *gorm.DB, appRepoID uint) ([]DependencyFinding, error) {
 	var deps []Dependency
 	if err := g.Where("repository_id = ?", appRepoID).Find(&deps).Error; err != nil {
@@ -213,7 +224,7 @@ func DependencyFindings(g *gorm.DB, appRepoID uint) ([]DependencyFinding, error)
 	}
 	var findings []Finding
 	if err := g.Where("repository_id IN ?", libIDs).
-		Where("status NOT IN ?", ClosedFindingLifecycles).
+		Where("status IN ?", dependencyFindingVisibleLifecycles).
 		Order("CASE severity WHEN 'Critical' THEN 0 WHEN 'High' THEN 1 WHEN 'Medium' THEN 2 ELSE 3 END, repository_id").
 		Find(&findings).Error; err != nil {
 		return nil, err

--- a/internal/db/ecosystem_test.go
+++ b/internal/db/ecosystem_test.go
@@ -145,7 +145,7 @@ func TestDependencyFindingsPURLJoin(t *testing.T) {
 
 	scan := Scan{RepositoryID: lib.ID, Kind: "skill", Status: ScanDone}
 	gdb.Create(&scan)
-	gdb.Create(&Finding{ScanID: scan.ID, RepositoryID: lib.ID, Title: "path traversal", Severity: "High", Status: FindingNew})
+	gdb.Create(&Finding{ScanID: scan.ID, RepositoryID: lib.ID, Title: "path traversal", Severity: "High", Status: FindingReported})
 
 	rows, err := DependencyFindings(gdb, app.ID)
 	if err != nil {
@@ -177,7 +177,7 @@ func TestDependencyFindingsIncludesNonRuntimeDependencies(t *testing.T) {
 
 	scan := Scan{RepositoryID: lib.ID, Kind: "skill", Status: ScanDone}
 	gdb.Create(&scan)
-	gdb.Create(&Finding{ScanID: scan.ID, RepositoryID: lib.ID, Title: "dev-only bug", Severity: "High", Status: FindingNew})
+	gdb.Create(&Finding{ScanID: scan.ID, RepositoryID: lib.ID, Title: "dev-only bug", Severity: "High", Status: FindingReported})
 
 	rows, err := DependencyFindings(gdb, app.ID)
 	if err != nil {
@@ -268,7 +268,7 @@ func TestDependencyFindingsMixedPURL(t *testing.T) {
 
 		scan := Scan{RepositoryID: lib.ID, Kind: "skill", Status: ScanDone}
 		gdb.Create(&scan)
-		gdb.Create(&Finding{ScanID: scan.ID, RepositoryID: lib.ID, Title: "x", Severity: "High", Status: FindingNew})
+		gdb.Create(&Finding{ScanID: scan.ID, RepositoryID: lib.ID, Title: "x", Severity: "High", Status: FindingReported})
 
 		rows, err := DependencyFindings(gdb, app.ID)
 		if err != nil {

--- a/internal/web/api_finding_writes.go
+++ b/internal/web/api_finding_writes.go
@@ -12,10 +12,10 @@ import (
 	"gorm.io/gorm"
 )
 
-// The handlers below let skills (and the browser UI) mutate a finding:
-// edit scoring fields, append notes, log communications, add references,
-// set labels, and read the full change history. Auth scoping holds: the
-// authenticated scan's repository must own the finding.
+// The handlers below let authenticated skills mutate a finding. Direct field
+// edits require the scan's finding scope; notes, communications, references,
+// labels, and history remain repository-scoped. Browser form edits use
+// separate routes.
 
 func (s *Server) apiPatchFinding(w http.ResponseWriter, r *http.Request) {
 	id, _ := strconv.Atoi(r.PathValue("id"))
@@ -33,6 +33,20 @@ func (s *Server) apiPatchFinding(w http.ResponseWriter, r *http.Request) {
 		By     string            `json:"by"`
 	}](w, r, "body must be JSON with a fields map")
 	if !ok {
+		return
+	}
+	if status, changesStatus := body.Fields["status"]; changesStatus {
+		switch db.FindingLifecycle(status) {
+		case db.FindingRejected, db.FindingDuplicate:
+			writeAPIError(w, http.StatusForbidden,
+				"scan tokens may not set finding status to rejected or duplicate")
+			return
+		}
+	}
+	scan := scanFromRequest(r)
+	if scan == nil || scan.FindingID == nil || *scan.FindingID != uint(id) {
+		writeAPIError(w, http.StatusForbidden,
+			"scan may only edit its scoped finding")
 		return
 	}
 	source := sourceFromRequest(r)

--- a/internal/web/api_finding_writes_test.go
+++ b/internal/web/api_finding_writes_test.go
@@ -45,11 +45,48 @@ func apiReq(t *testing.T, s *Server, method, path, token, body string) *httptest
 	return w
 }
 
+// seedEarlierFindingForAPI creates a finding from a completed scan and a
+// separate running scan on the same repository. The running scan starts
+// repository-scoped; individual tests may bind it to the finding explicitly.
+func seedEarlierFindingForAPI(t *testing.T, s *Server) (db.Finding, db.Scan) {
+	t.Helper()
+	repo, running := seedRunningScan(t, s)
+	prior := db.Scan{RepositoryID: repo.ID, Kind: "skill", Status: db.ScanDone}
+	if err := s.DB.Create(&prior).Error; err != nil {
+		t.Fatal(err)
+	}
+	f := db.Finding{ScanID: prior.ID, RepositoryID: repo.ID, Title: "earlier finding",
+		Severity: "High", Status: db.FindingNew}
+	if err := s.DB.Create(&f).Error; err != nil {
+		t.Fatal(err)
+	}
+	return f, running
+}
+
+func scopeAPITokenToFinding(t *testing.T, s *Server, token string, findingID uint) {
+	t.Helper()
+	if err := s.DB.Model(&db.Scan{}).Where("api_token = ?", token).
+		Update("finding_id", findingID).Error; err != nil {
+		t.Fatal(err)
+	}
+}
+
+func seedSiblingFindingForAPI(t *testing.T, s *Server, f db.Finding) db.Finding {
+	t.Helper()
+	sibling := db.Finding{ScanID: f.ScanID, RepositoryID: f.RepositoryID,
+		Title: "sibling finding", Severity: "High", Status: db.FindingNew}
+	if err := s.DB.Create(&sibling).Error; err != nil {
+		t.Fatal(err)
+	}
+	return sibling
+}
+
 func TestAPIPatchFinding(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()
 	f, tok, otherTok := seedFindingForAPI(t, s)
 	path := fmt.Sprintf("/api/findings/%d", f.ID)
+	scopeAPITokenToFinding(t, s, tok, f.ID)
 
 	w := apiReq(t, s, "PATCH", path, tok,
 		`{"fields":{"severity":"Critical","cve_id":"CVE-2026-12345"},"by":"disclose"}`)
@@ -98,11 +135,146 @@ func TestAPIPatchFinding(t *testing.T) {
 	}
 }
 
+func TestApiPatchFinding_refusesForeignFindingStatus(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	f, scan := seedEarlierFindingForAPI(t, s)
+
+	w := apiReq(t, s, http.MethodPatch, fmt.Sprintf("/api/findings/%d", f.ID),
+		scan.APIToken, `{"fields":{"status":"reported"}}`)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403; body=%s", w.Code, w.Body)
+	}
+	if !strings.Contains(w.Body.String(), "scoped finding") {
+		t.Errorf("body does not name the finding-scope constraint: %s", w.Body)
+	}
+	var got db.Finding
+	if err := s.DB.First(&got, f.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != db.FindingNew {
+		t.Fatalf("finding status = %q, want unchanged %q", got.Status, db.FindingNew)
+	}
+}
+
+func TestApiPatchFinding_refusesForeignFindingSeverity(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	f, scan := seedEarlierFindingForAPI(t, s)
+	sibling := seedSiblingFindingForAPI(t, s, f)
+	scopeAPITokenToFinding(t, s, scan.APIToken, sibling.ID)
+
+	w := apiReq(t, s, http.MethodPatch, fmt.Sprintf("/api/findings/%d", f.ID),
+		scan.APIToken, `{"fields":{"severity":"Low"}}`)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403; body=%s", w.Code, w.Body)
+	}
+	if !strings.Contains(w.Body.String(), "scoped finding") {
+		t.Errorf("body does not name the finding-scope constraint: %s", w.Body)
+	}
+	var got db.Finding
+	if err := s.DB.First(&got, f.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if got.Severity != "High" {
+		t.Fatalf("finding severity = %q, want unchanged High", got.Severity)
+	}
+	var historyCount int64
+	if err := s.DB.Model(&db.FindingHistory{}).Where("finding_id = ?", f.ID).
+		Count(&historyCount).Error; err != nil {
+		t.Fatal(err)
+	}
+	if historyCount != 0 {
+		t.Fatalf("history rows = %d, want 0", historyCount)
+	}
+}
+
+func TestApiPatchFinding_allowsOwnFindingScopedStatus(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	f, scan := seedEarlierFindingForAPI(t, s)
+	if err := s.DB.Model(&scan).Update("finding_id", f.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	w := apiReq(t, s, http.MethodPatch, fmt.Sprintf("/api/findings/%d", f.ID),
+		scan.APIToken, `{"fields":{"status":"reported"},"by":"report-upstream"}`)
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204; body=%s", w.Code, w.Body)
+	}
+	var got db.Finding
+	if err := s.DB.First(&got, f.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != db.FindingReported {
+		t.Fatalf("finding status = %q, want %q", got.Status, db.FindingReported)
+	}
+}
+
+func TestApiPatchFinding_refusesSuppressiveStatus(t *testing.T) {
+	for _, status := range []db.FindingLifecycle{db.FindingRejected, db.FindingDuplicate} {
+		for _, scope := range []string{"matching", "missing", "wrong"} {
+			t.Run(string(status)+"/"+scope, func(t *testing.T) {
+				s, done := newTestServer(t)
+				defer done()
+				f, scan := seedEarlierFindingForAPI(t, s)
+				switch scope {
+				case "matching":
+					scopeAPITokenToFinding(t, s, scan.APIToken, f.ID)
+				case "wrong":
+					sibling := seedSiblingFindingForAPI(t, s, f)
+					scopeAPITokenToFinding(t, s, scan.APIToken, sibling.ID)
+				}
+
+				body := fmt.Sprintf(`{"fields":{"status":%q}}`, status)
+				w := apiReq(t, s, http.MethodPatch, fmt.Sprintf("/api/findings/%d", f.ID),
+					scan.APIToken, body)
+				if w.Code != http.StatusForbidden {
+					t.Fatalf("status = %d, want 403; body=%s", w.Code, w.Body)
+				}
+				if !strings.Contains(w.Body.String(), "rejected") ||
+					!strings.Contains(w.Body.String(), "duplicate") {
+					t.Errorf("body does not name the suppressive-status constraint: %s", w.Body)
+				}
+				var got db.Finding
+				if err := s.DB.First(&got, f.ID).Error; err != nil {
+					t.Fatal(err)
+				}
+				if got.Status != db.FindingNew {
+					t.Fatalf("finding status = %q, want unchanged %q", got.Status, db.FindingNew)
+				}
+			})
+		}
+	}
+}
+
+func TestApiPatchFinding_allowsRepoScopedReferences(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	f, scan := seedEarlierFindingForAPI(t, s)
+
+	w := apiReq(t, s, http.MethodPost,
+		fmt.Sprintf("/api/findings/%d/references", f.ID), scan.APIToken,
+		`{"url":"https://example.com/staging/1","tags":"staging-issue"}`)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201; body=%s", w.Code, w.Body)
+	}
+	var count int64
+	if err := s.DB.Model(&db.FindingReference{}).Where("finding_id = ?", f.ID).
+		Count(&count).Error; err != nil {
+		t.Fatal(err)
+	}
+	if count != 1 {
+		t.Fatalf("reference rows = %d, want 1", count)
+	}
+}
+
 func TestAPIPatchFindingAtomicRollback(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()
 	f, tok, _ := seedFindingForAPI(t, s)
 	path := fmt.Sprintf("/api/findings/%d", f.ID)
+	scopeAPITokenToFinding(t, s, tok, f.ID)
 
 	w := apiReq(t, s, "PATCH", path, tok,
 		`{"fields":{"cve_id":"CVE-2026-12345","ghsa_id":"not-a-ghsa"},"by":"disclose"}`)
@@ -127,6 +299,7 @@ func TestAPIPatchFindingCVSSSyncsInsideTransaction(t *testing.T) {
 	defer done()
 	f, tok, _ := seedFindingForAPI(t, s)
 	path := fmt.Sprintf("/api/findings/%d", f.ID)
+	scopeAPITokenToFinding(t, s, tok, f.ID)
 	const vec = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
 
 	w := apiReq(t, s, "PATCH", path, tok,

--- a/internal/web/api_reads.go
+++ b/internal/web/api_reads.go
@@ -262,10 +262,10 @@ func (s *Server) apiListDependencies(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, out)
 }
 
-// apiListDependencyFindings returns findings on any library repository whose
-// published package appears in this repository's dependency list. The skill
-// token still only authorises the caller's own repo; the cross-repo read is
-// derived from that repo's dependencies, not chosen by the caller.
+// apiListDependencyFindings returns notified or published findings on any
+// library repository whose published package appears in this repository's
+// dependency list. The caller's dependency rows select candidate libraries,
+// but unpublished findings never cross the repository boundary.
 func (s *Server) apiListDependencyFindings(w http.ResponseWriter, r *http.Request) {
 	id, ok := s.repoScopedID(w, r)
 	if !ok {

--- a/internal/web/api_test.go
+++ b/internal/web/api_test.go
@@ -463,9 +463,9 @@ func TestAPIListDependencyFindings(t *testing.T) {
 	s.DB.Create(&db.Package{RepositoryID: lib.ID, Name: "roo", Ecosystem: "rubygems"})
 	libScan := db.Scan{RepositoryID: lib.ID, Kind: worker.JobSkill, Status: db.ScanDone}
 	s.DB.Create(&libScan)
-	s.DB.Create(&db.Finding{ScanID: libScan.ID, RepositoryID: lib.ID, Title: "xlsx bomb", Severity: sevHigh, CWE: "CWE-770", Location: "lib/roo/excelx.rb:42", Status: db.FindingNew, Trace: "t", Boundary: "b"})
-	s.DB.Create(&db.Finding{ScanID: libScan.ID, RepositoryID: lib.ID, Title: "ods bomb", Severity: "Medium", CWE: "CWE-770", Status: db.FindingNew})
-	s.DB.Create(&db.Finding{ScanID: libScan.ID, RepositoryID: lib.ID, Title: "old", Severity: sevHigh, Status: db.FindingFixed})
+	s.DB.Create(&db.Finding{ScanID: libScan.ID, RepositoryID: lib.ID, Title: "xlsx bomb", Severity: sevHigh, CWE: "CWE-770", Location: "lib/roo/excelx.rb:42", Status: db.FindingReported, Trace: "t", Boundary: "b"})
+	s.DB.Create(&db.Finding{ScanID: libScan.ID, RepositoryID: lib.ID, Title: "ods bomb", Severity: "Medium", CWE: "CWE-770", Status: db.FindingAcknowledged})
+	s.DB.Create(&db.Finding{ScanID: libScan.ID, RepositoryID: lib.ID, Title: "rejected", Severity: sevHigh, Status: db.FindingRejected})
 
 	// Self-published package on the app repo must not match its own findings.
 	s.DB.Create(&db.Package{RepositoryID: app.ID, Name: "leftpad", Ecosystem: "npm"})
@@ -484,7 +484,7 @@ func TestAPIListDependencyFindings(t *testing.T) {
 		t.Fatal(err)
 	}
 	if len(rows) != 2 {
-		t.Fatalf("rows=%d want=2 (live roo findings only): %+v", len(rows), rows)
+		t.Fatalf("rows=%d want=2 (notified roo findings only): %+v", len(rows), rows)
 	}
 	if rows[0].Severity != sevHigh || rows[0].Package != "roo" {
 		t.Errorf("first row should be the High roo finding, got %+v", rows[0])
@@ -506,6 +506,76 @@ func TestAPIListDependencyFindings(t *testing.T) {
 	_ = json.NewDecoder(w.Body).Decode(&rows)
 	if len(rows) != 1 || rows[0].Title != "xlsx bomb" {
 		t.Errorf("severity filter: %+v", rows)
+	}
+}
+
+func TestDependencyFindings_excludesUnpublishedCrossRepo(t *testing.T) {
+	cases := []struct {
+		status db.FindingLifecycle
+		want   bool
+	}{
+		{db.FindingNew, false},
+		{db.FindingEnriched, false},
+		{db.FindingTriaged, false},
+		{db.FindingReady, false},
+		{db.FindingReported, true},
+		{db.FindingAcknowledged, true},
+		{db.FindingFixed, true},
+		{db.FindingPublished, true},
+		{db.FindingRejected, false},
+		{db.FindingDuplicate, false},
+	}
+	for _, tc := range cases {
+		t.Run(string(tc.status), func(t *testing.T) {
+			s, done := newTestServer(t)
+			defer done()
+			app, scan := seedRunningScan(t, s)
+			pkg := "library-" + string(tc.status)
+			s.DB.Create(&db.Dependency{RepositoryID: app.ID, Name: pkg,
+				Ecosystem: "npm", ManifestPath: "package.json"})
+
+			libURL := "https://example.com/" + pkg
+			lib := db.Repository{URL: libURL, Name: pkg}
+			s.DB.Create(&lib)
+			s.DB.Create(&db.Package{RepositoryID: lib.ID, Name: pkg, Ecosystem: "npm"})
+			libScan := db.Scan{RepositoryID: lib.ID, Kind: worker.JobSkill, Status: db.ScanDone}
+			s.DB.Create(&libScan)
+			title := "cross-repository-" + string(tc.status)
+			f := db.Finding{ScanID: libScan.ID, RepositoryID: lib.ID, Title: title,
+				Severity: sevHigh, Status: tc.status, Trace: "private trace",
+				Boundary: "private boundary"}
+			s.DB.Create(&f)
+
+			path := "/api/repositories/" + strconv.FormatUint(uint64(app.ID), 10) +
+				"/dependency-findings"
+			r := httptest.NewRequest(http.MethodGet, path, nil)
+			r.Host = testHost
+			r.Header.Set("Authorization", "Bearer "+scan.APIToken)
+			w := httptest.NewRecorder()
+			s.Handler().ServeHTTP(w, r)
+			if w.Code != http.StatusOK {
+				t.Fatalf("status %d: %s", w.Code, w.Body)
+			}
+			body := w.Body.String()
+			var rows []db.DependencyFinding
+			if err := json.NewDecoder(strings.NewReader(body)).Decode(&rows); err != nil {
+				t.Fatal(err)
+			}
+			if tc.want {
+				if len(rows) != 1 || rows[0].FindingID != f.ID || rows[0].Status != tc.status {
+					t.Fatalf("rows = %+v, want the %s finding", rows, tc.status)
+				}
+				return
+			}
+			if len(rows) != 0 {
+				t.Fatalf("rows = %+v, want no cross-repository data for %s", rows, tc.status)
+			}
+			for _, secret := range []string{title, libURL, "private trace", "private boundary"} {
+				if strings.Contains(body, secret) {
+					t.Errorf("response disclosed %q for %s: %s", secret, tc.status, body)
+				}
+			}
+		})
 	}
 }
 

--- a/internal/web/finding_attack_path_test.go
+++ b/internal/web/finding_attack_path_test.go
@@ -97,6 +97,10 @@ func TestAPINonViableFindingCannotEnterReportingStates(t *testing.T) {
 	defer done()
 	f, token, _ := seedFindingForAPI(t, s)
 	s.DB.Model(&f).Update("production_viability", db.ProductionViabilityNonViable)
+	if err := s.DB.Model(&db.Scan{}).Where("api_token = ?", token).
+		Update("finding_id", f.ID).Error; err != nil {
+		t.Fatal(err)
+	}
 	for _, status := range []db.FindingLifecycle{db.FindingReady, db.FindingReported} {
 		t.Run(string(status), func(t *testing.T) {
 			body := fmt.Sprintf(`{"fields":{"status":%q},"by":"report-upstream"}`, status)

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -504,10 +504,11 @@ paths:
       summary: Update mutable fields on a finding
       operationId: patchFinding
       description: |
+        The authenticated scan must be finding-scoped to this finding ID.
         Each field value is written through the history-tracked path.
-        Skills write with source=model_suggested; the browser UI (behind
-        its own session) writes with source=analyst. Unknown field names
-        are rejected.
+        Finding-scoped skills write with source=model_suggested; browser
+        form edits use separate routes and write with source=analyst.
+        Unknown field names are rejected.
       requestBody:
         required: true
         content:


### PR DESCRIPTION
A scan's bearer token is staged into its workspace in `context.json`, so repository code running inside the scan can read it. `apiPatchFinding` authorised on `repository_id` alone, which let that token rewrite durable fields on findings recorded by earlier scans of the same repository: `status`, `severity`, and the disclosure draft and recipients. `threatmodel.md` names status and severity as the fields that drive the analyst's disclosure decisions, and `SECURITY.md` puts another scan's data in scope. Separately, `DependencyFindings` joined a repository's dependency rows against every package row on the instance and returned the matched library's open findings, so declaring a dependency on a victim package disclosed that library's unpublished findings.

Direct field PATCHes now require the scan's `finding_id` to match the target, and `rejected` and `duplicate` are refused from a scan token outright. Notes, communications, references and labels stay repository-scoped so `fork` and `finding-dedup` keep working across findings, and every bundled PATCH caller already runs finding-scoped through `POST /findings/{id}/skills/{name}/run`. Cross-repository dependency findings are limited to `reported`, `acknowledged`, `fixed` and `published`, a positive allowlist so an unrecognised or future lifecycle value fails closed.

Codex was used to implement this, Opus 5 to review it.
