### PR TITLE
Add coverage completeness filtering to the Scans page

### DIFF
--- a/docs/diff-based-rescans.md
+++ b/docs/diff-based-rescans.md
@@ -69,6 +69,10 @@ other files that affect how untrusted input reaches security-sensitive code.
 
 ## Coverage Metadata
 
+The Scans page (`/scans`) displays coverage completeness separately from execution status. Filter by `complete`, `partial`, or `unknown` using the Completeness menu or, for example, `/scans?completeness=partial&status=done`. Skill and status filters combine with completeness, and the selection persists through sorting, pagination, live refresh, and **Retry all failed**. Pause and resume actions remain instance-wide, as their confirmations state.
+
+Completeness is the worker's recorded assessment of the staged scope, not a claim that the repository is vulnerability-free. Legacy scans with no recorded verdict display as `unknown` and are included in the unknown filter. Full and focus-area scans also remain unknown until their scope can be independently reconciled. Invalid completeness filter values return HTTP 400.
+
 Diff scans record structured coverage metadata on the scan row. The scan page
 shows the requested and actual mode, the fallback reason when the run degraded
 to a full scan, the changed-file count and patch size, and a collapsible list

--- a/internal/web/scans.go
+++ b/internal/web/scans.go
@@ -20,9 +20,15 @@ import (
 )
 
 func (s *Server) jobs(w http.ResponseWriter, r *http.Request) {
+	completeness, err := parseScanCompletenessFilter(r.URL.Query().Get("completeness"))
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
 	skillFilter := parseScanSkillFilter(r.URL.Query().Get("skill"))
 	r = requestWithScanSkillFilter(r, skillFilter.value())
 	q := skillFilter.apply(s.DB.Model(&db.Scan{}))
+	q = applyScanCompletenessFilter(q, completeness)
 	status := r.URL.Query().Get(statusKey)
 	if status != "" {
 		q = q.Where("status = ?", status)
@@ -69,7 +75,8 @@ func (s *Server) jobs(w http.ResponseWriter, r *http.Request) {
 		"Scans": scans, "Page": page,
 		"Skill": skillFilter.value(), "SkillLabel": skillFilter.label(),
 		"Status": status, "Sort": sort, "Skills": skillNames,
-		"AnySubPath": anySubPath, "QueuedCount": stats.QueuedCount, "PausedCount": stats.PausedCount,
+		"Completeness": completeness,
+		"AnySubPath":   anySubPath, "QueuedCount": stats.QueuedCount, "PausedCount": stats.PausedCount,
 		"AccountPausedCount": stats.AccountPausedCount,
 		"NextAccountResume":  stats.NextAccountResume,
 		"ModelDowngraded":    s.Worker.ShouldDowngradeModel(),
@@ -82,6 +89,27 @@ func (s *Server) jobs(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	s.render(w, r, "jobs.html", data)
+}
+
+func parseScanCompletenessFilter(raw string) (string, error) {
+	switch raw {
+	case "", coverage.CompletenessComplete, coverage.CompletenessPartial, coverage.CompletenessUnknown:
+		return raw, nil
+	default:
+		return "", errors.New("invalid completeness filter: expected complete, partial or unknown")
+	}
+}
+
+func applyScanCompletenessFilter(q *gorm.DB, value string) *gorm.DB {
+	switch value {
+	case "":
+		return q
+	case coverage.CompletenessUnknown:
+		// Older scans have no indexed verdict; they make no completeness claim.
+		return q.Where("(scans.completeness IN ? OR scans.completeness IS NULL)", []string{value, ""})
+	default:
+		return q.Where("scans.completeness = ?", value)
+	}
 }
 
 type scanSkillFilter struct {
@@ -387,10 +415,16 @@ func (s *Server) resumeOpts(scan db.Scan) (sessionID string, resumeOf *uint) {
 }
 
 func (s *Server) scansRetryFailed(w http.ResponseWriter, r *http.Request) {
+	completeness, err := parseScanCompletenessFilter(r.URL.Query().Get("completeness"))
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
 	skillFilter := parseScanSkillFilter(r.URL.Query().Get("skill"))
 	repoID, _ := strconv.Atoi(r.URL.Query().Get("repository"))
 	q := skillFilter.apply(s.DB.Model(&db.Scan{}).
 		Where("status = ? AND kind = ? AND skill_id IS NOT NULL", db.ScanFailed, worker.JobSkill))
+	q = applyScanCompletenessFilter(q, completeness)
 	if repoID > 0 {
 		q = q.Where("repository_id = ?", repoID)
 	}
@@ -405,7 +439,7 @@ func (s *Server) scansRetryFailed(w http.ResponseWriter, r *http.Request) {
 	// deliberately absent: a user-cancelled newer run shouldn't block
 	// retrying an older genuine failure.
 	var scans []db.Scan
-	err := q.Select("id, repository_id, skill_id, model, effort, finding_id, remediation_attempt_id, sub_path, scope_mode, ref, profile, rescan_mode, diff_base_scan_id, scan_group, focus_area, backend, status, session_id, resumed_from_scan_id, import_payload").
+	err = q.Select("id, repository_id, skill_id, model, effort, finding_id, remediation_attempt_id, sub_path, scope_mode, ref, profile, rescan_mode, diff_base_scan_id, scan_group, focus_area, backend, status, session_id, resumed_from_scan_id, import_payload").
 		Where(`NOT EXISTS (
 			SELECT 1 FROM scans n
 			WHERE n.id > scans.id
@@ -463,6 +497,9 @@ func (s *Server) scansRetryFailed(w http.ResponseWriter, r *http.Request) {
 		target = fmt.Sprintf("/repositories/%d#rt3", repoID)
 	} else if skillFilter.value() != "" {
 		target += "&skill=" + url.QueryEscape(skillFilter.value())
+	}
+	if repoID <= 0 && completeness != "" {
+		target += "&completeness=" + url.QueryEscape(completeness)
 	}
 	s.redirect(w, r, target)
 }

--- a/internal/web/scans_completeness_test.go
+++ b/internal/web/scans_completeness_test.go
@@ -1,0 +1,187 @@
+package web
+
+import (
+	"fmt"
+	"html"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"strings"
+	"testing"
+
+	"scrutineer/internal/db"
+	"scrutineer/internal/worker"
+)
+
+func TestJobsCompletenessFilter(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	repo := db.Repository{URL: "https://example.com/completeness", Name: "completeness"}
+	if err := s.DB.Create(&repo).Error; err != nil {
+		t.Fatal(err)
+	}
+	var scans []db.Scan
+	for _, value := range []string{"complete", "partial", "unknown", "", "null"} {
+		scan := db.Scan{RepositoryID: repo.ID, Kind: worker.JobSkill, SkillName: "alpha", Status: db.ScanDone, Completeness: value}
+		if err := s.DB.Create(&scan).Error; err != nil {
+			t.Fatal(err)
+		}
+		if value == "null" {
+			if err := s.DB.Model(&scan).UpdateColumn("completeness", nil).Error; err != nil {
+				t.Fatal(err)
+			}
+		}
+		scans = append(scans, scan)
+	}
+	for _, tc := range []struct {
+		value string
+		want  []int
+	}{
+		{"", []int{0, 1, 2, 3, 4}},
+		{"complete", []int{0}},
+		{"partial", []int{1}},
+		{"unknown", []int{2, 3, 4}},
+	} {
+		for _, hx := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%s/hx=%t", tc.value, hx), func(t *testing.T) {
+				r := localReq(http.MethodGet, "/scans?completeness="+tc.value+"&sort=repository")
+				if hx {
+					r.Header.Set("HX-Request", "true")
+				}
+				w := httptest.NewRecorder()
+				s.Handler().ServeHTTP(w, r)
+				if w.Code != http.StatusOK {
+					t.Fatalf("status = %d: %s", w.Code, w.Body)
+				}
+				body := w.Body.String()
+				assertCompletenessRows(t, body, scans, tc.want, tc.value)
+			})
+		}
+	}
+}
+
+func assertCompletenessRows(t *testing.T, body string, scans []db.Scan, want []int, value string) {
+	t.Helper()
+	for i, scan := range scans {
+		if got := strings.Contains(body, fmt.Sprintf(`id="scan-%d"`, scan.ID)); got != slices.Contains(want, i) {
+			t.Errorf("scan %d rendered = %t", scan.ID, got)
+		}
+	}
+	if value != "" && !strings.Contains(body, `aria-current="true">`+value+`</a>`) {
+		t.Error("selected completeness is not marked")
+	}
+	if value == "unknown" && strings.Count(body, `<span class="text-muted-foreground">unknown</span>`) != len(want) {
+		t.Error("legacy and explicit unknown rows must display unknown")
+	}
+}
+
+func TestJobsCompletenessPreservesCombinedFilters(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	repo := db.Repository{URL: "https://example.com/combined-coverage"}
+	if err := s.DB.Create(&repo).Error; err != nil {
+		t.Fatal(err)
+	}
+	var matching []db.Scan
+	for i := range perPage + 1 {
+		scan := db.Scan{RepositoryID: repo.ID, Kind: worker.JobSkill, SkillName: "alpha", Status: db.ScanDone, Completeness: "partial"}
+		if i%2 == 0 {
+			scan.SkillName = "bravo"
+		}
+		if err := s.DB.Create(&scan).Error; err != nil {
+			t.Fatal(err)
+		}
+		matching = append(matching, scan)
+	}
+	nonmatching := []db.Scan{
+		{RepositoryID: repo.ID, SkillName: "charlie", Status: db.ScanDone, Completeness: "partial"},
+		{RepositoryID: repo.ID, SkillName: "alpha", Status: db.ScanFailed, Completeness: "partial"},
+		{RepositoryID: repo.ID, SkillName: "alpha", Status: db.ScanDone, Completeness: "complete"},
+	}
+	if err := s.DB.Create(&nonmatching).Error; err != nil {
+		t.Fatal(err)
+	}
+	for _, hx := range []bool{false, true} {
+		r := localReq(http.MethodGet, "/scans?skill=alpha,bravo&status=done&completeness=partial&sort=id&page=2")
+		if hx {
+			r.Header.Set("HX-Request", "true")
+		}
+		w := httptest.NewRecorder()
+		s.Handler().ServeHTTP(w, r)
+		if w.Code != http.StatusOK {
+			t.Fatalf("status = %d: %s", w.Code, w.Body)
+		}
+		body := html.UnescapeString(w.Body.String())
+		if strings.Count(body, `id="scan-`) != 1 || !strings.Contains(body, fmt.Sprintf(`id="scan-%d"`, matching[0].ID)) {
+			t.Fatal("page 2 should contain exactly the oldest matching scan")
+		}
+		for _, want := range []string{
+			`href="/scans?completeness=partial&page=1&skill=alpha%2Cbravo&sort=id&status=done"`,
+			`href="/scans?completeness=partial&skill=alpha%2Cbravo&sort=id.asc&status=done"`,
+			`href="/scans?status=done&sort=id&completeness=partial"`,
+			`href="/scans?skill=alpha%2cbravo&sort=id&completeness=partial"`,
+			`href="/scans?skill=alpha%2cbravo&status=done&sort=repository&completeness=partial"`,
+		} {
+			if !strings.Contains(body, want) {
+				t.Errorf("missing filter-preserving link %s", want)
+			}
+		}
+		if !hx && !strings.Contains(body, `hx-get="/scans?completeness=partial&page=2&skill=alpha%2Cbravo&sort=id&status=done"`) {
+			t.Error("live refresh URL lost filters")
+		}
+	}
+}
+
+func TestScanCompletenessRejectsInvalidFilter(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	for _, tc := range []struct{ method, path string }{
+		{http.MethodGet, "/scans"},
+		{http.MethodPost, "/scans/retry-failed"},
+	} {
+		w := httptest.NewRecorder()
+		s.Handler().ServeHTTP(w, localReq(tc.method, tc.path+"?completeness=invalid"))
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("%s: status = %d, want 400", tc.path, w.Code)
+		}
+	}
+}
+
+func TestScansRetryFailedFiltersByCompleteness(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	repo := db.Repository{URL: "https://example.com/retry-completeness"}
+	if err := s.DB.Create(&repo).Error; err != nil {
+		t.Fatal(err)
+	}
+	skill := db.Skill{Name: "alpha", Body: "b", OutputFile: "report.json", OutputKind: "freeform", Version: 1, Active: true, Source: "ui"}
+	if err := s.DB.Create(&skill).Error; err != nil {
+		t.Fatal(err)
+	}
+	for _, value := range []string{"partial", "complete", "unknown"} {
+		scan := db.Scan{RepositoryID: repo.ID, Kind: worker.JobSkill, SkillID: &skill.ID, SkillName: skill.Name, Status: db.ScanFailed, Completeness: value, SubPath: value}
+		if err := s.DB.Create(&scan).Error; err != nil {
+			t.Fatal(err)
+		}
+	}
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq(http.MethodGet, "/scans?skill=alpha&status=failed&completeness=partial"))
+	if w.Code != http.StatusOK || !strings.Contains(html.UnescapeString(w.Body.String()), `action="/scans/retry-failed?skill=alpha&completeness=partial"`) {
+		t.Fatal("retry form must carry the completeness selection")
+	}
+	w = httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq(http.MethodPost, "/scans/retry-failed?skill=alpha&completeness=partial"))
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("status = %d: %s", w.Code, w.Body)
+	}
+	if got := w.Header().Get("Location"); got != "/scans?status=failed&skill=alpha&completeness=partial" {
+		t.Errorf("redirect = %q", got)
+	}
+	var queued []db.Scan
+	if err := s.DB.Where("status = ?", db.ScanQueued).Find(&queued).Error; err != nil {
+		t.Fatal(err)
+	}
+	if len(queued) != 1 || queued[0].SubPath != "partial" {
+		t.Fatalf("expected only the partial scan to be retried: %+v", queued)
+	}
+}

