### PR TITLE
Build changed docker/profiles/ images on PR

### DIFF
--- a/.github/workflows/profile-images.yml
+++ b/.github/workflows/profile-images.yml
@@ -7,7 +7,7 @@ name: Profile Images
 on:
   pull_request:
     paths:
-      - docker/profiles/**
+      - docker/profiles/*/**
       - .github/workflows/profile-images.yml
 
 defaults:
@@ -71,7 +71,7 @@ jobs:
           RUNNER_IMAGE: ghcr.io/${{ github.repository }}-runner:latest
         run: |
           dir="docker/profiles/$PROFILE"
-          test -f "$dir/Dockerfile" || { echo "no Dockerfile for $PROFILE"; exit 0; }
+          test -f "$dir/Dockerfile" || { echo "no Dockerfile at $dir/Dockerfile"; exit 1; }
           base_image="$RUNNER_IMAGE"
           # ruby-rails is the one chained profile: it builds FROM the ruby
           # profile via BASE_IMAGE, not the runner via RUNNER_IMAGE.

--- a/.github/workflows/profile-images.yml
+++ b/.github/workflows/profile-images.yml
@@ -1,0 +1,86 @@
+name: Profile Images
+
+# Builds each changed docker/profiles/<name>/ image against the published
+# runner so a bad checksum, dead URL, or broken smoke test fails the PR
+# instead of surfacing at the worker's on-demand EnsureImage.
+
+on:
+  pull_request:
+    paths:
+      - docker/profiles/**
+      - .github/workflows/profile-images.yml
+
+defaults:
+  run:
+    shell: bash -euo pipefail {0}
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  changed:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    outputs:
+      profiles: ${{ steps.list.outputs.profiles }}
+    steps:
+      - name: Set up Git repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: List changed profiles
+        id: list
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          profiles=$(git diff --name-only "$BASE_SHA"...HEAD -- 'docker/profiles/*/*' \
+            | awk -F/ '{print $3}' | sort -u \
+            | jq -R . | jq -sc .)
+          echo "profiles=$profiles" >> "$GITHUB_OUTPUT"
+          echo "changed: $profiles"
+
+  build:
+    name: build (${{ matrix.profile }})
+    needs: changed
+    if: needs.changed.outputs.profiles != '[]'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        profile: ${{ fromJson(needs.changed.outputs.profiles) }}
+    steps:
+      - name: Set up Git repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Build profile image
+        env:
+          PROFILE: ${{ matrix.profile }}
+          RUNNER_IMAGE: ghcr.io/${{ github.repository }}-runner:latest
+        run: |
+          dir="docker/profiles/$PROFILE"
+          test -f "$dir/Dockerfile" || { echo "no Dockerfile for $PROFILE"; exit 0; }
+          base_image="$RUNNER_IMAGE"
+          # ruby-rails is the one chained profile: it builds FROM the ruby
+          # profile via BASE_IMAGE, not the runner via RUNNER_IMAGE.
+          if [[ "$PROFILE" == "ruby-rails" ]]; then
+            docker build -t scrutineer-profile-ruby:ci \
+              --build-arg "RUNNER_IMAGE=$RUNNER_IMAGE" \
+              -f docker/profiles/ruby/Dockerfile docker/profiles/ruby
+            base_image=scrutineer-profile-ruby:ci
+          fi
+          docker build -t "scrutineer-profile-$PROFILE:ci" \
+            --build-arg "RUNNER_IMAGE=$RUNNER_IMAGE" \
+            --build-arg "BASE_IMAGE=$base_image" \
+            -f "$dir/Dockerfile" "$dir"

--- a/.github/workflows/profile-images.yml
+++ b/.github/workflows/profile-images.yml
@@ -22,6 +22,7 @@ concurrency:
 
 jobs:
   changed:
+    name: list changed profiles
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     permissions:


### PR DESCRIPTION
Nothing under `.github/workflows/` triggers on `docker/profiles/**`, so a bad checksum, dead download URL, or broken toolchain smoke test in a profile Dockerfile only surfaces when a worker first runs `EnsureImage`. #962 was merged on manual checksum verification for that reason.

Adds a workflow that diffs the PR against its base, extracts the changed profile directories, and builds each one against `ghcr.io/alpha-omega-security/scrutineer-runner:latest`. `ruby-rails` is the one chained profile (`BaseProfile: "ruby"` in `internal/worker/profile.go`), so its job builds `ruby` first and passes it as `BASE_IMAGE`.

The workflow's own path is in the trigger list so this PR runs the detect job; it outputs `[]` here since no profile file changed, and the build matrix is skipped. The build job first exercises on the next PR that touches a profile.