### PR TITLE
Show "focus area" in scan lists and list filters

### DIFF
--- a/internal/web/focus_area_display.go
+++ b/internal/web/focus_area_display.go
@@ -1,0 +1,45 @@
+package web
+
+import (
+	"encoding/json"
+	"strings"
+
+	"scrutineer/internal/db"
+	"scrutineer/internal/repoconfig"
+)
+
+type focusAreaView struct {
+	Name    string
+	Paths   string
+	Surface string
+	Group   string
+}
+
+func (v focusAreaView) Tooltip() string {
+	var parts []string
+	if v.Paths != "" {
+		parts = append(parts, "paths: "+v.Paths)
+	}
+	if v.Surface != "" {
+		parts = append(parts, "surface: "+v.Surface)
+	}
+	if v.Group != "" {
+		parts = append(parts, "batch: "+v.Group)
+	}
+	return strings.Join(parts, "\n")
+}
+
+// Display legacy focus areas even if they no longer pass enqueue validation.
+func scanFocus(scan db.Scan) focusAreaView {
+	view := focusAreaView{Group: scan.ScanGroup}
+	var area repoconfig.FocusArea
+	if err := json.Unmarshal([]byte(scan.FocusArea), &area); err != nil {
+		return view
+	}
+	if name := strings.TrimSpace(area.Name); name != "" {
+		view.Name = name
+		view.Paths = strings.Join(area.Paths, ", ")
+		view.Surface = strings.TrimSpace(area.Surface)
+	}
+	return view
+}

