### PR TITLE
fix(web): route subproject exports through v1 API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/yuin/goldmark v1.8.5
 	go.yaml.in/yaml/v3 v3.0.5
 	golang.org/x/crypto v0.55.0
+	golang.org/x/net v0.58.0
 	golang.org/x/term v0.45.0
 	gorm.io/gorm v1.31.2
 	maragu.dev/goqite v0.4.0
@@ -57,7 +58,6 @@ require (
 	github.com/pandatix/go-cvss v0.6.4 // indirect
 	github.com/pjbgf/sha1cd v0.6.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
-	golang.org/x/net v0.58.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/text v0.41.0 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect

--- a/internal/web/subproject_ui_test.go
+++ b/internal/web/subproject_ui_test.go
@@ -45,7 +45,7 @@ func TestSubprojectShow(t *testing.T) {
 			t.Errorf("subproject page missing %q", want)
 		}
 	}
-	match := regexp.MustCompile(`href="([^"]+)"><i data-lucide="download"></i> Export findings`).FindStringSubmatch(body)
+	match := regexp.MustCompile(`href="([^"]*/api/v1/repositories/[0-9]+/findings\?[^"]*)"`).FindStringSubmatch(body)
 	if len(match) != 2 {
 		t.Fatal("subproject page missing export findings link")
 	}

--- a/internal/web/subproject_ui_test.go
+++ b/internal/web/subproject_ui_test.go
@@ -1,14 +1,14 @@
 package web
 
 import (
-	"html"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"regexp"
 	"strconv"
 	"strings"
 	"testing"
+
+	"golang.org/x/net/html"
 
 	"scrutineer/internal/db"
 )
@@ -45,13 +45,34 @@ func TestSubprojectShow(t *testing.T) {
 			t.Errorf("subproject page missing %q", want)
 		}
 	}
