### PR TITLE
Fix range location normalization in finding fingerprints

### DIFF
--- a/internal/db/fingerprint.go
+++ b/internal/db/fingerprint.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 
 	"gorm.io/gorm"
+
+	"scrutineer/internal/findingnorm"
 )
 
 // FingerprintFinding returns a stable hash for deduplicating the same
@@ -37,28 +39,17 @@ func FingerprintFinding(skillName, subPath, cwe, location, title string) string 
 	return hex.EncodeToString(h[:])
 }
 
-// normaliseLocation reduces "path/to/file.go:42:7" to "path/to/file.go".
-// A leading "./" is stripped so "./src/x.go" and "src/x.go" agree.
+// normaliseLocation strips line, line:column, and line-range suffixes from a
+// location. A leading "./" is stripped so "./src/x.go" and "src/x.go" agree.
 func normaliseLocation(loc string) string {
 	loc = strings.TrimSpace(loc)
 	loc = strings.TrimPrefix(loc, "./")
 	for {
 		i := strings.LastIndexByte(loc, ':')
-		if i <= 0 {
+		if i <= 0 || !findingnorm.IsPositionalSuffix(loc[i+1:]) {
 			break
 		}
-		isNum := true
-		for _, c := range loc[i+1:] {
-			if c < '0' || c > '9' {
-				isNum = false
-				break
-			}
-		}
-		if isNum && len(loc[i+1:]) > 0 {
-			loc = loc[:i]
-		} else {
-			break
-		}
+		loc = loc[:i]
 	}
 	return strings.ToLower(loc)
 }

--- a/internal/db/fingerprint_test.go
+++ b/internal/db/fingerprint_test.go
@@ -4,15 +4,17 @@ import "testing"
 
 func TestNormaliseLocation(t *testing.T) {
 	cases := map[string]string{
-		"src/users.rb:42":                "src/users.rb",
-		"src/users.rb:42:7":              "src/users.rb",
-		"src/users.rb":                   "src/users.rb",
-		"./src/users.rb:1":               "src/users.rb",
-		"  Src/Users.rb:10  ":            "src/users.rb",
-		"C:\\project\\src\\main.go:42":   "c:\\project\\src\\main.go",
-		"C:\\project\\src\\main.go:42:7": "c:\\project\\src\\main.go",
-		"C:\\project\\src\\main.go":      "c:\\project\\src\\main.go",
-		"":                               "",
+		"src/users.rb:42":                 "src/users.rb",
+		"src/users.rb:42:7":               "src/users.rb",
+		"src/users.rb:12-34":              "src/users.rb",
+		"src/users.rb":                    "src/users.rb",
+		"./src/users.rb:1":                "src/users.rb",
+		"  Src/Users.rb:10  ":             "src/users.rb",
+		"C:\\project\\src\\main.go:42":    "c:\\project\\src\\main.go",
+		"C:\\project\\src\\main.go:42:7":  "c:\\project\\src\\main.go",
+		"C:\\project\\src\\main.go:12-34": "c:\\project\\src\\main.go",
+		"C:\\project\\src\\main.go":       "c:\\project\\src\\main.go",
+		"":                                "",
 	}
 	for in, want := range cases {
 		if got := normaliseLocation(in); got != want {
@@ -26,6 +28,10 @@ func TestFingerprintFinding(t *testing.T) {
 
 	if base != FingerprintFinding("security-deep-dive", "", "CWE-89", "src/users.rb:77", "SQLi rephrased") {
 		t.Errorf("line drift / title change must not change fingerprint")
+	}
+	if FingerprintFinding("security-deep-dive", "", "CWE-89", "src/users.rb:12-34", "SQLi") !=
+		FingerprintFinding("security-deep-dive", "", "CWE-89", "src/users.rb:14-36", "SQLi") {
+		t.Errorf("range drift must not change fingerprint")
 	}
 	if base != FingerprintFinding("Security-Deep-Dive", "", "cwe-89", "./SRC/users.rb", "x") {
 		t.Errorf("skill/cwe/location case must not change fingerprint")

--- a/internal/findingnorm/normalize.go
+++ b/internal/findingnorm/normalize.go
@@ -13,7 +13,7 @@ func LocationFile(loc string) string {
 	loc = strings.TrimSpace(strings.Split(strings.TrimSpace(loc), "\n")[0])
 	for {
 		i := strings.LastIndexByte(loc, ':')
-		if i < 0 || !allDigits(loc[i+1:]) {
+		if i < 0 || !IsPositionalSuffix(loc[i+1:]) {
 			break
 		}
 		loc = loc[:i]
@@ -39,6 +39,16 @@ func HasParentPathSegment(p string) bool {
 		}
 	}
 	return false
+}
+
+// IsPositionalSuffix reports whether s is a line ("42") or line range
+// ("10-20") used as the final component of a finding location.
+func IsPositionalSuffix(s string) bool {
+	start, end, isRange := strings.Cut(s, "-")
+	if isRange {
+		return allDigits(start) && allDigits(end)
+	}
+	return allDigits(start)
 }
 
 func allDigits(s string) bool {

--- a/internal/findingnorm/normalize_test.go
+++ b/internal/findingnorm/normalize_test.go
@@ -14,6 +14,7 @@ func TestFindingPath(t *testing.T) {
 		"root-scoped keeps the location's file": {"", "internal/web/server.go:120", "internal/web/server.go"},
 		"subpath is prefixed onto the location": {"internal", "web/server.go:120", "internal/web/server.go"},
 		"nested subpath joins in order":         {"services/api", "handler.go:8:3", "services/api/handler.go"},
+		"line range is stripped":                {"services/api", "handler.go:8-13", "services/api/handler.go"},
 		"leading ./ is normalised away":         {"./internal", "./web/server.go", "internal/web/server.go"},
 
 		// A malformed location must produce no match rather than a match
@@ -30,5 +31,22 @@ func TestFindingPath(t *testing.T) {
 				t.Errorf("FindingPath(%q, %q) = %q, want %q", tc.subPath, tc.location, got, tc.want)
 			}
 		})
+	}
+}
+
+func TestIsPositionalSuffix(t *testing.T) {
+	for input, want := range map[string]bool{
+		"42":       true,
+		"10-20":    true,
+		"":         false,
+		"-20":      false,
+		"10-":      false,
+		"10-20-30": false,
+		"line":     false,
+		"42:7":     false,
+	} {
+		if got := IsPositionalSuffix(input); got != want {
+			t.Errorf("IsPositionalSuffix(%q) = %t, want %t", input, got, want)
+		}
 	}
 }

--- a/internal/interchange/hash.go
+++ b/internal/interchange/hash.go
@@ -6,6 +6,8 @@ import (
 	"path"
 	"slices"
 	"strings"
+
+	"scrutineer/internal/findingnorm"
 )
 
 // FindingHash is the salted federation identifier for one finding:
@@ -14,9 +16,10 @@ import (
 // sharing the salt derive the same hash for the same vulnerability
 // without exchanging finding bodies; without the salt the hash reveals
 // nothing enumerable. The canonicalisation here is a wire contract
-// shared across instances, so it is deliberately self-contained instead
-// of reusing findingnorm or the fingerprint helpers: an internal
-// normalisation tweak must never silently change every published hash.
+// shared across instances, so its transformations remain defined here
+// instead of reusing a higher-level location normaliser: an internal tweak
+// must never silently change every published hash. Only the positional
+// suffix grammar is shared so location producers agree on its syntax.
 func FindingHash(salt, repoURL, subPath, location, cwe string) string {
 	h := sha256.Sum256([]byte(strings.Join([]string{
 		salt,
@@ -60,7 +63,7 @@ func canonicalLocation(subPath, location string) string {
 	loc := strings.TrimSpace(strings.Split(location, "\n")[0])
 	for {
 		i := strings.LastIndexByte(loc, ':')
-		if i < 0 || !positionalSuffix(loc[i+1:]) {
+		if i < 0 || !findingnorm.IsPositionalSuffix(loc[i+1:]) {
 			break
 		}
 		loc = loc[:i]
@@ -81,26 +84,4 @@ func cleanPath(p string) string {
 		return ""
 	}
 	return path.Clean(p)
-}
-
-// positionalSuffix reports whether s is a line ("42") or range ("10-20")
-// location suffix.
-func positionalSuffix(s string) bool {
-	start, end, isRange := strings.Cut(s, "-")
-	if isRange {
-		return allDigits(start) && allDigits(end)
-	}
-	return allDigits(start)
-}
-
-func allDigits(s string) bool {
-	if s == "" {
-		return false
-	}
-	for _, r := range s {
-		if r < '0' || r > '9' {
-			return false
-		}
-	}
-	return true
 }


### PR DESCRIPTION
Fixes #945

## Summary

Normalizes source locations containing line ranges so findings remain stable when only the reported range endpoints change.

Locations such as `src/parser.go:10-20` and `src/parser.go:12-22` now canonicalize to the same file path before fingerprinting, preventing duplicate findings across scans.

## Changes

- Add a shared positional-suffix predicate supporting line numbers and line ranges.
- Use the shared predicate in database fingerprint normalization.
- Reuse it in finding-path and interchange hash normalization to keep location parsing consistent.
- Preserve the distinct canonicalization behavior required by database fingerprints and federation hashes.
- Add regression coverage for Unix and Windows-style range locations.
- Verify that changing range endpoints does not change a finding fingerprint.
- Add malformed suffix coverage to avoid stripping non-positional path content.

## Tests

- `go mod tidy -diff`
- `go test ./...`
- `go test -race -gcflags='modernc.org/...=-d=checkptr=0' ./...`
- `go vet ./...`
- `go vet -tags evals ./internal/evals/...`
- `go test -race -tags evals ./internal/evals/...`
- `go vet -tags podman ./...`
- `golangci-lint run`
- `git diff --check`