### PR TITLE
Gate the patch on a pristine checkout

### DIFF
--- a/internal/worker/patch_gate.go
+++ b/internal/worker/patch_gate.go
@@ -3,6 +3,7 @@ package worker
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -31,7 +32,7 @@ type patchReport struct {
 // on pass, appends an immutable RemediationAttempt and updates the
 // Finding.SuggestedFix projection through WriteFindingField. A gate failure is
 // not a scan error: the scan completed and the diff remains in Scan.Report.
-func (w *Worker) parsePatchOutput(scan *db.Scan, report string, emit func(Event)) error {
+func (w *Worker) parsePatchOutput(ctx context.Context, scan *db.Scan, report string, emit func(Event)) error {
 	var rep patchReport
 	if err := json.Unmarshal([]byte(report), &rep); err != nil {
 		return fmt.Errorf("parse patch: %w", err)
@@ -52,6 +53,12 @@ func (w *Worker) parsePatchOutput(scan *db.Scan, report string, emit func(Event)
 		emit(Event{Kind: KindText, Text: "patch: gate rejected: base_commit is required for reproducible re-attack"})
 		return nil
 	}
+	scanCommit := strings.TrimSpace(scan.Commit)
+	if scanCommit == "" || strings.TrimSpace(rep.BaseCommit) != scanCommit {
+		emit(Event{Kind: KindText, Text: fmt.Sprintf(
+			"patch: gate rejected: base_commit %q does not match scan commit %q", rep.BaseCommit, scanCommit)})
+		return nil
+	}
 
 	var f db.Finding
 	if err := w.DB.First(&f, *scan.FindingID).Error; err != nil {
@@ -64,14 +71,12 @@ func (w *Worker) parsePatchOutput(scan *db.Scan, report string, emit func(Event)
 			return fmt.Errorf("load repository %d: %w", scan.RepositoryID, err)
 		}
 	}
-	head, reason := w.gatePatch(repo, f.Location, rep.Patch)
+	reason, err := w.gatePatch(ctx, repo, scanCommit, f.Location, rep.Patch)
+	if err != nil {
+		return err
+	}
 	if reason != "" {
 		emit(Event{Kind: KindText, Text: "patch: gate rejected: " + reason})
-		return nil
-	}
-	if head == "" || strings.TrimSpace(rep.BaseCommit) != head {
-		emit(Event{Kind: KindText, Text: fmt.Sprintf(
-			"patch: gate rejected: base_commit %q does not match staged HEAD %q", rep.BaseCommit, head)})
 		return nil
 	}
 
@@ -174,32 +179,49 @@ func cloneLocalPatchGateSrc(localPath, dst string) error {
 	return nil
 }
 
-// gatePatch validates a diff only against a fresh checkout the runner never
-// touched. It returns that checkout's HEAD for the base-commit comparison and
-// a one-line rejection reason, if any.
-func (w *Worker) gatePatch(repo db.Repository, location, diff string) (string, string) {
+// gatePatch validates a diff only against the scan's commit in a fresh checkout
+// the runner never touched. It returns a one-line rejection reason, if any.
+func (w *Worker) gatePatch(
+	ctx context.Context,
+	repo db.Repository,
+	commit, location, diff string,
+) (string, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+	if !repo.IsLocal() {
+		if err := w.EnsureCommit(ctx, repo.URL, commit); err != nil {
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return "", ctxErr
+			}
+			return "ensure scan commit: " + firstLine(err.Error()), nil
+		}
+	}
 	srcDir, cleanup, err := w.stagePatchGateSrc(repo)
 	if err != nil {
-		return "", "stage pristine checkout: " + firstLine(err.Error())
+		return "stage pristine checkout: " + firstLine(err.Error()), nil
 	}
 	defer cleanup()
-	if reason := gatePatchTree(srcDir, location, diff); reason != "" {
-		return "", reason
+	if err := ctx.Err(); err != nil {
+		return "", err
 	}
-	return gitHead(srcDir), ""
+	return gatePatchTree(srcDir, commit, location, diff), nil
 }
 
 // gatePatchTree returns "" when the diff is acceptable, otherwise a one-line
-// reason. The caller must supply a host-owned tree. Checks: diff parses; every
-// target file exists; the diff touches a file named in location; git
-// apply --check accepts it.
-func gatePatchTree(srcDir, location, diff string) string {
+// reason. The caller must supply a host-owned tree. Checks: diff parses; the
+// tree resets to the scan's commit; every target file exists; the diff touches
+// a file named in location; git apply --check accepts it.
+func gatePatchTree(srcDir, commit, location, diff string) string {
 	files, err := parseUnifiedDiff(diff)
 	if err != nil {
 		return "diff does not parse: " + err.Error()
 	}
 	if len(files) == 0 {
 		return "diff has no file headers"
+	}
+	if out, err := resetPatchGateTree(srcDir, commit); err != nil {
+		return "reset to scan commit: " + firstLine(out)
 	}
 
 	for _, df := range files {
@@ -321,15 +343,19 @@ func locationPaths(location string) []string {
 	return paths
 }
 
-func gitApplyCheck(srcDir, diff string) (string, error) {
+func resetPatchGateTree(srcDir, commit string) (string, error) {
 	// The caller supplies a fresh host-owned copy. Keep reset and clean so every
-	// applicability check starts from HEAD even if staging copied local changes
-	// or cache bookkeeping; neither command runs in the runner's checkout.
-	for _, args := range [][]string{{"reset", "-q", "--hard", "HEAD"}, {"clean", "-qfd"}} {
+	// applicability check starts from the commit the scan saw even if the shared
+	// cache has advanced; neither command runs in the runner's checkout.
+	for _, args := range [][]string{{"reset", "-q", "--hard", commit}, {"clean", "-qfd"}} {
 		if out, err := exec.Command("git", append([]string{"-C", srcDir}, args...)...).CombinedOutput(); err != nil {
 			return string(out), err
 		}
 	}
+	return "", nil
+}
+
+func gitApplyCheck(srcDir, diff string) (string, error) {
 	cmd := exec.Command("git", "-C", srcDir, "apply", "--check", "-")
 	cmd.Stdin = strings.NewReader(diff)
 	var out bytes.Buffer

--- a/internal/worker/patch_gate.go
+++ b/internal/worker/patch_gate.go
@@ -58,12 +58,18 @@ func (w *Worker) parsePatchOutput(scan *db.Scan, report string, emit func(Event)
 		return fmt.Errorf("load finding %d: %w", *scan.FindingID, err)
 	}
 
-	srcDir := filepath.Join(w.scanWorkRoot(scan), "src")
-	if reason := gatePatch(srcDir, f.Location, rep.Patch); reason != "" {
+	repo := scan.Repository
+	if repo.ID == 0 {
+		if err := w.DB.First(&repo, scan.RepositoryID).Error; err != nil {
+			return fmt.Errorf("load repository %d: %w", scan.RepositoryID, err)
+		}
+	}
+	head, reason := w.gatePatch(repo, f.Location, rep.Patch)
+	if reason != "" {
 		emit(Event{Kind: KindText, Text: "patch: gate rejected: " + reason})
 		return nil
 	}
-	if head := gitHead(srcDir); head == "" || strings.TrimSpace(rep.BaseCommit) != head {
+	if head == "" || strings.TrimSpace(rep.BaseCommit) != head {
 		emit(Event{Kind: KindText, Text: fmt.Sprintf(
 			"patch: gate rejected: base_commit %q does not match staged HEAD %q", rep.BaseCommit, head)})
 		return nil
@@ -122,10 +128,72 @@ func (w *Worker) recordRemediationAttempt(scan *db.Scan, findingID uint, rep pat
 	return attempt, err
 }
 
-// gatePatch returns "" when the diff is acceptable, otherwise a one-line
-// reason. Checks: diff parses; every target file exists under srcDir; the
-// diff touches a file named in location; git apply --check accepts it.
-func gatePatch(srcDir, location, diff string) string {
+// stagePatchGateSrc creates a host-owned copy that has never been exposed to
+// the scan runner. Git must not inspect the runner's checkout after a skill
+// returns because the runner can rewrite .git/config and make Git execute a
+// filter, hook, or monitor as the host user. Remote repositories come from the
+// persistent clone cache under its per-URL lock; local repositories are cloned
+// with independent Git metadata so linked-worktree pointers cannot lead back to
+// the operator's real index.
+func (w *Worker) stagePatchGateSrc(repo db.Repository) (string, func(), error) {
+	tmp, err := os.MkdirTemp("", "scrutineer-gate-")
+	if err != nil {
+		return "", nil, err
+	}
+	cleanup := func() { _ = os.RemoveAll(tmp) }
+	if repo.IsLocal() {
+		if err := cloneLocalPatchGateSrc(repo.LocalPath(), filepath.Join(tmp, "src")); err != nil {
+			cleanup()
+			return "", nil, err
+		}
+	} else {
+		mu := w.cacheMutex(repo.URL)
+		mu.Lock()
+		err = CopyTree(
+			filepath.Join(RepoCacheRoot(w.DataDir, repo.URL), "src"),
+			filepath.Join(tmp, "src"),
+		)
+		mu.Unlock()
+		if err != nil {
+			cleanup()
+			return "", nil, fmt.Errorf("copy repository cache: %w", err)
+		}
+	}
+	return filepath.Join(tmp, "src"), cleanup, nil
+}
+
+// cloneLocalPatchGateSrc uses the normal Git transport instead of the local
+// hard-link optimization. Besides avoiding shared objects, this dereferences a
+// linked worktree's .git file into independent metadata under dst.
+func cloneLocalPatchGateSrc(localPath, dst string) error {
+	cmd := exec.Command("git", "clone", "--quiet", "--no-local", "--", localPath, dst)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("clone local source: %w: %s", err, firstLine(string(out)))
+	}
+	return nil
+}
+
+// gatePatch validates a diff only against a fresh checkout the runner never
+// touched. It returns that checkout's HEAD for the base-commit comparison and
+// a one-line rejection reason, if any.
+func (w *Worker) gatePatch(repo db.Repository, location, diff string) (string, string) {
+	srcDir, cleanup, err := w.stagePatchGateSrc(repo)
+	if err != nil {
+		return "", "stage pristine checkout: " + firstLine(err.Error())
+	}
+	defer cleanup()
+	if reason := gatePatchTree(srcDir, location, diff); reason != "" {
+		return "", reason
+	}
+	return gitHead(srcDir), ""
+}
+
+// gatePatchTree returns "" when the diff is acceptable, otherwise a one-line
+// reason. The caller must supply a host-owned tree. Checks: diff parses; every
+// target file exists; the diff touches a file named in location; git
+// apply --check accepts it.
+func gatePatchTree(srcDir, location, diff string) string {
 	files, err := parseUnifiedDiff(diff)
 	if err != nil {
 		return "diff does not parse: " + err.Error()
@@ -254,11 +322,9 @@ func locationPaths(location string) []string {
 }
 
 func gitApplyCheck(srcDir, diff string) (string, error) {
-	// The patch skill captures its diff with `git diff HEAD` and leaves the
-	// edits applied in srcDir; it never reverts. Re-applying an already-applied
-	// diff always fails, so reset the per-scan copy to HEAD first. reset --hard
-	// clears the skill's `git add -N` index entries; clean -fd drops any new
-	// files it created so a /dev/null hunk can recreate them.
+	// The caller supplies a fresh host-owned copy. Keep reset and clean so every
+	// applicability check starts from HEAD even if staging copied local changes
+	// or cache bookkeeping; neither command runs in the runner's checkout.
 	for _, args := range [][]string{{"reset", "-q", "--hard", "HEAD"}, {"clean", "-qfd"}} {
 		if out, err := exec.Command("git", append([]string{"-C", srcDir}, args...)...).CombinedOutput(); err != nil {
 			return string(out), err

--- a/internal/worker/patch_gate_test.go
+++ b/internal/worker/patch_gate_test.go
@@ -1,6 +1,7 @@
 package worker
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"log/slog"
@@ -192,50 +193,36 @@ func seedPatchCache(t *testing.T, w *Worker, repo db.Repository) (string, string
 	return diff, gitHead(cacheSrc)
 }
 
-func stagePatchSkillEdits(t *testing.T, w *Worker, scan *db.Scan, repo db.Repository, diff string) {
-	t.Helper()
-	cacheSrc := filepath.Join(RepoCacheRoot(w.DataDir, repo.URL), "src")
-	workSrc := filepath.Join(w.scanWorkRoot(scan), "src")
-	if err := CopyTree(cacheSrc, workSrc); err != nil {
-		t.Fatal(err)
-	}
-	apply := exec.Command("git", "-C", workSrc, "apply", "-")
-	apply.Env = testutil.GitEnv()
-	apply.Stdin = strings.NewReader(diff)
-	if out, err := apply.CombinedOutput(); err != nil {
-		t.Fatalf("seed skill edits: %v: %s", err, out)
-	}
-}
-
 func TestGatePatch(t *testing.T) {
 	src := t.TempDir()
 	rel, diff := gateRepo(t, src)
+	commit := gitHead(src)
 
-	if r := gatePatchTree(src, rel+":12", diff); r != "" {
+	if r := gatePatchTree(src, commit, rel+":12", diff); r != "" {
 		t.Errorf("pass case rejected: %q", r)
 	}
 	// File-level match: a fix to pkg/foo.go passes even when the flagged line
 	// (:3) sits far from the hunk (line 12). This is the choke-point case the
 	// old line-overlap gate wrongly rejected.
-	if r := gatePatchTree(src, rel+":3", diff); r != "" {
+	if r := gatePatchTree(src, commit, rel+":3", diff); r != "" {
 		t.Errorf("file-level pass case rejected: %q", r)
 	}
-	if r := gatePatchTree(src, "pkg/unrelated.go:12", diff); !strings.Contains(r, "no patched file matches location") {
+	if r := gatePatchTree(src, commit, "pkg/unrelated.go:12", diff); !strings.Contains(r, "no patched file matches location") {
 		t.Errorf("expected unrelated-location rejection, got %q", r)
 	}
-	if r := gatePatchTree(src, "pkg/missing.go:12",
+	if r := gatePatchTree(src, commit, "pkg/missing.go:12",
 		"--- a/pkg/missing.go\n+++ b/pkg/missing.go\n@@ -1 +1 @@\n-x\n+y\n"); !strings.Contains(r, "missing file") {
 		t.Errorf("expected missing-file rejection, got %q", r)
 	}
-	if r := gatePatchTree(src, rel+":12", "not a diff"); !strings.Contains(r, "no file headers") {
+	if r := gatePatchTree(src, commit, rel+":12", "not a diff"); !strings.Contains(r, "no file headers") {
 		t.Errorf("expected no-file-headers rejection, got %q", r)
 	}
 	bad := strings.Replace(diff, "-line 12", "-WRONG", 1)
-	if r := gatePatchTree(src, rel+":12", bad); !strings.Contains(r, "git apply --check") {
+	if r := gatePatchTree(src, commit, rel+":12", bad); !strings.Contains(r, "git apply --check") {
 		t.Errorf("expected git apply rejection, got %q", r)
 	}
 	newFileDiff := "--- /dev/null\n+++ b/pkg/foo_test.go\n@@ -0,0 +1 @@\n+test\n" + diff
-	if r := gatePatchTree(src, rel+":12", newFileDiff); r != "" {
+	if r := gatePatchTree(src, commit, rel+":12", newFileDiff); r != "" {
 		t.Errorf("new-file alongside fix rejected: %q", r)
 	}
 }
@@ -248,14 +235,31 @@ func TestGatePatch_dirtyWorkspaceFromSkill(t *testing.T) {
 	// skill's behaviour by re-applying the diff to dirty it first.
 	src := t.TempDir()
 	rel, diff := gateRepo(t, src)
+	commit := gitHead(src)
 	apply := exec.Command("git", "-C", src, "apply", "-")
 	apply.Env = testutil.GitEnv()
 	apply.Stdin = strings.NewReader(diff)
 	if out, err := apply.CombinedOutput(); err != nil {
 		t.Fatalf("seed dirty workspace: %v: %s", err, out)
 	}
-	if r := gatePatchTree(src, rel+":12", diff); r != "" {
+	if r := gatePatchTree(src, commit, rel+":12", diff); r != "" {
 		t.Errorf("gate rejected a valid patch against a skill-dirtied workspace: %q", r)
+	}
+}
+
+func TestGatePatch_checksFilesAtScanCommit(t *testing.T) {
+	src := t.TempDir()
+	rel, diff := gateRepo(t, src)
+	commitA := gitHead(src)
+	for _, args := range [][]string{{"rm", "-q", rel}, {"commit", "-q", "-m", "delete target"}} {
+		cmd := exec.Command("git", append([]string{"-C", src}, args...)...)
+		cmd.Env = testutil.GitEnv()
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
+	if r := gatePatchTree(src, commitA, rel+":12", diff); r != "" {
+		t.Fatalf("A-based patch rejected after commit B deleted its target: %s", r)
 	}
 }
 
@@ -299,25 +303,19 @@ func TestGitApplyCheck_ignoresRunnerInstalledFilter(t *testing.T) {
 		t.Fatalf("seed skill edits: %v: %s", err, out)
 	}
 
-	marker := filepath.Join(t.TempDir(), "filter-ran")
-	config, err := os.OpenFile(filepath.Join(workSrc, ".git", "config"), os.O_WRONLY|os.O_APPEND, 0)
-	if err != nil {
-		t.Fatal(err)
+	marker := filepath.Join(t.TempDir(), "filter ran")
+	shellQuote := func(s string) string {
+		return "'" + strings.ReplaceAll(s, "'", "'\"'\"'") + "'"
 	}
-	if _, err := fmt.Fprintf(config,
-		"\n[filter \"pwn\"]\n\tsmudge = sh -c \"id > %s 2>&1; cat\"\n", marker); err != nil {
-		_ = config.Close()
-		t.Fatal(err)
-	}
-	if err := config.Close(); err != nil {
-		t.Fatal(err)
-	}
+	smudge := "sh -c " + shellQuote("id > "+shellQuote(marker)+" 2>&1; cat")
+	runGit(workSrc, "config", "--local", "filter.pwn.smudge", smudge)
 	if got := runGit(workSrc, "config", "--local", "--get", "filter.pwn.smudge"); !strings.Contains(got, marker) {
 		t.Fatalf("filter command = %q, want marker path %q", got, marker)
 	}
 
-	report := fmt.Sprintf(`{"patch":%q,"base_commit":%q}`, diff, gitHead(cacheSrc))
-	if err := w.parsePatchOutput(&scan, report, func(Event) {}); err != nil {
+	scan.Commit = gitHead(cacheSrc)
+	report := fmt.Sprintf(`{"patch":%q,"base_commit":%q}`, diff, scan.Commit)
+	if err := w.parsePatchOutput(context.Background(), &scan, report, func(Event) {}); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := os.Stat(marker); err == nil {
@@ -334,24 +332,92 @@ func TestGitApplyCheck_ignoresRunnerInstalledFilter(t *testing.T) {
 	}
 }
 
+func TestPatchGate_acceptsPatchAfterCacheAdvances(t *testing.T) {
+	w, finding := newPatchOutputFixture(t)
+	repo := findingRepoForPatch(t, w, finding)
+	diff, commitA := seedPatchCache(t, w, repo)
+	scan := db.Scan{RepositoryID: repo.ID, Repository: repo, Kind: JobSkill,
+		Status: db.ScanRunning, FindingID: &finding.ID, Commit: commitA}
+	if err := w.DB.Create(&scan).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	cacheSrc := filepath.Join(RepoCacheRoot(w.DataDir, repo.URL), "src")
+	if err := os.WriteFile(filepath.Join(cacheSrc, "later.txt"), []byte("commit B\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command("git", "-C", cacheSrc, "add", "later.txt")
+	cmd.Env = testutil.GitEnv()
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("stage commit B: %v: %s", err, out)
+	}
+	cmd = exec.Command("git", "-C", cacheSrc, "commit", "-q", "-m", "advance cache")
+	cmd.Env = testutil.GitEnv()
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("create commit B: %v: %s", err, out)
+	}
+	if commitB := gitHead(cacheSrc); commitB == commitA {
+		t.Fatal("test precondition: cache HEAD did not advance")
+	}
+
+	report := fmt.Sprintf(`{"patch":%q,"base_commit":%q}`, diff, commitA)
+	var events []string
+	if err := w.parsePatchOutput(context.Background(), &scan, report, func(e Event) { events = append(events, e.Text) }); err != nil {
+		t.Fatal(err)
+	}
+	var got db.Finding
+	if err := w.DB.First(&got, finding.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if got.SuggestedFix != diff || got.SuggestedFixCommit != commitA {
+		t.Fatalf("A-based patch was not recorded after cache advanced: fix=%q commit=%q events=%v",
+			got.SuggestedFix, got.SuggestedFixCommit, events)
+	}
+	var attempts []db.RemediationAttempt
+	w.DB.Where("finding_id = ?", finding.ID).Find(&attempts)
+	if len(attempts) != 1 || attempts[0].BaseCommit != commitA {
+		t.Fatalf("remediation attempts = %+v, want one attempt at commit A", attempts)
+	}
+}
+
 func TestPatchGate_stagesLocalRepositoryWithoutMutatingIt(t *testing.T) {
 	src := t.TempDir()
 	rel, diff := gateRepo(t, src)
-	head := gitHead(src)
+	scanCommit := gitHead(src)
 	apply := exec.Command("git", "-C", src, "apply", "-")
 	apply.Env = testutil.GitEnv()
 	apply.Stdin = strings.NewReader(diff)
 	if out, err := apply.CombinedOutput(); err != nil {
 		t.Fatalf("seed local edits: %v: %s", err, out)
 	}
+	if err := os.WriteFile(filepath.Join(src, "later.txt"), []byte("commit B\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	advance := exec.Command("git", "-C", src, "add", "later.txt")
+	advance.Env = testutil.GitEnv()
+	if out, err := advance.CombinedOutput(); err != nil {
+		t.Fatalf("stage local commit B: %v: %s", err, out)
+	}
+	advance = exec.Command("git", "-C", src, "commit", "-q", "-m", "advance local repository")
+	advance.Env = testutil.GitEnv()
+	if out, err := advance.CombinedOutput(); err != nil {
+		t.Fatalf("create local commit B: %v: %s", err, out)
+	}
+	localHead := gitHead(src)
+	if localHead == scanCommit {
+		t.Fatal("test precondition: local repository HEAD did not advance")
+	}
 
 	w := &Worker{}
-	gotHead, reason := w.gatePatch(db.Repository{URL: "file://" + src}, rel+":12", diff)
+	reason, err := w.gatePatch(context.Background(), db.Repository{URL: "file://" + src}, scanCommit, rel+":12", diff)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if reason != "" {
 		t.Fatalf("local patch rejected: %s", reason)
 	}
-	if gotHead != head {
-		t.Fatalf("staged HEAD = %q, want %q", gotHead, head)
+	if got := gitHead(src); got != localHead {
+		t.Fatalf("patch gate changed local HEAD from %q to %q", localHead, got)
 	}
 	local, err := os.ReadFile(filepath.Join(src, rel))
 	if err != nil {
@@ -377,6 +443,7 @@ func TestPatchGate_stagesLinkedWorktreeWithoutMutatingIndex(t *testing.T) {
 		return string(out)
 	}
 	runGit(main, "worktree", "add", "-q", "--detach", linked, "HEAD")
+	scanCommit := gitHead(linked)
 	tracked := filepath.Join(linked, rel)
 	if err := os.WriteFile(tracked, []byte("operator staged change\n"), 0o644); err != nil {
 		t.Fatal(err)
@@ -388,7 +455,11 @@ func TestPatchGate_stagesLinkedWorktreeWithoutMutatingIndex(t *testing.T) {
 	}
 
 	w := &Worker{}
-	if _, reason := w.gatePatch(db.Repository{URL: "file://" + linked}, rel+":12", diff); reason != "" {
+	reason, err := w.gatePatch(context.Background(), db.Repository{URL: "file://" + linked}, scanCommit, rel+":12", diff)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reason != "" {
 		t.Fatalf("linked-worktree patch rejected: %s", reason)
 	}
 	if after := runGit(linked, "diff", "--cached", "--binary"); after != before {
@@ -422,17 +493,16 @@ func newPatchOutputFixture(t *testing.T) (*Worker, db.Finding) {
 func TestParsePatchOutput_passWritesColumnsAndHistory(t *testing.T) {
 	w, finding := newPatchOutputFixture(t)
 	repo := findingRepoForPatch(t, w, finding)
+	diff, head := seedPatchCache(t, w, repo)
 	sc := db.Scan{RepositoryID: finding.RepositoryID, Repository: repo,
-		Kind: JobSkill, Status: db.ScanRunning, FindingID: &finding.ID}
+		Kind: JobSkill, Status: db.ScanRunning, FindingID: &finding.ID, Commit: head}
 	if err := w.DB.Create(&sc).Error; err != nil {
 		t.Fatal(err)
 	}
-	diff, head := seedPatchCache(t, w, repo)
-	stagePatchSkillEdits(t, w, &sc, repo, diff)
 	report := fmt.Sprintf(`{"patch":%q,"base_commit":%q}`, diff, head)
 
 	var events []string
-	if err := w.parsePatchOutput(&sc, report, func(e Event) { events = append(events, e.Text) }); err != nil {
+	if err := w.parsePatchOutput(context.Background(), &sc, report, func(e Event) { events = append(events, e.Text) }); err != nil {
 		t.Fatal(err)
 	}
 	var f db.Finding
@@ -456,7 +526,7 @@ func TestParsePatchOutput_passWritesColumnsAndHistory(t *testing.T) {
 	if len(attempts) != 1 || attempts[0].Attempt != 1 || attempts[0].PatchScanID != sc.ID || attempts[0].Patch != diff {
 		t.Errorf("remediation attempts = %+v, want immutable attempt 1 for scan %d", attempts, sc.ID)
 	}
-	if err := w.parsePatchOutput(&sc, report, func(Event) {}); err != nil {
+	if err := w.parsePatchOutput(context.Background(), &sc, report, func(Event) {}); err != nil {
 		t.Fatal(err)
 	}
 	w.DB.Where("finding_id = ?", finding.ID).Find(&attempts)
@@ -471,13 +541,12 @@ func TestParsePatchOutput_newScanCreatesNextImmutableAttempt(t *testing.T) {
 	diff, head := seedPatchCache(t, w, repo)
 	for want := 1; want <= 2; want++ {
 		scan := db.Scan{RepositoryID: finding.RepositoryID, Repository: repo,
-			Kind: JobSkill, Status: db.ScanRunning, FindingID: &finding.ID}
+			Kind: JobSkill, Status: db.ScanRunning, FindingID: &finding.ID, Commit: head}
 		if err := w.DB.Create(&scan).Error; err != nil {
 			t.Fatal(err)
 		}
-		stagePatchSkillEdits(t, w, &scan, repo, diff)
 		report := fmt.Sprintf(`{"patch":%q,"base_commit":%q}`, diff, head)
-		if err := w.parsePatchOutput(&scan, report, func(Event) {}); err != nil {
+		if err := w.parsePatchOutput(context.Background(), &scan, report, func(Event) {}); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -485,43 +554,6 @@ func TestParsePatchOutput_newScanCreatesNextImmutableAttempt(t *testing.T) {
 	w.DB.Where("finding_id = ?", finding.ID).Order("attempt").Find(&attempts)
 	if len(attempts) != 2 || attempts[0].Attempt != 1 || attempts[1].Attempt != 2 || attempts[0].BaseCommit == "" {
 		t.Fatalf("attempts = %+v", attempts)
-	}
-}
-
-func TestParsePatchOutput_resumedScanUsesLineageWorkspace(t *testing.T) {
-	// A resumed patch run stages its skill edits under the lineage-root
-	// workspace. The gate no longer trusts either workspace path, but the diff
-	// produced there must still validate against the pristine cache copy.
-	w, finding := newPatchOutputFixture(t)
-	repo := findingRepoForPatch(t, w, finding)
-	root := db.Scan{RepositoryID: finding.RepositoryID, Kind: JobSkill, Status: db.ScanDone}
-	if err := w.DB.Create(&root).Error; err != nil {
-		t.Fatal(err)
-	}
-	resumed := db.Scan{RepositoryID: finding.RepositoryID, Repository: repo, Kind: JobSkill,
-		Status: db.ScanRunning, FindingID: &finding.ID, ResumedFromScanID: &root.ID}
-	if err := w.DB.Create(&resumed).Error; err != nil {
-		t.Fatal(err)
-	}
-	// Confirm the retry's own id resolves to a different, nonexistent dir.
-	if got := w.scanWorkRoot(&resumed); got == w.workRoot(resumed.ID) {
-		t.Fatalf("test precondition broken: lineage workspace %q equals retry workspace", got)
-	}
-	diff, head := seedPatchCache(t, w, repo)
-	stagePatchSkillEdits(t, w, &resumed, repo, diff)
-	report := fmt.Sprintf(`{"patch":%q,"base_commit":%q}`, diff, head)
-
-	var events []string
-	if err := w.parsePatchOutput(&resumed, report, func(e Event) { events = append(events, e.Text) }); err != nil {
-		t.Fatal(err)
-	}
-	var f db.Finding
-	w.DB.First(&f, finding.ID)
-	if f.SuggestedFix != diff {
-		t.Errorf("SuggestedFix not written for resumed scan; got %q (events=%v)", f.SuggestedFix, events)
-	}
-	if !containsSubstr(events, "gate passed") {
-		t.Errorf("events = %v, want gate-passed message", events)
 	}
 }
 
@@ -533,11 +565,12 @@ func TestParsePatchOutput_gateRejectLeavesColumnsEmpty(t *testing.T) {
 	if err := w.DB.Create(&sc).Error; err != nil {
 		t.Fatal(err)
 	}
-	seedPatchCache(t, w, repo)
-	report := `{"patch":"--- a/pkg/missing.go\n+++ b/pkg/missing.go\n@@ -1 +1 @@\n-x\n+y\n","base_commit":"abc"}`
+	_, head := seedPatchCache(t, w, repo)
+	sc.Commit = head
+	report := fmt.Sprintf(`{"patch":"--- a/pkg/missing.go\n+++ b/pkg/missing.go\n@@ -1 +1 @@\n-x\n+y\n","base_commit":%q}`, head)
 
 	var events []string
-	if err := w.parsePatchOutput(&sc, report, func(e Event) { events = append(events, e.Text) }); err != nil {
+	if err := w.parsePatchOutput(context.Background(), &sc, report, func(e Event) { events = append(events, e.Text) }); err != nil {
 		t.Fatal(err)
 	}
 	var f db.Finding
@@ -562,7 +595,7 @@ func TestParsePatchOutput_skillRefused(t *testing.T) {
 		t.Fatal(err)
 	}
 	var events []string
-	if err := w.parsePatchOutput(&sc, `{"error":"thin prose"}`, func(e Event) { events = append(events, e.Text) }); err != nil {
+	if err := w.parsePatchOutput(context.Background(), &sc, `{"error":"thin prose"}`, func(e Event) { events = append(events, e.Text) }); err != nil {
 		t.Fatal(err)
 	}
 	var f db.Finding
@@ -582,7 +615,7 @@ func TestParsePatchOutput_notFindingScoped(t *testing.T) {
 		t.Fatal(err)
 	}
 	var events []string
-	if err := w.parsePatchOutput(&sc, `{"patch":"--- a/x\n+++ b/x\n@@ -1 +1 @@\n-a\n+b\n"}`,
+	if err := w.parsePatchOutput(context.Background(), &sc, `{"patch":"--- a/x\n+++ b/x\n@@ -1 +1 @@\n-a\n+b\n"}`,
 		func(e Event) { events = append(events, e.Text) }); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/worker/patch_gate_test.go
+++ b/internal/worker/patch_gate_test.go
@@ -176,35 +176,66 @@ func gateRepo(t *testing.T, dir string) (relPath, diff string) {
 	return relPath, diff
 }
 
+func findingRepoForPatch(t *testing.T, w *Worker, finding db.Finding) db.Repository {
+	t.Helper()
+	var repo db.Repository
+	if err := w.DB.First(&repo, finding.RepositoryID).Error; err != nil {
+		t.Fatal(err)
+	}
+	return repo
+}
+
+func seedPatchCache(t *testing.T, w *Worker, repo db.Repository) (string, string) {
+	t.Helper()
+	cacheSrc := filepath.Join(RepoCacheRoot(w.DataDir, repo.URL), "src")
+	_, diff := gateRepo(t, cacheSrc)
+	return diff, gitHead(cacheSrc)
+}
+
+func stagePatchSkillEdits(t *testing.T, w *Worker, scan *db.Scan, repo db.Repository, diff string) {
+	t.Helper()
+	cacheSrc := filepath.Join(RepoCacheRoot(w.DataDir, repo.URL), "src")
+	workSrc := filepath.Join(w.scanWorkRoot(scan), "src")
+	if err := CopyTree(cacheSrc, workSrc); err != nil {
+		t.Fatal(err)
+	}
+	apply := exec.Command("git", "-C", workSrc, "apply", "-")
+	apply.Env = testutil.GitEnv()
+	apply.Stdin = strings.NewReader(diff)
+	if out, err := apply.CombinedOutput(); err != nil {
+		t.Fatalf("seed skill edits: %v: %s", err, out)
+	}
+}
+
 func TestGatePatch(t *testing.T) {
 	src := t.TempDir()
 	rel, diff := gateRepo(t, src)
 
-	if r := gatePatch(src, rel+":12", diff); r != "" {
+	if r := gatePatchTree(src, rel+":12", diff); r != "" {
 		t.Errorf("pass case rejected: %q", r)
 	}
 	// File-level match: a fix to pkg/foo.go passes even when the flagged line
 	// (:3) sits far from the hunk (line 12). This is the choke-point case the
 	// old line-overlap gate wrongly rejected.
-	if r := gatePatch(src, rel+":3", diff); r != "" {
+	if r := gatePatchTree(src, rel+":3", diff); r != "" {
 		t.Errorf("file-level pass case rejected: %q", r)
 	}
-	if r := gatePatch(src, "pkg/unrelated.go:12", diff); !strings.Contains(r, "no patched file matches location") {
+	if r := gatePatchTree(src, "pkg/unrelated.go:12", diff); !strings.Contains(r, "no patched file matches location") {
 		t.Errorf("expected unrelated-location rejection, got %q", r)
 	}
-	if r := gatePatch(src, "pkg/missing.go:12",
+	if r := gatePatchTree(src, "pkg/missing.go:12",
 		"--- a/pkg/missing.go\n+++ b/pkg/missing.go\n@@ -1 +1 @@\n-x\n+y\n"); !strings.Contains(r, "missing file") {
 		t.Errorf("expected missing-file rejection, got %q", r)
 	}
-	if r := gatePatch(src, rel+":12", "not a diff"); !strings.Contains(r, "no file headers") {
+	if r := gatePatchTree(src, rel+":12", "not a diff"); !strings.Contains(r, "no file headers") {
 		t.Errorf("expected no-file-headers rejection, got %q", r)
 	}
 	bad := strings.Replace(diff, "-line 12", "-WRONG", 1)
-	if r := gatePatch(src, rel+":12", bad); !strings.Contains(r, "git apply --check") {
+	if r := gatePatchTree(src, rel+":12", bad); !strings.Contains(r, "git apply --check") {
 		t.Errorf("expected git apply rejection, got %q", r)
 	}
 	newFileDiff := "--- /dev/null\n+++ b/pkg/foo_test.go\n@@ -0,0 +1 @@\n+test\n" + diff
-	if r := gatePatch(src, rel+":12", newFileDiff); r != "" {
+	if r := gatePatchTree(src, rel+":12", newFileDiff); r != "" {
 		t.Errorf("new-file alongside fix rejected: %q", r)
 	}
 }
@@ -223,8 +254,145 @@ func TestGatePatch_dirtyWorkspaceFromSkill(t *testing.T) {
 	if out, err := apply.CombinedOutput(); err != nil {
 		t.Fatalf("seed dirty workspace: %v: %s", err, out)
 	}
-	if r := gatePatch(src, rel+":12", diff); r != "" {
+	if r := gatePatchTree(src, rel+":12", diff); r != "" {
 		t.Errorf("gate rejected a valid patch against a skill-dirtied workspace: %q", r)
+	}
+}
+
+func TestGitApplyCheck_ignoresRunnerInstalledFilter(t *testing.T) {
+	w, finding := newPatchOutputFixture(t)
+	repo := findingRepoForPatch(t, w, finding)
+	scan := db.Scan{RepositoryID: repo.ID, Repository: repo, Kind: JobSkill,
+		Status: db.ScanRunning, FindingID: &finding.ID}
+	if err := w.DB.Create(&scan).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	runGit := func(dir string, args ...string) string {
+		t.Helper()
+		cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+		cmd.Env = testutil.GitEnv()
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+		return string(out)
+	}
+
+	cacheSrc := filepath.Join(RepoCacheRoot(w.DataDir, repo.URL), "src")
+	rel, diff := gateRepo(t, cacheSrc)
+	if err := os.WriteFile(filepath.Join(cacheSrc, ".gitattributes"),
+		[]byte(rel+" filter=pwn\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(cacheSrc, "add", ".gitattributes")
+	runGit(cacheSrc, "commit", "-q", "-m", "add filter attribute")
+
+	workSrc := filepath.Join(w.scanWorkRoot(&scan), "src")
+	if err := CopyTree(cacheSrc, workSrc); err != nil {
+		t.Fatal(err)
+	}
+	apply := exec.Command("git", "-C", workSrc, "apply", "-")
+	apply.Env = testutil.GitEnv()
+	apply.Stdin = strings.NewReader(diff)
+	if out, err := apply.CombinedOutput(); err != nil {
+		t.Fatalf("seed skill edits: %v: %s", err, out)
+	}
+
+	marker := filepath.Join(t.TempDir(), "filter-ran")
+	config, err := os.OpenFile(filepath.Join(workSrc, ".git", "config"), os.O_WRONLY|os.O_APPEND, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := fmt.Fprintf(config,
+		"\n[filter \"pwn\"]\n\tsmudge = sh -c \"id > %s 2>&1; cat\"\n", marker); err != nil {
+		_ = config.Close()
+		t.Fatal(err)
+	}
+	if err := config.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if got := runGit(workSrc, "config", "--local", "--get", "filter.pwn.smudge"); !strings.Contains(got, marker) {
+		t.Fatalf("filter command = %q, want marker path %q", got, marker)
+	}
+
+	report := fmt.Sprintf(`{"patch":%q,"base_commit":%q}`, diff, gitHead(cacheSrc))
+	if err := w.parsePatchOutput(&scan, report, func(Event) {}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(marker); err == nil {
+		t.Fatal("runner-installed smudge filter executed in the host patch gate")
+	} else if !os.IsNotExist(err) {
+		t.Fatal(err)
+	}
+	var got db.Finding
+	if err := w.DB.First(&got, finding.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if got.SuggestedFix != diff {
+		t.Fatalf("valid patch was not recorded; got %q", got.SuggestedFix)
+	}
+}
+
+func TestPatchGate_stagesLocalRepositoryWithoutMutatingIt(t *testing.T) {
+	src := t.TempDir()
+	rel, diff := gateRepo(t, src)
+	head := gitHead(src)
+	apply := exec.Command("git", "-C", src, "apply", "-")
+	apply.Env = testutil.GitEnv()
+	apply.Stdin = strings.NewReader(diff)
+	if out, err := apply.CombinedOutput(); err != nil {
+		t.Fatalf("seed local edits: %v: %s", err, out)
+	}
+
+	w := &Worker{}
+	gotHead, reason := w.gatePatch(db.Repository{URL: "file://" + src}, rel+":12", diff)
+	if reason != "" {
+		t.Fatalf("local patch rejected: %s", reason)
+	}
+	if gotHead != head {
+		t.Fatalf("staged HEAD = %q, want %q", gotHead, head)
+	}
+	local, err := os.ReadFile(filepath.Join(src, rel))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(local), "patched 12") {
+		t.Fatal("patch gate mutated the operator's local repository")
+	}
+}
+
+func TestPatchGate_stagesLinkedWorktreeWithoutMutatingIndex(t *testing.T) {
+	main := t.TempDir()
+	rel, diff := gateRepo(t, main)
+	linked := filepath.Join(t.TempDir(), "linked")
+	runGit := func(dir string, args ...string) string {
+		t.Helper()
+		cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+		cmd.Env = testutil.GitEnv()
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+		return string(out)
+	}
+	runGit(main, "worktree", "add", "-q", "--detach", linked, "HEAD")
+	tracked := filepath.Join(linked, rel)
+	if err := os.WriteFile(tracked, []byte("operator staged change\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(linked, "add", rel)
+	before := runGit(linked, "diff", "--cached", "--binary")
+	if before == "" {
+		t.Fatal("test precondition: linked worktree has no staged change")
+	}
+
+	w := &Worker{}
+	if _, reason := w.gatePatch(db.Repository{URL: "file://" + linked}, rel+":12", diff); reason != "" {
+		t.Fatalf("linked-worktree patch rejected: %s", reason)
+	}
+	if after := runGit(linked, "diff", "--cached", "--binary"); after != before {
+		t.Fatalf("patch gate mutated linked-worktree index\nbefore:\n%s\nafter:\n%s", before, after)
 	}
 }
 
@@ -253,13 +421,14 @@ func newPatchOutputFixture(t *testing.T) (*Worker, db.Finding) {
 
 func TestParsePatchOutput_passWritesColumnsAndHistory(t *testing.T) {
 	w, finding := newPatchOutputFixture(t)
-	sc := db.Scan{RepositoryID: finding.RepositoryID, Kind: JobSkill, Status: db.ScanRunning, FindingID: &finding.ID}
+	repo := findingRepoForPatch(t, w, finding)
+	sc := db.Scan{RepositoryID: finding.RepositoryID, Repository: repo,
+		Kind: JobSkill, Status: db.ScanRunning, FindingID: &finding.ID}
 	if err := w.DB.Create(&sc).Error; err != nil {
 		t.Fatal(err)
 	}
-	src := filepath.Join(w.workRoot(sc.ID), "src")
-	_, diff := gateRepo(t, src)
-	head := gitHead(src)
+	diff, head := seedPatchCache(t, w, repo)
+	stagePatchSkillEdits(t, w, &sc, repo, diff)
 	report := fmt.Sprintf(`{"patch":%q,"base_commit":%q}`, diff, head)
 
 	var events []string
@@ -298,14 +467,16 @@ func TestParsePatchOutput_passWritesColumnsAndHistory(t *testing.T) {
 
 func TestParsePatchOutput_newScanCreatesNextImmutableAttempt(t *testing.T) {
 	w, finding := newPatchOutputFixture(t)
+	repo := findingRepoForPatch(t, w, finding)
+	diff, head := seedPatchCache(t, w, repo)
 	for want := 1; want <= 2; want++ {
-		scan := db.Scan{RepositoryID: finding.RepositoryID, Kind: JobSkill, Status: db.ScanRunning, FindingID: &finding.ID}
+		scan := db.Scan{RepositoryID: finding.RepositoryID, Repository: repo,
+			Kind: JobSkill, Status: db.ScanRunning, FindingID: &finding.ID}
 		if err := w.DB.Create(&scan).Error; err != nil {
 			t.Fatal(err)
 		}
-		src := filepath.Join(w.workRoot(scan.ID), "src")
-		_, diff := gateRepo(t, src)
-		report := fmt.Sprintf(`{"patch":%q,"base_commit":%q}`, diff, gitHead(src))
+		stagePatchSkillEdits(t, w, &scan, repo, diff)
+		report := fmt.Sprintf(`{"patch":%q,"base_commit":%q}`, diff, head)
 		if err := w.parsePatchOutput(&scan, report, func(Event) {}); err != nil {
 			t.Fatal(err)
 		}
@@ -318,29 +489,27 @@ func TestParsePatchOutput_newScanCreatesNextImmutableAttempt(t *testing.T) {
 }
 
 func TestParsePatchOutput_resumedScanUsesLineageWorkspace(t *testing.T) {
-	// A patch run that resumes a session (ResumedFromScanID set) stages its
-	// src tree under the lineage-root workspace, not scan-<retryID>/src. The
-	// gate must resolve through scanWorkRoot like every other stage; using
-	// workRoot(scan.ID) here stat'd a directory that was never created and
-	// rejected every valid diff with "diff targets missing file".
+	// A resumed patch run stages its skill edits under the lineage-root
+	// workspace. The gate no longer trusts either workspace path, but the diff
+	// produced there must still validate against the pristine cache copy.
 	w, finding := newPatchOutputFixture(t)
+	repo := findingRepoForPatch(t, w, finding)
 	root := db.Scan{RepositoryID: finding.RepositoryID, Kind: JobSkill, Status: db.ScanDone}
 	if err := w.DB.Create(&root).Error; err != nil {
 		t.Fatal(err)
 	}
-	resumed := db.Scan{RepositoryID: finding.RepositoryID, Kind: JobSkill,
+	resumed := db.Scan{RepositoryID: finding.RepositoryID, Repository: repo, Kind: JobSkill,
 		Status: db.ScanRunning, FindingID: &finding.ID, ResumedFromScanID: &root.ID}
 	if err := w.DB.Create(&resumed).Error; err != nil {
 		t.Fatal(err)
 	}
-	// Stage where the workspace actually lives (lineage root), and confirm the
-	// retry's own id resolves to a different, nonexistent dir.
-	src := filepath.Join(w.scanWorkRoot(&resumed), "src")
+	// Confirm the retry's own id resolves to a different, nonexistent dir.
 	if got := w.scanWorkRoot(&resumed); got == w.workRoot(resumed.ID) {
 		t.Fatalf("test precondition broken: lineage workspace %q equals retry workspace", got)
 	}
-	_, diff := gateRepo(t, src)
-	report := fmt.Sprintf(`{"patch":%q,"base_commit":%q}`, diff, gitHead(src))
+	diff, head := seedPatchCache(t, w, repo)
+	stagePatchSkillEdits(t, w, &resumed, repo, diff)
+	report := fmt.Sprintf(`{"patch":%q,"base_commit":%q}`, diff, head)
 
 	var events []string
 	if err := w.parsePatchOutput(&resumed, report, func(e Event) { events = append(events, e.Text) }); err != nil {
@@ -358,12 +527,13 @@ func TestParsePatchOutput_resumedScanUsesLineageWorkspace(t *testing.T) {
 
 func TestParsePatchOutput_gateRejectLeavesColumnsEmpty(t *testing.T) {
 	w, finding := newPatchOutputFixture(t)
-	sc := db.Scan{RepositoryID: finding.RepositoryID, Kind: JobSkill, Status: db.ScanRunning, FindingID: &finding.ID}
+	repo := findingRepoForPatch(t, w, finding)
+	sc := db.Scan{RepositoryID: finding.RepositoryID, Repository: repo,
+		Kind: JobSkill, Status: db.ScanRunning, FindingID: &finding.ID}
 	if err := w.DB.Create(&sc).Error; err != nil {
 		t.Fatal(err)
 	}
-	src := filepath.Join(w.workRoot(sc.ID), "src")
-	gateRepo(t, src)
+	seedPatchCache(t, w, repo)
 	report := `{"patch":"--- a/pkg/missing.go\n+++ b/pkg/missing.go\n@@ -1 +1 @@\n-x\n+y\n","base_commit":"abc"}`
 
 	var events []string
@@ -375,8 +545,8 @@ func TestParsePatchOutput_gateRejectLeavesColumnsEmpty(t *testing.T) {
 	if f.SuggestedFix != "" || f.SuggestedFixCommit != "" {
 		t.Errorf("columns should be empty after gate reject: fix=%q commit=%q", f.SuggestedFix, f.SuggestedFixCommit)
 	}
-	if !containsSubstr(events, "gate rejected") {
-		t.Errorf("events = %v, want gate-rejected message", events)
+	if !containsSubstr(events, "diff targets missing file") {
+		t.Errorf("events = %v, want missing-file gate rejection", events)
 	}
 	var count int64
 	w.DB.Model(&db.RemediationAttempt{}).Where("finding_id = ?", finding.ID).Count(&count)

--- a/internal/worker/schema_validate_test.go
+++ b/internal/worker/schema_validate_test.go
@@ -171,7 +171,7 @@ func TestParseSkillOutput_schemaWarnAndContinue(t *testing.T) {
 	// posture parser only decodes tier+summary and ignores unknown keys.
 	report := `{"tier":"ready","summary":"ok","extra":1}`
 	var events []Event
-	err := w.parseSkillOutput(skill, scan, report, func(e Event) { events = append(events, e) })
+	err := w.parseSkillOutput(context.Background(), skill, scan, report, func(e Event) { events = append(events, e) })
 	if err != nil {
 		t.Fatalf("warn mode should not return error: %v", err)
 	}
@@ -341,7 +341,7 @@ func TestParseSkillOutput_schemaStrictFails(t *testing.T) {
 
 	report := `{"tier":{"x":1}}`
 	var events []Event
-	err := w.parseSkillOutput(skill, scan, report, func(e Event) { events = append(events, e) })
+	err := w.parseSkillOutput(context.Background(), skill, scan, report, func(e Event) { events = append(events, e) })
 
 	var sve *SchemaValidationError
 	if !errors.As(err, &sve) {
@@ -366,7 +366,7 @@ func TestParseSkillOutput_schemaMessageUsesOutputFile(t *testing.T) {
 	skill.OutputFile = "custom-output.json"
 
 	var events []Event
-	err := w.parseSkillOutput(skill, scan, `{"tier":"ready","summary":"ok","extra":1}`, func(e Event) { events = append(events, e) })
+	err := w.parseSkillOutput(context.Background(), skill, scan, `{"tier":"ready","summary":"ok","extra":1}`, func(e Event) { events = append(events, e) })
 	if err != nil {
 		t.Fatalf("warn mode should not fail on schema mismatch: %v", err)
 	}
@@ -385,7 +385,7 @@ func TestParseSkillOutput_schemaStrictPassesThrough(t *testing.T) {
 	w, skill, scan := newSchemaTestWorker(t, true)
 
 	report := `{"tier":"partial","summary":"ok"}`
-	if err := w.parseSkillOutput(skill, scan, report, func(Event) {}); err != nil {
+	if err := w.parseSkillOutput(context.Background(), skill, scan, report, func(Event) {}); err != nil {
 		t.Fatalf("valid report should not error in strict mode: %v", err)
 	}
 	var repo db.Repository
@@ -442,7 +442,7 @@ func TestParseSkillOutput_noSchemaSkipsValidation(t *testing.T) {
 	w, skill, scan := newSchemaTestWorker(t, true)
 	skill.SchemaJSON = ""
 
-	if err := w.parseSkillOutput(skill, scan, `{"tier":"ready"}`, func(Event) {}); err != nil {
+	if err := w.parseSkillOutput(context.Background(), skill, scan, `{"tier":"ready"}`, func(Event) {}); err != nil {
 		t.Fatalf("no schema should skip validation: %v", err)
 	}
 }

--- a/internal/worker/skill.go
+++ b/internal/worker/skill.go
@@ -239,7 +239,7 @@ func (w *Worker) doSkill(ctx context.Context, scan *db.Scan, emit func(Event)) (
 	w.applySkillResult(scan, res)
 	if err != nil {
 		if _, ok := errors.AsType[*MaxTurnsReachedError](err); ok && res.Report != "" {
-			w.parsePartialSkillReport(&skill, scan, res.Report, emit)
+			w.parsePartialSkillReport(ctx, &skill, scan, res.Report, emit)
 		}
 		return res.Report, err
 	}
@@ -340,8 +340,8 @@ func (w *Worker) applySkillResult(scan *db.Scan, res SkillResult) {
 // partial and logs on failure. The scan is already returning a
 // MaxTurnsReachedError so the parse error has nowhere useful to
 // propagate; logging keeps a silently-malformed partial from vanishing.
-func (w *Worker) parsePartialSkillReport(skill *db.Skill, scan *db.Scan, report string, emit func(Event)) {
-	if err := w.parseSkillOutput(skill, scan, report, emit); err != nil {
+func (w *Worker) parsePartialSkillReport(ctx context.Context, skill *db.Skill, scan *db.Scan, report string, emit func(Event)) {
+	if err := w.parseSkillOutput(ctx, skill, scan, report, emit); err != nil {
 		w.Log.Warn("parse partial skill output after max turns", "scan", scan.ID, "skill", skill.Name, "err", err)
 	}
 }
@@ -354,7 +354,7 @@ func (w *Worker) repairAndParseSkillOutput(ctx context.Context, skill *db.Skill,
 			}
 		}
 	}
-	if err := w.parseSkillOutput(skill, scan, report, emit); err != nil {
+	if err := w.parseSkillOutput(ctx, skill, scan, report, emit); err != nil {
 		return report, err
 	}
 	return report, nil
@@ -421,7 +421,7 @@ func truncateSchemaRepairReport(report string) string {
 	return report[:schemaRepairReportMaxSize] + "\n... truncated ..."
 }
 
-func (w *Worker) parseSkillOutput(skill *db.Skill, scan *db.Scan, report string, emit func(Event)) error {
+func (w *Worker) parseSkillOutput(ctx context.Context, skill *db.Skill, scan *db.Scan, report string, emit func(Event)) error {
 	if skill.SchemaJSON != "" {
 		if detail, recoverable := reportValidationForParsing(skill, report); detail != "" {
 			emit(reportValidationEvent(skill, detail))
@@ -430,7 +430,7 @@ func (w *Worker) parseSkillOutput(skill *db.Skill, scan *db.Scan, report string,
 			}
 		}
 	}
-	if err := w.parseSkillOutputKind(skill, scan, report, emit); err != nil {
+	if err := w.parseSkillOutputKind(ctx, skill, scan, report, emit); err != nil {
 		return err
 	}
 	if scan.RescanMode != db.ScanRescanModeDiff {
@@ -443,7 +443,7 @@ func (w *Worker) parseSkillOutput(skill *db.Skill, scan *db.Scan, report string,
 	return applySkillCoverageClaim(scan, claim)
 }
 
-func (w *Worker) parseSkillOutputKind(skill *db.Skill, scan *db.Scan, report string, emit func(Event)) error {
+func (w *Worker) parseSkillOutputKind(ctx context.Context, skill *db.Skill, scan *db.Scan, report string, emit func(Event)) error {
 	switch skill.OutputKind {
 	case "findings":
 		return w.parseFindingsOutput(skill, scan, report, emit)
@@ -482,7 +482,7 @@ func (w *Worker) parseSkillOutputKind(skill *db.Skill, scan *db.Scan, report str
 	case "posture":
 		return w.parsePostureOutput(scan, report, emit)
 	case "patch":
-		return w.parsePatchOutput(scan, report, emit)
+		return w.parsePatchOutput(ctx, scan, report, emit)
 	case "reattack":
 		return w.parseReattackOutput(scan, report, emit)
 	}

--- a/internal/worker/skill_coverage_test.go
+++ b/internal/worker/skill_coverage_test.go
@@ -1,6 +1,7 @@
 package worker
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -27,7 +28,7 @@ func TestParseSkillOutputIngestsCoverageClaim(t *testing.T) {
 		"surfaces":[{"name":"parser","disposition":"reviewed_findings","evidence_ref":"b.go:12"}],
 		"open_questions":[],"dropped_findings":[]}}`
 	w := &Worker{}
-	if err := w.parseSkillOutput(&db.Skill{}, &scan, report, func(Event) {}); err != nil {
+	if err := w.parseSkillOutput(context.Background(), &db.Skill{}, &scan, report, func(Event) {}); err != nil {
 		t.Fatal(err)
 	}
 	rec, ok := coverage.Parse(scan.Coverage)
@@ -56,7 +57,7 @@ func TestParseSkillOutputKeepsDiffPartialWhenReceiptIsMissing(t *testing.T) {
 	}
 	scan := db.Scan{RescanMode: db.ScanRescanModeDiff, Coverage: initial}
 	report := `{"coverage":{"receipts":[{"path":"a.go","disposition":"reviewed_clean"}]}}`
-	if err := (&Worker{}).parseSkillOutput(&db.Skill{}, &scan, report, func(Event) {}); err != nil {
+	if err := (&Worker{}).parseSkillOutput(context.Background(), &db.Skill{}, &scan, report, func(Event) {}); err != nil {
 		t.Fatal(err)
 	}
 	rec, ok := coverage.Parse(scan.Coverage)
@@ -90,7 +91,7 @@ func TestParseSkillOutputPersistsFindingsBeforeRejectingInvalidCoverage(t *testi
 	w.DB.Create(&scan)
 	report := `{"findings":[{"id":"F1","title":"finding survives","severity":"High","location":"a.go:1"}],` +
 		`"coverage":{"receipts":[{"path":"./a.go","disposition":"reviewed_findings"}]}}`
-	err = w.parseSkillOutput(&db.Skill{OutputKind: "findings"}, &scan, report, func(Event) {})
+	err = w.parseSkillOutput(context.Background(), &db.Skill{OutputKind: "findings"}, &scan, report, func(Event) {})
 	if err == nil || !strings.Contains(err.Error(), "repository-relative") {
 		t.Fatalf("error = %v, want repository-relative validation", err)
 	}
@@ -108,7 +109,7 @@ func TestParseSkillOutputReportsStoredCoverageCorruption(t *testing.T) {
 	const corrupted = `{"version":"invalid"}`
 	scan := db.Scan{RescanMode: db.ScanRescanModeDiff, Coverage: corrupted, Completeness: coverage.CompletenessPartial}
 	report := `{"coverage":{"receipts":[]}}`
-	err := (&Worker{}).parseSkillOutput(&db.Skill{}, &scan, report, func(Event) {})
+	err := (&Worker{}).parseSkillOutput(context.Background(), &db.Skill{}, &scan, report, func(Event) {})
 	if err == nil || !strings.Contains(err.Error(), "stored coverage record") {
 		t.Fatalf("error = %v, want stored coverage corruption detail", err)
 	}
@@ -120,7 +121,7 @@ func TestParseSkillOutputReportsStoredCoverageCorruption(t *testing.T) {
 func TestParseSkillOutputNeverClaimsCompleteWithoutWorkerScope(t *testing.T) {
 	scan := db.Scan{RescanMode: db.ScanRescanModeDiff}
 	report := `{"coverage":{"receipts":[{"path":"a.go","disposition":"reviewed_clean"}]}}`
-	if err := (&Worker{}).parseSkillOutput(&db.Skill{}, &scan, report, func(Event) {}); err != nil {
+	if err := (&Worker{}).parseSkillOutput(context.Background(), &db.Skill{}, &scan, report, func(Event) {}); err != nil {
 		t.Fatal(err)
 	}
 	rec, ok := coverage.Parse(scan.Coverage)
@@ -136,7 +137,7 @@ func TestParseSkillOutputIgnoresCoverageOutsideDiffRescan(t *testing.T) {
 	const initial = `{"producer":"other-skill"}`
 	scan := db.Scan{Coverage: initial, Completeness: coverage.CompletenessUnknown}
 	report := `{"coverage":{"format":"skill-specific"}}`
-	if err := (&Worker{}).parseSkillOutput(&db.Skill{}, &scan, report, func(Event) {}); err != nil {
+	if err := (&Worker{}).parseSkillOutput(context.Background(), &db.Skill{}, &scan, report, func(Event) {}); err != nil {
 		t.Fatal(err)
 	}
 	if scan.Coverage != initial || scan.Completeness != coverage.CompletenessUnknown {
@@ -146,7 +147,7 @@ func TestParseSkillOutputIgnoresCoverageOutsideDiffRescan(t *testing.T) {
 
 func TestParseSkillOutputLeavesMalformedCoverageEnvelopeToKindParser(t *testing.T) {
 	scan := db.Scan{RescanMode: db.ScanRescanModeDiff}
-	err := (&Worker{}).parseSkillOutput(&db.Skill{OutputKind: "maintainers"}, &scan, `{"coverage":`, func(Event) {})
+	err := (&Worker{}).parseSkillOutput(context.Background(), &db.Skill{OutputKind: "maintainers"}, &scan, `{"coverage":`, func(Event) {})
 	if err == nil || !strings.Contains(err.Error(), "parse maintainers report") {
 		t.Fatalf("error = %v, want maintainers parser error", err)
 	}


### PR DESCRIPTION
The patch gate ran host Git inside the per-scan workspace, which is bind-mounted read-write into the runner as the host uid. A repository that gets code execution during a scan can append to `src/.git/config`, and the `git reset --hard HEAD` at the top of `gitApplyCheck` then runs a `filter.<name>.smudge` command as the operator when it re-materialises a path bound by `.gitattributes`. No Git flag ignores local repository config, so hardening the invocation does not help: the gate has to run somewhere the runner never had write access.

Validation now happens in a temporary copy staged from the host-only clone cache under its per-URL lock. Local repositories are cloned with `--no-local` rather than copied, so a linked worktree's `gitdir:` pointer cannot lead Git back to the operator's real index and discard their staged work. The HEAD used for the `base_commit` comparison now comes from that pristine copy too, rather than from the runner's checkout where both sides of the comparison were attacker-controlled.

Codex was used to implement this, Opus 5 to review it.