--- a/internal/web/focus_area_display_test.go
+++ b/internal/web/focus_area_display_test.go
@@ -1,0 +1,137 @@
+package web
+
+import (
+	"fmt"
+	"html"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"scrutineer/internal/db"
+	"scrutineer/internal/worker"
+)
+
+func TestJobsCombinedBatchFiltersSurviveLiveRefresh(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	repo := db.Repository{URL: "https://example.com/combined-batch"}
+	if err := s.DB.Create(&repo).Error; err != nil {
+		t.Fatal(err)
+	}
+	scans := []db.Scan{
+		{SkillName: "alpha", ScanGroup: "batch-a", Completeness: "partial"},
+		{SkillName: "bravo", ScanGroup: "batch-a", Completeness: "partial"},
+		{SkillName: "charlie", ScanGroup: "batch-a", Completeness: "partial"},
+		{SkillName: "alpha", ScanGroup: "batch-b", Completeness: "partial"},
+		{SkillName: "alpha", ScanGroup: "batch-a", Completeness: "complete"},
+	}
+	for i := range scans {
+		scans[i].RepositoryID = repo.ID
+		scans[i].Status = db.ScanFailed
+		scans[i].FocusArea = fmt.Sprintf(`{"name":"Area %d","paths":["config/**"]}`, i)
+		if err := s.DB.Create(&scans[i]).Error; err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, hx := range []bool{false, true} {
+		r := localReq(http.MethodGet, "/scans?skill=alpha,bravo&status=failed&completeness=partial&group=batch-a")
+		if hx {
+			r.Header.Set("HX-Request", "true")
+		}
+		w := httptest.NewRecorder()
+		s.Handler().ServeHTTP(w, r)
+		if w.Code != http.StatusOK {
+			t.Fatalf("status %d: %s", w.Code, w.Body)
+		}
+		body := html.UnescapeString(w.Body.String())
+		for i, scan := range scans {
+			if got := strings.Contains(body, fmt.Sprintf(`id="scan-%d"`, scan.ID)); got != (i < 2) {
+				t.Errorf("HX=%v: scan %d presence = %v", hx, scan.ID, got)
+			}
+		}
+		for _, want := range []string{
+			"Focus area", "Area 0", "Area 1", "config/**", "2 skills", "Showing one batch:",
+			`href="/scans?group=batch-a"`,
+			`/scans/retry-failed?skill=alpha%2cbravo&completeness=partial&group=batch-a`,
+			`/scans?skill=alpha%2cbravo&status=failed&sort=repository&completeness=partial&group=batch-a`,
+		} {
+			if !strings.Contains(body, want) {
+				t.Errorf("HX=%v: missing %q", hx, want)
+			}
+		}
+	}
+}
+
+func TestScansRetryFailed_batchScoped(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	repo := db.Repository{URL: "https://github.com/laravel/pint", Name: "pint"}
+	s.DB.Create(&repo)
+	skill := db.Skill{Name: "security-deep-dive", Description: "x", Body: "b", Active: true, Source: "ui", Version: 1}
+	s.DB.Create(&skill)
+	for _, group := range []string{"focus-1", "focus-2"} {
+		s.DB.Create(&db.Scan{
+			RepositoryID: repo.ID, Kind: worker.JobSkill, SkillName: skill.Name, SkillID: &skill.ID,
+			Status: db.ScanFailed, StatusPriority: db.StatusPriorityFor(db.ScanFailed),
+			ScanGroup: group,
+			FocusArea: `{"name":"Area ` + group + `","paths":["app/a.php"],"surface":"cli input"}`,
+		})
+	}
+
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq("POST", "/scans/retry-failed?group=focus-1"))
+	if w.Code != http.StatusOK && w.Code != http.StatusSeeOther {
+		t.Fatalf("status %d: %s", w.Code, w.Body.String())
+	}
+	var requeued []db.Scan
+	s.DB.Where("status = ?", db.ScanQueued).Find(&requeued)
+	if len(requeued) != 1 {
+		t.Fatalf("retried %d scans, want only the batch's one", len(requeued))
+	}
+	if requeued[0].ScanGroup != "focus-1" {
+		t.Errorf("retried batch %q, want focus-1", requeued[0].ScanGroup)
+	}
+}
+
+func TestScansIndex_noFocusColumnWithoutFannedOutScans(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	repo := db.Repository{URL: "https://github.com/spf13/cobra", Name: "cobra"}
+	s.DB.Create(&repo)
+	s.DB.Create(&db.Scan{
+		RepositoryID: repo.ID, Kind: "skill", SkillName: "security-deep-dive",
+		Status: db.ScanDone, StatusPriority: db.StatusPriorityFor(db.ScanDone),
+	})
+
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, localReq("GET", "/scans"))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status %d", w.Code)
+	}
+	if strings.Contains(w.Body.String(), "Focus area") {
+		t.Error("unscoped scans must not add a focus-area column")
+	}
+}
+
+func TestScanFocus(t *testing.T) {
+	for _, raw := range []string{"", "not json", `{"name":" "}`} {
+		if got := scanFocus(db.Scan{FocusArea: raw}); got != (focusAreaView{}) {
+			t.Errorf("focus(%q) = %+v, want empty view", raw, got)
+		}
+	}
+	got := scanFocus(db.Scan{
+		FocusArea: `{"name":" Worker Spawning ","paths":["a.php","b/**"],"surface":" process args "}`,
+		ScanGroup: "batch-a",
+	})
+	want := focusAreaView{Name: "Worker Spawning", Paths: "a.php, b/**", Surface: "process args", Group: "batch-a"}
+	if got != want {
+		t.Errorf("focus = %+v, want %+v", got, want)
+	}
+	if tip := got.Tooltip(); tip != "paths: a.php, b/**\nsurface: process args\nbatch: batch-a" {
+		t.Errorf("tooltip = %q", tip)
+	}
+	if got := scanFocus(db.Scan{FocusArea: `{"name":"Legacy Area","paths":[]}`}); got.Name != "Legacy Area" {
+		t.Errorf("legacy area = %+v", got)
+	}
+}

--- a/internal/web/repo_show_test.go
+++ b/internal/web/repo_show_test.go
@@ -45,6 +45,42 @@ func getRepoPagePath(t *testing.T, s *Server, path string) string {
 	return w.Body.String()
 }
 