--- a/internal/web/templates/job_list.html
+++ b/internal/web/templates/job_list.html
@@ -1,9 +1,9 @@
 <div id="jobs">
-<div class="flex items-center justify-between gap-4 mb-6">
+<div class="flex flex-wrap items-center justify-between gap-4 mb-6">
   <h2 class="text-2xl font-semibold flex items-center gap-2">
     <i data-lucide="list-checks"></i> Scans
   </h2>
-  <div class="flex items-center gap-2">
+  <div class="flex flex-wrap items-center gap-2">
     {{if .QueuedCount}}
       <form method="post" action="/scans/pause-queued"
             hx-post="/scans/pause-queued" hx-swap="none"
@@ -19,9 +19,9 @@
       </form>
     {{end}}
     {{if and (eq .Status "failed") .Page.Total}}
-      <form method="post" action="/scans/retry-failed?skill={{.Skill}}"
-            hx-post="/scans/retry-failed?skill={{.Skill}}" hx-swap="none"
-            hx-confirm="Re-enqueue every failed scan{{if .Skill}} for {{.Skill}}{{end}}?">
+      <form method="post" action="/scans/retry-failed?skill={{.Skill}}&completeness={{.Completeness}}"
+            hx-post="/scans/retry-failed?skill={{.Skill}}&completeness={{.Completeness}}" hx-swap="none"
+            hx-confirm="Re-enqueue every failed scan{{if .Skill}} for {{.Skill}}{{end}}{{if .Completeness}} with {{.Completeness}} coverage{{end}}?">
         <button type="submit" class="btn-outline"><i data-lucide="refresh-cw"></i> Retry all failed</button>
       </form>
     {{end}}
