### PR TITLE
fix(web): stop the repository list reading every cached ecosyste.ms payload

### DIFF
--- a/docs/database.md
+++ b/docs/database.md
@@ -55,7 +55,7 @@ The central entity. One row per git URL.
 | upstream_url | text | Upstream this repository is a pushed staging copy of (no forge fork relationship). When set, the scheduler force-syncs the repository from it (a mirror push that overwrites local-only commits) before the new-commit check. Empty for ordinary repos. |
 | next_scheduled_scan_at | datetime | Scheduler bookkeeping: when the next scheduled run is due. Null means "recompute on the next tick"; schedule edits reset it instead of computing inline. |
 | created_at | datetime | |
-| updated_at | datetime | |
+| updated_at | datetime | Indexed for the repository list's default newest-first order. |
 
 ## audit_events
 

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -141,7 +141,10 @@ type Repository struct {
 	NextScheduledScanAt *time.Time `gorm:"index"`
 
 	CreatedAt time.Time
-	UpdatedAt time.Time
+	// UpdatedAt drives the repository list's default newest-first order. Keep
+	// it indexed so SQLite can find the first page without scanning through
+	// every repository's large cache columns and building a temporary sort.
+	UpdatedAt time.Time `gorm:"index"`
 
 	Scans            []Scan            `gorm:"constraint:OnDelete:CASCADE"`
 	ExpectedFindings []ExpectedFinding `gorm:"constraint:OnDelete:CASCADE"`

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -743,6 +743,43 @@ func TestWithPragmas_joinsOnExistingQuery(t *testing.T) {
 	}
 }
 
+func TestOpen_addsRepositoryUpdatedAtIndexToExistingDatabase(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "existing.db")
+	gdb, err := Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sqldb, err := gdb.DB()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = sqldb.Close() }()
+	if err := gdb.Migrator().DropIndex(&Repository{}, "idx_repositories_updated_at"); err != nil {
+		t.Fatal(err)
+	}
+	// Prove the precondition: without this the reopen below could pass on an
+	// index the drop never removed, and the test would assert nothing.
+	if gdb.Migrator().HasIndex(&Repository{}, "idx_repositories_updated_at") {
+		t.Fatal("DropIndex left idx_repositories_updated_at in place")
+	}
+	if err := sqldb.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	reopened, err := Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	reopenedSQL, err := reopened.DB()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = reopenedSQL.Close() }()
+	if !reopened.Migrator().HasIndex(&Repository{}, "idx_repositories_updated_at") {
+		t.Fatal("Open did not add idx_repositories_updated_at to an existing database")
+	}
+}
+
 // foreign_keys and busy_timeout are per-connection in SQLite. Setting them
 // via a single gdb.Exec only configures whichever pooled connection that
 // Exec lands on, leaving the rest at the defaults (#457). Open now folds

