### PR TITLE
Reject unknown finding status values in WriteFindingField

### DIFF
--- a/internal/db/finding_helpers.go
+++ b/internal/db/finding_helpers.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -43,6 +44,9 @@ func validateFindingField(field, value string) error {
 	}
 	if field == "ghsa_id" && !ghsaIDRE.MatchString(value) {
 		return fmt.Errorf("ghsa_id %q is not a valid GHSA id (expected GHSA-xxxx-xxxx-xxxx)", value)
+	}
+	if field == "status" && !slices.Contains(FindingLifecycles, FindingLifecycle(value)) {
+		return fmt.Errorf("status %q is not a valid finding lifecycle", value)
 	}
 	return nil
 }

--- a/internal/db/finding_helpers_test.go
+++ b/internal/db/finding_helpers_test.go
@@ -441,6 +441,26 @@ func TestWriteFindingField_rejectsUnknownField(t *testing.T) {
 	}
 }
 
+func TestWriteFindingField_rejectsUnknownStatus(t *testing.T) {
+	gdb := newTestDB(t)
+	f := seedFinding(t, gdb)
+	for _, bad := range []string{"Rejected", "closed", "REPORTED"} {
+		if err := WriteFindingField(gdb, f.ID, "status", bad, SourceAnalyst, ""); err == nil {
+			t.Errorf("status %q: expected error", bad)
+		}
+	}
+	var got Finding
+	gdb.First(&got, f.ID)
+	if got.Status != FindingNew {
+		t.Errorf("status = %q, want unchanged", got.Status)
+	}
+	for _, ok := range FindingLifecycles {
+		if err := WriteFindingField(gdb, f.ID, "status", string(ok), SourceAnalyst, ""); err != nil {
+			t.Errorf("status %q: %v", ok, err)
+		}
+	}
+}
+
 func TestWriteFindingField_cvssVectorSyncsScore(t *testing.T) {
 	gdb := newTestDB(t)
 	f := seedFinding(t, gdb)
@@ -750,6 +770,8 @@ func fieldTestValue(field string) string {
 	switch field {
 	case "ghsa_id":
 		return "GHSA-aaaa-bbbb-cccc"
+	case "status":
+		return string(FindingTriaged)
 	case "cvss_vector":
 		return "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
 	case "cvss_v4_vector":


### PR DESCRIPTION
`validateFindingField` checked `ghsa_id` format but let any string through as `status`. The browser form and internal callers already pass enum values, so the only unguarded path was `PATCH /api/findings/{id}`, which #961 narrowed to a scan's own finding but still accepted off-enum strings like `"Rejected"` or `"closed"`.

Rejects any non-empty status that isn't in `FindingLifecycles`, matching the switch the browser status handler already has.