### PR TITLE
fix(worker): contain hard-scope pruning

### DIFF
--- a/internal/worker/scope.go
+++ b/internal/worker/scope.go
@@ -3,6 +3,7 @@ package worker
 import (
 	"context"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -121,16 +122,44 @@ func pruneToSubPath(srcDir, subPath string) error {
 	if clean == "" {
 		return nil
 	}
-	full := filepath.Join(srcDir, filepath.FromSlash(clean))
-	if _, err := os.Stat(full); err != nil {
-		return fmt.Errorf("sub_path %q not found in repository: %w", clean, err)
+	srcInfo, err := os.Lstat(srcDir)
+	if err != nil {
+		return fmt.Errorf("open source root: %w", err)
 	}
+	if !srcInfo.IsDir() {
+		return fmt.Errorf("source root %q is not a directory", srcDir)
+	}
+	root, err := os.OpenRoot(srcDir)
+	if err != nil {
+		return fmt.Errorf("open source root: %w", err)
+	}
+	defer func() { _ = root.Close() }()
+
+	// Validate the complete keep-path before deleting anything. A repository
+	// symlink in that path would otherwise let the next ReadDir and RemoveAll
+	// operate outside srcDir. Root-relative operations also keep later pruning
+	// contained if the filesystem changes after this check.
+	parts := strings.Split(clean, "/")
+	cur := "."
+	for i, part := range parts {
+		cur = filepath.Join(cur, part)
+		info, err := root.Lstat(cur)
+		if err != nil {
+			return fmt.Errorf("sub_path %q not found in repository: %w", clean, err)
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("sub_path %q contains symlink component %q", clean, strings.Join(parts[:i+1], "/"))
+		}
+		if i < len(parts)-1 && !info.IsDir() {
+			return fmt.Errorf("sub_path %q component %q is not a directory", clean, strings.Join(parts[:i+1], "/"))
+		}
+	}
+
 	// Walk the keep-path one level at a time, deleting siblings that are not
 	// the next component (and, at the repo root, not .git).
-	parts := strings.Split(clean, "/")
-	cur := srcDir
+	cur = "."
 	for i, part := range parts {
-		entries, err := os.ReadDir(cur)
+		entries, err := fs.ReadDir(root.FS(), filepath.ToSlash(cur))
 		if err != nil {
 			return err
 		}
@@ -141,7 +170,7 @@ func pruneToSubPath(srcDir, subPath string) error {
 			if i == 0 && e.Name() == ".git" {
 				continue
 			}
-			if err := os.RemoveAll(filepath.Join(cur, e.Name())); err != nil {
+			if err := root.RemoveAll(filepath.Join(cur, e.Name())); err != nil {
 				return err
 			}
 		}

--- a/internal/worker/scope_test.go
+++ b/internal/worker/scope_test.go
@@ -125,6 +125,45 @@ func TestPruneToSubPath_prunesSymlinkedSiblingWithoutFollowing(t *testing.T) {
 	present(t, filepath.Join(root, "outside/index.js"))
 }
 
+func TestPruneToSubPath_prunesNestedSymlinkedSiblingWithoutFollowing(t *testing.T) {
+	root := t.TempDir()
+	src := filepath.Join(root, "src")
+	writeScopeFile(t, src, "packages/core/index.js")
+	writeScopeFile(t, root, "outside/index.js")
+	if err := os.Symlink("../../outside", filepath.Join(src, "packages", "linked")); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := pruneToSubPath(src, "packages/core"); err != nil {
+		t.Fatal(err)
+	}
+	present(t, filepath.Join(src, "packages/core/index.js"))
+	gone(t, filepath.Join(src, "packages/linked"))
+	present(t, filepath.Join(root, "outside/index.js"))
+}
+
+// A link that stays inside the checkout is refused as well: pruning through
+// it would delete the aliased directory as a sibling of the kept path. The
+// refusal has to land before anything is removed, so the tree is checked
+// intact afterwards, alias included.
+func TestPruneToSubPath_refusesInTreeAliasBeforeMutating(t *testing.T) {
+	src := t.TempDir()
+	writeScopeFile(t, src, "packages/core/index.js")
+	writeScopeFile(t, src, "README.md")
+	if err := os.Symlink("packages", filepath.Join(src, "alias")); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := pruneToSubPath(src, "alias/core"); err == nil {
+		t.Error("expected error for a symlinked sub_path component inside the checkout")
+	}
+	present(t, filepath.Join(src, "packages/core/index.js"))
+	present(t, filepath.Join(src, "README.md"))
+	if info, err := os.Lstat(filepath.Join(src, "alias")); err != nil || info.Mode()&os.ModeSymlink == 0 {
+		t.Errorf("alias link disturbed: %v, %v", info, err)
+	}
+}
+
 func TestScanScopeHard(t *testing.T) {
 	hard := &Worker{SubprojectScope: "hard"}
 	soft := &Worker{SubprojectScope: "soft"}

--- a/internal/worker/scope_test.go
+++ b/internal/worker/scope_test.go
@@ -74,6 +74,57 @@ func TestPruneToSubPath_missing(t *testing.T) {
 	}
 }
 
+func TestPruneToSubPath_refusesSymlinkedComponent(t *testing.T) {
+	dataDir := t.TempDir()
+	src := filepath.Join(dataDir, "scan-1", "src")
+	writeScopeFile(t, src, "README.md")
+	writeScopeFile(t, dataDir, "keep/index.js")
+	victim := filepath.Join(dataDir, "repo-cache", "cache.db")
+	writeScopeFile(t, dataDir, "repo-cache/cache.db")
+	if err := os.Symlink("../..", filepath.Join(src, "escape")); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := pruneToSubPath(src, "escape/keep"); err == nil {
+		t.Error("expected error for a symlinked sub_path component")
+	}
+	present(t, victim)
+	present(t, filepath.Join(src, "README.md"))
+}
+
+func TestPruneToSubPath_refusesTerminalSymlink(t *testing.T) {
+	root := t.TempDir()
+	src := filepath.Join(root, "src")
+	writeScopeFile(t, src, "README.md")
+	writeScopeFile(t, root, "outside/index.js")
+	if err := os.Symlink("../outside", filepath.Join(src, "linked")); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := pruneToSubPath(src, "linked"); err == nil {
+		t.Error("expected error for a symlinked sub_path")
+	}
+	present(t, filepath.Join(root, "outside/index.js"))
+	present(t, filepath.Join(src, "README.md"))
+}
+
+func TestPruneToSubPath_prunesSymlinkedSiblingWithoutFollowing(t *testing.T) {
+	root := t.TempDir()
+	src := filepath.Join(root, "src")
+	writeScopeFile(t, src, "keep/index.js")
+	writeScopeFile(t, root, "outside/index.js")
+	if err := os.Symlink("../outside", filepath.Join(src, "linked")); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := pruneToSubPath(src, "keep"); err != nil {
+		t.Fatal(err)
+	}
+	present(t, filepath.Join(src, "keep/index.js"))
+	gone(t, filepath.Join(src, "linked"))
+	present(t, filepath.Join(root, "outside/index.js"))
+}
+
 func TestScanScopeHard(t *testing.T) {
 	hard := &Worker{SubprojectScope: "hard"}
 	soft := &Worker{SubprojectScope: "soft"}


### PR DESCRIPTION
A hard-scoped sub-path scan prunes the per-scan checkout down to `sub_path`, and the repository decides what that path is made of. `pruneToSubPath` stat'ed the sub-path, listed each directory on the way down with `os.ReadDir`, and removed every sibling with `os.RemoveAll`, all by name, so a symlink at any component (`escape -> ../..` with `sub_path: escape/keep`, say) had the listing and the removals run in the link's target: the data directory, the clone cache, the findings database, anything else the host user can delete. A symlink at the last component alone was enough to prune the directory it pointed at.

The prune now opens an `os.Root` at `./src` and validates the whole keep-path through it before touching anything: every component is `Lstat`ed, a symlink anywhere on the path (including one that stays inside the checkout, which would otherwise prune the aliased directory as a sibling of the alias) fails the scan, and only then does it list and remove through the root, whose operations cannot resolve outside `./src` even if the tree changes underneath. Sibling links are still removed as links, never followed, so ordinary nested pruning is unchanged. `./src` is created by the host from the clone cache before the agent runs, so the root is opened on a directory the repository cannot substitute.

Tests cover the intermediate and terminal link, the in-tree alias with the tree checked intact after the refusal, and nested sibling links left in place outside. Run against main's `scope.go`, the escape test deletes the temp data directory's cache and the source tree itself. `go test -race` across the module, `go vet` with the evals and podman tags, `golangci-lint`, `go mod tidy -diff` and `govulncheck` all pass. Soft-scoped scans still hand `./src/<sub_path>` to profile detection without this check; that mount-side path is closed in #994.

Claude Fable 5.1 was used to review and refresh this branch.