--- a/internal/web/list_performance_test.go
+++ b/internal/web/list_performance_test.go
@@ -77,13 +77,14 @@ func BenchmarkListPagesLargeDataset(b *testing.B) {
 	s, done := newTestServer(b)
 	defer done()
 	seedListPagePerfFixtures(b, s, 500)
+	handler := s.Handler()
 
 	for _, path := range []string{"/", "/findings", "/scans"} {
 		b.Run(path, func(b *testing.B) {
 			b.ReportAllocs()
 			for i := 0; i < b.N; i++ {
 				w := httptest.NewRecorder()
-				s.Handler().ServeHTTP(w, localReq("GET", path))
+				handler.ServeHTTP(w, localReq("GET", path))
 				if w.Code != 200 {
 					b.Fatalf("%s status %d: %s", path, w.Code, w.Body)
 				}
@@ -116,6 +117,221 @@ func TestRepoList_diskBadgeReadsCachedColumn(t *testing.T) {
 	}
 }
 
+func TestRepoList_projectsRenderedRepositoryColumns(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	repo := db.Repository{
+		URL:        "https://example.com/rendered-fields",
+		Name:       "rendered-fields",
+		Languages:  "Go, Ruby",
+		Health:     db.RepositoryHealthActive,
+		CloneError: "clone unavailable",
+		DiskBytes:  2048,
+	}
+	if err := s.DB.Create(&repo).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	listSQL := captureRepoListSQL(t, s)
+	handler := s.Handler()
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, localReq("GET", "/"))
+	if w.Code != 200 {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+	row := requireRepoListRow(t, w.Body.String(), repo.ID)
+	for _, want := range []string{
+		"example.com/rendered-fields", "Go, Ruby", string(db.RepositoryHealthActive),
+		"clone unavailable", "2.0 KB",
+	} {
+		if !strings.Contains(row, want) {
+			t.Errorf("repo row missing rendered field %q: %s", want, row)
+		}
+	}
+
+	if *listSQL == "" {
+		t.Fatal("did not capture repository list query")
+	}
+	projection := func(sql string) string {
+		selectClause, _, _ := strings.Cut(strings.ToLower(sql), " from ")
+		selectClause = strings.TrimPrefix(selectClause, "select ")
+		selectClause = strings.ReplaceAll(selectClause, "`", "")
+		selectClause = strings.ReplaceAll(selectClause, "repositories.", "")
+		return strings.ReplaceAll(selectClause, " ", "")
+	}
+	const wantProjection = "id,url,languages,health,clone_error,disk_bytes"
+	if got := projection(*listSQL); got != wantProjection {
+		t.Errorf("repository list query projection = %s, want %s", got, wantProjection)
+	}
+	lowerSQL := strings.ToLower(*listSQL)
+	if strings.Contains(lowerSQL, "select *") {
+		t.Errorf("repository list query hydrates every column: %s", *listSQL)
+	}
+	for _, blobColumn := range []string{
+		"metadata", "threat_model", "scan_config",
+		"ecosystems_repo_data", "ecosystems_packages_data", "ecosystems_advisories_data",
+		"ecosystems_commits_data", "ecosystems_issues_data", "ecosystems_dependents_data",
+	} {
+		if strings.Contains(lowerSQL, blobColumn) {
+			t.Errorf("repository list query hydrates %s: %s", blobColumn, *listSQL)
+		}
+	}
+
+	// Every sort branch shares the one Find, so clearing between requests
+	// catches a branch that stops issuing it rather than rechecking the
+	// statement the previous request left behind.
+	for _, sort := range []string{"name", "stars", "language", "size", "findings", "scanned", statusKey} {
+		*listSQL = ""
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, localReq("GET", "/?sort="+sort))
+		if w.Code != 200 {
+			t.Fatalf("sort %s status %d: %s", sort, w.Code, w.Body)
+		}
+		if got := projection(*listSQL); got != wantProjection {
+			t.Errorf("sort %s repository projection = %s, want %s", sort, got, wantProjection)
+		}
+	}
+}
+
+// The default newest-first order runs on every / and /repositories render.
+// Without an index on updated_at SQLite scans the whole table and builds a
+// temporary sort, dragging each row's large cache columns through it: the
+// projection alone leaves that scan in place, so both halves of the fix have
+// to hold for the page to stay fast.
+func TestRepoList_defaultSortUsesUpdatedAtIndex(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	repo := db.Repository{URL: "https://example.com/indexed-order", Name: "indexed-order"}
+	if err := s.DB.Create(&repo).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	listSQL := captureRepoListSQL(t, s)
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq("GET", "/"))
+	if w.Code != 200 {
+		t.Fatalf("status %d: %s", w.Code, w.Body)
+	}
+	if *listSQL == "" {
+		t.Fatal("did not capture repository list query")
+	}
+
+	var plan []struct{ Detail string }
+	if err := s.DB.Raw("EXPLAIN QUERY PLAN " + *listSQL).Scan(&plan).Error; err != nil {
+		t.Fatal(err)
+	}
+	joinedPlan := fmt.Sprint(plan)
+	if !strings.Contains(joinedPlan, "USING INDEX idx_repositories_updated_at") {
+		t.Errorf("repository list query plan does not use updated_at index: %s", joinedPlan)
+	}
+	if strings.Contains(joinedPlan, "USE TEMP B-TREE FOR ORDER BY") {
+		t.Errorf("repository list query plan still builds a temporary sort: %s", joinedPlan)
+	}
+}
+
+// captureRepoListSQL returns a handle on the SELECT the repository list last
+// issued, so a test can assert against the statement the handler really ran
+// rather than one it rebuilt itself. The callback outlives the test by design:
+// it is scoped to the per-test database newTestServer closes on cleanup, and
+// GORM logs a warning on every callback removal.
+func captureRepoListSQL(t *testing.T, s *Server) *string {
+	t.Helper()
+	var listSQL string
+	name := fmt.Sprintf("scrutineer:test-repo-list-sql:%d", time.Now().UnixNano())
+	if err := s.DB.Callback().Query().After("gorm:query").Register(name, func(tx *gorm.DB) {
+		if _, ok := tx.Statement.Dest.(*[]repoListFields); ok && tx.Statement.Table == "repositories" {
+			listSQL = tx.Statement.SQL.String()
+		}
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return &listSQL
+}
+
+func BenchmarkRepoListLargeCachedRows(b *testing.B) {
+	s, done := newTestServer(b)
+	defer done()
+
+	const (
+		repositories = 75
+		blobBytes    = 256 << 10
+	)
+	blob := strings.Repeat("x", blobBytes)
+	repoIDs := make([]uint, 0, repositories)
+	for i := 0; i < repositories; i++ {
+		repo := db.Repository{
+			URL:                      fmt.Sprintf("https://example.com/large-%03d", i),
+			Name:                     fmt.Sprintf("large-%03d", i),
+			Languages:                "Go",
+			Metadata:                 blob,
+			EcosystemsRepoData:       blob,
+			EcosystemsPackagesData:   blob,
+			EcosystemsAdvisoriesData: blob,
+			EcosystemsCommitsData:    blob,
+			EcosystemsIssuesData:     blob,
+			EcosystemsDependentsData: blob,
+		}
+		if err := s.DB.Create(&repo).Error; err != nil {
+			b.Fatal(err)
+		}
+		repoIDs = append(repoIDs, repo.ID)
+	}
+
+	// Build the mux once, as main does. Re-registering ~200 routes per
+	// iteration costs ~200us and ~2200 allocations, which would otherwise
+	// swamp the allocation figure this benchmark exists to watch.
+	handler := s.Handler()
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, localReq("GET", "/"))
+	if w.Code != 200 {
+		b.Fatalf("fixture status %d: %s", w.Code, w.Body)
+	}
+	lastRepoID := repoIDs[len(repoIDs)-1]
+	if !strings.Contains(w.Body.String(), fmt.Sprintf(`<tr id="repo-%d">`, lastRepoID)) {
+		b.Fatalf("fixture repository %d did not render", lastRepoID)
+	}
+	run := func(b *testing.B) {
+		b.Helper()
+		b.ReportAllocs()
+		b.ReportMetric(float64(repositories*7*blobBytes)/(1<<20), "cache-MiB")
+		for i := 0; i < b.N; i++ {
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, localReq("GET", "/"))
+			if w.Code != 200 {
+				b.Fatalf("status %d: %s", w.Code, w.Body)
+			}
+		}
+	}
+
+	b.Run("idle", run)
+	b.Run("with-enrichment-writes", func(b *testing.B) {
+		stop := make(chan struct{})
+		done := make(chan struct{})
+		// RefreshEcosystems writes each source as a single-row UPDATE of that
+		// source's cached payload column. Keep one such writer active to
+		// exercise WAL read/write concurrency without involving the network
+		// or a live database.
+		go func() {
+			defer close(done)
+			for i := 0; ; i++ {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				_ = s.DB.Model(&db.Repository{}).
+					Where("id = ?", repoIDs[i%len(repoIDs)]).
+					Update("ecosystems_issues_data", blob).Error
+			}
+		}()
+		b.Cleanup(func() {
+			close(stop)
+			<-done
+		})
+		run(b)
+	})
+}
+
 func listPageQueryCount(t *testing.T, path string, rows int) int64 {
 	t.Helper()
 	s, done := newTestServer(t)
@@ -139,6 +355,13 @@ func countDBQueries(t testing.TB, s *Server) func() int64 {
 		count.Add(1)
 	}
 	if err := s.DB.Callback().Query().Before("gorm:query").Register(name+":query", callback); err != nil {
+		t.Fatal(err)
+	}
+	// GORM routes statements through three processors: Find/First/Pluck use
+	// Query, Scan (including Raw(...).Scan) uses Row, and Exec uses Raw.
+	// Register on all three so the bound counts every statement a handler
+	// issues rather than whichever processor it happens to reach for.
+	if err := s.DB.Callback().Row().Before("gorm:row").Register(name+":row", callback); err != nil {
 		t.Fatal(err)
 	}
 	if err := s.DB.Callback().Raw().Before("gorm:raw").Register(name+":raw", callback); err != nil {

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -835,12 +835,25 @@ func paginate(r *http.Request, total int64) Page {
 	return Page{N: n, Pages: pages, Total: total, Path: r.URL.Path, Query: r.URL.Query()}
 }
 
+// repoListFields is the complete Repository surface rendered by
+// repo_list.html. Querying into this narrow type makes GORM derive the SELECT
+// list from the template's data contract while keeping the potentially large
+// Repository cache fields out. A template reference to an unlisted field then
+// fails loudly instead of silently rendering an unhydrated zero value.
+type repoListFields struct {
+	ID         uint
+	URL        string
+	Languages  string
+	Health     db.RepositoryHealth
+	CloneError string
+	DiskBytes  int64
+}
+
 type repoRow struct {
-	db.Repository
+	repoListFields
 	LastScan      *db.Scan
 	StatusScan    *db.Scan
 	FindingsTotal int
-	DiskBytes     int64
 	// Branches lists the distinct non-default refs this repo has been
 	// scanned on, for the branch tags next to its name. Empty when every
 	// scan ran on the default branch.
@@ -927,7 +940,7 @@ func (s *Server) repoList(w http.ResponseWriter, r *http.Request) {
 	q.Count(&total)
 	page := paginate(r, total)
 
-	var repos []db.Repository
+	var repos []repoListFields
 	q.Limit(perPage).Offset((page.N - 1) * perPage).Find(&repos)
 
 	// Batch-load findings count and last scan per page (N rows) rather
@@ -1023,15 +1036,11 @@ func (s *Server) repoList(w http.ResponseWriter, r *http.Request) {
 	rows := make([]repoRow, 0, len(repos))
 	for _, repo := range repos {
 		rows = append(rows, repoRow{
-			Repository:    repo,
-			LastScan:      lastScans[repo.ID],
-			StatusScan:    statusScans[repo.ID],
-			FindingsTotal: findingCounts[repo.ID],
-			// Read the cached size from the row; the worker refreshes it on
-			// each scan and a startup backfill seeds it, so the list never
-			// walks the clone cache per row (#126).
-			DiskBytes: repo.DiskBytes,
-			Branches:  branchesByRepo[repo.ID],
+			repoListFields: repo,
+			LastScan:       lastScans[repo.ID],
+			StatusScan:     statusScans[repo.ID],
+			FindingsTotal:  findingCounts[repo.ID],
+			Branches:       branchesByRepo[repo.ID],
 		})
 	}
 	languages := distinctLanguages(s.DB)


### PR DESCRIPTION
`GET /` and `/repositories` timed out once repository rows carried large cached ecosyste.ms payloads. `repoList` hydrated whole `db.Repository` rows and the default `updated_at desc` order had no index, so SQLite dragged every row's `metadata` and six ecosyste.ms blobs through a temporary sort: 404ms for the list query on a 600 repository, 528 MiB fixture.

The list now selects only the six columns `repo_list.html` renders, and `updated_at` is indexed, which plans the default order as an index scan and takes that query to 1.5ms. Orders keyed on `disk_bytes` or a scan subquery still sort the table, so this covers the landing page rather than every column header.

Opus 5 was used to implement this.
