### PR TITLE
Fix OpenCode provider egress under Podman

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -255,10 +255,14 @@ var (
 
 var reservedOpencodePassEnv = map[string]bool{
 	"ALL_PROXY":                     true,
+	"all_proxy":                     true,
 	"HOME":                          true,
 	"HTTP_PROXY":                    true,
+	"http_proxy":                    true,
 	"HTTPS_PROXY":                   true,
+	"https_proxy":                   true,
 	"NO_PROXY":                      true,
+	"no_proxy":                      true,
 	"OPENCODE_AUTH_CONTENT":         true,
 	"OPENCODE_CONFIG_CONTENT":       true,
 	"OPENCODE_CONFIG_DIR":           true,

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -266,6 +266,24 @@ func TestValidateOpencodeRejectsHarnessSafetyEnvironment(t *testing.T) {
 	}
 }
 
+func TestValidateOpencodeRejectsManagedProxyEnvironment(t *testing.T) {
+	for _, name := range []string{
+		"HTTPS_PROXY", "https_proxy",
+		"HTTP_PROXY", "http_proxy",
+		"ALL_PROXY", "all_proxy",
+		"NO_PROXY", "no_proxy",
+	} {
+		t.Run(name, func(t *testing.T) {
+			err := ValidateOpencode(Opencode{Providers: map[string]OpencodeProvider{
+				"groq": {PassEnv: []string{name}, EgressAllow: []string{"api.groq.com"}},
+			}})
+			if err == nil || !strings.Contains(err.Error(), "managed by scrutineer") {
+				t.Fatalf("ValidateOpencode error = %v", err)
+			}
+		})
+	}
+}
+
 func TestLoad_noContainerAlias(t *testing.T) {
 	// no_docker is the retained pre-rename alias; Load folds it into NoContainer.
 	aliasOnly, err := Load(write(t, "no_docker: true\n"))

--- a/internal/worker/container.go
+++ b/internal/worker/container.go
@@ -982,16 +982,16 @@ func (d ContainerRunner) sidecarNetworkIP(name, network string) (string, error) 
 // an unreachable host API lingers long enough for verifyHardenedNetwork to
 // capture its logs.
 func (d ContainerRunner) proxySidecarRunArgs(name, network string) []string {
-	args := []string{
-		"run", "-d",
+	args := runtimeRunArgs(d.Runtime,
+		"-d",
 		"--name", name,
 		"--network", network,
 		"--cap-drop", "ALL",
 		"--security-opt", "no-new-privileges",
 		"--read-only",
 		"--tmpfs", "/tmp:rw,noexec,nosuid,size=16m",
-		"--add-host", HostGatewayAlias + ":" + d.Egress.GatewayIP,
-	}
+		"--add-host", HostGatewayAlias+":"+d.Egress.GatewayIP,
+	)
 	for _, e := range EgressSidecarEnv(d.Egress, SidecarListenFirstIface+":"+proxySidecarPort) {
 		args = append(args, "-e", e)
 	}
@@ -1073,8 +1073,9 @@ func VerifyProxyBinary(ctx context.Context, rt ContainerRuntime, image string) e
 	if image == "" || !imageExistsLocally(ctx, rt, image) {
 		return nil
 	}
-	out, err := exec.CommandContext(ctx, runtimeBin(rt), "run", "--rm", "--pull", "never",
-		"--", image, "scrutineer", "proxy", "-h").CombinedOutput()
+	args := runtimeRunArgs(rt, "--rm", "--pull", "never",
+		"--", image, "scrutineer", "proxy", "-h")
+	out, err := exec.CommandContext(ctx, runtimeBin(rt), args...).CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("runner image %q is missing the scrutineer binary required for the "+
 			"hardened egress proxy sidecar (rebuild it from Dockerfile.runner): %w: %s",

--- a/internal/worker/container.go
+++ b/internal/worker/container.go
@@ -1158,7 +1158,7 @@ func (d ContainerRunner) verifyProxySidecarReachable(hn hardenedNet, image strin
 	deadline := time.Now().Add(proxySidecarReadyTimeout)
 	var last string
 	for {
-		out, err := exec.Command(runtimeBin(d.Runtime), sidecarReachArgs(hn.name, hn.proxyEndpoint, image)...).CombinedOutput()
+		out, err := exec.Command(runtimeBin(d.Runtime), sidecarReachArgs(d.Runtime, hn.name, hn.proxyEndpoint, image)...).CombinedOutput()
 		last = strings.TrimSpace(string(out))
 		if err == nil && strings.Contains(last, "REACHED") {
 			return nil
@@ -1233,13 +1233,13 @@ func hardenedProxyReachArgs(rt ContainerRuntime, network, gatewayIP, proxyPort, 
 // answers, e.g. 407 without auth) means the in-network path to the sidecar is
 // open, which by the sidecar's readiness gate also means the host API is
 // reachable through it.
-func sidecarReachArgs(network, endpoint, image string) []string {
+func sidecarReachArgs(rt ContainerRuntime, network, endpoint, image string) []string {
 	target := "http://" + endpoint + "/"
 	script := "curl -s -m 5 -o /dev/null " + target + " && echo REACHED || echo UNREACHABLE"
-	return []string{
-		"run", "--rm", "--cap-drop", "ALL", "--network", network,
+	return runtimeRunArgs(rt,
+		"--rm", "--cap-drop", "ALL", "--network", network,
 		"--entrypoint", "sh", "--", image, "-c", script,
-	}
+	)
 }
 
 // proxyPortFromURL extracts the port from a proxy URL of the shape ProxyURL

--- a/internal/worker/container.go
+++ b/internal/worker/container.go
@@ -513,12 +513,19 @@ func (d ContainerRunner) buildRunArgsForProvider(absWork, image string, hnet har
 		proxyURL = proxyURLWithHost(d.ProxyURL, hnet.gatewayIP)
 	}
 	if proxyURL != "" {
-		args = append(args,
-			"-e", "HTTPS_PROXY="+proxyURL,
-			"-e", "HTTP_PROXY="+proxyURL,
-			"-e", "ALL_PROXY="+proxyURL,
-			"-e", "NO_PROXY=",
-		)
+		// Set both cases. Podman normally inherits both variants from its
+		// host, and curl prefers lowercase https_proxy over HTTPS_PROXY.
+		// runtimeRunArgs disables that Podman inheritance, while these explicit
+		// assignments also override image-provided proxy variables on every
+		// supported runtime.
+		for _, key := range []string{
+			"HTTPS_PROXY", "https_proxy",
+			"HTTP_PROXY", "http_proxy",
+			"ALL_PROXY", "all_proxy",
+		} {
+			args = append(args, "-e", key+"="+proxyURL)
+		}
+		args = append(args, "-e", "NO_PROXY=", "-e", "no_proxy=")
 	} else if !d.Hardened {
 		args = append(args, "--network", "none")
 	}

--- a/internal/worker/container_test.go
+++ b/internal/worker/container_test.go
@@ -632,6 +632,9 @@ func TestProxySidecarRunArgs(t *testing.T) {
 	}
 	args := d.proxySidecarRunArgs("scrutineer-proxy-7", "scrutineer-hardened-7")
 
+	if len(args) < 2 || !slices.Equal(args[:2], []string{"run", "--http-proxy=false"}) {
+		t.Errorf("podman sidecar must disable host proxy inheritance: %v", args)
+	}
 	// Detached and locked down -- the sidecar runs scrutineer's own trusted code
 	// but gets the same defense-in-depth as the scan container.
 	if !slices.Contains(args, "-d") {

--- a/internal/worker/container_test.go
+++ b/internal/worker/container_test.go
@@ -847,10 +847,23 @@ func TestBuildRunArgs_SidecarProxyURL(t *testing.T) {
 	// against the sidecar's own IP:port; it does not carry the host-proxy
 	// URL through. The basic-auth username is harness/egress's constant.
 	want := ProxyURLForEndpoint("tok", "10.89.1.2:3128")
-	for _, env := range []string{"HTTPS_PROXY=" + want, "HTTP_PROXY=" + want, "ALL_PROXY=" + want} {
+	for _, key := range []string{
+		"HTTPS_PROXY", "https_proxy",
+		"HTTP_PROXY", "http_proxy",
+		"ALL_PROXY", "all_proxy",
+	} {
+		env := key + "=" + want
 		if !hasAdjacent(args, "-e", env) {
 			t.Errorf("expected sidecar %s in %v", env, args)
 		}
+	}
+	for _, env := range []string{"NO_PROXY=", "no_proxy="} {
+		if !hasAdjacent(args, "-e", env) {
+			t.Errorf("expected empty proxy exclusion %s in %v", env, args)
+		}
+	}
+	if !slices.Contains(args, "--http-proxy=false") {
+		t.Errorf("podman host proxy inheritance is enabled: %v", args)
 	}
 	for _, a := range args {
 		if strings.Contains(a, "host.docker.internal:55000") {
@@ -868,8 +881,22 @@ func TestBuildRunArgs_HostProxyURLWhenNoSidecar(t *testing.T) {
 	// exactly as docker/rootful hardened and non-hardened scans do today.
 	d := ContainerRunner{ProxyURL: "http://scrutineer:tok@host.docker.internal:55000"}
 	args := d.buildRunArgs("img:latest", hardenedNet{}, "")
-	if !hasAdjacent(args, "-e", "HTTPS_PROXY=http://scrutineer:tok@host.docker.internal:55000") {
-		t.Errorf("expected the host proxy URL in %v", args)
+	want := "http://scrutineer:tok@host.docker.internal:55000"
+	for _, key := range []string{"HTTPS_PROXY", "https_proxy", "HTTP_PROXY", "http_proxy", "ALL_PROXY", "all_proxy"} {
+		if !hasAdjacent(args, "-e", key+"="+want) {
+			t.Errorf("expected %s host proxy URL in %v", key, args)
+		}
+	}
+}
+
+func TestBuildRunArgs_PodmanWithoutProxyRejectsInheritedHostProxy(t *testing.T) {
+	d := ContainerRunner{Runtime: ContainerRuntime{Bin: runtimePodman}}
+	args := d.buildRunArgs("img:latest", hardenedNet{}, "")
+	if !slices.Contains(args, "--http-proxy=false") {
+		t.Errorf("podman host proxy inheritance is enabled: %v", args)
+	}
+	if !hasAdjacent(args, "--network", "none") {
+		t.Errorf("unproxied container did not fail closed: %v", args)
 	}
 }
 

--- a/internal/worker/container_test.go
+++ b/internal/worker/container_test.go
@@ -816,7 +816,10 @@ if [ "$1" = inspect ]; then printf '192.0.2.10\n'; fi
 func TestSidecarReachArgs(t *testing.T) {
 	// Probe (b), sidecar variant: curl the sidecar by IP:port on the --internal
 	// network without relying on its DNS; no --add-host.
-	args := sidecarReachArgs("scrutineer-hardened-7", "10.89.1.2:3128", "img:latest")
+	args := sidecarReachArgs(ContainerRuntime{Bin: runtimePodman}, "scrutineer-hardened-7", "10.89.1.2:3128", "img:latest")
+	if len(args) < 2 || !slices.Equal(args[:2], []string{"run", "--http-proxy=false"}) {
+		t.Errorf("podman reach probe must disable host proxy inheritance: %v", args)
+	}
 	if !hasAdjacent(args, "--network", "scrutineer-hardened-7") {
 		t.Errorf("missing --network: %v", args)
 	}

--- a/internal/worker/opencode_provider_test.go
+++ b/internal/worker/opencode_provider_test.go
@@ -205,6 +205,7 @@ func TestEnsureOpencodeProviderStateRequiresStoredCredentials(t *testing.T) {
 func TestConfigureOpencodeProviderEgressScopesHostProxyToSelectedProvider(t *testing.T) {
 	d := ContainerRunner{
 		Harness: OpencodeHarness{},
+		Runtime: ContainerRuntime{Bin: runtimePodman},
 		OpencodeProviders: map[string]OpencodeProviderConfig{
 			"groq": {EgressHosts: []string{"api.groq.com", "auth.example.com"}},
 			"kiro": {EgressHosts: []string{"q.us-east-1.amazonaws.com"}},
@@ -236,6 +237,15 @@ func TestConfigureOpencodeProviderEgressScopesHostProxyToSelectedProvider(t *tes
 	}
 	if got.ProxyURL == "" || got.ProxyURL == d.ProxyURL {
 		t.Errorf("provider-scoped proxy URL = %q", got.ProxyURL)
+	}
+	args := got.buildRunArgsForProvider("/work/abs", "stock:1", hardenedNet{}, "", provider, "/tmp")
+	if !slices.Contains(args, "--http-proxy=false") {
+		t.Errorf("podman host proxy inheritance is enabled: %v", args)
+	}
+	for _, key := range []string{"HTTPS_PROXY", "https_proxy", "HTTP_PROXY", "http_proxy", "ALL_PROXY", "all_proxy"} {
+		if !hasAdjacent(args, "-e", key+"="+got.ProxyURL) {
+			t.Errorf("selected provider proxy missing from %s: %v", key, args)
+		}
 	}
 }
 

--- a/internal/worker/podman_integration_test.go
+++ b/internal/worker/podman_integration_test.go
@@ -209,7 +209,7 @@ func runnerImageOrSkip(t *testing.T, rt ContainerRuntime) string {
 // given extra run args and returns trimmed combined output.
 func containerScriptOutput(t *testing.T, rt ContainerRuntime, extra []string, image, script string) string {
 	t.Helper()
-	args := append([]string{"run", "--rm"}, extra...)
+	args := append(runtimeRunArgs(rt, "--rm"), extra...)
 	args = append(args, "--entrypoint", "sh", "--", image, "-c", script)
 	out, _ := exec.Command(runtimeBin(rt), args...).CombinedOutput()
 	return strings.TrimSpace(string(out))

--- a/internal/worker/runtime.go
+++ b/internal/worker/runtime.go
@@ -43,8 +43,14 @@ func runtimeBin(rt ContainerRuntime) string {
 // stream-json reader only see the container payload.
 func runtimeRunArgs(rt ContainerRuntime, args ...string) []string {
 	out := []string{"run"}
-	if rt.Bin == runtimeApple {
+	switch rt.Bin {
+	case runtimeApple:
 		out = append(out, "--progress", "none")
+	case runtimePodman:
+		// Podman otherwise copies every host proxy variable into the
+		// container. In particular, an inherited lowercase https_proxy takes
+		// precedence over the uppercase provider-scoped proxy below.
+		out = append(out, "--http-proxy=false")
 	}
 	return append(out, args...)
 }

--- a/internal/worker/runtime_test.go
+++ b/internal/worker/runtime_test.go
@@ -104,8 +104,9 @@ func TestContainerRuntimeEnginePredicates(t *testing.T) {
 
 // TestContainerRuntimeCapabilityFlags is the run-flag parity matrix: for each
 // runtime it pins exactly which Docker/Podman flags apply and how `run` starts.
-// docker and podman are identical; apple diverges only where its CLI lacks the
-// flag (--add-host, --pull never, --security-opt) and adds --progress none.
+// Podman disables automatic host proxy inheritance; apple diverges where its
+// CLI lacks flags (--add-host, --pull never, --security-opt) and adds progress
+// suppression.
 func TestContainerRuntimeCapabilityFlags(t *testing.T) {
 	tests := []struct {
 		name                string
@@ -117,7 +118,7 @@ func TestContainerRuntimeCapabilityFlags(t *testing.T) {
 	}{
 		{"docker zero value", ContainerRuntime{}, true, true, true, []string{"run", "--rm"}},
 		{"docker explicit", ContainerRuntime{Bin: "docker"}, true, true, true, []string{"run", "--rm"}},
-		{"podman", ContainerRuntime{Bin: "podman"}, true, true, true, []string{"run", "--rm"}},
+		{"podman", ContainerRuntime{Bin: "podman"}, true, true, true, []string{"run", "--http-proxy=false", "--rm"}},
 		{"apple", ContainerRuntime{Bin: "apple"}, false, false, false, []string{"run", "--progress", "none", "--rm"}},
 	}
 	for _, tc := range tests {


### PR DESCRIPTION
Fixes #963

## Summary

Fixes configured OpenCode providers failing hardened egress checks under Podman because Podman automatically inherited host proxy environment variables.

Scrutineer now disables Podman's automatic host proxy injection and explicitly supplies both uppercase and lowercase forms of its controlled proxy variables. This prevents inherited lowercase variables from overriding the per-scan egress proxy.

## Changes

- Pass `--http-proxy=false` to Podman container runs to prevent automatic host proxy inheritance.
- Set both uppercase and lowercase variants of:
  - `HTTPS_PROXY`
  - `HTTP_PROXY`
  - `ALL_PROXY`
- Clear both `NO_PROXY` and `no_proxy` for proxied scan containers.
- Preserve Docker behavior.
- Extend runtime and container tests to cover:
  - Podman proxy-inheritance suppression.
  - Uppercase and lowercase controlled proxy variables.
  - Fail-closed networking behavior.
  - Configured OpenCode provider run arguments.

## Verification

- `go test ./...`
- `go test -race -gcflags='modernc.org/...=-d=checkptr=0' ./...`
- `go test -tags podman ./internal/worker -count=1`
- `go test -race -tags evals ./internal/evals/...`
- `go vet ./...`
- `go vet -tags evals ./internal/evals/...`
- `go vet -tags podman ./...`
- `golangci-lint run`
- `git diff --check`

Live verification was also completed with Podman 6.1.1 using a rootless ARM64 Linux VM. The hardened proxy-sidecar integration, host-gateway resolution, keep-ID ownership and egress-blocking tests all passed.