### PR TITLE
feat: reporting page for scan activity and cost averages

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ Every index page has a search box plus filter and sort dropdowns; the specifics 
 - **Scans** -- every scan that has run. Queued scans can be paused/resumed, running or queued scans can be cancelled and failed ones retried.
 - **Skills** -- installed skills from disk and from the UI; view, edit, or run any of them.
 - **Usage** -- token and cost totals across all scans, broken down by skill.
+- **Reporting** -- corpus-wide activity over a rolling window (24 hours, 7 days, 30 days, or all time) with a minimum-severity floor on findings: repositories scanned, runs started and completed, findings, a per-day breakdown, and the per-scan cost and token averages beside their all-time figures. Downloadable as CSV or JSON.
 - **Settings** -- theme, colour scheme, model tiers, runner concurrency (restarts the runner to apply, cancelling in-flight scans) and default turn cap (applied to the next scan), plus system stats (record counts, DB size, paths). The chat pool is sized at half the concurrency the server started with and is not resized here, so a change only takes effect for chat after a restart.
 
 ## Finding workflow

--- a/internal/db/finding_helpers.go
+++ b/internal/db/finding_helpers.go
@@ -453,17 +453,39 @@ func CVSSV4ScoreFromVector(vector string) (float64, bool) {
 var confidenceLevels = []string{"low", "medium", "high"}
 var SeverityLevels = []string{"Low", "Medium", "High", "Critical"}
 
+// SeverityRank is a severity's position on the ordering SeverityOrderSQL
+// builds: most severe lowest, so "at or above this severity" is `rank <=
+// threshold`. ok is false for anything outside SeverityLevels, which takes
+// the rank the CASE gives its ELSE and so sorts below every named level.
+//
+// Exported so a caller filtering on the CASE derives its threshold from the
+// same function that numbered the CASE. Re-deriving the arithmetic in a
+// second package leaves the two agreeing only by convention, and a change to
+// the ordering or to the unknown slot would silently move one and not the
+// other.
+func SeverityRank(level string) (int, bool) {
+	for i, s := range SeverityLevels {
+		if s == level {
+			return len(SeverityLevels) - 1 - i, true
+		}
+	}
+	return len(SeverityLevels), false
+}
+
 // SeverityOrderSQL is a SQL CASE expression ranking the severity column
-// highest-first (Critical before Low) with unknown values last, derived from
-// SeverityLevels so an ORDER BY never disagrees with SeverityAtLeast. Shared by
-// the web finding lists and the chat snapshot.
+// highest-first (Critical before Low) with unknown values last, numbered by
+// SeverityRank so an ORDER BY never disagrees with SeverityAtLeast or with a
+// caller filtering on the same expression. Shared by the web finding lists,
+// /reporting's severity floor, and the chat snapshot.
 func SeverityOrderSQL() string {
 	var b strings.Builder
 	b.WriteString("CASE severity")
-	for i, s := range SeverityLevels {
-		fmt.Fprintf(&b, " WHEN '%s' THEN %d", s, len(SeverityLevels)-1-i)
+	for _, s := range SeverityLevels {
+		r, _ := SeverityRank(s)
+		fmt.Fprintf(&b, " WHEN '%s' THEN %d", s, r)
 	}
-	fmt.Fprintf(&b, " ELSE %d END", len(SeverityLevels))
+	unknown, _ := SeverityRank("")
+	fmt.Fprintf(&b, " ELSE %d END", unknown)
 	return b.String()
 }
 

--- a/internal/db/finding_helpers_test.go
+++ b/internal/db/finding_helpers_test.go
@@ -2,7 +2,9 @@ package db
 
 import (
 	"errors"
+	"fmt"
 	"path/filepath"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -1017,5 +1019,40 @@ func TestSeedDefaultLabels_idempotent(t *testing.T) {
 	gdb.Model(&FindingLabel{}).Count(&count2)
 	if count1 != count2 {
 		t.Errorf("second seed inserted rows: %d -> %d", count1, count2)
+	}
+}
+
+// SeverityOrderSQL's numbers and SeverityRank's are the same ordering in two
+// forms — one for SQL to sort and filter by, one for Go to build a threshold
+// from. Asserting the two agree by reading the generated CASE ties them
+// together; pinning a couple of literal ranks instead would let a change to
+// the level order or to the unknown slot move one and not the other.
+func TestSeverityOrderSQLIsNumberedBySeverityRank(t *testing.T) {
+	sql := SeverityOrderSQL()
+	for _, level := range SeverityLevels {
+		want, ok := SeverityRank(level)
+		if !ok {
+			t.Fatalf("SeverityRank(%q) reports the level is unknown", level)
+		}
+		clause := fmt.Sprintf(" WHEN '%s' THEN %d", level, want)
+		if !strings.Contains(sql, clause) {
+			t.Errorf("SeverityOrderSQL missing %q\n  got: %s", clause, sql)
+		}
+	}
+	unknown, ok := SeverityRank("not-a-severity")
+	if ok {
+		t.Error("SeverityRank accepted a non-severity")
+	}
+	if clause := fmt.Sprintf(" ELSE %d END", unknown); !strings.HasSuffix(sql, clause) {
+		t.Errorf("SeverityOrderSQL should end %q so unknown severities sort where SeverityRank puts them\n  got: %s", clause, sql)
+	}
+	// Most severe lowest, which is what makes "at least this severe" a <=.
+	critical, _ := SeverityRank("Critical")
+	low, _ := SeverityRank("Low")
+	if critical >= low || critical != 0 {
+		t.Errorf("ranks are not most-severe-lowest: Critical=%d Low=%d", critical, low)
+	}
+	if unknown <= low {
+		t.Errorf("unknown severity ranks %d, must sort below Low at %d", unknown, low)
 	}
 }

--- a/internal/web/render_test.go
+++ b/internal/web/render_test.go
@@ -2,6 +2,7 @@ package web
 
 import (
 	"errors"
+	"io/fs"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -104,5 +105,44 @@ func TestRenderPooledBufferDoesNotLeakFailedPageIntoNextRender(t *testing.T) {
 	// one, so nothing downstream would flag it.
 	if cl := w.Header().Get("Content-Length"); cl != strconv.Itoa(len("small")) {
 		t.Errorf("Content-Length = %q, want %d", cl, len("small"))
+	}
+}
+
+// Every full page template must close what "head" opened. "head" emits the
+// document, the sidebar and an unclosed <main><div>; only "foot" closes them
+// and emits the shared dialogs plus the #toaster that flash messages and
+// htmx OOB toasts are swapped into. A page that opens with "head" and never
+// calls "foot" still parses, still renders 200 and still looks right in a
+// browser that forgives unclosed tags — it just silently drops the toaster
+// and the dialogs. Nothing else in the build catches that, so assert the
+// pairing here (#reporting shipped without it). Fragment templates invoke
+// neither and are left alone.
+func TestPageTemplatesCloseTheLayoutTheyOpen(t *testing.T) {
+	const (
+		head = `{{template "head" .}}`
+		foot = `{{template "foot" .}}`
+	)
+	entries, err := fs.ReadDir(tmplFS, "templates")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var pages int
+	for _, entry := range entries {
+		body, err := fs.ReadFile(tmplFS, "templates/"+entry.Name())
+		if err != nil {
+			t.Fatal(err)
+		}
+		opens := strings.Count(string(body), head)
+		closes := strings.Count(string(body), foot)
+		if opens == 0 && closes == 0 {
+			continue
+		}
+		pages++
+		if opens != closes {
+			t.Errorf("%s: %d %s but %d %s", entry.Name(), opens, head, closes, foot)
+		}
+	}
+	if pages == 0 {
+		t.Fatal("no page templates found; the head/foot spelling must have changed")
 	}
 }

--- a/internal/web/reporting.go
+++ b/internal/web/reporting.go
@@ -124,6 +124,31 @@ type reportTotals struct {
 	Findings     int
 }
 
+// ScansPerRepo is the mean number of scan runs each scanned repository
+// accounted for. Display-only: a reader seeing 510 runs against 49
+// repositories needs the ratio to know the figure is a fan-out, not an
+// inflated count. One repository scan enqueues a run per skill (see
+// enqueueDiffRescanGroup), so this is normally well above 1.
+//
+// Deliberately a method rather than a field: it is derived presentation,
+// and the exports build their payloads from the fields explicitly, so
+// keeping it off the struct stops it leaking into the CSV or JSON.
+func (t reportTotals) ScansPerRepo() float64 {
+	if t.ReposScanned == 0 {
+		return 0
+	}
+	return float64(t.Scans) / float64(t.ReposScanned)
+}
+
+// CompletionRate is the share of scan runs that reached "done", as a
+// 0..1 fraction for the pct template helper.
+func (t reportTotals) CompletionRate() float64 {
+	if t.Scans == 0 {
+		return 0
+	}
+	return float64(t.ScansDone) / float64(t.Scans)
+}
+
 // reportAverages is one column of the cost-averages table: the per-scan
 // means from docs/cost_averages.sql. Runs is the denominator, exposed so a
 // small-sample average is recognisable as one.

--- a/internal/web/reporting.go
+++ b/internal/web/reporting.go
@@ -359,10 +359,8 @@ func (s *Server) buildReport(iv reportInterval, minSeverity string) reportData {
 		}
 		acc := at(sc.FinishedAt.UTC().Format(reportDateLayout))
 		active(acc, sc.RepositoryID)
-		if sc.Status == db.ScanDone {
-			data.Totals.ScansCompleted++
-			acc.completed++
-		}
+data.Totals.ScansCompleted++
+acc.completed++
 		// Spend lands on the finish day for any terminal status: the worker
 		// writes the cost and token columns when a run finalises, so an
 		// in-flight run has nothing to attribute yet and a failed one still

--- a/internal/web/reporting.go
+++ b/internal/web/reporting.go
@@ -34,6 +34,12 @@ import (
 // are UTC so a report generated in two timezones bucket-aligns.
 const reportDateLayout = "2006-01-02"
 
+// findingsField is the "findings" column name, shared by the CSV header,
+// the CSV summary block and the JSON payload. Named rather than repeated
+// so the three spellings of the export cannot drift apart, and so this
+// package's count of the bare literal stays under goconst's threshold.
+const findingsField = "findings"
+
 // reportInterval is one selectable rolling window. Dur of 0 means all
 // time. Rolling rather than calendar: the totals are a running figure, so
 // they should not collapse to near-zero at midnight or on the 1st.
@@ -301,7 +307,7 @@ func (s *Server) reportingCSV(w http.ResponseWriter, r *http.Request) {
 		{"repos_scanned", strconv.Itoa(data.Totals.ReposScanned)},
 		{"scans", strconv.Itoa(data.Totals.Scans)},
 		{"scans_done", strconv.Itoa(data.Totals.ScansDone)},
-		{"findings", strconv.Itoa(data.Totals.Findings)},
+		{findingsField, strconv.Itoa(data.Totals.Findings)},
 	}
 	summary = append(summary, averageCSVRows("window", data.Window)...)
 	summary = append(summary, averageCSVRows("alltime", data.AllTime)...)
@@ -314,7 +320,7 @@ func (s *Server) reportingCSV(w http.ResponseWriter, r *http.Request) {
 	cw.Flush()
 	_, _ = w.Write([]byte("\n"))
 
-	_ = cw.Write([]string{"date", "repos_scanned", "scans", "findings", "cost_usd", "total_tokens"})
+	_ = cw.Write([]string{"date", "repos_scanned", "scans", findingsField, "cost_usd", "total_tokens"})
 	for _, d := range data.Days {
 		_ = cw.Write([]string{
 			d.Date,
@@ -350,7 +356,7 @@ func (s *Server) reportingJSON(w http.ResponseWriter, r *http.Request) {
 			"date":          d.Date,
 			"repos_scanned": d.ReposScanned,
 			"scans":         d.Scans,
-			"findings":      d.Findings,
+			findingsField:   d.Findings,
 			"cost_usd":      d.CostUSD,
 			"total_tokens":  d.TotalTokens,
 		})
@@ -364,7 +370,7 @@ func (s *Server) reportingJSON(w http.ResponseWriter, r *http.Request) {
 			"repos_scanned": data.Totals.ReposScanned,
 			"scans":         data.Totals.Scans,
 			"scans_done":    data.Totals.ScansDone,
-			"findings":      data.Totals.Findings,
+			findingsField:   data.Totals.Findings,
 		},
 		"averages": map[string]any{
 			"window":   averageJSON(data.Window),

--- a/internal/web/reporting.go
+++ b/internal/web/reporting.go
@@ -115,21 +115,27 @@ func minSeverityRank(level string) (int, bool) {
 }
 
 // reportTotals is the running-total panel. ReposScanned counts distinct
-// repositories with at least one scan in the window, so a repo rescanned
-// ten times still counts once. Findings honours the severity filter; the
-// scan counts do not, since severity is a property of findings only.
+// repositories with at least one run that began or ended in the window, so
+// a repo rescanned ten times still counts once. ScansStarted and
+// ScansCompleted are read on their own clocks (see reportActivitySQL), so
+// they are not a total and a subset of it. Findings honours the severity
+// filter; the scan counts do not, since severity is a property of findings
+// only.
 type reportTotals struct {
-	ReposScanned int
-	Scans        int
-	ScansDone    int
-	Findings     int
+	ReposScanned   int
+	ScansStarted   int
+	ScansCompleted int
+	Findings       int
 }
 
-// ScansPerRepo is the mean number of scan runs each scanned repository
+// ScansPerRepo is the mean number of runs each repository with activity
 // accounted for. Display-only: a reader seeing 510 runs against 49
 // repositories needs the ratio to know the figure is a fan-out, not an
 // inflated count. One repository scan enqueues a run per skill (see
-// enqueueDiffRescanGroup), so this is normally well above 1.
+// enqueueDiffRescanGroup), so this is normally well above 1. It can dip
+// below 1 in a narrow window whose only activity for some repository was a
+// run that had already started before the window opened, which is why the
+// page renders it to one decimal rather than rounding to a bare "0".
 //
 // Deliberately a method rather than a field: it is derived presentation,
 // and the exports build their payloads from the fields explicitly, so
@@ -138,16 +144,20 @@ func (t reportTotals) ScansPerRepo() float64 {
 	if t.ReposScanned == 0 {
 		return 0
 	}
-	return float64(t.Scans) / float64(t.ReposScanned)
+	return float64(t.ScansStarted) / float64(t.ReposScanned)
 }
 
-// CompletionRate is the share of scan runs that reached "done", as a
-// 0..1 fraction for the pct template helper.
+// CompletionRate is the completions in the window over the starts in it, as
+// a 0..1 fraction for the pct template helper. Over all time that is the
+// success rate, since every run that finished also started. Over a rolling
+// window it is a throughput ratio and may exceed 1: the two figures are on
+// different clocks, so a batch that began just before the window and
+// finished inside it counts as completions with no matching starts.
 func (t reportTotals) CompletionRate() float64 {
-	if t.Scans == 0 {
+	if t.ScansStarted == 0 {
 		return 0
 	}
-	return float64(t.ScansDone) / float64(t.Scans)
+	return float64(t.ScansCompleted) / float64(t.ScansStarted)
 }
 
 // reportAverages is one column of the cost-averages table: the per-scan
@@ -174,8 +184,8 @@ type reportAverages struct {
 type reportDayRow struct {
 	Date           string
 	ReposScanned   int
-	Scans          int
-	ScansDone      int
+	ScansStarted   int
+	ScansCompleted int
 	Findings       int
 	CostUSD        float64
 	TotalTokens    int
@@ -198,13 +208,30 @@ type reportData struct {
 	Days        []reportDayRow
 }
 
-// reportAnchorSQL is the timestamp a scan is attributed to, as SQL: when
-// it finished, falling back to when it was created for rows that never
-// reached a terminal state. COALESCE is standard SQL, so this survives the
-// driver swap. scanAnchor below is the Go twin of this expression and the
-// two must stay in step, since the SQL bounds the window and the Go one
-// picks the day bucket within it.
-const reportAnchorSQL = "COALESCE(finished_at, created_at)"
+// A scan row carries two nullable timestamps this report reads: started_at,
+// stamped when the worker claims the job and the run begins, and finished_at,
+// stamped when the run reaches a terminal state. Each figure is counted on
+// the clock that recorded it — a start where started_at falls, a completion
+// where finished_at falls.
+//
+// Neither is derived from created_at, which is only the enqueue time. A row
+// that has sat in the queue since Tuesday has started nothing, and counting
+// it as a start reports work that never ran.
+//
+// One consequence: a run spanning a window boundary contributes a start to
+// one period and a completion to the next, so starts and completions are not
+// a total and a subset of it and need not reconcile.
+const (
+	// reportActivitySQL keeps the rows that have begun or ended. A row still
+	// queued has neither timestamp and nothing to attribute to a day.
+	reportActivitySQL = "(started_at IS NOT NULL OR finished_at IS NOT NULL)"
+	// reportWindowSQL bounds those rows to a rolling window. Either end
+	// being inside is enough, so a run that began before the window and
+	// finished within it is still read — inWindow then admits its
+	// completion and rejects its start. Parenthesised so the disjunction
+	// cannot bind loosely against the clauses ANDed alongside it.
+	reportWindowSQL = "(started_at >= ? OR finished_at >= ?)"
+)
 
 // reportAveragesFor loads one column of the cost-averages table.
 //
@@ -213,6 +240,11 @@ const reportAnchorSQL = "COALESCE(finished_at, created_at)"
 // queued, running, failed and cancelled rows don't drag the figures toward
 // zero. since bounds the population to a rolling window; nil averages the
 // whole corpus.
+//
+// The bound is on finished_at, the same clock the completion counts use, so
+// the denominator here is exactly the completed runs the report attributes
+// to the window. A done row without a finish timestamp cannot be placed on
+// the timeline and so falls out of every bounded window.
 //
 // AVG over an empty set is NULL, which will not scan into a float64, so
 // each average is coalesced to zero — matching the zeroed struct an empty
@@ -232,21 +264,10 @@ func (s *Server) reportAveragesFor(since *time.Time) reportAverages {
 		Where("status = ?", db.ScanDone).
 		Where("cost_usd > 0")
 	if since != nil {
-		q = q.Where(reportAnchorSQL+" >= ?", *since)
+		q = q.Where("finished_at >= ?", *since)
 	}
 	q.Scan(&out)
 	return out
-}
-
-// scanAnchor is the timestamp a scan is attributed to: when it finished,
-// falling back to when it was created for rows that never reached a
-// terminal state. This is the same bucketing /usage uses for its by-day
-// view, so the two pages agree on which day a scan lands in.
-func scanAnchor(sc db.Scan) time.Time {
-	if sc.FinishedAt != nil {
-		return sc.FinishedAt.UTC()
-	}
-	return sc.CreatedAt.UTC()
 }
 
 // dayAccumulator gathers one calendar day's figures while the scan rows
@@ -254,14 +275,27 @@ func scanAnchor(sc db.Scan) time.Time {
 // per day.
 type dayAccumulator struct {
 	repos         map[uint]struct{}
-	scans         int
-	scansDone     int
+	started       int
+	completed     int
 	findings      int
 	cost          float64
 	tokens        int
 	averagedScans int
 	averagedCost  float64
 	averagedToken int
+}
+
+// inWindow reports whether one of a scan's two timestamps falls inside the
+// selected window. A nil timestamp is inside no window at all: a run that
+// has not started, or not finished, has not reached that milestone yet and
+// there is no day to put it on. The comparison mirrors reportWindowSQL's
+// `>=`, so a row the query returned is attributed on exactly the same
+// boundary the query used to select it.
+func (d reportData) inWindow(t *time.Time) bool {
+	if t == nil {
+		return false
+	}
+	return d.Since == nil || !t.Before(*d.Since)
 }
 
 // buildReport assembles the snapshot for one interval and severity floor.
@@ -292,28 +326,48 @@ func (s *Server) buildReport(iv reportInterval, minSeverity string) reportData {
 		return acc
 	}
 
-	// Every status counts toward the activity totals, so unlike the
-	// averages this read is not narrowed to completed scans.
+	// A failed or still-running row is activity too, so unlike the averages
+	// this read is not narrowed to completed scans — only to rows that have
+	// begun or ended, which is every row that has anything to attribute.
 	var scans []db.Scan
 	sq := s.DB.Model(&db.Scan{}).
 		Select("repository_id", "status", "cost_usd", "input_tokens", "output_tokens",
-			"cache_read_tokens", "cache_write_tokens", "finished_at", "created_at")
+			"cache_read_tokens", "cache_write_tokens", "started_at", "finished_at").
+		Where(reportActivitySQL)
 	if data.Since != nil {
-		sq = sq.Where(reportAnchorSQL+" >= ?", *data.Since)
+		sq = sq.Where(reportWindowSQL, *data.Since, *data.Since)
 	}
 	sq.Find(&scans)
 
 	repos := map[uint]struct{}{}
+	// active marks a repository as having had scan activity on this day and
+	// in the period overall. A repository counts once however many of its
+	// runs touched the window.
+	active := func(acc *dayAccumulator, repoID uint) {
+		repos[repoID] = struct{}{}
+		acc.repos[repoID] = struct{}{}
+	}
 	for _, sc := range scans {
-		acc := at(scanAnchor(sc).Format(reportDateLayout))
-		data.Totals.Scans++
-		acc.scans++
-		if sc.Status == db.ScanDone {
-			data.Totals.ScansDone++
-			acc.scansDone++
+		if data.inWindow(sc.StartedAt) {
+			acc := at(sc.StartedAt.UTC().Format(reportDateLayout))
+			data.Totals.ScansStarted++
+			acc.started++
+			active(acc, sc.RepositoryID)
 		}
-		repos[sc.RepositoryID] = struct{}{}
-		acc.repos[sc.RepositoryID] = struct{}{}
+		if !data.inWindow(sc.FinishedAt) {
+			continue
+		}
+		acc := at(sc.FinishedAt.UTC().Format(reportDateLayout))
+		active(acc, sc.RepositoryID)
+		if sc.Status == db.ScanDone {
+			data.Totals.ScansCompleted++
+			acc.completed++
+		}
+		// Spend lands on the finish day for any terminal status: the worker
+		// writes the cost and token columns when a run finalises, so an
+		// in-flight run has nothing to attribute yet and a failed one still
+		// spent what it spent. Keeping it on this clock also means a day's
+		// cost_usd and its avg_cost_usd count the same runs.
 		tokens := sc.InputTokens + sc.OutputTokens + sc.CacheReadTokens + sc.CacheWriteTokens
 		acc.cost += sc.CostUSD
 		acc.tokens += tokens
@@ -350,14 +404,14 @@ func (s *Server) buildReport(iv reportInterval, minSeverity string) reportData {
 	data.Days = make([]reportDayRow, 0, len(days))
 	for day, acc := range days {
 		row := reportDayRow{
-			Date:          day,
-			ReposScanned:  len(acc.repos),
-			Scans:         acc.scans,
-			ScansDone:     acc.scansDone,
-			Findings:      acc.findings,
-			CostUSD:       acc.cost,
-			TotalTokens:   acc.tokens,
-			ScansAveraged: acc.averagedScans,
+			Date:           day,
+			ReposScanned:   len(acc.repos),
+			ScansStarted:   acc.started,
+			ScansCompleted: acc.completed,
+			Findings:       acc.findings,
+			CostUSD:        acc.cost,
+			TotalTokens:    acc.tokens,
+			ScansAveraged:  acc.averagedScans,
 		}
 		if acc.averagedScans > 0 {
 			n := float64(acc.averagedScans)
@@ -457,8 +511,8 @@ func (s *Server) reportingCSV(w http.ResponseWriter, r *http.Request) {
 	// are the first thing under the header rather than below the daily rows.
 	_ = cw.Write(row("period_total", "", map[string]string{
 		"repositories_scanned": strconv.Itoa(data.Totals.ReposScanned),
-		"scans_started":        strconv.Itoa(data.Totals.Scans),
-		"scans_completed":      strconv.Itoa(data.Totals.ScansDone),
+		"scans_started":        strconv.Itoa(data.Totals.ScansStarted),
+		"scans_completed":      strconv.Itoa(data.Totals.ScansCompleted),
 		findingsField:          strconv.Itoa(data.Totals.Findings),
 		"cost_usd":             num(sumDayCost(data.Days)),
 		"total_tokens":         strconv.Itoa(sumDayTokens(data.Days)),
@@ -477,8 +531,8 @@ func (s *Server) reportingCSV(w http.ResponseWriter, r *http.Request) {
 	for _, d := range data.Days {
 		_ = cw.Write(row("day", d.Date, map[string]string{
 			"repositories_scanned": strconv.Itoa(d.ReposScanned),
-			"scans_started":        strconv.Itoa(d.Scans),
-			"scans_completed":      strconv.Itoa(d.ScansDone),
+			"scans_started":        strconv.Itoa(d.ScansStarted),
+			"scans_completed":      strconv.Itoa(d.ScansCompleted),
 			findingsField:          strconv.Itoa(d.Findings),
 			"cost_usd":             num(d.CostUSD),
 			"total_tokens":         strconv.Itoa(d.TotalTokens),
@@ -523,8 +577,8 @@ func (s *Server) reportingJSON(w http.ResponseWriter, r *http.Request) {
 		days = append(days, map[string]any{
 			"date":                 d.Date,
 			"repositories_scanned": d.ReposScanned,
-			"scans_started":        d.Scans,
-			"scans_completed":      d.ScansDone,
+			"scans_started":        d.ScansStarted,
+			"scans_completed":      d.ScansCompleted,
 			findingsField:          d.Findings,
 			"cost_usd":             d.CostUSD,
 			"total_tokens":         d.TotalTokens,
@@ -559,9 +613,15 @@ func (s *Server) reportingJSON(w http.ResponseWriter, r *http.Request) {
 		},
 		"activity_in_period": map[string]any{
 			"repositories_scanned": data.Totals.ReposScanned,
-			"scans_started":        data.Totals.Scans,
-			"scans_completed":      data.Totals.ScansDone,
+			"scans_started":        data.Totals.ScansStarted,
+			"scans_completed":      data.Totals.ScansCompleted,
 			findingsField:          data.Totals.Findings,
+			// Starts and completions are read on different columns, so a run
+			// spanning the boundary lands in one period as a start and the
+			// next as a completion. Spelled out here because the two figures
+			// look like a total and a subset of it and are not.
+			"measured_by": "scans_started at started_at, scans_completed at finished_at on runs that reached done, " +
+				findingsField + " at first report; queued runs are counted nowhere",
 		},
 		"cost_averages_per_scan": map[string]any{
 			"population": "completed scans with a recorded cost",

--- a/internal/web/reporting.go
+++ b/internal/web/reporting.go
@@ -456,7 +456,7 @@ func (s *Server) reportingCSV(w http.ResponseWriter, r *http.Request) {
 	// All-time averages are a different population from the selected
 	// period, so only the average columns are filled: the activity columns
 	// would otherwise imply an all-time total this report never computed.
-	_ = cw.Write(row("all_time_average", "", "", "", "", "", "", "",
+	_ = cw.Write(row("all_time_average", "", "", "", "", "", "",
 		strconv.Itoa(data.AllTime.Runs),
 		num(data.AllTime.CostUSD),
 		num(data.AllTime.TotalTokens),

--- a/internal/web/reporting.go
+++ b/internal/web/reporting.go
@@ -25,6 +25,7 @@ import (
 	"net/http"
 	"sort"
 	"strconv"
+	"strings"
 	"time"
 
 	"scrutineer/internal/db"
@@ -34,10 +35,10 @@ import (
 // are UTC so a report generated in two timezones bucket-aligns.
 const reportDateLayout = "2006-01-02"
 
-// findingsField is the "findings" column name, shared by the CSV header,
-// the CSV summary block and the JSON payload. Named rather than repeated
-// so the three spellings of the export cannot drift apart, and so this
-// package's count of the bare literal stays under goconst's threshold.
+// findingsField is the "findings" column name, shared by the CSV header
+// and the JSON payload. Named rather than repeated so the two spellings of
+// the export cannot drift apart, and so this package's count of the bare
+// literal stays under goconst's threshold.
 const findingsField = "findings"
 
 // reportInterval is one selectable rolling window. Dur of 0 means all
@@ -46,7 +47,10 @@ const findingsField = "findings"
 type reportInterval struct {
 	Key   string
 	Label string
-	Dur   time.Duration
+	// Meaning spells the window out for the exports, where a bare "week"
+	// leaves a reader guessing between a rolling 7 days and an ISO week.
+	Meaning string
+	Dur     time.Duration
 }
 
 const (
@@ -56,10 +60,10 @@ const (
 )
 
 var reportIntervals = []reportInterval{
-	{Key: "all", Label: "All time"},
-	{Key: "month", Label: "Month", Dur: reportMonth},
-	{Key: "week", Label: "Week", Dur: reportWeek},
-	{Key: "day", Label: "Day", Dur: reportDay},
+	{Key: "all", Label: "All time", Meaning: "every scan and finding on record"},
+	{Key: "month", Label: "Month", Meaning: "rolling 30 days ending at generated_at", Dur: reportMonth},
+	{Key: "week", Label: "Week", Meaning: "rolling 7 days ending at generated_at", Dur: reportWeek},
+	{Key: "day", Label: "Day", Meaning: "rolling 24 hours ending at generated_at", Dur: reportDay},
 }
 
 // resolveReportInterval maps the ?interval query value to a window,
@@ -73,9 +77,46 @@ func resolveReportInterval(key string) reportInterval {
 	return reportIntervals[0]
 }
 
+// reportSeverities lists the selectable minimum-severity thresholds, least
+// severe first so the UI reads as a widening filter. Derived from
+// db.SeverityLevels so a new level appears here automatically.
+var reportSeverities = db.SeverityLevels
+
+// resolveMinSeverity canonicalises the ?severity query value, returning ""
+// (no filter) for anything unrecognised. displaySeverity folds the casing
+// variants the corpus carries, so ?severity=critical works.
+func resolveMinSeverity(v string) string {
+	if v == "" {
+		return ""
+	}
+	// displaySeverity folds the "CRITICAL"/"MODERATE" spellings the corpus
+	// carries but not lowercase ones, and a query parameter is usually
+	// typed lowercase, so upcase before asking.
+	canonical := displaySeverity(strings.ToUpper(v))
+	for _, level := range db.SeverityLevels {
+		if level == canonical {
+			return canonical
+		}
+	}
+	return ""
+}
+
+// minSeverityRank converts a canonical severity to its severityOrder rank.
+// severityOrder ranks the most severe LOWEST (Critical 0 … Low 3, unknown
+// last), so "at least this severe" is `rank <= threshold`.
+func minSeverityRank(level string) (int, bool) {
+	for i, l := range db.SeverityLevels {
+		if l == level {
+			return len(db.SeverityLevels) - 1 - i, true
+		}
+	}
+	return 0, false
+}
+
 // reportTotals is the running-total panel. ReposScanned counts distinct
 // repositories with at least one scan in the window, so a repo rescanned
-// ten times still counts once.
+// ten times still counts once. Findings honours the severity filter; the
+// scan counts do not, since severity is a property of findings only.
 type reportTotals struct {
 	ReposScanned int
 	Scans        int
@@ -89,7 +130,8 @@ type reportTotals struct {
 //
 // The population matches that SQL exactly — completed scans with a
 // recorded cost — so queued, running, failed and cancelled rows don't drag
-// the figures toward zero.
+// the figures toward zero. The severity filter does not apply: these
+// average scans, not findings.
 type reportAverages struct {
 	Runs             int     `gorm:"column:runs"`
 	CostUSD          float64 `gorm:"column:cost_usd"`
@@ -100,27 +142,34 @@ type reportAverages struct {
 	TotalTokens      float64 `gorm:"column:total_tokens"`
 }
 
-// reportDayRow is one row of the per-day breakdown carried by the exports.
+// reportDayRow is one row of the per-day breakdown. ScansAveraged is the
+// day's completed-and-costed scan count — the denominator behind that
+// day's averages, and the same population the period averages use.
 type reportDayRow struct {
-	Date         string
-	ReposScanned int
-	Scans        int
-	Findings     int
-	CostUSD      float64
-	TotalTokens  int
+	Date           string
+	ReposScanned   int
+	Scans          int
+	ScansDone      int
+	Findings       int
+	CostUSD        float64
+	TotalTokens    int
+	ScansAveraged  int
+	AvgCostUSD     float64
+	AvgTotalTokens float64
 }
 
 // reportData is the whole snapshot. The page render and both exports read
 // from this one value, so a downloaded report always matches the screen it
 // was downloaded from.
 type reportData struct {
-	Interval  reportInterval
-	Since     *time.Time
-	Generated time.Time
-	Totals    reportTotals
-	Window    reportAverages
-	AllTime   reportAverages
-	Days      []reportDayRow
+	Interval    reportInterval
+	MinSeverity string
+	Since       *time.Time
+	Generated   time.Time
+	Totals      reportTotals
+	Period      reportAverages
+	AllTime     reportAverages
+	Days        []reportDayRow
 }
 
 // reportAnchorSQL is the timestamp a scan is attributed to, as SQL: when
@@ -131,7 +180,7 @@ type reportData struct {
 // picks the day bucket within it.
 const reportAnchorSQL = "COALESCE(finished_at, created_at)"
 
-// reportAverages loads one column of the cost-averages table.
+// reportAveragesFor loads one column of the cost-averages table.
 //
 // The WHERE clause and the averaged expressions are a direct transcription
 // of docs/cost_averages.sql: completed scans carrying a recorded cost, so
@@ -174,23 +223,48 @@ func scanAnchor(sc db.Scan) time.Time {
 	return sc.CreatedAt.UTC()
 }
 
-// buildReport assembles the snapshot for one interval.
+// dayAccumulator gathers one calendar day's figures while the scan rows
+// stream past, so the day breakdown costs one pass rather than a query
+// per day.
+type dayAccumulator struct {
+	repos         map[uint]struct{}
+	scans         int
+	scansDone     int
+	findings      int
+	cost          float64
+	tokens        int
+	averagedScans int
+	averagedCost  float64
+	averagedToken int
+}
+
+// buildReport assembles the snapshot for one interval and severity floor.
 //
 // Both averages columns are aggregated in the database. Only the totals
 // and the day breakdown need individual rows, and that read is bounded to
 // the selected window and to the columns the report reads, so picking a
 // narrower interval genuinely costs less rather than filtering a full
 // table scan in memory.
-func (s *Server) buildReport(iv reportInterval) reportData {
+func (s *Server) buildReport(iv reportInterval, minSeverity string) reportData {
 	now := time.Now().UTC()
-	data := reportData{Interval: iv, Generated: now}
+	data := reportData{Interval: iv, MinSeverity: minSeverity, Generated: now}
 	if iv.Dur > 0 {
 		since := now.Add(-iv.Dur)
 		data.Since = &since
 	}
 
 	data.AllTime = s.reportAveragesFor(nil)
-	data.Window = s.reportAveragesFor(data.Since)
+	data.Period = s.reportAveragesFor(data.Since)
+
+	days := map[string]*dayAccumulator{}
+	at := func(day string) *dayAccumulator {
+		acc := days[day]
+		if acc == nil {
+			acc = &dayAccumulator{repos: map[uint]struct{}{}}
+			days[day] = acc
+		}
+		return acc
+	}
 
 	// Every status counts toward the activity totals, so unlike the
 	// averages this read is not narrowed to completed scans.
@@ -204,25 +278,26 @@ func (s *Server) buildReport(iv reportInterval) reportData {
 	sq.Find(&scans)
 
 	repos := map[uint]struct{}{}
-	reposByDay := map[string]map[uint]struct{}{}
-	scansByDay := map[string]int{}
-	costByDay := map[string]float64{}
-	tokensByDay := map[string]int{}
-
 	for _, sc := range scans {
-		day := scanAnchor(sc).Format(reportDateLayout)
+		acc := at(scanAnchor(sc).Format(reportDateLayout))
 		data.Totals.Scans++
+		acc.scans++
 		if sc.Status == db.ScanDone {
 			data.Totals.ScansDone++
+			acc.scansDone++
 		}
 		repos[sc.RepositoryID] = struct{}{}
-		if reposByDay[day] == nil {
-			reposByDay[day] = map[uint]struct{}{}
+		acc.repos[sc.RepositoryID] = struct{}{}
+		tokens := sc.InputTokens + sc.OutputTokens + sc.CacheReadTokens + sc.CacheWriteTokens
+		acc.cost += sc.CostUSD
+		acc.tokens += tokens
+		// Same population as reportAveragesFor, so a day's average and the
+		// period average are the same measurement at two resolutions.
+		if sc.Status == db.ScanDone && sc.CostUSD > 0 {
+			acc.averagedScans++
+			acc.averagedCost += sc.CostUSD
+			acc.averagedToken += tokens
 		}
-		reposByDay[day][sc.RepositoryID] = struct{}{}
-		scansByDay[day]++
-		costByDay[day] += sc.CostUSD
-		tokensByDay[day] += sc.InputTokens + sc.OutputTokens + sc.CacheReadTokens + sc.CacheWriteTokens
 	}
 	data.Totals.ReposScanned = len(repos)
 
@@ -234,42 +309,54 @@ func (s *Server) buildReport(iv reportInterval) reportData {
 	if data.Since != nil {
 		fq = fq.Where("created_at >= ?", *data.Since)
 	}
+	// severityOrder ranks the most severe lowest, so "at or above this
+	// severity" is `<=`. Reusing that shared CASE keeps this filter from
+	// ever disagreeing with the finding lists' ordering.
+	if rank, ok := minSeverityRank(minSeverity); ok {
+		fq = fq.Where("("+severityOrder+") <= ?", rank)
+	}
 	fq.Scan(&found)
-	findingsByDay := map[string]int{}
 	for _, f := range found {
 		data.Totals.Findings++
-		findingsByDay[f.CreatedAt.UTC().Format(reportDateLayout)]++
+		at(f.CreatedAt.UTC().Format(reportDateLayout)).findings++
 	}
 
-	// A day appears if it saw either activity, so a day with findings
-	// carried over from an earlier scan is not silently dropped.
-	days := map[string]struct{}{}
-	for day := range scansByDay {
-		days[day] = struct{}{}
-	}
-	for day := range findingsByDay {
-		days[day] = struct{}{}
-	}
 	data.Days = make([]reportDayRow, 0, len(days))
-	for day := range days {
-		data.Days = append(data.Days, reportDayRow{
-			Date:         day,
-			ReposScanned: len(reposByDay[day]),
-			Scans:        scansByDay[day],
-			Findings:     findingsByDay[day],
-			CostUSD:      costByDay[day],
-			TotalTokens:  tokensByDay[day],
-		})
+	for day, acc := range days {
+		row := reportDayRow{
+			Date:          day,
+			ReposScanned:  len(acc.repos),
+			Scans:         acc.scans,
+			ScansDone:     acc.scansDone,
+			Findings:      acc.findings,
+			CostUSD:       acc.cost,
+			TotalTokens:   acc.tokens,
+			ScansAveraged: acc.averagedScans,
+		}
+		if acc.averagedScans > 0 {
+			n := float64(acc.averagedScans)
+			row.AvgCostUSD = acc.averagedCost / n
+			row.AvgTotalTokens = float64(acc.averagedToken) / n
+		}
+		data.Days = append(data.Days, row)
 	}
 	sort.Slice(data.Days, func(i, j int) bool { return data.Days[i].Date > data.Days[j].Date })
 	return data
 }
 
+// reportFromRequest builds the snapshot the request asks for. Shared by the
+// page and both exports so a download can never disagree with the screen.
+func (s *Server) reportFromRequest(r *http.Request) reportData {
+	q := r.URL.Query()
+	return s.buildReport(resolveReportInterval(q.Get("interval")), resolveMinSeverity(q.Get("severity")))
+}
+
 func (s *Server) reporting(w http.ResponseWriter, r *http.Request) {
-	data := s.buildReport(resolveReportInterval(r.URL.Query().Get("interval")))
+	data := s.reportFromRequest(r)
 	s.render(w, r, "reporting.html", map[string]any{
-		"Report":    data,
-		"Intervals": reportIntervals,
+		"Report":     data,
+		"Intervals":  reportIntervals,
+		"Severities": reportSeverities,
 	})
 }
 
@@ -287,99 +374,152 @@ func reportTimestamp(t *time.Time) string {
 	return t.Format(time.RFC3339)
 }
 
-// reportingCSV writes the snapshot as two CSV blocks: a metric/value
-// summary, a blank line, then the per-day table. One file rather than two
-// downloads, at the cost of a reader needing to split on the blank line —
-// the two halves have genuinely different shapes and flattening them into
-// one wide table would pad every day row with repeated summary columns.
+// severityFilterLabel names the active filter for the exports, where an
+// empty string would read as "the filter is broken" rather than "off".
+func severityFilterLabel(minSeverity string) string {
+	if minSeverity == "" {
+		return "all"
+	}
+	return minSeverity
+}
+
+// reportCSVHeader is the single header row of the CSV export.
+//
+// The export is one rectangular table with a uniform column count so that
+// Excel, Numbers and pandas all open it as a single sheet. An earlier
+// version emitted a summary block, a blank line and then the daily table;
+// that is two tables in one file and spreadsheets render it as a ragged
+// sheet. row_type instead distinguishes the summary rows from the daily
+// ones, which also makes the file filterable and pivotable in place.
+//
+// period and minimum_severity repeat on every row so several exports can
+// be concatenated into one sheet and still be told apart.
+var reportCSVHeader = []string{
+	"period", "minimum_severity", "row_type", "date",
+	"repositories_scanned", "scans_started", "scans_completed", findingsField,
+	"cost_usd", "total_tokens", "scans_averaged", "avg_cost_usd", "avg_total_tokens",
+}
+
 func (s *Server) reportingCSV(w http.ResponseWriter, r *http.Request) {
-	data := s.buildReport(resolveReportInterval(r.URL.Query().Get("interval")))
+	data := s.reportFromRequest(r)
 	w.Header().Set("Content-Type", "text/csv; charset=utf-8")
 	w.Header().Set("Content-Disposition", `attachment; filename="`+reportFilename(data, "csv")+`"`)
 
 	cw := csv.NewWriter(w)
 	defer cw.Flush()
-	_ = cw.Write([]string{"metric", "value"})
-	summary := [][2]string{
-		{"interval", data.Interval.Key},
-		{"generated_at", data.Generated.Format(time.RFC3339)},
-		{"window_start", reportTimestamp(data.Since)},
-		{"repos_scanned", strconv.Itoa(data.Totals.ReposScanned)},
-		{"scans", strconv.Itoa(data.Totals.Scans)},
-		{"scans_done", strconv.Itoa(data.Totals.ScansDone)},
-		{findingsField, strconv.Itoa(data.Totals.Findings)},
-	}
-	summary = append(summary, averageCSVRows("window", data.Window)...)
-	summary = append(summary, averageCSVRows("alltime", data.AllTime)...)
-	for _, row := range summary {
-		_ = cw.Write([]string{row[0], row[1]})
+
+	period, severity := data.Interval.Key, severityFilterLabel(data.MinSeverity)
+	num := func(v float64) string { return strconv.FormatFloat(v, 'f', 2, 64) }
+	row := func(rowType, date string, cells ...string) []string {
+		return append([]string{period, severity, rowType, date}, cells...)
 	}
 
-	// csv.Writer quotes nothing here, so a bare blank line separates the
-	// two blocks; it must be flushed first to land in the right order.
-	cw.Flush()
-	_, _ = w.Write([]byte("\n"))
-
-	_ = cw.Write([]string{"date", "repos_scanned", "scans", findingsField, "cost_usd", "total_tokens"})
+	_ = cw.Write(reportCSVHeader)
+	// The period total leads: opened in a spreadsheet, the headline numbers
+	// are the first thing under the header rather than below the daily rows.
+	_ = cw.Write(row("period_total", "",
+		strconv.Itoa(data.Totals.ReposScanned),
+		strconv.Itoa(data.Totals.Scans),
+		strconv.Itoa(data.Totals.ScansDone),
+		strconv.Itoa(data.Totals.Findings),
+		num(sumDayCost(data.Days)),
+		strconv.Itoa(sumDayTokens(data.Days)),
+		strconv.Itoa(data.Period.Runs),
+		num(data.Period.CostUSD),
+		num(data.Period.TotalTokens),
+	))
+	// All-time averages are a different population from the selected
+	// period, so only the average columns are filled: the activity columns
+	// would otherwise imply an all-time total this report never computed.
+	_ = cw.Write(row("all_time_average", "", "", "", "", "", "", "",
+		strconv.Itoa(data.AllTime.Runs),
+		num(data.AllTime.CostUSD),
+		num(data.AllTime.TotalTokens),
+	))
 	for _, d := range data.Days {
-		_ = cw.Write([]string{
-			d.Date,
+		_ = cw.Write(row("day", d.Date,
 			strconv.Itoa(d.ReposScanned),
 			strconv.Itoa(d.Scans),
+			strconv.Itoa(d.ScansDone),
 			strconv.Itoa(d.Findings),
-			strconv.FormatFloat(d.CostUSD, 'f', 2, 64),
+			num(d.CostUSD),
 			strconv.Itoa(d.TotalTokens),
-		})
+			strconv.Itoa(d.ScansAveraged),
+			num(d.AvgCostUSD),
+			num(d.AvgTotalTokens),
+		))
 	}
 }
 
-// averageCSVRows flattens one averages column under a prefix, so the
-// window and all-time figures share a key namespace in the flat CSV.
-func averageCSVRows(prefix string, a reportAverages) [][2]string {
-	f := func(v float64) string { return strconv.FormatFloat(v, 'f', 2, 64) }
-	return [][2]string{
-		{prefix + "_scans_costed", strconv.Itoa(a.Runs)},
-		{prefix + "_avg_cost_usd", f(a.CostUSD)},
-		{prefix + "_avg_input_tokens", f(a.InputTokens)},
-		{prefix + "_avg_output_tokens", f(a.OutputTokens)},
-		{prefix + "_avg_cache_read_tokens", f(a.CacheReadTokens)},
-		{prefix + "_avg_cache_write_tokens", f(a.CacheWriteTokens)},
-		{prefix + "_avg_total_tokens", f(a.TotalTokens)},
+func sumDayCost(days []reportDayRow) float64 {
+	var total float64
+	for _, d := range days {
+		total += d.CostUSD
 	}
+	return total
+}
+
+func sumDayTokens(days []reportDayRow) int {
+	var total int
+	for _, d := range days {
+		total += d.TotalTokens
+	}
+	return total
 }
 
 func (s *Server) reportingJSON(w http.ResponseWriter, r *http.Request) {
-	data := s.buildReport(resolveReportInterval(r.URL.Query().Get("interval")))
+	data := s.reportFromRequest(r)
 	days := make([]map[string]any, 0, len(data.Days))
 	for _, d := range data.Days {
 		days = append(days, map[string]any{
-			"date":          d.Date,
-			"repos_scanned": d.ReposScanned,
-			"scans":         d.Scans,
-			findingsField:   d.Findings,
-			"cost_usd":      d.CostUSD,
-			"total_tokens":  d.TotalTokens,
+			"date":                 d.Date,
+			"repositories_scanned": d.ReposScanned,
+			"scans_started":        d.Scans,
+			"scans_completed":      d.ScansDone,
+			findingsField:          d.Findings,
+			"cost_usd":             d.CostUSD,
+			"total_tokens":         d.TotalTokens,
+			"scans_averaged":       d.ScansAveraged,
+			"avg_cost_usd":         d.AvgCostUSD,
+			"avg_total_tokens":     d.AvgTotalTokens,
 		})
 	}
-	out := map[string]any{
-		"interval":       data.Interval.Key,
-		"interval_label": data.Interval.Label,
-		"generated_at":   data.Generated.Format(time.RFC3339),
-		"window_start":   nil,
-		"totals": map[string]any{
-			"repos_scanned": data.Totals.ReposScanned,
-			"scans":         data.Totals.Scans,
-			"scans_done":    data.Totals.ScansDone,
-			findingsField:   data.Totals.Findings,
-		},
-		"averages": map[string]any{
-			"window":   averageJSON(data.Window),
-			"all_time": averageJSON(data.AllTime),
-		},
-		"days": days,
+	period := map[string]any{
+		"key":       data.Interval.Key,
+		"label":     data.Interval.Label,
+		"meaning":   data.Interval.Meaning,
+		"starts_at": nil,
+		"ends_at":   data.Generated.Format(time.RFC3339),
 	}
 	if data.Since != nil {
-		out["window_start"] = data.Since.Format(time.RFC3339)
+		period["starts_at"] = reportTimestamp(data.Since)
+	}
+	var minSeverity any
+	if data.MinSeverity != "" {
+		minSeverity = data.MinSeverity
+	}
+	out := map[string]any{
+		"generated_at": data.Generated.Format(time.RFC3339),
+		"period":       period,
+		"filters": map[string]any{
+			// null means unfiltered; the scan counts are never filtered by
+			// severity, which belongs to findings alone.
+			"minimum_severity":  minSeverity,
+			"applies_to":        []string{findingsField},
+			"severity_ordering": db.SeverityLevels,
+		},
+		"activity_in_period": map[string]any{
+			"repositories_scanned": data.Totals.ReposScanned,
+			"scans_started":        data.Totals.Scans,
+			"scans_completed":      data.Totals.ScansDone,
+			findingsField:          data.Totals.Findings,
+		},
+		"cost_averages_per_scan": map[string]any{
+			"population": "completed scans with a recorded cost",
+			"in_period":  averageJSON(data.Period),
+			"all_time":   averageJSON(data.AllTime),
+		},
+		"activity_by_day": days,
 	}
 	w.Header().Set("Content-Disposition", `attachment; filename="`+reportFilename(data, "json")+`"`)
 	writeJSON(w, http.StatusOK, out)
@@ -387,7 +527,7 @@ func (s *Server) reportingJSON(w http.ResponseWriter, r *http.Request) {
 
 func averageJSON(a reportAverages) map[string]any {
 	return map[string]any{
-		"scans_costed":           a.Runs,
+		"scans_averaged":         a.Runs,
 		"avg_cost_usd":           a.CostUSD,
 		"avg_input_tokens":       a.InputTokens,
 		"avg_output_tokens":      a.OutputTokens,

--- a/internal/web/reporting.go
+++ b/internal/web/reporting.go
@@ -1,0 +1,392 @@
+package web
+
+// /reporting is the corpus-wide reporting page: a running total of scan
+// activity over a rolling window, alongside the cost and token averages
+// that docs/cost_averages.sql computes from the command line.
+//
+// It deliberately overlaps /usage only on the averages. /usage answers
+// "which skill costs what" by slicing cost per skill and per day; this
+// page answers "what has the corpus done lately" and pairs that with the
+// single-number averages, so the two can be read side by side. Both draw
+// on the same cost_usd/*_tokens columns the worker writes.
+//
+// The cost averages are computed SQL-side so the GORM query maps clause
+// for clause onto docs/cost_averages.sql, and so a growing corpus is not
+// read into memory to be averaged. AVG/COUNT are standard SQL and survive
+// the PostgreSQL driver swap internal/db documents.
+//
+// The day bucketing is the one thing done in Go: grouping by calendar day
+// needs date()/strftime()/date_trunc, which differ per dialect and would
+// pin this file to SQLite. /usage bins its days in Go for the same reason.
+
+import (
+	"encoding/csv"
+	"fmt"
+	"net/http"
+	"sort"
+	"strconv"
+	"time"
+
+	"scrutineer/internal/db"
+)
+
+// reportDateLayout is the calendar-day key for the per-day breakdown. Days
+// are UTC so a report generated in two timezones bucket-aligns.
+const reportDateLayout = "2006-01-02"
+
+// reportInterval is one selectable rolling window. Dur of 0 means all
+// time. Rolling rather than calendar: the totals are a running figure, so
+// they should not collapse to near-zero at midnight or on the 1st.
+type reportInterval struct {
+	Key   string
+	Label string
+	Dur   time.Duration
+}
+
+const (
+	reportDay   = 24 * time.Hour
+	reportWeek  = 7 * reportDay
+	reportMonth = 30 * reportDay
+)
+
+var reportIntervals = []reportInterval{
+	{Key: "all", Label: "All time"},
+	{Key: "month", Label: "Month", Dur: reportMonth},
+	{Key: "week", Label: "Week", Dur: reportWeek},
+	{Key: "day", Label: "Day", Dur: reportDay},
+}
+
+// resolveReportInterval maps the ?interval query value to a window,
+// defaulting to all time for anything unrecognised.
+func resolveReportInterval(key string) reportInterval {
+	for _, iv := range reportIntervals {
+		if iv.Key == key {
+			return iv
+		}
+	}
+	return reportIntervals[0]
+}
+
+// reportTotals is the running-total panel. ReposScanned counts distinct
+// repositories with at least one scan in the window, so a repo rescanned
+// ten times still counts once.
+type reportTotals struct {
+	ReposScanned int
+	Scans        int
+	ScansDone    int
+	Findings     int
+}
+
+// reportAverages is one column of the cost-averages table: the per-scan
+// means from docs/cost_averages.sql. Runs is the denominator, exposed so a
+// small-sample average is recognisable as one.
+//
+// The population matches that SQL exactly — completed scans with a
+// recorded cost — so queued, running, failed and cancelled rows don't drag
+// the figures toward zero.
+type reportAverages struct {
+	Runs             int     `gorm:"column:runs"`
+	CostUSD          float64 `gorm:"column:cost_usd"`
+	InputTokens      float64 `gorm:"column:input_tokens"`
+	OutputTokens     float64 `gorm:"column:output_tokens"`
+	CacheReadTokens  float64 `gorm:"column:cache_read_tokens"`
+	CacheWriteTokens float64 `gorm:"column:cache_write_tokens"`
+	TotalTokens      float64 `gorm:"column:total_tokens"`
+}
+
+// reportDayRow is one row of the per-day breakdown carried by the exports.
+type reportDayRow struct {
+	Date         string
+	ReposScanned int
+	Scans        int
+	Findings     int
+	CostUSD      float64
+	TotalTokens  int
+}
+
+// reportData is the whole snapshot. The page render and both exports read
+// from this one value, so a downloaded report always matches the screen it
+// was downloaded from.
+type reportData struct {
+	Interval  reportInterval
+	Since     *time.Time
+	Generated time.Time
+	Totals    reportTotals
+	Window    reportAverages
+	AllTime   reportAverages
+	Days      []reportDayRow
+}
+
+// reportAnchorSQL is the timestamp a scan is attributed to, as SQL: when
+// it finished, falling back to when it was created for rows that never
+// reached a terminal state. COALESCE is standard SQL, so this survives the
+// driver swap. scanAnchor below is the Go twin of this expression and the
+// two must stay in step, since the SQL bounds the window and the Go one
+// picks the day bucket within it.
+const reportAnchorSQL = "COALESCE(finished_at, created_at)"
+
+// reportAverages loads one column of the cost-averages table.
+//
+// The WHERE clause and the averaged expressions are a direct transcription
+// of docs/cost_averages.sql: completed scans carrying a recorded cost, so
+// queued, running, failed and cancelled rows don't drag the figures toward
+// zero. since bounds the population to a rolling window; nil averages the
+// whole corpus.
+//
+// AVG over an empty set is NULL, which will not scan into a float64, so
+// each average is coalesced to zero — matching the zeroed struct an empty
+// corpus should produce. Rounding is left to the display layer: the SQL
+// file's ROUND(AVG(cost_usd), 2) has no round(double precision, integer)
+// overload on PostgreSQL and would not survive the driver swap.
+func (s *Server) reportAveragesFor(since *time.Time) reportAverages {
+	var out reportAverages
+	q := s.DB.Model(&db.Scan{}).
+		Select(`COUNT(*) AS runs,
+			COALESCE(AVG(cost_usd), 0)            AS cost_usd,
+			COALESCE(AVG(input_tokens), 0)        AS input_tokens,
+			COALESCE(AVG(output_tokens), 0)       AS output_tokens,
+			COALESCE(AVG(cache_read_tokens), 0)   AS cache_read_tokens,
+			COALESCE(AVG(cache_write_tokens), 0)  AS cache_write_tokens,
+			COALESCE(AVG(input_tokens + output_tokens + cache_read_tokens + cache_write_tokens), 0) AS total_tokens`).
+		Where("status = ?", db.ScanDone).
+		Where("cost_usd > 0")
+	if since != nil {
+		q = q.Where(reportAnchorSQL+" >= ?", *since)
+	}
+	q.Scan(&out)
+	return out
+}
+
+// scanAnchor is the timestamp a scan is attributed to: when it finished,
+// falling back to when it was created for rows that never reached a
+// terminal state. This is the same bucketing /usage uses for its by-day
+// view, so the two pages agree on which day a scan lands in.
+func scanAnchor(sc db.Scan) time.Time {
+	if sc.FinishedAt != nil {
+		return sc.FinishedAt.UTC()
+	}
+	return sc.CreatedAt.UTC()
+}
+
+// buildReport assembles the snapshot for one interval.
+//
+// Both averages columns are aggregated in the database. Only the totals
+// and the day breakdown need individual rows, and that read is bounded to
+// the selected window and to the columns the report reads, so picking a
+// narrower interval genuinely costs less rather than filtering a full
+// table scan in memory.
+func (s *Server) buildReport(iv reportInterval) reportData {
+	now := time.Now().UTC()
+	data := reportData{Interval: iv, Generated: now}
+	if iv.Dur > 0 {
+		since := now.Add(-iv.Dur)
+		data.Since = &since
+	}
+
+	data.AllTime = s.reportAveragesFor(nil)
+	data.Window = s.reportAveragesFor(data.Since)
+
+	// Every status counts toward the activity totals, so unlike the
+	// averages this read is not narrowed to completed scans.
+	var scans []db.Scan
+	sq := s.DB.Model(&db.Scan{}).
+		Select("repository_id", "status", "cost_usd", "input_tokens", "output_tokens",
+			"cache_read_tokens", "cache_write_tokens", "finished_at", "created_at")
+	if data.Since != nil {
+		sq = sq.Where(reportAnchorSQL+" >= ?", *data.Since)
+	}
+	sq.Find(&scans)
+
+	repos := map[uint]struct{}{}
+	reposByDay := map[string]map[uint]struct{}{}
+	scansByDay := map[string]int{}
+	costByDay := map[string]float64{}
+	tokensByDay := map[string]int{}
+
+	for _, sc := range scans {
+		day := scanAnchor(sc).Format(reportDateLayout)
+		data.Totals.Scans++
+		if sc.Status == db.ScanDone {
+			data.Totals.ScansDone++
+		}
+		repos[sc.RepositoryID] = struct{}{}
+		if reposByDay[day] == nil {
+			reposByDay[day] = map[uint]struct{}{}
+		}
+		reposByDay[day][sc.RepositoryID] = struct{}{}
+		scansByDay[day]++
+		costByDay[day] += sc.CostUSD
+		tokensByDay[day] += sc.InputTokens + sc.OutputTokens + sc.CacheReadTokens + sc.CacheWriteTokens
+	}
+	data.Totals.ReposScanned = len(repos)
+
+	// Findings are counted by creation time: a finding belongs to the
+	// window it was first reported in, not to a later re-observation.
+	type findingRow struct{ CreatedAt time.Time }
+	var found []findingRow
+	fq := s.DB.Model(&db.Finding{}).Select("created_at")
+	if data.Since != nil {
+		fq = fq.Where("created_at >= ?", *data.Since)
+	}
+	fq.Scan(&found)
+	findingsByDay := map[string]int{}
+	for _, f := range found {
+		data.Totals.Findings++
+		findingsByDay[f.CreatedAt.UTC().Format(reportDateLayout)]++
+	}
+
+	// A day appears if it saw either activity, so a day with findings
+	// carried over from an earlier scan is not silently dropped.
+	days := map[string]struct{}{}
+	for day := range scansByDay {
+		days[day] = struct{}{}
+	}
+	for day := range findingsByDay {
+		days[day] = struct{}{}
+	}
+	data.Days = make([]reportDayRow, 0, len(days))
+	for day := range days {
+		data.Days = append(data.Days, reportDayRow{
+			Date:         day,
+			ReposScanned: len(reposByDay[day]),
+			Scans:        scansByDay[day],
+			Findings:     findingsByDay[day],
+			CostUSD:      costByDay[day],
+			TotalTokens:  tokensByDay[day],
+		})
+	}
+	sort.Slice(data.Days, func(i, j int) bool { return data.Days[i].Date > data.Days[j].Date })
+	return data
+}
+
+func (s *Server) reporting(w http.ResponseWriter, r *http.Request) {
+	data := s.buildReport(resolveReportInterval(r.URL.Query().Get("interval")))
+	s.render(w, r, "reporting.html", map[string]any{
+		"Report":    data,
+		"Intervals": reportIntervals,
+	})
+}
+
+// reportFilename names a download after the window it covers, so reports
+// pulled on different days don't overwrite each other in a downloads dir.
+func reportFilename(data reportData, ext string) string {
+	return fmt.Sprintf("scrutineer-report-%s-%s.%s",
+		data.Interval.Key, data.Generated.Format(reportDateLayout), ext)
+}
+
+func reportTimestamp(t *time.Time) string {
+	if t == nil {
+		return ""
+	}
+	return t.Format(time.RFC3339)
+}
+
+// reportingCSV writes the snapshot as two CSV blocks: a metric/value
+// summary, a blank line, then the per-day table. One file rather than two
+// downloads, at the cost of a reader needing to split on the blank line —
+// the two halves have genuinely different shapes and flattening them into
+// one wide table would pad every day row with repeated summary columns.
+func (s *Server) reportingCSV(w http.ResponseWriter, r *http.Request) {
+	data := s.buildReport(resolveReportInterval(r.URL.Query().Get("interval")))
+	w.Header().Set("Content-Type", "text/csv; charset=utf-8")
+	w.Header().Set("Content-Disposition", `attachment; filename="`+reportFilename(data, "csv")+`"`)
+
+	cw := csv.NewWriter(w)
+	defer cw.Flush()
+	_ = cw.Write([]string{"metric", "value"})
+	summary := [][2]string{
+		{"interval", data.Interval.Key},
+		{"generated_at", data.Generated.Format(time.RFC3339)},
+		{"window_start", reportTimestamp(data.Since)},
+		{"repos_scanned", strconv.Itoa(data.Totals.ReposScanned)},
+		{"scans", strconv.Itoa(data.Totals.Scans)},
+		{"scans_done", strconv.Itoa(data.Totals.ScansDone)},
+		{"findings", strconv.Itoa(data.Totals.Findings)},
+	}
+	summary = append(summary, averageCSVRows("window", data.Window)...)
+	summary = append(summary, averageCSVRows("alltime", data.AllTime)...)
+	for _, row := range summary {
+		_ = cw.Write([]string{row[0], row[1]})
+	}
+
+	// csv.Writer quotes nothing here, so a bare blank line separates the
+	// two blocks; it must be flushed first to land in the right order.
+	cw.Flush()
+	_, _ = w.Write([]byte("\n"))
+
+	_ = cw.Write([]string{"date", "repos_scanned", "scans", "findings", "cost_usd", "total_tokens"})
+	for _, d := range data.Days {
+		_ = cw.Write([]string{
+			d.Date,
+			strconv.Itoa(d.ReposScanned),
+			strconv.Itoa(d.Scans),
+			strconv.Itoa(d.Findings),
+			strconv.FormatFloat(d.CostUSD, 'f', 2, 64),
+			strconv.Itoa(d.TotalTokens),
+		})
+	}
+}
+
+// averageCSVRows flattens one averages column under a prefix, so the
+// window and all-time figures share a key namespace in the flat CSV.
+func averageCSVRows(prefix string, a reportAverages) [][2]string {
+	f := func(v float64) string { return strconv.FormatFloat(v, 'f', 2, 64) }
+	return [][2]string{
+		{prefix + "_scans_costed", strconv.Itoa(a.Runs)},
+		{prefix + "_avg_cost_usd", f(a.CostUSD)},
+		{prefix + "_avg_input_tokens", f(a.InputTokens)},
+		{prefix + "_avg_output_tokens", f(a.OutputTokens)},
+		{prefix + "_avg_cache_read_tokens", f(a.CacheReadTokens)},
+		{prefix + "_avg_cache_write_tokens", f(a.CacheWriteTokens)},
+		{prefix + "_avg_total_tokens", f(a.TotalTokens)},
+	}
+}
+
+func (s *Server) reportingJSON(w http.ResponseWriter, r *http.Request) {
+	data := s.buildReport(resolveReportInterval(r.URL.Query().Get("interval")))
+	days := make([]map[string]any, 0, len(data.Days))
+	for _, d := range data.Days {
+		days = append(days, map[string]any{
+			"date":          d.Date,
+			"repos_scanned": d.ReposScanned,
+			"scans":         d.Scans,
+			"findings":      d.Findings,
+			"cost_usd":      d.CostUSD,
+			"total_tokens":  d.TotalTokens,
+		})
+	}
+	out := map[string]any{
+		"interval":       data.Interval.Key,
+		"interval_label": data.Interval.Label,
+		"generated_at":   data.Generated.Format(time.RFC3339),
+		"window_start":   nil,
+		"totals": map[string]any{
+			"repos_scanned": data.Totals.ReposScanned,
+			"scans":         data.Totals.Scans,
+			"scans_done":    data.Totals.ScansDone,
+			"findings":      data.Totals.Findings,
+		},
+		"averages": map[string]any{
+			"window":   averageJSON(data.Window),
+			"all_time": averageJSON(data.AllTime),
+		},
+		"days": days,
+	}
+	if data.Since != nil {
+		out["window_start"] = data.Since.Format(time.RFC3339)
+	}
+	w.Header().Set("Content-Disposition", `attachment; filename="`+reportFilename(data, "json")+`"`)
+	writeJSON(w, http.StatusOK, out)
+}
+
+func averageJSON(a reportAverages) map[string]any {
+	return map[string]any{
+		"scans_costed":           a.Runs,
+		"avg_cost_usd":           a.CostUSD,
+		"avg_input_tokens":       a.InputTokens,
+		"avg_output_tokens":      a.OutputTokens,
+		"avg_cache_read_tokens":  a.CacheReadTokens,
+		"avg_cache_write_tokens": a.CacheWriteTokens,
+		"avg_total_tokens":       a.TotalTokens,
+	}
+}

--- a/internal/web/reporting.go
+++ b/internal/web/reporting.go
@@ -359,8 +359,17 @@ func (s *Server) buildReport(iv reportInterval, minSeverity string) reportData {
 		}
 		acc := at(sc.FinishedAt.UTC().Format(reportDateLayout))
 		active(acc, sc.RepositoryID)
-data.Totals.ScansCompleted++
-acc.completed++
+		// A completion is a run that reached done. Failed, cancelled and
+		// skipped runs stop here too, and their spend is counted below, but
+		// counting them as completions would make the tile's success rate
+		// read ~100% however many runs were failing, and would put this
+		// figure at odds with the cost averages on the same page, whose
+		// population is the completed-and-costed scans docs/cost_averages.sql
+		// defines.
+		if sc.Status == db.ScanDone {
+			data.Totals.ScansCompleted++
+			acc.completed++
+		}
 		// Spend lands on the finish day for any terminal status: the worker
 		// writes the cost and token columns when a run finalises, so an
 		// in-flight run has nothing to attribute yet and a failed one still

--- a/internal/web/reporting.go
+++ b/internal/web/reporting.go
@@ -22,6 +22,7 @@ package web
 import (
 	"encoding/csv"
 	"fmt"
+	"maps"
 	"net/http"
 	"sort"
 	"strconv"
@@ -435,45 +436,68 @@ func (s *Server) reportingCSV(w http.ResponseWriter, r *http.Request) {
 
 	period, severity := data.Interval.Key, severityFilterLabel(data.MinSeverity)
 	num := func(v float64) string { return strconv.FormatFloat(v, 'f', 2, 64) }
-	row := func(rowType, date string, cells ...string) []string {
-		return append([]string{period, severity, rowType, date}, cells...)
+	// Columns are addressed by name, never by position. A partially filled
+	// row (the all-time averages fill three of thirteen) would otherwise be
+	// a run of anonymous "" literals that nobody — human or tool — can
+	// recount safely, and dropping one silently shifts every later value
+	// into its neighbour's column.
+	row := func(rowType, date string, cells map[string]string) []string {
+		values := map[string]string{
+			"period":           period,
+			"minimum_severity": severity,
+			"row_type":         rowType,
+			"date":             date,
+		}
+		maps.Copy(values, cells)
+		return csvRecord(values)
 	}
 
 	_ = cw.Write(reportCSVHeader)
 	// The period total leads: opened in a spreadsheet, the headline numbers
 	// are the first thing under the header rather than below the daily rows.
-	_ = cw.Write(row("period_total", "",
-		strconv.Itoa(data.Totals.ReposScanned),
-		strconv.Itoa(data.Totals.Scans),
-		strconv.Itoa(data.Totals.ScansDone),
-		strconv.Itoa(data.Totals.Findings),
-		num(sumDayCost(data.Days)),
-		strconv.Itoa(sumDayTokens(data.Days)),
-		strconv.Itoa(data.Period.Runs),
-		num(data.Period.CostUSD),
-		num(data.Period.TotalTokens),
-	))
+	_ = cw.Write(row("period_total", "", map[string]string{
+		"repositories_scanned": strconv.Itoa(data.Totals.ReposScanned),
+		"scans_started":        strconv.Itoa(data.Totals.Scans),
+		"scans_completed":      strconv.Itoa(data.Totals.ScansDone),
+		findingsField:          strconv.Itoa(data.Totals.Findings),
+		"cost_usd":             num(sumDayCost(data.Days)),
+		"total_tokens":         strconv.Itoa(sumDayTokens(data.Days)),
+		"scans_averaged":       strconv.Itoa(data.Period.Runs),
+		"avg_cost_usd":         num(data.Period.CostUSD),
+		"avg_total_tokens":     num(data.Period.TotalTokens),
+	}))
 	// All-time averages are a different population from the selected
 	// period, so only the average columns are filled: the activity columns
 	// would otherwise imply an all-time total this report never computed.
-	_ = cw.Write(row("all_time_average", "", "", "", "", "", "",
-		strconv.Itoa(data.AllTime.Runs),
-		num(data.AllTime.CostUSD),
-		num(data.AllTime.TotalTokens),
-	))
+	_ = cw.Write(row("all_time_average", "", map[string]string{
+		"scans_averaged":   strconv.Itoa(data.AllTime.Runs),
+		"avg_cost_usd":     num(data.AllTime.CostUSD),
+		"avg_total_tokens": num(data.AllTime.TotalTokens),
+	}))
 	for _, d := range data.Days {
-		_ = cw.Write(row("day", d.Date,
-			strconv.Itoa(d.ReposScanned),
-			strconv.Itoa(d.Scans),
-			strconv.Itoa(d.ScansDone),
-			strconv.Itoa(d.Findings),
-			num(d.CostUSD),
-			strconv.Itoa(d.TotalTokens),
-			strconv.Itoa(d.ScansAveraged),
-			num(d.AvgCostUSD),
-			num(d.AvgTotalTokens),
-		))
+		_ = cw.Write(row("day", d.Date, map[string]string{
+			"repositories_scanned": strconv.Itoa(d.ReposScanned),
+			"scans_started":        strconv.Itoa(d.Scans),
+			"scans_completed":      strconv.Itoa(d.ScansDone),
+			findingsField:          strconv.Itoa(d.Findings),
+			"cost_usd":             num(d.CostUSD),
+			"total_tokens":         strconv.Itoa(d.TotalTokens),
+			"scans_averaged":       strconv.Itoa(d.ScansAveraged),
+			"avg_cost_usd":         num(d.AvgCostUSD),
+			"avg_total_tokens":     num(d.AvgTotalTokens),
+		}))
 	}
+}
+
+// csvRecord renders one record in reportCSVHeader order. The result is
+// always exactly as wide as the header, so no caller can make the sheet
+// ragged; columns the caller did not set stay empty.
+func csvRecord(values map[string]string) []string {
+	rec := make([]string, len(reportCSVHeader))
+	for i, column := range reportCSVHeader {
+		rec[i] = values[column]
+	}
+	return rec
 }
 
 func sumDayCost(days []reportDayRow) float64 {

--- a/internal/web/reporting.go
+++ b/internal/web/reporting.go
@@ -102,18 +102,6 @@ func resolveMinSeverity(v string) string {
 	return ""
 }
 
-// minSeverityRank converts a canonical severity to its severityOrder rank.
-// severityOrder ranks the most severe LOWEST (Critical 0 … Low 3, unknown
-// last), so "at least this severe" is `rank <= threshold`.
-func minSeverityRank(level string) (int, bool) {
-	for i, l := range db.SeverityLevels {
-		if l == level {
-			return len(db.SeverityLevels) - 1 - i, true
-		}
-	}
-	return 0, false
-}
-
 // reportTotals is the running-total panel. ReposScanned counts distinct
 // repositories with at least one run that began or ended in the window, so
 // a repo rescanned ten times still counts once. ScansStarted and
@@ -251,7 +239,7 @@ const (
 // corpus should produce. Rounding is left to the display layer: the SQL
 // file's ROUND(AVG(cost_usd), 2) has no round(double precision, integer)
 // overload on PostgreSQL and would not survive the driver swap.
-func (s *Server) reportAveragesFor(since *time.Time) reportAverages {
+func (s *Server) reportAveragesFor(since *time.Time) (reportAverages, error) {
 	var out reportAverages
 	q := s.DB.Model(&db.Scan{}).
 		Select(`COUNT(*) AS runs,
@@ -266,8 +254,7 @@ func (s *Server) reportAveragesFor(since *time.Time) reportAverages {
 	if since != nil {
 		q = q.Where("finished_at >= ?", *since)
 	}
-	q.Scan(&out)
-	return out
+	return out, q.Scan(&out).Error
 }
 
 // dayAccumulator gathers one calendar day's figures while the scan rows
@@ -300,12 +287,16 @@ func (d reportData) inWindow(t *time.Time) bool {
 
 // buildReport assembles the snapshot for one interval and severity floor.
 //
+// Every read is checked. A failed query would otherwise leave this returning
+// a report of zeros that is indistinguishable from a quiet week, and the
+// exports would hand an operator that report as a file to archive.
+//
 // Both averages columns are aggregated in the database. Only the totals
 // and the day breakdown need individual rows, and that read is bounded to
 // the selected window and to the columns the report reads, so picking a
 // narrower interval genuinely costs less rather than filtering a full
 // table scan in memory.
-func (s *Server) buildReport(iv reportInterval, minSeverity string) reportData {
+func (s *Server) buildReport(iv reportInterval, minSeverity string) (reportData, error) {
 	now := time.Now().UTC()
 	data := reportData{Interval: iv, MinSeverity: minSeverity, Generated: now}
 	if iv.Dur > 0 {
@@ -313,8 +304,13 @@ func (s *Server) buildReport(iv reportInterval, minSeverity string) reportData {
 		data.Since = &since
 	}
 
-	data.AllTime = s.reportAveragesFor(nil)
-	data.Period = s.reportAveragesFor(data.Since)
+	var err error
+	if data.AllTime, err = s.reportAveragesFor(nil); err != nil {
+		return data, fmt.Errorf("all-time cost averages: %w", err)
+	}
+	if data.Period, err = s.reportAveragesFor(data.Since); err != nil {
+		return data, fmt.Errorf("cost averages for %s: %w", iv.Key, err)
+	}
 
 	days := map[string]*dayAccumulator{}
 	at := func(day string) *dayAccumulator {
@@ -337,7 +333,9 @@ func (s *Server) buildReport(iv reportInterval, minSeverity string) reportData {
 	if data.Since != nil {
 		sq = sq.Where(reportWindowSQL, *data.Since, *data.Since)
 	}
-	sq.Find(&scans)
+	if err := sq.Find(&scans).Error; err != nil {
+		return data, fmt.Errorf("scan activity: %w", err)
+	}
 
 	repos := map[uint]struct{}{}
 	// active marks a repository as having had scan activity on this day and
@@ -399,10 +397,12 @@ func (s *Server) buildReport(iv reportInterval, minSeverity string) reportData {
 	// severityOrder ranks the most severe lowest, so "at or above this
 	// severity" is `<=`. Reusing that shared CASE keeps this filter from
 	// ever disagreeing with the finding lists' ordering.
-	if rank, ok := minSeverityRank(minSeverity); ok {
+	if rank, ok := db.SeverityRank(minSeverity); ok {
 		fq = fq.Where("("+severityOrder+") <= ?", rank)
 	}
-	fq.Scan(&found)
+	if err := fq.Scan(&found).Error; err != nil {
+		return data, fmt.Errorf("findings: %w", err)
+	}
 	for _, f := range found {
 		data.Totals.Findings++
 		at(f.CreatedAt.UTC().Format(reportDateLayout)).findings++
@@ -428,18 +428,34 @@ func (s *Server) buildReport(iv reportInterval, minSeverity string) reportData {
 		data.Days = append(data.Days, row)
 	}
 	sort.Slice(data.Days, func(i, j int) bool { return data.Days[i].Date > data.Days[j].Date })
-	return data
+	return data, nil
 }
 
 // reportFromRequest builds the snapshot the request asks for. Shared by the
 // page and both exports so a download can never disagree with the screen.
-func (s *Server) reportFromRequest(r *http.Request) reportData {
+func (s *Server) reportFromRequest(r *http.Request) (reportData, error) {
 	q := r.URL.Query()
 	return s.buildReport(resolveReportInterval(q.Get("interval")), resolveMinSeverity(q.Get("severity")))
 }
 
+// reportOrError builds the snapshot or fails the request. Every caller has to
+// answer before writing a byte of the response, so a broken read shows as a
+// 500 rather than as a page or a download full of zeros.
+func (s *Server) reportOrError(w http.ResponseWriter, r *http.Request) (reportData, bool) {
+	data, err := s.reportFromRequest(r)
+	if err != nil {
+		s.Log.Error("build report", "err", err)
+		http.Error(w, "report unavailable", http.StatusInternalServerError)
+		return data, false
+	}
+	return data, true
+}
+
 func (s *Server) reporting(w http.ResponseWriter, r *http.Request) {
-	data := s.reportFromRequest(r)
+	data, ok := s.reportOrError(w, r)
+	if !ok {
+		return
+	}
 	s.render(w, r, "reporting.html", map[string]any{
 		"Report":     data,
 		"Intervals":  reportIntervals,
@@ -488,7 +504,10 @@ var reportCSVHeader = []string{
 }
 
 func (s *Server) reportingCSV(w http.ResponseWriter, r *http.Request) {
-	data := s.reportFromRequest(r)
+	data, ok := s.reportOrError(w, r)
+	if !ok {
+		return
+	}
 	w.Header().Set("Content-Type", "text/csv; charset=utf-8")
 	w.Header().Set("Content-Disposition", `attachment; filename="`+reportFilename(data, "csv")+`"`)
 
@@ -578,7 +597,10 @@ func sumDayTokens(days []reportDayRow) int {
 }
 
 func (s *Server) reportingJSON(w http.ResponseWriter, r *http.Request) {
-	data := s.reportFromRequest(r)
+	data, ok := s.reportOrError(w, r)
+	if !ok {
+		return
+	}
 	days := make([]map[string]any, 0, len(data.Days))
 	for _, d := range data.Days {
 		days = append(days, map[string]any{

--- a/internal/web/reporting.go
+++ b/internal/web/reporting.go
@@ -183,8 +183,18 @@ type reportDayRow struct {
 }
 
 // reportData is the whole snapshot. The page render and both exports read
-// from this one value, so a downloaded report always matches the screen it
-// was downloaded from.
+// from this one value, so no figure in a download can disagree with the
+// screen it came from — a weaker promise than carrying the same columns,
+// and the one that matters.
+//
+// The exports do carry more: each day's averages (scans_averaged,
+// avg_cost_usd, avg_total_tokens) have no column in the daily table. The
+// page shows the averages for the period as a whole instead, and a day's
+// average is over a narrower population than the same row's Cost column —
+// the completed-and-costed runs, not every run that spent — so putting the
+// two side by side invites reading one as the other's mean. The daily table
+// says so under its heading rather than leaving the difference to be found
+// on download.
 type reportData struct {
 	Interval    reportInterval
 	MinSeverity string

--- a/internal/web/reporting_test.go
+++ b/internal/web/reporting_test.go
@@ -3,6 +3,7 @@ package web
 import (
 	"encoding/csv"
 	"encoding/json"
+	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -21,6 +22,17 @@ import (
 // Day sees repo 1 only; week sees repos 1-2; month adds nothing further;
 // all time adds repo 3. Findings carry three different severities so the
 // minimum-severity filter has something to bite on.
+// mustBuildReport fails the test rather than letting a query error return a
+// zeroed report that would then be asserted against as though it were data.
+func mustBuildReport(t *testing.T, s *Server, iv reportInterval, minSeverity string) reportData {
+	t.Helper()
+	data, err := s.buildReport(iv, minSeverity)
+	if err != nil {
+		t.Fatalf("buildReport(%s, %q): %v", iv.Key, minSeverity, err)
+	}
+	return data
+}
+
 func seedReportCorpus(t *testing.T, s *Server) {
 	t.Helper()
 	now := time.Now().UTC()
@@ -141,20 +153,6 @@ func TestResolveMinSeverity(t *testing.T) {
 // minSeverityRank must agree with severityOrder, which ranks the most
 // severe lowest. If these drift, the filter silently selects the wrong end
 // of the scale.
-func TestMinSeverityRankMatchesSeverityOrder(t *testing.T) {
-	critical, ok := minSeverityRank("Critical")
-	if !ok || critical != 0 {
-		t.Fatalf("Critical rank = %d, %v, want 0, true", critical, ok)
-	}
-	low, ok := minSeverityRank("Low")
-	if !ok || low != 3 {
-		t.Fatalf("Low rank = %d, %v, want 3, true", low, ok)
-	}
-	if _, ok := minSeverityRank("nonsense"); ok {
-		t.Error("minSeverityRank accepted a non-severity")
-	}
-}
-
 func TestBuildReportIntervalTotals(t *testing.T) {
 	s, cleanup := newTestServer(t)
 	defer cleanup()
@@ -176,7 +174,7 @@ func TestBuildReportIntervalTotals(t *testing.T) {
 		{"all", 3, 6, 4, 3, 4},
 	} {
 		t.Run(tc.interval, func(t *testing.T) {
-			got := s.buildReport(resolveReportInterval(tc.interval), "")
+			got := mustBuildReport(t, s, resolveReportInterval(tc.interval), "")
 			if got.Totals.ReposScanned != tc.repos {
 				t.Errorf("ReposScanned = %d, want %d", got.Totals.ReposScanned, tc.repos)
 			}
@@ -236,7 +234,7 @@ func TestBuildReportCountsRunsOnTheirOwnClock(t *testing.T) {
 	// Enqueued and never claimed: no timestamps, no activity.
 	mkScan(mkRepo("queued"), db.ScanQueued, 0, nil, nil)
 
-	day := s.buildReport(resolveReportInterval("day"), "")
+	day := mustBuildReport(t, s, resolveReportInterval("day"), "")
 	if day.Totals.ScansStarted != 1 {
 		t.Errorf("day ScansStarted = %d, want 1 (the running run only)", day.Totals.ScansStarted)
 	}
@@ -267,7 +265,7 @@ func TestBuildReportCountsRunsOnTheirOwnClock(t *testing.T) {
 
 	// Widening the window brings the straddler's start in. The queued run
 	// was enqueued inside this window and must still be counted nowhere.
-	week := s.buildReport(resolveReportInterval("week"), "")
+	week := mustBuildReport(t, s, resolveReportInterval("week"), "")
 	if week.Totals.ScansStarted != 2 {
 		t.Errorf("week ScansStarted = %d, want 2", week.Totals.ScansStarted)
 	}
@@ -319,7 +317,7 @@ func TestBuildReportCountsOnlyDoneRunsAsCompleted(t *testing.T) {
 		}
 	}
 
-	got := s.buildReport(resolveReportInterval("day"), "")
+	got := mustBuildReport(t, s, resolveReportInterval("day"), "")
 	if got.Totals.ScansStarted != len(stoppedRuns) {
 		t.Errorf("ScansStarted = %d, want %d", got.Totals.ScansStarted, len(stoppedRuns))
 	}
@@ -364,7 +362,7 @@ func TestBuildReportMinSeverityFiltersFindingsOnly(t *testing.T) {
 		{"High", 2},     // Critical + High
 		{"Critical", 1}, // Critical only
 	} {
-		got := s.buildReport(all, tc.severity)
+		got := mustBuildReport(t, s, all, tc.severity)
 		if got.Totals.Findings != tc.findings {
 			t.Errorf("severity %q: findings = %d, want %d", tc.severity, got.Totals.Findings, tc.findings)
 		}
@@ -380,8 +378,8 @@ func TestBuildReportMinSeverityAppliesToDayRows(t *testing.T) {
 	defer cleanup()
 	seedReportCorpus(t, s)
 
-	unfiltered := s.buildReport(reportIntervals[0], "")
-	filtered := s.buildReport(reportIntervals[0], "Critical")
+	unfiltered := mustBuildReport(t, s, reportIntervals[0], "")
+	filtered := mustBuildReport(t, s, reportIntervals[0], "Critical")
 	sum := func(days []reportDayRow) int {
 		var n int
 		for _, d := range days {
@@ -404,7 +402,7 @@ func TestBuildReportAveragesMatchCostAveragesSQL(t *testing.T) {
 	defer cleanup()
 	seedReportCorpus(t, s)
 
-	got := s.buildReport(reportIntervals[0], "").AllTime
+	got := mustBuildReport(t, s, reportIntervals[0], "").AllTime
 	// (2+4+6+8)/4
 	if got.CostUSD != 5 {
 		t.Errorf("avg cost = %v, want 5", got.CostUSD)
@@ -435,7 +433,7 @@ func TestBuildReportDayAveragesShareThePeriodPopulation(t *testing.T) {
 	defer cleanup()
 	seedReportCorpus(t, s)
 
-	got := s.buildReport(reportIntervals[0], "")
+	got := mustBuildReport(t, s, reportIntervals[0], "")
 	var averaged int
 	var cost float64
 	for _, d := range got.Days {
@@ -454,7 +452,7 @@ func TestBuildReportEmptyCorpus(t *testing.T) {
 	s, cleanup := newTestServer(t)
 	defer cleanup()
 
-	got := s.buildReport(resolveReportInterval("week"), "")
+	got := mustBuildReport(t, s, resolveReportInterval("week"), "")
 	if got.Totals.ScansStarted != 0 || got.AllTime.Runs != 0 || len(got.Days) != 0 {
 		t.Fatalf("empty corpus report = %+v, want zeroed", got)
 	}
@@ -818,7 +816,7 @@ func TestReportTotalsDerivedRatios(t *testing.T) {
 		s, cleanup := newTestServer(t)
 		defer cleanup()
 		seedReportCorpus(t, s)
-		got := s.buildReport(reportIntervals[0], "").Totals
+		got := mustBuildReport(t, s, reportIntervals[0], "").Totals
 		if want := 2.0; got.ScansPerRepo() != want {
 			t.Errorf("ScansPerRepo() = %v, want %v", got.ScansPerRepo(), want)
 		}
@@ -967,4 +965,28 @@ func TestReportingCostAveragesColumnsMatchThePeriod(t *testing.T) {
 			t.Errorf("Week column count = %d, want 1", got)
 		}
 	})
+}
+
+// A failing read must not render as a quiet week. The exports are files an
+// operator archives, so a zeroed report passing as a real one is worse than
+// an error.
+func TestReportingFailsRatherThanReportingZeros(t *testing.T) {
+	for _, path := range []string{"/reporting", "/reporting/report.csv", "/reporting/report.json"} {
+		t.Run(path, func(t *testing.T) {
+			s, cleanup := newTestServer(t)
+			defer cleanup()
+			seedReportCorpus(t, s)
+			if err := s.DB.Exec("DROP TABLE scans").Error; err != nil {
+				t.Fatal(err)
+			}
+			w := httptest.NewRecorder()
+			s.Handler().ServeHTTP(w, localReq("GET", path))
+			if w.Code != http.StatusInternalServerError {
+				t.Errorf("status = %d, want 500; body: %s", w.Code, w.Body)
+			}
+			if strings.Contains(w.Body.String(), "repositories_scanned") {
+				t.Error("a failed read still produced report content")
+			}
+		})
+	}
 }

--- a/internal/web/reporting_test.go
+++ b/internal/web/reporting_test.go
@@ -279,6 +279,74 @@ func TestBuildReportCountsRunsOnTheirOwnClock(t *testing.T) {
 	}
 }
 
+// Every state below stamps finished_at, so reaching the completion count is
+// not the same as belonging in it. The guard on db.ScanDone is what tells
+// them apart, and it reads as redundant next to the finished_at check that
+// selects the row — it is not, and this test says so out loud rather than
+// leaving a reviewer to infer it from an arithmetic shift elsewhere.
+//
+// The paused row is the clearest case: it has not finished at all. Counting
+// it would report a completion now and another when the run actually
+// finishes after resuming.
+func TestBuildReportCountsOnlyDoneRunsAsCompleted(t *testing.T) {
+	s, cleanup := newTestServer(t)
+	defer cleanup()
+	now := time.Now().UTC()
+
+	repo := db.Repository{URL: "https://example.test/stopped", Name: "stopped", FullName: "acme/stopped"}
+	if err := s.DB.Create(&repo).Error; err != nil {
+		t.Fatal(err)
+	}
+	started, stopped := now.Add(-2*time.Hour), now.Add(-time.Hour)
+	stoppedRuns := []struct {
+		status db.ScanStatus
+		cost   float64
+	}{
+		{db.ScanDone, 2.00},
+		{db.ScanFailed, 1.00},
+		{db.ScanCancelled, 3.00},
+		{db.ScanSkipped, 4.00},
+		{db.ScanPaused, 5.00},
+	}
+	for _, run := range stoppedRuns {
+		sc := db.Scan{
+			RepositoryID: repo.ID, Kind: "skill", Status: run.status, SkillName: "vuln-scan",
+			CostUSD: run.cost, InputTokens: 100,
+			StartedAt: &started, FinishedAt: &stopped, CreatedAt: started,
+		}
+		if err := s.DB.Create(&sc).Error; err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	got := s.buildReport(resolveReportInterval("day"), "")
+	if got.Totals.ScansStarted != len(stoppedRuns) {
+		t.Errorf("ScansStarted = %d, want %d", got.Totals.ScansStarted, len(stoppedRuns))
+	}
+	if got.Totals.ScansCompleted != 1 {
+		t.Errorf("ScansCompleted = %d, want 1: only the done run completed, but every row here "+
+			"carries a finished_at and so reaches the count", got.Totals.ScansCompleted)
+	}
+
+	// Spend is accumulated after the completion guard, so the full total
+	// proves all five rows passed the finished_at check and arrived at it.
+	// Without that guard every one of them would have been a completion.
+	var spend float64
+	for _, d := range got.Days {
+		spend += d.CostUSD
+	}
+	if want := 15.00; spend != want {
+		t.Errorf("attributed spend = %v, want %v; every stopped run should reach the guard", spend, want)
+	}
+
+	// And the averages population stays the completed-and-costed scans
+	// docs/cost_averages.sql defines, so the two figures on the page agree
+	// on what "completed" means.
+	if got.Period.Runs != 1 || got.Period.CostUSD != 2 {
+		t.Errorf("averages = %d runs at %v, want 1 at 2", got.Period.Runs, got.Period.CostUSD)
+	}
+}
+
 // The severity floor must filter findings and leave scan activity alone.
 func TestBuildReportMinSeverityFiltersFindingsOnly(t *testing.T) {
 	s, cleanup := newTestServer(t)

--- a/internal/web/reporting_test.go
+++ b/internal/web/reporting_test.go
@@ -1,0 +1,347 @@
+package web
+
+import (
+	"encoding/csv"
+	"encoding/json"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"scrutineer/internal/db"
+)
+
+// seedReportCorpus lays down scans and findings either side of the rolling
+// window boundaries so each interval selects a known subset:
+//
+//	repo 1: one costed scan 2h ago, one costed scan 3 days ago
+//	repo 2: one costed scan 10 days ago
+//	repo 3: one costed scan 100 days ago, plus a failed and a queued scan
+//
+// Day sees repo 1 only; week sees repos 1-2; month adds nothing further;
+// all time adds repo 3.
+func seedReportCorpus(t *testing.T, s *Server) {
+	t.Helper()
+	now := time.Now().UTC()
+	mkRepo := func(name string) db.Repository {
+		repo := db.Repository{URL: "https://example.test/" + name, Name: name, FullName: "acme/" + name}
+		if err := s.DB.Create(&repo).Error; err != nil {
+			t.Fatal(err)
+		}
+		return repo
+	}
+	r1, r2, r3 := mkRepo("one"), mkRepo("two"), mkRepo("three")
+
+	mkScan := func(repo db.Repository, status db.ScanStatus, cost float64, in, out, cr, cw int, ago time.Duration) db.Scan {
+		at := now.Add(-ago)
+		sc := db.Scan{
+			RepositoryID: repo.ID, Kind: "skill", Status: status, SkillName: "vuln-scan",
+			CostUSD: cost, InputTokens: in, OutputTokens: out,
+			CacheReadTokens: cr, CacheWriteTokens: cw,
+			FinishedAt: &at, CreatedAt: at,
+		}
+		if err := s.DB.Create(&sc).Error; err != nil {
+			t.Fatal(err)
+		}
+		return sc
+	}
+
+	inWindow := mkScan(r1, db.ScanDone, 2.00, 100, 10, 1000, 50, 2*time.Hour)
+	mkScan(r1, db.ScanDone, 4.00, 300, 30, 3000, 150, 3*reportDay)
+	mkScan(r2, db.ScanDone, 6.00, 200, 20, 2000, 100, 10*reportDay)
+	mkScan(r3, db.ScanDone, 8.00, 400, 40, 4000, 200, 100*reportDay)
+	// Failed and queued rows are activity but not costed scans, so they
+	// move the scan totals without touching the averages.
+	mkScan(r3, db.ScanFailed, 1.00, 10, 1, 10, 1, time.Hour)
+	mkScan(r3, db.ScanQueued, 0, 0, 0, 0, 0, time.Hour)
+
+	recent := now.Add(-2 * time.Hour)
+	old := now.Add(-100 * reportDay)
+	for _, at := range []time.Time{recent, recent, old} {
+		f := db.Finding{
+			RepositoryID: r1.ID, ScanID: inWindow.ID, Title: "x",
+			Severity: "Low", CreatedAt: at,
+		}
+		if err := s.DB.Create(&f).Error; err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func TestResolveReportInterval(t *testing.T) {
+	for _, tc := range []struct {
+		key  string
+		want string
+		dur  time.Duration
+	}{
+		{"day", "day", reportDay},
+		{"week", "week", reportWeek},
+		{"month", "month", reportMonth},
+		{"all", "all", 0},
+		{"", "all", 0},
+		{"fortnight", "all", 0},
+	} {
+		got := resolveReportInterval(tc.key)
+		if got.Key != tc.want || got.Dur != tc.dur {
+			t.Errorf("resolveReportInterval(%q) = %q/%v, want %q/%v", tc.key, got.Key, got.Dur, tc.want, tc.dur)
+		}
+	}
+}
+
+func TestBuildReportIntervalTotals(t *testing.T) {
+	s, cleanup := newTestServer(t)
+	defer cleanup()
+	seedReportCorpus(t, s)
+
+	for _, tc := range []struct {
+		interval                                     string
+		repos, scans, done, findings, costedInWindow int
+	}{
+		// Day: repo 1's 2h scan, plus repo 3's failed and queued rows.
+		{"day", 2, 3, 1, 2, 1},
+		// Week: adds repo 1's 3-day scan and repo 2's 10-day scan is out.
+		{"week", 2, 4, 2, 2, 2},
+		// Month: adds repo 2's 10-day scan.
+		{"month", 3, 5, 3, 2, 3},
+		// All time: adds repo 3's 100-day scan and the old finding.
+		{"all", 3, 6, 4, 3, 4},
+	} {
+		t.Run(tc.interval, func(t *testing.T) {
+			got := s.buildReport(resolveReportInterval(tc.interval))
+			if got.Totals.ReposScanned != tc.repos {
+				t.Errorf("ReposScanned = %d, want %d", got.Totals.ReposScanned, tc.repos)
+			}
+			if got.Totals.Scans != tc.scans {
+				t.Errorf("Scans = %d, want %d", got.Totals.Scans, tc.scans)
+			}
+			if got.Totals.ScansDone != tc.done {
+				t.Errorf("ScansDone = %d, want %d", got.Totals.ScansDone, tc.done)
+			}
+			if got.Totals.Findings != tc.findings {
+				t.Errorf("Findings = %d, want %d", got.Totals.Findings, tc.findings)
+			}
+			if got.Window.Runs != tc.costedInWindow {
+				t.Errorf("Window.Runs = %d, want %d", got.Window.Runs, tc.costedInWindow)
+			}
+			// The all-time column never moves with the selector.
+			if got.AllTime.Runs != 4 {
+				t.Errorf("AllTime.Runs = %d, want 4", got.AllTime.Runs)
+			}
+		})
+	}
+}
+
+// The averages must reproduce docs/cost_averages.sql: mean over completed
+// scans with a positive cost, so the failed and queued rows stay out.
+func TestBuildReportAveragesMatchCostAveragesSQL(t *testing.T) {
+	s, cleanup := newTestServer(t)
+	defer cleanup()
+	seedReportCorpus(t, s)
+
+	got := s.buildReport(resolveReportInterval("all")).AllTime
+	// (2+4+6+8)/4
+	if got.CostUSD != 5 {
+		t.Errorf("avg cost = %v, want 5", got.CostUSD)
+	}
+	// (100+300+200+400)/4
+	if got.InputTokens != 250 {
+		t.Errorf("avg input = %v, want 250", got.InputTokens)
+	}
+	if got.OutputTokens != 25 {
+		t.Errorf("avg output = %v, want 25", got.OutputTokens)
+	}
+	if got.CacheReadTokens != 2500 {
+		t.Errorf("avg cache read = %v, want 2500", got.CacheReadTokens)
+	}
+	if got.CacheWriteTokens != 125 {
+		t.Errorf("avg cache write = %v, want 125", got.CacheWriteTokens)
+	}
+	if got.TotalTokens != 2900 {
+		t.Errorf("avg total = %v, want 2900", got.TotalTokens)
+	}
+}
+
+func TestBuildReportEmptyCorpus(t *testing.T) {
+	s, cleanup := newTestServer(t)
+	defer cleanup()
+
+	got := s.buildReport(resolveReportInterval("week"))
+	if got.Totals.Scans != 0 || got.AllTime.Runs != 0 || len(got.Days) != 0 {
+		t.Fatalf("empty corpus report = %+v, want zeroed", got)
+	}
+	// A zero denominator must not produce NaN in the rendered averages.
+	if got.AllTime.CostUSD != 0 || got.AllTime.TotalTokens != 0 {
+		t.Errorf("averages over no runs = %+v, want zeros", got.AllTime)
+	}
+}
+
+func TestReportingPageRenders(t *testing.T) {
+	s, cleanup := newTestServer(t)
+	defer cleanup()
+	seedReportCorpus(t, s)
+
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq("GET", "/reporting?interval=week"))
+	if w.Code != 200 {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+	body := w.Body.String()
+	for _, want := range []string{
+		"Reporting",
+		"Repositories scanned",
+		"Cost averages",
+		"Daily breakdown",
+		"/reporting/report.csv?interval=week",
+		"/reporting/report.json?interval=week",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("body missing %q", want)
+		}
+	}
+	// The sidebar entry is present and marked current on this page.
+	if !strings.Contains(body, `href="/reporting" aria-current="page"`) {
+		t.Error("sidebar Reporting entry not marked current")
+	}
+}
+
+func TestReportingNavKey(t *testing.T) {
+	if got := navKey("/reporting"); got != "reporting" {
+		t.Errorf("navKey(/reporting) = %q, want reporting", got)
+	}
+	// The neighbouring repository routes must not be captured by the new prefix.
+	if got := navKey("/repositories/1"); got != "repos" {
+		t.Errorf("navKey(/repositories/1) = %q, want repos", got)
+	}
+}
+
+func TestReportingCSVExport(t *testing.T) {
+	s, cleanup := newTestServer(t)
+	defer cleanup()
+	seedReportCorpus(t, s)
+
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq("GET", "/reporting/report.csv?interval=week"))
+	if w.Code != 200 {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+	if ct := w.Header().Get("Content-Type"); !strings.HasPrefix(ct, "text/csv") {
+		t.Errorf("Content-Type = %q, want text/csv", ct)
+	}
+	if cd := w.Header().Get("Content-Disposition"); !strings.Contains(cd, "attachment") ||
+		!strings.Contains(cd, "scrutineer-report-week-") || !strings.Contains(cd, ".csv") {
+		t.Errorf("Content-Disposition = %q", cd)
+	}
+
+	blocks := strings.SplitN(strings.TrimRight(w.Body.String(), "\n"), "\n\n", 2)
+	if len(blocks) != 2 {
+		t.Fatalf("expected a summary block and a daily block, got %d:\n%s", len(blocks), w.Body.String())
+	}
+
+	summary := map[string]string{}
+	rows, err := csv.NewReader(strings.NewReader(blocks[0])).ReadAll()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rows[0][0] != "metric" || rows[0][1] != "value" {
+		t.Fatalf("summary header = %v", rows[0])
+	}
+	for _, row := range rows[1:] {
+		summary[row[0]] = row[1]
+	}
+	for key, want := range map[string]string{
+		"interval":                 "week",
+		"repos_scanned":            "2",
+		"scans":                    "4",
+		"scans_done":               "2",
+		"findings":                 "2",
+		"window_scans_costed":      "2",
+		"window_avg_cost_usd":      "3.00",
+		"alltime_scans_costed":     "4",
+		"alltime_avg_cost_usd":     "5.00",
+		"alltime_avg_total_tokens": "2900.00",
+	} {
+		if summary[key] != want {
+			t.Errorf("summary[%q] = %q, want %q", key, summary[key], want)
+		}
+	}
+	if summary["window_start"] == "" {
+		t.Error("bounded interval should record a window_start")
+	}
+
+	daily, err := csv.NewReader(strings.NewReader(blocks[1])).ReadAll()
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantHeader := []string{"date", "repos_scanned", "scans", "findings", "cost_usd", "total_tokens"}
+	if strings.Join(daily[0], ",") != strings.Join(wantHeader, ",") {
+		t.Fatalf("daily header = %v, want %v", daily[0], wantHeader)
+	}
+	if len(daily) < 2 {
+		t.Fatal("daily block has no rows")
+	}
+	// Newest day first.
+	for i := 2; i < len(daily); i++ {
+		if daily[i-1][0] < daily[i][0] {
+			t.Fatalf("daily rows not sorted newest first: %v then %v", daily[i-1][0], daily[i][0])
+		}
+	}
+}
+
+func TestReportingJSONExport(t *testing.T) {
+	s, cleanup := newTestServer(t)
+	defer cleanup()
+	seedReportCorpus(t, s)
+
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq("GET", "/reporting/report.json?interval=all"))
+	if w.Code != 200 {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+	if cd := w.Header().Get("Content-Disposition"); !strings.Contains(cd, "scrutineer-report-all-") {
+		t.Errorf("Content-Disposition = %q", cd)
+	}
+
+	var out struct {
+		Interval    string  `json:"interval"`
+		WindowStart *string `json:"window_start"`
+		Totals      struct {
+			ReposScanned int `json:"repos_scanned"`
+			Scans        int `json:"scans"`
+			ScansDone    int `json:"scans_done"`
+			Findings     int `json:"findings"`
+		} `json:"totals"`
+		Averages struct {
+			Window  map[string]float64 `json:"window"`
+			AllTime map[string]float64 `json:"all_time"`
+		} `json:"averages"`
+		Days []struct {
+			Date        string  `json:"date"`
+			Scans       int     `json:"scans"`
+			CostUSD     float64 `json:"cost_usd"`
+			TotalTokens int     `json:"total_tokens"`
+		} `json:"days"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &out); err != nil {
+		t.Fatalf("decode: %v\n%s", err, w.Body)
+	}
+	if out.Interval != "all" {
+		t.Errorf("interval = %q, want all", out.Interval)
+	}
+	if out.WindowStart != nil {
+		t.Errorf("window_start = %v, want null for all time", *out.WindowStart)
+	}
+	if out.Totals.ReposScanned != 3 || out.Totals.Scans != 6 || out.Totals.ScansDone != 4 || out.Totals.Findings != 3 {
+		t.Errorf("totals = %+v", out.Totals)
+	}
+	if out.Averages.AllTime["avg_cost_usd"] != 5 {
+		t.Errorf("all_time avg_cost_usd = %v, want 5", out.Averages.AllTime["avg_cost_usd"])
+	}
+	// All time makes both columns the same population.
+	if out.Averages.Window["avg_total_tokens"] != out.Averages.AllTime["avg_total_tokens"] {
+		t.Errorf("window and all-time should agree over the all-time interval: %v vs %v",
+			out.Averages.Window["avg_total_tokens"], out.Averages.AllTime["avg_total_tokens"])
+	}
+	if len(out.Days) == 0 {
+		t.Fatal("days is empty")
+	}
+}

--- a/internal/web/reporting_test.go
+++ b/internal/web/reporting_test.go
@@ -33,13 +33,19 @@ func seedReportCorpus(t *testing.T, s *Server) {
 	}
 	r1, r2, r3 := mkRepo("one"), mkRepo("two"), mkRepo("three")
 
+	// mkScan seeds a terminal run that finished `ago` before now, having
+	// started a few minutes earlier so both ends land in the same window.
+	// created_at sits before the start, as an enqueue always does, so any
+	// code reaching for it instead of started_at buckets the row wrong.
+	const ranFor = 5 * time.Minute
 	mkScan := func(repo db.Repository, status db.ScanStatus, cost float64, in, out, cr, cw int, ago time.Duration) db.Scan {
-		at := now.Add(-ago)
+		finished := now.Add(-ago)
+		started := finished.Add(-ranFor)
 		sc := db.Scan{
 			RepositoryID: repo.ID, Kind: "skill", Status: status, SkillName: "vuln-scan",
 			CostUSD: cost, InputTokens: in, OutputTokens: out,
 			CacheReadTokens: cr, CacheWriteTokens: cw,
-			FinishedAt: &at, CreatedAt: at,
+			StartedAt: &started, FinishedAt: &finished, CreatedAt: started.Add(-time.Minute),
 		}
 		if err := s.DB.Create(&sc).Error; err != nil {
 			t.Fatal(err)
@@ -51,10 +57,28 @@ func seedReportCorpus(t *testing.T, s *Server) {
 	mkScan(r1, db.ScanDone, 4.00, 300, 30, 3000, 150, 3*reportDay)
 	mkScan(r2, db.ScanDone, 6.00, 200, 20, 2000, 100, 10*reportDay)
 	mkScan(r3, db.ScanDone, 8.00, 400, 40, 4000, 200, 100*reportDay)
-	// Failed and queued rows are activity but not costed scans, so they
-	// move the scan totals without touching the averages.
+	// A failed run is a start and a spend but never a completion, so it
+	// moves the scan totals without touching the averages.
 	mkScan(r3, db.ScanFailed, 1.00, 10, 1, 10, 1, time.Hour)
-	mkScan(r3, db.ScanQueued, 0, 0, 0, 0, 0, time.Hour)
+
+	// A queued run has neither timestamp: it is enqueued work, not scan
+	// activity, and must be counted in no window. A running one has only a
+	// start, and is counted as one.
+	mkPending := func(repo db.Repository, status db.ScanStatus, startedAgo time.Duration) {
+		sc := db.Scan{
+			RepositoryID: repo.ID, Kind: "skill", Status: status, SkillName: "vuln-scan",
+			CreatedAt: now.Add(-time.Hour),
+		}
+		if startedAgo > 0 {
+			started := now.Add(-startedAgo)
+			sc.StartedAt = &started
+		}
+		if err := s.DB.Create(&sc).Error; err != nil {
+			t.Fatal(err)
+		}
+	}
+	mkPending(r3, db.ScanQueued, 0)
+	mkPending(r2, db.ScanRunning, 30*time.Minute)
 
 	recent := now.Add(-2 * time.Hour)
 	old := now.Add(-100 * reportDay)
@@ -137,16 +161,18 @@ func TestBuildReportIntervalTotals(t *testing.T) {
 	seedReportCorpus(t, s)
 
 	for _, tc := range []struct {
-		interval                                     string
-		repos, scans, done, findings, costedInWindow int
+		interval                                       string
+		repos, started, done, findings, costedInWindow int
 	}{
-		// Day: repo 1's 2h scan, plus repo 3's failed and queued rows.
-		{"day", 2, 3, 1, 2, 1},
-		// Week: adds repo 1's 3-day scan; repo 2's 10-day scan is out.
-		{"week", 2, 4, 2, 2, 2},
-		// Month: adds repo 2's 10-day scan.
+		// Day: repo 1's 2h run, repo 3's failed run and repo 2's running
+		// one all started inside it; only repo 1's reached done. The queued
+		// row is not activity and is counted nowhere.
+		{"day", 3, 3, 1, 2, 1},
+		// Week: adds repo 1's 3-day run; repo 2's 10-day one is out.
+		{"week", 3, 4, 2, 2, 2},
+		// Month: adds repo 2's 10-day run.
 		{"month", 3, 5, 3, 2, 3},
-		// All time: adds repo 3's 100-day scan and the old finding.
+		// All time: adds repo 3's 100-day run and the old finding.
 		{"all", 3, 6, 4, 3, 4},
 	} {
 		t.Run(tc.interval, func(t *testing.T) {
@@ -154,11 +180,11 @@ func TestBuildReportIntervalTotals(t *testing.T) {
 			if got.Totals.ReposScanned != tc.repos {
 				t.Errorf("ReposScanned = %d, want %d", got.Totals.ReposScanned, tc.repos)
 			}
-			if got.Totals.Scans != tc.scans {
-				t.Errorf("Scans = %d, want %d", got.Totals.Scans, tc.scans)
+			if got.Totals.ScansStarted != tc.started {
+				t.Errorf("ScansStarted = %d, want %d", got.Totals.ScansStarted, tc.started)
 			}
-			if got.Totals.ScansDone != tc.done {
-				t.Errorf("ScansDone = %d, want %d", got.Totals.ScansDone, tc.done)
+			if got.Totals.ScansCompleted != tc.done {
+				t.Errorf("ScansCompleted = %d, want %d", got.Totals.ScansCompleted, tc.done)
 			}
 			if got.Totals.Findings != tc.findings {
 				t.Errorf("Findings = %d, want %d", got.Totals.Findings, tc.findings)
@@ -171,6 +197,85 @@ func TestBuildReportIntervalTotals(t *testing.T) {
 				t.Errorf("AllTime.Runs = %d, want 4", got.AllTime.Runs)
 			}
 		})
+	}
+}
+
+// A start is read from started_at and a completion from finished_at, so a
+// run spanning a window boundary belongs to two different periods and a run
+// still on the queue belongs to none. created_at is only the enqueue time
+// and must not stand in for either.
+func TestBuildReportCountsRunsOnTheirOwnClock(t *testing.T) {
+	s, cleanup := newTestServer(t)
+	defer cleanup()
+	now := time.Now().UTC()
+
+	mkRepo := func(name string) db.Repository {
+		repo := db.Repository{URL: "https://example.test/" + name, Name: name, FullName: "acme/" + name}
+		if err := s.DB.Create(&repo).Error; err != nil {
+			t.Fatal(err)
+		}
+		return repo
+	}
+	mkScan := func(repo db.Repository, status db.ScanStatus, cost float64, started, finished *time.Time) {
+		sc := db.Scan{
+			RepositoryID: repo.ID, Kind: "skill", Status: status, SkillName: "vuln-scan",
+			CostUSD: cost, StartedAt: started, FinishedAt: finished,
+			// Enqueued 40 hours ago: outside the day window but inside the
+			// week, so counting rows by created_at would show up here.
+			CreatedAt: now.Add(-40 * time.Hour),
+		}
+		if err := s.DB.Create(&sc).Error; err != nil {
+			t.Fatal(err)
+		}
+	}
+	began, ended, running := now.Add(-30*time.Hour), now.Add(-2*time.Hour), now.Add(-30*time.Minute)
+	// Began before the day window and finished inside it.
+	mkScan(mkRepo("straddler"), db.ScanDone, 3.00, &began, &ended)
+	// Began inside the day window and has not finished.
+	mkScan(mkRepo("inflight"), db.ScanRunning, 0, &running, nil)
+	// Enqueued and never claimed: no timestamps, no activity.
+	mkScan(mkRepo("queued"), db.ScanQueued, 0, nil, nil)
+
+	day := s.buildReport(resolveReportInterval("day"), "")
+	if day.Totals.ScansStarted != 1 {
+		t.Errorf("day ScansStarted = %d, want 1 (the running run only)", day.Totals.ScansStarted)
+	}
+	if day.Totals.ScansCompleted != 1 {
+		t.Errorf("day ScansCompleted = %d, want 1 (the straddler only)", day.Totals.ScansCompleted)
+	}
+	// Both repositories saw activity in the window even though neither had a
+	// whole run inside it; the queued repository saw none.
+	if day.Totals.ReposScanned != 2 {
+		t.Errorf("day ReposScanned = %d, want 2", day.Totals.ReposScanned)
+	}
+	// Starts can trail the repository count once completions bring their own
+	// repositories in, so the fan-out ratio is allowed below one.
+	if got := day.Totals.ScansPerRepo(); got != 0.5 {
+		t.Errorf("day ScansPerRepo() = %v, want 0.5", got)
+	}
+	// The averages window is bounded on finished_at, the same clock the
+	// completion count uses, so the straddler is inside it.
+	if day.Period.Runs != 1 || day.Period.CostUSD != 3 {
+		t.Errorf("day averages = %d runs at %v, want 1 at 3", day.Period.Runs, day.Period.CostUSD)
+	}
+	// Its spend lands on the day it finished, not the day it began.
+	for _, d := range day.Days {
+		if d.Date == ended.Format(reportDateLayout) && d.CostUSD != 3 {
+			t.Errorf("finish day %s cost = %v, want 3", d.Date, d.CostUSD)
+		}
+	}
+
+	// Widening the window brings the straddler's start in. The queued run
+	// was enqueued inside this window and must still be counted nowhere.
+	week := s.buildReport(resolveReportInterval("week"), "")
+	if week.Totals.ScansStarted != 2 {
+		t.Errorf("week ScansStarted = %d, want 2", week.Totals.ScansStarted)
+	}
+	if week.Totals.ScansCompleted != 1 {
+		t.Errorf("week ScansCompleted = %d, want 1", week.Totals.ScansCompleted)
+	}
+	if week.Totals.ReposScanned != 2 {
+		t.Errorf("week ReposScanned = %d, want 2; the queued repository has no activity", week.Totals.ReposScanned)
 	}
 }
 
@@ -196,7 +301,7 @@ func TestBuildReportMinSeverityFiltersFindingsOnly(t *testing.T) {
 			t.Errorf("severity %q: findings = %d, want %d", tc.severity, got.Totals.Findings, tc.findings)
 		}
 		// Scan-side numbers are a property of scans, not findings.
-		if got.Totals.Scans != 6 || got.Totals.ScansDone != 4 || got.AllTime.Runs != 4 {
+		if got.Totals.ScansStarted != 6 || got.Totals.ScansCompleted != 4 || got.AllTime.Runs != 4 {
 			t.Errorf("severity %q moved scan totals: %+v", tc.severity, got.Totals)
 		}
 	}
@@ -282,7 +387,7 @@ func TestBuildReportEmptyCorpus(t *testing.T) {
 	defer cleanup()
 
 	got := s.buildReport(resolveReportInterval("week"), "")
-	if got.Totals.Scans != 0 || got.AllTime.Runs != 0 || len(got.Days) != 0 {
+	if got.Totals.ScansStarted != 0 || got.AllTime.Runs != 0 || len(got.Days) != 0 {
 		t.Fatalf("empty corpus report = %+v, want zeroed", got)
 	}
 	// A zero denominator must not produce NaN in the rendered averages.
@@ -309,10 +414,11 @@ func TestReportingPageRenders(t *testing.T) {
 		"Daily breakdown",
 		"Minimum severity",
 		// The scan tiles name their unit and show why the count outruns
-		// the repository count.
-		"Scan runs",
+		// the repository count, and each names the clock it is read on.
+		"Scan runs started",
+		"Scan runs completed",
 		"per repository",
-		"of runs",
+		"of runs started",
 		"/reporting/report.csv?interval=week",
 		"/reporting/report.json?interval=week",
 	} {
@@ -330,6 +436,14 @@ func TestReportingPageRenders(t *testing.T) {
 	}
 	if !strings.Contains(body, `href="/reporting" aria-current="page"`) {
 		t.Error("sidebar Reporting entry not marked current")
+	}
+	// The page must invoke the shared foot: it closes the <main> wrapper
+	// "head" opened and carries the dialogs and the #toaster that flash
+	// messages and htmx OOB toasts land in.
+	for _, want := range []string{`id="toaster"`, "</main>", "</body>", "</html>"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("page never reaches the shared foot: missing %q", want)
+		}
 	}
 }
 
@@ -423,7 +537,7 @@ func TestReportingCSVIsOneRectangularTable(t *testing.T) {
 		t.Fatal("no period_total row")
 	}
 	// repositories_scanned, scans_started, scans_completed, findings
-	if total[4] != "2" || total[5] != "4" || total[6] != "2" || total[7] != "2" {
+	if total[4] != "3" || total[5] != "4" || total[6] != "2" || total[7] != "2" {
 		t.Errorf("period_total activity = %v", total[4:8])
 	}
 	if total[11] != "3.00" {
@@ -619,7 +733,7 @@ func TestReportTotalsDerivedRatios(t *testing.T) {
 	})
 
 	t.Run("fan-out ratio", func(t *testing.T) {
-		totals := reportTotals{ReposScanned: 49, Scans: 510, ScansDone: 321}
+		totals := reportTotals{ReposScanned: 49, ScansStarted: 510, ScansCompleted: 321}
 		if got := totals.ScansPerRepo(); got < 10.4 || got > 10.5 {
 			t.Errorf("ScansPerRepo() = %v, want ~10.41", got)
 		}
@@ -628,15 +742,17 @@ func TestReportTotalsDerivedRatios(t *testing.T) {
 		}
 	})
 
-	// Scans >= ReposScanned always holds, since ReposScanned counts distinct
-	// repositories among the very scans being counted.
-	t.Run("ratio never drops below one for a non-empty corpus", func(t *testing.T) {
+	// Over all time the corpus\'s six started runs span three repositories.
+	// The ratio can fall below one in a narrow window — see
+	// TestBuildReportCountsRunsOnTheirOwnClock — which is why the tile
+	// renders it to one decimal.
+	t.Run("fan-out over the seeded corpus", func(t *testing.T) {
 		s, cleanup := newTestServer(t)
 		defer cleanup()
 		seedReportCorpus(t, s)
 		got := s.buildReport(reportIntervals[0], "").Totals
-		if got.ScansPerRepo() < 1 {
-			t.Errorf("ScansPerRepo() = %v, want >= 1", got.ScansPerRepo())
+		if want := 2.0; got.ScansPerRepo() != want {
+			t.Errorf("ScansPerRepo() = %v, want %v", got.ScansPerRepo(), want)
 		}
 	})
 }

--- a/internal/web/reporting_test.go
+++ b/internal/web/reporting_test.go
@@ -19,7 +19,8 @@ import (
 //	repo 3: one costed scan 100 days ago, plus a failed and a queued scan
 //
 // Day sees repo 1 only; week sees repos 1-2; month adds nothing further;
-// all time adds repo 3.
+// all time adds repo 3. Findings carry three different severities so the
+// minimum-severity filter has something to bite on.
 func seedReportCorpus(t *testing.T, s *Server) {
 	t.Helper()
 	now := time.Now().UTC()
@@ -57,12 +58,19 @@ func seedReportCorpus(t *testing.T, s *Server) {
 
 	recent := now.Add(-2 * time.Hour)
 	old := now.Add(-100 * reportDay)
-	for _, at := range []time.Time{recent, recent, old} {
-		f := db.Finding{
+	for _, f := range []struct {
+		severity string
+		at       time.Time
+	}{
+		{"Critical", recent},
+		{"Low", recent},
+		{"High", old},
+	} {
+		row := db.Finding{
 			RepositoryID: r1.ID, ScanID: inWindow.ID, Title: "x",
-			Severity: "Low", CreatedAt: at,
+			Severity: f.severity, CreatedAt: f.at,
 		}
-		if err := s.DB.Create(&f).Error; err != nil {
+		if err := s.DB.Create(&row).Error; err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -88,6 +96,41 @@ func TestResolveReportInterval(t *testing.T) {
 	}
 }
 
+func TestResolveMinSeverity(t *testing.T) {
+	for _, tc := range []struct{ in, want string }{
+		{"Critical", "Critical"},
+		{"critical", "Critical"},
+		{"CRITICAL", "Critical"},
+		{"MODERATE", "Medium"},
+		{"Low", "Low"},
+		{"", ""},
+		{"catastrophic", ""},
+		// Not a severity: must not leak through as a filter value.
+		{"'; DROP TABLE findings; --", ""},
+	} {
+		if got := resolveMinSeverity(tc.in); got != tc.want {
+			t.Errorf("resolveMinSeverity(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// minSeverityRank must agree with severityOrder, which ranks the most
+// severe lowest. If these drift, the filter silently selects the wrong end
+// of the scale.
+func TestMinSeverityRankMatchesSeverityOrder(t *testing.T) {
+	critical, ok := minSeverityRank("Critical")
+	if !ok || critical != 0 {
+		t.Fatalf("Critical rank = %d, %v, want 0, true", critical, ok)
+	}
+	low, ok := minSeverityRank("Low")
+	if !ok || low != 3 {
+		t.Fatalf("Low rank = %d, %v, want 3, true", low, ok)
+	}
+	if _, ok := minSeverityRank("nonsense"); ok {
+		t.Error("minSeverityRank accepted a non-severity")
+	}
+}
+
 func TestBuildReportIntervalTotals(t *testing.T) {
 	s, cleanup := newTestServer(t)
 	defer cleanup()
@@ -99,7 +142,7 @@ func TestBuildReportIntervalTotals(t *testing.T) {
 	}{
 		// Day: repo 1's 2h scan, plus repo 3's failed and queued rows.
 		{"day", 2, 3, 1, 2, 1},
-		// Week: adds repo 1's 3-day scan and repo 2's 10-day scan is out.
+		// Week: adds repo 1's 3-day scan; repo 2's 10-day scan is out.
 		{"week", 2, 4, 2, 2, 2},
 		// Month: adds repo 2's 10-day scan.
 		{"month", 3, 5, 3, 2, 3},
@@ -107,7 +150,7 @@ func TestBuildReportIntervalTotals(t *testing.T) {
 		{"all", 3, 6, 4, 3, 4},
 	} {
 		t.Run(tc.interval, func(t *testing.T) {
-			got := s.buildReport(resolveReportInterval(tc.interval))
+			got := s.buildReport(resolveReportInterval(tc.interval), "")
 			if got.Totals.ReposScanned != tc.repos {
 				t.Errorf("ReposScanned = %d, want %d", got.Totals.ReposScanned, tc.repos)
 			}
@@ -120,14 +163,64 @@ func TestBuildReportIntervalTotals(t *testing.T) {
 			if got.Totals.Findings != tc.findings {
 				t.Errorf("Findings = %d, want %d", got.Totals.Findings, tc.findings)
 			}
-			if got.Window.Runs != tc.costedInWindow {
-				t.Errorf("Window.Runs = %d, want %d", got.Window.Runs, tc.costedInWindow)
+			if got.Period.Runs != tc.costedInWindow {
+				t.Errorf("Period.Runs = %d, want %d", got.Period.Runs, tc.costedInWindow)
 			}
 			// The all-time column never moves with the selector.
 			if got.AllTime.Runs != 4 {
 				t.Errorf("AllTime.Runs = %d, want 4", got.AllTime.Runs)
 			}
 		})
+	}
+}
+
+// The severity floor must filter findings and leave scan activity alone.
+func TestBuildReportMinSeverityFiltersFindingsOnly(t *testing.T) {
+	s, cleanup := newTestServer(t)
+	defer cleanup()
+	seedReportCorpus(t, s)
+
+	all := reportIntervals[0]
+	for _, tc := range []struct {
+		severity string
+		findings int
+	}{
+		{"", 3},         // Critical + Low + High
+		{"Low", 3},      // the floor admits everything
+		{"Medium", 2},   // drops Low
+		{"High", 2},     // Critical + High
+		{"Critical", 1}, // Critical only
+	} {
+		got := s.buildReport(all, tc.severity)
+		if got.Totals.Findings != tc.findings {
+			t.Errorf("severity %q: findings = %d, want %d", tc.severity, got.Totals.Findings, tc.findings)
+		}
+		// Scan-side numbers are a property of scans, not findings.
+		if got.Totals.Scans != 6 || got.Totals.ScansDone != 4 || got.AllTime.Runs != 4 {
+			t.Errorf("severity %q moved scan totals: %+v", tc.severity, got.Totals)
+		}
+	}
+}
+
+func TestBuildReportMinSeverityAppliesToDayRows(t *testing.T) {
+	s, cleanup := newTestServer(t)
+	defer cleanup()
+	seedReportCorpus(t, s)
+
+	unfiltered := s.buildReport(reportIntervals[0], "")
+	filtered := s.buildReport(reportIntervals[0], "Critical")
+	sum := func(days []reportDayRow) int {
+		var n int
+		for _, d := range days {
+			n += d.Findings
+		}
+		return n
+	}
+	if got := sum(unfiltered.Days); got != 3 {
+		t.Errorf("unfiltered day findings = %d, want 3", got)
+	}
+	if got := sum(filtered.Days); got != 1 {
+		t.Errorf("Critical-only day findings = %d, want 1", got)
 	}
 }
 
@@ -138,7 +231,7 @@ func TestBuildReportAveragesMatchCostAveragesSQL(t *testing.T) {
 	defer cleanup()
 	seedReportCorpus(t, s)
 
-	got := s.buildReport(resolveReportInterval("all")).AllTime
+	got := s.buildReport(reportIntervals[0], "").AllTime
 	// (2+4+6+8)/4
 	if got.CostUSD != 5 {
 		t.Errorf("avg cost = %v, want 5", got.CostUSD)
@@ -161,11 +254,34 @@ func TestBuildReportAveragesMatchCostAveragesSQL(t *testing.T) {
 	}
 }
 
+// A day's averages and the period averages must be the same measurement at
+// two resolutions, so the per-day denominators have to add up to the
+// period denominator the SQL aggregate returned.
+func TestBuildReportDayAveragesShareThePeriodPopulation(t *testing.T) {
+	s, cleanup := newTestServer(t)
+	defer cleanup()
+	seedReportCorpus(t, s)
+
+	got := s.buildReport(reportIntervals[0], "")
+	var averaged int
+	var cost float64
+	for _, d := range got.Days {
+		averaged += d.ScansAveraged
+		cost += d.AvgCostUSD * float64(d.ScansAveraged)
+	}
+	if averaged != got.AllTime.Runs {
+		t.Errorf("day denominators sum to %d, period says %d", averaged, got.AllTime.Runs)
+	}
+	if want := got.AllTime.CostUSD * float64(got.AllTime.Runs); cost != want {
+		t.Errorf("day costs sum to %v, period implies %v", cost, want)
+	}
+}
+
 func TestBuildReportEmptyCorpus(t *testing.T) {
 	s, cleanup := newTestServer(t)
 	defer cleanup()
 
-	got := s.buildReport(resolveReportInterval("week"))
+	got := s.buildReport(resolveReportInterval("week"), "")
 	if got.Totals.Scans != 0 || got.AllTime.Runs != 0 || len(got.Days) != 0 {
 		t.Fatalf("empty corpus report = %+v, want zeroed", got)
 	}
@@ -191,6 +307,7 @@ func TestReportingPageRenders(t *testing.T) {
 		"Repositories scanned",
 		"Cost averages",
 		"Daily breakdown",
+		"Minimum severity",
 		"/reporting/report.csv?interval=week",
 		"/reporting/report.json?interval=week",
 	} {
@@ -198,9 +315,41 @@ func TestReportingPageRenders(t *testing.T) {
 			t.Errorf("body missing %q", want)
 		}
 	}
-	// The sidebar entry is present and marked current on this page.
+	// The orphaned right-aligned caption is gone; the wording now lives in
+	// the paragraph under the heading.
+	if strings.Contains(body, `<span class="text-xs text-muted-foreground">per completed scan with a recorded cost</span>`) {
+		t.Error("floating cost-averages caption is still present")
+	}
+	if !strings.Contains(body, "Averaged per completed scan with a recorded cost.") {
+		t.Error("cost-averages population is not explained in the prose")
+	}
 	if !strings.Contains(body, `href="/reporting" aria-current="page"`) {
 		t.Error("sidebar Reporting entry not marked current")
+	}
+}
+
+// Selecting a severity must survive into the period links and both export
+// links, or switching period silently drops the filter.
+func TestReportingPagePreservesSeverityInLinks(t *testing.T) {
+	s, cleanup := newTestServer(t)
+	defer cleanup()
+	seedReportCorpus(t, s)
+
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq("GET", "/reporting?interval=week&severity=High"))
+	if w.Code != 200 {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+	body := w.Body.String()
+	for _, want := range []string{
+		"/reporting?interval=day&amp;severity=High",
+		"/reporting/report.csv?interval=week&amp;severity=High",
+		"/reporting/report.json?interval=week&amp;severity=High",
+		"Findings (High+)",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("body missing %q", want)
+		}
 	}
 }
 
@@ -214,7 +363,10 @@ func TestReportingNavKey(t *testing.T) {
 	}
 }
 
-func TestReportingCSVExport(t *testing.T) {
+// The CSV must be one rectangular table: a single header, a uniform column
+// count and no blank separator line. Anything else opens as a ragged sheet
+// in Excel and breaks strict parsers.
+func TestReportingCSVIsOneRectangularTable(t *testing.T) {
 	s, cleanup := newTestServer(t)
 	defer cleanup()
 	seedReportCorpus(t, s)
@@ -231,58 +383,83 @@ func TestReportingCSVExport(t *testing.T) {
 		!strings.Contains(cd, "scrutineer-report-week-") || !strings.Contains(cd, ".csv") {
 		t.Errorf("Content-Disposition = %q", cd)
 	}
-
-	blocks := strings.SplitN(strings.TrimRight(w.Body.String(), "\n"), "\n\n", 2)
-	if len(blocks) != 2 {
-		t.Fatalf("expected a summary block and a daily block, got %d:\n%s", len(blocks), w.Body.String())
+	if strings.Contains(w.Body.String(), "\n\n") {
+		t.Error("CSV contains a blank line; it is no longer a single table")
 	}
 
-	summary := map[string]string{}
-	rows, err := csv.NewReader(strings.NewReader(blocks[0])).ReadAll()
+	// FieldsPerRecord defaults to the first record's count and errors on
+	// any row that disagrees, so a successful ReadAll proves rectangularity.
+	rows, err := csv.NewReader(strings.NewReader(w.Body.String())).ReadAll()
+	if err != nil {
+		t.Fatalf("not a rectangular CSV: %v", err)
+	}
+	if strings.Join(rows[0], ",") != strings.Join(reportCSVHeader, ",") {
+		t.Fatalf("header = %v, want %v", rows[0], reportCSVHeader)
+	}
+	if len(rows) < 3 {
+		t.Fatalf("expected a period_total, an all_time_average and day rows, got %d", len(rows)-1)
+	}
+
+	byType := map[string][]string{}
+	for _, row := range rows[1:] {
+		if len(row) != len(reportCSVHeader) {
+			t.Fatalf("row %v has %d cells, want %d", row, len(row), len(reportCSVHeader))
+		}
+		if row[0] != "week" {
+			t.Errorf("period column = %q, want week", row[0])
+		}
+		if row[1] != "all" {
+			t.Errorf("minimum_severity column = %q, want all", row[1])
+		}
+		byType[row[2]] = row
+	}
+	total, ok := byType["period_total"]
+	if !ok {
+		t.Fatal("no period_total row")
+	}
+	// repositories_scanned, scans_started, scans_completed, findings
+	if total[4] != "2" || total[5] != "4" || total[6] != "2" || total[7] != "2" {
+		t.Errorf("period_total activity = %v", total[4:8])
+	}
+	if total[11] != "3.00" {
+		t.Errorf("period avg_cost_usd = %q, want 3.00", total[11])
+	}
+	allTime, ok := byType["all_time_average"]
+	if !ok {
+		t.Fatal("no all_time_average row")
+	}
+	if allTime[11] != "5.00" {
+		t.Errorf("all-time avg_cost_usd = %q, want 5.00", allTime[11])
+	}
+	// The all-time row must not imply activity totals it never computed.
+	if allTime[4] != "" || allTime[7] != "" {
+		t.Errorf("all_time_average leaked activity figures: %v", allTime)
+	}
+	if _, ok := byType["day"]; !ok {
+		t.Fatal("no day rows")
+	}
+}
+
+func TestReportingCSVCarriesSeverityFilter(t *testing.T) {
+	s, cleanup := newTestServer(t)
+	defer cleanup()
+	seedReportCorpus(t, s)
+
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq("GET", "/reporting/report.csv?interval=all&severity=Critical"))
+	if w.Code != 200 {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+	rows, err := csv.NewReader(strings.NewReader(w.Body.String())).ReadAll()
 	if err != nil {
 		t.Fatal(err)
-	}
-	if rows[0][0] != "metric" || rows[0][1] != "value" {
-		t.Fatalf("summary header = %v", rows[0])
 	}
 	for _, row := range rows[1:] {
-		summary[row[0]] = row[1]
-	}
-	for key, want := range map[string]string{
-		"interval":                 "week",
-		"repos_scanned":            "2",
-		"scans":                    "4",
-		"scans_done":               "2",
-		"findings":                 "2",
-		"window_scans_costed":      "2",
-		"window_avg_cost_usd":      "3.00",
-		"alltime_scans_costed":     "4",
-		"alltime_avg_cost_usd":     "5.00",
-		"alltime_avg_total_tokens": "2900.00",
-	} {
-		if summary[key] != want {
-			t.Errorf("summary[%q] = %q, want %q", key, summary[key], want)
+		if row[1] != "Critical" {
+			t.Fatalf("minimum_severity column = %q, want Critical", row[1])
 		}
-	}
-	if summary["window_start"] == "" {
-		t.Error("bounded interval should record a window_start")
-	}
-
-	daily, err := csv.NewReader(strings.NewReader(blocks[1])).ReadAll()
-	if err != nil {
-		t.Fatal(err)
-	}
-	wantHeader := []string{"date", "repos_scanned", "scans", "findings", "cost_usd", "total_tokens"}
-	if strings.Join(daily[0], ",") != strings.Join(wantHeader, ",") {
-		t.Fatalf("daily header = %v, want %v", daily[0], wantHeader)
-	}
-	if len(daily) < 2 {
-		t.Fatal("daily block has no rows")
-	}
-	// Newest day first.
-	for i := 2; i < len(daily); i++ {
-		if daily[i-1][0] < daily[i][0] {
-			t.Fatalf("daily rows not sorted newest first: %v then %v", daily[i-1][0], daily[i][0])
+		if row[2] == "period_total" && row[7] != "1" {
+			t.Errorf("filtered findings total = %q, want 1", row[7])
 		}
 	}
 }
@@ -302,46 +479,123 @@ func TestReportingJSONExport(t *testing.T) {
 	}
 
 	var out struct {
-		Interval    string  `json:"interval"`
-		WindowStart *string `json:"window_start"`
-		Totals      struct {
-			ReposScanned int `json:"repos_scanned"`
-			Scans        int `json:"scans"`
-			ScansDone    int `json:"scans_done"`
-			Findings     int `json:"findings"`
-		} `json:"totals"`
+		GeneratedAt string `json:"generated_at"`
+		Period      struct {
+			Key      string  `json:"key"`
+			Label    string  `json:"label"`
+			Meaning  string  `json:"meaning"`
+			StartsAt *string `json:"starts_at"`
+			EndsAt   string  `json:"ends_at"`
+		} `json:"period"`
+		Filters struct {
+			MinimumSeverity *string  `json:"minimum_severity"`
+			AppliesTo       []string `json:"applies_to"`
+		} `json:"filters"`
+		Activity struct {
+			RepositoriesScanned int `json:"repositories_scanned"`
+			ScansStarted        int `json:"scans_started"`
+			ScansCompleted      int `json:"scans_completed"`
+			Findings            int `json:"findings"`
+		} `json:"activity_in_period"`
 		Averages struct {
-			Window  map[string]float64 `json:"window"`
-			AllTime map[string]float64 `json:"all_time"`
-		} `json:"averages"`
-		Days []struct {
-			Date        string  `json:"date"`
-			Scans       int     `json:"scans"`
-			CostUSD     float64 `json:"cost_usd"`
-			TotalTokens int     `json:"total_tokens"`
-		} `json:"days"`
+			Population string             `json:"population"`
+			InPeriod   map[string]float64 `json:"in_period"`
+			AllTime    map[string]float64 `json:"all_time"`
+		} `json:"cost_averages_per_scan"`
+		ByDay []struct {
+			Date           string  `json:"date"`
+			ScansStarted   int     `json:"scans_started"`
+			ScansCompleted int     `json:"scans_completed"`
+			Findings       int     `json:"findings"`
+			CostUSD        float64 `json:"cost_usd"`
+		} `json:"activity_by_day"`
 	}
 	if err := json.Unmarshal(w.Body.Bytes(), &out); err != nil {
 		t.Fatalf("decode: %v\n%s", err, w.Body)
 	}
-	if out.Interval != "all" {
-		t.Errorf("interval = %q, want all", out.Interval)
+
+	// The old ambiguous key names must be gone.
+	var raw map[string]any
+	_ = json.Unmarshal(w.Body.Bytes(), &raw)
+	for _, gone := range []string{"totals", "days", "averages", "window_start", "interval"} {
+		if _, ok := raw[gone]; ok {
+			t.Errorf("ambiguous key %q is still present at the top level", gone)
+		}
 	}
-	if out.WindowStart != nil {
-		t.Errorf("window_start = %v, want null for all time", *out.WindowStart)
+	if _, ok := out.Averages.InPeriod["avg_cost_usd"]; !ok {
+		t.Error("cost_averages_per_scan.in_period missing avg_cost_usd")
 	}
-	if out.Totals.ReposScanned != 3 || out.Totals.Scans != 6 || out.Totals.ScansDone != 4 || out.Totals.Findings != 3 {
-		t.Errorf("totals = %+v", out.Totals)
+
+	if out.Period.Key != "all" || out.Period.Label != "All time" || out.Period.Meaning == "" {
+		t.Errorf("period = %+v", out.Period)
+	}
+	if out.Period.StartsAt != nil {
+		t.Errorf("starts_at = %v, want null for all time", *out.Period.StartsAt)
+	}
+	if out.Period.EndsAt == "" || out.GeneratedAt == "" {
+		t.Error("generated_at/ends_at should always be set")
+	}
+	if out.Filters.MinimumSeverity != nil {
+		t.Errorf("minimum_severity = %v, want null", *out.Filters.MinimumSeverity)
+	}
+	if len(out.Filters.AppliesTo) != 1 || out.Filters.AppliesTo[0] != "findings" {
+		t.Errorf("applies_to = %v, want [findings]", out.Filters.AppliesTo)
+	}
+	if out.Activity.RepositoriesScanned != 3 || out.Activity.ScansStarted != 6 ||
+		out.Activity.ScansCompleted != 4 || out.Activity.Findings != 3 {
+		t.Errorf("activity_in_period = %+v", out.Activity)
+	}
+	if out.Averages.Population == "" {
+		t.Error("cost_averages_per_scan.population should explain the denominator")
 	}
 	if out.Averages.AllTime["avg_cost_usd"] != 5 {
 		t.Errorf("all_time avg_cost_usd = %v, want 5", out.Averages.AllTime["avg_cost_usd"])
 	}
 	// All time makes both columns the same population.
-	if out.Averages.Window["avg_total_tokens"] != out.Averages.AllTime["avg_total_tokens"] {
-		t.Errorf("window and all-time should agree over the all-time interval: %v vs %v",
-			out.Averages.Window["avg_total_tokens"], out.Averages.AllTime["avg_total_tokens"])
+	if out.Averages.InPeriod["avg_total_tokens"] != out.Averages.AllTime["avg_total_tokens"] {
+		t.Errorf("in_period and all_time should agree over the all-time period: %v vs %v",
+			out.Averages.InPeriod["avg_total_tokens"], out.Averages.AllTime["avg_total_tokens"])
 	}
-	if len(out.Days) == 0 {
-		t.Fatal("days is empty")
+	if len(out.ByDay) == 0 {
+		t.Fatal("activity_by_day is empty")
+	}
+	for i := 1; i < len(out.ByDay); i++ {
+		if out.ByDay[i-1].Date < out.ByDay[i].Date {
+			t.Fatalf("activity_by_day not newest first: %q then %q", out.ByDay[i-1].Date, out.ByDay[i].Date)
+		}
+	}
+}
+
+func TestReportingJSONCarriesSeverityFilter(t *testing.T) {
+	s, cleanup := newTestServer(t)
+	defer cleanup()
+	seedReportCorpus(t, s)
+
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq("GET", "/reporting/report.json?interval=all&severity=high"))
+	if w.Code != 200 {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+	var out struct {
+		Filters struct {
+			MinimumSeverity *string `json:"minimum_severity"`
+		} `json:"filters"`
+		Activity struct {
+			Findings       int `json:"findings"`
+			ScansCompleted int `json:"scans_completed"`
+		} `json:"activity_in_period"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &out); err != nil {
+		t.Fatal(err)
+	}
+	// Lowercase input is canonicalised on the way in.
+	if out.Filters.MinimumSeverity == nil || *out.Filters.MinimumSeverity != "High" {
+		t.Errorf("minimum_severity = %v, want High", out.Filters.MinimumSeverity)
+	}
+	if out.Activity.Findings != 2 {
+		t.Errorf("findings = %d, want 2 (Critical + High)", out.Activity.Findings)
+	}
+	if out.Activity.ScansCompleted != 4 {
+		t.Errorf("scans_completed = %d, want 4; severity must not touch scan counts", out.Activity.ScansCompleted)
 	}
 }

--- a/internal/web/reporting_test.go
+++ b/internal/web/reporting_test.go
@@ -308,6 +308,11 @@ func TestReportingPageRenders(t *testing.T) {
 		"Cost averages",
 		"Daily breakdown",
 		"Minimum severity",
+		// The scan tiles name their unit and show why the count outruns
+		// the repository count.
+		"Scan runs",
+		"per repository",
+		"of runs",
 		"/reporting/report.csv?interval=week",
 		"/reporting/report.json?interval=week",
 	} {
@@ -597,5 +602,74 @@ func TestReportingJSONCarriesSeverityFilter(t *testing.T) {
 	}
 	if out.Activity.ScansCompleted != 4 {
 		t.Errorf("scans_completed = %d, want 4; severity must not touch scan counts", out.Activity.ScansCompleted)
+	}
+}
+
+// The tile captions are derived presentation, so they must be safe on an
+// empty corpus and must not appear in either export.
+func TestReportTotalsDerivedRatios(t *testing.T) {
+	t.Run("zero corpus does not divide by zero", func(t *testing.T) {
+		var empty reportTotals
+		if got := empty.ScansPerRepo(); got != 0 {
+			t.Errorf("ScansPerRepo() = %v, want 0", got)
+		}
+		if got := empty.CompletionRate(); got != 0 {
+			t.Errorf("CompletionRate() = %v, want 0", got)
+		}
+	})
+
+	t.Run("fan-out ratio", func(t *testing.T) {
+		totals := reportTotals{ReposScanned: 49, Scans: 510, ScansDone: 321}
+		if got := totals.ScansPerRepo(); got < 10.4 || got > 10.5 {
+			t.Errorf("ScansPerRepo() = %v, want ~10.41", got)
+		}
+		if got := totals.CompletionRate(); got < 0.62 || got > 0.63 {
+			t.Errorf("CompletionRate() = %v, want ~0.629", got)
+		}
+	})
+
+	// Scans >= ReposScanned always holds, since ReposScanned counts distinct
+	// repositories among the very scans being counted.
+	t.Run("ratio never drops below one for a non-empty corpus", func(t *testing.T) {
+		s, cleanup := newTestServer(t)
+		defer cleanup()
+		seedReportCorpus(t, s)
+		got := s.buildReport(reportIntervals[0], "").Totals
+		if got.ScansPerRepo() < 1 {
+			t.Errorf("ScansPerRepo() = %v, want >= 1", got.ScansPerRepo())
+		}
+	})
+}
+
+// The rename was a UI decision; the export contract stays as published.
+func TestReportingExportsKeepScanFieldNames(t *testing.T) {
+	s, cleanup := newTestServer(t)
+	defer cleanup()
+	seedReportCorpus(t, s)
+
+	csvRec := httptest.NewRecorder()
+	s.Handler().ServeHTTP(csvRec, localReq("GET", "/reporting/report.csv?interval=all"))
+	header := strings.SplitN(csvRec.Body.String(), "\n", 2)[0]
+	for _, want := range []string{"scans_started", "scans_completed"} {
+		if !strings.Contains(header, want) {
+			t.Errorf("CSV header lost %q: %s", want, header)
+		}
+	}
+	if strings.Contains(header, "scan_runs") {
+		t.Error("CSV header picked up the UI-only rename")
+	}
+
+	jsonRec := httptest.NewRecorder()
+	s.Handler().ServeHTTP(jsonRec, localReq("GET", "/reporting/report.json?interval=all"))
+	body := jsonRec.Body.String()
+	for _, want := range []string{`"scans_started"`, `"scans_completed"`} {
+		if !strings.Contains(body, want) {
+			t.Errorf("JSON lost %q", want)
+		}
+	}
+	for _, gone := range []string{`"scan_runs"`, `"scans_per_repo"`, `"completion_rate"`} {
+		if strings.Contains(body, gone) {
+			t.Errorf("JSON leaked display-only value %q", gone)
+		}
 	}
 }

--- a/internal/web/reporting_test.go
+++ b/internal/web/reporting_test.go
@@ -673,3 +673,114 @@ func TestReportingExportsKeepScanFieldNames(t *testing.T) {
 		}
 	}
 }
+
+// Columns are addressed by name, so a mistyped key renders an empty cell
+// instead of failing to compile. Assert which columns each row type is
+// meant to fill, so a typo shows up as a test failure rather than a blank
+// column in someone's spreadsheet.
+func TestReportingCSVRowsFillTheirColumns(t *testing.T) {
+	s, cleanup := newTestServer(t)
+	defer cleanup()
+	seedReportCorpus(t, s)
+
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq("GET", "/reporting/report.csv?interval=all"))
+	rows, err := csv.NewReader(strings.NewReader(w.Body.String())).ReadAll()
+	if err != nil {
+		t.Fatal(err)
+	}
+	index := map[string]int{}
+	for i, col := range rows[0] {
+		index[col] = i
+	}
+
+	// The all-time row deliberately leaves the activity columns blank; every
+	// other column of every other row carries a value.
+	blankForAllTime := map[string]bool{
+		"date": true, "repositories_scanned": true, "scans_started": true,
+		"scans_completed": true, findingsField: true, "cost_usd": true,
+		"total_tokens": true,
+	}
+	seen := map[string]bool{}
+	for _, row := range rows[1:] {
+		rowType := row[index["row_type"]]
+		seen[rowType] = true
+		for col, i := range index {
+			// period_total covers the whole window, so it has no single date.
+			wantBlank := (rowType == "period_total" && col == "date") ||
+				(rowType == "all_time_average" && blankForAllTime[col])
+			if wantBlank {
+				if row[i] != "" {
+					t.Errorf("%s: column %q = %q, want empty", rowType, col, row[i])
+				}
+				continue
+			}
+			if row[i] == "" {
+				t.Errorf("%s: column %q is empty; check the key spelling", rowType, col)
+			}
+		}
+	}
+	for _, want := range []string{"period_total", "all_time_average", "day"} {
+		if !seen[want] {
+			t.Errorf("no %s row emitted", want)
+		}
+	}
+}
+
+func TestCSVRecordIsAlwaysHeaderWidth(t *testing.T) {
+	if got := csvRecord(nil); len(got) != len(reportCSVHeader) {
+		t.Errorf("csvRecord(nil) width = %d, want %d", len(got), len(reportCSVHeader))
+	}
+	// An unknown column is dropped rather than widening the record.
+	got := csvRecord(map[string]string{"period": "week", "not_a_column": "x"})
+	if len(got) != len(reportCSVHeader) {
+		t.Fatalf("width = %d, want %d", len(got), len(reportCSVHeader))
+	}
+	if got[0] != "week" {
+		t.Errorf("period cell = %q, want week", got[0])
+	}
+	for _, cell := range got[1:] {
+		if cell == "x" {
+			t.Error("unknown column leaked into the record")
+		}
+	}
+}
+
+// With an unbounded period the "selected period" and "all time" columns are
+// the same population, so rendering both put two identical "All time"
+// headings side by side on the default view.
+func TestReportingCostAveragesColumnsMatchThePeriod(t *testing.T) {
+	s, cleanup := newTestServer(t)
+	defer cleanup()
+	seedReportCorpus(t, s)
+
+	countHeadings := func(body, heading string) int {
+		return strings.Count(body, `<th class="text-right">`+heading+`</th>`)
+	}
+
+	t.Run("all time collapses to one column", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		s.Handler().ServeHTTP(w, localReq("GET", "/reporting?interval=all"))
+		if w.Code != 200 {
+			t.Fatalf("status %d", w.Code)
+		}
+		if got := countHeadings(w.Body.String(), "All time"); got != 1 {
+			t.Errorf("All time column count = %d, want 1", got)
+		}
+	})
+
+	t.Run("bounded period keeps both columns", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		s.Handler().ServeHTTP(w, localReq("GET", "/reporting?interval=week"))
+		if w.Code != 200 {
+			t.Fatalf("status %d", w.Code)
+		}
+		body := w.Body.String()
+		if got := countHeadings(body, "All time"); got != 1 {
+			t.Errorf("All time column count = %d, want 1", got)
+		}
+		if got := countHeadings(body, "Week"); got != 1 {
+			t.Errorf("Week column count = %d, want 1", got)
+		}
+	})
+}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -598,6 +598,9 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("POST /scans/{id}/cancel", s.scanCancel)
 	mux.HandleFunc("GET /scans/{id}/log", s.scanLog)
 	mux.HandleFunc("GET /usage", s.usage)
+	mux.HandleFunc("GET /reporting", s.reporting)
+	mux.HandleFunc("GET /reporting/report.csv", s.reportingCSV)
+	mux.HandleFunc("GET /reporting/report.json", s.reportingJSON)
 	s.registerSBOMRoutes(mux)
 	mux.HandleFunc("GET /skills", s.skillsList)
 	mux.HandleFunc("GET /skills/new", s.skillNew)
@@ -741,7 +744,7 @@ func popFlash(w http.ResponseWriter, r *http.Request) *Flash {
 // index, which is also the home page.
 func navKey(path string) string {
 	for _, p := range []struct{ prefix, key string }{
-		{"/settings", "settings"}, {"/usage", "usage"}, {"/skills", "skills"}, {"/maintainers", "maintainers"},
+		{"/settings", "settings"}, {"/usage", "usage"}, {"/reporting", "reporting"}, {"/skills", "skills"}, {"/maintainers", "maintainers"},
 		{"/orgs", "orgs"}, {"/packages", "packages"}, {"/advisories", "advisories"},
 		{"/findings", "findings"}, {"/benchmark", "benchmark"}, {"/scans", "scans"}, {"/sboms", "sboms"}, {"/audit", "audit"},
 	} {

--- a/internal/web/templates/layout.html
+++ b/internal/web/templates/layout.html
@@ -57,6 +57,7 @@
           <li><a href="/audit"{{if eq $nav "audit"}} aria-current="page"{{end}}><i data-lucide="clipboard-check"></i><span>Audit</span></a></li>
           <li><a href="/skills"{{if eq $nav "skills"}} aria-current="page"{{end}}><i data-lucide="sparkles"></i><span>Skills</span></a></li>
           <li><a href="/usage"{{if eq $nav "usage"}} aria-current="page"{{end}}><i data-lucide="coins"></i><span>Usage</span></a></li>
+          <li><a href="/reporting"{{if eq $nav "reporting"}} aria-current="page"{{end}}><i data-lucide="file-chart-column"></i><span>Reporting</span></a></li>
         </ul>
       </div>
     </section>

--- a/internal/web/templates/reporting.html
+++ b/internal/web/templates/reporting.html
@@ -78,48 +78,52 @@
   the better measure of how much the model processed.
 </p>
 {{if $r.AllTime.Runs}}
+  {{/* Since is nil only when the selected period already IS all time. The
+       period and all-time columns are then the same population, so showing
+       both would repeat one number under two identical headings. */}}
+  {{$bounded := $r.Since}}
   <div class="overflow-x-auto mb-8">
     <table class="table w-full">
       <thead><tr>
         <th>Metric</th>
-        <th class="text-right">{{$r.Interval.Label}}</th>
+        {{if $bounded}}<th class="text-right">{{$r.Interval.Label}}</th>{{end}}
         <th class="text-right">All time</th>
       </tr></thead>
       <tbody>
         <tr>
           <td class="font-medium">Scans counted</td>
-          <td class="text-right">{{bignum $r.Period.Runs}}</td>
-          <td class="text-right text-muted-foreground">{{bignum $r.AllTime.Runs}}</td>
+          {{if $bounded}}<td class="text-right">{{bignum $r.Period.Runs}}</td>{{end}}
+          <td class="text-right{{if $bounded}} text-muted-foreground{{end}}">{{bignum $r.AllTime.Runs}}</td>
         </tr>
         <tr>
           <td class="font-medium">Average cost</td>
-          <td class="text-right">{{usd $r.Period.CostUSD}}</td>
-          <td class="text-right text-muted-foreground">{{usd $r.AllTime.CostUSD}}</td>
+          {{if $bounded}}<td class="text-right">{{usd $r.Period.CostUSD}}</td>{{end}}
+          <td class="text-right{{if $bounded}} text-muted-foreground{{end}}">{{usd $r.AllTime.CostUSD}}</td>
         </tr>
         <tr>
           <td class="font-medium">Average input tokens</td>
-          <td class="text-right">{{printf "%.0f" $r.Period.InputTokens}}</td>
-          <td class="text-right text-muted-foreground">{{printf "%.0f" $r.AllTime.InputTokens}}</td>
+          {{if $bounded}}<td class="text-right">{{printf "%.0f" $r.Period.InputTokens}}</td>{{end}}
+          <td class="text-right{{if $bounded}} text-muted-foreground{{end}}">{{printf "%.0f" $r.AllTime.InputTokens}}</td>
         </tr>
         <tr>
           <td class="font-medium">Average output tokens</td>
-          <td class="text-right">{{printf "%.0f" $r.Period.OutputTokens}}</td>
-          <td class="text-right text-muted-foreground">{{printf "%.0f" $r.AllTime.OutputTokens}}</td>
+          {{if $bounded}}<td class="text-right">{{printf "%.0f" $r.Period.OutputTokens}}</td>{{end}}
+          <td class="text-right{{if $bounded}} text-muted-foreground{{end}}">{{printf "%.0f" $r.AllTime.OutputTokens}}</td>
         </tr>
         <tr>
           <td class="font-medium">Average cache read tokens</td>
-          <td class="text-right">{{printf "%.0f" $r.Period.CacheReadTokens}}</td>
-          <td class="text-right text-muted-foreground">{{printf "%.0f" $r.AllTime.CacheReadTokens}}</td>
+          {{if $bounded}}<td class="text-right">{{printf "%.0f" $r.Period.CacheReadTokens}}</td>{{end}}
+          <td class="text-right{{if $bounded}} text-muted-foreground{{end}}">{{printf "%.0f" $r.AllTime.CacheReadTokens}}</td>
         </tr>
         <tr>
           <td class="font-medium">Average cache write tokens</td>
-          <td class="text-right">{{printf "%.0f" $r.Period.CacheWriteTokens}}</td>
-          <td class="text-right text-muted-foreground">{{printf "%.0f" $r.AllTime.CacheWriteTokens}}</td>
+          {{if $bounded}}<td class="text-right">{{printf "%.0f" $r.Period.CacheWriteTokens}}</td>{{end}}
+          <td class="text-right{{if $bounded}} text-muted-foreground{{end}}">{{printf "%.0f" $r.AllTime.CacheWriteTokens}}</td>
         </tr>
         <tr>
           <td class="font-medium">Average total tokens</td>
-          <td class="text-right">{{printf "%.0f" $r.Period.TotalTokens}}</td>
-          <td class="text-right text-muted-foreground">{{printf "%.0f" $r.AllTime.TotalTokens}}</td>
+          {{if $bounded}}<td class="text-right">{{printf "%.0f" $r.Period.TotalTokens}}</td>{{end}}
+          <td class="text-right{{if $bounded}} text-muted-foreground{{end}}">{{printf "%.0f" $r.AllTime.TotalTokens}}</td>
         </tr>
       </tbody>
     </table>

--- a/internal/web/templates/reporting.html
+++ b/internal/web/templates/reporting.html
@@ -20,6 +20,9 @@
 
 <p class="text-sm text-muted-foreground mb-4">
   Scan activity over a rolling window, with the per-scan cost and token averages.
+  Runs are counted when they begin and again when they finish, so a run spanning the
+  boundary is a start in one period and a completion in the next; queued runs count
+  in neither.
   {{if $r.Since}}Covering {{$r.Since.Format "2006-01-02 15:04 UTC"}} onward.{{else}}Covering every scan on record.{{end}}
 </p>
 
@@ -52,17 +55,17 @@
     <p class="text-2xl font-semibold mt-1">{{bignum $r.Totals.ReposScanned}}</p>
   </div>
   <div class="card p-4">
-    <p class="text-sm text-muted-foreground">Scan runs</p>
-    <p class="text-2xl font-semibold mt-1">{{bignum $r.Totals.Scans}}</p>
+    <p class="text-sm text-muted-foreground">Scan runs started</p>
+    <p class="text-2xl font-semibold mt-1">{{bignum $r.Totals.ScansStarted}}</p>
     {{if $r.Totals.ReposScanned}}
-      <p class="text-xs text-muted-foreground mt-1">&#8776;{{printf "%.0f" $r.Totals.ScansPerRepo}} per repository</p>
+      <p class="text-xs text-muted-foreground mt-1">&#8776;{{printf "%.1f" $r.Totals.ScansPerRepo}} per repository</p>
     {{end}}
   </div>
   <div class="card p-4">
-    <p class="text-sm text-muted-foreground">Completed</p>
-    <p class="text-2xl font-semibold mt-1">{{bignum $r.Totals.ScansDone}}</p>
-    {{if $r.Totals.Scans}}
-      <p class="text-xs text-muted-foreground mt-1">{{pct $r.Totals.CompletionRate}} of runs</p>
+    <p class="text-sm text-muted-foreground">Scan runs completed</p>
+    <p class="text-2xl font-semibold mt-1">{{bignum $r.Totals.ScansCompleted}}</p>
+    {{if $r.Totals.ScansStarted}}
+      <p class="text-xs text-muted-foreground mt-1">{{pct $r.Totals.CompletionRate}} of runs started</p>
     {{end}}
   </div>
   <div class="card p-4">
@@ -141,7 +144,7 @@
       <thead><tr>
         <th>Date</th>
         <th class="text-right">Repositories</th>
-        <th class="text-right">Runs</th>
+        <th class="text-right">Started</th>
         <th class="text-right">Completed</th>
         <th class="text-right">Findings{{if $r.MinSeverity}} ({{$r.MinSeverity}}+){{end}}</th>
         <th class="text-right">Cost</th>
@@ -152,8 +155,8 @@
         <tr>
           <td class="font-medium">{{.Date}}</td>
           <td class="text-right text-muted-foreground">{{bignum .ReposScanned}}</td>
-          <td class="text-right text-muted-foreground">{{bignum .Scans}}</td>
-          <td class="text-right text-muted-foreground">{{bignum .ScansDone}}</td>
+          <td class="text-right text-muted-foreground">{{bignum .ScansStarted}}</td>
+          <td class="text-right text-muted-foreground">{{bignum .ScansCompleted}}</td>
           <td class="text-right text-muted-foreground">{{bignum .Findings}}</td>
           <td class="text-right">{{usd .CostUSD}}</td>
           <td class="text-right text-muted-foreground">{{bignum .TotalTokens}}</td>
@@ -165,3 +168,4 @@
 {{else}}
   {{template "empty" (dict "Icon" "calendar-off" "Title" "No activity in this window" "Body" "Widen the interval, or run a scan to start populating the report.")}}
 {{end}}
+{{template "foot" .}}

--- a/internal/web/templates/reporting.html
+++ b/internal/web/templates/reporting.html
@@ -1,0 +1,142 @@
+{{template "head" .}}
+{{$r := .Report}}
+
+<div class="flex items-start justify-between gap-4 mb-6">
+  <div>
+    {{template "crumbs" (crumbs "Reporting" "")}}
+    <h2 class="text-2xl font-semibold mt-1 flex items-center gap-2">
+      <i data-lucide="file-chart-column"></i> Reporting
+    </h2>
+  </div>
+  <div class="flex items-center gap-2 shrink-0" hx-boost="false">
+    <a href="/reporting/report.csv?interval={{$r.Interval.Key}}" class="btn-outline">
+      <i data-lucide="download"></i> CSV
+    </a>
+    <a href="/reporting/report.json?interval={{$r.Interval.Key}}" class="btn-outline">
+      <i data-lucide="download"></i> JSON
+    </a>
+  </div>
+</div>
+
+<div class="flex items-center justify-between gap-4 mb-6">
+  <p class="text-sm text-muted-foreground">
+    Scan activity over a rolling window, with the per-scan cost and token averages.
+    {{if $r.Since}}Covering {{$r.Since.Format "2006-01-02 15:04 UTC"}} onward.{{else}}Covering every scan on record.{{end}}
+  </p>
+  <div class="flex items-center gap-1 shrink-0 ml-4">
+    {{range $.Intervals}}
+      <a href="/reporting?interval={{.Key}}"
+         class="{{if eq $r.Interval.Key .Key}}btn-outline{{else}}btn-sm-ghost{{end}}">{{.Label}}</a>
+    {{end}}
+  </div>
+</div>
+
+<div class="grid grid-cols-2 lg:grid-cols-4 gap-4 mb-8">
+  <div class="card p-4">
+    <p class="text-sm text-muted-foreground">Repositories scanned</p>
+    <p class="text-2xl font-semibold mt-1">{{bignum $r.Totals.ReposScanned}}</p>
+  </div>
+  <div class="card p-4">
+    <p class="text-sm text-muted-foreground">Scans</p>
+    <p class="text-2xl font-semibold mt-1">{{bignum $r.Totals.Scans}}</p>
+  </div>
+  <div class="card p-4">
+    <p class="text-sm text-muted-foreground">Scans completed</p>
+    <p class="text-2xl font-semibold mt-1">{{bignum $r.Totals.ScansDone}}</p>
+  </div>
+  <div class="card p-4">
+    <p class="text-sm text-muted-foreground">Findings</p>
+    <p class="text-2xl font-semibold mt-1">{{bignum $r.Totals.Findings}}</p>
+  </div>
+</div>
+
+<div class="flex items-baseline justify-between gap-4 mb-3">
+  <h3 class="text-lg font-semibold">Cost averages</h3>
+  <span class="text-xs text-muted-foreground">per completed scan with a recorded cost</span>
+</div>
+<p class="text-sm text-muted-foreground mb-3">
+  Cost is API list-price equivalent, not what a subscription was billed. Input excludes
+  cached reads, so total tokens is the better measure of how much the model processed.
+</p>
+{{if $r.AllTime.Runs}}
+  <div class="overflow-x-auto mb-8">
+    <table class="table w-full">
+      <thead><tr>
+        <th>Metric</th>
+        <th class="text-right">{{$r.Interval.Label}}</th>
+        <th class="text-right">All time</th>
+      </tr></thead>
+      <tbody>
+        <tr>
+          <td class="font-medium">Scans counted</td>
+          <td class="text-right">{{bignum $r.Window.Runs}}</td>
+          <td class="text-right text-muted-foreground">{{bignum $r.AllTime.Runs}}</td>
+        </tr>
+        <tr>
+          <td class="font-medium">Average cost</td>
+          <td class="text-right">{{usd $r.Window.CostUSD}}</td>
+          <td class="text-right text-muted-foreground">{{usd $r.AllTime.CostUSD}}</td>
+        </tr>
+        <tr>
+          <td class="font-medium">Average input tokens</td>
+          <td class="text-right">{{printf "%.0f" $r.Window.InputTokens}}</td>
+          <td class="text-right text-muted-foreground">{{printf "%.0f" $r.AllTime.InputTokens}}</td>
+        </tr>
+        <tr>
+          <td class="font-medium">Average output tokens</td>
+          <td class="text-right">{{printf "%.0f" $r.Window.OutputTokens}}</td>
+          <td class="text-right text-muted-foreground">{{printf "%.0f" $r.AllTime.OutputTokens}}</td>
+        </tr>
+        <tr>
+          <td class="font-medium">Average cache read tokens</td>
+          <td class="text-right">{{printf "%.0f" $r.Window.CacheReadTokens}}</td>
+          <td class="text-right text-muted-foreground">{{printf "%.0f" $r.AllTime.CacheReadTokens}}</td>
+        </tr>
+        <tr>
+          <td class="font-medium">Average cache write tokens</td>
+          <td class="text-right">{{printf "%.0f" $r.Window.CacheWriteTokens}}</td>
+          <td class="text-right text-muted-foreground">{{printf "%.0f" $r.AllTime.CacheWriteTokens}}</td>
+        </tr>
+        <tr>
+          <td class="font-medium">Average total tokens</td>
+          <td class="text-right">{{printf "%.0f" $r.Window.TotalTokens}}</td>
+          <td class="text-right text-muted-foreground">{{printf "%.0f" $r.AllTime.TotalTokens}}</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+{{else}}
+  <div class="mb-8">
+    {{template "empty" (dict "Icon" "coins" "Title" "No costed scans yet" "Body" "Averages appear once a scan has completed with a recorded cost.")}}
+  </div>
+{{end}}
+
+<h3 class="text-lg font-semibold mb-3">Daily breakdown</h3>
+{{if $r.Days}}
+  <div class="overflow-x-auto">
+    <table class="table w-full">
+      <thead><tr>
+        <th>Date</th>
+        <th class="text-right">Repositories</th>
+        <th class="text-right">Scans</th>
+        <th class="text-right">Findings</th>
+        <th class="text-right">Cost</th>
+        <th class="text-right">Total tokens</th>
+      </tr></thead>
+      <tbody>
+      {{range $r.Days}}
+        <tr>
+          <td class="font-medium">{{.Date}}</td>
+          <td class="text-right text-muted-foreground">{{bignum .ReposScanned}}</td>
+          <td class="text-right text-muted-foreground">{{bignum .Scans}}</td>
+          <td class="text-right text-muted-foreground">{{bignum .Findings}}</td>
+          <td class="text-right">{{usd .CostUSD}}</td>
+          <td class="text-right text-muted-foreground">{{bignum .TotalTokens}}</td>
+        </tr>
+      {{end}}
+      </tbody>
+    </table>
+  </div>
+{{else}}
+  {{template "empty" (dict "Icon" "calendar-off" "Title" "No activity in this window" "Body" "Widen the interval, or run a scan to start populating the report.")}}
+{{end}}

--- a/internal/web/templates/reporting.html
+++ b/internal/web/templates/reporting.html
@@ -137,7 +137,11 @@
   </div>
 {{end}}
 
-<h3 class="text-lg font-semibold mb-3">Daily breakdown</h3>
+<h3 class="text-lg font-semibold mb-1">Daily breakdown</h3>
+<p class="text-sm text-muted-foreground mb-3">
+  Totals per day. The CSV and JSON exports add each day's per-scan averages, which are
+  taken over that day's completed and costed runs rather than over the Cost column here.
+</p>
 {{if $r.Days}}
   <div class="overflow-x-auto">
     <table class="table w-full">

--- a/internal/web/templates/reporting.html
+++ b/internal/web/templates/reporting.html
@@ -52,12 +52,18 @@
     <p class="text-2xl font-semibold mt-1">{{bignum $r.Totals.ReposScanned}}</p>
   </div>
   <div class="card p-4">
-    <p class="text-sm text-muted-foreground">Scans</p>
+    <p class="text-sm text-muted-foreground">Scan runs</p>
     <p class="text-2xl font-semibold mt-1">{{bignum $r.Totals.Scans}}</p>
+    {{if $r.Totals.ReposScanned}}
+      <p class="text-xs text-muted-foreground mt-1">&#8776;{{printf "%.0f" $r.Totals.ScansPerRepo}} per repository</p>
+    {{end}}
   </div>
   <div class="card p-4">
-    <p class="text-sm text-muted-foreground">Scans completed</p>
+    <p class="text-sm text-muted-foreground">Completed</p>
     <p class="text-2xl font-semibold mt-1">{{bignum $r.Totals.ScansDone}}</p>
+    {{if $r.Totals.Scans}}
+      <p class="text-xs text-muted-foreground mt-1">{{pct $r.Totals.CompletionRate}} of runs</p>
+    {{end}}
   </div>
   <div class="card p-4">
     <p class="text-sm text-muted-foreground">Findings{{if $r.MinSeverity}} ({{$r.MinSeverity}}+){{end}}</p>
@@ -131,7 +137,7 @@
       <thead><tr>
         <th>Date</th>
         <th class="text-right">Repositories</th>
-        <th class="text-right">Scans</th>
+        <th class="text-right">Runs</th>
         <th class="text-right">Completed</th>
         <th class="text-right">Findings{{if $r.MinSeverity}} ({{$r.MinSeverity}}+){{end}}</th>
         <th class="text-right">Cost</th>

--- a/internal/web/templates/reporting.html
+++ b/internal/web/templates/reporting.html
@@ -9,25 +9,40 @@
     </h2>
   </div>
   <div class="flex items-center gap-2 shrink-0" hx-boost="false">
-    <a href="/reporting/report.csv?interval={{$r.Interval.Key}}" class="btn-outline">
+    <a href="/reporting/report.csv?interval={{$r.Interval.Key}}{{if $r.MinSeverity}}&amp;severity={{$r.MinSeverity}}{{end}}" class="btn-outline">
       <i data-lucide="download"></i> CSV
     </a>
-    <a href="/reporting/report.json?interval={{$r.Interval.Key}}" class="btn-outline">
+    <a href="/reporting/report.json?interval={{$r.Interval.Key}}{{if $r.MinSeverity}}&amp;severity={{$r.MinSeverity}}{{end}}" class="btn-outline">
       <i data-lucide="download"></i> JSON
     </a>
   </div>
 </div>
 
-<div class="flex items-center justify-between gap-4 mb-6">
-  <p class="text-sm text-muted-foreground">
-    Scan activity over a rolling window, with the per-scan cost and token averages.
-    {{if $r.Since}}Covering {{$r.Since.Format "2006-01-02 15:04 UTC"}} onward.{{else}}Covering every scan on record.{{end}}
-  </p>
-  <div class="flex items-center gap-1 shrink-0 ml-4">
-    {{range $.Intervals}}
-      <a href="/reporting?interval={{.Key}}"
-         class="{{if eq $r.Interval.Key .Key}}btn-outline{{else}}btn-sm-ghost{{end}}">{{.Label}}</a>
-    {{end}}
+<p class="text-sm text-muted-foreground mb-4">
+  Scan activity over a rolling window, with the per-scan cost and token averages.
+  {{if $r.Since}}Covering {{$r.Since.Format "2006-01-02 15:04 UTC"}} onward.{{else}}Covering every scan on record.{{end}}
+</p>
+
+<div class="flex flex-wrap items-center justify-between gap-x-8 gap-y-3 mb-6">
+  <div class="flex items-center gap-2">
+    <span class="text-sm font-medium text-muted-foreground">Period</span>
+    <div class="flex items-center gap-1">
+      {{range $.Intervals}}
+        <a href="/reporting?interval={{.Key}}{{if $r.MinSeverity}}&amp;severity={{$r.MinSeverity}}{{end}}"
+           class="{{if eq $r.Interval.Key .Key}}btn-outline{{else}}btn-sm-ghost{{end}}">{{.Label}}</a>
+      {{end}}
+    </div>
+  </div>
+  <div class="flex items-center gap-2">
+    <span class="text-sm font-medium text-muted-foreground">Minimum severity</span>
+    <div class="flex items-center gap-1">
+      <a href="/reporting?interval={{$r.Interval.Key}}"
+         class="{{if not $r.MinSeverity}}btn-outline{{else}}btn-sm-ghost{{end}}">All</a>
+      {{range $.Severities}}
+        <a href="/reporting?interval={{$r.Interval.Key}}&amp;severity={{.}}"
+           class="{{if eq $r.MinSeverity .}}btn-outline{{else}}btn-sm-ghost{{end}}">{{.}}</a>
+      {{end}}
+    </div>
   </div>
 </div>
 
@@ -45,18 +60,16 @@
     <p class="text-2xl font-semibold mt-1">{{bignum $r.Totals.ScansDone}}</p>
   </div>
   <div class="card p-4">
-    <p class="text-sm text-muted-foreground">Findings</p>
+    <p class="text-sm text-muted-foreground">Findings{{if $r.MinSeverity}} ({{$r.MinSeverity}}+){{end}}</p>
     <p class="text-2xl font-semibold mt-1">{{bignum $r.Totals.Findings}}</p>
   </div>
 </div>
 
-<div class="flex items-baseline justify-between gap-4 mb-3">
-  <h3 class="text-lg font-semibold">Cost averages</h3>
-  <span class="text-xs text-muted-foreground">per completed scan with a recorded cost</span>
-</div>
+<h3 class="text-lg font-semibold mb-1">Cost averages</h3>
 <p class="text-sm text-muted-foreground mb-3">
-  Cost is API list-price equivalent, not what a subscription was billed. Input excludes
-  cached reads, so total tokens is the better measure of how much the model processed.
+  Averaged per completed scan with a recorded cost. Cost is API list-price equivalent,
+  not what a subscription was billed. Input excludes cached reads, so total tokens is
+  the better measure of how much the model processed.
 </p>
 {{if $r.AllTime.Runs}}
   <div class="overflow-x-auto mb-8">
@@ -69,37 +82,37 @@
       <tbody>
         <tr>
           <td class="font-medium">Scans counted</td>
-          <td class="text-right">{{bignum $r.Window.Runs}}</td>
+          <td class="text-right">{{bignum $r.Period.Runs}}</td>
           <td class="text-right text-muted-foreground">{{bignum $r.AllTime.Runs}}</td>
         </tr>
         <tr>
           <td class="font-medium">Average cost</td>
-          <td class="text-right">{{usd $r.Window.CostUSD}}</td>
+          <td class="text-right">{{usd $r.Period.CostUSD}}</td>
           <td class="text-right text-muted-foreground">{{usd $r.AllTime.CostUSD}}</td>
         </tr>
         <tr>
           <td class="font-medium">Average input tokens</td>
-          <td class="text-right">{{printf "%.0f" $r.Window.InputTokens}}</td>
+          <td class="text-right">{{printf "%.0f" $r.Period.InputTokens}}</td>
           <td class="text-right text-muted-foreground">{{printf "%.0f" $r.AllTime.InputTokens}}</td>
         </tr>
         <tr>
           <td class="font-medium">Average output tokens</td>
-          <td class="text-right">{{printf "%.0f" $r.Window.OutputTokens}}</td>
+          <td class="text-right">{{printf "%.0f" $r.Period.OutputTokens}}</td>
           <td class="text-right text-muted-foreground">{{printf "%.0f" $r.AllTime.OutputTokens}}</td>
         </tr>
         <tr>
           <td class="font-medium">Average cache read tokens</td>
-          <td class="text-right">{{printf "%.0f" $r.Window.CacheReadTokens}}</td>
+          <td class="text-right">{{printf "%.0f" $r.Period.CacheReadTokens}}</td>
           <td class="text-right text-muted-foreground">{{printf "%.0f" $r.AllTime.CacheReadTokens}}</td>
         </tr>
         <tr>
           <td class="font-medium">Average cache write tokens</td>
-          <td class="text-right">{{printf "%.0f" $r.Window.CacheWriteTokens}}</td>
+          <td class="text-right">{{printf "%.0f" $r.Period.CacheWriteTokens}}</td>
           <td class="text-right text-muted-foreground">{{printf "%.0f" $r.AllTime.CacheWriteTokens}}</td>
         </tr>
         <tr>
           <td class="font-medium">Average total tokens</td>
-          <td class="text-right">{{printf "%.0f" $r.Window.TotalTokens}}</td>
+          <td class="text-right">{{printf "%.0f" $r.Period.TotalTokens}}</td>
           <td class="text-right text-muted-foreground">{{printf "%.0f" $r.AllTime.TotalTokens}}</td>
         </tr>
       </tbody>
@@ -119,7 +132,8 @@
         <th>Date</th>
         <th class="text-right">Repositories</th>
         <th class="text-right">Scans</th>
-        <th class="text-right">Findings</th>
+        <th class="text-right">Completed</th>
+        <th class="text-right">Findings{{if $r.MinSeverity}} ({{$r.MinSeverity}}+){{end}}</th>
         <th class="text-right">Cost</th>
         <th class="text-right">Total tokens</th>
       </tr></thead>
@@ -129,6 +143,7 @@
           <td class="font-medium">{{.Date}}</td>
           <td class="text-right text-muted-foreground">{{bignum .ReposScanned}}</td>
           <td class="text-right text-muted-foreground">{{bignum .Scans}}</td>
+          <td class="text-right text-muted-foreground">{{bignum .ScansDone}}</td>
           <td class="text-right text-muted-foreground">{{bignum .Findings}}</td>
           <td class="text-right">{{usd .CostUSD}}</td>
           <td class="text-right text-muted-foreground">{{bignum .TotalTokens}}</td>


### PR DESCRIPTION
# feat: reporting page for scan activity and cost averages

Adds `/reporting`, plus a sidebar entry: repositories scanned, scans started,
scans completed and findings raised over a rolling **All time / Month / Week /
Day** window, with an optional **minimum-severity floor** on the findings.

Alongside the totals it shows the per-scan cost and token averages from
`docs/cost_averages.sql` for the selected period next to the all-time figures.
Those averages are aggregated in SQL through GORM, transcribing that file's
`WHERE status = 'done' AND cost_usd > 0` population directly; day bucketing
stays in Go because `date()`/`date_trunc` are dialect-specific and
`internal/db` keeps the schema portable.

The severity floor reuses `db.SeverityOrderSQL()`, so it can never disagree
with how the finding lists rank severity. It applies to findings only — scan
counts and cost averages are properties of scans — and is carried through the
period links and both download links.

The snapshot downloads from `/reporting/report.csv` and
`/reporting/report.json`. The CSV is a single rectangular table (one header,
uniform columns, no blank separator) with a `row_type` column marking the
period total, the all-time averages and the daily rows, so it opens as one
clean sheet in Excel. The JSON is named for what it holds: `period`,
`filters`, `activity_in_period`, `cost_averages_per_scan.in_period` /
`.all_time`, and `activity_by_day`. Both carry aggregate counts only — no
repository names, finding titles or API tokens.

Overlap with `/usage` is limited to the averages, which use a different
population (`done` + `failed` there, completed-and-costed here). All three
routes are read-only GETs on the existing browser mux and add no auth surface.
