### PR TITLE
Add scala runner profile

### DIFF
--- a/.github/workflows/profile-images.yml
+++ b/.github/workflows/profile-images.yml
@@ -73,13 +73,18 @@ jobs:
           dir="docker/profiles/$PROFILE"
           test -f "$dir/Dockerfile" || { echo "no Dockerfile at $dir/Dockerfile"; exit 1; }
           base_image="$RUNNER_IMAGE"
-          # ruby-rails is the one chained profile: it builds FROM the ruby
-          # profile via BASE_IMAGE, not the runner via RUNNER_IMAGE.
-          if [[ "$PROFILE" == "ruby-rails" ]]; then
-            docker build -t scrutineer-profile-ruby:ci \
+          # Chained profiles build FROM another profile via BASE_IMAGE, not
+          # the runner via RUNNER_IMAGE. Build the base first.
+          case "$PROFILE" in
+            ruby-rails) base=ruby ;;
+            scala)      base=java ;;
+            *)          base= ;;
+          esac
+          if [[ -n "$base" ]]; then
+            docker build -t "scrutineer-profile-$base:ci" \
               --build-arg "RUNNER_IMAGE=$RUNNER_IMAGE" \
-              -f docker/profiles/ruby/Dockerfile docker/profiles/ruby
-            base_image=scrutineer-profile-ruby:ci
+              -f "docker/profiles/$base/Dockerfile" "docker/profiles/$base"
+            base_image="scrutineer-profile-$base:ci"
           fi
           docker build -t "scrutineer-profile-$PROFILE:ci" \
             --build-arg "RUNNER_IMAGE=$RUNNER_IMAGE" \

--- a/README.md
+++ b/README.md
@@ -291,10 +291,13 @@ When the container runner is active, scrutineer auto-detects a per-ecosystem **p
 | `ruby-rails` | `tools.build:Rails` | A superset of `ruby` plus **Brakeman**, Rails-specific SAST |
 | `node` | npm/pnpm/Yarn/Bun | Node.js |
 | `go` | Go Modules | Go toolchain |
+| `scala` | sbt or Scala language detection | A superset of `java` plus **sbt** and Scala-specific reproducer guidance |
 | `java` | Maven/Gradle | JDK |
 | `dotnet` | NuGet/dotnet CLI | .NET SDK |
 | `beam` | Mix/rebar3 | Erlang/Elixir |
 | `rust` | Cargo | Rust stable + nightly, Miri, sanitizers |
+| `ocaml` | opam, `tools.build:Dune`, or OCaml language detection | opam + a compiled OCaml 5.x switch + dune |
+| `swift` | Swift Package Manager or Swift language detection | Swift toolchain + swiftly |
 | `perl` | cpanm or Perl language detection | Perl toolchain |
 | `c-cpp` | `tools.build:CMake` / `Make` / `Autotools` / `Meson`, or C/C++ language detection, after language ecosystems have had a chance to match | C/C++ build toolchain |
 

