### PR TITLE
fix(worker): refuse symlinked paths in host workspace I/O

### DIFF
--- a/internal/worker/chat.go
+++ b/internal/worker/chat.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"path"
-	"path/filepath"
 	"strings"
 	"unicode/utf8"
 
@@ -112,7 +111,7 @@ func (c *ChatRunner) RunTurn(ctx context.Context, conv *db.Conversation, userMes
 	if err != nil {
 		return ChatTurnResult{}, err
 	}
-	if err := replaceWorkspaceFile(filepath.Join(workRoot, chatSnapshotFile), []byte(snapshot), filePerm); err != nil {
+	if err := replaceWorkspaceFile(workRoot, chatSnapshotFile, []byte(snapshot)); err != nil {
 		return ChatTurnResult{}, fmt.Errorf("stage snapshot: %w", err)
 	}
 
@@ -213,8 +212,7 @@ func (c *ChatRunner) RunTurn(ctx context.Context, conv *db.Conversation, userMes
 // scan does. Later turns reuse the tree, so the whole conversation reasons
 // about one revision of the code.
 func (c *ChatRunner) ensureSrc(ctx context.Context, repo *db.Repository, workRoot string, emit func(Event)) (bool, error) {
-	marker := filepath.Join(workRoot, chatSrcReadyFile)
-	if _, err := os.Stat(marker); err == nil {
+	if chatSrcReady(workRoot) {
 		return true, nil
 	}
 	switch {
@@ -236,10 +234,28 @@ func (c *ChatRunner) ensureSrc(ctx context.Context, repo *db.Repository, workRoo
 	if err := stripWorkspaceAgentDirectives(workRoot, emit); err != nil {
 		return false, err
 	}
-	if err := os.WriteFile(marker, nil, filePerm); err != nil {
+	// The workspace persists across turns and the agent writes to it, so the
+	// marker is replaced through the workspace root like the snapshot: a link
+	// the agent left in its place cannot turn this write into a file created
+	// elsewhere on the host.
+	if err := replaceWorkspaceFile(workRoot, chatSrcReadyFile, nil); err != nil {
 		return false, fmt.Errorf("mark chat source ready: %w", err)
 	}
 	return true, nil
+}
+
+// chatSrcReady reports whether the workspace carries the source-ready marker
+// as a regular file. Anything else at that name — a link the agent planted, a
+// directory — is not proof of a finished clone; the source is prepared again
+// and the entry replaced.
+func chatSrcReady(workRoot string) bool {
+	root, err := os.OpenRoot(workRoot)
+	if err != nil {
+		return false
+	}
+	defer func() { _ = root.Close() }()
+	info, err := root.Lstat(chatSrcReadyFile)
+	return err == nil && info.Mode().IsRegular()
 }
 
 // buildChatPrompt is the fresh-run prompt for a conversation: it frames the

--- a/internal/worker/chat.go
+++ b/internal/worker/chat.go
@@ -112,7 +112,7 @@ func (c *ChatRunner) RunTurn(ctx context.Context, conv *db.Conversation, userMes
 	if err != nil {
 		return ChatTurnResult{}, err
 	}
-	if err := os.WriteFile(filepath.Join(workRoot, chatSnapshotFile), []byte(snapshot), filePerm); err != nil {
+	if err := replaceWorkspaceFile(filepath.Join(workRoot, chatSnapshotFile), []byte(snapshot), filePerm); err != nil {
 		return ChatTurnResult{}, fmt.Errorf("stage snapshot: %w", err)
 	}
 

--- a/internal/worker/chat_test.go
+++ b/internal/worker/chat_test.go
@@ -321,6 +321,52 @@ func TestChatRunnerStagesSnapshot(t *testing.T) {
 	}
 }
 
+func TestRunTurn_replacesSymlinkedSnapshot(t *testing.T) {
+	gdb, repo := chatTestDB(t)
+	conv, err := db.CreateConversation(gdb, repo.ID, nil, "claude-x", "first")
+	if err != nil {
+		t.Fatal(err)
+	}
+	dataDir := t.TempDir()
+	workRoot := chatWorkRoot(dataDir, conv.ID)
+	if err := os.MkdirAll(workRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	victim := filepath.Join(dataDir, "host-file")
+	original := []byte("do not overwrite\n")
+	if err := os.WriteFile(victim, original, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	snapshotPath := filepath.Join(workRoot, chatSnapshotFile)
+	if err := os.Symlink("../host-file", snapshotPath); err != nil {
+		t.Fatal(err)
+	}
+
+	runner := &chatStubRunner{backend: "claude", resultText: "ok", emitResult: true}
+	cr := &ChatRunner{Runner: runner, DB: gdb, DataDir: dataDir}
+	if _, err := cr.RunTurn(context.Background(), conv, "hi", func(Event) {}); err != nil {
+		t.Fatal(err)
+	}
+
+	if got, err := os.ReadFile(victim); err != nil {
+		t.Fatal(err)
+	} else if string(got) != string(original) {
+		t.Errorf("snapshot write overwrote symlink target: got %q, want %q", got, original)
+	}
+	info, err := os.Lstat(snapshotPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		t.Fatal("snapshot remained a symlink")
+	}
+	if got, err := os.ReadFile(snapshotPath); err != nil {
+		t.Fatal(err)
+	} else if !strings.Contains(string(got), "acme") {
+		t.Errorf("replacement snapshot missing repository context:\n%s", got)
+	}
+}
+
 func TestChatRunnerLocalRepo(t *testing.T) {
 	gdb, _ := chatTestDB(t)
 	localDir := t.TempDir()

--- a/internal/worker/chat_test.go
+++ b/internal/worker/chat_test.go
@@ -769,3 +769,42 @@ func TestChatRunnerFindingSnapshotCarriesTheAnalysis(t *testing.T) {
 		t.Error("an oversized narrative field must be truncated, not inlined whole")
 	}
 }
+
+func TestEnsureSrc_symlinkedMarkerDoesNotCreateHostFile(t *testing.T) {
+	gdb, repo := chatTestDB(t)
+	conv, err := db.CreateConversation(gdb, repo.ID, nil, "claude-x", "first")
+	if err != nil {
+		t.Fatal(err)
+	}
+	dataDir := t.TempDir()
+	workRoot := chatWorkRoot(dataDir, conv.ID)
+	if err := os.MkdirAll(workRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// The agent left the ready marker as a link to a host path that does not
+	// exist yet; a plain WriteFile would create the file there.
+	victim := filepath.Join(dataDir, "host-marker")
+	if err := os.Symlink("../host-marker", filepath.Join(workRoot, chatSrcReadyFile)); err != nil {
+		t.Fatal(err)
+	}
+
+	prepared := 0
+	runner := &chatStubRunner{backend: "claude", resultText: "ok", emitResult: true}
+	cr := &ChatRunner{Runner: runner, DB: gdb, DataDir: dataDir, PrepareSrc: stubPrepareSrc(&prepared)}
+	if _, err := cr.RunTurn(context.Background(), conv, "hi", func(Event) {}); err != nil {
+		t.Fatal(err)
+	}
+	if prepared != 1 {
+		t.Errorf("a linked marker was accepted as a finished clone: prepared=%d, want 1", prepared)
+	}
+	if _, err := os.Lstat(victim); !os.IsNotExist(err) {
+		t.Errorf("marker write followed the link onto the host: lstat err = %v", err)
+	}
+	info, err := os.Lstat(filepath.Join(workRoot, chatSrcReadyFile))
+	if err != nil || !info.Mode().IsRegular() {
+		t.Errorf("marker = %v, %v; want a regular file", info, err)
+	}
+	if !runner.got.SrcReady {
+		t.Error("turn ran without the source marked ready")
+	}
+}

--- a/internal/worker/claude.go
+++ b/internal/worker/claude.go
@@ -320,6 +320,14 @@ const maxReportBytes = 50 << 20
 // at path, or an empty string if the file doesn't exist. Oversize files
 // are truncated and a log line is emitted to the scan so the operator
 // knows the report was clipped.
+//
+// The report is whatever the agent left under that name in a workspace it
+// controls, so the read goes through a root opened at the parent directory
+// and accepts only a regular file: a link to a host file, or to the
+// context.json beside it, yields no report rather than that file's contents.
+// The parent is the workspace root itself — validateSkillPaths keeps
+// output_file to a bare name — which the agent cannot replace from inside its
+// bind mount.
 func readCappedReport(path string, emit func(Event)) string {
 	root, err := os.OpenRoot(filepath.Dir(path))
 	if err != nil {

--- a/internal/worker/claude.go
+++ b/internal/worker/claude.go
@@ -321,13 +321,23 @@ const maxReportBytes = 50 << 20
 // are truncated and a log line is emitted to the scan so the operator
 // knows the report was clipped.
 func readCappedReport(path string, emit func(Event)) string {
-	f, err := os.Open(path)
+	root, err := os.OpenRoot(filepath.Dir(path))
+	if err != nil {
+		return ""
+	}
+	defer func() { _ = root.Close() }()
+	name := filepath.Base(path)
+	entryInfo, err := root.Lstat(name)
+	if err != nil || !entryInfo.Mode().IsRegular() {
+		return ""
+	}
+	f, err := root.Open(name)
 	if err != nil {
 		return ""
 	}
 	defer func() { _ = f.Close() }()
 	info, err := f.Stat()
-	if err != nil {
+	if err != nil || !info.Mode().IsRegular() || !os.SameFile(entryInfo, info) {
 		return ""
 	}
 	if info.Size() > maxReportBytes {

--- a/internal/worker/container.go
+++ b/internal/worker/container.go
@@ -650,11 +650,36 @@ func (d ContainerRunner) injectProfileGuide(profile, absWork string, emit func(E
 		emit(Event{Kind: KindText, Text: "profile guide: read " + guide + ": " + err.Error()})
 		return
 	}
-	if err := os.WriteFile(target, data, profileGuideFileMode); err != nil {
+	if err := replaceWorkspaceFile(target, data, profileGuideFileMode); err != nil {
 		emit(Event{Kind: KindText, Text: "profile guide: write " + target + ": " + err.Error()})
 		return
 	}
 	emit(Event{Kind: KindText, Text: "profile guide: " + guide + " -> /work/" + name})
+}
+
+// replaceWorkspaceFile unlinks an existing workspace entry, then creates its
+// replacement exclusively through a directory-scoped root. A runner that left
+// a symlink behind cannot redirect the write, and a concurrent replant makes
+// the create fail instead of being followed.
+func replaceWorkspaceFile(path string, data []byte, mode os.FileMode) error {
+	root, err := os.OpenRoot(filepath.Dir(path))
+	if err != nil {
+		return err
+	}
+	defer func() { _ = root.Close() }()
+	name := filepath.Base(path)
+	if err := root.Remove(name); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	f, err := root.OpenFile(name, os.O_WRONLY|os.O_CREATE|os.O_EXCL, mode)
+	if err != nil {
+		return err
+	}
+	if _, err := f.Write(data); err != nil {
+		_ = f.Close()
+		return err
+	}
+	return f.Close()
 }
 
 // SkillDir delegates to the harness so the worker stages SKILL.md

--- a/internal/worker/container.go
+++ b/internal/worker/container.go
@@ -9,7 +9,9 @@ package worker
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io/fs"
 	"log/slog"
 	"net"
 	"net/url"
@@ -563,9 +565,10 @@ func (d ContainerRunner) resolveProfile(ctx context.Context, requested, src, sub
 			return "", defaultImg
 		}
 	} else {
-		srcDir := src
-		if subPath != "" {
-			srcDir = filepath.Join(src, subPath)
+		srcDir, err := detectionSrcDir(src, subPath)
+		if err != nil {
+			emit(Event{Kind: KindText, Text: "profile: " + err.Error() + "; using default"})
+			return "", defaultImg
 		}
 		detect := d.detectProfile
 		if detect == nil {
@@ -608,11 +611,49 @@ func (d ContainerRunner) resolveProfile(ctx context.Context, requested, src, sub
 	return p.Name, img
 }
 
-// profileGuideFileMode is the mode used when copying a profile's
-// PROFILE.md into the workspace as CLAUDE.md. The workspace already
-// belongs to the host user (the container runner mounts it as that uid),
-// so a plain 0644 keeps it readable by the agent without surprises.
-const profileGuideFileMode os.FileMode = 0o644
+// detectionSrcDir returns the directory profile detection bind-mounts for
+// src/subPath, refusing one that a symlink would carry outside the workspace.
+// The container runtime resolves the host side of a bind mount itself, so a
+// repository link at the sub-path (a soft-scoped scan prunes nothing and
+// checks nothing there) or one the agent planted in the checkout before a
+// repair or audit run in the same workspace would otherwise mount an
+// arbitrary host directory into the detection container. Links are checked
+// through a root opened at the workspace, which follows them only while they
+// stay inside it; a dangling link is refused the same way rather than handed
+// to the runtime, which creates a missing bind source. A sub-path that plainly
+// does not exist is passed on unchanged so detection degrades to the default
+// profile as before.
+func detectionSrcDir(src, subPath string) (string, error) {
+	workspace := filepath.Dir(src)
+	rel := filepath.Base(src)
+	if subPath != "" {
+		rel = filepath.Join(rel, subPath)
+	}
+	srcDir := filepath.Join(workspace, rel)
+	root, err := os.OpenRoot(workspace)
+	if err != nil {
+		return "", fmt.Errorf("open workspace for profile detection: %w", err)
+	}
+	defer func() { _ = root.Close() }()
+	cur := ""
+	for part := range strings.SplitSeq(filepath.ToSlash(rel), "/") {
+		cur = filepath.Join(cur, part)
+		info, err := root.Lstat(cur)
+		if errors.Is(err, fs.ErrNotExist) {
+			return srcDir, nil
+		}
+		if err != nil {
+			return "", fmt.Errorf("detection path %s: %w", srcDir, err)
+		}
+		if info.Mode()&os.ModeSymlink == 0 {
+			continue
+		}
+		if info, err = root.Stat(cur); err != nil || !info.IsDir() {
+			return "", fmt.Errorf("detection path %s: link %s does not resolve inside the workspace", srcDir, cur)
+		}
+	}
+	return srcDir, nil
+}
 
 // checkHardenedWorkspace returns an error when a hardening mode is on and the
 // cloned workspace exceeds HardenedWorkspaceCapBytes. It applies under both
@@ -650,36 +691,11 @@ func (d ContainerRunner) injectProfileGuide(profile, absWork string, emit func(E
 		emit(Event{Kind: KindText, Text: "profile guide: read " + guide + ": " + err.Error()})
 		return
 	}
-	if err := replaceWorkspaceFile(target, data, profileGuideFileMode); err != nil {
+	if err := replaceWorkspaceFile(absWork, name, data); err != nil {
 		emit(Event{Kind: KindText, Text: "profile guide: write " + target + ": " + err.Error()})
 		return
 	}
 	emit(Event{Kind: KindText, Text: "profile guide: " + guide + " -> /work/" + name})
-}
-
-// replaceWorkspaceFile unlinks an existing workspace entry, then creates its
-// replacement exclusively through a directory-scoped root. A runner that left
-// a symlink behind cannot redirect the write, and a concurrent replant makes
-// the create fail instead of being followed.
-func replaceWorkspaceFile(path string, data []byte, mode os.FileMode) error {
-	root, err := os.OpenRoot(filepath.Dir(path))
-	if err != nil {
-		return err
-	}
-	defer func() { _ = root.Close() }()
-	name := filepath.Base(path)
-	if err := root.Remove(name); err != nil && !os.IsNotExist(err) {
-		return err
-	}
-	f, err := root.OpenFile(name, os.O_WRONLY|os.O_CREATE|os.O_EXCL, mode)
-	if err != nil {
-		return err
-	}
-	if _, err := f.Write(data); err != nil {
-		_ = f.Close()
-		return err
-	}
-	return f.Close()
 }
 
 // SkillDir delegates to the harness so the worker stages SKILL.md

--- a/internal/worker/container_test.go
+++ b/internal/worker/container_test.go
@@ -956,3 +956,68 @@ func TestParseProxySidecarNames_KeepsStrictPrefixOnly(t *testing.T) {
 		t.Errorf("empty input should yield nil, got %v", names)
 	}
 }
+
+func TestResolveProfile_refusesDetectionPathLeavingWorkspace(t *testing.T) {
+	outside := t.TempDir()
+	work := t.TempDir()
+	src := filepath.Join(work, "src")
+	if err := os.MkdirAll(filepath.Join(src, "pkg"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, filepath.Join(src, "escape")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("../../..", filepath.Join(src, "pkg", "up")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("nowhere", filepath.Join(src, "dangling")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(work, "sibling"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("../sibling", filepath.Join(src, "inside")); err != nil {
+		t.Fatal(err)
+	}
+
+	var seen []string
+	d := ContainerRunner{
+		ProfilesDir: t.TempDir(),
+		detectProfile: func(_ context.Context, _ ContainerRuntime, _, srcDir string, _ bool) Profile {
+			seen = append(seen, srcDir)
+			return Profile{}
+		},
+	}
+	var events []string
+	emit := func(e Event) { events = append(events, e.Text) }
+
+	for _, subPath := range []string{"escape", "escape/deeper", "pkg/up", "dangling"} {
+		d.resolveProfile(context.Background(), "", src, subPath, emit)
+	}
+	// The whole checkout swapped for a link is refused the same way.
+	swapped := filepath.Join(work, "swapped-src")
+	if err := os.Symlink(outside, swapped); err != nil {
+		t.Fatal(err)
+	}
+	d.resolveProfile(context.Background(), "", swapped, "", emit)
+	if len(seen) != 0 {
+		t.Errorf("detection ran against a path leaving the workspace: %q", seen)
+	}
+	if len(events) != 5 {
+		t.Fatalf("expected one refusal per escaping path, got %q", events)
+	}
+	for _, e := range events {
+		if !strings.Contains(e, "using default") {
+			t.Errorf("refusal not reported as a default fallback: %q", e)
+		}
+	}
+
+	// A link that stays inside the workspace, and a sub-path that does not
+	// exist, still reach detection as before.
+	d.resolveProfile(context.Background(), "", src, "inside", emit)
+	d.resolveProfile(context.Background(), "", src, "pkg/missing", emit)
+	want := []string{filepath.Join(src, "inside"), filepath.Join(src, "pkg", "missing")}
+	if !reflect.DeepEqual(seen, want) {
+		t.Errorf("detection paths = %q, want %q", seen, want)
+	}
+}

--- a/internal/worker/exposure.go
+++ b/internal/worker/exposure.go
@@ -101,7 +101,7 @@ func (w *Worker) doExposure(ctx context.Context, scan *db.Scan, emit func(Event)
 	if err := validateSkillPaths(skill.Name, skill.OutputFile); err != nil {
 		return "", err
 	}
-	if err := os.MkdirAll(workRoot, dirPerm); err != nil {
+	if err := resetWorkspace(workRoot); err != nil {
 		return "", err
 	}
 	cacheCommit, err := w.prepareDependentSrc(ctx, dep.RepositoryURL, scan.Ref, workRoot, emit)

--- a/internal/worker/harness_test.go
+++ b/internal/worker/harness_test.go
@@ -267,6 +267,53 @@ func TestInjectProfileGuide_noopWithoutProfile(t *testing.T) {
 	}
 }
 
+func TestInjectProfileGuide_replacesSymlinkTarget(t *testing.T) {
+	profilesDir := t.TempDir()
+	profileDir := filepath.Join(profilesDir, "ruby")
+	if err := os.MkdirAll(profileDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	guide := []byte("# Ruby scanning container\n")
+	if err := os.WriteFile(filepath.Join(profileDir, "PROFILE.md"), guide, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	parent := t.TempDir()
+	victim := filepath.Join(parent, "host-file")
+	original := []byte("do not overwrite\n")
+	if err := os.WriteFile(victim, original, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	work := filepath.Join(parent, "work")
+	if err := os.Mkdir(work, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(work, "CLAUDE.md")
+	if err := os.Symlink("../host-file", target); err != nil {
+		t.Fatal(err)
+	}
+
+	ContainerRunner{ProfilesDir: profilesDir}.injectProfileGuide("ruby", work, func(Event) {})
+
+	if got, err := os.ReadFile(victim); err != nil {
+		t.Fatal(err)
+	} else if string(got) != string(original) {
+		t.Errorf("profile guide overwrote symlink target: got %q, want %q", got, original)
+	}
+	info, err := os.Lstat(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		t.Fatal("profile guide remained a symlink")
+	}
+	if got, err := os.ReadFile(target); err != nil {
+		t.Fatal(err)
+	} else if string(got) != string(guide) {
+		t.Errorf("profile guide = %q, want %q", got, guide)
+	}
+}
+
 // TestScrutineerValidationHint pins the exact API-endpoint text so a
 // wording change is deliberate.
 func TestScrutineerValidationHint(t *testing.T) {

--- a/internal/worker/harness_test.go
+++ b/internal/worker/harness_test.go
@@ -439,3 +439,50 @@ func TestCopilotArgsNeverCarryMaxEffort(t *testing.T) {
 		t.Errorf("copilot argv still carries scrutineer's max: %v", args)
 	}
 }
+
+func TestInjectProfileGuide_nestedGuideStaysInsideWorkspace(t *testing.T) {
+	profilesDir := t.TempDir()
+	profileDir := filepath.Join(profilesDir, "ruby")
+	if err := os.MkdirAll(profileDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	guide := []byte("# Ruby scanning container\n")
+	if err := os.WriteFile(filepath.Join(profileDir, "PROFILE.md"), guide, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	const nested = ".github/copilot-instructions.md"
+	d := ContainerRunner{ProfilesDir: profilesDir, Harness: stubHarness{guide: nested}}
+
+	// A fresh workspace gets the guide's directory created for it.
+	work := t.TempDir()
+	d.injectProfileGuide("ruby", work, func(Event) {})
+	if got, err := os.ReadFile(filepath.Join(work, nested)); err != nil || string(got) != string(guide) {
+		t.Errorf("nested guide = %q, %v; want %q", got, err, guide)
+	}
+
+	// An agent that turned the guide's directory into a link out of the
+	// workspace gets no guide, and the host directory stays untouched.
+	parent := t.TempDir()
+	hostDir := filepath.Join(parent, "host-dir")
+	if err := os.Mkdir(hostDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	work = filepath.Join(parent, "work")
+	if err := os.Mkdir(work, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("../host-dir", filepath.Join(work, ".github")); err != nil {
+		t.Fatal(err)
+	}
+	var events []string
+	d.injectProfileGuide("ruby", work, func(e Event) { events = append(events, e.Text) })
+	if _, err := os.Lstat(filepath.Join(hostDir, "copilot-instructions.md")); !os.IsNotExist(err) {
+		t.Errorf("guide escaped through the linked directory: lstat err = %v", err)
+	}
+	if info, err := os.Lstat(filepath.Join(work, ".github")); err != nil || info.Mode()&os.ModeSymlink == 0 {
+		t.Errorf("linked guide directory was disturbed: %v, %v", info, err)
+	}
+	if len(events) != 1 || !strings.Contains(events[0], "profile guide: write") {
+		t.Errorf("expected the refused write to be reported, got %q", events)
+	}
+}

--- a/internal/worker/opencode_provider.go
+++ b/internal/worker/opencode_provider.go
@@ -364,11 +364,29 @@ func prepareOpencodeScanState(provider opencodeProvider, harnessStateDir string)
 	if harnessStateDir == "" {
 		return fmt.Errorf("OpenCode provider %q stored auth requires a per-scan harness state directory", provider.ID)
 	}
-	target := filepath.Join(harnessStateDir, "data", "opencode", "auth.json")
-	if err := os.MkdirAll(filepath.Dir(target), opencodeProviderStatePerm); err != nil {
+	// The state directory is mounted read-write at /harness-state and
+	// XDG_DATA_HOME points the agent at data/ below it, so after the first
+	// invocation everything under data/ is the agent's. The placeholder the
+	// auth.json bind mount lands on is therefore created through a root
+	// opened at the state directory: a link the agent left at the path, or at
+	// data/ or data/opencode/, cannot carry the create outside the directory,
+	// and anything there that is not already a regular file is replaced.
+	root, err := os.OpenRoot(harnessStateDir)
+	if err != nil {
 		return fmt.Errorf("prepare OpenCode provider %q scan auth directory: %w", provider.ID, err)
 	}
-	file, err := os.OpenFile(target, os.O_WRONLY|os.O_CREATE, opencodeAuthFilePerm)
+	defer func() { _ = root.Close() }()
+	rel := filepath.Join("data", "opencode", "auth.json")
+	if err := root.MkdirAll(filepath.Dir(rel), opencodeProviderStatePerm); err != nil {
+		return fmt.Errorf("prepare OpenCode provider %q scan auth directory: %w", provider.ID, err)
+	}
+	if info, err := root.Lstat(rel); err == nil && info.Mode().IsRegular() {
+		return nil
+	}
+	if err := root.RemoveAll(rel); err != nil {
+		return fmt.Errorf("prepare OpenCode provider %q scan auth mountpoint: %w", provider.ID, err)
+	}
+	file, err := root.OpenFile(rel, os.O_WRONLY|os.O_CREATE|os.O_EXCL, opencodeAuthFilePerm)
 	if err != nil {
 		return fmt.Errorf("prepare OpenCode provider %q scan auth mountpoint: %w", provider.ID, err)
 	}

--- a/internal/worker/opencode_provider_test.go
+++ b/internal/worker/opencode_provider_test.go
@@ -607,3 +607,64 @@ func TestRunnerImageContentDigestParsesAppleInspectJSON(t *testing.T) {
 		t.Errorf("apple runner image id fallback = %q, want sha256:localid", got)
 	}
 }
+
+func TestPrepareOpencodeScanStateRefusesSymlinkedMountpoint(t *testing.T) {
+	provider := opencodeProvider{ID: "kiro", StateDir: t.TempDir()}
+	parent := t.TempDir()
+	state := filepath.Join(parent, "state")
+	if err := os.MkdirAll(filepath.Join(state, "data", "opencode"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	// The agent owns data/ (its XDG_DATA_HOME) and left the mountpoint name
+	// as a link to a host path outside the state directory.
+	victim := filepath.Join(parent, "victim")
+	mountpoint := filepath.Join(state, "data", "opencode", "auth.json")
+	if err := os.Symlink("../../../victim", mountpoint); err != nil {
+		t.Fatal(err)
+	}
+	if err := prepareOpencodeScanState(provider, state); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Lstat(victim); !os.IsNotExist(err) {
+		t.Errorf("mountpoint create followed the link onto the host: lstat err = %v", err)
+	}
+	if info, err := os.Lstat(mountpoint); err != nil || !info.Mode().IsRegular() {
+		t.Errorf("mountpoint = %v, %v; want a regular file", info, err)
+	}
+
+	// A link to an existing host file is replaced without touching the target.
+	original := []byte("keep\n")
+	if err := os.WriteFile(victim, original, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(mountpoint); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("../../../victim", mountpoint); err != nil {
+		t.Fatal(err)
+	}
+	if err := prepareOpencodeScanState(provider, state); err != nil {
+		t.Fatal(err)
+	}
+	if got, err := os.ReadFile(victim); err != nil || string(got) != string(original) {
+		t.Errorf("host file changed: %q, %v", got, err)
+	}
+	if info, err := os.Lstat(mountpoint); err != nil || !info.Mode().IsRegular() {
+		t.Errorf("mountpoint = %v, %v; want a regular file", info, err)
+	}
+
+	// A data/ that leaves the state directory fails the scan instead of being
+	// followed, and creates nothing outside it.
+	if err := os.RemoveAll(filepath.Join(state, "data")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("..", filepath.Join(state, "data")); err != nil {
+		t.Fatal(err)
+	}
+	if err := prepareOpencodeScanState(provider, state); err == nil {
+		t.Error("expected a linked data directory to be refused")
+	}
+	if _, err := os.Lstat(filepath.Join(parent, "opencode")); !os.IsNotExist(err) {
+		t.Errorf("directory created outside the state directory: lstat err = %v", err)
+	}
+}

--- a/internal/worker/report_cap_test.go
+++ b/internal/worker/report_cap_test.go
@@ -56,3 +56,25 @@ func TestReadCappedReport_missingFileIsEmpty(t *testing.T) {
 		t.Errorf("missing file should return empty, got %q", got)
 	}
 }
+
+func TestReadCappedReport_refusesSymlink(t *testing.T) {
+	const secret = `{"host_secret":"do-not-emit"}`
+	target := filepath.Join(t.TempDir(), "host-secret.json")
+	if err := os.WriteFile(target, []byte(secret), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	report := filepath.Join(t.TempDir(), "report.json")
+	if err := os.Symlink(target, report); err != nil {
+		t.Fatal(err)
+	}
+
+	var events []Event
+	if got := readCappedReport(report, func(e Event) { events = append(events, e) }); got != "" {
+		t.Errorf("symlinked report returned target contents %q, want empty", got)
+	}
+	for _, event := range events {
+		if strings.Contains(event.Text, secret) {
+			t.Errorf("symlinked report leaked target contents in event %q", event.Text)
+		}
+	}
+}

--- a/internal/worker/report_cap_test.go
+++ b/internal/worker/report_cap_test.go
@@ -78,3 +78,18 @@ func TestReadCappedReport_refusesSymlink(t *testing.T) {
 		}
 	}
 }
+
+func TestReadCappedReport_refusesLinkToWorkspaceFile(t *testing.T) {
+	work := t.TempDir()
+	const token = `{"scrutineer":{"token":"secret-token"}}`
+	if err := os.WriteFile(filepath.Join(work, "context.json"), []byte(token), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	report := filepath.Join(work, "report.json")
+	if err := os.Symlink("context.json", report); err != nil {
+		t.Fatal(err)
+	}
+	if got := readCappedReport(report, func(Event) {}); got != "" {
+		t.Errorf("report linked to context.json returned %q, want empty", got)
+	}
+}

--- a/internal/worker/skill.go
+++ b/internal/worker/skill.go
@@ -165,10 +165,12 @@ func (w *Worker) doSkill(ctx context.Context, scan *db.Scan, emit func(Event)) (
 	}
 
 	// Per-scan workspace keeps concurrent skills on the same repo from
-	// clobbering each other's src/ and report.json. wrap() removes it on
-	// successful completion; failed/cancelled dirs are left so the
-	// operator can inspect what the skill saw. The clone itself lives in
-	// the persistent repo-cache and is copied in by prepareRepoSrc.
+	// clobbering each other's src/ and report.json. wrap() removes it once
+	// the scan reaches a terminal status. A paused scan keeps it and comes
+	// back through here on resume, after the agent has had the run of it, so
+	// staging always starts from an empty directory rather than writing into
+	// one the agent shaped (see resetWorkspace). The clone itself lives in the
+	// persistent repo-cache and is copied in by prepareRepoSrc.
 	workRoot := w.scanWorkRoot(scan)
 	if err := validateSkillPaths(skill.Name, skill.OutputFile); err != nil {
 		return "", err
@@ -176,8 +178,8 @@ func (w *Worker) doSkill(ctx context.Context, scan *db.Scan, emit func(Event)) (
 	if scan.Repository.IsLocal() && skill.RequiresRemote {
 		return "", fmt.Errorf("skill %q requires a remote repository; cannot run on local directory", skill.Name)
 	}
-	if err := os.MkdirAll(workRoot, dirPerm); err != nil {
-		return "", fmt.Errorf("mkdir work: %w", err)
+	if err := resetWorkspace(workRoot); err != nil {
+		return "", fmt.Errorf("reset work: %w", err)
 	}
 	if scan.Repository.IsLocal() {
 		if err := prepareLocalSrc(scan.Repository.LocalPath(), workRoot, emit); err != nil {

--- a/internal/worker/skill_test.go
+++ b/internal/worker/skill_test.go
@@ -1199,3 +1199,84 @@ func hasMatchingEvent(events []string, substr string) bool {
 	}
 	return false
 }
+
+// workspaceInspectingRunner records what the workspace looked like when the
+// agent was invoked; wrap() removes it once the scan finishes, so the test
+// cannot look afterwards.
+type workspaceInspectingRunner struct {
+	fakeRunner
+	scratchPresent bool
+	contextIsFile  bool
+}
+
+func (r *workspaceInspectingRunner) RunSkill(ctx context.Context, sj SkillJob, emit func(Event)) (SkillResult, error) {
+	_, err := os.Lstat(filepath.Join(sj.WorkRoot, "scratch.txt"))
+	r.scratchPresent = err == nil
+	info, err := os.Lstat(filepath.Join(sj.WorkRoot, "context.json"))
+	r.contextIsFile = err == nil && info.Mode().IsRegular()
+	return r.fakeRunner.RunSkill(ctx, sj, emit)
+}
+
+func TestDoSkill_resetsReusedWorkspace(t *testing.T) {
+	gdb, err := db.Open(filepath.Join(t.TempDir(), "s.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo := db.Repository{URL: "https://example.com/x", Name: "x"}
+	gdb.Create(&repo)
+	skill := db.Skill{
+		Name:       "spec-deep",
+		Body:       "Do the thing.",
+		OutputFile: "report.json",
+		OutputKind: "findings",
+		Version:    1,
+		Active:     true,
+		Source:     "ui",
+	}
+	gdb.Create(&skill)
+	scan := db.Scan{RepositoryID: repo.ID, Kind: JobSkill, Status: db.ScanQueued, Model: "fake", SkillID: &skill.ID}
+	gdb.Create(&scan)
+
+	dataDir := t.TempDir()
+	runner := &workspaceInspectingRunner{fakeRunner: fakeRunner{skillRes: SkillResult{Commit: "abc", Report: `{"findings":[]}`}}}
+	w := &Worker{
+		DB:             gdb,
+		Log:            slog.New(slog.NewTextHandler(io.Discard, nil)),
+		DataDir:        dataDir,
+		Runner:         runner,
+		PrepareRepoSrc: stubPrepareRepoSrc,
+	}
+	// A paused scan comes back through doSkill with the workspace its agent
+	// already shaped: context.json, which carries the scan's API token,
+	// replaced by a link to a host path, plus a scratch file of its own.
+	workRoot := w.workRoot(scan.ID)
+	if err := os.MkdirAll(workRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	victim := filepath.Join(dataDir, "host-file")
+	if err := os.Symlink("../host-file", filepath.Join(workRoot, "context.json")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(workRoot, "scratch.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	body, _ := json.Marshal(queue.Payload{ScanID: scan.ID})
+	if err := w.wrap(w.doSkill)(context.Background(), body); err != nil {
+		t.Fatal(err)
+	}
+	var got db.Scan
+	gdb.First(&got, scan.ID)
+	if got.Status != db.ScanDone {
+		t.Fatalf("status = %s: %s", got.Status, got.Error)
+	}
+	if _, err := os.Lstat(victim); !os.IsNotExist(err) {
+		t.Errorf("context.json followed the planted link onto the host: lstat err = %v", err)
+	}
+	if !runner.contextIsFile {
+		t.Error("context.json was not staged as a regular file")
+	}
+	if runner.scratchPresent {
+		t.Error("the previous invocation's scratch file survived into the new run")
+	}
+}

--- a/internal/worker/snippet.go
+++ b/internal/worker/snippet.go
@@ -1,6 +1,7 @@
 package worker
 
 import (
+	"io"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -15,9 +16,9 @@ const snippetContextLines = 5
 // location (file:line) read from srcDir, with snippetContextLines of
 // context on either side. It applies the same untrusted-path discipline as
 // vidSinks: the location must parse to a path with a line number, stay
-// inside the checkout after symlink resolution, and point at a regular
-// file. Returns "" when any of that fails or the line is past EOF, so
-// callers treat a missing snippet as not-captured rather than an error.
+// inside the descriptor-rooted checkout, and point at a regular file. Returns
+// "" when any of that fails or the line is past EOF, so callers treat a
+// missing snippet as not-captured rather than an error.
 func readSnippet(srcDir, location string) string {
 	loc := strings.TrimPrefix(strings.TrimSpace(location), "./")
 	m := vidLocRE.FindStringSubmatch(loc)
@@ -29,18 +30,20 @@ func readSnippet(srcDir, location string) string {
 	if err != nil || path == "" || line < 1 || !filepath.IsLocal(path) {
 		return ""
 	}
-	root, err := filepath.EvalSymlinks(srcDir)
+	root := openSourceRoot(srcDir)
+	if root == nil {
+		return ""
+	}
+	defer func() { _ = root.Close() }()
+	f, err := root.Open(path)
 	if err != nil {
 		return ""
 	}
-	resolved, err := filepath.EvalSymlinks(filepath.Join(srcDir, path))
-	if err != nil || !strings.HasPrefix(resolved, root+string(filepath.Separator)) {
+	defer func() { _ = f.Close() }()
+	if info, err := f.Stat(); err != nil || !info.Mode().IsRegular() {
 		return ""
 	}
-	if fi, err := os.Stat(resolved); err != nil || !fi.Mode().IsRegular() {
-		return ""
-	}
-	data, err := os.ReadFile(resolved)
+	data, err := io.ReadAll(f)
 	if err != nil {
 		return ""
 	}
@@ -51,4 +54,25 @@ func readSnippet(srcDir, location string) string {
 	start := max(line-1-snippetContextLines, 0)
 	end := min(line+snippetContextLines, len(lines))
 	return strings.Join(lines[start:end], "\n")
+}
+
+// openSourceRoot rejects a symlink at srcDir itself and verifies that the
+// descriptor still names the directory inspected before opening it. All child
+// operations through the returned Root are then confined beneath that inode,
+// including when a runner changes symlinks concurrently.
+func openSourceRoot(srcDir string) *os.Root {
+	entryInfo, err := os.Lstat(srcDir)
+	if err != nil || !entryInfo.IsDir() {
+		return nil
+	}
+	root, err := os.OpenRoot(srcDir)
+	if err != nil {
+		return nil
+	}
+	rootInfo, err := root.Stat(".")
+	if err != nil || !rootInfo.IsDir() || !os.SameFile(entryInfo, rootInfo) {
+		_ = root.Close()
+		return nil
+	}
+	return root
 }

--- a/internal/worker/snippet_test.go
+++ b/internal/worker/snippet_test.go
@@ -98,3 +98,27 @@ func TestReadSnippet(t *testing.T) {
 		}
 	})
 }
+
+func TestReadSnippet_allowsContainedSymlink(t *testing.T) {
+	srcDir := t.TempDir()
+	writeNumberedFile(t, srcDir, "a.go", 20)
+	if err := os.Symlink("a.go", filepath.Join(srcDir, "alias.go")); err != nil {
+		t.Fatal(err)
+	}
+	if got := readSnippet(srcDir, "alias.go:10"); !strings.Contains(got, "line 10") {
+		t.Errorf("readSnippet via contained symlink = %q, want line 10", got)
+	}
+}
+
+func TestReadSnippet_refusesSymlinkedRoot(t *testing.T) {
+	realRoot := t.TempDir()
+	writeNumberedFile(t, realRoot, "host-secret.go", 2)
+	srcDir := filepath.Join(t.TempDir(), "src")
+	if err := os.Symlink(realRoot, srcDir); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := readSnippet(srcDir, "host-secret.go:1"); got != "" {
+		t.Errorf("readSnippet through symlinked root = %q, want empty", got)
+	}
+}

--- a/internal/worker/vid.go
+++ b/internal/worker/vid.go
@@ -3,6 +3,7 @@ package worker
 import (
 	"bytes"
 	"context"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -11,7 +12,11 @@ import (
 	"time"
 )
 
-const vidTimeout = 30 * time.Second
+const (
+	vidTimeout       = 30 * time.Second
+	vidStageDirMode  = 0o700
+	vidStageFileMode = 0o600
+)
 
 // vidLocRE matches a finding location ("file.rb:12", "file.rb:12-34",
 // "file.js:42:7") and captures the path and the first line number.
@@ -21,15 +26,19 @@ var vidLocRE = regexp.MustCompile(`^(.*?):(\d+)(?:-\d+)?(?::\d+(?:-\d+)?)?$`)
 
 // vidSinks turns a finding's newline-joined Locations into the
 // file:line arguments the vid CLI expects, keeping only entries that
-// resolve to a real file inside srcDir. Model output is untrusted, so
-// paths that escape the checkout are dropped rather than read; the
-// checkout may contain hostile symlinks, so containment is checked on
-// the symlink-resolved path, not the lexical one.
+// resolve to a real file inside srcDir. Model output is untrusted, so paths
+// that escape the checkout are dropped rather than read. The descriptor-rooted
+// lookup confines hostile symlinks even if a runner changes them concurrently.
 func vidSinks(srcDir, locations string) []string {
-	root, err := filepath.EvalSymlinks(srcDir)
-	if err != nil {
+	root := openSourceRoot(srcDir)
+	if root == nil {
 		return nil
 	}
+	defer func() { _ = root.Close() }()
+	return vidSinksFromRoot(root, locations)
+}
+
+func vidSinksFromRoot(root *os.Root, locations string) []string {
 	seen := map[string]bool{}
 	var out []string
 	for loc := range strings.SplitSeq(locations, "\n") {
@@ -42,11 +51,13 @@ func vidSinks(srcDir, locations string) []string {
 		if path == "" || !filepath.IsLocal(path) {
 			continue
 		}
-		resolved, err := filepath.EvalSymlinks(filepath.Join(srcDir, path))
-		if err != nil || !strings.HasPrefix(resolved, root+string(filepath.Separator)) {
+		f, err := root.Open(path)
+		if err != nil {
 			continue
 		}
-		if fi, err := os.Stat(resolved); err != nil || !fi.Mode().IsRegular() {
+		info, statErr := f.Stat()
+		_ = f.Close()
+		if statErr != nil || !info.Mode().IsRegular() {
 			continue
 		}
 		sink := path + ":" + line
@@ -66,7 +77,12 @@ func vidSinks(srcDir, locations string) []string {
 // not-computed rather than an error, since the finding itself is still
 // valid without one.
 func (w *Worker) computeVID(srcDir, locations string) string {
-	sinks := vidSinks(srcDir, locations)
+	sourceRoot := openSourceRoot(srcDir)
+	if sourceRoot == nil {
+		return ""
+	}
+	defer func() { _ = sourceRoot.Close() }()
+	sinks := vidSinksFromRoot(sourceRoot, locations)
 	if len(sinks) == 0 {
 		return ""
 	}
@@ -81,10 +97,35 @@ func (w *Worker) computeVID(srcDir, locations string) string {
 		})
 		return ""
 	}
+	stageDir, err := os.MkdirTemp("", "scrutineer-vid-")
+	if err != nil {
+		return ""
+	}
+	defer func() { _ = os.RemoveAll(stageDir) }()
+	stageRoot, err := os.OpenRoot(stageDir)
+	if err != nil {
+		return ""
+	}
+	defer func() { _ = stageRoot.Close() }()
+	staged := map[string]bool{}
+	for _, sink := range sinks {
+		match := vidLocRE.FindStringSubmatch(sink)
+		if match == nil {
+			return ""
+		}
+		path := match[1]
+		if staged[path] {
+			continue
+		}
+		if err := stageVIDFile(sourceRoot, stageRoot, path); err != nil {
+			return ""
+		}
+		staged[path] = true
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), vidTimeout)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, bin, append([]string{"--"}, sinks...)...)
-	cmd.Dir = srcDir
+	cmd.Dir = stageDir
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
@@ -97,4 +138,34 @@ func (w *Worker) computeVID(srcDir, locations string) string {
 		return ""
 	}
 	return v
+}
+
+func stageVIDFile(sourceRoot, stageRoot *os.Root, path string) error {
+	in, err := sourceRoot.Open(path)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = in.Close() }()
+	info, err := in.Stat()
+	if err != nil {
+		return err
+	}
+	if !info.Mode().IsRegular() {
+		return os.ErrInvalid
+	}
+	dir := filepath.Dir(path)
+	if dir != "." {
+		if err := stageRoot.MkdirAll(dir, vidStageDirMode); err != nil {
+			return err
+		}
+	}
+	out, err := stageRoot.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, vidStageFileMode)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		_ = out.Close()
+		return err
+	}
+	return out.Close()
 }

--- a/internal/worker/vid.go
+++ b/internal/worker/vid.go
@@ -3,7 +3,9 @@ package worker
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -160,6 +162,13 @@ func stageVIDFile(sourceRoot, stageRoot *os.Root, path string) error {
 		}
 	}
 	out, err := stageRoot.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, vidStageFileMode)
+	if errors.Is(err, fs.ErrExist) {
+		// The staging directory is private and fresh, so an entry that already
+		// exists is this file under another spelling of its path: two sinks
+		// that differ only in case on a case-insensitive filesystem name the
+		// same source file, and its copy is already in place.
+		return nil
+	}
 	if err != nil {
 		return err
 	}

--- a/internal/worker/vid_test.go
+++ b/internal/worker/vid_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 
 	"scrutineer/internal/db"
@@ -23,14 +24,15 @@ func writeSrcFile(t *testing.T, srcDir, rel string) {
 	}
 }
 
-// stubVid writes an executable that prints out and exits with code,
-// recording its argv (one per line) to args.txt next to it.
+// stubVid writes an executable that prints out and exits with code, recording
+// its argv and working directory next to it. It also requires the first sink's
+// file to exist in that directory, like the real CLI does.
 func stubVid(t *testing.T, out string, code int) string {
 	t.Helper()
 	dir := t.TempDir()
 	script := filepath.Join(dir, "vid")
-	body := fmt.Sprintf("#!/bin/sh\nprintf '%%s\\n' \"$@\" > %q\necho %q\nexit %d\n",
-		filepath.Join(dir, "args.txt"), out, code)
+	body := fmt.Sprintf("#!/bin/sh\nprintf '%%s\\n' \"$@\" > %q\npwd > %q\ntest -f \"${2%%:*}\" || exit 97\necho %q\nexit %d\n",
+		filepath.Join(dir, "args.txt"), filepath.Join(dir, "cwd.txt"), out, code)
 	if err := os.WriteFile(script, []byte(body), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -74,6 +76,19 @@ func TestVidSinks(t *testing.T) {
 	}
 }
 
+func TestVidSinks_refusesSymlinkedRoot(t *testing.T) {
+	realRoot := t.TempDir()
+	writeSrcFile(t, realRoot, "host-secret.rb")
+	srcDir := filepath.Join(t.TempDir(), "src")
+	if err := os.Symlink(realRoot, srcDir); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := vidSinks(srcDir, "host-secret.rb:1"); got != nil {
+		t.Errorf("vidSinks through symlinked root = %v, want nil", got)
+	}
+}
+
 func TestComputeVID(t *testing.T) {
 	srcDir := t.TempDir()
 	writeSrcFile(t, srcDir, "a.rb")
@@ -89,6 +104,13 @@ func TestComputeVID(t *testing.T) {
 	}
 	if string(args) != "--\na.rb:12\n" {
 		t.Errorf("vid argv = %q, want %q", args, "--\na.rb:12\n")
+	}
+	cwd, err := os.ReadFile(filepath.Join(filepath.Dir(w.VIDCommand), "cwd.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if filepath.Clean(strings.TrimSpace(string(cwd))) == filepath.Clean(srcDir) {
+		t.Error("vid ran directly in the runner-controlled source directory")
 	}
 
 	w.VIDCommand = stubVid(t, "VID-aaaa-bbbb-cccc-dddd-eeee-ffff", 1)

--- a/internal/worker/workspace.go
+++ b/internal/worker/workspace.go
@@ -1,0 +1,65 @@
+package worker
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// The per-scan workspace and the chat workspace are bind-mounted read-write
+// into the agent's container, so once an invocation has run in a workspace,
+// every entry below its root is the agent's to shape. A host write that opens
+// a workspace path by name would follow a symlink the agent left there. These
+// two helpers are how the host writes into a workspace an agent has already
+// used: either the tree is emptied first, or the write goes through a root
+// opened at the workspace so it cannot leave it.
+
+// resetWorkspace makes workRoot an empty directory. Every host-side write
+// that follows — the clone copy, the staged skill, context.json with the
+// scan's API token, patch and diff inputs — then lands in a tree the agent
+// has never seen. Writing into whatever the previous invocation left behind
+// would let a link it planted turn any of those writes into a write elsewhere
+// on the host.
+func resetWorkspace(workRoot string) error {
+	if err := os.RemoveAll(workRoot); err != nil {
+		return err
+	}
+	return os.MkdirAll(workRoot, dirPerm)
+}
+
+// replaceWorkspaceFile writes data to the workspace-relative rel as a
+// host-readable regular file by removing whatever entry sits there and
+// creating its replacement exclusively, all through a root opened at workRoot. A symlink, hard link, or directory the
+// agent left at rel, or at any directory between workRoot and rel, cannot
+// redirect the write: os.Root refuses a path that resolves outside the
+// workspace, and O_EXCL refuses to open anything that already exists, so a
+// concurrent replant fails the write instead of being followed. workRoot
+// itself is a host-owned path: the agent sees only the inside of the mount
+// and cannot rename or replace the mount point.
+func replaceWorkspaceFile(workRoot, rel string, data []byte) error {
+	if !filepath.IsLocal(rel) {
+		return fmt.Errorf("workspace file %q is not workspace-relative", rel)
+	}
+	root, err := os.OpenRoot(workRoot)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = root.Close() }()
+	if dir := filepath.Dir(rel); dir != "." {
+		if err := root.MkdirAll(dir, dirPerm); err != nil {
+			return err
+		}
+	}
+	if err := root.RemoveAll(rel); err != nil {
+		return err
+	}
+	f, err := root.OpenFile(rel, os.O_WRONLY|os.O_CREATE|os.O_EXCL, filePerm)
+	if err != nil {
+		return err
+	}
+	if _, err := f.Write(data); err != nil {
+		_ = f.Close()
+		return err
+	}
+	return f.Close()
+}

--- a/internal/worker/workspace_test.go
+++ b/internal/worker/workspace_test.go
@@ -1,0 +1,64 @@
+package worker
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestReplaceWorkspaceFile_replacesPlantedDirectory(t *testing.T) {
+	work := t.TempDir()
+	planted := filepath.Join(work, "CLAUDE.md")
+	if err := os.MkdirAll(filepath.Join(planted, "nested"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := replaceWorkspaceFile(work, "CLAUDE.md", []byte("guide\n")); err != nil {
+		t.Fatal(err)
+	}
+	if got, err := os.ReadFile(planted); err != nil || string(got) != "guide\n" {
+		t.Errorf("replacement = %q, %v", got, err)
+	}
+}
+
+func TestReplaceWorkspaceFile_refusesNonLocalPath(t *testing.T) {
+	parent := t.TempDir()
+	work := filepath.Join(parent, "work")
+	if err := os.Mkdir(work, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, rel := range []string{"../escape.md", "/etc/escape.md", ""} {
+		if err := replaceWorkspaceFile(work, rel, nil); err == nil {
+			t.Errorf("rel %q: expected a refusal", rel)
+		}
+	}
+	if _, err := os.Lstat(filepath.Join(parent, "escape.md")); !os.IsNotExist(err) {
+		t.Errorf("wrote outside the workspace: lstat err = %v", err)
+	}
+}
+
+func TestResetWorkspace_emptiesAnExistingTree(t *testing.T) {
+	parent := t.TempDir()
+	work := filepath.Join(parent, "work")
+	if err := os.MkdirAll(filepath.Join(work, "src", "deep"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("../victim", filepath.Join(work, "context.json")); err != nil {
+		t.Fatal(err)
+	}
+	if err := resetWorkspace(work); err != nil {
+		t.Fatal(err)
+	}
+	entries, err := os.ReadDir(work)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("workspace not emptied: %d entries", len(entries))
+	}
+	if _, err := os.Lstat(filepath.Join(parent, "victim")); !os.IsNotExist(err) {
+		t.Errorf("reset touched the link target: lstat err = %v", err)
+	}
+	if err := resetWorkspace(filepath.Join(parent, "fresh")); err != nil {
+		t.Errorf("reset of a missing workspace: %v", err)
+	}
+}


### PR DESCRIPTION
The per-scan workspace is bind-mounted read-write into the agent's container, so after one invocation every entry below it is the agent's, and the host keeps using it afterwards: it reads the report and the snippet and VID sources once the run ends, writes the profile guide and the chat snapshot before the next turn, and re-runs the whole staging pass in the same directory when a scan paused on an account error resumes. Each of those opened workspace paths by name, so a symlink the agent left behind redirected the read to a host file (report.json, a finding location under `./src`) or the write onto one (`CLAUDE.md` and the nested copilot guide, the chat snapshot and source marker, `context.json` with the scan's API token). Profile detection bind-mounted `./src/<sub_path>` by name as well, so a link there, from the repository under soft scope or planted before a repair or audit run, mounted an arbitrary host directory into the detection container, and the OpenCode auth placeholder was created through the agent-owned state directory the same way.

Reads now go through an `os.Root` opened at the workspace, or at `./src` after checking the opened directory is the inode that was inspected, and accept only regular files, so the report, snippet and VID inputs come from the checkout or not at all; the VID CLI runs in a private staging copy rather than the agent's tree. Host writes into a used workspace take one of two forms: a scan starts from an empty directory (`resetWorkspace`), which covers every staging write on resume, and the files written between invocations (guide, chat snapshot and marker, the OpenCode auth placeholder) are replaced through a root opened at the workspace or state directory with an exclusive create, so neither a link at the file nor one at a parent directory can carry the write outside it, and nothing already there is opened for writing. Detection refuses a sub-path that a link carries outside the workspace or that dangles, and hands a missing one on unchanged. The invariant is that the workspace and state directory roots are host-owned paths the agent cannot replace from inside its mount, and every host operation below them either follows an empty reset or goes through that root. This also closes the mount-side path left open in #993.

Six new tests plant links (dangling, to a host file, to `context.json` beside the report, at the guide's parent directory, at the detection sub-path and at the whole checkout, at `data/` in the state directory) and check the host side afterwards; each of them fails against the branch's earlier code and passes now, alongside the branch's own symlink tests. `go test -race` across the module, the evals harness, `go vet` with the evals and podman tags, `golangci-lint`, `go mod tidy -diff` and `govulncheck` pass. Two residuals: `gitHead` still runs `git rev-parse` in the agent's `./src` before a repair or audit run, and rev-parse executes nothing from a hostile config, so the worst case is a wrong commit id; the bare-metal runner (`--no-container`, `host_skills`) has no boundary to keep, as before.

Claude Fable 5.1 was used to review and refresh this branch.
