### PR TITLE
Separate Go language version updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -104,6 +104,12 @@
       "postUpdateOptions": ["gomodTidy", "gomodUpdateImportPaths"]
     },
     {
+      "description": "Raising the go directive raises the minimum Go version for every consumer",
+      "matchManagers": ["gomod"],
+      "matchDepTypes": ["golang", "toolchain"],
+      "groupName": "Go language version"
+    },
+    {
       "matchManagers": ["gomod"],
       "matchDepTypes": ["indirect"],
       "enabled": true


### PR DESCRIPTION
Scrutineer's general Go module rule currently groups its `go` and `toolchain` directives with ordinary module updates. Harness and Hyrum override those two dependency types into a separate Go language version group, keeping compatibility-floor and preferred-toolchain changes visible as explicit language updates.

This adds the same override to Scrutineer. Language updates continue to inherit the existing seven-day release age, strict constraint filtering, tidy and import-path behavior, and manual merge policy. The module group, indirect-dependency handling, Scrutineer-specific Docker timing rule, and disabled GitHub Dependency Dashboard remain unchanged; Mend remains the update view.

The configuration validates against Renovate 44.61.3. JSON parsing, the exact-rule assertion, and diff checks also pass.

Codex was used to implement this.
