### PR TITLE
build(renovate): stop mirroring tool versions in the threat model

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,15 +11,22 @@ ARG COMMIT=""
 RUN CGO_ENABLED=0 go build -ldflags "-X main.commit=${COMMIT}" -o /scrutineer ./cmd/scrutineer
 
 FROM node:26-alpine@sha256:2d984a15c9b54fd0aeb608b8e0d0d83529eb34d2966db27a1fb4f1edc3d298a3 AS claude
+
 RUN npm install -g @anthropic-ai/claude-code@2.1.261
 
 FROM python:3.14-alpine@sha256:c6ead215bfd31f1e433d968853b7a769989117115b728874824e6c0a27cb96fc AS python-tools
-RUN pip install --no-cache-dir semgrep==1.176.1 "setuptools<81" bandit==1.9.4
+
+ARG SEMGREP_VERSION=1.176.1
+
+ARG BANDIT_VERSION=1.9.4
+
+RUN pip install --no-cache-dir "semgrep==${SEMGREP_VERSION}" "setuptools<81" "bandit==${BANDIT_VERSION}"
 
 FROM golang:1.27.1-alpine@sha256:cf6fca6641884b8433441b2b0652976f975e1d0fdd26d177eaaf8596087f3125 AS go-tools
 RUN apk add --no-cache git
-RUN GOBIN=/out go install github.com/git-pkgs/git-pkgs@v0.20.0 && \
-    GOBIN=/out go install github.com/git-pkgs/brief/cmd/brief@v0.13.0
+RUN GOBIN=/out go install github.com/git-pkgs/git-pkgs@v0.20.0
+
+RUN GOBIN=/out go install github.com/git-pkgs/brief/cmd/brief@v0.13.0
 
 # vid links tree-sitter grammars (C), so unlike the main binary it needs
 # cgo; build-base provides gcc and musl headers, matching the musl-based

--- a/Dockerfile.runner
+++ b/Dockerfile.runner
@@ -9,18 +9,25 @@
 # failed upstream.
 ARG CLAUDE_AMD64_LOCK=v2.1.261@sha256:9c798b18618cb6c0ec6e6e7ab56eb338fd6f0f679f372a4d6ed76e1ab95c14a0
 ARG CLAUDE_ARM64_LOCK=v2.1.261@sha256:40772aed92ae8dafc719c23b58c595e50b5c2dfd006840fa1ba5cd0a21eea107
+
 ARG CODEX_AMD64_LOCK=rust-v0.154.0@sha256:d7e18b2597ae8f242f5f31ee9e90deef48dbc9edd634d9868fb6435d08c07f02
 ARG CODEX_ARM64_LOCK=rust-v0.154.0@sha256:583b48df32804213bdcd338c2e5adb06b34340821fa757a726cc0a524fa33c27
+
 ARG OPENCODE_AMD64_LOCK=v1.18.29@sha256:ea800b7ff56226b70952126c9fc1e2517ca4c4b5682fd9d3f9e87449697a1194
 ARG OPENCODE_ARM64_LOCK=v1.18.29@sha256:70baf769395ca4e7a68924026530c390eace194f3b7e4919d4efcb2aa2eed3c0
+
 ARG COPILOT_AMD64_LOCK=v1.0.83@sha256:ffbe1c429664b8a05efed67ecdb467123e40fcaa3c6c14ef9a98ba74da4687b7
 ARG COPILOT_ARM64_LOCK=v1.0.83@sha256:213b3a267042dbac3cd8ae22c82f5ea04ff3cabc008108c0f895055d46be4473
+
 ARG SEMGREP_VERSION=1.176.1
+
 ARG BANDIT_VERSION=1.9.4
 
 FROM golang:1.27.1-trixie@sha256:9baa6b4187bbb98d240372a8a235ac0bb6b5ddd52bba1431dc2f7c0705862728 AS go-tools
