### PR TITLE
Align Go compatibility constraints

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module scrutineer
 
-go 1.26.7
+go 1.27.0
 
-toolchain go1.27.0
+toolchain go1.27.1
 
 require (
 	filippo.io/age v1.3.1

--- a/renovate.json
+++ b/renovate.json
@@ -100,6 +100,7 @@
       "matchManagers": ["gomod"],
       "groupName": "Go modules",
       "minimumReleaseAge": "7 days",
+      "constraintsFiltering": "strict",
       "postUpdateOptions": ["gomodTidy", "gomodUpdateImportPaths"]
     },
     {


### PR DESCRIPTION
Scrutineer's documented source-build floor and Go execution surfaces are now on Go 1.27, but #981 left the module compatibility directive at Go 1.26.7. Because Renovate selects module releases before gomodTidy runs, that stale constraint can allow a dependency update to raise the directive as a generated side effect instead of treating the floor change as an explicit maintainer decision.

This raises the module compatibility floor to Go 1.27.0, advances the preferred toolchain to Go 1.27.1 to match the builder images from #984, and enables strict constraint filtering for Go modules. Renovate will now reject candidate module releases that do not support the declared floor before it creates an update. The existing seven-day module delay, grouping, tidy and import-path updates, manual merges, and disabled GitHub Dependency Dashboard remain unchanged; Mend remains the repository update view.

The configuration validates against Renovate 44.61.3. The module tidy check, standard and tagged vet passes, standard and eval race suites, JSON validation, and diff checks all pass.

Codex was used to implement this.
