### PR TITLE
Reword "caches live on" in profile guides

### DIFF
--- a/docker/profiles/beam/PROFILE.md
+++ b/docker/profiles/beam/PROFILE.md
@@ -7,7 +7,7 @@ The repository under `./src` is an Erlang or Elixir project, built with rebar3 o
 - **Erlang/OTP 27** — `erl`, `erlc`, `escript`.
 - **Elixir 1.20** — `elixir`, `iex`, `mix` (for `mix.exs` projects).
 - **`rebar3`** on PATH for Erlang (`rebar.config`) projects.
-- **Hex** is installed; the package cache (`/opt/hex`) and Mix archives (`/opt/mix`) live on an exec-capable path rather than under `HOME`, which is a small noexec mount.
+- **Hex** is installed; the package cache (`/opt/hex`) and Mix archives (`/opt/mix`) are on an exec-capable path rather than under `HOME`, which is a small noexec mount.
 
 ## Operating procedure
 

--- a/docker/profiles/dotnet/PROFILE.md
+++ b/docker/profiles/dotnet/PROFILE.md
@@ -5,7 +5,7 @@ The repository under `./src` is a .NET project (C#, F#, or VB), built with NuGet
 ## Runtime
 
 - **.NET SDK 10** — `dotnet`. Covers restore, build, test, and run.
-- The NuGet package cache (`/opt/nuget`) and CLI home (`/opt/dotnet-home`) live on an exec-capable path rather than under `HOME`, which is a small noexec mount. Telemetry and the first-run banner are off.
+- The NuGet package cache (`/opt/nuget`) and CLI home (`/opt/dotnet-home`) are on an exec-capable path rather than under `HOME`, which is a small noexec mount. Telemetry and the first-run banner are off.
 
 ## Operating procedure
 

--- a/docker/profiles/go/PROFILE.md
+++ b/docker/profiles/go/PROFILE.md
@@ -8,7 +8,7 @@ The repository under `./src` is a Go module.
 - **`govulncheck`** on PATH — reports known vulnerabilities in the module graph and, with source, which are actually reachable.
 - C toolchain (`build-essential`) for cgo, so a project that imports `"C"` builds, tests, and reproduces.
 
-The Go module cache, build cache, and tmp dir live under `/opt/go` (an exec-capable path), because `HOME` is a noexec
+The Go module cache, build cache, and tmp dir are under `/opt/go` (an exec-capable path), because `HOME` is a noexec
 mount and `go run`/`go test` execute the binaries they build.
 
 ## Operating procedure

--- a/docker/profiles/java/PROFILE.md
+++ b/docker/profiles/java/PROFILE.md
@@ -8,7 +8,7 @@ The repository under `./src` is a JVM project, built with Maven or Gradle.
 - **`mvn`** (Maven 3.9) on PATH for `pom.xml` projects.
 - **`gradle`** (Gradle 9) on PATH for `build.gradle` / `build.gradle.kts` projects.
 
-The Maven local repository (`/opt/m2/repo`) and Gradle home (`/opt/gradle-home`) live on an exec-capable path rather
+The Maven local repository (`/opt/m2/repo`) and Gradle home (`/opt/gradle-home`) are on an exec-capable path rather
 than under `HOME`, which is a small noexec mount. `mvn` and `gradle` already run with `java.io.tmpdir=/opt/java-tmp` so
 JVM libraries that unpack native `.so` files can load them; a standalone `java` reproducer that loads a native library
 should pass `-Djava.io.tmpdir=/opt/java-tmp` too.


### PR DESCRIPTION
Replaces `live on` / `live under` with `are on` / `are under` in the java, go, dotnet, and beam `PROFILE.md` files.

The same phrase appears in five Dockerfile comments (`java`, `dotnet`, `beam`, `go`, `perl`); those are left as-is because editing a Dockerfile changes its content-addressed tag and forces every worker to rebuild that profile image on the next scan, which is disproportionate for a comment-only change. They can be reworded the next time each Dockerfile changes for a real reason.