### PR TITLE
fix(db): keep retrying finding writes while the lock is held

### DIFF
--- a/internal/db/finding_helpers.go
+++ b/internal/db/finding_helpers.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"regexp"
@@ -8,6 +9,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"scrutineer/internal/retry"
 
 	"github.com/git-pkgs/vulns"
 	"gorm.io/gorm"
@@ -24,9 +27,11 @@ const GHSAIDPattern = `(?i)GHSA(-[0-9a-z]{4}){3}`
 var ghsaIDRE = regexp.MustCompile("^" + GHSAIDPattern + "$")
 
 const (
-	findingWriteMaxAttempts  = 5
+	findingWriteRetryTimeout = 5 * time.Second
+	findingWriteMaxDelay     = 100 * time.Millisecond
 	findingCapHistoryMaxRows = 20
 	sqliteBusyCode           = 5
+	sqliteBusySnapshotCode   = 517
 )
 
 var errFindingWriteConflict = errors.New("finding changed concurrently")
@@ -64,7 +69,7 @@ func WriteFindingField(gdb *gorm.DB, findingID uint, field, newValue string, sou
 	// sync must commit together: a failure between them would change the
 	// stored value with no matching history row (breaking the audit
 	// trail) or leave cvss_score inconsistent with cvss_vector.
-	return retryFindingWrite(gdb, findingID, func(tx *gorm.DB) error {
+	return FindingWriteTransaction(gdb, findingID, func(tx *gorm.DB) error {
 		var f Finding
 		if err := tx.First(&f, findingID).Error; err != nil {
 			return fmt.Errorf("load finding %d: %w", findingID, err)
@@ -144,7 +149,7 @@ func ReconcileFindingSeverityCap(
 	}
 
 	var effective string
-	err := retryFindingWrite(gdb, findingID, func(tx *gorm.DB) error {
+	err := FindingWriteTransaction(gdb, findingID, func(tx *gorm.DB) error {
 		var f Finding
 		if err := tx.First(&f, findingID).Error; err != nil {
 			return fmt.Errorf("load finding %d: %w", findingID, err)
@@ -279,7 +284,7 @@ func WriteFindingTimeField(gdb *gorm.DB, findingID uint, field string, newValue 
 	newUTC := newValue.UTC()
 	// Column update and history row must commit together so the audit
 	// trail can't lose a row on a mid-write failure.
-	return retryFindingWrite(gdb, findingID, func(tx *gorm.DB) error {
+	return FindingWriteTransaction(gdb, findingID, func(tx *gorm.DB) error {
 		var f Finding
 		if err := tx.First(&f, findingID).Error; err != nil {
 			return fmt.Errorf("load finding %d: %w", findingID, err)
@@ -310,10 +315,12 @@ func WriteFindingTimeField(gdb *gorm.DB, findingID uint, field string, newValue 
 	})
 }
 
-// retryFindingWrite owns and retries transactions created for raw database
-// handles. A caller-owned transaction cannot be restarted here, so it gets
-// one conditional attempt and returns any conflict to its caller for rollback.
-func retryFindingWrite(gdb *gorm.DB, findingID uint, write func(*gorm.DB) error) error {
+// FindingWriteTransaction atomically applies database-only finding writes,
+// retrying owned transactions on contention. The callback may run more than
+// once and must reset per-attempt state and avoid external side effects.
+// A caller-owned transaction gets one savepoint-backed attempt; its owner
+// must retry the whole transaction because its earlier work cannot be replayed here.
+func FindingWriteTransaction(gdb *gorm.DB, findingID uint, write func(*gorm.DB) error) error {
 	if _, inTransaction := gdb.Statement.ConnPool.(gorm.TxCommitter); inTransaction {
 		// Keep the helper atomic with a single GORM savepoint, but leave any
 		// outer transaction retry to its owner because its earlier work and
@@ -321,20 +328,29 @@ func retryFindingWrite(gdb *gorm.DB, findingID uint, write func(*gorm.DB) error)
 		return gdb.Transaction(write)
 	}
 
-	var err error
-	for attempt := 1; attempt <= findingWriteMaxAttempts; attempt++ {
-		err = gdb.Transaction(write)
+	// A deferred transaction that has already read can get SQLITE_BUSY
+	// without invoking SQLite's busy handler. Give whole-transaction retries
+	// the same time budget as our connection's busy_timeout, and honor a
+	// shorter caller deadline or cancellation throughout the wait.
+	ctx, cancel := context.WithTimeout(gdb.Statement.Context, findingWriteRetryTimeout)
+	defer cancel()
+	gdb = gdb.WithContext(ctx)
+	for attempt := 1; ; attempt++ {
+		err := gdb.Transaction(write)
 		if err == nil {
 			return nil
 		}
-		if !errors.Is(err, errFindingWriteConflict) && !isSQLiteBusy(err) {
+		delay, retryable := findingWriteRetryDelay(err, attempt)
+		if !retryable {
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return errors.Join(err, ctxErr)
+			}
 			return err
 		}
-		if attempt < findingWriteMaxAttempts {
-			time.Sleep(time.Millisecond << (attempt - 1))
+		if waitErr := retry.Sleep(ctx, delay); waitErr != nil {
+			return fmt.Errorf("write finding %d stopped after %d attempts: %w", findingID, attempt, errors.Join(err, waitErr))
 		}
 	}
-	return fmt.Errorf("write finding %d failed after %d attempts: %w", findingID, findingWriteMaxAttempts, err)
 }
 
 // conditionalFindingUpdate is the optimistic compare-and-swap shared by
@@ -354,12 +370,20 @@ func conditionalFindingUpdate(gdb *gorm.DB, findingID uint, column string, oldVa
 	return nil
 }
 
-// SQLite reports a stale WAL read transaction as SQLITE_BUSY_SNAPSHOT (an
-// extended SQLITE_BUSY code) instead of returning zero rows from the compare-
-// and-swap. The whole owned transaction must be restarted to get a new snapshot.
-func isSQLiteBusy(err error) bool {
+func findingWriteRetryDelay(err error, attempt int) (time.Duration, bool) {
+	if errors.Is(err, errFindingWriteConflict) {
+		return 0, true
+	}
 	var sqliteErr interface{ Code() int }
-	return errors.As(err, &sqliteErr) && sqliteErr.Code()&0xff == sqliteBusyCode
+	if !errors.As(err, &sqliteErr) || sqliteErr.Code()&0xff != sqliteBusyCode {
+		return 0, false
+	}
+	// A stale WAL snapshot needs a fresh transaction immediately; an active
+	// writer needs time to release its lock. Both retries start after rollback.
+	if sqliteErr.Code() == sqliteBusySnapshotCode {
+		return 0, true
+	}
+	return retry.BackoffDelay(attempt, time.Millisecond, findingWriteMaxDelay), true
 }
 
 // findingTimeFieldAccessor mirrors findingFieldAccessor for timestamp

--- a/internal/db/finding_helpers_test.go
+++ b/internal/db/finding_helpers_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -377,13 +378,19 @@ func TestWriteFindingField_concurrentUpdatesKeepHistoryChain(t *testing.T) {
 	gdb := newTestDB(t)
 	f := seedFinding(t, gdb)
 
-	// Hold both first reads until each writer has loaded the same value. The
-	// second write must detect that its snapshot lost the race, reload, and
-	// record a transition from the first writer's value.
+	// Hold both first reads until each writer has loaded the same value.
+	// Release one writer at a time so the second must retry a stale snapshot
+	// after the first commits, without racing the live writer's commit against
+	// the bounded busy-retry backoff.
 	const callbackName = "test:barrier_finding_reads"
 	var reads atomic.Int32
 	arrived := make(chan struct{}, 2)
 	release := make(chan struct{})
+	var writers sync.WaitGroup
+	defer func() {
+		close(release)
+		writers.Wait()
+	}()
 	if err := gdb.Callback().Query().After("gorm:query").Register(callbackName, func(d *gorm.DB) {
 		loaded, ok := d.Statement.Dest.(*Finding)
 		if !ok || loaded.ID != f.ID || d.Error != nil {
@@ -403,23 +410,26 @@ func TestWriteFindingField_concurrentUpdatesKeepHistoryChain(t *testing.T) {
 	})
 
 	errs := make(chan error, 2)
-	go func() {
+	writers.Go(func() {
 		errs <- WriteFindingField(gdb, f.ID, severityField, "Critical", SourceAnalyst, "analyst-a")
-	}()
-	go func() {
+	})
+	writers.Go(func() {
 		errs <- WriteFindingField(gdb, f.ID, severityField, "Medium", SourceModel, "worker-b")
-	}()
+	})
 
 	for range 2 {
 		select {
 		case <-arrived:
 		case <-time.After(10 * time.Second):
-			close(release)
 			t.Fatal("timed out waiting for concurrent finding reads")
 		}
 	}
-	close(release)
 	for range 2 {
+		select {
+		case release <- struct{}{}:
+		case <-time.After(10 * time.Second):
+			t.Fatal("timed out releasing a concurrent finding writer")
+		}
 		select {
 		case err := <-errs:
 			if err != nil {
@@ -428,6 +438,9 @@ func TestWriteFindingField_concurrentUpdatesKeepHistoryChain(t *testing.T) {
 		case <-time.After(10 * time.Second):
 			t.Fatal("timed out waiting for concurrent finding writes")
 		}
+	}
+	if reads.Load() < 3 {
+		t.Fatal("expected the stale writer to reload the finding on retry")
 	}
 
 	var refreshed Finding

--- a/internal/db/finding_retry_test.go
+++ b/internal/db/finding_retry_test.go
@@ -1,0 +1,275 @@
+package db
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"gorm.io/gorm"
+)
+
+func holdFindingWriteLock(t *testing.T, gdb *gorm.DB, findingID uint) *gorm.DB {
+	t.Helper()
+	tx := gdb.Begin()
+	if tx.Error != nil {
+		t.Fatal(tx.Error)
+	}
+	t.Cleanup(func() { _ = tx.Rollback().Error })
+	if err := tx.Model(&Finding{}).Where("id = ?", findingID).UpdateColumn("title", "lock holder").Error; err != nil {
+		t.Fatal(err)
+	}
+	return tx
+}
+
+func observeFindingWriteBusy(t *testing.T, gdb *gorm.DB) <-chan struct{} {
+	t.Helper()
+	busy := make(chan struct{}, 1)
+	const name = "test:observe_finding_write_busy"
+	if err := gdb.Callback().Update().After("gorm:update").Register(name, func(d *gorm.DB) {
+		var sqliteErr interface{ Code() int }
+		if d.Statement.Table != "findings" || !errors.As(d.Error, &sqliteErr) || sqliteErr.Code() != sqliteBusyCode {
+			return
+		}
+		select {
+		case busy <- struct{}{}:
+		default:
+		}
+	}); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := gdb.Callback().Update().Remove(name); err != nil {
+			t.Errorf("remove busy observer: %v", err)
+		}
+	})
+	return busy
+}
+
+func startFindingWrite(t *testing.T, gdb *gorm.DB, write func(*gorm.DB) error) <-chan error {
+	t.Helper()
+	ctx, cancel := context.WithCancel(gdb.Statement.Context)
+	errs := make(chan error, 1)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		errs <- write(gdb.WithContext(ctx))
+	}()
+	t.Cleanup(func() {
+		cancel()
+		<-done
+	})
+	return errs
+}
+
+func waitForFindingWriteBusy(t *testing.T, busy <-chan struct{}, errs <-chan error) {
+	t.Helper()
+	select {
+	case <-busy:
+	case err := <-errs:
+		t.Fatalf("write returned before observing SQLITE_BUSY: %v", err)
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for SQLITE_BUSY")
+	}
+}
+
+func awaitFindingWrite(t *testing.T, errs <-chan error) error {
+	t.Helper()
+	select {
+	case err := <-errs:
+		return err
+	case <-time.After(findingWriteRetryTimeout + 5*time.Second):
+		t.Fatalf("finding write exceeded the %s retry budget plus cleanup allowance", findingWriteRetryTimeout)
+		return nil
+	}
+}
+
+func findingWriteHistory(t *testing.T, gdb *gorm.DB, findingID uint) []FindingHistory {
+	t.Helper()
+	var history []FindingHistory
+	if err := gdb.Where("finding_id = ?", findingID).Find(&history).Error; err != nil {
+		t.Fatal(err)
+	}
+	return history
+}
+
+func TestFindingWrites_waitForActiveWriter(t *testing.T) {
+	at := time.Date(2026, time.September, 10, 12, 0, 0, 0, time.UTC)
+	for _, tc := range []struct {
+		name, field, oldValue, newValue string
+		write                           func(*gorm.DB, uint) error
+	}{
+		{"field", severityField, "High", "Medium", func(gdb *gorm.DB, id uint) error {
+			return WriteFindingField(gdb, id, severityField, "Medium", SourceAnalyst, "test")
+		}},
+		{"time", "released_at", "", at.Format(time.RFC3339), func(gdb *gorm.DB, id uint) error {
+			return WriteFindingTimeField(gdb, id, "released_at", at, SourceAnalyst, "test")
+		}},
+		{"severity cap", severityField, "High", "Medium", func(gdb *gorm.DB, id uint) error {
+			_, err := ReconcileFindingSeverityCap(gdb, id, "Medium", SourceSystem, "test")
+			return err
+		}},
+		{"outer transaction", severityField, "High", "Medium", func(gdb *gorm.DB, id uint) error {
+			return FindingWriteTransaction(gdb, id, func(tx *gorm.DB) error {
+				return WriteFindingField(tx, id, severityField, "Medium", SourceAnalyst, "test")
+			})
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			gdb := newTestDB(t)
+			f := seedFinding(t, gdb)
+			lock := holdFindingWriteLock(t, gdb, f.ID)
+			busy := observeFindingWriteBusy(t, gdb)
+			errs := startFindingWrite(t, gdb, func(gdb *gorm.DB) error { return tc.write(gdb, f.ID) })
+			waitForFindingWriteBusy(t, busy, errs)
+
+			// A real read-to-write upgrade must survive contention longer than
+			// the former 15 ms retry budget, not just reload a stale snapshot.
+			select {
+			case err := <-errs:
+				t.Fatalf("write returned while the lock was held: %v", err)
+			case <-time.After(200 * time.Millisecond):
+			}
+			if err := lock.Commit().Error; err != nil {
+				t.Fatal(err)
+			}
+			if err := awaitFindingWrite(t, errs); err != nil {
+				t.Fatalf("write after lock release: %v", err)
+			}
+
+			var stored Finding
+			if err := gdb.First(&stored, f.ID).Error; err != nil {
+				t.Fatal(err)
+			}
+			if tc.field == severityField && stored.Severity != tc.newValue {
+				t.Errorf("severity = %q, want %q", stored.Severity, tc.newValue)
+			}
+			if tc.field == "released_at" && (stored.ReleasedAt == nil || !stored.ReleasedAt.Equal(at)) {
+				t.Errorf("released_at = %v, want %v", stored.ReleasedAt, at)
+			}
+			history := findingWriteHistory(t, gdb, f.ID)
+			if len(history) != 1 {
+				t.Fatalf("history len = %d, want 1: %+v", len(history), history)
+			}
+			if h := history[0]; h.Field != tc.field || h.OldValue != tc.oldValue || h.NewValue != tc.newValue {
+				t.Errorf("unexpected history: %+v", h)
+			}
+		})
+	}
+}
+
+func TestWriteFindingField_lockWaitStops(t *testing.T) {
+	for _, mode := range []string{"cancel", "caller deadline", "retry deadline"} {
+		t.Run(mode, func(t *testing.T) {
+			gdb := newTestDB(t)
+			f := seedFinding(t, gdb)
+			lock := holdFindingWriteLock(t, gdb, f.ID)
+			busy := observeFindingWriteBusy(t, gdb)
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
+			if mode == "caller deadline" {
+				var stop context.CancelFunc
+				ctx, stop = context.WithTimeout(ctx, 200*time.Millisecond)
+				defer stop()
+			}
+			errs := startFindingWrite(t, gdb.WithContext(ctx), func(gdb *gorm.DB) error {
+				return WriteFindingField(gdb, f.ID, severityField, "Medium", SourceAnalyst, "test")
+			})
+			waitForFindingWriteBusy(t, busy, errs)
+			wantErr := context.DeadlineExceeded
+			if mode == "cancel" {
+				cancel()
+				wantErr = context.Canceled
+			}
+			if err := awaitFindingWrite(t, errs); !errors.Is(err, wantErr) {
+				t.Fatalf("write error = %v, want %v", err, wantErr)
+			}
+			if err := lock.Rollback().Error; err != nil {
+				t.Fatal(err)
+			}
+			var stored Finding
+			if err := gdb.First(&stored, f.ID).Error; err != nil {
+				t.Fatal(err)
+			}
+			if stored.Severity != "High" {
+				t.Errorf("severity = %q, want High after failed write", stored.Severity)
+			}
+			if history := findingWriteHistory(t, gdb, f.ID); len(history) != 0 {
+				t.Errorf("history = %+v, want none after failed write", history)
+			}
+			if err := WriteFindingField(gdb, f.ID, severityField, "Medium", SourceAnalyst, "retry"); err != nil {
+				t.Fatalf("write after cancellation and lock release: %v", err)
+			}
+		})
+	}
+}
+
+func TestFindingWriteTransaction_retriesWholeOperation(t *testing.T) {
+	gdb := newTestDB(t)
+	f := seedFinding(t, gdb)
+	var attempts int
+	err := FindingWriteTransaction(gdb, f.ID, func(tx *gorm.DB) error {
+		attempts++
+		var current Finding
+		if err := tx.First(&current, f.ID).Error; err != nil {
+			return err
+		}
+		if current.Severity != "High" || current.Title != "t" {
+			t.Errorf("attempt %d saw an unrolled-back write: %+v", attempts, current)
+		}
+		if err := WriteFindingField(tx, f.ID, severityField, "Medium", SourceAnalyst, "test"); err != nil {
+			return err
+		}
+		if err := WriteFindingField(tx, f.ID, "title", "changed", SourceAnalyst, "test"); err != nil {
+			return err
+		}
+		if attempts == 1 {
+			return errFindingWriteConflict
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if attempts != 2 {
+		t.Errorf("attempts = %d, want 2", attempts)
+	}
+	history := findingWriteHistory(t, gdb, f.ID)
+	if len(history) != 2 {
+		t.Fatalf("history len = %d, want 2: %+v", len(history), history)
+	}
+	var stored Finding
+	if err := gdb.First(&stored, f.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if stored.Severity != "Medium" || stored.Title != "changed" {
+		t.Errorf("finding = severity %q, title %q", stored.Severity, stored.Title)
+	}
+}
+
+func TestFindingWriteTransaction_leavesCallerOwnedRetryToOwner(t *testing.T) {
+	gdb := newTestDB(t)
+	f := seedFinding(t, gdb)
+	var attempts int
+	if err := gdb.Transaction(func(tx *gorm.DB) error {
+		err := FindingWriteTransaction(tx, f.ID, func(tx *gorm.DB) error {
+			attempts++
+			if err := WriteFindingField(tx, f.ID, severityField, "Medium", SourceAnalyst, "test"); err != nil {
+				return err
+			}
+			return errFindingWriteConflict
+		})
+		if !errors.Is(err, errFindingWriteConflict) {
+			t.Errorf("error = %v, want conflict returned to transaction owner", err)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if attempts != 1 {
+		t.Errorf("attempts = %d, want 1 inside caller-owned transaction", attempts)
+	}
+	if history := findingWriteHistory(t, gdb, f.ID); len(history) != 0 {
+		t.Errorf("history = %+v, want none after savepoint rollback", history)
+	}
+}

--- a/internal/web/api_finding_writes.go
+++ b/internal/web/api_finding_writes.go
@@ -67,7 +67,7 @@ func (s *Server) apiPatchFinding(w http.ResponseWriter, r *http.Request) {
 			writeAPIError(w, http.StatusPreconditionFailed, err.Error())
 			return
 		}
-		writeAPIError(w, findingWriteErrorStatus(err), err.Error())
+		writeAPIError(w, findingWriteErrorStatus(err, http.StatusUnprocessableEntity), err.Error())
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)

--- a/internal/web/api_finding_writes.go
+++ b/internal/web/api_finding_writes.go
@@ -67,7 +67,7 @@ func (s *Server) apiPatchFinding(w http.ResponseWriter, r *http.Request) {
 			writeAPIError(w, http.StatusPreconditionFailed, err.Error())
 			return
 		}
-		writeAPIError(w, http.StatusUnprocessableEntity, err.Error())
+		writeAPIError(w, findingWriteErrorStatus(err), err.Error())
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)

--- a/internal/web/api_finding_writes.go
+++ b/internal/web/api_finding_writes.go
@@ -55,7 +55,7 @@ func (s *Server) apiPatchFinding(w http.ResponseWriter, r *http.Request) {
 		fields = append(fields, field)
 	}
 	sort.Strings(fields)
-	if err := s.DB.Transaction(func(tx *gorm.DB) error {
+	if err := db.FindingWriteTransaction(s.DB.WithContext(r.Context()), uint(id), func(tx *gorm.DB) error {
 		for _, field := range fields {
 			if err := db.WriteFindingField(tx, uint(id), field, body.Fields[field], source, body.By); err != nil {
 				return err

--- a/internal/web/finding_forms.go
+++ b/internal/web/finding_forms.go
@@ -1,6 +1,8 @@
 package web
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -24,6 +26,13 @@ var analystFields = []string{
 	"resolution", "disclosure_draft", "disclosure_title", "suggested_recipients", "assignee",
 }
 
+func findingWriteErrorStatus(err error) int {
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+		return http.StatusServiceUnavailable
+	}
+	return http.StatusUnprocessableEntity
+}
+
 func (s *Server) findingFields(w http.ResponseWriter, r *http.Request) {
 	f, ok := loadByID[db.Finding](s, w, r)
 	if !ok {
@@ -45,7 +54,7 @@ func (s *Server) findingFields(w http.ResponseWriter, r *http.Request) {
 		}
 		return nil
 	}); err != nil {
-		http.Error(w, err.Error(), http.StatusUnprocessableEntity)
+		http.Error(w, err.Error(), findingWriteErrorStatus(err))
 		return
 	}
 	s.redirect(w, r, fmt.Sprintf("/findings/%d", f.ID))

--- a/internal/web/finding_forms.go
+++ b/internal/web/finding_forms.go
@@ -26,11 +26,11 @@ var analystFields = []string{
 	"resolution", "disclosure_draft", "disclosure_title", "suggested_recipients", "assignee",
 }
 
-func findingWriteErrorStatus(err error) int {
+func findingWriteErrorStatus(err error, fallback int) int {
 	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
 		return http.StatusServiceUnavailable
 	}
-	return http.StatusUnprocessableEntity
+	return fallback
 }
 
 func (s *Server) findingFields(w http.ResponseWriter, r *http.Request) {
@@ -54,7 +54,7 @@ func (s *Server) findingFields(w http.ResponseWriter, r *http.Request) {
 		}
 		return nil
 	}); err != nil {
-		http.Error(w, err.Error(), findingWriteErrorStatus(err))
+		http.Error(w, err.Error(), findingWriteErrorStatus(err, http.StatusUnprocessableEntity))
 		return
 	}
 	s.redirect(w, r, fmt.Sprintf("/findings/%d", f.ID))
@@ -71,8 +71,8 @@ func (s *Server) findingDisclosureDraftSave(w http.ResponseWriter, r *http.Reque
 		return
 	}
 	draft := strings.TrimSpace(strings.ReplaceAll(r.FormValue("disclosure_draft"), "\r\n", "\n"))
-	if err := db.WriteFindingField(s.DB, f.ID, "disclosure_draft", draft, db.SourceAnalyst, ""); err != nil {
-		http.Error(w, err.Error(), http.StatusUnprocessableEntity)
+	if err := db.WriteFindingField(s.DB.WithContext(r.Context()), f.ID, "disclosure_draft", draft, db.SourceAnalyst, ""); err != nil {
+		http.Error(w, err.Error(), findingWriteErrorStatus(err, http.StatusUnprocessableEntity))
 		return
 	}
 	setFlash(w, Flash{Category: successKey, Title: "Disclosure draft saved"})

--- a/internal/web/finding_forms.go
+++ b/internal/web/finding_forms.go
@@ -33,7 +33,7 @@ func (s *Server) findingFields(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-	if err := s.DB.Transaction(func(tx *gorm.DB) error {
+	if err := db.FindingWriteTransaction(s.DB.WithContext(r.Context()), f.ID, func(tx *gorm.DB) error {
 		for _, field := range analystFields {
 			value, ok := r.Form[field]
 			if !ok {

--- a/internal/web/finding_vince.go
+++ b/internal/web/finding_vince.go
@@ -654,7 +654,7 @@ func attachmentHash(attachment *vince.Attachment) string {
 }
 
 func (s *Server) persistVINCESubmission(findingID uint, vrfID, reportsURL, attachmentName string) error {
-	return s.DB.Transaction(func(tx *gorm.DB) error {
+	return db.FindingWriteTransaction(s.DB, findingID, func(tx *gorm.DB) error {
 		var refs []db.FindingReference
 		if err := tx.Where("finding_id = ?", findingID).Find(&refs).Error; err != nil {
 			return err

--- a/internal/web/finding_write_contention_test.go
+++ b/internal/web/finding_write_contention_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 	"time"
 
@@ -29,61 +30,9 @@ func testFindingEditWaitsForWriter(t *testing.T, api bool) {
 	t.Cleanup(cleanup)
 	f, token, _ := seedFindingForAPI(t, s)
 	scopeAPITokenToFinding(t, s, token, f.ID)
-	ctx, cancel := context.WithCancel(t.Context())
-	t.Cleanup(cancel)
-	s.DB = s.DB.WithContext(ctx)
-	lock := s.DB.Begin()
-	if lock.Error != nil {
-		t.Fatal(lock.Error)
-	}
-	t.Cleanup(func() { _ = lock.Rollback().Error })
-	if err := lock.Model(&db.Finding{}).Where("id = ?", f.ID).UpdateColumn("title", "lock holder").Error; err != nil {
-		t.Fatal(err)
-	}
-
-	busy := make(chan struct{}, 1)
-	const callbackName = "test:observe_edit_busy"
-	const sqliteBusyCode = 5
-	if err := s.DB.Callback().Update().After("gorm:update").Register(callbackName, func(d *gorm.DB) {
-		var sqliteErr interface{ Code() int }
-		if !errors.As(d.Error, &sqliteErr) || sqliteErr.Code() != sqliteBusyCode {
-			return
-		}
-		select {
-		case busy <- struct{}{}:
-		default:
-		}
-	}); err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() {
-		if err := s.DB.Callback().Update().Remove(callbackName); err != nil {
-			t.Errorf("remove busy observer: %v", err)
-		}
-	})
-	responses := make(chan *httptest.ResponseRecorder, 1)
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		if api {
-			responses <- apiReq(t, s, http.MethodPatch, fmt.Sprintf("/api/findings/%d", f.ID), token,
-				`{"fields":{"severity":"Medium","cve_id":"CVE-2026-12345"}}`)
-		} else {
-			responses <- postForm(t, s, fmt.Sprintf("/findings/%d/fields", f.ID),
-				url.Values{"severity": {"Medium"}, "cve_id": {"CVE-2026-12345"}})
-		}
-	}()
-	t.Cleanup(func() {
-		cancel()
-		<-done
-	})
-	select {
-	case <-busy:
-	case response := <-responses:
-		t.Fatalf("request returned before observing SQLITE_BUSY: %d %s", response.Code, response.Body)
-	case <-time.After(10 * time.Second):
-		t.Fatal("timed out waiting for request to contend with writer")
-	}
+	lock := holdFindingEditWriteLock(t, s.DB, f.ID)
+	responses, busy := startFindingEdit(t, s, t.Context(), api, f.ID, token)
+	waitForFindingEditBusy(t, busy, responses)
 	select {
 	case response := <-responses:
 		t.Fatalf("request returned while lock was held: %d %s", response.Code, response.Body)
@@ -117,5 +66,152 @@ func testFindingEditWaitsForWriter(t *testing.T, api bool) {
 	}
 	if len(history) != 2 {
 		t.Errorf("history len = %d, want 2: %+v", len(history), history)
+	}
+}
+
+func TestFindingEdits_lockWaitStops(t *testing.T) {
+	for _, api := range []bool{false, true} {
+		for _, mode := range []string{"cancel", "caller deadline", "retry deadline"} {
+			t.Run(fmt.Sprintf("api=%t/%s", api, mode), func(t *testing.T) {
+				testFindingEditLockWaitStops(t, api, mode)
+			})
+		}
+	}
+}
+
+func testFindingEditLockWaitStops(t *testing.T, api bool, mode string) {
+	t.Helper()
+	s, cleanup := newTestServer(t)
+	t.Cleanup(cleanup)
+	f, token, _ := seedFindingForAPI(t, s)
+	scopeAPITokenToFinding(t, s, token, f.ID)
+	// Keep the writer independent so ending the request cannot release its lock.
+	lock := holdFindingEditWriteLock(t, s.DB, f.ID)
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	if mode == "caller deadline" {
+		var stop context.CancelFunc
+		ctx, stop = context.WithTimeout(ctx, 200*time.Millisecond)
+		defer stop()
+	}
+	responses, busy := startFindingEdit(t, s, ctx, api, f.ID, token)
+	waitForFindingEditBusy(t, busy, responses)
+	wantErr := context.DeadlineExceeded
+	if mode == "cancel" {
+		cancel()
+		wantErr = context.Canceled
+	}
+	responseTimeout := 2 * time.Second
+	if mode == "retry deadline" {
+		responseTimeout = 10 * time.Second
+	}
+	select {
+	case response := <-responses:
+		if response.Code != http.StatusServiceUnavailable {
+			t.Fatalf("status = %d, want 503; body=%s", response.Code, response.Body)
+		}
+		if !strings.Contains(response.Body.String(), wantErr.Error()) {
+			t.Errorf("body = %s, want %q", response.Body, wantErr)
+		}
+	case <-time.After(responseTimeout):
+		t.Fatal("request did not stop within its cancellation or retry budget")
+	}
+	if err := lock.Commit().Error; err != nil {
+		t.Fatalf("independent writer could not commit: %v", err)
+	}
+	var stored db.Finding
+	if err := s.DB.First(&stored, f.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if stored.Severity != f.Severity || stored.CVEID != f.CVEID {
+		t.Errorf("finding changed after failed write: severity %q, cve_id %q", stored.Severity, stored.CVEID)
+	}
+	var history []db.FindingHistory
+	if err := s.DB.Where("finding_id = ?", f.ID).Find(&history).Error; err != nil {
+		t.Fatal(err)
+	}
+	if len(history) != 0 {
+		t.Errorf("history = %+v, want none after failed write", history)
+	}
+}
+
+func holdFindingEditWriteLock(t *testing.T, gdb *gorm.DB, findingID uint) *gorm.DB {
+	t.Helper()
+	lock := gdb.Begin()
+	if lock.Error != nil {
+		t.Fatal(lock.Error)
+	}
+	t.Cleanup(func() { _ = lock.Rollback().Error })
+	if err := lock.Model(&db.Finding{}).Where("id = ?", findingID).UpdateColumn("title", "lock holder").Error; err != nil {
+		t.Fatal(err)
+	}
+	return lock
+}
+
+func startFindingEdit(t *testing.T, s *Server, ctx context.Context, api bool, findingID uint, token string) (<-chan *httptest.ResponseRecorder, <-chan struct{}) {
+	t.Helper()
+	busy := make(chan struct{}, 1)
+	const callbackName = "test:observe_edit_busy"
+	const sqliteBusyCode = 5
+	if err := s.DB.Callback().Update().After("gorm:update").Register(callbackName, func(d *gorm.DB) {
+		var sqliteErr interface{ Code() int }
+		if !errors.As(d.Error, &sqliteErr) || sqliteErr.Code() != sqliteBusyCode {
+			return
+		}
+		select {
+		case busy <- struct{}{}:
+		default:
+		}
+	}); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := s.DB.Callback().Update().Remove(callbackName); err != nil {
+			t.Errorf("remove busy observer: %v", err)
+		}
+	})
+	ctx, cancel := context.WithCancel(ctx)
+	r := findingEditRequest(ctx, api, findingID, token)
+	handler := s.Handler()
+	responses := make(chan *httptest.ResponseRecorder, 1)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		response := httptest.NewRecorder()
+		handler.ServeHTTP(response, r)
+		responses <- response
+	}()
+	t.Cleanup(func() {
+		cancel()
+		<-done
+	})
+	return responses, busy
+}
+
+func findingEditRequest(ctx context.Context, api bool, findingID uint, token string) *http.Request {
+	var r *http.Request
+	if api {
+		r = httptest.NewRequestWithContext(ctx, http.MethodPatch, fmt.Sprintf("/api/findings/%d", findingID),
+			strings.NewReader(`{"fields":{"severity":"Medium","cve_id":"CVE-2026-12345"}}`))
+		r.Header.Set("Authorization", "Bearer "+token)
+		r.Header.Set("Content-Type", "application/json")
+	} else {
+		form := url.Values{"severity": {"Medium"}, "cve_id": {"CVE-2026-12345"}}
+		r = httptest.NewRequestWithContext(ctx, http.MethodPost, fmt.Sprintf("/findings/%d/fields", findingID), strings.NewReader(form.Encode()))
+		r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		r.Header.Set("Sec-Fetch-Site", "same-origin")
+	}
+	r.Host = testHost
+	return r
+}
+
+func waitForFindingEditBusy(t *testing.T, busy <-chan struct{}, responses <-chan *httptest.ResponseRecorder) {
+	t.Helper()
+	select {
+	case <-busy:
+	case response := <-responses:
+		t.Fatalf("request returned before observing SQLITE_BUSY: %d %s", response.Code, response.Body)
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for request to contend with writer")
 	}
 }

--- a/internal/web/finding_write_contention_test.go
+++ b/internal/web/finding_write_contention_test.go
@@ -73,13 +73,40 @@ func TestFindingEdits_lockWaitStops(t *testing.T) {
 	for _, api := range []bool{false, true} {
 		for _, mode := range []string{"cancel", "caller deadline", "retry deadline"} {
 			t.Run(fmt.Sprintf("api=%t/%s", api, mode), func(t *testing.T) {
-				testFindingEditLockWaitStops(t, api, mode)
+				testFindingEditLockWaitStops(t, mode, func(ctx context.Context, findingID uint, token string) *http.Request {
+					return findingEditRequest(ctx, api, findingID, token)
+				})
 			})
 		}
 	}
 }
 
-func testFindingEditLockWaitStops(t *testing.T, api bool, mode string) {
+func TestFindingBrowserWrites_lockWaitStops(t *testing.T) {
+	for _, tc := range []struct {
+		name, route string
+		form        url.Values
+	}{
+		{"disclosure draft", "disclosure-draft", url.Values{"disclosure_draft": {"edited draft"}}},
+		{"status", "status", url.Values{"status": {"triaged"}}},
+		{"exploited status", "exploited-in-wild", url.Values{"exploited_in_wild": {"yes"}}},
+		{"exploited evidence", "exploited-in-wild", url.Values{"exploited_in_wild_evidence": {"observed activity"}}},
+	} {
+		for _, mode := range []string{"cancel", "caller deadline", "retry deadline"} {
+			t.Run(tc.name+"/"+mode, func(t *testing.T) {
+				testFindingEditLockWaitStops(t, mode, func(ctx context.Context, findingID uint, _ string) *http.Request {
+					r := httptest.NewRequestWithContext(ctx, http.MethodPost,
+						fmt.Sprintf("/findings/%d/%s", findingID, tc.route), strings.NewReader(tc.form.Encode()))
+					r.Host = testHost
+					r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+					r.Header.Set("Sec-Fetch-Site", "same-origin")
+					return r
+				})
+			})
+		}
+	}
+}
+
+func testFindingEditLockWaitStops(t *testing.T, mode string, request func(context.Context, uint, string) *http.Request) {
 	t.Helper()
 	s, cleanup := newTestServer(t)
 	t.Cleanup(cleanup)
@@ -94,7 +121,7 @@ func testFindingEditLockWaitStops(t *testing.T, api bool, mode string) {
 		ctx, stop = context.WithTimeout(ctx, 200*time.Millisecond)
 		defer stop()
 	}
-	responses, busy := startFindingEdit(t, s, ctx, api, f.ID, token)
+	responses, busy := startFindingEditRequest(t, s, request(ctx, f.ID, token))
 	waitForFindingEditBusy(t, busy, responses)
 	wantErr := context.DeadlineExceeded
 	if mode == "cancel" {
@@ -123,8 +150,17 @@ func testFindingEditLockWaitStops(t *testing.T, api bool, mode string) {
 	if err := s.DB.First(&stored, f.ID).Error; err != nil {
 		t.Fatal(err)
 	}
-	if stored.Severity != f.Severity || stored.CVEID != f.CVEID {
-		t.Errorf("finding changed after failed write: severity %q, cve_id %q", stored.Severity, stored.CVEID)
+	for field, values := range map[string][2]string{
+		"severity":                   {stored.Severity, f.Severity},
+		"cve_id":                     {stored.CVEID, f.CVEID},
+		"disclosure_draft":           {stored.DisclosureDraft, f.DisclosureDraft},
+		"status":                     {string(stored.Status), string(f.Status)},
+		"exploited_in_wild":          {stored.ExploitedInWild, f.ExploitedInWild},
+		"exploited_in_wild_evidence": {stored.ExploitedInWildEvidence, f.ExploitedInWildEvidence},
+	} {
+		if values[0] != values[1] {
+			t.Errorf("%s changed after failed write: got %q, want %q", field, values[0], values[1])
+		}
 	}
 	var history []db.FindingHistory
 	if err := s.DB.Where("finding_id = ?", f.ID).Find(&history).Error; err != nil {
@@ -150,6 +186,11 @@ func holdFindingEditWriteLock(t *testing.T, gdb *gorm.DB, findingID uint) *gorm.
 
 func startFindingEdit(t *testing.T, s *Server, ctx context.Context, api bool, findingID uint, token string) (<-chan *httptest.ResponseRecorder, <-chan struct{}) {
 	t.Helper()
+	return startFindingEditRequest(t, s, findingEditRequest(ctx, api, findingID, token))
+}
+
+func startFindingEditRequest(t *testing.T, s *Server, r *http.Request) (<-chan *httptest.ResponseRecorder, <-chan struct{}) {
+	t.Helper()
 	busy := make(chan struct{}, 1)
 	const callbackName = "test:observe_edit_busy"
 	const sqliteBusyCode = 5
@@ -170,8 +211,8 @@ func startFindingEdit(t *testing.T, s *Server, ctx context.Context, api bool, fi
 			t.Errorf("remove busy observer: %v", err)
 		}
 	})
-	ctx, cancel := context.WithCancel(ctx)
-	r := findingEditRequest(ctx, api, findingID, token)
+	ctx, cancel := context.WithCancel(r.Context())
+	r = r.WithContext(ctx)
 	handler := s.Handler()
 	responses := make(chan *httptest.ResponseRecorder, 1)
 	done := make(chan struct{})

--- a/internal/web/finding_write_contention_test.go
+++ b/internal/web/finding_write_contention_test.go
@@ -1,0 +1,121 @@
+package web
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"scrutineer/internal/db"
+
+	"gorm.io/gorm"
+)
+
+func TestFindingEdits_waitForActiveWriter(t *testing.T) {
+	for _, api := range []bool{false, true} {
+		t.Run(fmt.Sprintf("api=%t", api), func(t *testing.T) {
+			testFindingEditWaitsForWriter(t, api)
+		})
+	}
+}
+
+func testFindingEditWaitsForWriter(t *testing.T, api bool) {
+	t.Helper()
+	s, cleanup := newTestServer(t)
+	t.Cleanup(cleanup)
+	f, token, _ := seedFindingForAPI(t, s)
+	scopeAPITokenToFinding(t, s, token, f.ID)
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+	s.DB = s.DB.WithContext(ctx)
+	lock := s.DB.Begin()
+	if lock.Error != nil {
+		t.Fatal(lock.Error)
+	}
+	t.Cleanup(func() { _ = lock.Rollback().Error })
+	if err := lock.Model(&db.Finding{}).Where("id = ?", f.ID).UpdateColumn("title", "lock holder").Error; err != nil {
+		t.Fatal(err)
+	}
+
+	busy := make(chan struct{}, 1)
+	const callbackName = "test:observe_edit_busy"
+	const sqliteBusyCode = 5
+	if err := s.DB.Callback().Update().After("gorm:update").Register(callbackName, func(d *gorm.DB) {
+		var sqliteErr interface{ Code() int }
+		if !errors.As(d.Error, &sqliteErr) || sqliteErr.Code() != sqliteBusyCode {
+			return
+		}
+		select {
+		case busy <- struct{}{}:
+		default:
+		}
+	}); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := s.DB.Callback().Update().Remove(callbackName); err != nil {
+			t.Errorf("remove busy observer: %v", err)
+		}
+	})
+	responses := make(chan *httptest.ResponseRecorder, 1)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		if api {
+			responses <- apiReq(t, s, http.MethodPatch, fmt.Sprintf("/api/findings/%d", f.ID), token,
+				`{"fields":{"severity":"Medium","cve_id":"CVE-2026-12345"}}`)
+		} else {
+			responses <- postForm(t, s, fmt.Sprintf("/findings/%d/fields", f.ID),
+				url.Values{"severity": {"Medium"}, "cve_id": {"CVE-2026-12345"}})
+		}
+	}()
+	t.Cleanup(func() {
+		cancel()
+		<-done
+	})
+	select {
+	case <-busy:
+	case response := <-responses:
+		t.Fatalf("request returned before observing SQLITE_BUSY: %d %s", response.Code, response.Body)
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for request to contend with writer")
+	}
+	select {
+	case response := <-responses:
+		t.Fatalf("request returned while lock was held: %d %s", response.Code, response.Body)
+	case <-time.After(200 * time.Millisecond):
+	}
+	if err := lock.Commit().Error; err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case response := <-responses:
+		wantStatus := http.StatusSeeOther
+		if api {
+			wantStatus = http.StatusNoContent
+		}
+		if response.Code != wantStatus {
+			t.Fatalf("status = %d, want %d; body=%s", response.Code, wantStatus, response.Body)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for request after lock release")
+	}
+	var stored db.Finding
+	if err := s.DB.First(&stored, f.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if stored.Severity != "Medium" || stored.CVEID != "CVE-2026-12345" {
+		t.Errorf("finding = severity %q, cve_id %q", stored.Severity, stored.CVEID)
+	}
+	var history []db.FindingHistory
+	if err := s.DB.Where("finding_id = ?", f.ID).Find(&history).Error; err != nil {
+		t.Fatal(err)
+	}
+	if len(history) != 2 {
+		t.Errorf("history len = %d, want 2: %+v", len(history), history)
+	}
+}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -1586,12 +1586,12 @@ func (s *Server) findingStatus(w http.ResponseWriter, r *http.Request) {
 	case db.FindingNew, db.FindingEnriched, db.FindingTriaged, db.FindingReady,
 		db.FindingReported, db.FindingAcknowledged, db.FindingFixed, db.FindingPublished,
 		db.FindingRejected, db.FindingDuplicate:
-		if err := db.WriteFindingField(s.DB, f.ID, statusKey, string(status), db.SourceAnalyst, ""); err != nil {
+		if err := db.WriteFindingField(s.DB.WithContext(r.Context()), f.ID, statusKey, string(status), db.SourceAnalyst, ""); err != nil {
 			if errors.Is(err, db.ErrFindingNonViable) {
 				http.Error(w, err.Error(), http.StatusPreconditionFailed)
 				return
 			}
-			http.Error(w, err.Error(), http.StatusInternalServerError)
+			http.Error(w, err.Error(), findingWriteErrorStatus(err, http.StatusInternalServerError))
 			return
 		}
 	default:
@@ -1621,12 +1621,13 @@ func (s *Server) findingExploitedInWild(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	evidence := strings.TrimSpace(r.FormValue("exploited_in_wild_evidence"))
-	if err := db.WriteFindingField(s.DB, f.ID, "exploited_in_wild", status, db.SourceAnalyst, ""); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+	gdb := s.DB.WithContext(r.Context())
+	if err := db.WriteFindingField(gdb, f.ID, "exploited_in_wild", status, db.SourceAnalyst, ""); err != nil {
+		http.Error(w, err.Error(), findingWriteErrorStatus(err, http.StatusInternalServerError))
 		return
 	}
-	if err := db.WriteFindingField(s.DB, f.ID, "exploited_in_wild_evidence", evidence, db.SourceAnalyst, ""); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+	if err := db.WriteFindingField(gdb, f.ID, "exploited_in_wild_evidence", evidence, db.SourceAnalyst, ""); err != nil {
+		http.Error(w, err.Error(), findingWriteErrorStatus(err, http.StatusInternalServerError))
 		return
 	}
 	s.redirect(w, r, fmt.Sprintf("/findings/%d", f.ID))

--- a/internal/worker/patch_gate.go
+++ b/internal/worker/patch_gate.go
@@ -91,7 +91,8 @@ func (w *Worker) parsePatchOutput(ctx context.Context, scan *db.Scan, report str
 
 func (w *Worker) recordRemediationAttempt(scan *db.Scan, findingID uint, rep patchReport) (db.RemediationAttempt, error) {
 	var attempt db.RemediationAttempt
-	err := w.DB.Transaction(func(tx *gorm.DB) error {
+	err := db.FindingWriteTransaction(w.DB, findingID, func(tx *gorm.DB) error {
+		attempt = db.RemediationAttempt{}
 		result := tx.Where("patch_scan_id = ?", scan.ID).Limit(1).Find(&attempt)
 		if result.Error != nil {
 			return fmt.Errorf("check existing remediation attempt: %w", result.Error)

--- a/internal/worker/skill_parsers.go
+++ b/internal/worker/skill_parsers.go
@@ -1202,7 +1202,8 @@ type verifyRecord struct {
 }
 
 func (w *Worker) recordVerifyOutput(scan *db.Scan, f db.Finding, record verifyRecord) error {
-	return w.DB.Transaction(func(tx *gorm.DB) error {
+	return db.FindingWriteTransaction(w.DB, f.ID, func(tx *gorm.DB) error {
+		calibration := record.calibration
 		var existing db.FindingVerification
 		lookup := tx.Where("finding_id = ? AND scan_id = ?", f.ID, scan.ID).Limit(1).Find(&existing)
 		if lookup.Error != nil {
@@ -1216,22 +1217,22 @@ func (w *Worker) recordVerifyOutput(scan *db.Scan, f db.Finding, record verifyRe
 				return fmt.Errorf("update status: %w", err)
 			}
 		}
-		if record.calibration.Evaluated {
+		if calibration.Evaluated {
 			effectiveSeverity, err := db.ReconcileFindingSeverityCap(
-				tx, f.ID, record.calibration.Maximum, db.SourceSystem, verifySkillName,
+				tx, f.ID, calibration.Maximum, db.SourceSystem, verifySkillName,
 			)
 			if err != nil {
 				return fmt.Errorf("reconcile severity cap: %w", err)
 			}
 			if !db.SeverityAtLeast(effectiveSeverity, "Low") {
-				record.calibration.Incomplete = true
-				record.calibration.Caps = nil
-			} else if record.calibration.Maximum != "" && !db.SeverityAtLeast(effectiveSeverity, record.calibration.Maximum) {
-				record.calibration.Caps = nil
+				calibration.Incomplete = true
+				calibration.Caps = nil
+			} else if calibration.Maximum != "" && !db.SeverityAtLeast(effectiveSeverity, calibration.Maximum) {
+				calibration.Caps = nil
 			}
 			if err := tx.Model(&db.Finding{}).Where("id = ?", f.ID).Updates(map[string]any{
-				"severity_caps":                   strings.Join(record.calibration.Caps, "\n"),
-				"severity_calibration_incomplete": record.calibration.Incomplete,
+				"severity_caps":                   strings.Join(calibration.Caps, "\n"),
+				"severity_calibration_incomplete": calibration.Incomplete,
 			}).Error; err != nil {
 				return fmt.Errorf("record severity calibration: %w", err)
 			}
@@ -1246,7 +1247,7 @@ func (w *Worker) recordVerifyOutput(scan *db.Scan, f db.Finding, record verifyRe
 		if err := tx.Create(&row).Error; err != nil {
 			return fmt.Errorf("record verification: %w", err)
 		}
-		note := verifyNote(record.result, record.rubric, record.score, record.gradingError, record.calibration)
+		note := verifyNote(record.result, record.rubric, record.score, record.gradingError, calibration)
 		if _, err := db.AddFindingNote(tx, f.ID, note, "verify"); err != nil {
 			return fmt.Errorf("record verify note: %w", err)
 		}


### PR DESCRIPTION
`WriteFindingField` reads then updates the row in one deferred transaction, and SQLite skips the busy handler when such a transaction takes the write lock, so `busy_timeout(5000)` never applied. The only protection was five attempts over 15 ms, so anything holding the lock longer failed the write: CI hit it in the concurrent history test, and a worker mid-transaction turned analyst edits into HTTP 422s.

`FindingWriteTransaction` now retries the whole transaction under a five-second, cancellation-aware budget matching the busy timeout, with jittered backoff for an active writer and an immediate retry for a stale snapshot. The browser, API, verification, remediation and VINCE transactions go through it too, since a nested call gets one savepoint-backed attempt; callbacks can run more than once, so they stay database-only and reset per-attempt state. Browser and API edits use the request context; VINCE persistence does not, because the submission has already succeeded.

Codex was used to implement this; Opus 5 reviewed and revised it.