+func TestRepoShow_scansTabListsEveryQueuedFocusArea(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	repo := db.Repository{URL: "https://github.com/laravel/pint", Name: "pint"}
+	s.DB.Create(&repo)
+	areas := []string{"Configuration File Loading", "Git-based Path Resolution", "Prettier Node Worker IPC"}
+	for _, name := range areas {
+		s.DB.Create(&db.Scan{
+			RepositoryID: repo.ID, Kind: "skill", SkillName: "security-deep-dive",
+			Status: db.ScanQueued, StatusPriority: db.StatusPriorityFor(db.ScanQueued),
+			ScanGroup: "focus-7",
+			FocusArea: fmt.Sprintf(`{"name":%q,"paths":["app/**"],"surface":"untrusted input"}`, name),
+		})
+	}
+	for i := 0; i < 2; i++ {
+		s.DB.Create(&db.Scan{
+			RepositoryID: repo.ID, Kind: "skill", SkillName: "recon",
+			Status: db.ScanDone, StatusPriority: db.StatusPriorityFor(db.ScanDone),
+		})
+	}
+
+	body := getRepoPage(t, s, repo.ID)
+	rows := strings.Count(body, `<tr id="scan-`)
+	if rows != len(areas)+1 {
+		t.Errorf("scans tab rendered %d rows, want %d (one per queued focus area + one recon)", rows, len(areas)+1)
+	}
+	for _, name := range areas {
+		if !strings.Contains(body, name) {
+			t.Errorf("scans tab should name queued focus area %q", name)
+		}
+	}
+	if !strings.Contains(body, `href="/scans?group=focus-7"`) {
+		t.Error("a fanned-out row should link to the rest of its batch")
+	}
+}
+
 func TestRepoShow_scanAllButton(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()
@@ -333,6 +369,7 @@ func TestRepoScansFragment_rowMatchesTheFullPage(t *testing.T) {
 		FindingsCount: 3, Model: "claude-opus-5", CostUSD: 1.25, Commit: "deadbeefcafe",
 		StartedAt: &startedAt, FinishedAt: &finishedAt,
 		Log: strings.Repeat("log line\n", 100), Report: `{"big":"report"}`,
+		FocusArea: `{"name":"API routes","paths":["pkg/api/**"]}`, ScanGroup: "batch-api",
 	}
 	s.DB.Create(&scan)
 	skill := db.Skill{Name: "audit", Body: "b", Active: true, Source: "ui", Version: 1}

--- a/internal/web/scans.go
+++ b/internal/web/scans.go
@@ -33,6 +33,10 @@ func (s *Server) jobs(w http.ResponseWriter, r *http.Request) {
 	if status != "" {
 		q = q.Where("status = ?", status)
 	}
+	group := r.URL.Query().Get("group")
+	if group != "" {
+		q = q.Where("scan_group = ?", group)
+	}
 
 	sortCol, dir := splitSort(r.URL.Query().Get("sort"))
 	switch sortCol {
@@ -64,19 +68,19 @@ func (s *Server) jobs(w http.ResponseWriter, r *http.Request) {
 	skillNames := s.scanSkillNames()
 	stats := s.scanListStats()
 
-	anySubPath := false
+	anySubPath, anyFocusArea := false, false
 	for _, sc := range scans {
-		if sc.SubPath != "" {
-			anySubPath = true
-			break
-		}
+		anySubPath = anySubPath || sc.SubPath != ""
+		anyFocusArea = anyFocusArea || sc.FocusArea != ""
 	}
 	data := map[string]any{
 		"Scans": scans, "Page": page,
 		"Skill": skillFilter.value(), "SkillLabel": skillFilter.label(),
 		"Status": status, "Sort": sort, "Skills": skillNames,
 		"Completeness": completeness,
-		"AnySubPath":   anySubPath, "QueuedCount": stats.QueuedCount, "PausedCount": stats.PausedCount,
+		"Group":        group,
+		"AnySubPath":   anySubPath, "AnyFocusArea": anyFocusArea,
+		"QueuedCount": stats.QueuedCount, "PausedCount": stats.PausedCount,
 		"AccountPausedCount": stats.AccountPausedCount,
 		"NextAccountResume":  stats.NextAccountResume,
 		"ModelDowngraded":    s.Worker.ShouldDowngradeModel(),
@@ -425,6 +429,10 @@ func (s *Server) scansRetryFailed(w http.ResponseWriter, r *http.Request) {
 	q := skillFilter.apply(s.DB.Model(&db.Scan{}).
 		Where("status = ? AND kind = ? AND skill_id IS NOT NULL", db.ScanFailed, worker.JobSkill))
 	q = applyScanCompletenessFilter(q, completeness)
+	group := r.URL.Query().Get("group")
+	if group != "" {
+		q = q.Where("scan_group = ?", group)
+	}
 	if repoID > 0 {
 		q = q.Where("repository_id = ?", repoID)
 	}
@@ -432,12 +440,8 @@ func (s *Server) scansRetryFailed(w http.ResponseWriter, r *http.Request) {
 	var totalFailed int64
 	q.Count(&totalFailed)
 
-	// Skip any failed scan that has a later scan with the same
-	// (repository, skill, sub_path, ref, finding_id) tuple already in
-	// queued/running/done, or superseded by a newer failed/paused attempt,
-	// so repeated failures retry only the newest row per tuple. Cancelled is
-	// deliberately absent: a user-cancelled newer run shouldn't block
-	// retrying an older genuine failure.
+	// A newer cancelled attempt must not block retries. Include focus_area
+	// in the match so retrying one area does not suppress the others.
 	var scans []db.Scan
 	err = q.Select("id, repository_id, skill_id, model, effort, finding_id, remediation_attempt_id, sub_path, scope_mode, ref, profile, rescan_mode, diff_base_scan_id, scan_group, focus_area, backend, status, session_id, resumed_from_scan_id, import_payload").
 		Where(`NOT EXISTS (
@@ -448,6 +452,7 @@ func (s *Server) scansRetryFailed(w http.ResponseWriter, r *http.Request) {
 			  AND COALESCE(n.sub_path, '') = COALESCE(scans.sub_path, '')
 			  AND COALESCE(n.ref, '') = COALESCE(scans.ref, '')
 			  AND COALESCE(n.finding_id, 0) = COALESCE(scans.finding_id, 0)
+			  AND COALESCE(n.focus_area, '') = COALESCE(scans.focus_area, '')
 			  AND n.status IN ?
 		)`, []db.ScanStatus{db.ScanQueued, db.ScanRunning, db.ScanDone, db.ScanFailed, db.ScanPaused}).
 		Find(&scans).Error
@@ -500,6 +505,9 @@ func (s *Server) scansRetryFailed(w http.ResponseWriter, r *http.Request) {
 	}
 	if repoID <= 0 && completeness != "" {
 		target += "&completeness=" + url.QueryEscape(completeness)
+	}
+	if repoID <= 0 && group != "" {
+		target += "&group=" + url.QueryEscape(group)
 	}
 	s.redirect(w, r, target)
 }

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -437,6 +437,7 @@ func New(gdb *gorm.DB, q *queue.Queue, log *slog.Logger, broker *Broker, w *work
 		"findingDisclosureMarkdownFilename": func(repo db.Repository, f db.Finding) string {
 			return findingDisclosureMarkdownFilename(&repo, &f)
 		},
+		"focus": scanFocus,
 	}
 	t, err := template.New("").Funcs(funcs).ParseFS(tmplFS, "templates/*.html")
 	if err != nil {
@@ -2599,7 +2600,7 @@ func loadRepoLatestScans(gdb *gorm.DB, repoID uint) []db.Scan {
 // prompt) they don't. TestRepoScansFragment_rowMatchesTheFullPage fails if this
 // projection ever falls behind the template.
 const scanRowColumns = `s.id, s.repository_id, s.skill_id, s.skill_name, s.kind, s.ref,
-	s.sub_path, s.rescan_mode, s.status, s.max_turns_hit, s.refusal_audit_warning,
+	s.sub_path, s.focus_area, s.scan_group, s.rescan_mode, s.status, s.max_turns_hit, s.refusal_audit_warning,
 	s.findings_count, s.model, s.cost_usd, s."commit", s.started_at, s.finished_at`
 
 // loadRepoLatestScanRows is loadRepoLatestScans projected down to what the Scans
@@ -2613,16 +2614,15 @@ func loadRepoLatestScanRows(gdb *gorm.DB, repoID uint) []db.Scan {
 
 func loadRepoLatestScansSelect(gdb *gorm.DB, repoID uint, columns string) []db.Scan {
 	var scans []db.Scan
-	// Per (skill_name, sub_path) we want just the latest scan — the repo
-	// page should read like "this is the state of each job on this repo",
-	// not a scroll of every historical attempt. Older runs are still
-	// reachable via /scans/{id} and the global /scans index.
+	// Show the latest attempt per skill, sub-path and focus area. Separate
+	// areas in a batch are independent jobs, not retries of one another.
 	gdb.Raw(`
 		SELECT `+columns+` FROM scans s
 		JOIN (
-			SELECT COALESCE(skill_name, '') AS sn, COALESCE(sub_path, '') AS sp, MAX(id) AS max_id
+			SELECT COALESCE(skill_name, '') AS sn, COALESCE(sub_path, '') AS sp,
+			       COALESCE(focus_area, '') AS fa, MAX(id) AS max_id
 			FROM scans WHERE repository_id = ?
-			GROUP BY sn, sp
+			GROUP BY sn, sp, fa
 		) latest ON latest.max_id = s.id
 		ORDER BY s.id DESC
 	`, repoID).Scan(&scans)
@@ -2762,9 +2762,6 @@ func (s *Server) loadRepoSubprojectView(repoID uint) repoSubprojectView {
 }
 
 func countFailedScans(scans []db.Scan) int {
-	// Count failed scans in the latest-per-skill set: same scope as the
-	// retry-failed handler would act on for this repo. Drives the
-	// "Retry failed" button on the Scans tab.
 	total := 0
 	for _, sc := range scans {
 		if sc.Status == db.ScanFailed {

--- a/internal/web/templates/job_list.html
+++ b/internal/web/templates/job_list.html
@@ -19,9 +19,9 @@
       </form>
     {{end}}
     {{if and (eq .Status "failed") .Page.Total}}
-      <form method="post" action="/scans/retry-failed?skill={{.Skill}}&completeness={{.Completeness}}"
-            hx-post="/scans/retry-failed?skill={{.Skill}}&completeness={{.Completeness}}" hx-swap="none"
-            hx-confirm="Re-enqueue every failed scan{{if .Skill}} for {{.Skill}}{{end}}{{if .Completeness}} with {{.Completeness}} coverage{{end}}?">
+      <form method="post" action="/scans/retry-failed?skill={{.Skill}}&completeness={{.Completeness}}{{if $.Group}}&group={{$.Group}}{{end}}"
+            hx-post="/scans/retry-failed?skill={{.Skill}}&completeness={{.Completeness}}{{if $.Group}}&group={{$.Group}}{{end}}" hx-swap="none"
+            hx-confirm="Re-enqueue every failed scan{{if .Skill}} for {{.Skill}}{{end}}{{if .Completeness}} with {{.Completeness}} coverage{{end}}{{if .Group}} in batch {{.Group}}{{end}}?">
         <button type="submit" class="btn-outline"><i data-lucide="refresh-cw"></i> Retry all failed</button>
       </form>
     {{end}}
@@ -33,9 +33,9 @@
       </button>
       <div data-popover aria-hidden="true" data-align="end">
         <div role="menu">
-          <a role="menuitem" href="/scans?status={{.Status}}&sort={{.Sort}}&completeness={{.Completeness}}">All skills</a>
+          <a role="menuitem" href="/scans?status={{.Status}}&sort={{.Sort}}&completeness={{.Completeness}}{{if $.Group}}&group={{$.Group}}{{end}}">All skills</a>
           {{range .Skills}}
-            <a role="menuitem" href="/scans?skill={{.}}&status={{$.Status}}&sort={{$.Sort}}&completeness={{$.Completeness}}"
+            <a role="menuitem" href="/scans?skill={{.}}&status={{$.Status}}&sort={{$.Sort}}&completeness={{$.Completeness}}{{if $.Group}}&group={{$.Group}}{{end}}"
                {{if eq . $.Skill}}aria-current="true"{{end}}>{{.}}</a>
           {{end}}
         </div>
@@ -49,9 +49,9 @@
       </button>
       <div data-popover aria-hidden="true" data-align="end">
         <div role="menu">
-          <a role="menuitem" href="/scans?skill={{.Skill}}&sort={{.Sort}}&completeness={{.Completeness}}">All statuses</a>
+          <a role="menuitem" href="/scans?skill={{.Skill}}&sort={{.Sort}}&completeness={{.Completeness}}{{if $.Group}}&group={{$.Group}}{{end}}">All statuses</a>
           {{range (list "queued" "paused" "running" "done" "failed" "skipped" "cancelled")}}
-            <a role="menuitem" href="/scans?skill={{$.Skill}}&status={{.}}&sort={{$.Sort}}&completeness={{$.Completeness}}"
+            <a role="menuitem" href="/scans?skill={{$.Skill}}&status={{.}}&sort={{$.Sort}}&completeness={{$.Completeness}}{{if $.Group}}&group={{$.Group}}{{end}}"
                {{if eq . $.Status}}aria-current="true"{{end}}>{{.}}</a>
           {{end}}
         </div>
@@ -65,9 +65,9 @@
       </button>
       <div data-popover aria-hidden="true" data-align="end">
         <div role="menu">
-          <a role="menuitem" href="/scans?skill={{.Skill}}&status={{.Status}}&sort={{.Sort}}"{{if not .Completeness}} aria-current="true"{{end}}>All completeness</a>
+          <a role="menuitem" href="/scans?skill={{.Skill}}&status={{.Status}}&sort={{.Sort}}{{if $.Group}}&group={{$.Group}}{{end}}"{{if not .Completeness}} aria-current="true"{{end}}>All completeness</a>
           {{range (list "complete" "partial" "unknown")}}
-            <a role="menuitem" href="/scans?skill={{$.Skill}}&status={{$.Status}}&sort={{$.Sort}}&completeness={{.}}"
+            <a role="menuitem" href="/scans?skill={{$.Skill}}&status={{$.Status}}&sort={{$.Sort}}&completeness={{.}}{{if $.Group}}&group={{$.Group}}{{end}}"
                {{if eq . $.Completeness}}aria-current="true"{{end}}>{{.}}</a>
           {{end}}
         </div>
@@ -82,7 +82,7 @@
       <div data-popover aria-hidden="true" data-align="end">
         <div role="menu">
           {{range (list "newest" "skill" "status" "repository")}}
-            <a role="menuitem" href="/scans?skill={{$.Skill}}&status={{$.Status}}&sort={{.}}&completeness={{$.Completeness}}"
+            <a role="menuitem" href="/scans?skill={{$.Skill}}&status={{$.Status}}&sort={{.}}&completeness={{$.Completeness}}{{if $.Group}}&group={{$.Group}}{{end}}"
                {{if eq . (sortkey $.Sort)}}aria-current="true"{{end}}>{{.}}</a>
           {{end}}
         </div>
@@ -90,6 +90,14 @@
     </div>
   </div>
 </div>
+
+{{if .Group}}
+  <div class="flex items-center gap-2 mb-4 text-sm text-muted-foreground">
+    <i data-lucide="crosshair"></i>
+    <span>Showing one batch: <code>{{.Group}}</code> ({{.Page.Total}} scan{{if ne .Page.Total 1}}s{{end}})</span>
+    <a href="/scans?skill={{.Skill}}&status={{.Status}}&sort={{.Sort}}&completeness={{.Completeness}}" class="btn-sm-ghost"><i data-lucide="x"></i> Clear</a>
+  </div>
+{{end}}
 
 {{if .AccountPausedCount}}
   <div class="alert-destructive mb-6">
@@ -123,12 +131,14 @@
         {{template "th-sort" (dict "Sorter" .Sorter "Key" "skill" "Def" "asc" "Label" "Skill" "Class" "")}}
         {{template "th-sort" (dict "Sorter" .Sorter "Key" "status" "Def" "asc" "Label" "Status" "Class" "")}}
         <th>Completeness</th>
+        {{if .AnyFocusArea}}<th>Focus area</th>{{end}}
         {{template "th-sort" (dict "Sorter" .Sorter "Key" "findings" "Def" "desc" "Label" "Findings" "Class" "")}}
         <th>Model</th><th>Cost</th><th>Started</th><th>Duration</th><th class="w-12"></th>
       </tr>
     </thead>
     <tbody>
     {{$showSub := .AnySubPath}}
+    {{$showFocus := .AnyFocusArea}}
     {{range .Scans}}
       <tr id="scan-{{.ID}}">
         <td><a href="/scans/{{.ID}}">{{.ID}}</a></td>
@@ -139,6 +149,7 @@
         <td>{{if .SkillName}}{{.SkillName}}{{else}}{{.Kind}}{{end}} {{template "branch-tag" .Ref}}</td>
         <td>{{template "status-badge" (status .Status)}} {{if .MaxTurnsHit}}<span class="badge-outline"><i data-lucide="timer-off"></i> max turns</span>{{end}}</td>
         <td>{{if eq .Completeness "complete"}}<span class="badge-outline">complete</span>{{else if eq .Completeness "partial"}}<span class="badge-outline">partial</span>{{else}}<span class="text-muted-foreground">unknown</span>{{end}}</td>
+        {{if $showFocus}}<td class="text-xs">{{template "focus-area" (focus .)}}</td>{{end}}
         <td>{{if gt .FindingsCount 0}}{{template "findings-badge" .FindingsCount}}{{end}}</td>
         <td class="text-muted-foreground">{{if .Model}}{{.Model}}{{else}}-{{end}}</td>
         <td class="text-muted-foreground">{{if gt .CostUSD 0.0}}{{usd .CostUSD}}{{else}}-{{end}}</td>
@@ -152,7 +163,7 @@
   </div>
   {{template "pagination" .Page}}
 {{else}}
-  {{if or .Skill .Status .Completeness}}
+  {{if or .Skill .Status .Completeness .Group}}
   {{template "empty" (dict "Icon" "list-checks" "Title" "No matching scans" "Body" "")}}
   {{else}}
   {{template "empty" (dict "Icon" "list-checks" "Title" "No jobs yet" "Body" "Jobs appear here once a repository has been queued.")}}

--- a/internal/web/templates/layout.html
+++ b/internal/web/templates/layout.html
@@ -225,17 +225,17 @@
   {{if or (eq (status .Status) "queued") (eq (status .Status) "running")}}
     <form method="post" action="/scans/{{.ID}}/cancel" hx-post="/scans/{{.ID}}/cancel"
           hx-swap="none">
-      <button type="submit" class="btn-sm-ghost" aria-label="Cancel scan" data-tooltip="Cancel"><i data-lucide="x"></i></button>
+      <button type="submit" class="btn-sm-ghost" aria-label="Cancel scan" data-tooltip="Cancel" data-align="end"><i data-lucide="x"></i></button>
     </form>
   {{else if eq (status .Status) "paused"}}
     <form method="post" action="/scans/{{.ID}}/resume" hx-post="/scans/{{.ID}}/resume"
           hx-swap="none">
-      <button type="submit" class="btn-sm-ghost" aria-label="Resume scan" data-tooltip="Resume"><i data-lucide="play"></i></button>
+      <button type="submit" class="btn-sm-ghost" aria-label="Resume scan" data-tooltip="Resume" data-align="end"><i data-lucide="play"></i></button>
     </form>
   {{else if and (or (eq (status .Status) "failed") (eq (status .Status) "cancelled") .MaxTurnsHit) .SkillID}}
     <form method="post" action="/scans/{{.ID}}/retry" hx-post="/scans/{{.ID}}/retry"
           hx-swap="none">
-      <button type="submit" class="btn-sm-ghost" aria-label="Retry scan" data-tooltip="Retry"><i data-lucide="refresh-cw"></i></button>
+      <button type="submit" class="btn-sm-ghost" aria-label="Retry scan" data-tooltip="Retry" data-align="end"><i data-lucide="refresh-cw"></i></button>
     </form>
   {{end}}
 {{end}}
@@ -303,6 +303,19 @@
 {{define "branch-options"}}{{range .}}<option value="{{.}}"></option>{{end}}{{end}}
 
 {{define "branch-tag"}}{{if .}}<span class="badge-outline"><i data-lucide="git-branch"></i>{{.}}</span>{{end}}{{end}}
+
+{{define "focus-area"}}
+  {{if .Name}}{{template "focus-tag" .}}
+  {{else}}<span class="text-muted-foreground">-</span>
+  {{end}}
+{{end}}
+
+{{define "focus-tag"}}
+  {{- if .Name -}}
+    {{if .Group}}<a href="/scans?group={{.Group}}" class="badge-outline max-w-[16rem]" title="{{.Tooltip}}"><i data-lucide="crosshair"></i> <span class="truncate">{{.Name}}</span></a>
+    {{else}}<span class="badge-outline max-w-[16rem]" title="{{.Tooltip}}"><i data-lucide="crosshair"></i> <span class="truncate">{{.Name}}</span></span>{{end}}
+  {{- end -}}
+{{end}}
 
 {{define "status-badge"}}
   {{if eq . "done"}}<span class="badge-secondary"><i data-lucide="check"></i> complete</span>

--- a/internal/web/templates/repo_show.html
+++ b/internal/web/templates/repo_show.html
@@ -744,7 +744,7 @@
 {{define "scan-row"}}{{with .S}}
   <tr id="scan-{{.ID}}"{{if $.OOB}} hx-swap-oob="true"{{end}}>
     <td><a href="/scans/{{.ID}}">{{.ID}}</a></td>
-    <td>{{if .SkillName}}{{.SkillName}}{{else}}{{.Kind}}{{end}} {{template "branch-tag" .Ref}}{{if eq .RescanMode "diff"}} <span class="badge-outline text-xs">diff</span>{{end}}</td>
+    <td>{{if .SkillName}}{{.SkillName}}{{else}}{{.Kind}}{{end}} {{template "branch-tag" .Ref}}{{if eq .RescanMode "diff"}} <span class="badge-outline text-xs">diff</span>{{end}} {{template "focus-tag" (focus .)}}</td>
     <td>{{template "status-badge" (status .Status)}} {{if .MaxTurnsHit}}<span class="badge-outline"><i data-lucide="timer-off"></i> max turns</span>{{end}}{{if .RefusalAuditWarning}} <span class="badge-outline" data-tooltip="The deep-dive reported refused or skipped analysis"><i data-lucide="triangle-alert"></i> analysis incomplete</span>{{end}}</td>
     <td>{{if gt .FindingsCount 0}}{{template "findings-badge" .FindingsCount}}{{end}}</td>
     <td class="text-muted-foreground">{{if .Model}}{{.Model}}{{else}}-{{end}}</td>


### PR DESCRIPTION
Clicking a focus-area label opens /scans?group=<batch-id>, showing only scans from that batch.

The batch filter stays active when changing skill, status, completeness, or sorting. “Retry all failed” also stays scoped to that batch.


# Before

All on the same (omitted) repo, making the /scans overview quite samey and how to parse

<img width="1078" height="813" alt="Security-deep-dive" src="https://github.com/user-attachments/assets/67972059-e192-464b-8744-2483202085bc" />


# After

<img width="1291" height="862" alt="I paused" src="https://github.com/user-attachments/assets/a785560f-1380-4d29-ac38-27dbcead6c58" />
