### PR TITLE
Fix Go image update timing

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -125,6 +125,14 @@
       "minimumReleaseAge": "7 days"
     },
     {
+      "description": "Update Go builder image versions before Go modules can require the newer toolchain",
+      "matchManagers": ["dockerfile"],
+      "matchPackageNames": ["golang"],
+      "matchUpdateTypes": ["major", "minor", "patch"],
+      "groupName": "Go Docker images",
+      "minimumReleaseAge": "0 days"
+    },
+    {
       "matchManagers": ["custom.regex"],
       "minimumReleaseAge": "7 days"
     },


### PR DESCRIPTION
Renovate's #981 updates `github.com/git-pkgs/sbom` to v0.1.6, whose `go.mod` requires Go 1.26.7. The configured `gomodTidy` step therefore raises Scrutineer's `go` directive to 1.26.7, but `Dockerfile.runner` still builds with Go 1.26.6 and `GOTOOLCHAIN=local`, so both runner-image builds fail at `go mod download`. Renovate did see the compatible `trixie` tags: its strict seven-day Docker-image age rule suppressed them because Docker Hub reset the tag-level `tag_last_pushed` timestamp when the later riscv64 image arrived, even though the amd64 and arm64 images had already aged past the threshold. The same run consequently put only the unrelated Node digest refresh in #980.

This gives version updates for the `golang` Docker image a targeted zero-day minimum release age and a separate group, allowing builder upgrades to arrive before seven-day-aged Go modules can require them. The existing delay remains in force for every other Docker image and for digest-only Go refreshes, automerge stays disabled, and the resulting image PR still has to pass native amd64 and arm64 builds. After this lands, Renovate can propose the held `trixie` update and #981 can be rebased onto the compatible builder.

The configuration validates successfully against Renovate 44.61.3; `jq empty renovate.json` and `git diff --check` also pass.

Codex was used to implement this.
