### PR TITLE
Fix repository deletion blocked by paused scans

### DIFF
--- a/internal/web/api_export_test.go
+++ b/internal/web/api_export_test.go
@@ -328,6 +328,9 @@ func TestAPIv1DeleteRepository(t *testing.T) {
 	s.DB.Create(&repo)
 	scan := db.Scan{RepositoryID: repo.ID, Kind: "skill", Status: db.ScanDone, SkillName: deepDiveSkillName}
 	s.DB.Create(&scan)
+	if err := s.DB.Create(&db.Scan{RepositoryID: repo.ID, Kind: "skill", Status: db.ScanPaused, SkillName: "verify"}).Error; err != nil {
+		t.Fatal(err)
+	}
 	finding := db.Finding{ScanID: scan.ID, RepositoryID: repo.ID, Title: "doomed", Severity: sevHigh}
 	s.DB.Create(&finding)
 	s.DB.Create(&db.FindingReview{FindingID: finding.ID, Verdict: "true_positive", Reviewer: "analyst"})

--- a/internal/web/api_export_test.go
+++ b/internal/web/api_export_test.go
@@ -377,7 +377,7 @@ func TestAPIv1DeleteRepositoryRejectsInFlightScans(t *testing.T) {
 			if w.Code != http.StatusConflict {
 				t.Fatalf("status %d, want 409. body=%s", w.Code, w.Body)
 			}
-			if !strings.Contains(w.Body.String(), "queued, running, or paused scans") {
+			if !strings.Contains(w.Body.String(), "queued or running scans") {
 				t.Fatalf("body %q missing in-flight scan explanation", w.Body.String())
 			}
 			if n := countRows(t, s, &db.Repository{}, "id = ?", repo.ID); n != 1 {

--- a/internal/web/repo_delete_test.go
+++ b/internal/web/repo_delete_test.go
@@ -261,10 +261,8 @@ func TestRepoDelete_confirmWarnsAboutActiveScans(t *testing.T) {
 	}
 }
 
-// Neither terminal scans (done/failed/cancelled) nor a paused one are in the
-// cancellable running/queued set, so the warning must stay out of the confirm
-// while the base copy survives. The paused case pins the deliberate exclusion:
-// it can't be cancelled and the worker isn't writing for it.
+// Terminal and paused scans do not block deletion. Paused scans are explicitly
+// included in the confirmation because deleting them discards resumable work.
 func TestRepoDelete_confirmNoWarningWhenNoActiveScans(t *testing.T) {
 	s, done := newTestServer(t)
 	defer done()
@@ -287,6 +285,83 @@ func TestRepoDelete_confirmNoWarningWhenNoActiveScans(t *testing.T) {
 	}
 	if !strings.Contains(body, "all its scans and findings, and its cached clone") {
 		t.Errorf("base delete confirm copy missing; body=%s", body)
+	}
+	if !strings.Contains(body, "1 paused scan(s) will also be permanently removed") {
+		t.Errorf("delete confirm should describe paused scan removal; body=%s", body)
+	}
+}
+
+func TestRepoDelete_removesPausedScans(t *testing.T) {
+	s, done := newTestServer(t)
+	defer done()
+	s.Worker.DataDir = t.TempDir()
+	repo := db.Repository{URL: "https://github.com/acme/paused", Name: "paused"}
+	if err := s.DB.Create(&repo).Error; err != nil {
+		t.Fatal(err)
+	}
+	scan := db.Scan{RepositoryID: repo.ID, Kind: "skill", Status: db.ScanPaused, SkillName: deepDiveSkillName}
+	if err := s.DB.Create(&scan).Error; err != nil {
+		t.Fatal(err)
+	}
+	workspace, config := mkScanDirs(t, s.Worker.DataDir, scan.ID)
+	r := localReq("POST", fmt.Sprintf("/repositories/%d/delete", repo.ID))
+	r.Header.Set("HX-Request", "true")
+	r.Header.Set("Sec-Fetch-Site", "same-origin")
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, r)
+	if w.Code != http.StatusNoContent || w.Header().Get("HX-Redirect") != "/" {
+		t.Fatalf("delete response: %d %v %s", w.Code, w.Header(), w.Body)
+	}
+	if countRows(t, s, &db.Repository{}, "id = ?", repo.ID) != 0 || countRows(t, s, &db.Scan{}, "id = ?", scan.ID) != 0 {
+		t.Fatal("repository or paused scan survived deletion")
+	}
+	for _, path := range []string{workspace, config} {
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Fatalf("workspace survived deletion: %s: %v", path, err)
+		}
+	}
+	if err := s.resumeScan(r.Context(), &scan); err == nil {
+		t.Fatal("a stale paused scan must not resume after deletion")
+	}
+}
+
+func TestRepoDelete_showsFailure(t *testing.T) {
+	for _, hx := range []bool{false, true} {
+		t.Run(fmt.Sprint(hx), func(t *testing.T) {
+			s, done := newTestServer(t)
+			defer done()
+			repo := db.Repository{URL: "https://github.com/acme/running", Name: "running"}
+			if err := s.DB.Create(&repo).Error; err != nil {
+				t.Fatal(err)
+			}
+			if err := s.DB.Create(&db.Scan{RepositoryID: repo.ID, Status: db.ScanRunning}).Error; err != nil {
+				t.Fatal(err)
+			}
+			path := fmt.Sprintf("/repositories/%d", repo.ID)
+			r := localReq("POST", path+"/delete")
+			r.Header.Set("Sec-Fetch-Site", "same-origin")
+			if hx {
+				r.Header.Set("HX-Request", "true")
+			}
+			w := httptest.NewRecorder()
+			s.Handler().ServeHTTP(w, r)
+			if hx {
+				if w.Code != http.StatusNoContent || w.Header().Get("HX-Redirect") != path {
+					t.Fatalf("missing htmx redirect: %d %v", w.Code, w.Header())
+				}
+			} else if w.Code != http.StatusSeeOther || w.Header().Get("Location") != path {
+				t.Fatalf("missing redirect: %d %v", w.Code, w.Header())
+			}
+			get := localReq("GET", path)
+			for _, cookie := range w.Result().Cookies() {
+				get.AddCookie(cookie)
+			}
+			page := httptest.NewRecorder()
+			s.Handler().ServeHTTP(page, get)
+			if page.Code != http.StatusOK || !strings.Contains(page.Body.String(), "Repository not deleted") || !strings.Contains(page.Body.String(), "1 linked scan(s) remain") {
+				t.Fatalf("failure is not visible: %d %s", page.Code, page.Body)
+			}
+		})
 	}
 }
 

--- a/internal/web/repo_delete_test.go
+++ b/internal/web/repo_delete_test.go
@@ -13,17 +13,25 @@ import (
 	"scrutineer/internal/worker"
 )
 
-//nolint:maintidx // exhaustive fixture: seeds one of every linked table then asserts each is gone; splitting would scatter the coverage.
 func TestRepoDelete_removesRepoAndAllLinkedData(t *testing.T) {
+	for _, foreignKeys := range []bool{true, false} {
+		t.Run(fmt.Sprintf("foreign_keys=%t", foreignKeys), func(t *testing.T) {
+			testRepoDeleteLinkedData(t, foreignKeys)
+		})
+	}
+}
+
+//nolint:maintidx // exhaustive fixture: seeds linked tables then asserts each is gone; splitting would scatter the coverage.
+func testRepoDeleteLinkedData(t *testing.T, foreignKeys bool) {
+	t.Helper()
 	s, done := newTestServer(t)
 	defer done()
 
-	// Pin to one connection and force foreign_keys ON so this test enforces
-	// FK constraints exactly as production does — a pooled in-memory DB applies
-	// the pragma to only one connection, which silently disables enforcement.
+	// Pin the connection so each case exercises the requested FK mode.
+	// Cleanup must work both with and without database cascades.
 	sqldb, _ := s.DB.DB()
 	sqldb.SetMaxOpenConns(1)
-	if err := s.DB.Exec("PRAGMA foreign_keys=ON").Error; err != nil {
+	if err := s.DB.Exec(fmt.Sprintf("PRAGMA foreign_keys=%t", foreignKeys)).Error; err != nil {
 		t.Fatal(err)
 	}
 
@@ -49,7 +57,7 @@ func TestRepoDelete_removesRepoAndAllLinkedData(t *testing.T) {
 	// whose FK to findings is ON DELETE NO ACTION — this is what blocks naive
 	// "delete findings then scans" ordering in production.
 	verifyScan := db.Scan{RepositoryID: repo.ID, FindingID: &finding.ID, Kind: "skill",
-		Status: db.ScanDone, SkillName: "verify"}
+		Status: db.ScanPaused, SkillName: "verify"}
 	s.DB.Create(&verifyScan)
 
 	// A finding-scoped scan living on a *different* repo but pointing at the
@@ -79,6 +87,7 @@ func TestRepoDelete_removesRepoAndAllLinkedData(t *testing.T) {
 	s.DB.Create(&db.Dependency{RepositoryID: repo.ID, Name: "left-pad", Ecosystem: "npm"})
 	s.DB.Create(&db.Package{RepositoryID: repo.ID, Name: "acme-pkg", Ecosystem: "npm"})
 	s.DB.Create(&db.Advisory{RepositoryID: repo.ID, Title: "CVE-2026-0001"})
+	seedRepoDeleteAssessments(t, s, repo, finding, scan)
 
 	maintainer := db.Maintainer{Login: "alice", Name: "Alice", Status: db.MaintainerActive}
 	s.DB.Create(&maintainer)
@@ -134,19 +143,25 @@ func TestRepoDelete_removesRepoAndAllLinkedData(t *testing.T) {
 		t.Errorf("repository row survived (%d)", n)
 	}
 	for name, n := range map[string]int64{
-		"scans":        count(&db.Scan{}, "repository_id = ?", repo.ID),
-		"findings":     count(&db.Finding{}, "repository_id = ?", repo.ID),
-		"subprojects":  count(&db.Subproject{}, "repository_id = ?", repo.ID),
-		"dependencies": count(&db.Dependency{}, "repository_id = ?", repo.ID),
-		"dependents":   count(&db.Dependent{}, "repository_id = ?", repo.ID),
-		"packages":     count(&db.Package{}, "repository_id = ?", repo.ID),
-		"advisories":   count(&db.Advisory{}, "repository_id = ?", repo.ID),
-		"notes":        count(&db.FindingNote{}, "finding_id = ?", finding.ID),
-		"comms":        count(&db.FindingCommunication{}, "finding_id = ?", finding.ID),
-		"refs":         count(&db.FindingReference{}, "finding_id = ?", finding.ID),
-		"history":      count(&db.FindingHistory{}, "finding_id = ?", finding.ID),
-		"reviews":      count(&db.FindingReview{}, "finding_id = ?", finding.ID),
-		"findingdep":   count(&db.FindingDependent{}, "finding_id = ?", finding.ID),
+		"scans":         count(&db.Scan{}, "repository_id = ?", repo.ID),
+		"findings":      count(&db.Finding{}, "repository_id = ?", repo.ID),
+		"subprojects":   count(&db.Subproject{}, "repository_id = ?", repo.ID),
+		"dependencies":  count(&db.Dependency{}, "repository_id = ?", repo.ID),
+		"dependents":    count(&db.Dependent{}, "repository_id = ?", repo.ID),
+		"packages":      count(&db.Package{}, "repository_id = ?", repo.ID),
+		"advisories":    count(&db.Advisory{}, "repository_id = ?", repo.ID),
+		"notes":         count(&db.FindingNote{}, "finding_id = ?", finding.ID),
+		"comms":         count(&db.FindingCommunication{}, "finding_id = ?", finding.ID),
+		"refs":          count(&db.FindingReference{}, "finding_id = ?", finding.ID),
+		"history":       count(&db.FindingHistory{}, "finding_id = ?", finding.ID),
+		"reviews":       count(&db.FindingReview{}, "finding_id = ?", finding.ID),
+		"findingdep":    count(&db.FindingDependent{}, "finding_id = ?", finding.ID),
+		"alternatives":  count(&db.PackageAlternative{}, "repository_id = ?", repo.ID),
+		"expected":      count(&db.ExpectedFinding{}, "repository_id = ?", repo.ID),
+		"verifications": count(&db.FindingVerification{}, "finding_id = ?", finding.ID),
+		"attackpaths":   count(&db.FindingAttackPath{}, "finding_id = ?", finding.ID),
+		"attempts":      count(&db.RemediationAttempt{}, "finding_id = ?", finding.ID),
+		"validations":   count(&db.RemediationValidation{}, "finding_id = ?", finding.ID),
 	} {
 		if n != 0 {
 			t.Errorf("%s rows survived the delete (%d)", name, n)
@@ -426,5 +441,24 @@ func TestRepoDiskSize_renderedInListAndSummary(t *testing.T) {
 func TestRepoDiskUsage_localRepoIsZero(t *testing.T) {
 	if n := worker.RepoDiskUsage(t.TempDir(), db.Repository{URL: "file:///srv/code/app"}); n != 0 {
 		t.Errorf("local repo disk usage = %d, want 0 (no managed clone)", n)
+	}
+}
+
+func seedRepoDeleteAssessments(t *testing.T, s *Server, repo db.Repository, finding db.Finding, scan db.Scan) {
+	t.Helper()
+	attempt := db.RemediationAttempt{FindingID: finding.ID, PatchScanID: scan.ID, Attempt: 1}
+	if err := s.DB.Create(&attempt).Error; err != nil {
+		t.Fatal(err)
+	}
+	for _, row := range []any{
+		&db.PackageAlternative{RepositoryID: repo.ID, PURL: "pkg:npm/replacement", Kind: db.PackageAlternativeFork},
+		&db.ExpectedFinding{RepositoryID: repo.ID, File: "src/test.php", CWE: "CWE-79"},
+		&db.FindingVerification{FindingID: finding.ID, ScanID: scan.ID, Status: "verified", Report: "{}"},
+		&db.FindingAttackPath{FindingID: finding.ID, ScanID: scan.ID, ProductionViability: db.ProductionViabilityViable, Report: "{}"},
+		&db.RemediationValidation{FindingID: finding.ID, ScanID: scan.ID, RemediationAttemptID: attempt.ID, RootCauseStatus: db.ReattackFailedToBypass, Report: "{}"},
+	} {
+		if err := s.DB.Create(row).Error; err != nil {
+			t.Fatal(err)
+		}
 	}
 }

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -3037,9 +3037,14 @@ func (s *Server) deleteRepository(repo db.Repository) (deletedRepository, error)
 		if err := deleteFindingChildren(tx, repo.ID); err != nil {
 			return err
 		}
+		if err := tx.Where("sbom_upload_id IN (SELECT id FROM sbom_uploads WHERE repository_id = ?)", repo.ID).
+			Delete(&db.SBOMPackage{}).Error; err != nil {
+			return err
+		}
 		for _, child := range []any{
 			&db.Finding{}, &db.Scan{}, &db.Subproject{}, &db.Dependency{},
 			&db.Dependent{}, &db.Package{}, &db.Advisory{}, &db.SBOMUpload{},
+			&db.PackageAlternative{}, &db.ExpectedFinding{},
 		} {
 			if err := tx.Where("repository_id = ?", repo.ID).Delete(child).Error; err != nil {
 				return err
@@ -3161,6 +3166,8 @@ func deleteFindingChildren(tx *gorm.DB, repoID uint) error {
 	for _, child := range []any{
 		&db.FindingNote{}, &db.FindingCommunication{}, &db.FindingReference{},
 		&db.FindingHistory{}, &db.FindingDependent{}, &db.FindingReview{},
+		&db.FindingVerification{}, &db.FindingAttackPath{},
+		&db.RemediationValidation{}, &db.RemediationAttempt{},
 	} {
 		if err := tx.Where(findingsOfRepo, repoID).Delete(child).Error; err != nil {
 			return err

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -2971,11 +2971,14 @@ func (s *Server) repoDelete(w http.ResponseWriter, r *http.Request) {
 
 	deleted, err := s.deleteRepository(repo)
 	if err != nil {
+		message := "The repository could not be deleted. Check the server logs for details."
 		if errors.Is(err, errRepositoryDeleteInFlight) {
-			http.Error(w, err.Error(), http.StatusConflict)
-			return
+			message = err.Error()
+		} else {
+			s.Log.Error("delete repository", "repo", repo.ID, "err", err)
 		}
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		setFlash(w, Flash{Category: errorKey, Title: "Repository not deleted", Description: message})
+		s.redirect(w, r, fmt.Sprintf("/repositories/%d", repo.ID))
 		return
 	}
 	s.removeRepositoryArtifacts(deleted)
@@ -2991,7 +2994,7 @@ type deletedRepository struct {
 	ConversationIDs []uint
 }
 
-var errRepositoryDeleteInFlight = errors.New("repository has queued, running, or paused scans")
+var errRepositoryDeleteInFlight = errors.New("repository has queued or running scans, or a linked paused scan on another repository")
 
 func (s *Server) deleteRepository(repo db.Repository) (deletedRepository, error) {
 	deleted := deletedRepository{Repo: repo}
@@ -3002,13 +3005,18 @@ func (s *Server) deleteRepository(repo db.Repository) (deletedRepository, error)
 		// the finding it points at, and any scan referencing a doomed finding
 		// must have its NO ACTION link cleared or the finding delete 787s.
 		var inFlight int64
+		// Paused scans owned by this repo are removed in this transaction.
+		// Resume uses a conditional UPDATE, so it cannot resurrect a deleted
+		// scan. A paused scan on another repo survives this deletion and must
+		// retain its finding until it finishes, just like other in-flight work.
 		if err := tx.Model(&db.Scan{}).
 			Where("(repository_id = ? OR "+findingsOfRepo+") AND status IN ?", repo.ID, repo.ID, inFlightScanStatuses()).
+			Where("NOT (repository_id = ? AND status = ?)", repo.ID, db.ScanPaused).
 			Count(&inFlight).Error; err != nil {
 			return err
 		}
 		if inFlight > 0 {
-			return fmt.Errorf("%w; cancel or wait for %d linked scan(s) before deleting", errRepositoryDeleteInFlight, inFlight)
+			return fmt.Errorf("%w; finish or cancel active scans (resume paused scans first) before deleting; %d linked scan(s) remain", errRepositoryDeleteInFlight, inFlight)
 		}
 		// Collected before the transaction deletes the scan rows: each scan's
 		// per-scan workspace and claude session store under DataDir are reclaimed

--- a/internal/web/templates/repo_show.html
+++ b/internal/web/templates/repo_show.html
@@ -49,7 +49,7 @@
     </a>
     <form method="post" action="/repositories/{{.Repo.ID}}/delete"
           hx-post="/repositories/{{.Repo.ID}}/delete" hx-swap="none"
-          hx-confirm="{{if .ActiveScans}}{{.ActiveScans}} scan(s) on {{.Repo.Name}} are still running or queued and will keep writing to disk until they finish; cancel them first. {{end}}Permanently delete {{.Repo.Name}}? This removes the repository, all its scans and findings, and its cached clone on disk. This cannot be undone.">
+          hx-confirm="{{if .ActiveScans}}{{.ActiveScans}} scan(s) on {{.Repo.Name}} are still running or queued and will keep writing to disk until they finish; cancel them first. {{end}}{{if .PausedScans}}{{.PausedScans}} paused scan(s) will also be permanently removed. {{end}}Permanently delete {{.Repo.Name}}? This removes the repository, all its scans and findings, and its cached clone on disk. This cannot be undone.">
       <button class="btn-destructive" type="submit"><i data-lucide="trash-2"></i> Delete</button>
     </form>
     <form method="post" action="/repositories/{{.Repo.ID}}/scan"

--- a/internal/worker/preflight.go
+++ b/internal/worker/preflight.go
@@ -197,9 +197,19 @@ func (w *Worker) failScanPrereqs(scan *db.Scan, skillName, msg string, missing [
 	scan.Error = msg
 	scan.StartedAt = &now
 	scan.FinishedAt = &now
-	if err := w.DB.Save(scan).Error; err != nil {
+	// Dispatch may have read this scan before it was paused and deleted.
+	// Never upsert a stale scan or its preloaded repository back into the DB.
+	res := w.DB.Model(&db.Scan{}).Where("id = ? AND status = ?", scan.ID, db.ScanQueued).
+		Updates(map[string]any{
+			"status": scan.Status, "status_priority": scan.StatusPriority,
+			errorColumn: scan.Error, "started_at": scan.StartedAt, "finished_at": scan.FinishedAt,
+		})
+	if res.Error != nil {
 		w.Log.Error("save failed-prereq scan",
-			"scan", scan.ID, "skill", skillName, "err", err)
+			"scan", scan.ID, "skill", skillName, "err", res.Error)
+		return
+	}
+	if res.RowsAffected == 0 {
 		return
 	}
 	w.publish(scan.ID, scan.RepositoryID, "scan-status", string(scan.Status))

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -641,7 +641,15 @@ func (w *Worker) wrap(h handler) func(context.Context, []byte) error {
 			return fmt.Errorf("decode payload: %w", err)
 		}
 		var scan db.Scan
-		if err := w.DB.Preload("Repository").First(&scan, p.ScanID).Error; err != nil {
+		err := w.DB.Preload("Repository").First(&scan, p.ScanID).Error
+		// Paused scans may be deleted with their repository while their
+		// original queue messages still await delivery. Acknowledge those
+		// stale messages rather than retrying work that no longer exists.
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			w.Log.Info("dropping stale job: scan deleted", "scan", p.ScanID)
+			return nil
+		}
+		if err != nil {
 			return fmt.Errorf("load scan %d: %w", p.ScanID, err)
 		}
 		if scan.Status != db.ScanQueued {
@@ -719,8 +727,18 @@ func (w *Worker) cancelOptedOut(scan *db.Scan) {
 	scan.StatusPriority = db.StatusPriorityFor(db.ScanCancelled)
 	scan.Error = OptOutCancelReason
 	scan.FinishedAt = &now
-	if err := w.DB.Save(scan).Error; err != nil {
-		w.Log.Error("save opted-out scan", "scan", scan.ID, "err", err)
+	// A pause and repository deletion may have won since dispatch loaded
+	// this row. Only transition an existing queued scan; Save would upsert it.
+	res := w.DB.Model(&db.Scan{}).Where("id = ? AND status = ?", scan.ID, db.ScanQueued).
+		Updates(map[string]any{
+			"status": scan.Status, "status_priority": scan.StatusPriority,
+			errorColumn: scan.Error, "finished_at": scan.FinishedAt,
+		})
+	if res.Error != nil {
+		w.Log.Error("save opted-out scan", "scan", scan.ID, "err", res.Error)
+		return
+	}
+	if res.RowsAffected == 0 {
 		return
 	}
 	w.publish(scan.ID, scan.RepositoryID, "scan-status", string(scan.Status))

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"scrutineer/internal/db"
+	"scrutineer/internal/db/dbtest"
 	"scrutineer/internal/queue"
 )
 
@@ -849,6 +850,107 @@ func TestWorker_resumeAccountPausedRestoreOnEnqueueError(t *testing.T) {
 	}
 	if strings.Contains(got.Error, autoResumeAfterPrefix) {
 		t.Fatalf("error = %q, stale auto-resume timestamp should have been dropped", got.Error)
+	}
+}
+
+func TestWorker_skipsDeletedPausedScan(t *testing.T) {
+	gdb := dbtest.Open(t)
+	repo := db.Repository{URL: "https://example.com/deleted", Name: "deleted"}
+	if err := gdb.Create(&repo).Error; err != nil {
+		t.Fatal(err)
+	}
+	scan := db.Scan{RepositoryID: repo.ID, Kind: JobSkill, Status: db.ScanQueued}
+	if err := gdb.Create(&scan).Error; err != nil {
+		t.Fatal(err)
+	}
+	// A queue message can outlive the scan: account errors pause queued rows
+	// without removing their jobs, then repository deletion removes the rows.
+	body, err := json.Marshal(queue.Payload{ScanID: scan.ID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	w := &Worker{DB: gdb, Log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	w.pauseQueuedOnAccountError(0)
+	if err := gdb.First(&scan, scan.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if scan.Status != db.ScanPaused {
+		t.Fatalf("scan status = %s, want paused", scan.Status)
+	}
+	if err := gdb.Delete(&scan).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := gdb.Delete(&repo).Error; err != nil {
+		t.Fatal(err)
+	}
+	err = w.wrap(func(context.Context, *db.Scan, func(Event)) (string, error) {
+		t.Error("handler called for deleted scan")
+		return "", nil
+	})(context.Background(), body)
+	if err != nil {
+		t.Fatalf("stale job should be acknowledged without retry: %v", err)
+	}
+}
+
+func TestWorker_scanLoadDatabaseErrorIsRetryable(t *testing.T) {
+	gdb := dbtest.Open(t)
+	sqlDB, err := gdb.DB()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := sqlDB.Close(); err != nil {
+		t.Fatal(err)
+	}
+	w := &Worker{DB: gdb, Log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	err = w.wrap(func(context.Context, *db.Scan, func(Event)) (string, error) {
+		t.Error("handler called after database failure")
+		return "", nil
+	})(context.Background(), []byte(`{"scan_id":1}`))
+	if err == nil || !strings.Contains(err.Error(), "load scan 1:") {
+		t.Fatalf("database failure must remain retryable: %v", err)
+	}
+}
+
+func TestWorker_staleDispatchCannotRestoreDeletedScan(t *testing.T) {
+	for _, action := range []string{"failed prerequisites", "opted out"} {
+		t.Run(action, func(t *testing.T) {
+			gdb := dbtest.Open(t)
+			repo := db.Repository{URL: "https://example.com/stale", Name: "stale"}
+			if err := gdb.Create(&repo).Error; err != nil {
+				t.Fatal(err)
+			}
+			scan := db.Scan{RepositoryID: repo.ID, Kind: JobSkill, Status: db.ScanQueued}
+			if err := gdb.Create(&scan).Error; err != nil {
+				t.Fatal(err)
+			}
+			// Dispatch loaded the row before a concurrent pause and deletion.
+			if err := gdb.Preload("Repository").First(&scan, scan.ID).Error; err != nil {
+				t.Fatal(err)
+			}
+			w := &Worker{DB: gdb, Log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+			w.pauseQueuedOnAccountError(0)
+			if err := gdb.Delete(&db.Scan{}, scan.ID).Error; err != nil {
+				t.Fatal(err)
+			}
+			if err := gdb.Delete(&repo).Error; err != nil {
+				t.Fatal(err)
+			}
+			switch action {
+			case "failed prerequisites":
+				w.failScanPrereqs(&scan, "verify", "prereqs failed", []string{"deep-dive"})
+			case "opted out":
+				w.cancelOptedOut(&scan)
+			}
+			for _, model := range []any{&db.Scan{}, &db.Repository{}} {
+				var n int64
+				if err := gdb.Model(model).Count(&n).Error; err != nil {
+					t.Fatal(err)
+				}
+				if n != 0 {
+					t.Errorf("stale dispatch restored %d %T row(s)", n, model)
+				}
+			}
+		})
 	}
 }
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1011,7 +1011,7 @@ paths:
         '400': { description: Invalid repository id }
         '403': { description: Host header is not localhost }
         '404': { description: Repository not found }
-        '409': { description: Repository has queued, running, or paused scans }
+        '409': { description: Repository has queued or running scans, or a linked paused scan on another repository }
         '500': { description: Delete failed }
 
   /v1/repositories/{id}/findings:


### PR DESCRIPTION
Currently, a repository with paused scans cannot be deleted. The delete handler rejects the request, but the UI hides the error, making the button appear unresponsive. Paused scans cannot be cancelled through the UI either.

Delete the repository’s paused scans as part of the deletion transaction, and display any deletion failures on the page.