-RUN GOBIN=/out go install github.com/git-pkgs/git-pkgs@v0.20.0 && \
-    GOBIN=/out go install github.com/git-pkgs/brief/cmd/brief@v0.13.0
+
+RUN GOBIN=/out go install github.com/git-pkgs/git-pkgs@v0.20.0
+
+RUN GOBIN=/out go install github.com/git-pkgs/brief/cmd/brief@v0.13.0
 
 FROM rust:1.98-trixie@sha256:620dbcd124499c59e2406d3741574b5c5838cf9eb9656f0c3a03948f79b02959 AS zizmor-build
 ENV CARGO_HTTP_MULTIPLEXING=false

--- a/renovate.json
+++ b/renovate.json
@@ -88,13 +88,10 @@
     },
     {
       "customType": "regex",
-      "description": "Update Claude Code image and documented versions from GitHub releases",
-      "managerFilePatterns": [
-        "/^Dockerfile$/",
-        "/^threatmodel\\.md$/"
-      ],
+      "description": "Update the Claude Code image version from GitHub releases",
+      "managerFilePatterns": ["/^Dockerfile$/"],
       "matchStrings": [
-        "(?:@anthropic-ai/claude-code@|`claude-code@)(?<currentValue>\\d+\\.\\d+\\.\\d+)"
+        "@anthropic-ai/claude-code@(?<currentValue>\\d+\\.\\d+\\.\\d+)"
       ],
       "packageNameTemplate": "anthropics/claude-code",
       "depNameTemplate": "anthropics/claude-code",
@@ -117,13 +114,9 @@
     {
       "customType": "regex",
       "description": "Update the zizmor workflow pin",
-      "managerFilePatterns": [
-        "/^\\.github/workflows/tests\\.yml$/",
-        "/^threatmodel\\.md$/"
-      ],
+      "managerFilePatterns": ["/^\\.github/workflows/tests\\.yml$/"],
       "matchStrings": [
-        "pipx install zizmor==(?<currentValue>\\d+\\.\\d+\\.\\d+)",
-        "`zizmor@(?<currentValue>\\d+\\.\\d+\\.\\d+)`"
+        "pipx install zizmor==(?<currentValue>\\d+\\.\\d+\\.\\d+)"
       ],
       "packageNameTemplate": "zizmor",
       "depNameTemplate": "zizmor",
@@ -132,14 +125,12 @@
     },
     {
       "customType": "regex",
-      "description": "Update the semgrep container-image pins and the documented version",
+      "description": "Update the semgrep container-image pins",
       "managerFilePatterns": [
         "/^Dockerfile$/",
-        "/^Dockerfile\\.runner$/",
-        "/^threatmodel\\.md$/"
+        "/^Dockerfile\\.runner$/"
       ],
       "matchStrings": [
-        "semgrep==(?<currentValue>\\d+\\.\\d+\\.\\d+)",
         "ARG SEMGREP_VERSION=(?<currentValue>\\d+\\.\\d+\\.\\d+)"
       ],
       "packageNameTemplate": "semgrep",
@@ -149,14 +140,12 @@
     },
     {
       "customType": "regex",
-      "description": "Update the bandit container-image pins and the documented version",
+      "description": "Update the bandit container-image pins",
       "managerFilePatterns": [
         "/^Dockerfile$/",
-        "/^Dockerfile\\.runner$/",
-        "/^threatmodel\\.md$/"
+        "/^Dockerfile\\.runner$/"
       ],
       "matchStrings": [
-        "bandit==(?<currentValue>\\d+\\.\\d+\\.\\d+)",
         "ARG BANDIT_VERSION=(?<currentValue>\\d+\\.\\d+\\.\\d+)"
       ],
       "packageNameTemplate": "bandit",
@@ -192,41 +181,6 @@
       "packageNameTemplate": "{{{depName}}}",
       "datasourceTemplate": "go",
       "versioningTemplate": "semver"
-    },
-    {
-      "customType": "regex",
-      "description": "Update the documented git-pkgs version",
-      "managerFilePatterns": ["/^threatmodel\\.md$/"],
-      "matchStrings": [
-        "`git-pkgs@(?<currentValue>v\\d+\\.\\d+\\.\\d+)`"
-      ],
-      "packageNameTemplate": "github.com/git-pkgs/git-pkgs",
-      "depNameTemplate": "github.com/git-pkgs/git-pkgs",
-      "datasourceTemplate": "go",
-      "versioningTemplate": "semver"
-    },
-    {
-      "customType": "regex",
-      "description": "Update documented builder image versions",
-      "managerFilePatterns": ["/^threatmodel\\.md$/"],
-      "matchStrings": [
-        "`(?<depName>golang|rust):(?<currentValue>\\d+\\.\\d+(?:\\.\\d+)?)-(?:trixie|alpine)`"
-      ],
-      "packageNameTemplate": "{{{depName}}}",
-      "datasourceTemplate": "docker",
-      "versioningTemplate": "docker"
-    },
-    {
-      "customType": "regex",
-      "description": "Update documented Go toolchain versions",
-      "managerFilePatterns": ["/^threatmodel\\.md$/"],
-      "matchStrings": [
-        "`toolchain go(?<currentValue>\\d+\\.\\d+\\.\\d+)`"
-      ],
-      "packageNameTemplate": "go",
-      "depNameTemplate": "go",
-      "datasourceTemplate": "golang-version",
-      "versioningTemplate": "semver"
     }
   ],
   "packageRules": [
@@ -239,10 +193,9 @@
     },
     {
       "description": "Raising the go directive raises the minimum Go version for every consumer",
-      "matchManagers": ["gomod", "custom.regex"],
+      "matchManagers": ["gomod"],
       "matchPackageNames": ["go"],
-      "groupName": "Go language version",
-      "minimumGroupSize": 4
+      "groupName": "Go language version"
     },
     {
       "matchManagers": ["gomod"],
@@ -272,43 +225,43 @@
     },
     {
       "description": "Update Go builder image versions before Go modules can require the newer toolchain",
-      "matchManagers": ["dockerfile", "custom.regex"],
+      "matchManagers": ["dockerfile"],
       "matchPackageNames": ["golang"],
       "matchUpdateTypes": ["major", "minor", "patch"],
       "groupName": "Go Docker images",
-      "minimumGroupSize": 7,
+      "minimumGroupSize": 5,
       "minimumReleaseAge": "0 days"
     },
     {
-      "description": "Keep the Rust builder images and documented version synchronized",
-      "matchManagers": ["dockerfile", "custom.regex"],
+      "description": "Keep the Rust builder images synchronized",
+      "matchManagers": ["dockerfile"],
       "matchPackageNames": ["rust"],
       "groupName": "Rust Docker images",
-      "minimumGroupSize": 3
+      "minimumGroupSize": 2
     },
     {
-      "description": "Keep the container-image and documented bandit pins synchronized",
+      "description": "Keep both container-image bandit pins synchronized",
       "matchPackageNames": ["bandit"],
       "groupName": "bandit",
-      "minimumGroupSize": 3
+      "minimumGroupSize": 2
     },
     {
-      "description": "Keep the container-image and documented semgrep pins synchronized",
+      "description": "Keep both container-image semgrep pins synchronized",
       "matchPackageNames": ["semgrep"],
       "groupName": "semgrep",
-      "minimumGroupSize": 3
+      "minimumGroupSize": 2
     },
     {
       "description": "Keep the workflow and container-image zizmor pins synchronized",
       "matchPackageNames": ["zizmor"],
       "groupName": "zizmor",
-      "minimumGroupSize": 4
+      "minimumGroupSize": 3
     },
     {
-      "description": "Keep all four Claude Code pins on one GitHub release",
+      "description": "Keep all three Claude Code pins on one GitHub release",
       "matchPackageNames": ["anthropics/claude-code"],
       "groupName": "Claude Code",
-      "minimumGroupSize": 4,
+      "minimumGroupSize": 3,
       "minimumReleaseAge": "7 days"
     },
     {
@@ -330,10 +283,10 @@
       "minimumGroupSize": 2
     },
     {
-      "description": "Keep the container-image and documented git-pkgs pins synchronized",
+      "description": "Keep both container-image git-pkgs pins synchronized",
       "matchPackageNames": ["github.com/git-pkgs/git-pkgs"],
       "groupName": "git-pkgs",
-      "minimumGroupSize": 3
+      "minimumGroupSize": 2
     },
     {
       "description": "Keep both container-image brief pins synchronized",

--- a/scripts/check-runner-cli-version-pins.sh
+++ b/scripts/check-runner-cli-version-pins.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # Ensures Renovate or a manual edit cannot leave architecture-specific runner
-# assets on different releases. Claude Code also has matching pins in the main
-# image and threat-model documentation. Keep this compatible with macOS bash
-# 3.2 and BSD userland so it also runs locally.
+# assets on different releases, or let zizmor drift between images and CI.
+# Claude Code also has a matching pin in the main image. Keep this compatible
+# with macOS bash 3.2 and BSD userland so it also runs locally.
 
 set -euo pipefail
 
@@ -17,11 +17,6 @@ runner_arm64=$(sed -E -n \
 main_image=$(sed -E -n \
   's|^RUN npm install -g @anthropic-ai/claude-code@([0-9]+\.[0-9]+\.[0-9]+)$|\1|p' \
   "$root/Dockerfile")
-# Backticks in this pattern are literal Markdown delimiters, not shell syntax.
-# shellcheck disable=SC2016
-documented=$(sed -E -n \
-  's/.*`claude-code@([0-9]+\.[0-9]+\.[0-9]+)`.*/\1/p' \
-  "$root/threatmodel.md")
 codex_amd64=$(sed -E -n \
   's/^ARG CODEX_AMD64_LOCK=(rust-v[0-9]+\.[0-9]+\.[0-9]+)@sha256:[0-9a-f]{64}$/\1/p' \
   "$root/Dockerfile.runner")
@@ -58,7 +53,6 @@ require_single() {
 require_single 'Dockerfile.runner amd64 lock' "$runner_amd64"
 require_single 'Dockerfile.runner arm64 lock' "$runner_arm64"
 require_single 'Dockerfile npm install' "$main_image"
-require_single 'threatmodel.md tool list' "$documented"
 require_single 'Dockerfile.runner Codex amd64 lock' "$codex_amd64"
 require_single 'Dockerfile.runner Codex arm64 lock' "$codex_arm64"
 require_single 'Scrutineer Codex model catalog' "$codex_catalog"
@@ -68,14 +62,12 @@ require_single 'Dockerfile.runner Copilot amd64 lock' "$copilot_amd64"
 require_single 'Dockerfile.runner Copilot arm64 lock' "$copilot_arm64"
 
 if [ "$runner_amd64" != "$runner_arm64" ] || \
-   [ "$runner_amd64" != "$main_image" ] || \
-   [ "$runner_amd64" != "$documented" ]; then
+   [ "$runner_amd64" != "$main_image" ]; then
   printf '%s\n' \
     'Claude Code version pins disagree:' \
     "  Dockerfile.runner amd64: $runner_amd64" \
     "  Dockerfile.runner arm64: $runner_arm64" \
-    "  Dockerfile npm install:  $main_image" \
-    "  threatmodel.md:          $documented" >&2
+    "  Dockerfile npm install:  $main_image" >&2
   exit 1
 fi
 
@@ -97,3 +89,31 @@ require_pair 'Codex' "$codex_amd64" "$codex_arm64"
 require_pair 'Codex runner and model catalog' "$codex_amd64" "$codex_catalog"
 require_pair 'OpenCode' "$opencode_amd64" "$opencode_arm64"
 require_pair 'Copilot' "$copilot_amd64" "$copilot_arm64"
+
+# PyPI and crates.io can publish at different times; check the actual pins even
+# when Renovate is updating an existing branch past its minimumGroupSize gate.
+zizmor_main=$(sed -E -n \
+  's/^RUN cargo install --locked --root \/out zizmor@([0-9]+\.[0-9]+\.[0-9]+)[[:space:]]*$/\1/p' \
+  "$root/Dockerfile")
+zizmor_runner=$(sed -E -n \
+  's/^RUN cargo install --locked --root \/out zizmor@([0-9]+\.[0-9]+\.[0-9]+)[[:space:]]*$/\1/p' \
+  "$root/Dockerfile.runner")
+zizmor_workflow=$(sed -E -n \
+  's/^[[:space:]]*run: pipx install zizmor==([0-9]+\.[0-9]+\.[0-9]+)[[:space:]]*$/\1/p' \
+  "$root/.github/workflows/tests.yml")
+
+require_single 'Dockerfile zizmor pin' "$zizmor_main"
+require_single 'Dockerfile.runner zizmor pin' "$zizmor_runner"
+require_single '.github/workflows/tests.yml zizmor pin' "$zizmor_workflow"
+
+if [ "$zizmor_main" != "$zizmor_runner" ] || \
+   [ "$zizmor_main" != "$zizmor_workflow" ]; then
+  printf '%s\n' \
+    'zizmor version pins disagree:' \
+    "  Dockerfile:                  $zizmor_main" \
+    "  Dockerfile.runner:           $zizmor_runner" \
+    "  .github/workflows/tests.yml: $zizmor_workflow" >&2
+  exit 1
+fi
+
+printf 'zizmor version pins agree: %s\n' "$zizmor_main"

--- a/threatmodel.md
+++ b/threatmodel.md
@@ -96,7 +96,7 @@ Mitigation remaining: tag finding rows with their source job; render claude-sour
 
 Go's `html/template` auto-escapes all finding fields. `internal/web/jsontree.go` returns `template.HTML` but escapes every leaf through `html.EscapeString`. `internal/web/location.go` builds hrefs from `HTMLURL`, which is scheme-validated at the write site by `safeURL` (see T7).
 
-The two `html/template` XSS vulnerabilities (`GO-2026-4865`, `GO-2026-4603`) are fixed by `toolchain go1.27.1` in go.mod.
+The two `html/template` XSS vulnerabilities (`GO-2026-4865`, `GO-2026-4603`) are fixed by the Go toolchain selected in [go.mod](go.mod).
 
 ### T7: Untrusted upstream metadata (mitigated)
 
@@ -116,15 +116,15 @@ No rate limiting on `POST /repositories`, no cap on clone size, no timeout on th
 
 ### T10: Stale Go toolchain (resolved)
 
-`go.mod` specifies `toolchain go1.27.1`. The Dockerfile builds with `golang:1.27.1-alpine`. All nine stdlib vulnerabilities are fixed.
+The Go toolchain is selected in [go.mod](go.mod); container builds use the pinned Go builder images in [Dockerfile](Dockerfile) and [Dockerfile.runner](Dockerfile.runner). The previously identified stdlib vulnerabilities are fixed by these toolchain updates.
 
 ### T11: Image supply chain (partially mitigated)
 
-The agent CLIs are release-and-SHA-pinned per architecture in [Dockerfile.runner](Dockerfile.runner): `claude-code@2.1.261`, Codex, OpenCode, and Copilot. Other tool versions are pinned: `semgrep==1.176.1`, `bandit==1.9.4`, `git-pkgs@v0.20.0`, `zizmor@1.30.0`. The final stage is `debian:trixie-slim`; the `golang:1.27.1-trixie` and `rust:1.98-trixie` builder stages are pinned by sha256 digest. The container runs as non-root user `runner`. The runner image is built in CI, smoke-tested, and published to GHCR; users pull a known-good artifact rather than rebuilding against live registries.
+Claude Code, Codex, OpenCode, and Copilot are pinned by release tag and per-architecture SHA256 digest in [Dockerfile.runner](Dockerfile.runner). Other tool versions and base-image digests are pinned there and in [Dockerfile](Dockerfile); workflow tools are pinned in [CI](.github/workflows/tests.yml). The container runs as non-root user `runner`. The runner image is built in CI, smoke-tested, and published to GHCR; users pull a known-good artifact rather than rebuilding against live registries.
 
 Supply-chain surface in the final stage:
 - `apt` pulls from Debian's official mirrors plus the GitHub CLI repo at `cli.github.com/packages` (signed-by keyring under `/etc/apt/keyrings/`). `gh` is used at scan time by the `fork` and `report-upstream` skills.
-- `claude` is the glibc tarball from `github.com/anthropics/claude-code` releases, SHA256-pinned per architecture. Renovate maps each current digest to its architecture-specific filename using upstream's `SHASUMS256.txt`, then copies the corresponding digest from the new release's manifest. This pipeline does not verify the manifest's accompanying signature, so the pin detects tarball bytes that differ from the digest selected at update time but does not protect against a compromised upstream release at selection time. CI asserts that all four version pins agree, verifies each downloaded tarball against its selected digest, and smoke-tests that the installed binary runs.
+- `claude` is the glibc tarball from `github.com/anthropics/claude-code` releases, SHA256-pinned per architecture. Renovate maps each current digest to its architecture-specific filename using upstream's `SHASUMS256.txt`, then copies the corresponding digest from the new release's manifest. This pipeline does not verify the manifest's accompanying signature, so the pin detects tarball bytes that differ from the digest selected at update time but does not protect against a compromised upstream release at selection time. CI asserts that the image version pins agree, verifies each downloaded tarball against its selected digest, and smoke-tests that the installed binary runs.
 - `codex`, `opencode`, and `copilot` are architecture-specific GitHub release tarballs pinned to the SHA256 digest published for each release attachment. Renovate reads Codex's per-asset digests from GitHub release metadata instead of downloading and hashing its large release set, and updates each CLI's two architecture locks as one group. The image build verifies the selected digest and smoke-tests the installed binary.
 - `semgrep` and `bandit` are installed via `pip` into venvs at `/opt/semgrep` and `/opt/bandit` (PEP 668 dodge without `--break-system-packages`), one each so their pins move independently. `pip` is therefore present, scoped to those venvs.
 - `curl` remains on PATH; used at build time to fetch the claude tarball and apt keyrings, and at scan time inside the egress-proxied container. `npm` is not installed.
@@ -214,7 +214,7 @@ GORM usage is consistently parameterised; no `Raw`, no string-built `Where`, and
 - [x] `io.LimitReader` (10 MB cap) on all ecosyste.ms response bodies (T7).
 - [x] `safeURL` validation on HTMLURL and IconURL before storing (T7).
 - [x] `0700` on the data directory at startup (T8).
-- [x] `toolchain go1.27.1` in go.mod so host builds match the image (T10).
+- [x] Select the Go toolchain in [go.mod](go.mod) so host builds match the image (T10).
 - [x] Pin tool versions in Dockerfile: claude-code, semgrep, bandit, git-pkgs, brief, zizmor (T11).
 - [x] Non-root `USER runner` in Dockerfile (T11).
 - [x] Trim final Docker stage: `npm` absent, `pip` scoped to the `/opt/semgrep` and `/opt/bandit` venvs, `curl` retained for build- and scan-time fetches (T11).


### PR DESCRIPTION
The threat model repeated the exact versions pinned in `Dockerfile` and `Dockerfile.runner`, so every tool bump also edited the same paragraph and consecutive Renovate PRs (#1028, #1029, #1030) conflicted on it and needed sequential rebases. Nothing reads those numbers back; keeping them in sync cost seven regex managers and a padded `minimumGroupSize` on eight groups.

This points the threat model at the files that hold the pins, deletes the documentation-only managers, and lowers each group threshold to the number of image and workflow sites it actually covers. Every update site now sits on its own line in both Dockerfiles, so all 105 pairwise combinations of Renovate PR shapes merge cleanly, and the pin script gains a three-way zizmor check since its PyPI and crates.io pins can move on different runs.

Codex was used to implement this; Opus 5 reviewed it.