@@ -33,9 +33,9 @@
       </button>
       <div data-popover aria-hidden="true" data-align="end">
         <div role="menu">
-          <a role="menuitem" href="/scans?status={{.Status}}&sort={{.Sort}}">All skills</a>
+          <a role="menuitem" href="/scans?status={{.Status}}&sort={{.Sort}}&completeness={{.Completeness}}">All skills</a>
           {{range .Skills}}
-            <a role="menuitem" href="/scans?skill={{.}}&status={{$.Status}}&sort={{$.Sort}}"
+            <a role="menuitem" href="/scans?skill={{.}}&status={{$.Status}}&sort={{$.Sort}}&completeness={{$.Completeness}}"
                {{if eq . $.Skill}}aria-current="true"{{end}}>{{.}}</a>
           {{end}}
         </div>
@@ -49,10 +49,26 @@
       </button>
       <div data-popover aria-hidden="true" data-align="end">
         <div role="menu">
-          <a role="menuitem" href="/scans?skill={{.Skill}}&sort={{.Sort}}">All statuses</a>
+          <a role="menuitem" href="/scans?skill={{.Skill}}&sort={{.Sort}}&completeness={{.Completeness}}">All statuses</a>
           {{range (list "queued" "paused" "running" "done" "failed" "skipped" "cancelled")}}
