### PR TITLE
Align the Go profile toolchain

### DIFF
--- a/docker/profiles/go/Dockerfile
+++ b/docker/profiles/go/Dockerfile
@@ -34,9 +34,9 @@ FROM ${RUNNER_IMAGE}
 # Explicit, sha256-verifiable Go version. Bump GO_VERSION and both
 # checksums together; the content-addressed image tag invalidates the
 # cache on any edit to this file.
-ARG GO_VERSION=1.27.0
-ARG GO_SHA256_AMD64=675c26c449cbb18fc24b74650de1eabbae6e16f64326fd85a283fb3b58280685
-ARG GO_SHA256_ARM64=51798d2c42d0e1c6ed7fd9f48728b4193abac9e8aad6dbac2fe96a81f5909bda
+ARG GO_VERSION=1.27.1
+ARG GO_SHA256_AMD64=63d339f0da5ab53635a56f2490a7984dfe12dfcff22ad749f63edaf590168445
+ARG GO_SHA256_ARM64=3450b45a3f9ee8568792736a5c5e70a1f2e9b36c35a8f74958c03e51d7d92bec
 # govulncheck reports known vulns in the project's module graph and (with
 # source) which are actually reachable. Pinned; built from source below.
 ARG GOVULNCHECK_VERSION=v1.7.0

--- a/threatmodel.md
+++ b/threatmodel.md
@@ -96,7 +96,7 @@ Mitigation remaining: tag finding rows with their source job; render claude-sour
 
 Go's `html/template` auto-escapes all finding fields. `internal/web/jsontree.go` returns `template.HTML` but escapes every leaf through `html.EscapeString`. `internal/web/location.go` builds hrefs from `HTMLURL`, which is scheme-validated at the write site by `safeURL` (see T7).
 
-The two `html/template` XSS vulnerabilities (`GO-2026-4865`, `GO-2026-4603`) are fixed by `toolchain go1.27.0` in go.mod.
+The two `html/template` XSS vulnerabilities (`GO-2026-4865`, `GO-2026-4603`) are fixed by `toolchain go1.27.1` in go.mod.
 
 ### T7: Untrusted upstream metadata (mitigated)
 
@@ -116,11 +116,11 @@ No rate limiting on `POST /repositories`, no cap on clone size, no timeout on th
 
 ### T10: Stale Go toolchain (resolved)
 
-`go.mod` specifies `toolchain go1.27.0`. The Dockerfile builds with `golang:1.27.0-alpine`. All nine stdlib vulnerabilities are fixed.
+`go.mod` specifies `toolchain go1.27.1`. The Dockerfile builds with `golang:1.27.1-alpine`. All nine stdlib vulnerabilities are fixed.
 
 ### T11: Image supply chain (partially mitigated)
 
-Tool versions are pinned: `claude-code@2.1.259`, `semgrep==1.167.0`, `bandit==1.9.4`, `git-pkgs@v0.19.0`, `zizmor@1.26.1`. The final stage is `debian:trixie-slim`; the `golang:1.27.0-trixie` and `rust:1.96-trixie` builder stages are pinned by sha256 digest. The container runs as non-root user `runner`. The runner image is built in CI, smoke-tested, and published to GHCR; users pull a known-good artifact rather than rebuilding against live registries.
+Tool versions are pinned: `claude-code@2.1.259`, `semgrep==1.167.0`, `bandit==1.9.4`, `git-pkgs@v0.19.0`, `zizmor@1.26.1`. The final stage is `debian:trixie-slim`; the `golang:1.27.1-trixie` and `rust:1.96-trixie` builder stages are pinned by sha256 digest. The container runs as non-root user `runner`. The runner image is built in CI, smoke-tested, and published to GHCR; users pull a known-good artifact rather than rebuilding against live registries.
 
 Supply-chain surface in the final stage:
 - `apt` pulls from Debian's official mirrors plus the GitHub CLI repo at `cli.github.com/packages` (signed-by keyring under `/etc/apt/keyrings/`). `gh` is used at scan time by the `fork` and `report-upstream` skills.
@@ -213,7 +213,7 @@ GORM usage is consistently parameterised; no `Raw`, no string-built `Where`, and
 - [x] `io.LimitReader` (10 MB cap) on all ecosyste.ms response bodies (T7).
 - [x] `safeURL` validation on HTMLURL and IconURL before storing (T7).
 - [x] `0700` on the data directory at startup (T8).
-- [x] `toolchain go1.27.0` in go.mod so host builds match the image (T10).
+- [x] `toolchain go1.27.1` in go.mod so host builds match the image (T10).
 - [x] Pin tool versions in Dockerfile: claude-code, semgrep, bandit, git-pkgs, brief, zizmor (T11).
 - [x] Non-root `USER runner` in Dockerfile (T11).
 - [x] Trim final Docker stage: `npm` absent, `pip` scoped to the `/opt/semgrep` and `/opt/bandit` venvs, `curl` retained for build- and scan-time fetches (T11).


### PR DESCRIPTION
Scrutineer's module and builder images already use Go 1.27.1, but the Go scanner profile still downloads Go 1.27.0. Because that profile sets `GOTOOLCHAIN=local`, scans remain on the older patch release, and Mend's Detected Dependencies view does not expose the manually paired `GO_VERSION` and checksum arguments.

This raises the scanner profile to Go 1.27.1 and replaces both Linux archive SHA-256 values with the official release hashes. It also synchronises the corresponding threat-model references. The module compatibility floor remains Go 1.27.0; the Renovate policy and existing base-image pins are unchanged.

Both archive hashes match Go's official release metadata. Diff and stale-reference checks also pass, and the existing profile-image workflow will build the changed Go profile in CI.

Codex was used to implement this.