--- a/docker/profiles/scala/Dockerfile
+++ b/docker/profiles/scala/Dockerfile
@@ -1,0 +1,67 @@
+# Scala/sbt profile.
+#
+# The `java` profile image + sbt, so scans of Scala projects can resolve
+# dependencies, compile, run tests, and reproduce findings. Chained on `java`
+# (BASE_IMAGE) rather than the runner so the JDK is the same Temurin build the
+# Maven/Gradle profile uses, downloaded once.
+#
+# sbt is a launcher: it reads project/build.properties and bootstraps
+# whichever sbt.version the project pins (1.x or 2.x), so the SBT_VERSION
+# below is only the launcher's own default for projects that omit the pin.
+#
+# Auto-selected when brief reports sbt in package_managers or Scala as the
+# dominant language; also selectable via ?profile=scala.
+#
+# Built on demand by the worker (EnsureImage): it builds the `java` profile
+# first and passes its content-addressed tag as BASE_IMAGE, then tags this
+# image scrutineer-profile-scala:<sha>. To build it manually:
+#
+#   docker build -t scrutineer-runner:local -f Dockerfile.runner .
+#   docker build -t scrutineer-profile-java \
+#       -f docker/profiles/java/Dockerfile \
+#       --build-arg RUNNER_IMAGE=scrutineer-runner:local \
+#       docker/profiles/java
+#   docker build -t scrutineer-profile-scala \
+#       -f docker/profiles/scala/Dockerfile \
+#       --build-arg BASE_IMAGE=scrutineer-profile-java \
+#       docker/profiles/scala
+#   docker run --rm --entrypoint sh scrutineer-profile-scala \
+#       -c 'java -version && sbt --script-version'
+
+ARG BASE_IMAGE=ghcr.io/alpha-omega-security/scrutineer-runner:latest
+FROM ${BASE_IMAGE}
+
+ARG SBT_VERSION=1.13.0
+ARG SBT_SHA256=06806805ffd26232727326216766ed4793b549f8c1e6ffeef2e610db7245b698
+
+USER root
+
+# sbt's boot dir (the launcher downloads the pinned sbt.version + scala-library
+# there), the ivy2 cache, and the coursier cache all default under $HOME=/tmp,
+# which the worker mounts noexec and caps at 256m -- far too small once the
+# scala-compiler and a project's dependency set are written there. Redirect
+# them to /opt, 1777 so the host uid the scan runs as can write. java.io.tmpdir
+# already points at /opt/java-tmp via the base image; SBT_OPTS repeats it
+# because sbt ignores MAVEN_OPTS/GRADLE_OPTS. The sbt server is disabled
+# (scans are one-shot).
+ENV COURSIER_CACHE=/opt/coursier \
+    SBT_OPTS="-Dsbt.global.base=/opt/sbt-home -Dsbt.boot.directory=/opt/sbt-home/boot -Dsbt.ivy.home=/opt/ivy2 -Dsbt.server.autostart=false -Djava.io.tmpdir=/opt/java-tmp" \
+    PATH=/opt/sbt/bin:$PATH
+
+RUN curl -fsSL -o /tmp/sbt.tgz \
+        "https://github.com/sbt/sbt/releases/download/v${SBT_VERSION}/sbt-${SBT_VERSION}.tgz" \
+ && echo "${SBT_SHA256}  /tmp/sbt.tgz" | sha256sum -c - \
+ && tar -xzf /tmp/sbt.tgz -C /opt \
+ && rm /tmp/sbt.tgz /opt/sbt/bin/sbtn-* \
+ && install -d -m 1777 /opt/sbt-home /opt/sbt-home/boot /opt/ivy2 /opt/coursier \
+ # Smoke-test with throwaway home/boot/cache dirs so the build does not seed
+ # /opt/{sbt-home,ivy2,coursier} with root-owned files the scan uid could not
+ # then write beside; the scan populates them fresh as that uid.
+ && BOOT=/tmp/sbt-bootstrap \
+ && mkdir -p "$BOOT/home" "$BOOT/boot" "$BOOT/ivy2" "$BOOT/coursier" \
+ && COURSIER_CACHE="$BOOT/coursier" \
+    SBT_OPTS="-Dsbt.global.base=$BOOT/home -Dsbt.boot.directory=$BOOT/boot -Dsbt.ivy.home=$BOOT/ivy2 -Djava.io.tmpdir=/opt/java-tmp" \
+    sbt --script-version \
+ && rm -rf "$BOOT"
+
+USER runner

--- a/docker/profiles/scala/Dockerfile
+++ b/docker/profiles/scala/Dockerfile
@@ -52,7 +52,11 @@ RUN curl -fsSL -o /tmp/sbt.tgz \
         "https://github.com/sbt/sbt/releases/download/v${SBT_VERSION}/sbt-${SBT_VERSION}.tgz" \
  && echo "${SBT_SHA256}  /tmp/sbt.tgz" | sha256sum -c - \
  && tar -xzf /tmp/sbt.tgz -C /opt \