-	match := regexp.MustCompile(`href="([^"]*/api/v1/repositories/[0-9]+/findings\?[^"]*)"`).FindStringSubmatch(body)
-	if len(match) != 2 {
+	doc, err := html.Parse(strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("parse subproject page: %v", err)
+	}
+	var exportHref string
+	var visit func(*html.Node)
+	visit = func(node *html.Node) {
+		if node.Type == html.ElementNode && node.Data == "a" {
+			for _, attr := range node.Attr {
+				if attr.Key == "href" && strings.HasPrefix(attr.Val, "/api/v1/repositories/") && strings.Contains(attr.Val, "/findings?") {
+					exportHref = attr.Val
+				}
+			}
+		}
+		for child := node.FirstChild; child != nil && exportHref == ""; child = child.NextSibling {
+			visit(child)
+		}
+	}
+	visit(doc)
+	if exportHref == "" {
 		t.Fatal("subproject page missing export findings link")
 	}
-	exportURL, err := url.Parse(html.UnescapeString(match[1]))
+	exportURL, err := url.Parse(exportHref)
 	if err != nil {
 		t.Fatalf("parse export URL: %v", err)
+	}
+	if exportURL.Scheme != "" || exportURL.Host != "" {
+		t.Fatalf("export URL must be relative, got %q", exportHref)
 	}
 	wantPath := "/api/v1/repositories/" + strconv.FormatUint(uint64(repo.ID), 10) + "/findings"
 	if exportURL.Path != wantPath {

--- a/internal/web/subproject_ui_test.go
+++ b/internal/web/subproject_ui_test.go
@@ -1,9 +1,11 @@
 package web
 
 import (
+	"html"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"regexp"
 	"strconv"
 	"strings"
 	"testing"
@@ -22,11 +24,11 @@ func TestSubprojectShow(t *testing.T) {
 	s.MonorepoAttribution = true // show the attributed packages/advisories sections
 	repo := db.Repository{URL: "https://github.com/rails/rails", Name: "rails", DisclosureChannel: "repo@example.org"}
 	s.DB.Create(&repo)
-	sub := db.Subproject{RepositoryID: repo.ID, Path: "activesupport", Name: "activesupport", Kind: "ruby-gem"}
+	sub := db.Subproject{RepositoryID: repo.ID, Path: "active support/core&next=all", Name: "activesupport", Kind: "ruby-gem"}
 	s.DB.Create(&sub)
-	scan := db.Scan{RepositoryID: repo.ID, Status: db.ScanDone, SubPath: "activesupport"}
+	scan := db.Scan{RepositoryID: repo.ID, Status: db.ScanDone, SubPath: sub.Path}
 	s.DB.Create(&scan)
-	s.DB.Create(&db.Finding{ScanID: scan.ID, RepositoryID: repo.ID, SubPath: "activesupport",
+	s.DB.Create(&db.Finding{ScanID: scan.ID, RepositoryID: repo.ID, SubPath: sub.Path,
 		FindingID: "F1", Title: "XSS in ActiveSupport", Severity: "High", Status: db.FindingNew, Location: "lib/x.rb:1"})
 	s.DB.Create(&db.Package{RepositoryID: repo.ID, SubprojectID: &sub.ID, Name: "activesupport", Ecosystem: "rubygems"})
 
@@ -42,6 +44,21 @@ func TestSubprojectShow(t *testing.T) {
 		if !strings.Contains(body, want) {
 			t.Errorf("subproject page missing %q", want)
 		}
+	}
+	match := regexp.MustCompile(`href="([^"]+)"><i data-lucide="download"></i> Export findings`).FindStringSubmatch(body)
+	if len(match) != 2 {
+		t.Fatal("subproject page missing export findings link")
+	}
+	exportURL, err := url.Parse(html.UnescapeString(match[1]))
+	if err != nil {
+		t.Fatalf("parse export URL: %v", err)
+	}
+	wantPath := "/api/v1/repositories/" + strconv.FormatUint(uint64(repo.ID), 10) + "/findings"
+	if exportURL.Path != wantPath {
+		t.Errorf("export URL path = %q, want %q", exportURL.Path, wantPath)
+	}
+	if got := exportURL.Query().Get("sub_path"); got != sub.Path {
+		t.Errorf("export URL sub_path = %q, want %q", got, sub.Path)
 	}
 }
 

--- a/internal/web/templates/subproject_show.html
+++ b/internal/web/templates/subproject_show.html
@@ -18,7 +18,7 @@
     <input type="hidden" name="sub_path" value="{{.Sub.Path}}">
     <button type="submit" class="btn-sm-outline"><i data-lucide="play"></i> Scan this sub-package</button>
   </form>
-  <a class="btn-sm-outline" href="/api/repositories/{{.Repo.ID}}/findings?sub_path={{.Sub.Path}}"><i data-lucide="download"></i> Export findings</a>
+  <a class="btn-sm-outline" href="/api/v1/repositories/{{.Repo.ID}}/findings?sub_path={{.Sub.Path}}"><i data-lucide="download"></i> Export findings</a>
 </div>
 
 <div class="mb-6 max-w-3xl">


### PR DESCRIPTION
## Summary

- route the subproject **Export findings** action through the host-only `/api/v1/` endpoint
- keep the repository ID and `sub_path` filter intact
- verify the rendered link preserves URL-sensitive subproject paths

## Test plan

- `go mod tidy -diff`
- `go vet ./...`
- `go test -race -gcflags='modernc.org/...=-d=checkptr=0' ./...`
- `go vet -tags evals ./internal/evals/...`
- `go test -race -tags evals ./internal/evals/...`
- `go vet -tags podman ./...`
- `golangci-lint run ./...`
- `scripts/release-resolver_test.sh`
- `scripts/wait-for-runner-image_test.sh`

## AI assistance

Codex was used to implement and validate this change. The reported route failure was reproduced with a rendered-template regression before the fix.

Closes #998