-            <a role="menuitem" href="/scans?skill={{$.Skill}}&status={{.}}&sort={{$.Sort}}"
+            <a role="menuitem" href="/scans?skill={{$.Skill}}&status={{.}}&sort={{$.Sort}}&completeness={{$.Completeness}}"
                {{if eq . $.Status}}aria-current="true"{{end}}>{{.}}</a>
+          {{end}}
+        </div>
+      </div>
+    </div>
+    <div class="dropdown-menu">
+      <button type="button" class="btn-outline" aria-haspopup="menu" aria-expanded="false" aria-label="Coverage completeness{{if .Completeness}}: {{.Completeness}}{{end}}">
+        <i data-lucide="filter"></i>
+        {{if .Completeness}}{{.Completeness}}{{else}}Completeness{{end}}
+        <i data-lucide="chevron-down"></i>
+      </button>
+      <div data-popover aria-hidden="true" data-align="end">
+        <div role="menu">
+          <a role="menuitem" href="/scans?skill={{.Skill}}&status={{.Status}}&sort={{.Sort}}"{{if not .Completeness}} aria-current="true"{{end}}>All completeness</a>
+          {{range (list "complete" "partial" "unknown")}}
+            <a role="menuitem" href="/scans?skill={{$.Skill}}&status={{$.Status}}&sort={{$.Sort}}&completeness={{.}}"
+               {{if eq . $.Completeness}}aria-current="true"{{end}}>{{.}}</a>
           {{end}}
         </div>
       </div>