- && rm /tmp/sbt.tgz /opt/sbt/bin/sbtn-* \
+ && rm /tmp/sbt.tgz \
+ # sbtn-* are per-arch native thin clients for the sbt server; scans are
+ # one-shot so they are unused. -f so a future sbt tgz that drops them still
+ # builds instead of failing on an unexpanded glob.
+ && rm -f /opt/sbt/bin/sbtn-* \
  && install -d -m 1777 /opt/sbt-home /opt/sbt-home/boot /opt/ivy2 /opt/coursier \
  # Smoke-test with throwaway home/boot/cache dirs so the build does not seed
  # /opt/{sbt-home,ivy2,coursier} with root-owned files the scan uid could not

--- a/docker/profiles/scala/PROFILE.md
+++ b/docker/profiles/scala/PROFILE.md
@@ -1,0 +1,64 @@
+# Scala scanning container
+
+The repository under `./src` is a Scala project, built with sbt.
+
+## Runtime
+
+- **Temurin JDK 25** — `java`, `javac`. `JAVA_HOME=/opt/java`.
+- **`sbt`** on PATH. The launcher reads `project/build.properties` and bootstraps whichever `sbt.version` the project
+  pins (1.x or 2.x), so the first `sbt` invocation downloads that sbt and the Scala compiler into `/opt/sbt-home/boot`.
+- **`mvn`**, **`gradle`** — inherited from the java base, for a Scala module inside a mixed Maven/Gradle build.
+
+sbt's boot directory, ivy cache (`/opt/ivy2`), and coursier cache (`/opt/coursier`) are on an exec-capable path rather
+than under `HOME`, which is a small noexec mount. `java.io.tmpdir` is `/opt/java-tmp` for the same reason.
+
+## Operating procedure
+
+### Code scanning preparations
+
+```bash
+cd src
+sbt --batch compile          # or `sbt --batch Test/compile` to compile tests too
+```
+
+`--batch` runs sbt non-interactively (fails instead of prompting). The first run resolves the pinned sbt version, the
+Scala compiler, and every library dependency; that can take a couple of minutes. If it fails with `Error downloading`
+or `UnknownHostException` the scan is offline — work from the source already present and note which checks you had to
+skip. For a multi-project build, `sbt --batch projects` lists the sub-projects; scope a task with
+`sbt --batch <sub>/compile`.
+
+### Scala-specific analysis
+
+Scala interoperates with the whole JVM standard library, so every Java sink applies. Scala adds:
+
+- **`scala.sys.process`** — the string forms (`"ls $x".!`, `"ls $x".!!`, `Process(s"cmd $x").run()`, `.lazyLines`) split
+  on whitespace like `Runtime.exec(String)`; a value that is *substituted into the string* controls argv. The `Seq`
+  form (`Seq("ls", x).!`) passes each element as its own argv entry.
+- **`scala.xml.XML.load` / `XML.loadFile` / `XML.loadString`** — the default parser resolves external entities (XXE)
+  unless the caller supplies a hardened `SAXParser`.
+- **`scala.io.Source.fromURL`** — SSRF when the URL is user-supplied. `Source.fromFile` on a user path is traversal.
+- **`scala.util.Random`** — wraps `java.util.Random` (predictable); a token or nonce needs `java.security.SecureRandom`.
+- **Java interop** — `ObjectInputStream.readObject`, `Runtime.getRuntime().exec`, `ScriptEngine.eval`,
+  `Class.forName(x).newInstance()`, JDBC string concatenation: all reachable from Scala unchanged.
+
+### Creating reproducers
+
+Every finding ships with a reproducer — code that, when run in this container, actually triggers the issue. Paste the
+exact command you ran and the verbatim output into the finding. Reasoning-only or "this would" reproducers do not
+count; if you couldn't run it here, say so explicitly instead of inventing one.
+
+- **A focused test**: add a spec under the project's `src/test/scala` and run only that one:
+  ```bash
+  sbt --batch "testOnly *ReproSpec"
+  ```
+  ScalaTest, MUnit, and specs2 all wire through `testOnly`. The test output is the evidence.
+- **The sbt console**: `sbt --batch "runMain com.example.Repro arg"` if you drop a small `object Repro { def main... }`
+  under `src/main/scala`; or `sbt --batch console <<'EOF' ... EOF` for a REPL one-liner against the compiled classpath.
+- **Standalone**: sbt writes classes to `target/scala-<v>/classes`; `sbt --batch "export Runtime/fullClasspath"` prints
+  a colon-separated classpath you can pass to `java -cp` or `scala -cp` for a script that drives the vulnerable method
+  directly with the malicious input (a crafted string, a hostile serialized blob, an XXE payload).
+
+## Out of scope
+
+- Dependencies under `/opt/ivy2`, `/opt/coursier`, `/opt/m2/repo`, and `/opt/gradle-home` — third-party code, not the
+  target of this scan unless a finding specifically pivots through one.

