### PR TITLE
chore(renovate): update import paths on major Go module updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -100,7 +100,7 @@
       "matchManagers": ["gomod"],
       "groupName": "Go modules",
       "minimumReleaseAge": "7 days",
-      "postUpdateOptions": ["gomodTidy"]
+      "postUpdateOptions": ["gomodTidy", "gomodUpdateImportPaths"]
     },
     {
       "matchManagers": ["gomod"],


### PR DESCRIPTION
As we don't - currently - set this by default for users.