@@ -66,7 +82,7 @@
       <div data-popover aria-hidden="true" data-align="end">
         <div role="menu">
           {{range (list "newest" "skill" "status" "repository")}}
-            <a role="menuitem" href="/scans?skill={{$.Skill}}&status={{$.Status}}&sort={{.}}"
+            <a role="menuitem" href="/scans?skill={{$.Skill}}&status={{$.Status}}&sort={{.}}&completeness={{$.Completeness}}"
                {{if eq . (sortkey $.Sort)}}aria-current="true"{{end}}>{{.}}</a>
           {{end}}
         </div>
@@ -97,6 +113,7 @@
 {{end}}
 
 {{if .Scans}}
+  <div class="overflow-x-auto">
   <table class="table">
     <thead>
       <tr>
@@ -105,6 +122,7 @@
         {{if .AnySubPath}}<th>Sub-path</th>{{end}}
         {{template "th-sort" (dict "Sorter" .Sorter "Key" "skill" "Def" "asc" "Label" "Skill" "Class" "")}}
         {{template "th-sort" (dict "Sorter" .Sorter "Key" "status" "Def" "asc" "Label" "Status" "Class" "")}}
+        <th>Completeness</th>
         {{template "th-sort" (dict "Sorter" .Sorter "Key" "findings" "Def" "desc" "Label" "Findings" "Class" "")}}
         <th>Model</th><th>Cost</th><th>Started</th><th>Duration</th><th class="w-12"></th>
       </tr>
@@ -120,6 +138,7 @@
         {{end}}
         <td>{{if .SkillName}}{{.SkillName}}{{else}}{{.Kind}}{{end}} {{template "branch-tag" .Ref}}</td>
         <td>{{template "status-badge" (status .Status)}} {{if .MaxTurnsHit}}<span class="badge-outline"><i data-lucide="timer-off"></i> max turns</span>{{end}}</td>
+        <td>{{if eq .Completeness "complete"}}<span class="badge-outline">complete</span>{{else if eq .Completeness "partial"}}<span class="badge-outline">partial</span>{{else}}<span class="text-muted-foreground">unknown</span>{{end}}</td>
         <td>{{if gt .FindingsCount 0}}{{template "findings-badge" .FindingsCount}}{{end}}</td>
         <td class="text-muted-foreground">{{if .Model}}{{.Model}}{{else}}-{{end}}</td>
         <td class="text-muted-foreground">{{if gt .CostUSD 0.0}}{{usd .CostUSD}}{{else}}-{{end}}</td>
@@ -130,9 +149,14 @@
     {{end}}
     </tbody>
   </table>
+  </div>
   {{template "pagination" .Page}}
 {{else}}
+  {{if or .Skill .Status .Completeness}}
+  {{template "empty" (dict "Icon" "list-checks" "Title" "No matching scans" "Body" "")}}
+  {{else}}
   {{template "empty" (dict "Icon" "list-checks" "Title" "No jobs yet" "Body" "Jobs appear here once a repository has been queued.")}}
+  {{end}}
 {{end}}
 
 </div>


### PR DESCRIPTION
Part of #771

## Summary

Adds coverage completeness indicators and filtering to the Scans page, allowing operators to distinguish execution status from how much of the intended scope was covered.

Uses the existing indexed `Scan.Completeness` field. Legacy scans with empty or NULL values display as `unknown` and are included in the unknown filter.

## Changes

- Add a completeness column and `complete`, `partial` and `unknown` filter options.
- Combine completeness with existing skill and status filters.
- Preserve the selection through sorting, pagination and live refresh.
- Apply the completeness filter to “Retry all failed” and preserve it on redirect.
- Return HTTP 400 for invalid completeness filter values.
- Show “No matching scans” when filters produce an empty result.
- Allow the toolbar to wrap and the table to scroll horizontally on narrow screens.
- Document filter behavior and add regression tests.

This change exposes existing worker-derived verdicts; it does not change coverage reconciliation or establish completeness for full and focus-area scans.

## Validation

- `go test ./...`
- `go test -race -gcflags='modernc.org/...=-d=checkptr=0' ./...`
- `go test -race -tags evals ./internal/evals/...`
- `go vet ./...`
- `go vet -tags evals ./internal/evals/...`
- `go vet -tags podman ./...`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run`
- `go mod tidy -diff`
- `git diff --check`
- Local HTTP checks confirmed valid filters return 200, invalid values return 400 and live-refresh URLs preserve the selection.