--- a/internal/worker/profile.go
+++ b/internal/worker/profile.go
@@ -137,6 +137,20 @@ var builtinProfiles = []Profile{
 	},
 	{Name: "python", Detect: pm("pip", "Pipenv", "Poetry", "uv", "PDM", "setuptools")},
 	{Name: "go", Detect: pm("Go Modules")},
+	{
+		// Before java: an sbt project also matches nothing under java (Maven/
+		// Gradle), but a Scala-on-Gradle build reports both Gradle and Scala,
+		// and the scala profile is a superset of java (BaseProfile) that adds
+		// sbt plus Scala-specific reproducer guidance. The language selector is
+		// a belt-and-braces for a *.scala-only checkout with no build.sbt.
+		Name:            "scala",
+		BaseProfile:     "java",
+		FallbackProfile: "java",
+		Detect: []BriefMatch{
+			{briefPackageManager, []string{"sbt"}},
+			{briefLanguage, []string{"Scala"}},
+		},
+	},
 	{Name: "java", Detect: pm("Maven", "Gradle")},
 	{Name: "dotnet", Detect: pm("NuGet", "dotnet CLI")},
 	{Name: "beam", Detect: pm("Mix", "rebar3")},

--- a/internal/worker/profile_test.go
+++ b/internal/worker/profile_test.go
@@ -102,6 +102,7 @@ func TestMatchProfile(t *testing.T) {
 		{"setuptools matches python", briefJSON("package_manager:setuptools"), "python"},
 		{"go modules matches go", briefJSON("package_manager:Go Modules"), "go"},
 		{"go modules case-insensitive", briefJSON("package_manager:go modules"), "go"},
+		{"sbt matches scala", briefJSON("package_manager:sbt"), "scala"},
 		{"maven matches java", briefJSON("package_manager:Maven"), "java"},
 		{"gradle matches java", briefJSON("package_manager:Gradle"), "java"},
 		{"gradle case-insensitive", briefJSON("package_manager:gradle"), "java"},
@@ -153,6 +154,7 @@ func TestMatchProfile(t *testing.T) {
 		{"Meson selects c-cpp", briefJSON("build:Meson"), "c-cpp"},
 
 		// language fallbacks
+		{"Scala language matches scala (belt-and-braces for a *.scala-only checkout)", briefJSON("language:Scala"), "scala"},
 		{"Perl language matches perl (belt-and-braces for a *.pl-only dist)", briefJSON("language:Perl"), "perl"},
 		{"C language matches c-cpp", briefJSON("language:C"), "c-cpp"},
 		{"C++ language matches c-cpp", briefJSON("language:C++"), "c-cpp"},
@@ -215,6 +217,22 @@ func TestMatchProfile(t *testing.T) {
 			"bundler + Make picks ruby over c-cpp",
 			briefJSON("package_manager:Bundler", "build:Make", "language:Ruby"),
 			"ruby",
+		},
+		{
+			// An sbt repo that also ships a Makefile (many do; it just
+			// wraps `sbt compile`) must not fall through to c-cpp.
+			"sbt + Make picks scala over c-cpp (registry order)",
+			briefJSON("package_manager:sbt", "build:Make", "language:Scala"),
+			"scala",
+		},
+		{
+			// A Scala-on-Gradle build reports both Gradle and Scala. scala
+			// is a superset of java (BaseProfile), so the Scala language
+			// selector routing here loses nothing and gains the sbt
+			// launcher plus Scala-specific reproducer guidance.
+			"Gradle + Scala language picks scala over java",
+			briefJSON("package_manager:Gradle", "language:Scala"),
+			"scala",
 		},
 
 		// no-match cases
@@ -552,6 +570,46 @@ func TestBrakemanVersionParity(t *testing.T) {
 	}
 	if rails != ext {
 		t.Errorf("BRAKEMAN_VERSION drift: ruby-rails=%q ruby-ext=%q (keep them in lockstep)", rails, ext)
+	}
+}
+
+// TestChainedProfilesInCIWorkflow keeps .github/workflows/profile-images.yml
+// in sync with builtinProfiles' BaseProfile entries. That workflow special-
+// cases chained profiles (it must build the base image first and pass it as
+// BASE_IMAGE); a new BaseProfile entry that is not listed there would build
+// FROM the runner in CI and pass, then fail at the worker's on-demand build
+// because the Dockerfile's ARG BASE_IMAGE never resolved to a java/ruby image.
+func TestChainedProfilesInCIWorkflow(t *testing.T) {
+	wd, _ := os.Getwd()
+	wf := filepath.Join(wd, "..", "..", ".github", "workflows", "profile-images.yml")
+	b, err := os.ReadFile(wf)
+	if err != nil {
+		t.Fatalf("read workflow: %v", err)
+	}
+	// Match `<profile>) base=<base> ;;` lines inside the case block.
+	re := regexp.MustCompile(`(?m)^\s+(\S+)\)\s+base=(\S+)\s+;;`)
+	got := map[string]string{}
+	for _, m := range re.FindAllStringSubmatch(string(b), -1) {
+		if m[1] != "*" {
+			got[m[1]] = m[2]
+		}
+	}
+	want := map[string]string{}
+	for _, p := range builtinProfiles {
+		if p.BaseProfile != "" {
+			want[p.Name] = p.BaseProfile
+		}
+	}
+	for name, base := range want {
+		if got[name] != base {
+			t.Errorf("workflow case for %q maps to base %q, want %q (add `%s) base=%s ;;` to %s)",
+				name, got[name], base, name, base, wf)
+		}
+	}
+	for name := range got {
+		if _, ok := want[name]; !ok {
+			t.Errorf("workflow case for %q has no matching BaseProfile in builtinProfiles (stale entry?)", name)
+		}
 	}
 }
 


### PR DESCRIPTION
sbt projects currently fall through every `builtinProfiles` entry and land on the default runner (no JDK, no sbt), so the agent can only read source. This adds a `scala` profile chained on `java` via `BaseProfile`, so the JDK/Maven/Gradle layer is shared and only sbt is added on top.

The sbt launcher (1.13.0, sha256-verified) reads `project/build.properties` and bootstraps whichever `sbt.version` the project pins. Boot, ivy, and coursier caches are redirected to `/opt` because `HOME=/tmp` is a 256 MB noexec tmpfs at scan time and a resolved compiler + dependency set exceeds that.

Selected when brief reports `sbt` under `package_managers` or Scala as the dominant language; falls back to `java` if the image build fails.

Also in this PR:

- `README.md`: profile-table rows for `scala`, and the previously missing `swift` / `ocaml`.
- `.github/workflows/profile-images.yml`: the chained-profile special case is now a `case` block covering `ruby-rails`→`ruby` and `scala`→`java`.
- `TestChainedProfilesInCIWorkflow`: fails when a `BaseProfile` entry in `builtinProfiles` has no matching case in that workflow, so the two lists stay in sync.